### PR TITLE
fix: trim leading swipe whitespace

### DIFF
--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -9,7 +9,7 @@ import 'package:xterm/src/ui/input_map.dart';
 import 'package:xterm/xterm.dart';
 
 const _deleteDetectionMarker = '\u200B\u200B';
-final _leadingSwipeNewlinePattern = RegExp(r'^[\r\n]+(?=\S)');
+final _leadingSwipeWhitespacePattern = RegExp(r'^[\r\n ]+(?=\S)');
 
 /// Whether a pointer-up event should request the terminal soft keyboard.
 ///
@@ -349,7 +349,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (_lastSentText.isNotEmpty) {
       return extractedText;
     }
-    return extractedText.replaceFirst(_leadingSwipeNewlinePattern, '');
+    return extractedText.replaceFirst(_leadingSwipeWhitespacePattern, '');
   }
 
   int _sendInputDelta(String currentText) {

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -9,7 +9,7 @@ import 'package:xterm/src/ui/input_map.dart';
 import 'package:xterm/xterm.dart';
 
 const _deleteDetectionMarker = '\u200B\u200B';
-final _leadingSwipeWhitespacePattern = RegExp(r'^[\r\n ]+(?=\S)');
+final _leadingSwipeNewlineArtifactPattern = RegExp(r'^[\r\n]+ ?(?=\S)');
 
 /// Whether a pointer-up event should request the terminal soft keyboard.
 ///
@@ -92,6 +92,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   final Map<int, Offset> _touchPointerDownPositions = <int, Offset>{};
   final Set<int> _touchPointersMovedBeyondTapSlop = <int>{};
   bool _touchSequenceHadMultiplePointers = false;
+  bool _sawImeComposition = false;
   String _lastSentText = '';
   int _pendingEnterActionSuppressions = 0;
 
@@ -302,6 +303,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
 
       _connection = TextInput.attach(this, config);
       _connection!.show();
+      _sawImeComposition = false;
       _lastSentText = '';
       _pendingEnterActionSuppressions = 0;
       _currentEditingState = _initEditingState.copyWith();
@@ -314,6 +316,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       _connection!.close();
       _connection = null;
     }
+    _sawImeComposition = false;
     _lastSentText = '';
     _pendingEnterActionSuppressions = 0;
     _currentEditingState = _initEditingState.copyWith();
@@ -349,7 +352,17 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (_lastSentText.isNotEmpty) {
       return extractedText;
     }
-    return extractedText.replaceFirst(_leadingSwipeWhitespacePattern, '');
+    final sanitizedText = extractedText.replaceFirst(
+      _leadingSwipeNewlineArtifactPattern,
+      '',
+    );
+    if (_sawImeComposition &&
+        sanitizedText.startsWith(' ') &&
+        !sanitizedText.startsWith('  ') &&
+        sanitizedText.trimLeft().isNotEmpty) {
+      return sanitizedText.substring(1);
+    }
+    return sanitizedText;
   }
 
   int _sendInputDelta(String currentText) {
@@ -403,12 +416,14 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
 
     // Handle composing (IME input in progress).
     if (!_currentEditingState.composing.isCollapsed) {
+      _sawImeComposition = true;
       return;
     }
 
     if (_currentEditingState.text.length < _initEditingState.text.length) {
       _notifyUserInput();
       widget.terminal.keyInput(TerminalKey.backspace);
+      _sawImeComposition = false;
       _lastSentText = '';
       _pendingEnterActionSuppressions = 0;
       _syncEditingStateWithUserText('');
@@ -421,6 +436,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
     _pendingEnterActionSuppressions += _sendInputDelta(currentText);
     _syncEditingStateWithUserText(currentText);
+    _sawImeComposition = false;
   }
 
   @override
@@ -449,6 +465,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   @override
   void connectionClosed() {
     _connection = null;
+    _sawImeComposition = false;
     _lastSentText = '';
     _pendingEnterActionSuppressions = 0;
     _currentEditingState = _initEditingState.copyWith();

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -7,6 +7,28 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
 import 'package:xterm/xterm.dart';
 
+const _deleteDetectionMarker = '\u200B\u200B';
+
+Future<void> _commitSwipeText(WidgetTester tester, String text) async {
+  final selection = TextSelection.collapsed(offset: text.length);
+  tester.testTextInput.updateEditingValue(
+    TextEditingValue(
+      text: text,
+      selection: selection,
+      composing: TextRange(
+        start: _deleteDetectionMarker.length,
+        end: text.length,
+      ),
+    ),
+  );
+  await tester.pump();
+
+  tester.testTextInput.updateEditingValue(
+    TextEditingValue(text: text, selection: selection),
+  );
+  await tester.pump();
+}
+
 void main() {
   group('TerminalTextInputHandler', () {
     testWidgets('preserves swipe typing context across short pauses', (
@@ -78,13 +100,7 @@ void main() {
       focusNode.requestFocus();
       await tester.pump();
 
-      tester.testTextInput.updateEditingValue(
-        const TextEditingValue(
-          text: '\u200B\u200B\nhello',
-          selection: TextSelection.collapsed(offset: 8),
-        ),
-      );
-      await tester.pump();
+      await _commitSwipeText(tester, '$_deleteDetectionMarker\nhello');
 
       expect(terminalOutput.join(), 'hello');
 
@@ -114,20 +130,14 @@ void main() {
       focusNode.requestFocus();
       await tester.pump();
 
-      tester.testTextInput.updateEditingValue(
-        const TextEditingValue(
-          text: '\u200B\u200B hello',
-          selection: TextSelection.collapsed(offset: 8),
-        ),
-      );
-      await tester.pump();
+      await _commitSwipeText(tester, '$_deleteDetectionMarker hello');
 
       expect(terminalOutput.join(), 'hello');
 
       focusNode.dispose();
     });
 
-    testWidgets('drops leading whitespace before first swipe text', (
+    testWidgets('preserves leading spaces for first non-swipe commit', (
       tester,
     ) async {
       final terminalOutput = <String>[];
@@ -152,11 +162,41 @@ void main() {
 
       tester.testTextInput.updateEditingValue(
         const TextEditingValue(
-          text: '\u200B\u200B \nhello',
+          text: '\u200B\u200B  hello',
           selection: TextSelection.collapsed(offset: 9),
         ),
       );
       await tester.pump();
+
+      expect(terminalOutput.join(), '  hello');
+
+      focusNode.dispose();
+    });
+
+    testWidgets('drops a swipe newline followed by a stray leading space', (
+      tester,
+    ) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalTextInputHandler(
+              terminal: terminal,
+              focusNode: focusNode,
+              deleteDetection: true,
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      await _commitSwipeText(tester, '$_deleteDetectionMarker\n hello');
 
       expect(terminalOutput.join(), 'hello');
 
@@ -186,13 +226,7 @@ void main() {
       focusNode.requestFocus();
       await tester.pump();
 
-      tester.testTextInput.updateEditingValue(
-        const TextEditingValue(
-          text: '\u200B\u200B hello ',
-          selection: TextSelection.collapsed(offset: 9),
-        ),
-      );
-      await tester.pump();
+      await _commitSwipeText(tester, '$_deleteDetectionMarker hello ');
 
       tester.testTextInput.updateEditingValue(
         const TextEditingValue(

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -91,6 +91,122 @@ void main() {
       focusNode.dispose();
     });
 
+    testWidgets('drops a leading space before first swipe text', (
+      tester,
+    ) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalTextInputHandler(
+              terminal: terminal,
+              focusNode: focusNode,
+              deleteDetection: true,
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      tester.testTextInput.updateEditingValue(
+        const TextEditingValue(
+          text: '\u200B\u200B hello',
+          selection: TextSelection.collapsed(offset: 8),
+        ),
+      );
+      await tester.pump();
+
+      expect(terminalOutput.join(), 'hello');
+
+      focusNode.dispose();
+    });
+
+    testWidgets('drops leading whitespace before first swipe text', (
+      tester,
+    ) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalTextInputHandler(
+              terminal: terminal,
+              focusNode: focusNode,
+              deleteDetection: true,
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      tester.testTextInput.updateEditingValue(
+        const TextEditingValue(
+          text: '\u200B\u200B \nhello',
+          selection: TextSelection.collapsed(offset: 9),
+        ),
+      );
+      await tester.pump();
+
+      expect(terminalOutput.join(), 'hello');
+
+      focusNode.dispose();
+    });
+
+    testWidgets('preserves later swipe spaces after trimming first input', (
+      tester,
+    ) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalTextInputHandler(
+              terminal: terminal,
+              focusNode: focusNode,
+              deleteDetection: true,
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      tester.testTextInput.updateEditingValue(
+        const TextEditingValue(
+          text: '\u200B\u200B hello ',
+          selection: TextSelection.collapsed(offset: 9),
+        ),
+      );
+      await tester.pump();
+
+      tester.testTextInput.updateEditingValue(
+        const TextEditingValue(
+          text: '\u200B\u200Bhello world ',
+          selection: TextSelection.collapsed(offset: 14),
+        ),
+      );
+      await tester.pump();
+
+      expect(terminalOutput.join(), 'hello world ');
+
+      focusNode.dispose();
+    });
+
     testWidgets('resyncs delete-detection marker after backspacing past it', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- trim stray leading whitespace from the first committed swipe-typing input so the first word no longer starts with a space
- keep the existing later-word spacing behavior by only sanitizing the first extracted swipe text
- add focused widget regressions for leading spaces, mixed leading whitespace, and continued spacing after the first word

## Testing

- `flutter test test/widget/terminal_text_input_handler_test.dart`
- `export JAVA_HOME=$(/usr/libexec/java_home -v 17) && flutter test integration_test/swipe_typing_leading_space_validation_test.dart -d emulator-5554 --flavor production` (temporary emulator validation probe, removed before commit)
- `dart format .`
- `flutter analyze`
- `flutter test`
