### PR TITLE
fix: support tel links and overlay copy

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -34,7 +34,7 @@ const _terminalFollowOutputTolerance = 1.0;
 const _selectionActionsBottomPadding = 12.0;
 final _trailingTerminalPaddingPattern = RegExp(r' +$');
 final _terminalLinkPattern = RegExp(
-  r'''(?:(?:https?:\/\/)|(?:mailto:)|(?:www\.))[^\s<>"']+''',
+  r'''(?:(?:https?:\/\/)|(?:mailto:)|(?:tel:)|(?:www\.))[^\s<>"']+''',
   caseSensitive: false,
 );
 
@@ -174,6 +174,17 @@ bool isLaunchableTerminalUri(Uri uri) =>
       'mailto',
       'tel',
     }.contains(uri.scheme.toLowerCase());
+
+/// Extracts the currently selected text from the native selection overlay.
+@visibleForTesting
+String selectedNativeOverlayText(TextEditingValue value) {
+  final selection = value.selection;
+  if (!selection.isValid || selection.isCollapsed) {
+    return '';
+  }
+
+  return selection.textInside(value.text);
+}
 
 /// Whether to let xterm synthesize Up/Down keys for alt-buffer scroll.
 ///
@@ -1913,11 +1924,26 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   );
 
   Future<void> _copySelection() async {
+    if (_isNativeSelectionMode) {
+      final text = selectedNativeOverlayText(_nativeSelectionController.value);
+      if (text.isEmpty) {
+        return;
+      }
+
+      await Clipboard.setData(ClipboardData(text: text));
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Copied')));
+      return;
+    }
+
     final selection = _terminalController.selection;
     if (selection == null) {
       return;
     }
-
     final text = trimTerminalSelectionText(_terminal.buffer.getText(selection));
     if (text.isEmpty) {
       _restoreTerminalFocus();

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 
@@ -86,6 +87,16 @@ void main() {
         isNull,
       );
     });
+
+    test('detects visible tel links at the tapped offset', () {
+      final detectedLink = detectTerminalLinkAtTextOffset(
+        'Call tel:+15551234567 for help.',
+        10,
+      );
+
+      expect(detectedLink, isNotNull);
+      expect(detectedLink!.uri.toString(), 'tel:+15551234567');
+    });
   });
 
   group('normalizeTerminalLinkCandidate', () {
@@ -115,6 +126,32 @@ void main() {
       expect(
         isLaunchableTerminalUri(Uri.parse('intent://example.com')),
         isFalse,
+      );
+    });
+  });
+
+  group('selectedNativeOverlayText', () {
+    test('returns the selected overlay substring', () {
+      expect(
+        selectedNativeOverlayText(
+          const TextEditingValue(
+            text: 'copilot cli',
+            selection: TextSelection(baseOffset: 0, extentOffset: 7),
+          ),
+        ),
+        'copilot',
+      );
+    });
+
+    test('returns empty text for a collapsed overlay selection', () {
+      expect(
+        selectedNativeOverlayText(
+          const TextEditingValue(
+            text: 'copilot cli',
+            selection: TextSelection.collapsed(offset: 7),
+          ),
+        ),
+        isEmpty,
       );
     });
   });


### PR DESCRIPTION
## Summary

- detect visible `tel:` links in terminal output so tappable phone links work the same as other supported schemes
- make app-level `Copy` work while native selection overlay owns the selected range
- add focused regression coverage for both behaviors

## Validation

- `flutter analyze lib/presentation/screens/terminal_screen.dart test/widget/terminal_screen_selection_test.dart`
- `flutter test test/widget/terminal_screen_selection_test.dart`
