### PR TITLE
fix: add INTERNET permission to main AndroidManifest.xml

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"


### PR DESCRIPTION
## Problem

SSH connections on Android release builds fail with 'host not found' and 'connection failed' errors, even when using IP addresses directly.

## Root Cause

The `INTERNET` permission was only declared in the **debug** and **profile** Android manifests (`src/debug/AndroidManifest.xml` and `src/profile/AndroidManifest.xml`), but was **missing from the main manifest** (`src/main/AndroidManifest.xml`).

Without this permission, Android blocks all network socket operations in release builds, causing DNS resolution and TCP connections to fail silently.

## Fix

Added `<uses-permission android:name="android.permission.INTERNET"/>` to the main `AndroidManifest.xml` so the permission applies to all build types (debug, profile, and release).