### PR TITLE
fix: unblock dependabot preview CI

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -88,12 +88,14 @@ jobs:
         run: flutter pub get
 
       - name: Decode keystore
+        if: inputs.deploy-android-to != 'none'
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
           echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > android/app/upload-keystore.jks
 
       - name: Create key.properties
+        if: inputs.deploy-android-to != 'none'
         env:
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}


### PR DESCRIPTION
## Summary

- skip Android keystore decoding and key.properties generation when the reusable workflow is running a non-deploy preview build
- preserve existing deploy behavior for Play Store releases, where the signing material is still required
- unblock the shared PR Preview failure affecting the currently open Dependabot PRs (#70-#79)

## Root cause

Preview builds call the reusable Android workflow with `deploy-android-to: none`, but the workflow still tried to decode the release keystore and package the APK with it. On the Dependabot PRs, that signing setup fails before the preview APK can be produced.

## Validation

- `flutter analyze lib test integration_test`
- `flutter test`
- `flutter build apk --release --flavor private --target lib/main.dart`
