### PR TITLE
fix(ci): use epoch seconds for build numbers to fix Play Store deploy

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -28,7 +28,7 @@ jobs:
         id: version
         run: |
           BASE_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | cut -d'+' -f1)
-          BUILD_NUMBER=$(( $(date +%s) / 60 ))
+          BUILD_NUMBER=$(( $(date +%s) / 10 ))
 
           echo "build-name=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "build-number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,7 +30,7 @@ jobs:
         id: version
         run: |
           BASE_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | cut -d'+' -f1)
-          BUILD_NUMBER=$(( $(date +%s) / 60 ))
+          BUILD_NUMBER=$(( $(date +%s) / 10 ))
 
           echo "build-name=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "build-number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             BUILD_NAME="${{ inputs.version }}"
           fi
 
-          BUILD_NUMBER=$(( $(date +%s) / 60 ))
+          BUILD_NUMBER=$(( $(date +%s) / 10 ))
 
           echo "build-name=${BUILD_NAME}" >> "$GITHUB_OUTPUT"
           echo "build-number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -49,7 +49,6 @@ platform :android do
       track: 'internal',
       aab: ENV['AAB_PATH'] || '../build/app/outputs/bundle/privateRelease/app-private-release.aab',
       json_key_data: ENV['PLAY_STORE_SERVICE_ACCOUNT_JSON'],
-      changes_not_sent_for_review: true,
       metadata_path: skip_meta ? nil : meta_path,
       skip_upload_metadata: skip_meta,
       skip_upload_images: skip_meta,


### PR DESCRIPTION
The Deploy Private workflow has been failing since inception with:

```
Google Api Error: You cannot rollout this release because it does not
allow any existing users to upgrade to the newly added APKs.
```

**Root cause:** The internal track already has a release with version code `100250021` (~100M), but the build number formula `$(date +%s) / 60` (epoch minutes) only produces ~29.5M — which is *lower*. Google Play rejects rollouts where existing users can't upgrade to the new version.

**Fix:** Switch from epoch minutes to epoch seconds / 10 (`$(date +%s) / 10`, ~177M today), which clears the existing 100M version code while lasting until ~2050 before hitting Android's versionCode int32 max of 2147483647.

Also reverts the unnecessary `changes_not_sent_for_review` added in #39, since the root cause was the version code, not the review flag.