### PR TITLE
chore: skip AAB build in preview/non-deploy builds

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -96,6 +96,7 @@ jobs:
           EOF
 
       - name: Build AAB
+        if: inputs.deploy-android-to != 'none'
         run: |
           flutter build appbundle \
             --flavor ${{ inputs.flavor }} \
@@ -112,6 +113,7 @@ jobs:
             --build-number=${{ inputs.build-number }}
 
       - name: Upload AAB artifact
+        if: inputs.deploy-android-to != 'none'
         uses: actions/upload-artifact@v6
         with:
           name: android-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}


### PR DESCRIPTION
## Summary

Skip the AAB (App Bundle) build in `build-deploy.yml` when `deploy-android-to` is `none` — i.e. PR preview builds.

## Problem

Preview builds were taking ~10 minutes, with ~9 minutes spent building an AAB that was never uploaded to the Play Store. The AAB is only needed for actual deployments.

## Fix

Added `if: inputs.deploy-android-to != 'none'` to the AAB build and upload steps. Preview builds now only build the APK (needed for the download link).

Combined with the Gradle caching from #62, this should cut preview Android builds from ~9m 40s to ~3-4 min.

## Changes
- `build-deploy.yml`: Conditional AAB build/upload (skip when not deploying)