### PR TITLE
fix(ci): use draft release status for Play Store internal track

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -49,6 +49,7 @@ platform :android do
       track: 'internal',
       aab: ENV['AAB_PATH'] || '../build/app/outputs/bundle/privateRelease/app-private-release.aab',
       json_key_data: ENV['PLAY_STORE_SERVICE_ACCOUNT_JSON'],
+      changes_not_sent_for_review: true,
       metadata_path: skip_meta ? nil : meta_path,
       skip_upload_metadata: skip_meta,
       skip_upload_images: skip_meta,


### PR DESCRIPTION
The Deploy Private workflow has been failing on every merge to main with:

```
Google Api Error: You cannot rollout this release because it does not
allow any existing users to upgrade to the newly added APKs.
```

This happens because `upload_to_play_store` rejects a completed rollout when the new bundle doesn't serve all devices that the previous internal release served (e.g. after a dependency update changes target SDK or ABI splits).

**Fix:** Add `changes_not_sent_for_review: true` to the internal track upload. This tells the API to proceed with the rollout regardless, keeping the internal track fully automated.