### PR TITLE
fix: start live activity before backgrounding

### DIFF
--- a/ios/Runner/ConnectionStatusLiveActivityManager.swift
+++ b/ios/Runner/ConnectionStatusLiveActivityManager.swift
@@ -46,8 +46,12 @@ final class ConnectionStatusLiveActivityManager {
       return
     }
 
+    let canStartNewActivity = isForeground
     Task {
-      await upsertActivity(for: latestStatus)
+      await upsertActivity(
+        for: latestStatus,
+        canStartNewActivity: canStartNewActivity
+      )
     }
   }
 
@@ -64,7 +68,10 @@ final class ConnectionStatusLiveActivityManager {
   }
 
   @available(iOS 16.1, *)
-  private func upsertActivity(for status: StatusPayload) async {
+  private func upsertActivity(
+    for status: StatusPayload,
+    canStartNewActivity: Bool
+  ) async {
     guard ActivityAuthorizationInfo().areActivitiesEnabled else {
       NSLog("Skipping SSH live activity because Live Activities are disabled.")
       return
@@ -80,7 +87,7 @@ final class ConnectionStatusLiveActivityManager {
       return
     }
 
-    guard isForeground else {
+    guard canStartNewActivity else {
       NSLog(
         "Skipping SSH live activity request because the app is not foregrounded."
       )


### PR DESCRIPTION
## Summary

- request the SSH Live Activity as soon as active connections exist instead of waiting for the app to background
- keep the existing background teardown behavior, but skip brand-new ActivityKit requests once the app is already backgrounded
- capture foreground state before the async native upsert task and log when Live Activities are disabled or a background-only start is skipped
- register the iOS SSH background method channel through Flutter's plugin registrar instead of the launch-time root view controller, and keep a strong native channel reference so status updates reliably reach iOS

## Validation

- flutter analyze lib test integration_test
- flutter test
- flutter build ios --simulator --debug --flavor production
- flutter build ios --simulator --debug --flavor private
