### PR TITLE
fix: point Play metadata path at locale root

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -2,8 +2,8 @@ default_platform(:android)
 
 platform :android do
   METADATA_DIRS = {
-    'xyz.depollsoft.monkeyssh.private' => File.expand_path('metadata-private', __dir__),
-    'xyz.depollsoft.monkeyssh' => File.expand_path('metadata-production', __dir__),
+    'xyz.depollsoft.monkeyssh.private' => File.expand_path('metadata-private/android', __dir__),
+    'xyz.depollsoft.monkeyssh' => File.expand_path('metadata-production/android', __dir__),
   }.freeze
 
   # Clear any stuck draft releases that would block a new upload
@@ -100,8 +100,8 @@ platform :android do
   desc 'Sync metadata to Play Store (no build required)'
   lane :sync_metadata do |options|
     package = options[:package_name] || 'xyz.depollsoft.monkeyssh'
-    meta_path = METADATA_DIRS[package] || File.expand_path('metadata-production', __dir__)
-    lang_dir = File.join(meta_path, 'android', 'en-US')
+    meta_path = METADATA_DIRS[package] || File.expand_path('metadata-production/android', __dir__)
+    lang_dir = File.join(meta_path, 'en-US')
 
     require 'supply'
     Supply.config = FastlaneCore::Configuration.create(Supply::Options.available_options, {


### PR DESCRIPTION
## Summary

Fix the Android Play Store metadata root used by Fastlane uploads.

## Why the merged fix still failed

`Release Internal` run `23426477061` failed in Android job `68142352911` during `Run Fastlane` with `android - Invalid request`.

The previous fix made Fastlane find the metadata directory, but it pointed Supply at:

`android/fastlane/metadata-production`

That directory contains an `android/` subfolder, so Supply treated `android` as the language code and logged `Preparing ... for language 'android'` before the Play API rejected the request.

## What changed

- point `METADATA_DIRS` to `android/fastlane/metadata-*/android`
- update the `sync_metadata` fallback and locale path handling to match that root

## Validation

- `ruby -c android/fastlane/Fastfile`
- `dart format .`
- `flutter analyze`
- `flutter test`
