### PR TITLE
fix: set uses_non_exempt_encryption in Fastlane pilot upload

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -91,6 +91,7 @@ platform :ios do
       ipa: lane_context[SharedValues::IPA_OUTPUT_PATH],
       skip_waiting_for_build_processing: true,
       skip_submission: true,
+      uses_non_exempt_encryption: false,
     )
 
     sync_metadata(app_identifier: app_id) unless skip_meta


### PR DESCRIPTION
The `ITSAppUsesNonExemptEncryption` key in Info.plist alone doesn't always auto-clear export compliance in App Store Connect. Fastlane's `pilot` needs the explicit `uses_non_exempt_encryption: false` option to programmatically set the compliance status when uploading to TestFlight.

This ensures builds skip the 'Missing Compliance' prompt and go straight to testers.