### PR TITLE
fix: clarify ios background ssh status

### DIFF
--- a/ios/ConnectionStatusLiveActivityExtension/ConnectionStatusLiveActivityWidget.swift
+++ b/ios/ConnectionStatusLiveActivityExtension/ConnectionStatusLiveActivityWidget.swift
@@ -20,7 +20,7 @@ struct ConnectionStatusLiveActivityWidget: Widget {
             .multilineTextAlignment(.trailing)
         }
 
-        Text("Keeping SSH connections alive in the background")
+        Text("Showing the last known SSH status")
           .font(.caption)
           .foregroundStyle(.secondary)
       }
@@ -48,7 +48,7 @@ struct ConnectionStatusLiveActivityWidget: Widget {
             .lineLimit(2)
         }
         DynamicIslandExpandedRegion(.bottom) {
-          Text("Keeping SSH connections alive in the background")
+          Text("Showing the last known SSH status")
             .font(.caption)
             .foregroundStyle(.secondary)
             .lineLimit(2)

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -6,8 +6,8 @@ import UIKit
   private let channelName = "xyz.depollsoft.monkeyssh/ssh_service"
   private var backgroundSshChannel: FlutterMethodChannel?
 
-  /// Background task identifier used to keep SSH connections alive
-  /// for a short period after the app enters the background.
+  /// Background task identifier used to request a brief grace period
+  /// before iOS suspends the app after entering the background.
   private var backgroundTaskId: UIBackgroundTaskIdentifier = .invalid
 
   override func application(
@@ -101,9 +101,10 @@ import UIKit
       )
     }
 
-    // Request extra background execution time so the Dart isolate can
-    // continue processing SSH keepalive packets and responses.
-    // iOS grants roughly 30 seconds before suspending the app.
+    // Request a brief amount of extra execution time so the Dart isolate can
+    // flush any in-flight SSH keepalive traffic before iOS suspends the app.
+    // The Live Activity remains a status surface only; it does not extend
+    // background execution beyond this short grace period.
     backgroundTaskId = application.beginBackgroundTask(withName: "SSHKeepAlive") {
       // Expiration handler — clean up when time runs out.
       application.endBackgroundTask(self.backgroundTaskId)

--- a/lib/domain/services/background_ssh_service.dart
+++ b/lib/domain/services/background_ssh_service.dart
@@ -3,11 +3,13 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
-/// Platform service that keeps SSH connections alive while the app is
-/// in the background.
+/// Platform service that publishes SSH session status to native background UI.
 ///
-/// On Android this controls the persistent keepalive notification.
+/// On Android this controls the foreground-service notification.
 /// On iOS this controls the Live Activity shown while the app is backgrounded.
+///
+/// This surface reports status only; iOS may still suspend the app shortly
+/// after it enters the background.
 class BackgroundSshService {
   BackgroundSshService._();
 
@@ -22,7 +24,7 @@ class BackgroundSshService {
   @visibleForTesting
   static bool? debugIsSupportedPlatformOverride;
 
-  /// Publish the latest active connection status to native keepalive surfaces.
+  /// Publish the latest active connection status to native background UI.
   static Future<void> updateStatus({
     required int connectionCount,
     required int connectedCount,
@@ -47,7 +49,7 @@ class BackgroundSshService {
     }
   }
 
-  /// Tell native keepalive surfaces whether the app is currently foregrounded.
+  /// Tell native background UI whether the app is currently foregrounded.
   static Future<void> setForegroundState({required bool isForeground}) async {
     if (!_supportsPlatform) {
       return;


### PR DESCRIPTION
## Summary

- clarify that the iOS Live Activity shows background SSH status rather than promising indefinite keepalive
- update the Live Activity copy to describe it as last-known status
- tighten iOS/Dart comments around the short `beginBackgroundTask` grace period before suspension

## Validation

- flutter analyze
- flutter build ios --simulator --debug --flavor production
- flutter build ios --simulator --debug --flavor private
