### PR TITLE
fix: improve UX and harden platform QA flows

### DIFF
--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,76 +1,189 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' as drift;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/data/repositories/key_repository.dart';
+import 'package:monkeyssh/data/security/secret_encryption_service.dart';
+import 'package:monkeyssh/domain/services/auth_service.dart';
+import 'package:monkeyssh/domain/services/key_service.dart';
 import 'package:monkeyssh/main.dart' as app;
+import 'package:monkeyssh/presentation/screens/home_screen.dart';
+import 'package:monkeyssh/presentation/screens/hosts_screen.dart';
+import 'package:xterm/xterm.dart';
+
+const _testSshEnabled = bool.fromEnvironment('TEST_SSH_ENABLED');
+const _testSshHost = String.fromEnvironment(
+  'TEST_SSH_HOST',
+  defaultValue: '127.0.0.1',
+);
+const _testSshPort = int.fromEnvironment('TEST_SSH_PORT', defaultValue: 22);
+const _testSshUsername = String.fromEnvironment('TEST_SSH_USERNAME');
+const _testSshPrivateKeyBase64 = String.fromEnvironment(
+  'TEST_SSH_PRIVATE_KEY_B64',
+);
+const _seededHostLabel = 'Local SSH Target';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('App Integration Tests', () {
-    testWidgets('Home screen loads and shows navigation options', (
+    testWidgets('home screen loads and shows navigation options', (
       tester,
     ) async {
       app.main();
-      await tester.pumpAndSettle(const Duration(seconds: 3));
+      await _pumpUntilVisible(tester, find.text('MonkeySSH'));
 
-      // Verify home screen elements
-      expect(find.text('Flutty'), findsOneWidget);
-      expect(find.text('Quick Connect'), findsOneWidget);
+      expect(find.text('MonkeySSH'), findsOneWidget);
       expect(find.text('Hosts'), findsOneWidget);
+      expect(find.text('Connections'), findsOneWidget);
       expect(find.text('Keys'), findsOneWidget);
       expect(find.text('Snippets'), findsOneWidget);
-      expect(find.text('Port Forward'), findsOneWidget);
     });
 
-    testWidgets('Navigate to Hosts screen', (tester) async {
+    testWidgets('settings exposes the security setup flow', (tester) async {
       app.main();
-      await tester.pumpAndSettle(const Duration(seconds: 3));
+      await _pumpUntilVisible(tester, find.byIcon(Icons.settings_outlined));
 
-      // Tap on Hosts card
-      await tester.tap(find.text('Hosts'));
-      await tester.pumpAndSettle();
-
-      // Verify hosts screen
-      expect(find.text('Hosts'), findsOneWidget);
-    });
-
-    testWidgets('Navigate to Settings screen', (tester) async {
-      app.main();
-      await tester.pumpAndSettle(const Duration(seconds: 3));
-
-      // Tap on settings icon
       await tester.tap(find.byIcon(Icons.settings_outlined));
-      await tester.pumpAndSettle();
+      await _pumpUntilVisible(tester, find.text('Settings'));
 
-      // Verify settings screen
       expect(find.text('Settings'), findsOneWidget);
-      expect(find.text('Appearance'), findsOneWidget);
-      expect(find.text('Security'), findsOneWidget);
-      expect(find.text('Terminal'), findsOneWidget);
+      expect(find.text('Set up app lock'), findsOneWidget);
+
+      await tester.tap(find.text('Set up app lock'));
+      await _pumpUntilVisible(tester, find.text('Security Setup'));
+
+      expect(find.text('Security Setup'), findsOneWidget);
+      expect(find.text('Skip for now'), findsOneWidget);
     });
 
-    testWidgets('Navigate to Keys screen', (tester) async {
+    testWidgets('hosts search waits for apply before dismissing', (
+      tester,
+    ) async {
       app.main();
-      await tester.pumpAndSettle(const Duration(seconds: 3));
+      await _pumpUntilVisible(tester, find.text('MonkeySSH'));
 
-      // Tap on Keys card
-      await tester.tap(find.text('Keys'));
-      await tester.pumpAndSettle();
+      final context = tester.element(find.byType(HomeScreen));
+      GoRouter.of(context).go('/hosts');
+      await _pumpUntilVisible(tester, find.byType(HostsScreen));
 
-      // Verify keys screen
-      expect(find.text('SSH Keys'), findsOneWidget);
+      await tester.tap(find.byTooltip('Search'));
+      await _pumpUntilVisible(tester, find.text('Search Hosts'));
+
+      expect(find.text('Search Hosts'), findsOneWidget);
+      await tester.enterText(find.byType(TextField), 'prod');
+      await tester.pump();
+      expect(find.text('Search Hosts'), findsOneWidget);
+
+      await tester.tap(find.text('Apply'));
+      await _pumpUntilVisible(tester, find.text('Search: prod'));
+
+      expect(find.text('No hosts match your search'), findsOneWidget);
+      expect(find.text('Search: prod'), findsOneWidget);
+      expect(find.text('Clear all'), findsOneWidget);
     });
 
-    testWidgets('Navigate to Snippets screen', (tester) async {
+    testWidgets('can connect to a seeded SSH host', (tester) async {
+      await _seedSshHost();
+
       app.main();
-      await tester.pumpAndSettle(const Duration(seconds: 3));
+      await _pumpUntilVisible(tester, find.text(_seededHostLabel));
 
-      // Tap on Snippets card
-      await tester.tap(find.text('Snippets'));
-      await tester.pumpAndSettle();
+      expect(find.text(_seededHostLabel), findsOneWidget);
 
-      // Verify snippets screen
-      expect(find.text('Snippets'), findsOneWidget);
-    });
+      await tester.tap(find.text(_seededHostLabel));
+      await tester.pump();
+      await _pumpUntilTerminalReady(tester);
+
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await _pumpUntilVisible(tester, find.text('Disconnect'));
+      expect(find.text('Disconnect'), findsOneWidget);
+    }, skip: !_testSshEnabled);
   });
+}
+
+Future<void> _seedSshHost() async {
+  final privateKeyPem = _decodeTestPrivateKey();
+  final authService = AuthService();
+  await authService.disableAuth();
+
+  final db = AppDatabase();
+  final secretEncryptionService = SecretEncryptionService();
+  final keyRepository = KeyRepository(db, secretEncryptionService);
+  final hostRepository = HostRepository(db, secretEncryptionService);
+  final keyService = KeyService(keyRepository);
+
+  try {
+    await db.delete(db.portForwards).go();
+    await db.delete(db.hosts).go();
+    await db.delete(db.sshKeys).go();
+
+    final importedKey = await keyService.importKey(
+      name: 'Integration SSH Key',
+      privateKeyPem: privateKeyPem,
+    );
+    if (importedKey == null) {
+      throw StateError('Failed to import integration SSH key');
+    }
+
+    await hostRepository.insert(
+      HostsCompanion.insert(
+        label: _seededHostLabel,
+        hostname: _testSshHost,
+        port: const drift.Value(_testSshPort),
+        username: _testSshUsername,
+        keyId: drift.Value(importedKey.id),
+      ),
+    );
+  } finally {
+    await db.close();
+  }
+}
+
+String _decodeTestPrivateKey() {
+  if (!_testSshEnabled ||
+      _testSshUsername.isEmpty ||
+      _testSshPrivateKeyBase64.isEmpty) {
+    throw StateError('Missing SSH integration test configuration');
+  }
+
+  return utf8.decode(base64Decode(_testSshPrivateKeyBase64));
+}
+
+Future<void> _pumpUntilVisible(
+  WidgetTester tester,
+  Finder finder, {
+  Duration step = const Duration(milliseconds: 200),
+  int maxTicks = 50,
+}) async {
+  for (var i = 0; i < maxTicks; i++) {
+    await tester.pump(step);
+    if (finder.evaluate().isNotEmpty) {
+      return;
+    }
+  }
+
+  fail('Timed out waiting for expected widget to appear');
+}
+
+Future<void> _pumpUntilTerminalReady(WidgetTester tester) async {
+  final terminalView = find.byType(TerminalView);
+  final connectionError = find.text('Connection Error');
+
+  for (var i = 0; i < 75; i++) {
+    await tester.pump(const Duration(milliseconds: 200));
+    if (connectionError.evaluate().isNotEmpty) {
+      fail('SSH integration test hit a connection error');
+    }
+    if (terminalView.evaluate().isNotEmpty) {
+      return;
+    }
+  }
+
+  fail('Timed out waiting for terminal connection to finish');
 }

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:drift/drift.dart' as drift;
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -11,6 +14,7 @@ import 'package:monkeyssh/app/app.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/key_repository.dart';
+import 'package:monkeyssh/data/repositories/snippet_repository.dart';
 import 'package:monkeyssh/data/security/secret_encryption_service.dart';
 import 'package:monkeyssh/domain/services/auth_service.dart';
 import 'package:monkeyssh/domain/services/key_service.dart';
@@ -29,6 +33,11 @@ const _testSshPrivateKeyBase64 = String.fromEnvironment(
   'TEST_SSH_PRIVATE_KEY_B64',
 );
 const _seededHostLabel = 'Local SSH Target';
+const _qaPublicKey =
+    'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIClipboardQaKey qa@device';
+const _qaPrivateKey =
+    '-----BEGIN OPENSSH PRIVATE KEY-----\nqa-private-key\n-----END OPENSSH PRIVATE KEY-----';
+const _qaSnippetCommand = 'echo "qa clipboard snippet"';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -100,6 +109,103 @@ void main() {
       expect(find.text('Clear all'), findsOneWidget);
     });
 
+    testWidgets('keys screen copies public and private keys to clipboard', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      await AuthService().disableAuth();
+      await _seedClipboardKey(db);
+
+      await _launchApp(tester, db);
+      await _pumpUntilVisible(tester, find.text('MonkeySSH'));
+
+      final context = tester.element(find.byType(HomeScreen));
+      GoRouter.of(context).go('/keys');
+      await _pumpUntilVisible(tester, find.text('QA Clipboard Key'));
+
+      await tester.tap(find.text('QA Clipboard Key'));
+      await _pumpUntilVisible(tester, find.text('Copy Public Key'));
+
+      await tester.tap(find.text('Copy Public Key'));
+      await _pumpUntilVisible(tester, find.text('Copied to clipboard'));
+      expect(
+        (await Clipboard.getData(Clipboard.kTextPlain))?.text,
+        _qaPublicKey,
+      );
+
+      await tester.tap(find.text('Reveal Private Key'));
+      await _pumpUntilVisible(tester, find.text('Copy Private Key'));
+      await tester.tap(find.text('Copy Private Key'));
+      await _pumpUntilVisible(tester, find.text('Copy private key?'));
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.widgetWithText(FilledButton, 'Copy'),
+        ),
+      );
+      await _pumpUntilVisible(tester, find.text('Copied to clipboard'));
+      expect(
+        (await Clipboard.getData(Clipboard.kTextPlain))?.text,
+        _qaPrivateKey,
+      );
+    });
+
+    testWidgets('snippets list scrolls and copies commands to clipboard', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      await AuthService().disableAuth();
+      await _seedClipboardSnippets(db);
+
+      await _launchApp(tester, db);
+      await _pumpUntilVisible(tester, find.text('MonkeySSH'));
+
+      final context = tester.element(find.byType(HomeScreen));
+      GoRouter.of(context).go('/snippets');
+      await _pumpUntilVisible(tester, find.text('QA Snippet 00'));
+
+      await tester.drag(find.byType(ListView).first, const Offset(0, -900));
+      await tester.pumpAndSettle();
+      await _pumpUntilVisible(tester, find.text('QA Snippet 11'));
+
+      await tester.tap(find.text('QA Snippet 11'));
+      await _pumpUntilVisible(
+        tester,
+        find.text('Copied "QA Snippet 11" to clipboard'),
+      );
+      expect(
+        (await Clipboard.getData(Clipboard.kTextPlain))?.text,
+        'printf "snippet-11"',
+      );
+    });
+
+    testWidgets('terminal connection error can navigate back to hosts', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      await AuthService().disableAuth();
+      final hostId = await _seedInvalidHost(db);
+
+      await _launchApp(tester, db);
+      await _pumpUntilVisible(tester, find.text('MonkeySSH'));
+
+      final context = tester.element(find.byType(HomeScreen));
+      unawaited(GoRouter.of(context).push('/terminal/$hostId'));
+      await _pumpUntilVisible(tester, find.text('Connection Error'));
+
+      expect(find.text('Back to Hosts'), findsOneWidget);
+      await tester.tap(find.widgetWithText(OutlinedButton, 'Back to Hosts'));
+      await tester.pumpAndSettle();
+      expect(
+        find.widgetWithText(OutlinedButton, 'Back to Hosts'),
+        findsNothing,
+      );
+      expect(find.text('Connection Error'), findsNothing);
+    });
+
     testWidgets('can connect to a seeded SSH host', (tester) async {
       final db = AppDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);
@@ -115,9 +221,8 @@ void main() {
       await tester.pump();
       await _pumpUntilTerminalReady(tester);
 
-      await tester.tap(find.byType(PopupMenuButton<String>));
-      await _pumpUntilVisible(tester, find.text('Disconnect'));
-      expect(find.text('Disconnect'), findsOneWidget);
+      expect(find.byType(TerminalView), findsOneWidget);
+      expect(find.text(_seededHostLabel), findsWidgets);
     }, skip: !_testSshEnabled);
   });
 }
@@ -130,6 +235,55 @@ Future<void> _launchApp(WidgetTester tester, AppDatabase db) async {
     ),
   );
   await tester.pump();
+}
+
+Future<void> _seedClipboardKey(AppDatabase db) async {
+  final secretEncryptionService = SecretEncryptionService();
+  final keyRepository = KeyRepository(db, secretEncryptionService);
+
+  await db.delete(db.sshKeys).go();
+
+  await keyRepository.insert(
+    SshKeysCompanion.insert(
+      name: 'QA Clipboard Key',
+      keyType: 'ed25519',
+      publicKey: _qaPublicKey,
+      privateKey: _qaPrivateKey,
+    ),
+  );
+}
+
+Future<void> _seedClipboardSnippets(AppDatabase db) async {
+  final snippetRepository = SnippetRepository(db);
+
+  await db.delete(db.snippets).go();
+
+  for (var index = 0; index < 12; index++) {
+    final number = index.toString().padLeft(2, '0');
+    await snippetRepository.insert(
+      SnippetsCompanion.insert(
+        name: 'QA Snippet $number',
+        command: index == 11 ? 'printf "snippet-11"' : _qaSnippetCommand,
+      ),
+    );
+  }
+}
+
+Future<int> _seedInvalidHost(AppDatabase db) async {
+  final secretEncryptionService = SecretEncryptionService();
+  final hostRepository = HostRepository(db, secretEncryptionService);
+
+  await db.delete(db.portForwards).go();
+  await db.delete(db.hosts).go();
+
+  return hostRepository.insert(
+    HostsCompanion.insert(
+      label: 'Broken QA Host',
+      hostname: '127.0.0.1',
+      port: const drift.Value(1),
+      username: 'qa',
+    ),
+  );
 }
 
 Future<void> _seedSshHost(AppDatabase db) async {
@@ -154,7 +308,7 @@ Future<void> _seedSshHost(AppDatabase db) async {
   await hostRepository.insert(
     HostsCompanion.insert(
       label: _seededHostLabel,
-      hostname: _testSshHost,
+      hostname: _runtimeSshHost(),
       port: const drift.Value(_testSshPort),
       username: _testSshUsername,
       keyId: drift.Value(importedKey.id),
@@ -170,6 +324,14 @@ String _decodeTestPrivateKey() {
   }
 
   return utf8.decode(base64Decode(_testSshPrivateKeyBase64));
+}
+
+String _runtimeSshHost() {
+  if (Platform.isAndroid && _testSshHost == '127.0.0.1') {
+    return '10.0.2.2';
+  }
+
+  return _testSshHost;
 }
 
 Future<void> _pumpUntilVisible(

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,17 +1,19 @@
 import 'dart:convert';
 
 import 'package:drift/drift.dart' as drift;
+import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:monkeyssh/app/app.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/key_repository.dart';
 import 'package:monkeyssh/data/security/secret_encryption_service.dart';
 import 'package:monkeyssh/domain/services/auth_service.dart';
 import 'package:monkeyssh/domain/services/key_service.dart';
-import 'package:monkeyssh/main.dart' as app;
 import 'package:monkeyssh/presentation/screens/home_screen.dart';
 import 'package:monkeyssh/presentation/screens/hosts_screen.dart';
 import 'package:xterm/xterm.dart';
@@ -35,21 +37,28 @@ void main() {
     testWidgets('home screen loads and shows navigation options', (
       tester,
     ) async {
-      app.main();
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      await AuthService().disableAuth();
+      await _launchApp(tester, db);
       await _pumpUntilVisible(tester, find.text('MonkeySSH'));
 
       expect(find.text('MonkeySSH'), findsOneWidget);
-      expect(find.text('Hosts'), findsOneWidget);
+      expect(find.text('Hosts'), findsWidgets);
       expect(find.text('Connections'), findsOneWidget);
       expect(find.text('Keys'), findsOneWidget);
       expect(find.text('Snippets'), findsOneWidget);
     });
 
     testWidgets('settings exposes the security setup flow', (tester) async {
-      app.main();
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      await AuthService().disableAuth();
+      await _launchApp(tester, db);
       await _pumpUntilVisible(tester, find.byIcon(Icons.settings_outlined));
 
       await tester.tap(find.byIcon(Icons.settings_outlined));
+      await tester.pump();
       await _pumpUntilVisible(tester, find.text('Settings'));
 
       expect(find.text('Settings'), findsOneWidget);
@@ -65,7 +74,10 @@ void main() {
     testWidgets('hosts search waits for apply before dismissing', (
       tester,
     ) async {
-      app.main();
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      await AuthService().disableAuth();
+      await _launchApp(tester, db);
       await _pumpUntilVisible(tester, find.text('MonkeySSH'));
 
       final context = tester.element(find.byType(HomeScreen));
@@ -89,9 +101,12 @@ void main() {
     });
 
     testWidgets('can connect to a seeded SSH host', (tester) async {
-      await _seedSshHost();
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      await AuthService().disableAuth();
+      await _seedSshHost(db);
 
-      app.main();
+      await _launchApp(tester, db);
       await _pumpUntilVisible(tester, find.text(_seededHostLabel));
 
       expect(find.text(_seededHostLabel), findsOneWidget);
@@ -107,42 +122,44 @@ void main() {
   });
 }
 
-Future<void> _seedSshHost() async {
-  final privateKeyPem = _decodeTestPrivateKey();
-  final authService = AuthService();
-  await authService.disableAuth();
+Future<void> _launchApp(WidgetTester tester, AppDatabase db) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [databaseProvider.overrideWithValue(db)],
+      child: const FluttyApp(),
+    ),
+  );
+  await tester.pump();
+}
 
-  final db = AppDatabase();
+Future<void> _seedSshHost(AppDatabase db) async {
+  final privateKeyPem = _decodeTestPrivateKey();
   final secretEncryptionService = SecretEncryptionService();
   final keyRepository = KeyRepository(db, secretEncryptionService);
   final hostRepository = HostRepository(db, secretEncryptionService);
   final keyService = KeyService(keyRepository);
 
-  try {
-    await db.delete(db.portForwards).go();
-    await db.delete(db.hosts).go();
-    await db.delete(db.sshKeys).go();
+  await db.delete(db.portForwards).go();
+  await db.delete(db.hosts).go();
+  await db.delete(db.sshKeys).go();
 
-    final importedKey = await keyService.importKey(
-      name: 'Integration SSH Key',
-      privateKeyPem: privateKeyPem,
-    );
-    if (importedKey == null) {
-      throw StateError('Failed to import integration SSH key');
-    }
-
-    await hostRepository.insert(
-      HostsCompanion.insert(
-        label: _seededHostLabel,
-        hostname: _testSshHost,
-        port: const drift.Value(_testSshPort),
-        username: _testSshUsername,
-        keyId: drift.Value(importedKey.id),
-      ),
-    );
-  } finally {
-    await db.close();
+  final importedKey = await keyService.importKey(
+    name: 'Integration SSH Key',
+    privateKeyPem: privateKeyPem,
+  );
+  if (importedKey == null) {
+    throw StateError('Failed to import integration SSH key');
   }
+
+  await hostRepository.insert(
+    HostsCompanion.insert(
+      label: _seededHostLabel,
+      hostname: _testSshHost,
+      port: const drift.Value(_testSshPort),
+      username: _testSshUsername,
+      keyId: drift.Value(importedKey.id),
+    ),
+  );
 }
 
 String _decodeTestPrivateKey() {

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -38,6 +38,9 @@ const _qaPublicKey =
 const _qaPrivateKey =
     '-----BEGIN OPENSSH PRIVATE KEY-----\nqa-private-key\n-----END OPENSSH PRIVATE KEY-----';
 const _qaSnippetCommand = 'echo "qa clipboard snippet"';
+const _qaCopyMarker = 'qatouchcopymarker';
+const _qaPasteMarker = 'qatouchpastemarker';
+const _qaResumeMarker = 'qaresumemarker';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -224,6 +227,83 @@ void main() {
       expect(find.byType(TerminalView), findsOneWidget);
       expect(find.text(_seededHostLabel), findsWidgets);
     }, skip: !_testSshEnabled);
+
+    testWidgets(
+      'mobile terminal supports touch copy and paste',
+      (tester) async {
+        final db = AppDatabase.forTesting(NativeDatabase.memory());
+        addTearDown(db.close);
+        await AuthService().disableAuth();
+        await _seedSshHost(db);
+
+        await _launchApp(tester, db);
+        await _pumpUntilVisible(tester, find.text(_seededHostLabel));
+
+        await tester.tap(find.text(_seededHostLabel).first);
+        await tester.pump();
+        await _pumpUntilTerminalReady(tester);
+
+        await _pasteCommandAndWaitForOutput(
+          tester,
+          command: "printf 'qatouchcopymarker\\n'\n",
+          output: _qaCopyMarker,
+        );
+        await _copyFromNativeOverlay(tester, _qaCopyMarker);
+
+        await _pasteCommandAndWaitForOutput(
+          tester,
+          command: "printf 'qatouchpastemarker\\n'\n",
+          output: _qaPasteMarker,
+        );
+      },
+      skip: !_testSshEnabled || !_isMobileDevice,
+    );
+
+    testWidgets(
+      'mobile terminal survives leaving app and returning',
+      (tester) async {
+        final db = AppDatabase.forTesting(NativeDatabase.memory());
+        addTearDown(db.close);
+        await AuthService().disableAuth();
+        await _seedSshHost(db);
+
+        await _launchApp(tester, db);
+        await _pumpUntilVisible(tester, find.text(_seededHostLabel));
+
+        await tester.tap(find.text(_seededHostLabel).first);
+        await tester.pump();
+        await _pumpUntilTerminalReady(tester);
+
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.inactive,
+        );
+        await tester.pump();
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+        await tester.pump();
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+        await tester.pump();
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+        await tester.pump();
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.inactive,
+        );
+        await tester.pump();
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(TerminalView), findsOneWidget);
+        expect(find.text('Connection Error'), findsNothing);
+
+        await _pasteCommandAndWaitForOutput(
+          tester,
+          command: "printf 'qaresumemarker\\n'\n",
+          output: _qaResumeMarker,
+        );
+      },
+      skip: !_testSshEnabled || !_isMobileDevice,
+    );
   });
 }
 
@@ -334,7 +414,76 @@ String _runtimeSshHost() {
   return _testSshHost;
 }
 
-Future<void> _pumpUntilVisible(
+bool get _isMobileDevice => Platform.isAndroid || Platform.isIOS;
+
+Future<void> _openTerminalMenu(WidgetTester tester) async {
+  final menuFinder = find.byType(PopupMenuButton<String>);
+  await _pumpUntilVisible(tester, menuFinder);
+  await tester.ensureVisible(menuFinder);
+  await tester.tap(menuFinder, warnIfMissed: false);
+  await tester.pumpAndSettle();
+  await _pumpUntilVisible(tester, find.text('Paste'));
+}
+
+Future<void> _pasteCommandAndWaitForOutput(
+  WidgetTester tester, {
+  required String command,
+  required String output,
+  int attempts = 3,
+}) async {
+  final outputFinder = find.textContaining(output);
+  for (var i = 0; i < attempts; i++) {
+    await Clipboard.setData(ClipboardData(text: command));
+    await _openTerminalMenu(tester);
+    await tester.tap(find.text('Paste'));
+    await tester.pumpAndSettle();
+    if (await _pumpUntilVisibleOrTimeout(tester, outputFinder)) {
+      return;
+    }
+  }
+
+  fail('Timed out waiting for terminal paste output: $output');
+}
+
+Future<void> _copyFromNativeOverlay(
+  WidgetTester tester,
+  String expectedText,
+) async {
+  final editableTextState = _nativeOverlayEditableTextState(tester);
+  final controller = editableTextState.widget.controller;
+  final start = controller.text.indexOf(expectedText);
+  expect(start, isNonNegative);
+
+  final localPoint = editableTextState.renderEditable
+      .getLocalRectForCaret(TextPosition(offset: start + 1))
+      .center;
+  final globalPoint = editableTextState.renderEditable.localToGlobal(
+    localPoint,
+  );
+
+  await tester.longPressAt(globalPoint);
+  await tester.pumpAndSettle();
+
+  final selection = controller.selection;
+  final selectedText = selection.textInside(controller.text);
+  expect(selectedText, contains(expectedText));
+
+  editableTextState.copySelection(SelectionChangedCause.toolbar);
+  await tester.pumpAndSettle();
+
+  final clipboard = await Clipboard.getData(Clipboard.kTextPlain);
+  expect(clipboard?.text, contains(expectedText));
+}
+
+EditableTextState _nativeOverlayEditableTextState(WidgetTester tester) {
+  final editableTextFinder = find.descendant(
+    of: find.byKey(const ValueKey('terminal-native-selection-field')),
+    matching: find.byType(EditableText),
+  );
+  return tester.state<EditableTextState>(editableTextFinder.first);
+}
+
+Future<bool> _pumpUntilVisibleOrTimeout(
   WidgetTester tester,
   Finder finder, {
   Duration step = const Duration(milliseconds: 200),
@@ -343,8 +492,26 @@ Future<void> _pumpUntilVisible(
   for (var i = 0; i < maxTicks; i++) {
     await tester.pump(step);
     if (finder.evaluate().isNotEmpty) {
-      return;
+      return true;
     }
+  }
+
+  return false;
+}
+
+Future<void> _pumpUntilVisible(
+  WidgetTester tester,
+  Finder finder, {
+  Duration step = const Duration(milliseconds: 200),
+  int maxTicks = 50,
+}) async {
+  if (await _pumpUntilVisibleOrTimeout(
+    tester,
+    finder,
+    step: step,
+    maxTicks: maxTicks,
+  )) {
+    return;
   }
 
   fail('Timed out waiting for expected widget to appear');

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -42,6 +42,9 @@ PODS:
   - local_auth_darwin (0.0.1):
     - Flutter
     - FlutterMacOS
+  - mobile_scanner (7.0.0):
+    - Flutter
+    - FlutterMacOS
   - SDWebImage (5.21.5):
     - SDWebImage/Core (= 5.21.5)
   - SDWebImage/Core (5.21.5)
@@ -80,6 +83,7 @@ DEPENDENCIES:
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
+  - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/darwin`)
 
@@ -102,6 +106,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
   local_auth_darwin:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
+  mobile_scanner:
+    :path: ".symlinks/plugins/mobile_scanner/darwin"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   sqlite3_flutter_libs:
@@ -115,6 +121,7 @@ SPEC CHECKSUMS:
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
+  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   SDWebImage: e9c98383c7572d713c1a0d7dd2783b10599b9838
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   sqlite3: 8d708bc63e9f4ce48f0ad9d6269e478c5ced1d9b

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -28,6 +28,40 @@ abstract final class FluttyTheme {
   /// Dark theme.
   static ThemeData get dark => _buildTheme(Brightness.dark);
 
+  /// Builds the input decoration theme for the provided [brightness].
+  static InputDecorationTheme buildInputDecorationTheme(Brightness brightness) {
+    final isDark = brightness == Brightness.dark;
+
+    return InputDecorationTheme(
+      filled: true,
+      fillColor: isDark ? _cardDark : Colors.grey.shade50,
+      hoverColor: isDark ? _borderDark : Colors.grey.shade100,
+      helperMaxLines: 3,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: isDark ? _borderDark : _borderLight),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: isDark ? _borderDark : _borderLight),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: _neonGreen, width: 2),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: _errorColor),
+      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+      labelStyle: TextStyle(color: isDark ? _textSecondary : Colors.black54),
+      hintStyle: TextStyle(
+        color: isDark ? _textSecondary.withAlpha(150) : Colors.black38,
+      ),
+      prefixIconColor: isDark ? _textSecondary : Colors.black45,
+    );
+  }
+
   static ThemeData _buildTheme(Brightness brightness) {
     final isDark = brightness == Brightness.dark;
 
@@ -146,36 +180,7 @@ abstract final class FluttyTheme {
       ),
 
       // Modern input fields
-      inputDecorationTheme: InputDecorationTheme(
-        filled: true,
-        fillColor: isDark ? _cardDark : Colors.grey.shade50,
-        hoverColor: isDark ? _borderDark : Colors.grey.shade100,
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(12),
-          borderSide: BorderSide(color: isDark ? _borderDark : _borderLight),
-        ),
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(12),
-          borderSide: BorderSide(color: isDark ? _borderDark : _borderLight),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: _neonGreen, width: 2),
-        ),
-        errorBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: _errorColor),
-        ),
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: 16,
-          vertical: 16,
-        ),
-        labelStyle: TextStyle(color: isDark ? _textSecondary : Colors.black54),
-        hintStyle: TextStyle(
-          color: isDark ? _textSecondary.withAlpha(150) : Colors.black38,
-        ),
-        prefixIconColor: isDark ? _textSecondary : Colors.black45,
-      ),
+      inputDecorationTheme: buildInputDecorationTheme(brightness),
 
       // Buttons with glow
       filledButtonTheme: FilledButtonThemeData(

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -506,9 +506,12 @@ class SshSession {
   final DateTime createdAt;
 
   SSHSession? _shell;
-  StreamController<String>? _shellStdoutController;
-  StreamController<String>? _shellStderrController;
-  StreamController<void>? _shellDoneController;
+  final StreamController<String> _shellStdoutController =
+      StreamController<String>.broadcast();
+  final StreamController<String> _shellStderrController =
+      StreamController<String>.broadcast();
+  final StreamController<void> _shellDoneController =
+      StreamController<void>.broadcast();
   StreamSubscription<String>? _shellStdoutSubscription;
   StreamSubscription<String>? _shellStderrSubscription;
   StreamSubscription<void>? _shellDoneSubscription;
@@ -555,16 +558,13 @@ class SshSession {
   }
 
   /// Shell stdout as a broadcast stream for screen re-attachment.
-  Stream<String> get shellStdoutStream =>
-      _shellStdoutController?.stream ?? const Stream.empty();
+  Stream<String> get shellStdoutStream => _shellStdoutController.stream;
 
   /// Shell stderr as a broadcast stream for screen re-attachment.
-  Stream<String> get shellStderrStream =>
-      _shellStderrController?.stream ?? const Stream.empty();
+  Stream<String> get shellStderrStream => _shellStderrController.stream;
 
   /// Shell done event stream for screen re-attachment.
-  Stream<void> get shellDoneStream =>
-      _shellDoneController?.stream ?? const Stream.empty();
+  Stream<void> get shellDoneStream => _shellDoneController.stream;
 
   /// Close only the interactive shell channel while keeping the SSH client.
   Future<void> closeShell() async {
@@ -574,45 +574,36 @@ class SshSession {
     _shellStdoutSubscription = null;
     _shellStderrSubscription = null;
     _shellDoneSubscription = null;
-    await _shellStdoutController?.close();
-    await _shellStderrController?.close();
-    await _shellDoneController?.close();
-    _shellStdoutController = null;
-    _shellStderrController = null;
-    _shellDoneController = null;
     _shell?.close();
     _shell = null;
     _terminal = null;
   }
 
   void _ensureShellStreamPipes() {
-    if (_shell == null || _shellStdoutController != null) {
+    if (_shell == null || _shellStdoutSubscription != null) {
       return;
     }
 
     final shell = _shell!;
     final terminal = getOrCreateTerminal();
-    _shellStdoutController = StreamController<String>.broadcast();
-    _shellStderrController = StreamController<String>.broadcast();
-    _shellDoneController = StreamController<void>.broadcast();
 
     _shellStdoutSubscription = shell.stdout
         .cast<List<int>>()
         .transform(utf8.decoder)
         .listen((data) {
           terminal.write(data);
-          _shellStdoutController!.add(data);
-        }, onError: _shellStdoutController!.addError);
+          _shellStdoutController.add(data);
+        }, onError: _shellStdoutController.addError);
     _shellStderrSubscription = shell.stderr
         .cast<List<int>>()
         .transform(utf8.decoder)
         .listen((data) {
           terminal.write(data);
-          _shellStderrController!.add(data);
-        }, onError: _shellStderrController!.addError);
+          _shellStderrController.add(data);
+        }, onError: _shellStderrController.addError);
     _shellDoneSubscription = shell.done.asStream().listen(
-      (_) => _shellDoneController!.add(null),
-      onError: _shellDoneController!.addError,
+      (_) => _shellDoneController.add(null),
+      onError: _shellDoneController.addError,
     );
 
     // Wire terminal keyboard output → shell stdin (persistent).
@@ -777,6 +768,9 @@ class SshSession {
   Future<void> close() async {
     await stopAllForwards();
     await closeShell();
+    await _shellStdoutController.close();
+    await _shellStderrController.close();
+    await _shellDoneController.close();
     client.close();
     for (final dependentClient in dependentClients) {
       dependentClient.close();
@@ -884,11 +878,18 @@ final activeSessionsProvider =
 class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
   late final SshService _sshService;
   final Map<int, int> _connectionHostIds = {};
+  final Map<int, StreamSubscription<void>> _shellDoneSubscriptions = {};
 
   @override
   Map<int, SshConnectionState> build() {
     _sshService = ref.watch(sshServiceProvider);
     _connectionHostIds.clear();
+    ref.onDispose(() {
+      for (final subscription in _shellDoneSubscriptions.values) {
+        unawaited(subscription.cancel());
+      }
+      _shellDoneSubscriptions.clear();
+    });
     return {};
   }
 
@@ -914,6 +915,7 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
       final connectionId = result.connectionId!;
       _connectionHostIds[connectionId] = hostId;
       state = {...state, connectionId: SshConnectionState.connected};
+      _subscribeToShellDone(connectionId);
     }
 
     return result;
@@ -921,6 +923,7 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
 
   /// Disconnect from a connection.
   Future<void> disconnect(int connectionId) async {
+    await _shellDoneSubscriptions.remove(connectionId)?.cancel();
     await _sshService.disconnect(connectionId);
     _connectionHostIds.remove(connectionId);
     final next = {...state}..remove(connectionId);
@@ -929,9 +932,37 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
 
   /// Disconnect all active sessions.
   Future<void> disconnectAll() async {
+    for (final subscription in _shellDoneSubscriptions.values) {
+      await subscription.cancel();
+    }
+    _shellDoneSubscriptions.clear();
     await _sshService.disconnectAll();
     _connectionHostIds.clear();
     state = {};
+  }
+
+  void _subscribeToShellDone(int connectionId) {
+    if (_shellDoneSubscriptions.containsKey(connectionId)) {
+      return;
+    }
+
+    final session = _sshService.getSession(connectionId);
+    if (session == null) {
+      return;
+    }
+
+    _shellDoneSubscriptions[connectionId] = session.shellDoneStream.listen(
+      (_) => unawaited(_handleShellDone(connectionId)),
+      onError: (error, stackTrace) => unawaited(_handleShellDone(connectionId)),
+    );
+  }
+
+  Future<void> _handleShellDone(int connectionId) async {
+    if (!state.containsKey(connectionId)) {
+      return;
+    }
+
+    await disconnect(connectionId);
   }
 
   /// Get the state of a connection.

--- a/lib/presentation/screens/auth_setup_screen.dart
+++ b/lib/presentation/screens/auth_setup_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../domain/services/auth_service.dart';
 
@@ -63,13 +64,47 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
     setState(() => _isLoading = false);
 
     if (mounted) {
-      Navigator.of(context).pop(true);
+      _closeSetup(true);
     }
   }
 
-  void _skip() {
+  void _closeSetup(bool configured) {
+    final navigator = Navigator.of(context);
+    if (navigator.canPop()) {
+      navigator.pop(configured);
+      return;
+    }
+
+    context.go('/');
+  }
+
+  Future<void> _skip() async {
+    final shouldSkip = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Skip security setup?'),
+        content: const Text(
+          'Your saved hosts, keys, and snippets will stay accessible until you '
+          'set up a PIN. You can always enable app lock later from Settings.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Keep setup'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Skip for now'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted || shouldSkip != true) {
+      return;
+    }
+
     ref.read(authStateProvider.notifier).skip();
-    Navigator.of(context).pop(false);
+    _closeSetup(false);
   }
 
   @override
@@ -87,7 +122,9 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Security Setup'),
-        actions: [TextButton(onPressed: _skip, child: const Text('Skip'))],
+        actions: [
+          TextButton(onPressed: _skip, child: const Text('Skip for now')),
+        ],
       ),
       body: SafeArea(
         child: Padding(

--- a/lib/presentation/screens/hosts_screen.dart
+++ b/lib/presentation/screens/hosts_screen.dart
@@ -22,6 +22,7 @@ class HostsScreen extends ConsumerStatefulWidget {
 class _HostsScreenState extends ConsumerState<HostsScreen> {
   String _searchQuery = '';
   int? _selectedGroupId;
+  String? _selectedGroupName;
 
   @override
   Widget build(BuildContext context) {
@@ -33,14 +34,20 @@ class _HostsScreenState extends ConsumerState<HostsScreen> {
         title: const Text('Hosts'),
         actions: [
           IconButton(
-            icon: const Icon(Icons.search),
+            icon: Icon(
+              _searchQuery.isEmpty ? Icons.search : Icons.search_rounded,
+            ),
             onPressed: _showSearchDialog,
             tooltip: 'Search',
+            color: _searchQuery.isEmpty ? null : theme.colorScheme.primary,
           ),
           IconButton(
-            icon: const Icon(Icons.folder),
+            icon: Icon(
+              _selectedGroupId == null ? Icons.folder : Icons.folder_open,
+            ),
             onPressed: _showGroupsDialog,
             tooltip: 'Groups',
+            color: _selectedGroupId == null ? null : theme.colorScheme.primary,
           ),
         ],
       ),
@@ -77,9 +84,11 @@ class _HostsScreenState extends ConsumerState<HostsScreen> {
 
   Widget _buildHostList(List<Host> hosts) {
     var filteredHosts = hosts;
+    final hasSearch = _searchQuery.isNotEmpty;
+    final hasGroupFilter = _selectedGroupId != null;
 
     // Apply search filter
-    if (_searchQuery.isNotEmpty) {
+    if (hasSearch) {
       final query = _searchQuery.toLowerCase();
       filteredHosts = filteredHosts
           .where(
@@ -92,56 +101,115 @@ class _HostsScreenState extends ConsumerState<HostsScreen> {
     }
 
     // Apply group filter
-    if (_selectedGroupId != null) {
+    if (hasGroupFilter) {
       filteredHosts = filteredHosts
           .where((h) => h.groupId == _selectedGroupId)
           .toList();
     }
 
-    if (filteredHosts.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              _searchQuery.isNotEmpty ? Icons.search_off : Icons.dns_outlined,
-              size: 64,
-              color: Theme.of(context).colorScheme.outline,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              _searchQuery.isNotEmpty
-                  ? 'No hosts match your search'
-                  : 'No hosts yet',
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-            if (_searchQuery.isEmpty) ...[
-              const SizedBox(height: 8),
-              Text(
-                'Tap + to add your first host',
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-            ],
-          ],
-        ),
-      );
+    final content = filteredHosts.isEmpty
+        ? _buildEmptyState(hasSearch: hasSearch, hasGroupFilter: hasGroupFilter)
+        : ListView.builder(
+            padding: const EdgeInsets.only(bottom: 88),
+            itemCount: filteredHosts.length,
+            itemBuilder: (context, index) {
+              final host = filteredHosts[index];
+              return _HostListTile(
+                host: host,
+                onTap: () => _connectToHost(host),
+                onNewConnection: () => unawaited(_openNewConnection(host)),
+                onEdit: () => context.push('/hosts/edit/${host.id}'),
+                onDelete: () => _deleteHost(host),
+              );
+            },
+          );
+
+    if (!hasSearch && !hasGroupFilter) {
+      return content;
     }
 
-    return ListView.builder(
-      padding: const EdgeInsets.only(bottom: 88),
-      itemCount: filteredHosts.length,
-      itemBuilder: (context, index) {
-        final host = filteredHosts[index];
-        return _HostListTile(
-          host: host,
-          onTap: () => _connectToHost(host),
-          onNewConnection: () => unawaited(_openNewConnection(host)),
-          onEdit: () => context.push('/hosts/edit/${host.id}'),
-          onDelete: () => _deleteHost(host),
-        );
-      },
+    return Column(
+      children: [
+        _buildActiveFilters(),
+        Expanded(child: content),
+      ],
     );
   }
+
+  Widget _buildEmptyState({
+    required bool hasSearch,
+    required bool hasGroupFilter,
+  }) => Center(
+    child: Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(
+          hasSearch || hasGroupFilter
+              ? Icons.filter_alt_off
+              : Icons.dns_outlined,
+          size: 64,
+          color: Theme.of(context).colorScheme.outline,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          hasSearch && hasGroupFilter
+              ? 'No hosts match your search in ${_selectedGroupName ?? 'the selected group'}'
+              : hasSearch
+              ? 'No hosts match your search'
+              : hasGroupFilter
+              ? 'No hosts in ${_selectedGroupName ?? 'the selected group'}'
+              : 'No hosts yet',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          hasSearch || hasGroupFilter
+              ? 'Try clearing one or more filters.'
+              : 'Tap + to add your first host',
+          style: Theme.of(context).textTheme.bodyMedium,
+          textAlign: TextAlign.center,
+        ),
+      ],
+    ),
+  );
+
+  Widget _buildActiveFilters() => Container(
+    width: double.infinity,
+    padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+    child: Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        if (_searchQuery.isNotEmpty)
+          InputChip(
+            label: Text('Search: $_searchQuery'),
+            onDeleted: () => setState(() => _searchQuery = ''),
+          ),
+        if (_selectedGroupId != null)
+          InputChip(
+            label: Text('Group: ${_selectedGroupName ?? 'Selected'}'),
+            onDeleted: () {
+              setState(() {
+                _selectedGroupId = null;
+                _selectedGroupName = null;
+              });
+            },
+          ),
+        TextButton.icon(
+          onPressed: () {
+            setState(() {
+              _searchQuery = '';
+              _selectedGroupId = null;
+              _selectedGroupName = null;
+            });
+          },
+          icon: const Icon(Icons.clear_all),
+          label: const Text('Clear all'),
+        ),
+      ],
+    ),
+  );
 
   Future<void> _openNewConnection(Host host) async {
     final result = await ref
@@ -280,18 +348,21 @@ class _HostsScreenState extends ConsumerState<HostsScreen> {
   }
 
   void _showSearchDialog() {
+    final controller = TextEditingController(text: _searchQuery);
     showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Search Hosts'),
         content: TextField(
+          controller: controller,
           autofocus: true,
           decoration: const InputDecoration(
             hintText: 'Search by name, hostname, or username',
             prefixIcon: Icon(Icons.search),
           ),
-          onChanged: (value) {
-            setState(() => _searchQuery = value);
+          textInputAction: TextInputAction.search,
+          onSubmitted: (_) {
+            setState(() => _searchQuery = controller.text.trim());
             Navigator.pop(context);
           },
         ),
@@ -299,6 +370,7 @@ class _HostsScreenState extends ConsumerState<HostsScreen> {
           if (_searchQuery.isNotEmpty)
             TextButton(
               onPressed: () {
+                controller.clear();
                 setState(() => _searchQuery = '');
                 Navigator.pop(context);
               },
@@ -306,7 +378,14 @@ class _HostsScreenState extends ConsumerState<HostsScreen> {
             ),
           TextButton(
             onPressed: () => Navigator.pop(context),
-            child: const Text('Close'),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              setState(() => _searchQuery = controller.text.trim());
+              Navigator.pop(context);
+            },
+            child: const Text('Apply'),
           ),
         ],
       ),
@@ -314,86 +393,94 @@ class _HostsScreenState extends ConsumerState<HostsScreen> {
   }
 
   Future<void> _showGroupsDialog() async {
-    final selection = await showModalBottomSheet<({int? groupId})>(
-      context: context,
-      showDragHandle: true,
-      builder: (context) {
-        final theme = Theme.of(context);
-        final groupRepo = ref.read(groupRepositoryProvider);
+    final selection =
+        await showModalBottomSheet<({int? groupId, String? groupName})>(
+          context: context,
+          showDragHandle: true,
+          builder: (context) {
+            final theme = Theme.of(context);
+            final groupRepo = ref.read(groupRepositoryProvider);
 
-        return SafeArea(
-          child: StreamBuilder<List<Group>>(
-            stream: groupRepo.watchAll(),
-            builder: (context, snapshot) {
-              final groups = snapshot.data ?? const <Group>[];
-              return SizedBox(
-                height: 420,
-                child: Column(
-                  children: [
-                    ListTile(
-                      title: const Text('Groups'),
-                      subtitle: Text(
-                        _selectedGroupId == null
-                            ? 'Showing all hosts'
-                            : 'Filtered by selected group',
-                      ),
-                      trailing: IconButton(
-                        icon: const Icon(Icons.create_new_folder_outlined),
-                        tooltip: 'Create group',
-                        onPressed: () {
-                          Navigator.pop(context);
-                          unawaited(_showCreateGroupDialog());
-                        },
-                      ),
-                    ),
-                    Expanded(
-                      child: ListView(
-                        children: [
-                          ListTile(
-                            leading: const Icon(Icons.list),
-                            title: const Text('All hosts'),
-                            selected: _selectedGroupId == null,
-                            onTap: () =>
-                                Navigator.pop(context, (groupId: null)),
+            return SafeArea(
+              child: StreamBuilder<List<Group>>(
+                stream: groupRepo.watchAll(),
+                builder: (context, snapshot) {
+                  final groups = snapshot.data ?? const <Group>[];
+                  return SizedBox(
+                    height: 420,
+                    child: Column(
+                      children: [
+                        ListTile(
+                          title: const Text('Groups'),
+                          subtitle: Text(
+                            _selectedGroupId == null
+                                ? 'Showing all hosts'
+                                : 'Filtered by selected group',
                           ),
-                          for (final group in groups)
-                            ListTile(
-                              leading: const Icon(Icons.folder_outlined),
-                              title: Text(group.name),
-                              selected: _selectedGroupId == group.id,
-                              trailing: _selectedGroupId == group.id
-                                  ? Icon(
-                                      Icons.check,
-                                      color: theme.colorScheme.primary,
-                                    )
-                                  : null,
-                              onTap: () =>
-                                  Navigator.pop(context, (groupId: group.id)),
-                            ),
-                          if (groups.isEmpty)
-                            const Padding(
-                              padding: EdgeInsets.fromLTRB(16, 0, 16, 16),
-                              child: Text(
-                                'No groups yet. Create one to organize hosts.',
+                          trailing: IconButton(
+                            icon: const Icon(Icons.create_new_folder_outlined),
+                            tooltip: 'Create group',
+                            onPressed: () {
+                              Navigator.pop(context);
+                              unawaited(_showCreateGroupDialog());
+                            },
+                          ),
+                        ),
+                        Expanded(
+                          child: ListView(
+                            children: [
+                              ListTile(
+                                leading: const Icon(Icons.list),
+                                title: const Text('All hosts'),
+                                selected: _selectedGroupId == null,
+                                onTap: () => Navigator.pop(context, (
+                                  groupId: null,
+                                  groupName: null,
+                                )),
                               ),
-                            ),
-                        ],
-                      ),
+                              for (final group in groups)
+                                ListTile(
+                                  leading: const Icon(Icons.folder_outlined),
+                                  title: Text(group.name),
+                                  selected: _selectedGroupId == group.id,
+                                  trailing: _selectedGroupId == group.id
+                                      ? Icon(
+                                          Icons.check,
+                                          color: theme.colorScheme.primary,
+                                        )
+                                      : null,
+                                  onTap: () => Navigator.pop(context, (
+                                    groupId: group.id,
+                                    groupName: group.name,
+                                  )),
+                                ),
+                              if (groups.isEmpty)
+                                const Padding(
+                                  padding: EdgeInsets.fromLTRB(16, 0, 16, 16),
+                                  child: Text(
+                                    'No groups yet. Create one to organize hosts.',
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
-              );
-            },
-          ),
+                  );
+                },
+              ),
+            );
+          },
         );
-      },
-    );
 
     if (!mounted || selection == null) {
       return;
     }
 
-    setState(() => _selectedGroupId = selection.groupId);
+    setState(() {
+      _selectedGroupId = selection.groupId;
+      _selectedGroupName = selection.groupName;
+    });
   }
 
   Future<void> _showCreateGroupDialog() async {

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 import '../../domain/models/terminal_themes.dart';
@@ -132,15 +133,18 @@ class _SecuritySection extends ConsumerWidget {
       children: [
         const _SectionHeader(title: 'Security'),
         ListTile(
-          leading: const Icon(Icons.pin_outlined),
-          title: const Text('Change PIN'),
-          subtitle: Text(
-            isAuthEnabled ? 'Update your PIN code' : 'PIN not set',
+          leading: Icon(
+            isAuthEnabled ? Icons.pin_outlined : Icons.lock_outline,
           ),
-          enabled: isAuthEnabled,
+          title: Text(isAuthEnabled ? 'Change PIN' : 'Set up app lock'),
+          subtitle: Text(
+            isAuthEnabled
+                ? 'Update your PIN code'
+                : 'Protect saved hosts, keys, and snippets with a PIN',
+          ),
           onTap: isAuthEnabled
               ? () => _showChangePinDialog(context, ref)
-              : null,
+              : () => context.push('/auth-setup'),
         ),
         FutureBuilder<bool>(
           future: ref.read(authServiceProvider).isBiometricAvailable(),
@@ -154,7 +158,9 @@ class _SecuritySection extends ConsumerWidget {
                   secondary: const Icon(Icons.fingerprint),
                   title: const Text('Biometric authentication'),
                   subtitle: Text(
-                    isAvailable
+                    !isAuthEnabled
+                        ? 'Set up a PIN before enabling biometrics'
+                        : isAvailable
                         ? 'Use fingerprint or face to unlock'
                         : 'Not available on this device',
                   ),
@@ -171,7 +177,9 @@ class _SecuritySection extends ConsumerWidget {
           leading: const Icon(Icons.timer_outlined),
           title: const Text('Auto-lock timeout'),
           subtitle: Text(
-            autoLockTimeout == 0
+            !isAuthEnabled
+                ? 'Set up a PIN to use auto-lock'
+                : autoLockTimeout == 0
                 ? 'Disabled'
                 : '$autoLockTimeout minute${autoLockTimeout == 1 ? '' : 's'}',
           ),

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -845,12 +845,25 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     child: Padding(
       padding: _terminalViewportPadding,
       child: SingleChildScrollView(
+        key: const ValueKey('terminal-native-selection-scroll-view'),
         controller: _nativeSelectionScrollController,
         physics: const ClampingScrollPhysics(),
         child: ValueListenableBuilder<TextEditingValue>(
           valueListenable: _nativeSelectionController,
-          builder: (context, value, _) => SelectableText(
-            value.text,
+          builder: (context, value, _) => TextField(
+            key: const ValueKey('terminal-native-selection-field'),
+            controller: _nativeSelectionController,
+            readOnly: true,
+            showCursor: false,
+            enableInteractiveSelection: true,
+            maxLines: null,
+            scrollPhysics: const NeverScrollableScrollPhysics(),
+            keyboardType: TextInputType.multiline,
+            decoration: const InputDecoration(
+              border: InputBorder.none,
+              isCollapsed: true,
+              contentPadding: EdgeInsets.zero,
+            ),
             style: textStyle,
             strutStyle: StrutStyle.fromTextStyle(
               textStyle,

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:xterm/xterm.dart' hide TerminalThemes;
 
@@ -430,6 +431,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
+  void _leaveConnectionError() {
+    final navigator = Navigator.of(context);
+    if (navigator.canPop()) {
+      navigator.pop();
+      return;
+    }
+
+    context.go('/');
+  }
+
   void _handleShellClosed() {
     final connectionId = _connectionId;
     if (!mounted) {
@@ -720,6 +731,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
               ElevatedButton(
                 onPressed: () => _connect(preferredConnectionId: _connectionId),
                 child: const Text('Retry'),
+              ),
+              const SizedBox(height: 12),
+              OutlinedButton(
+                onPressed: _leaveConnectionError,
+                child: const Text('Back to Hosts'),
               ),
             ],
           ),

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -432,9 +432,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   void _leaveConnectionError() {
-    final navigator = Navigator.of(context);
-    if (navigator.canPop()) {
-      navigator.pop();
+    if (GoRouter.of(context).canPop()) {
+      context.pop();
       return;
     }
 
@@ -529,6 +528,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS;
     final systemKeyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
+    final appBarTitleMaxWidth =
+        MediaQuery.sizeOf(context).width - (isMobile ? 144 : 220);
 
     // Use session override, or loaded theme, or fallback
     final terminalTheme =
@@ -538,13 +539,24 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(_host?.label ?? 'Terminal'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.palette_outlined),
-            onPressed: _showThemePicker,
-            tooltip: 'Change theme',
+        centerTitle: false,
+        title: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: appBarTitleMaxWidth > 0 ? appBarTitleMaxWidth : 120,
           ),
+          child: Text(
+            _host?.label ?? 'Terminal',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        actions: [
+          if (!isMobile)
+            IconButton(
+              icon: const Icon(Icons.palette_outlined),
+              onPressed: _showThemePicker,
+              tooltip: 'Change theme',
+            ),
           if (isMobile)
             IconButton(
               icon: Icon(
@@ -557,16 +569,28 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                   ? 'Hide system keyboard'
                   : 'Show system keyboard',
             ),
-          IconButton(
-            icon: Icon(
-              _showKeyboard ? Icons.space_bar : Icons.keyboard_outlined,
+          if (!isMobile)
+            IconButton(
+              icon: Icon(
+                _showKeyboard ? Icons.space_bar : Icons.keyboard_outlined,
+              ),
+              onPressed: () => setState(() => _showKeyboard = !_showKeyboard),
+              tooltip: _showKeyboard ? 'Hide toolbar' : 'Show toolbar',
             ),
-            onPressed: () => setState(() => _showKeyboard = !_showKeyboard),
-            tooltip: _showKeyboard ? 'Hide toolbar' : 'Show toolbar',
-          ),
           PopupMenuButton<String>(
             onSelected: _handleMenuAction,
             itemBuilder: (context) => [
+              if (isMobile)
+                const PopupMenuItem(
+                  value: 'theme',
+                  child: Text('Change Theme'),
+                ),
+              if (isMobile)
+                PopupMenuItem(
+                  value: 'toggle_toolbar',
+                  child: Text(_showKeyboard ? 'Hide Toolbar' : 'Show Toolbar'),
+                ),
+              if (isMobile) const PopupMenuDivider(),
               const PopupMenuItem(value: 'snippets', child: Text('Snippets')),
               const PopupMenuDivider(),
               if (!isMobile)
@@ -882,6 +906,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     switch (action) {
       case 'snippets':
         await _showSnippetPicker();
+        break;
+      case 'theme':
+        await _showThemePicker();
+        break;
+      case 'toggle_toolbar':
+        setState(() => _showKeyboard = !_showKeyboard);
         break;
       case 'native_select':
         _toggleNativeSelectionMode();

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -8,6 +8,9 @@ PODS:
   - local_auth_darwin (0.0.1):
     - Flutter
     - FlutterMacOS
+  - mobile_scanner (7.0.0):
+    - Flutter
+    - FlutterMacOS
   - share_plus (0.0.1):
     - FlutterMacOS
   - sqlite3 (3.51.1):
@@ -41,6 +44,7 @@ DEPENDENCIES:
   - flutter_secure_storage_darwin (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - local_auth_darwin (from `Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin`)
+  - mobile_scanner (from `Flutter/ephemeral/.symlinks/plugins/mobile_scanner/darwin`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - sqlite3_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin`)
 
@@ -57,6 +61,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral
   local_auth_darwin:
     :path: Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin
+  mobile_scanner:
+    :path: Flutter/ephemeral/.symlinks/plugins/mobile_scanner/darwin
   share_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   sqlite3_flutter_libs:
@@ -67,6 +73,7 @@ SPEC CHECKSUMS:
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
+  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
   sqlite3: 8d708bc63e9f4ce48f0ad9d6269e478c5ced1d9b
   sqlite3_flutter_libs: d13b8b3003f18f596e542bcb9482d105577eff41

--- a/test/app/theme_test.dart
+++ b/test/app/theme_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:monkeyssh/app/theme.dart';
+
+void main() {
+  group('FluttyTheme', () {
+    test('allows helper text to wrap in light theme', () {
+      expect(
+        FluttyTheme.buildInputDecorationTheme(Brightness.light).helperMaxLines,
+        3,
+      );
+    });
+
+    test('allows helper text to wrap in dark theme', () {
+      expect(
+        FluttyTheme.buildInputDecorationTheme(Brightness.dark).helperMaxLines,
+        3,
+      );
+    });
+  });
+}

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 // ignore_for_file: public_member_api_docs
 
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:monkeyssh/data/database/database.dart';
@@ -47,6 +50,79 @@ class _CountingKeyRepository extends KeyRepository {
       return null;
     }
     return super.getById(id);
+  }
+}
+
+class _FakeSshSession implements SshSession {
+  _FakeSshSession({required this.connectionId, required this.hostId});
+
+  @override
+  final int connectionId;
+
+  @override
+  final int hostId;
+
+  @override
+  final DateTime createdAt = DateTime(2026);
+
+  @override
+  final SshConnectionConfig config = const SshConnectionConfig(
+    hostname: 'example.com',
+    port: 22,
+    username: 'depoll',
+  );
+
+  final _shellDoneController = StreamController<void>.broadcast();
+
+  void emitShellDone() {
+    _shellDoneController.add(null);
+  }
+
+  Future<void> disposeFake() => _shellDoneController.close();
+
+  @override
+  Stream<void> get shellDoneStream => _shellDoneController.stream;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TrackingSshService extends SshService {
+  _TrackingSshService(this.session);
+
+  final _FakeSshSession session;
+  int disconnectCallCount = 0;
+  bool _isConnected = false;
+
+  @override
+  Map<int, SshSession> get sessions =>
+      _isConnected ? {session.connectionId: session} : const {};
+
+  @override
+  Future<SshConnectionResult> connectToHost(int hostId) async {
+    _isConnected = true;
+    return SshConnectionResult(
+      success: true,
+      connectionId: session.connectionId,
+    );
+  }
+
+  @override
+  SshSession? getSession(int connectionId) {
+    if (_isConnected && connectionId == session.connectionId) {
+      return session;
+    }
+    return null;
+  }
+
+  @override
+  Future<void> disconnect(int connectionId) async {
+    if (!_isConnected || connectionId != session.connectionId) {
+      return;
+    }
+    disconnectCallCount++;
+    _isConnected = false;
+    await session.disposeFake();
   }
 }
 
@@ -700,5 +776,35 @@ void main() {
         throwsA(isA<Error>()),
       );
     });
+  });
+
+  group('ActiveSessionsNotifier', () {
+    test(
+      'removes closed shell sessions even without a mounted terminal',
+      () async {
+        final session = _FakeSshSession(connectionId: 7, hostId: 42);
+        final service = _TrackingSshService(session);
+        final container = ProviderContainer(
+          overrides: [sshServiceProvider.overrideWith((ref) => service)],
+        );
+        addTearDown(container.dispose);
+
+        final notifier = container.read(activeSessionsProvider.notifier);
+        final result = await notifier.connect(42, forceNew: true);
+
+        expect(result.success, isTrue);
+        expect(result.connectionId, 7);
+        expect(container.read(activeSessionsProvider), {
+          7: SshConnectionState.connected,
+        });
+
+        session.emitShellDone();
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(container.read(activeSessionsProvider), isEmpty);
+        expect(service.disconnectCallCount, 1);
+      },
+    );
   });
 }

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -197,7 +197,7 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      expect(find.text('Change PIN'), findsOneWidget);
+      expect(find.text('Set up app lock'), findsOneWidget);
       expect(find.text('Biometric authentication'), findsOneWidget);
       expect(find.text('Auto-lock timeout'), findsOneWidget);
     });


### PR DESCRIPTION
## Summary

- keep the security and hosts UX fixes from the earlier QA pass, including reachable app-lock setup, safer auth-setup skip behavior, explicit host search apply/cancel flow, and the terminal error recovery action
- harden the terminal error-recovery path by popping back through GoRouter correctly instead of the raw Navigator stack
- tighten the terminal app bar on mobile so long host names do not push actions off-screen, and move mobile theme / toolbar actions into the overflow menu to keep the session menu reachable on iOS
- expand real-device integration coverage for clipboard-heavy flows and scrolling: key copy, snippet scroll + copy, terminal error recovery, and seeded SSH connectivity across Android and iOS

## Validation

- `flutter analyze lib test integration_test`
- `flutter test`
- `flutter test integration_test/app_test.dart -d emulator-5554 --flavor production --dart-define=TEST_SSH_ENABLED=true ...`
- `flutter test integration_test/app_test.dart -d 96C81AA7-D8AB-4F45-AE1B-F2FAF825567A --flavor production --dart-define=TEST_SSH_ENABLED=true ...`

## Platform QA notes

- Android emulator QA passed against a disposable local `sshd`, including key clipboard copy, snippet scrolling/copy, terminal error recovery, and seeded SSH session launch
- iOS simulator QA passed for the same integration surfaces after fixing the narrow-screen terminal app bar behavior
- macOS build launch still works, but foregrounding and desktop interaction remain blocked by the display-less environment, so exhaustive macOS interaction could not be completed here
- disposable SSH validation used a temporary local `sshd` because Docker daemon access was unavailable
