### PR TITLE
fix: terminal keyboard focus and indicator state

### DIFF
--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -86,11 +86,19 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   }
 
   @override
-  Widget build(BuildContext context) => Focus(
-    focusNode: widget.focusNode,
-    autofocus: true,
-    onKeyEvent: _onKeyEvent,
-    child: widget.child,
+  Widget build(BuildContext context) => Listener(
+    behavior: HitTestBehavior.translucent,
+    onPointerDown: (_) {
+      if (!widget.readOnly) {
+        requestKeyboard();
+      }
+    },
+    child: Focus(
+      focusNode: widget.focusNode,
+      autofocus: true,
+      onKeyEvent: _onKeyEvent,
+      child: widget.child,
+    ),
   );
 
   // -- Hardware key event handling --


### PR DESCRIPTION
## Summary
- make terminal taps re-open/re-request the mobile keyboard
- make keyboard toggle icon reflect actual keyboard visibility using viewInsets
- change hidden extra-keys icon to a keyboard icon to avoid duplicate overflow icons

## Validation
- dart format on changed files
- flutter analyze lib/presentation/screens/terminal_screen.dart lib/presentation/widgets/terminal_text_input_handler.dart
- flutter test test/widget/terminal_text_input_handler_test.dart