### PR TITLE
fix: show live activity icon in dynamic island

### DIFF
--- a/ios/ConnectionStatusLiveActivityExtension/ConnectionStatusLiveActivityWidget.swift
+++ b/ios/ConnectionStatusLiveActivityExtension/ConnectionStatusLiveActivityWidget.swift
@@ -107,10 +107,9 @@ struct ConnectionStatusLiveActivityWidget: Widget {
         Image("MonkeySSHDynamicIslandIcon")
           .resizable()
           .interpolation(.high)
-          .renderingMode(.template)
+          .renderingMode(.original)
           .scaledToFit()
           .frame(width: size, height: size)
-          .foregroundStyle(.white)
     }
   }
 


### PR DESCRIPTION
## Summary

Fix the iOS Live Activity Dynamic Island icon rendering so the MonkeySSH icon appears instead of a blank/black block in compact and minimal regions.

## What changed

- switch the Dynamic Island icon path to render the existing asset with `.renderingMode(.original)`
- remove the template tint that was being applied to the full-color PNG

## Validation

- `flutter analyze`
- `flutter test`
- `flutter build ios --simulator --debug`
