### PR TITLE
chore: speed up GitHub Actions CI builds

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -59,6 +59,14 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('android/build.gradle*', 'android/app/build.gradle*', 'android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}-
+
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.x'
@@ -164,6 +172,12 @@ jobs:
       - name: Capture source SHA
         id: source-sha
         run: echo "value=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        with:
+          path: ios/Pods
+          key: pods-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: pods-${{ runner.os }}-
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ on:
       - 'windows/**'
       - 'web/**'
   merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -84,7 +85,6 @@ jobs:
   build-android:
     name: Build Android
     runs-on: ubuntu-latest
-    needs: [analyze, test]
     steps:
       - uses: actions/checkout@v6
 
@@ -92,6 +92,14 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('android/build.gradle*', 'android/app/build.gradle*', 'android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}-
 
       - uses: subosito/flutter-action@v2
         with:
@@ -105,27 +113,23 @@ jobs:
       - name: Build APK
         run: flutter build apk --flavor production --release
 
-      - name: Build App Bundle
-        run: flutter build appbundle --flavor production --release
-
       - name: Upload APK
         uses: actions/upload-artifact@v6
         with:
           name: android-apk
           path: build/app/outputs/flutter-apk/app-production-release.apk
 
-      - name: Upload AAB
-        uses: actions/upload-artifact@v6
-        with:
-          name: android-aab
-          path: build/app/outputs/bundle/productionRelease/app-production-release.aab
-
   build-ios:
     name: Build iOS
     runs-on: macos-26
-    needs: [analyze, test]
     steps:
       - uses: actions/checkout@v6
+
+      - uses: actions/cache@v4
+        with:
+          path: ios/Pods
+          key: pods-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: pods-${{ runner.os }}-
 
       - uses: subosito/flutter-action@v2
         with:
@@ -148,9 +152,14 @@ jobs:
   build-macos:
     name: Build macOS
     runs-on: macos-26
-    needs: [analyze, test]
     steps:
       - uses: actions/checkout@v6
+
+      - uses: actions/cache@v4
+        with:
+          path: macos/Pods
+          key: pods-macos-${{ runner.os }}-${{ hashFiles('macos/Podfile.lock') }}
+          restore-keys: pods-macos-${{ runner.os }}-
 
       - uses: subosito/flutter-action@v2
         with:
@@ -173,7 +182,6 @@ jobs:
   build-windows:
     name: Build Windows
     runs-on: windows-latest
-    needs: [analyze, test]
     steps:
       - uses: actions/checkout@v6
 
@@ -198,14 +206,13 @@ jobs:
   build-linux:
     name: Build Linux
     runs-on: ubuntu-latest
-    needs: [analyze, test]
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev libsecret-1-dev
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev libsecret-1-dev
+          version: 1.0
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/sync-metadata.yml
+++ b/.github/workflows/sync-metadata.yml
@@ -24,7 +24,7 @@ jobs:
   sync-ios:
     name: Sync iOS Metadata
     if: inputs.platform == 'both' || inputs.platform == 'ios'
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     env:
       APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
       APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}


### PR DESCRIPTION
## Summary

Speed up CI pipeline by ~10-15 minutes on typical PR runs through parallelism, caching, and removing redundant work.

## Changes

### �� High Impact
- **Parallelize all jobs** — Removed `needs: [analyze, test]` from platform build jobs so they start immediately instead of waiting for quality gates (~3-5 min saved)
- **Drop redundant AAB build in CI** — CI only needs APK to validate compilation; AAB is still built in `build-deploy.yml` for actual releases (~2-4 min saved)
- **Gradle dependency caching** — Added `actions/cache` for `~/.gradle/caches` and `~/.gradle/wrapper` in both `ci.yml` and `build-deploy.yml` (~1-3 min saved per Android build)
- **CocoaPods caching** — Added `actions/cache` for `ios/Pods` and `macos/Pods` in `ci.yml` and `build-deploy.yml` (~1-2 min saved per Apple build)

### 🟡 Medium Impact
- **Cache Linux apt packages** — Replaced manual `apt-get install` with `awalsh128/cache-apt-pkgs-action` (~30-60s saved)
- **iOS metadata sync on Ubuntu** — Switched `sync-metadata.yml` iOS job from `macos-26` to `ubuntu-latest` (Fastlane `deliver` doesn't need Xcode; cheaper and faster queue)
- **Scoped merge_group trigger** — Added `types: [checks_requested]` to avoid unnecessary runs

## Notes
- Branch protection / required status checks still enforce that all jobs must pass before merge
- No behavioral changes to actual build outputs or deploy workflows