### PR TITLE
fix: show live activity icon in dynamic island

### DIFF
--- a/ios/ConnectionStatusLiveActivityExtension/ConnectionStatusLiveActivityWidget.swift
+++ b/ios/ConnectionStatusLiveActivityExtension/ConnectionStatusLiveActivityWidget.swift
@@ -102,7 +102,6 @@ struct ConnectionStatusLiveActivityWidget: Widget {
           .renderingMode(.original)
           .scaledToFit()
           .frame(width: size, height: size)
-          .foregroundStyle(.primary)
       case .dynamicIsland:
         Image("MonkeySSHDynamicIslandIcon")
           .resizable()


### PR DESCRIPTION
## Summary

- render the Live Activity logo as a template image in Dynamic Island regions so it stays visible against the system background
- keep the full-color logo for the lock screen Live Activity layout
- preserve accessibility labeling for the minimal Dynamic Island icon

## Validation

- `flutter analyze`
- `flutter test`
- `flutter build ios --simulator --debug --no-codesign`
