### PR TITLE
fix: improve Android terminal pinch zoom

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -97,7 +97,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   double? _lastPinchScale;
   double? _sessionFontSizeOverride;
   bool _isPinchZooming = false;
-  int _activeTouchPointers = 0;
 
   // Theme state
   Host? _host;
@@ -773,35 +772,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         .updateSessionFontSize(connectionId, nextFontSize);
   }
 
-  void _handleTerminalPointerDown(PointerDownEvent _) {
-    final nextPointerCount = _activeTouchPointers + 1;
-    final crossesThreshold =
-        (_activeTouchPointers >= 2) != (nextPointerCount >= 2);
-    if (crossesThreshold) {
-      setState(() {
-        _activeTouchPointers = nextPointerCount;
-      });
-      return;
-    }
-    _activeTouchPointers = nextPointerCount;
-  }
-
-  void _handleTerminalPointerUp(PointerEvent _) {
-    if (_activeTouchPointers == 0) {
-      return;
-    }
-    final nextPointerCount = _activeTouchPointers - 1;
-    final crossesThreshold =
-        (_activeTouchPointers >= 2) != (nextPointerCount >= 2);
-    if (crossesThreshold) {
-      setState(() {
-        _activeTouchPointers = nextPointerCount;
-      });
-      return;
-    }
-    _activeTouchPointers = nextPointerCount;
-  }
-
   Future<void> _showThemePicker() async {
     final currentId = _sessionThemeOverride?.id ?? _currentTheme?.id;
     final theme = await showThemePickerDialog(
@@ -926,7 +896,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       sessionFontSize: _sessionFontSizeOverride,
       pinchFontSize: _pinchFontSize,
     );
-    final isCapturingMultiTouch = _activeTouchPointers > 1;
 
     // Get font family from host (if set) or global settings
     final hostFont = _host?.terminalFontFamily;
@@ -1023,26 +992,20 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       );
     }
 
-    return Listener(
-      behavior: HitTestBehavior.opaque,
-      onPointerDown: _handleTerminalPointerDown,
-      onPointerUp: _handleTerminalPointerUp,
-      onPointerCancel: _handleTerminalPointerUp,
-      child: TerminalTextInputHandler(
-        terminal: _terminal,
-        focusNode: _terminalFocusNode,
-        deleteDetection: true,
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          dragStartBehavior: DragStartBehavior.down,
-          onScaleStart: (_) => _handleTerminalScaleStart(storedFontSize),
-          onScaleUpdate: (details) =>
-              _handleTerminalScaleUpdate(details, storedFontSize),
-          onScaleEnd: (_) => _handleTerminalScaleEnd(),
-          child: IgnorePointer(
-            ignoring: isCapturingMultiTouch,
-            child: mobileTerminalView,
-          ),
+    return TerminalTextInputHandler(
+      terminal: _terminal,
+      focusNode: _terminalFocusNode,
+      deleteDetection: true,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        dragStartBehavior: DragStartBehavior.down,
+        onScaleStart: (_) => _handleTerminalScaleStart(storedFontSize),
+        onScaleUpdate: (details) =>
+            _handleTerminalScaleUpdate(details, storedFontSize),
+        onScaleEnd: (_) => _handleTerminalScaleEnd(),
+        child: AbsorbPointer(
+          absorbing: _isPinchZooming,
+          child: mobileTerminalView,
         ),
       ),
     );

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show PointerDeviceKind;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -6,6 +8,23 @@ import 'package:flutter/widgets.dart';
 // ignore: implementation_imports
 import 'package:xterm/src/ui/input_map.dart';
 import 'package:xterm/xterm.dart';
+
+/// Whether a pointer-down event should request the terminal soft keyboard.
+///
+/// Touch input only opens the keyboard for the first active finger so pinch
+/// gestures do not re-open or disturb the IME on Android and iOS.
+@visibleForTesting
+bool shouldRequestKeyboardForTerminalPointerDown({
+  required PointerDeviceKind pointerKind,
+  required int activeTouchPointers,
+  required bool readOnly,
+}) {
+  if (readOnly) {
+    return false;
+  }
+
+  return pointerKind != PointerDeviceKind.touch || activeTouchPointers <= 1;
+}
 
 /// Wraps a [TerminalView] to provide soft keyboard input on mobile with
 /// proper IME configuration for swipe typing.
@@ -55,6 +74,7 @@ class TerminalTextInputHandler extends StatefulWidget {
 class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     with TextInputClient {
   TextInputConnection? _connection;
+  final Set<int> _activeTouchPointers = <int>{};
   String _lastSentText = '';
   int _pendingEnterActionSuppressions = 0;
 
@@ -81,6 +101,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   @override
   void dispose() {
     widget.focusNode.removeListener(_onFocusChange);
+    _activeTouchPointers.clear();
     _closeInputConnectionIfNeeded();
     super.dispose();
   }
@@ -88,11 +109,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   @override
   Widget build(BuildContext context) => Listener(
     behavior: HitTestBehavior.translucent,
-    onPointerDown: (_) {
-      if (!widget.readOnly) {
-        requestKeyboard();
-      }
-    },
+    onPointerDown: _handlePointerDown,
+    onPointerUp: _handlePointerFinished,
+    onPointerCancel: _handlePointerFinished,
     child: Focus(
       focusNode: widget.focusNode,
       autofocus: true,
@@ -100,6 +119,26 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       child: widget.child,
     ),
   );
+
+  void _handlePointerDown(PointerDownEvent event) {
+    if (event.kind == PointerDeviceKind.touch) {
+      _activeTouchPointers.add(event.pointer);
+    }
+
+    if (shouldRequestKeyboardForTerminalPointerDown(
+      pointerKind: event.kind,
+      activeTouchPointers: _activeTouchPointers.length,
+      readOnly: widget.readOnly,
+    )) {
+      requestKeyboard();
+    }
+  }
+
+  void _handlePointerFinished(PointerEvent event) {
+    if (event.kind == PointerDeviceKind.touch) {
+      _activeTouchPointers.remove(event.pointer);
+    }
+  }
 
   // -- Hardware key event handling --
 

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
@@ -49,6 +52,52 @@ void main() {
       expect(terminalOutput.join(), 'hello world ');
 
       focusNode.dispose();
+    });
+  });
+
+  group('shouldRequestKeyboardForTerminalPointerDown', () {
+    test('requests the keyboard for the first touch pointer', () {
+      expect(
+        shouldRequestKeyboardForTerminalPointerDown(
+          pointerKind: PointerDeviceKind.touch,
+          activeTouchPointers: 1,
+          readOnly: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('suppresses the keyboard for additional touch pointers', () {
+      expect(
+        shouldRequestKeyboardForTerminalPointerDown(
+          pointerKind: PointerDeviceKind.touch,
+          activeTouchPointers: 2,
+          readOnly: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('still requests the keyboard for non-touch pointers', () {
+      expect(
+        shouldRequestKeyboardForTerminalPointerDown(
+          pointerKind: PointerDeviceKind.mouse,
+          activeTouchPointers: 0,
+          readOnly: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('never requests the keyboard when input is read only', () {
+      expect(
+        shouldRequestKeyboardForTerminalPointerDown(
+          pointerKind: PointerDeviceKind.touch,
+          activeTouchPointers: 1,
+          readOnly: true,
+        ),
+        isFalse,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

- remove the race-prone manual multi-touch gating around the mobile terminal pinch gesture
- only request the soft keyboard for the first active touch so a second finger does not interfere with pinch recognition
- add coverage for the keyboard-request helper while preserving the existing swipe-typing widget test

## Testing

- `flutter analyze`
- `flutter test test/widget/terminal_screen_zoom_test.dart test/widget/terminal_text_input_handler_test.dart`
- `flutter test`
