### PR TITLE
refactor: remove qr transfer flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A cross-platform SSH client built with Flutter, inspired by [Termius](https://te
 - ⌨️ **Rich Keyboard** - Modifier keys, function keys, macros, gestures
 - 📁 **SFTP** - Browse, upload, download, edit remote files
 - 🔑 **Key Management** - Generate, import, export Ed25519/RSA keys
-- 🔄 **Offline Device Transfer** - Encrypted QR and `.monkeysshx` packages for host/key/device migration
+- 🔄 **Offline Device Transfer** - Encrypted `.monkeysshx` packages for host/key/device migration
 - 📂 **Organization** - Groups, folders, tags, favorites, search
 - 🚇 **Port Forwarding** - Local & remote tunnels
 - 📝 **Snippets** - Save and execute common commands
@@ -159,7 +159,7 @@ Recent hardening changes:
   - Android disables app backup and excludes app data from backup/device-transfer rules.
   - iOS disables `UIFileSharingEnabled` and `LSSupportsOpeningDocumentsInPlace`.
 
-Transfer packages are encrypted with a user-provided passphrase and are intended for direct device-to-device transfer (QR / encrypted file import). No cloud sync is required.
+Transfer packages are encrypted with a user-provided passphrase and are intended for direct device-to-device transfer through encrypted file import. No cloud sync is required.
 
 If you discover a security vulnerability, please open an issue.
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-    <uses-permission android:name="android.permission.CAMERA"/>
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -42,39 +42,11 @@ PODS:
   - local_auth_darwin (0.0.1):
     - Flutter
     - FlutterMacOS
-  - mobile_scanner (7.0.0):
-    - Flutter
-    - FlutterMacOS
   - SDWebImage (5.21.5):
     - SDWebImage/Core (= 5.21.5)
   - SDWebImage/Core (5.21.5)
   - share_plus (0.0.1):
     - Flutter
-  - sqlite3 (3.51.1):
-    - sqlite3/common (= 3.51.1)
-  - sqlite3/common (3.51.1)
-  - sqlite3/dbstatvtab (3.51.1):
-    - sqlite3/common
-  - sqlite3/fts5 (3.51.1):
-    - sqlite3/common
-  - sqlite3/math (3.51.1):
-    - sqlite3/common
-  - sqlite3/perf-threadsafe (3.51.1):
-    - sqlite3/common
-  - sqlite3/rtree (3.51.1):
-    - sqlite3/common
-  - sqlite3/session (3.51.1):
-    - sqlite3/common
-  - sqlite3_flutter_libs (0.0.1):
-    - Flutter
-    - FlutterMacOS
-    - sqlite3 (~> 3.51.1)
-    - sqlite3/dbstatvtab
-    - sqlite3/fts5
-    - sqlite3/math
-    - sqlite3/perf-threadsafe
-    - sqlite3/rtree
-    - sqlite3/session
   - SwiftyGif (5.4.5)
 
 DEPENDENCIES:
@@ -83,16 +55,13 @@ DEPENDENCIES:
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
-  - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
-  - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/darwin`)
 
 SPEC REPOS:
   trunk:
     - DKImagePickerController
     - DKPhotoGallery
     - SDWebImage
-    - sqlite3
     - SwiftyGif
 
 EXTERNAL SOURCES:
@@ -106,12 +75,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
   local_auth_darwin:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
-  mobile_scanner:
-    :path: ".symlinks/plugins/mobile_scanner/darwin"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
-  sqlite3_flutter_libs:
-    :path: ".symlinks/plugins/sqlite3_flutter_libs/darwin"
 
 SPEC CHECKSUMS:
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
@@ -121,11 +86,8 @@ SPEC CHECKSUMS:
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
-  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   SDWebImage: e9c98383c7572d713c1a0d7dd2783b10599b9838
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
-  sqlite3: 8d708bc63e9f4ce48f0ad9d6269e478c5ced1d9b
-  sqlite3_flutter_libs: d13b8b3003f18f596e542bcb9482d105577eff41
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
 
 PODFILE CHECKSUM: 7cd9bb08cae3d7a07fbdfd0ed7ce357b723aae93

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -51,8 +51,6 @@
 	<false/>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>MonkeySSH needs photo library access to select files for transfer.</string>
-	<key>NSCameraUsageDescription</key>
-	<string>MonkeySSH needs camera access to scan encrypted transfer QR codes.</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -892,14 +892,6 @@ class _HostRow extends ConsumerWidget {
               },
             ),
             ListTile(
-              leading: const Icon(Icons.qr_code_2),
-              title: const Text('Show Transfer QR'),
-              onTap: () {
-                Navigator.pop(sheetContext);
-                unawaited(_showTransferQr(parentContext, ref));
-              },
-            ),
-            ListTile(
               leading: const Icon(Icons.save_alt),
               title: const Text('Export Encrypted File'),
               onTap: () {
@@ -916,61 +908,6 @@ class _HostRow extends ConsumerWidget {
               },
             ),
           ],
-        ),
-      ),
-    );
-  }
-
-  Future<void> _showTransferQr(BuildContext context, WidgetRef ref) async {
-    if ((host.password?.isNotEmpty ?? false) || host.keyId != null) {
-      final isAuthorized = await authorizeSensitiveTransferExport(
-        context: context,
-        authService: ref.read(authServiceProvider),
-        reason: 'Authenticate to export host credentials',
-      );
-      if (!context.mounted) {
-        return;
-      }
-      if (!isAuthorized) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Authentication required for host export'),
-          ),
-        );
-        return;
-      }
-    }
-
-    final transferPassphrase = await showTransferPassphraseDialog(
-      context: context,
-      title: 'Host transfer passphrase',
-    );
-    if (!context.mounted || transferPassphrase == null) {
-      return;
-    }
-
-    final payload = await ref
-        .read(secureTransferServiceProvider)
-        .createHostPayload(
-          host: host,
-          transferPassphrase: transferPassphrase,
-          includeReferencedKey: host.keyId != null,
-        );
-
-    if (!context.mounted) {
-      return;
-    }
-
-    final defaultFileName = sanitizeTransferFileBaseName(
-      'host-${host.label.toLowerCase().replaceAll(' ', '-')}',
-    );
-
-    await Navigator.of(context).push<void>(
-      MaterialPageRoute(
-        builder: (_) => TransferQrScreen(
-          title: 'Host Transfer QR',
-          payload: payload,
-          defaultFileName: defaultFileName,
         ),
       ),
     );
@@ -1549,10 +1486,6 @@ class _KeyRow extends ConsumerWidget {
 
               // Transfer and key actions
               _SmallIconButton(
-                icon: Icons.qr_code_2,
-                onTap: () => unawaited(_showTransferQr(context, ref)),
-              ),
-              _SmallIconButton(
                 icon: Icons.save_alt,
                 onTap: () => unawaited(_exportEncryptedFile(context, ref)),
               ),
@@ -1585,53 +1518,6 @@ class _KeyRow extends ConsumerWidget {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(const SnackBar(content: Text('Public key copied')));
-  }
-
-  Future<void> _showTransferQr(BuildContext context, WidgetRef ref) async {
-    final isAuthorized = await authorizeSensitiveTransferExport(
-      context: context,
-      authService: ref.read(authServiceProvider),
-      reason: 'Authenticate to export private key',
-    );
-    if (!context.mounted) {
-      return;
-    }
-    if (!isAuthorized) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Authentication required for key export')),
-      );
-      return;
-    }
-
-    final transferPassphrase = await showTransferPassphraseDialog(
-      context: context,
-      title: 'Key transfer passphrase',
-    );
-    if (!context.mounted || transferPassphrase == null) {
-      return;
-    }
-
-    final payload = await ref
-        .read(secureTransferServiceProvider)
-        .createKeyPayload(key: sshKey, transferPassphrase: transferPassphrase);
-
-    if (!context.mounted) {
-      return;
-    }
-
-    final defaultFileName = sanitizeTransferFileBaseName(
-      'key-${sshKey.name.toLowerCase().replaceAll(' ', '-')}',
-    );
-
-    await Navigator.of(context).push<void>(
-      MaterialPageRoute(
-        builder: (_) => TransferQrScreen(
-          title: 'Key Transfer QR',
-          payload: payload,
-          defaultFileName: defaultFileName,
-        ),
-      ),
-    );
   }
 
   Future<void> _exportEncryptedFile(BuildContext context, WidgetRef ref) async {

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -747,17 +747,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   }
 
   Future<void> _importFromTransfer() async {
-    final source = await showTransferImportSourceSheet(context);
-    if (!mounted || source == null) {
-      return;
-    }
-
-    String? encodedPayload;
-    if (source == TransferImportSource.qr) {
-      encodedPayload = await scanTransferPayload(context);
-    } else {
-      encodedPayload = await pickTransferPayloadFromFile(context);
-    }
+    final encodedPayload = await pickTransferPayloadFromFile(context);
     if (!mounted || encodedPayload == null) {
       return;
     }

--- a/lib/presentation/screens/key_add_screen.dart
+++ b/lib/presentation/screens/key_add_screen.dart
@@ -300,14 +300,6 @@ class _ImportKeyTabState extends ConsumerState<_ImportKeyTab> {
                   children: [
                     Expanded(
                       child: OutlinedButton.icon(
-                        onPressed: _isImporting ? null : _importFromQrTransfer,
-                        icon: const Icon(Icons.qr_code_scanner),
-                        label: const Text('Scan QR'),
-                      ),
-                    ),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: OutlinedButton.icon(
                         onPressed: _isImporting
                             ? null
                             : _importFromEncryptedFile,
@@ -449,14 +441,6 @@ class _ImportKeyTabState extends ConsumerState<_ImportKeyTab> {
     } finally {
       if (mounted) setState(() => _isImporting = false);
     }
-  }
-
-  Future<void> _importFromQrTransfer() async {
-    if (_isImporting) {
-      return;
-    }
-    final encodedPayload = await scanTransferPayload(context);
-    await _importFromTransferPayload(encodedPayload);
   }
 
   Future<void> _importFromFile() async {

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -796,17 +796,7 @@ class _MigrationSection extends ConsumerWidget {
       return;
     }
 
-    final source = await showTransferImportSourceSheet(context);
-    if (!context.mounted || source == null) {
-      return;
-    }
-
-    String? encodedPayload;
-    if (source == TransferImportSource.qr) {
-      encodedPayload = await scanTransferPayload(context);
-    } else {
-      encodedPayload = await pickTransferPayloadFromFile(context);
-    }
+    final encodedPayload = await pickTransferPayloadFromFile(context);
     if (!context.mounted || encodedPayload == null) {
       return;
     }

--- a/lib/presentation/screens/transfer_screen.dart
+++ b/lib/presentation/screens/transfer_screen.dart
@@ -4,9 +4,6 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:mobile_scanner/mobile_scanner.dart';
-import 'package:qr_flutter/qr_flutter.dart';
 
 import '../../domain/services/auth_service.dart';
 import '../../domain/services/secure_transfer_service.dart';
@@ -26,124 +23,6 @@ String sanitizeTransferFileBaseName(String input) {
       .replaceAll(RegExp(r'^\.+|\.+$'), '')
       .replaceAll(RegExp(r'^-+|-+$'), '');
   return normalized.isEmpty ? _defaultTransferFileBaseName : normalized;
-}
-
-/// Source options for transfer imports.
-enum TransferImportSource {
-  /// Scan a transfer QR code.
-  qr,
-
-  /// Read an encrypted transfer file.
-  file,
-}
-
-/// Screen that displays a transfer payload as QR and encrypted file export.
-class TransferQrScreen extends StatelessWidget {
-  /// Creates a new [TransferQrScreen].
-  const TransferQrScreen({
-    required this.title,
-    required this.payload,
-    required this.defaultFileName,
-    super.key,
-  });
-
-  /// Screen title.
-  final String title;
-
-  /// Encrypted payload content.
-  final String payload;
-
-  /// Suggested file name without extension.
-  final String defaultFileName;
-
-  static const _qrWarningThreshold = 2600;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final payloadLength = payload.length;
-    final showQr = payloadLength <= _qrWarningThreshold;
-
-    return Scaffold(
-      appBar: AppBar(title: Text(title)),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                children: [
-                  if (showQr) ...[
-                    QrImageView(
-                      data: payload,
-                      size: 260,
-                      backgroundColor: Colors.white,
-                    ),
-                    const SizedBox(height: 12),
-                    Text(
-                      'Scan in MonkeySSH on your other device',
-                      style: theme.textTheme.bodyMedium,
-                      textAlign: TextAlign.center,
-                    ),
-                  ] else ...[
-                    Icon(
-                      Icons.qr_code_2,
-                      size: 72,
-                      color: theme.colorScheme.primary,
-                    ),
-                    const SizedBox(height: 12),
-                    Text(
-                      'Payload is too large for reliable QR scanning.',
-                      style: theme.textTheme.titleMedium,
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      'Use encrypted file export for AirDrop transfer.',
-                      style: theme.textTheme.bodyMedium,
-                      textAlign: TextAlign.center,
-                    ),
-                  ],
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(height: 12),
-          Text(
-            'Encrypted payload length: $payloadLength',
-            style: theme.textTheme.bodySmall,
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 24),
-          FilledButton.icon(
-            onPressed: () async {
-              await saveTransferPayloadToFile(
-                context: context,
-                payload: payload,
-                defaultFileName: defaultFileName,
-              );
-            },
-            icon: const Icon(Icons.save_alt),
-            label: const Text('Export Encrypted File'),
-          ),
-          const SizedBox(height: 12),
-          OutlinedButton.icon(
-            onPressed: () async {
-              await Clipboard.setData(ClipboardData(text: payload));
-              if (context.mounted) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Encrypted payload copied')),
-                );
-              }
-            },
-            icon: const Icon(Icons.copy),
-            label: const Text('Copy Encrypted Payload'),
-          ),
-        ],
-      ),
-    );
-  }
 }
 
 /// Exports payload bytes to an encrypted transfer file.
@@ -196,36 +75,6 @@ Future<void> saveTransferPayloadToFile({
     context,
   ).showSnackBar(SnackBar(content: Text('Encrypted file saved: $targetPath')));
 }
-
-/// Prompts for transfer import source.
-Future<TransferImportSource?> showTransferImportSourceSheet(
-  BuildContext context,
-) async => showModalBottomSheet<TransferImportSource>(
-  context: context,
-  builder: (context) => SafeArea(
-    child: Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        ListTile(
-          leading: const Icon(Icons.qr_code_scanner),
-          title: const Text('Scan QR'),
-          onTap: () => Navigator.pop(context, TransferImportSource.qr),
-        ),
-        ListTile(
-          leading: const Icon(Icons.file_open),
-          title: const Text('Import Encrypted File (.monkeysshx)'),
-          onTap: () => Navigator.pop(context, TransferImportSource.file),
-        ),
-      ],
-    ),
-  ),
-);
-
-/// Starts scanner and returns scanned payload text.
-Future<String?> scanTransferPayload(BuildContext context) async =>
-    Navigator.of(context).push<String>(
-      MaterialPageRoute(builder: (_) => const TransferScannerScreen()),
-    );
 
 /// Imports payload content from an encrypted transfer file.
 Future<String?> pickTransferPayloadFromFile(BuildContext context) async {
@@ -462,70 +311,3 @@ Future<MigrationImportMode?> showMigrationImportModeDialog({
     ],
   ),
 );
-
-/// Camera-based scanner for MonkeySSH transfer QR payloads.
-class TransferScannerScreen extends StatefulWidget {
-  /// Creates a new [TransferScannerScreen].
-  const TransferScannerScreen({super.key});
-
-  @override
-  State<TransferScannerScreen> createState() => _TransferScannerScreenState();
-}
-
-class _TransferScannerScreenState extends State<TransferScannerScreen> {
-  bool _isHandled = false;
-  final _controller = MobileScannerController();
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) => Scaffold(
-    appBar: AppBar(title: const Text('Scan Transfer QR')),
-    body: Stack(
-      fit: StackFit.expand,
-      children: [
-        MobileScanner(
-          controller: _controller,
-          onDetect: (capture) {
-            if (_isHandled) {
-              return;
-            }
-            String? rawValue;
-            for (final barcode in capture.barcodes) {
-              if (barcode.rawValue != null &&
-                  barcode.rawValue!.trim().isNotEmpty) {
-                rawValue = barcode.rawValue!.trim();
-                break;
-              }
-            }
-            if (rawValue == null || rawValue.trim().isEmpty) {
-              return;
-            }
-            _isHandled = true;
-            Navigator.of(context).pop(rawValue);
-          },
-        ),
-        Positioned(
-          left: 16,
-          right: 16,
-          bottom: 24,
-          child: Card(
-            color: Colors.black.withAlpha(200),
-            child: const Padding(
-              padding: EdgeInsets.all(12),
-              child: Text(
-                'Point camera at a MonkeySSH transfer QR code',
-                textAlign: TextAlign.center,
-                style: TextStyle(color: Colors.white),
-              ),
-            ),
-          ),
-        ),
-      ],
-    ),
-  );
-}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,13 +8,11 @@ import Foundation
 import file_picker
 import flutter_secure_storage_darwin
 import local_auth_darwin
-import mobile_scanner
 import share_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
-  MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -8,49 +8,15 @@ PODS:
   - local_auth_darwin (0.0.1):
     - Flutter
     - FlutterMacOS
-  - mobile_scanner (7.0.0):
-    - Flutter
-    - FlutterMacOS
   - share_plus (0.0.1):
     - FlutterMacOS
-  - sqlite3 (3.51.1):
-    - sqlite3/common (= 3.51.1)
-  - sqlite3/common (3.51.1)
-  - sqlite3/dbstatvtab (3.51.1):
-    - sqlite3/common
-  - sqlite3/fts5 (3.51.1):
-    - sqlite3/common
-  - sqlite3/math (3.51.1):
-    - sqlite3/common
-  - sqlite3/perf-threadsafe (3.51.1):
-    - sqlite3/common
-  - sqlite3/rtree (3.51.1):
-    - sqlite3/common
-  - sqlite3/session (3.51.1):
-    - sqlite3/common
-  - sqlite3_flutter_libs (0.0.1):
-    - Flutter
-    - FlutterMacOS
-    - sqlite3 (~> 3.51.1)
-    - sqlite3/dbstatvtab
-    - sqlite3/fts5
-    - sqlite3/math
-    - sqlite3/perf-threadsafe
-    - sqlite3/rtree
-    - sqlite3/session
 
 DEPENDENCIES:
   - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
   - flutter_secure_storage_darwin (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - local_auth_darwin (from `Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin`)
-  - mobile_scanner (from `Flutter/ephemeral/.symlinks/plugins/mobile_scanner/darwin`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
-  - sqlite3_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin`)
-
-SPEC REPOS:
-  trunk:
-    - sqlite3
 
 EXTERNAL SOURCES:
   file_picker:
@@ -61,22 +27,15 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral
   local_auth_darwin:
     :path: Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin
-  mobile_scanner:
-    :path: Flutter/ephemeral/.symlinks/plugins/mobile_scanner/darwin
   share_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
-  sqlite3_flutter_libs:
-    :path: Flutter/ephemeral/.symlinks/plugins/sqlite3_flutter_libs/darwin
 
 SPEC CHECKSUMS:
   file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
-  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
-  sqlite3: 8d708bc63e9f4ce48f0ad9d6269e478c5ced1d9b
-  sqlite3_flutter_libs: d13b8b3003f18f596e542bcb9482d105577eff41
 
 PODFILE CHECKSUM: d1e1928bd5528e69c95196c45658ad79f52fe5df
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -687,14 +687,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  mobile_scanner:
-    dependency: "direct main"
-    description:
-      name: mobile_scanner
-      sha256: c92c26bf2231695b6d3477c8dcf435f51e28f87b1745966b1fe4c47a286171ce
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.2.0"
   mockito:
     dependency: transitive
     description:
@@ -887,22 +879,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
-  qr:
-    dependency: transitive
-    description:
-      name: qr
-      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.2"
-  qr_flutter:
-    dependency: "direct main"
-    description:
-      name: qr_flutter
-      sha256: "5095f0fc6e3f71d08adef8feccc8cea4f12eec18a2e31c2e8d82cb6019f4b097"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.1.0"
   quiver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,8 +41,6 @@ dependencies:
   # File handling
   file_picker: ^10.3.10
   share_plus: ^12.0.1
-  qr_flutter: ^4.1.0
-  mobile_scanner: ^7.2.0
   cryptography: ^2.9.0
   
   # UI


### PR DESCRIPTION
## Summary

- remove QR-code export actions for hosts and keys
- remove QR scanning/import UI so transfer imports now use encrypted `.monkeysshx` files only
- drop scanner/rendering dependencies and remove unused camera permissions/documentation references

## Testing

- `dart format .`
- `flutter analyze`
- `flutter test`
