### PR TITLE
feat: default host auth to Auto keys

### DIFF
--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -258,7 +258,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                           labelText: 'SSH Key (optional)',
                           prefixIcon: Icon(Icons.key),
                           helperText:
-                              'Auto tries installed keys when password is empty',
+                              'Auto tries up to 5 installed keys when password is empty',
                         ),
                         items: [
                           const DropdownMenuItem<int?>(child: Text('Auto')),


### PR DESCRIPTION
## Summary
- default host key picker selection to **Auto** (null `keyId`) so hosts can use installed keys without explicit selection
- in Auto mode, load installed keys once per connection attempt and reuse them for host and jump-host auth
- keep explicit key override behavior, and fall back to Auto keys when a selected key reference is missing and password auth is not configured
- make Auto identity order deterministic by sorting keys by key ID before passing identities

## Review feedback addressed
- removed duplicate `getAll()` reads by caching Auto keys in `connectToHost`
- added missing-key fallback for both host and jump-host selected-key paths
- clarified deterministic order for Auto identity candidates

## Verification
- `dart format lib/domain/services/ssh_service.dart test/domain/services/ssh_service_test.dart`
- `flutter analyze`
- `flutter test test/domain/services/ssh_service_test.dart`
