### PR TITLE
fix: align TestFlight PR deploy build number scheme with other workflows

### DIFF
--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -28,7 +28,7 @@ jobs:
         id: version
         run: |
           BASE_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | cut -d'+' -f1)
-          BUILD_NUMBER=$(( $(date +%s) / 60 ))
+          BUILD_NUMBER=$(( $(date +%s) / 10 ))
 
           echo "build-name=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "build-number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The `deploy-testflight.yml` workflow was dividing epoch seconds by **60** (minutes) to compute the build number, while all other workflows (`develop`, `release`, `preview`) divide by **10** (deciseconds).

This caused PR deploy builds to always have a lower build number than existing builds, so TestFlight would not surface them as newer versions.

## Fix

Changed `BUILD_NUMBER=$(( $(date +%s) / 60 ))` → `BUILD_NUMBER=$(( $(date +%s) / 10 ))` to match the scheme used everywhere else.