### PR TITLE
fix: add ITSAppUsesNonExemptEncryption to auto-clear export compliance

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -47,5 +47,7 @@
 	<true/>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>MonkeySSH needs photo library access to select files for transfer.</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Builds were stuck waiting for manual export compliance confirmation in App Store Connect before reaching TestFlight.

Adding `ITSAppUsesNonExemptEncryption = NO` to `ios/Runner/Info.plist` auto-clears the compliance check since the app uses only standard, publicly available encryption algorithms (exempt under US BIS EAR 740.17(b)(1)).