### PR TITLE
fix: avoid reopening keyboard on touch scroll

### DIFF
--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -19,6 +19,7 @@ final _leadingSwipeNewlinePattern = RegExp(r'^[\r\n]+(?=\S)');
 bool shouldRequestKeyboardForTerminalPointerUp({
   required PointerDeviceKind pointerKind,
   required int activeTouchPointers,
+  required bool hadMultipleTouchPointers,
   required bool movedBeyondTapSlop,
   required bool readOnly,
 }) {
@@ -30,7 +31,9 @@ bool shouldRequestKeyboardForTerminalPointerUp({
     return true;
   }
 
-  return activeTouchPointers == 1 && !movedBeyondTapSlop;
+  return activeTouchPointers == 1 &&
+      !hadMultipleTouchPointers &&
+      !movedBeyondTapSlop;
 }
 
 /// Wraps a [TerminalView] to provide soft keyboard input on mobile with
@@ -88,6 +91,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   final Set<int> _activeTouchPointers = <int>{};
   final Map<int, Offset> _touchPointerDownPositions = <int, Offset>{};
   final Set<int> _touchPointersMovedBeyondTapSlop = <int>{};
+  bool _touchSequenceHadMultiplePointers = false;
   String _lastSentText = '';
   int _pendingEnterActionSuppressions = 0;
 
@@ -140,6 +144,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (event.kind == PointerDeviceKind.touch) {
       _activeTouchPointers.add(event.pointer);
       _touchPointerDownPositions[event.pointer] = event.position;
+      if (_activeTouchPointers.length > 1) {
+        _touchSequenceHadMultiplePointers = true;
+      }
     }
   }
 
@@ -164,6 +171,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     final shouldRequestKeyboard = shouldRequestKeyboardForTerminalPointerUp(
       pointerKind: event.kind,
       activeTouchPointers: _activeTouchPointers.length,
+      hadMultipleTouchPointers: _touchSequenceHadMultiplePointers,
       movedBeyondTapSlop: _touchPointersMovedBeyondTapSlop.contains(
         event.pointer,
       ),
@@ -187,6 +195,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _activeTouchPointers.remove(event.pointer);
     _touchPointerDownPositions.remove(event.pointer);
     _touchPointersMovedBeyondTapSlop.remove(event.pointer);
+    if (_activeTouchPointers.isEmpty) {
+      _touchSequenceHadMultiplePointers = false;
+    }
   }
 
   void _notifyUserInput() {

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -308,6 +308,60 @@ void main() {
 
       focusNode.dispose();
     });
+
+    testWidgets(
+      'does not open the keyboard after a multitouch gesture when the last finger stays still',
+      (tester) async {
+        final terminal = Terminal();
+        final focusNode = FocusNode();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TerminalTextInputHandler(
+                terminal: terminal,
+                focusNode: focusNode,
+                deleteDetection: true,
+                child: const SizedBox.expand(key: ValueKey('terminal-child')),
+              ),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(tester.testTextInput.isVisible, isTrue);
+
+        tester.testTextInput.hide();
+        await tester.pump();
+
+        expect(tester.testTextInput.isVisible, isFalse);
+
+        final origin =
+            tester.getTopLeft(find.byType(TerminalTextInputHandler)) +
+            const Offset(40, 40);
+        final firstGesture = await tester.createGesture(pointer: 1);
+        await firstGesture.down(origin);
+        await tester.pump();
+
+        final secondGesture = await tester.createGesture(pointer: 2);
+        await secondGesture.down(origin + const Offset(20, 0));
+        await tester.pump();
+        await secondGesture.moveBy(const Offset(0, 80));
+        await tester.pump();
+        await secondGesture.up();
+        await tester.pump();
+        await firstGesture.up();
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(tester.testTextInput.isVisible, isFalse);
+
+        focusNode.dispose();
+      },
+    );
   });
 
   group('shouldRequestKeyboardForTerminalPointerUp', () {
@@ -316,6 +370,7 @@ void main() {
         shouldRequestKeyboardForTerminalPointerUp(
           pointerKind: PointerDeviceKind.touch,
           activeTouchPointers: 1,
+          hadMultipleTouchPointers: false,
           movedBeyondTapSlop: false,
           readOnly: false,
         ),
@@ -328,6 +383,7 @@ void main() {
         shouldRequestKeyboardForTerminalPointerUp(
           pointerKind: PointerDeviceKind.touch,
           activeTouchPointers: 1,
+          hadMultipleTouchPointers: false,
           movedBeyondTapSlop: true,
           readOnly: false,
         ),
@@ -340,6 +396,20 @@ void main() {
         shouldRequestKeyboardForTerminalPointerUp(
           pointerKind: PointerDeviceKind.touch,
           activeTouchPointers: 2,
+          hadMultipleTouchPointers: true,
+          movedBeyondTapSlop: false,
+          readOnly: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('suppresses the keyboard after a multitouch gesture sequence', () {
+      expect(
+        shouldRequestKeyboardForTerminalPointerUp(
+          pointerKind: PointerDeviceKind.touch,
+          activeTouchPointers: 1,
+          hadMultipleTouchPointers: true,
           movedBeyondTapSlop: false,
           readOnly: false,
         ),
@@ -352,6 +422,7 @@ void main() {
         shouldRequestKeyboardForTerminalPointerUp(
           pointerKind: PointerDeviceKind.mouse,
           activeTouchPointers: 0,
+          hadMultipleTouchPointers: false,
           movedBeyondTapSlop: false,
           readOnly: false,
         ),
@@ -364,6 +435,7 @@ void main() {
         shouldRequestKeyboardForTerminalPointerUp(
           pointerKind: PointerDeviceKind.touch,
           activeTouchPointers: 1,
+          hadMultipleTouchPointers: false,
           movedBeyondTapSlop: false,
           readOnly: true,
         ),


### PR DESCRIPTION
## Summary

- only reopen the terminal keyboard after a tap-like pointer-up instead of on every touch down
- keep touch drags and multi-touch gestures from reopening the dismissed IME while scrolling
- add widget regressions for tap-opens-keyboard and drag-does-not

## Testing

- `flutter analyze`
- `flutter test test/widget/terminal_text_input_handler_test.dart test/widget/monkey_terminal_view_touch_scroll_test.dart`
