### PR TITLE
fix: resolve Android release metadata path

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -2,8 +2,8 @@ default_platform(:android)
 
 platform :android do
   METADATA_DIRS = {
-    'xyz.depollsoft.monkeyssh.private' => 'metadata-private',
-    'xyz.depollsoft.monkeyssh' => 'metadata-production',
+    'xyz.depollsoft.monkeyssh.private' => File.expand_path('metadata-private', __dir__),
+    'xyz.depollsoft.monkeyssh' => File.expand_path('metadata-production', __dir__),
   }.freeze
 
   # Clear any stuck draft releases that would block a new upload
@@ -100,7 +100,7 @@ platform :android do
   desc 'Sync metadata to Play Store (no build required)'
   lane :sync_metadata do |options|
     package = options[:package_name] || 'xyz.depollsoft.monkeyssh'
-    meta_path = METADATA_DIRS[package] || 'fastlane/metadata-production'
+    meta_path = METADATA_DIRS[package] || File.expand_path('metadata-production', __dir__)
     lang_dir = File.join(meta_path, 'android', 'en-US')
 
     require 'supply'


### PR DESCRIPTION
## Summary

Fix the Android Fastlane metadata path resolution used by release workflows.

## Why it failed

The `Release Internal` run `23425646800` failed in Android job `68139818043` during `bundle exec fastlane internal` with:

`Could not find folder metadata-production`

Fastlane was invoked from `android/`, but the metadata folders live under `android/fastlane/`. The lane was passing `metadata-production` / `metadata-private` as cwd-relative paths, so production internal uploads could not find their metadata directory.

## What changed

- resolve `METADATA_DIRS` relative to `android/fastlane/Fastfile` via `File.expand_path(..., __dir__)`
- update the `sync_metadata` fallback path to use the same anchored resolution

## Validation

- `ruby -c android/fastlane/Fastfile`
- `dart format .`
- `flutter analyze`
- `flutter test`
