### PR TITLE
fix: stop synthetic alt-buffer scroll fallback

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -57,6 +57,24 @@ double resolveTerminalFontSize({
   double? pinchFontSize,
 }) => pinchFontSize ?? sessionFontSize ?? globalFontSize;
 
+/// Whether to let xterm synthesize Up/Down keys for alt-buffer scroll.
+///
+/// We prefer explicit mouse-wheel reporting from terminal applications like
+/// tmux. That keeps wheel scrolling working when the remote app opts in, while
+/// avoiding surprise history navigation when it does not.
+@visibleForTesting
+bool shouldUseSyntheticAltBufferScrollFallback({
+  required bool isMobile,
+  required bool isUsingAltBuffer,
+  required bool preferExplicitMouseReporting,
+}) {
+  if (isMobile || !isUsingAltBuffer) {
+    return false;
+  }
+
+  return !preferExplicitMouseReporting;
+}
+
 /// Terminal screen for SSH sessions.
 class TerminalScreen extends ConsumerStatefulWidget {
   /// Creates a new [TerminalScreen].
@@ -917,9 +935,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       deleteDetection: !isMobile,
       autofocus: !isMobile,
       hardwareKeyboardOnly: isMobile,
-      // On touch devices, simulating wheel scroll with Up/Down keys in alt
-      // buffer makes swipe scroll behave like rapid history navigation.
-      simulateScroll: !isMobile && _isUsingAltBuffer,
+      // xterm already forwards wheel input as mouse events before consulting
+      // this fallback. Keep the synthetic Up/Down fallback disabled so tmux
+      // does not turn scroll gestures into history navigation.
+      simulateScroll: shouldUseSyntheticAltBufferScrollFallback(
+        isMobile: isMobile,
+        isUsingAltBuffer: _isUsingAltBuffer,
+        preferExplicitMouseReporting: true,
+      ),
     );
 
     if (!isMobile) return terminalView;

--- a/test/widget/terminal_screen_scroll_policy_test.dart
+++ b/test/widget/terminal_screen_scroll_policy_test.dart
@@ -1,0 +1,52 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
+
+void main() {
+  group('terminal scroll policy helpers', () {
+    test('never simulates alt-buffer scroll on mobile', () {
+      expect(
+        shouldUseSyntheticAltBufferScrollFallback(
+          isMobile: true,
+          isUsingAltBuffer: true,
+          preferExplicitMouseReporting: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('never simulates scroll outside the alt buffer', () {
+      expect(
+        shouldUseSyntheticAltBufferScrollFallback(
+          isMobile: false,
+          isUsingAltBuffer: false,
+          preferExplicitMouseReporting: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('prefers explicit mouse reporting for tmux-safe scrolling', () {
+      expect(
+        shouldUseSyntheticAltBufferScrollFallback(
+          isMobile: false,
+          isUsingAltBuffer: true,
+          preferExplicitMouseReporting: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('can still opt into the synthetic fallback when desired', () {
+      expect(
+        shouldUseSyntheticAltBufferScrollFallback(
+          isMobile: false,
+          isUsingAltBuffer: true,
+          preferExplicitMouseReporting: false,
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- disable xterm's synthetic Up/Down fallback for alternate-buffer wheel scrolling
- keep explicit mouse-wheel reporting intact so apps like tmux can handle scroll when they opt in
- add a regression test for the terminal scroll policy helper

## Validation

- `flutter pub get`
- `dart format .`
- `flutter analyze`
- `flutter test`
