### PR TITLE
fix: register iOS live activity channel reliably

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -4,6 +4,7 @@ import UIKit
 @main
 @objc class AppDelegate: FlutterAppDelegate {
   private let channelName = "xyz.depollsoft.monkeyssh/ssh_service"
+  private var backgroundSshChannel: FlutterMethodChannel?
 
   /// Background task identifier used to keep SSH connections alive
   /// for a short period after the app enters the background.
@@ -14,68 +15,83 @@ import UIKit
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
-    if let controller = window?.rootViewController as? FlutterViewController {
-      let channel = FlutterMethodChannel(
-        name: channelName,
-        binaryMessenger: controller.binaryMessenger
-      )
-      channel.setMethodCallHandler { call, result in
-        switch call.method {
-        case "updateStatus":
-          guard
-            let arguments = call.arguments as? [String: Any],
-            let connectionCount = arguments["connectionCount"] as? Int,
-            let connectedCount = arguments["connectedCount"] as? Int
-          else {
-            result(
-              FlutterError(
-                code: "invalid_args",
-                message: "Missing live activity status arguments",
-                details: nil
-              )
-            )
-            return
-          }
-
-          if #available(iOS 16.1, *) {
-            ConnectionStatusLiveActivityManager.shared.updateStatus(
-              connectionCount: connectionCount,
-              connectedCount: connectedCount
-            )
-          }
-          result(nil)
-        case "setForegroundState":
-          guard
-            let arguments = call.arguments as? [String: Any],
-            let isForeground = arguments["isForeground"] as? Bool
-          else {
-            result(
-              FlutterError(
-                code: "invalid_args",
-                message: "Missing foreground state argument",
-                details: nil
-              )
-            )
-            return
-          }
-
-          if #available(iOS 16.1, *) {
-            ConnectionStatusLiveActivityManager.shared.setForegroundState(
-              isForeground: isForeground
-            )
-          }
-          result(nil)
-        case "stopService":
-          if #available(iOS 16.1, *) {
-            ConnectionStatusLiveActivityManager.shared.stop()
-          }
-          result(nil)
-        default:
-          result(FlutterMethodNotImplemented)
-        }
-      }
+    guard let registrar = self.registrar(forPlugin: "BackgroundSshServiceBridge") else {
+      NSLog("Failed to configure SSH background method channel registrar.")
+      return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
+    backgroundSshChannel = FlutterMethodChannel(
+      name: channelName,
+      binaryMessenger: registrar.messenger()
+    )
+    backgroundSshChannel?.setMethodCallHandler(handleBackgroundSshMethodCall)
+    NSLog("Configured SSH background method channel.")
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  private func handleBackgroundSshMethodCall(
+    _ call: FlutterMethodCall,
+    result: @escaping FlutterResult
+  ) {
+    switch call.method {
+    case "updateStatus":
+      guard
+        let arguments = call.arguments as? [String: Any],
+        let connectionCount = arguments["connectionCount"] as? Int,
+        let connectedCount = arguments["connectedCount"] as? Int
+      else {
+        result(
+          FlutterError(
+            code: "invalid_args",
+            message: "Missing live activity status arguments",
+            details: nil
+          )
+        )
+        return
+      }
+
+      NSLog(
+        "Received SSH background status update: %d total, %d connected.",
+        connectionCount,
+        connectedCount
+      )
+      if #available(iOS 16.1, *) {
+        ConnectionStatusLiveActivityManager.shared.updateStatus(
+          connectionCount: connectionCount,
+          connectedCount: connectedCount
+        )
+      }
+      result(nil)
+    case "setForegroundState":
+      guard
+        let arguments = call.arguments as? [String: Any],
+        let isForeground = arguments["isForeground"] as? Bool
+      else {
+        result(
+          FlutterError(
+            code: "invalid_args",
+            message: "Missing foreground state argument",
+            details: nil
+          )
+        )
+        return
+      }
+
+      NSLog("Received SSH app foreground state update: %@.", isForeground.description)
+      if #available(iOS 16.1, *) {
+        ConnectionStatusLiveActivityManager.shared.setForegroundState(
+          isForeground: isForeground
+        )
+      }
+      result(nil)
+    case "stopService":
+      NSLog("Received SSH background stop request.")
+      if #available(iOS 16.1, *) {
+        ConnectionStatusLiveActivityManager.shared.stop()
+      }
+      result(nil)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
   }
 
   override func applicationDidEnterBackground(_ application: UIApplication) {


### PR DESCRIPTION
## Summary

- register the iOS SSH background method channel through Flutter's plugin registrar instead of the launch-time root view controller
- keep a strong native channel reference and add native logs so Live Activity status updates reliably reach iOS and are easier to diagnose on device

## Validation

- flutter analyze lib test integration_test
- flutter test
- flutter build ios --simulator --debug --flavor production
- flutter build ios --simulator --debug --flavor private
