### PR TITLE
fix: recreate preview PR comment

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -60,6 +60,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: preview-build
+          recreate: true
           message: |
             ## 📱 Preview Build
 


### PR DESCRIPTION
## Summary\n- update preview workflow comment step to recreate the comment instead of updating the original one\n- keep the latest preview status comment near the bottom of the PR timeline\n\n## Testing\n- parsed .github/workflows/preview.yml successfully with Ruby YAML loader