### PR TITLE
fix: refresh entity providers after migration import

### DIFF
--- a/integration_test/settings_import_refresh_validation_test.dart
+++ b/integration_test/settings_import_refresh_validation_test.dart
@@ -19,6 +19,8 @@ import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/presentation/providers/entity_list_providers.dart';
 import 'package:monkeyssh/presentation/screens/settings_screen.dart';
 
+import '../test/support/settings_import_test_helpers.dart';
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -31,7 +33,7 @@ void main() {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     addTearDown(db.close);
     final encryptionService = SecretEncryptionService.forTesting();
-    final transferService = _FakeSecureTransferService(
+    final transferService = FakeSecureTransferService(
       db,
       KeyRepository(db, encryptionService),
       HostRepository(db, encryptionService),
@@ -52,7 +54,7 @@ void main() {
       ),
     );
 
-    FilePicker.platform = _FakeFilePicker(
+    setFakeFilePickerResult(
       result: FilePickerResult([
         PlatformFile(
           name: 'migration.monkeysshx',
@@ -61,7 +63,6 @@ void main() {
         ),
       ]),
     );
-    addTearDown(() => FilePicker.platform = _FakeFilePicker(result: null));
 
     var hostBuilds = 0;
     var keyBuilds = 0;
@@ -71,20 +72,18 @@ void main() {
       ProviderScope(
         overrides: [
           databaseProvider.overrideWithValue(db),
-          authServiceProvider.overrideWithValue(_FakeAuthService()),
-          authStateProvider.overrideWith(_MockAuthStateNotifier.new),
+          authServiceProvider.overrideWithValue(FakeAuthService()),
+          authStateProvider.overrideWith(MockAuthStateNotifier.new),
           secureTransferServiceProvider.overrideWithValue(transferService),
-          themeModeNotifierProvider.overrideWith(_StaticThemeModeNotifier.new),
-          fontSizeNotifierProvider.overrideWith(_StaticFontSizeNotifier.new),
-          fontFamilyNotifierProvider.overrideWith(
-            _StaticFontFamilyNotifier.new,
-          ),
+          themeModeNotifierProvider.overrideWith(StaticThemeModeNotifier.new),
+          fontSizeNotifierProvider.overrideWith(StaticFontSizeNotifier.new),
+          fontFamilyNotifierProvider.overrideWith(StaticFontFamilyNotifier.new),
           cursorStyleNotifierProvider.overrideWith(
-            _StaticCursorStyleNotifier.new,
+            StaticCursorStyleNotifier.new,
           ),
-          bellSoundNotifierProvider.overrideWith(_StaticBellSoundNotifier.new),
+          bellSoundNotifierProvider.overrideWith(StaticBellSoundNotifier.new),
           terminalThemeSettingsProvider.overrideWith(
-            _StaticTerminalThemeSettingsNotifier.new,
+            StaticTerminalThemeSettingsNotifier.new,
           ),
           allHostsProvider.overrideWith((ref) {
             hostBuilds += 1;
@@ -100,7 +99,7 @@ void main() {
           }),
         ],
         child: const MaterialApp(
-          home: Stack(children: [SettingsScreen(), _EntityProviderProbe()]),
+          home: Stack(children: [SettingsScreen(), EntityProviderProbe()]),
         ),
       ),
     );
@@ -132,128 +131,4 @@ void main() {
     expect(groupBuilds, greaterThan(initialGroupBuilds));
     expect(find.text('Migration import completed'), findsOneWidget);
   });
-}
-
-class _EntityProviderProbe extends ConsumerWidget {
-  const _EntityProviderProbe();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    ref
-      ..watch(allHostsProvider)
-      ..watch(allKeysProvider)
-      ..watch(allGroupsProvider);
-    return const SizedBox.shrink();
-  }
-}
-
-class _MockAuthStateNotifier extends AuthStateNotifier {
-  @override
-  AuthState build() => AuthState.notConfigured;
-}
-
-class _FakeAuthService extends AuthService {
-  @override
-  Future<bool> isAuthEnabled() async => false;
-
-  @override
-  Future<bool> isBiometricEnabled() async => false;
-
-  @override
-  Future<bool> isBiometricAvailable() async => false;
-}
-
-class _FakeFilePicker extends FilePicker {
-  _FakeFilePicker({required this.result});
-
-  final FilePickerResult? result;
-
-  @override
-  Future<FilePickerResult?> pickFiles({
-    String? dialogTitle,
-    String? initialDirectory,
-    FileType type = FileType.any,
-    List<String>? allowedExtensions,
-    Function(FilePickerStatus)? onFileLoading,
-    bool allowCompression = false,
-    int compressionQuality = 0,
-    bool allowMultiple = false,
-    bool withData = false,
-    bool withReadStream = false,
-    bool lockParentWindow = false,
-    bool readSequential = false,
-  }) async => result;
-}
-
-class _FakeSecureTransferService extends SecureTransferService {
-  _FakeSecureTransferService(
-    super.db,
-    super.keyRepository,
-    super.hostRepository, {
-    required this.payload,
-  });
-
-  final TransferPayload payload;
-  int importCallCount = 0;
-
-  @override
-  Future<TransferPayload> decryptPayload({
-    required String encodedPayload,
-    required String transferPassphrase,
-  }) async => payload;
-
-  @override
-  MigrationPreview previewMigrationPayload(TransferPayload payload) =>
-      MigrationPreview(
-        settingsCount: 0,
-        hostCount: (payload.data['hosts'] as List).length,
-        keyCount: (payload.data['keys'] as List).length,
-        groupCount: (payload.data['groups'] as List).length,
-        snippetCount: (payload.data['snippets'] as List).length,
-        snippetFolderCount: (payload.data['snippetFolders'] as List).length,
-        portForwardCount: (payload.data['portForwards'] as List).length,
-        knownHostCount: (payload.data['knownHosts'] as List).length,
-      );
-
-  @override
-  Future<void> importFullMigrationPayload({
-    required TransferPayload payload,
-    required MigrationImportMode mode,
-  }) async {
-    importCallCount += 1;
-  }
-}
-
-class _StaticThemeModeNotifier extends ThemeModeNotifier {
-  @override
-  ThemeMode build() => ThemeMode.system;
-}
-
-class _StaticFontSizeNotifier extends FontSizeNotifier {
-  @override
-  double build() => 14;
-}
-
-class _StaticFontFamilyNotifier extends FontFamilyNotifier {
-  @override
-  String build() => 'System Monospace';
-}
-
-class _StaticCursorStyleNotifier extends CursorStyleNotifier {
-  @override
-  String build() => 'block';
-}
-
-class _StaticBellSoundNotifier extends BellSoundNotifier {
-  @override
-  bool build() => true;
-}
-
-class _StaticTerminalThemeSettingsNotifier
-    extends TerminalThemeSettingsNotifier {
-  @override
-  TerminalThemeSettings build() => const TerminalThemeSettings(
-    lightThemeId: 'github-light',
-    darkThemeId: 'dracula',
-  );
 }

--- a/lib/presentation/providers/entity_list_providers.dart
+++ b/lib/presentation/providers/entity_list_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show ProviderBase;
 
 import '../../data/database/database.dart';
 import '../../data/repositories/group_repository.dart';
@@ -23,10 +24,13 @@ final allGroupsProvider = StreamProvider<List<Group>>((ref) {
   return repo.watchAll();
 });
 
+/// Signature for invalidating shared providers from any Riverpod context.
+typedef ProviderInvalidator =
+    void Function(ProviderBase<Object?> provider, {bool asReload});
+
 /// Refreshes shared entity list providers after migration imports replace data.
-void invalidateImportedEntityProviders(WidgetRef ref) {
-  ref
-    ..invalidate(allHostsProvider)
-    ..invalidate(allKeysProvider)
-    ..invalidate(allGroupsProvider);
+void invalidateImportedEntityProviders(ProviderInvalidator invalidate) {
+  invalidate(allHostsProvider);
+  invalidate(allKeysProvider);
+  invalidate(allGroupsProvider);
 }

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -177,7 +177,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
             ..invalidate(cursorStyleNotifierProvider)
             ..invalidate(bellSoundNotifierProvider)
             ..invalidate(terminalThemeSettingsProvider);
-          invalidateImportedEntityProviders(ref);
+          invalidateImportedEntityProviders(ref.invalidate);
           if (!mounted) {
             return;
           }

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -846,7 +846,7 @@ class _MigrationSection extends ConsumerWidget {
         ..invalidate(cursorStyleNotifierProvider)
         ..invalidate(bellSoundNotifierProvider)
         ..invalidate(terminalThemeSettingsProvider);
-      invalidateImportedEntityProviders(ref);
+      invalidateImportedEntityProviders(ref.invalidate);
 
       if (!context.mounted) {
         return;

--- a/test/support/settings_import_test_helpers.dart
+++ b/test/support/settings_import_test_helpers.dart
@@ -1,0 +1,164 @@
+// ignore_for_file: public_member_api_docs, use_super_parameters
+
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/data/repositories/key_repository.dart';
+import 'package:monkeyssh/domain/services/auth_service.dart';
+import 'package:monkeyssh/domain/services/secure_transfer_service.dart';
+import 'package:monkeyssh/domain/services/settings_service.dart';
+import 'package:monkeyssh/presentation/providers/entity_list_providers.dart';
+
+void setFakeFilePickerResult({required FilePickerResult? result}) {
+  final originalPlatform = _currentFilePickerPlatform();
+  FilePicker.platform = FakeFilePicker(result: result);
+  addTearDown(() => FilePicker.platform = originalPlatform);
+}
+
+FilePicker _currentFilePickerPlatform() {
+  try {
+    return FilePicker.platform;
+  } catch (error) {
+    if (!error.toString().startsWith('LateInitializationError:')) {
+      rethrow;
+    }
+    final platform = Platform.isMacOS
+        ? FilePickerMacOS()
+        : Platform.isLinux
+        ? FilePickerLinux()
+        : Platform.isWindows
+        ? FilePickerWindows()
+        : FilePickerIO();
+    FilePicker.platform = platform;
+    return platform;
+  }
+}
+
+class EntityProviderProbe extends ConsumerWidget {
+  const EntityProviderProbe({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref
+      ..watch(allHostsProvider)
+      ..watch(allKeysProvider)
+      ..watch(allGroupsProvider);
+    return const SizedBox.shrink();
+  }
+}
+
+class MockAuthStateNotifier extends AuthStateNotifier {
+  @override
+  AuthState build() => AuthState.notConfigured;
+}
+
+class FakeAuthService extends AuthService {
+  @override
+  Future<bool> isAuthEnabled() async => false;
+
+  @override
+  Future<bool> isBiometricEnabled() async => false;
+
+  @override
+  Future<bool> isBiometricAvailable() async => false;
+}
+
+class FakeFilePicker extends FilePicker {
+  FakeFilePicker({required this.result});
+
+  final FilePickerResult? result;
+
+  @override
+  Future<FilePickerResult?> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    bool allowCompression = false,
+    int compressionQuality = 0,
+    bool allowMultiple = false,
+    bool withData = false,
+    bool withReadStream = false,
+    bool lockParentWindow = false,
+    bool readSequential = false,
+  }) async => result;
+}
+
+class FakeSecureTransferService extends SecureTransferService {
+  FakeSecureTransferService(
+    AppDatabase db,
+    KeyRepository keyRepository,
+    HostRepository hostRepository, {
+    required this.payload,
+  }) : super(db, keyRepository, hostRepository);
+
+  final TransferPayload payload;
+  int importCallCount = 0;
+
+  @override
+  Future<TransferPayload> decryptPayload({
+    required String encodedPayload,
+    required String transferPassphrase,
+  }) async => payload;
+
+  @override
+  MigrationPreview previewMigrationPayload(TransferPayload payload) =>
+      MigrationPreview(
+        settingsCount: 0,
+        hostCount: (payload.data['hosts'] as List).length,
+        keyCount: (payload.data['keys'] as List).length,
+        groupCount: (payload.data['groups'] as List).length,
+        snippetCount: (payload.data['snippets'] as List).length,
+        snippetFolderCount: (payload.data['snippetFolders'] as List).length,
+        portForwardCount: (payload.data['portForwards'] as List).length,
+        knownHostCount: (payload.data['knownHosts'] as List).length,
+      );
+
+  @override
+  Future<void> importFullMigrationPayload({
+    required TransferPayload payload,
+    required MigrationImportMode mode,
+  }) async {
+    importCallCount += 1;
+  }
+}
+
+class StaticThemeModeNotifier extends ThemeModeNotifier {
+  @override
+  ThemeMode build() => ThemeMode.system;
+}
+
+class StaticFontSizeNotifier extends FontSizeNotifier {
+  @override
+  double build() => 14;
+}
+
+class StaticFontFamilyNotifier extends FontFamilyNotifier {
+  @override
+  String build() => 'System Monospace';
+}
+
+class StaticCursorStyleNotifier extends CursorStyleNotifier {
+  @override
+  String build() => 'block';
+}
+
+class StaticBellSoundNotifier extends BellSoundNotifier {
+  @override
+  bool build() => true;
+}
+
+class StaticTerminalThemeSettingsNotifier
+    extends TerminalThemeSettingsNotifier {
+  @override
+  TerminalThemeSettings build() => const TerminalThemeSettings(
+    lightThemeId: 'github-light',
+    darkThemeId: 'dracula',
+  );
+}

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -19,6 +19,8 @@ import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/presentation/providers/entity_list_providers.dart';
 import 'package:monkeyssh/presentation/screens/settings_screen.dart';
 
+import '../support/settings_import_test_helpers.dart';
+
 void main() {
   group('SettingsScreen', () {
     testWidgets('displays all sections', (tester) async {
@@ -29,8 +31,8 @@ void main() {
         ProviderScope(
           overrides: [
             databaseProvider.overrideWithValue(db),
-            authServiceProvider.overrideWithValue(_FakeAuthService()),
-            authStateProvider.overrideWith(_MockAuthStateNotifier.new),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(MockAuthStateNotifier.new),
           ],
           child: const MaterialApp(home: SettingsScreen()),
         ),
@@ -61,8 +63,8 @@ void main() {
         ProviderScope(
           overrides: [
             databaseProvider.overrideWithValue(db),
-            authServiceProvider.overrideWithValue(_FakeAuthService()),
-            authStateProvider.overrideWith(_MockAuthStateNotifier.new),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(MockAuthStateNotifier.new),
           ],
           child: const MaterialApp(home: SettingsScreen()),
         ),
@@ -82,8 +84,8 @@ void main() {
         ProviderScope(
           overrides: [
             databaseProvider.overrideWithValue(db),
-            authServiceProvider.overrideWithValue(_FakeAuthService()),
-            authStateProvider.overrideWith(_MockAuthStateNotifier.new),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(MockAuthStateNotifier.new),
           ],
           child: const MaterialApp(home: SettingsScreen()),
         ),
@@ -103,8 +105,8 @@ void main() {
         ProviderScope(
           overrides: [
             databaseProvider.overrideWithValue(db),
-            authServiceProvider.overrideWithValue(_FakeAuthService()),
-            authStateProvider.overrideWith(_MockAuthStateNotifier.new),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(MockAuthStateNotifier.new),
           ],
           child: const MaterialApp(home: SettingsScreen()),
         ),
@@ -124,8 +126,8 @@ void main() {
         ProviderScope(
           overrides: [
             databaseProvider.overrideWithValue(db),
-            authServiceProvider.overrideWithValue(_FakeAuthService()),
-            authStateProvider.overrideWith(_MockAuthStateNotifier.new),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(MockAuthStateNotifier.new),
           ],
           child: const MaterialApp(home: SettingsScreen()),
         ),
@@ -145,8 +147,8 @@ void main() {
         ProviderScope(
           overrides: [
             databaseProvider.overrideWithValue(db),
-            authServiceProvider.overrideWithValue(_FakeAuthService()),
-            authStateProvider.overrideWith(_MockAuthStateNotifier.new),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(MockAuthStateNotifier.new),
           ],
           child: const MaterialApp(home: SettingsScreen()),
         ),
@@ -167,8 +169,8 @@ void main() {
         ProviderScope(
           overrides: [
             databaseProvider.overrideWithValue(db),
-            authServiceProvider.overrideWithValue(_FakeAuthService()),
-            authStateProvider.overrideWith(_MockAuthStateNotifier.new),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(MockAuthStateNotifier.new),
           ],
           child: const MaterialApp(home: SettingsScreen()),
         ),
@@ -198,8 +200,8 @@ void main() {
         ProviderScope(
           overrides: [
             databaseProvider.overrideWithValue(db),
-            authServiceProvider.overrideWithValue(_FakeAuthService()),
-            authStateProvider.overrideWith(_MockAuthStateNotifier.new),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(MockAuthStateNotifier.new),
           ],
           child: const MaterialApp(home: SettingsScreen()),
         ),
@@ -220,8 +222,8 @@ void main() {
         ProviderScope(
           overrides: [
             databaseProvider.overrideWithValue(db),
-            authServiceProvider.overrideWithValue(_FakeAuthService()),
-            authStateProvider.overrideWith(_MockAuthStateNotifier.new),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(MockAuthStateNotifier.new),
           ],
           child: const MaterialApp(home: SettingsScreen()),
         ),
@@ -238,7 +240,7 @@ void main() {
       final db = AppDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);
       final encryptionService = SecretEncryptionService.forTesting();
-      final transferService = _FakeSecureTransferService(
+      final transferService = FakeSecureTransferService(
         db,
         KeyRepository(db, encryptionService),
         HostRepository(db, encryptionService),
@@ -259,7 +261,7 @@ void main() {
         ),
       );
 
-      FilePicker.platform = _FakeFilePicker(
+      setFakeFilePickerResult(
         result: FilePickerResult([
           PlatformFile(
             name: 'migration.monkeysshx',
@@ -268,7 +270,6 @@ void main() {
           ),
         ]),
       );
-      addTearDown(() => FilePicker.platform = _FakeFilePicker(result: null));
 
       var hostBuilds = 0;
       var keyBuilds = 0;
@@ -278,24 +279,20 @@ void main() {
         ProviderScope(
           overrides: [
             databaseProvider.overrideWithValue(db),
-            authServiceProvider.overrideWithValue(_FakeAuthService()),
-            authStateProvider.overrideWith(_MockAuthStateNotifier.new),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(MockAuthStateNotifier.new),
             secureTransferServiceProvider.overrideWithValue(transferService),
-            themeModeNotifierProvider.overrideWith(
-              _StaticThemeModeNotifier.new,
-            ),
-            fontSizeNotifierProvider.overrideWith(_StaticFontSizeNotifier.new),
+            themeModeNotifierProvider.overrideWith(StaticThemeModeNotifier.new),
+            fontSizeNotifierProvider.overrideWith(StaticFontSizeNotifier.new),
             fontFamilyNotifierProvider.overrideWith(
-              _StaticFontFamilyNotifier.new,
+              StaticFontFamilyNotifier.new,
             ),
             cursorStyleNotifierProvider.overrideWith(
-              _StaticCursorStyleNotifier.new,
+              StaticCursorStyleNotifier.new,
             ),
-            bellSoundNotifierProvider.overrideWith(
-              _StaticBellSoundNotifier.new,
-            ),
+            bellSoundNotifierProvider.overrideWith(StaticBellSoundNotifier.new),
             terminalThemeSettingsProvider.overrideWith(
-              _StaticTerminalThemeSettingsNotifier.new,
+              StaticTerminalThemeSettingsNotifier.new,
             ),
             allHostsProvider.overrideWith((ref) {
               hostBuilds += 1;
@@ -311,7 +308,7 @@ void main() {
             }),
           ],
           child: const MaterialApp(
-            home: Stack(children: [SettingsScreen(), _EntityProviderProbe()]),
+            home: Stack(children: [SettingsScreen(), EntityProviderProbe()]),
           ),
         ),
       );
@@ -343,128 +340,4 @@ void main() {
       expect(groupBuilds, greaterThan(initialGroupBuilds));
     });
   });
-}
-
-class _EntityProviderProbe extends ConsumerWidget {
-  const _EntityProviderProbe();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    ref
-      ..watch(allHostsProvider)
-      ..watch(allKeysProvider)
-      ..watch(allGroupsProvider);
-    return const SizedBox.shrink();
-  }
-}
-
-class _MockAuthStateNotifier extends AuthStateNotifier {
-  @override
-  AuthState build() => AuthState.notConfigured;
-}
-
-class _FakeAuthService extends AuthService {
-  @override
-  Future<bool> isAuthEnabled() async => false;
-
-  @override
-  Future<bool> isBiometricEnabled() async => false;
-
-  @override
-  Future<bool> isBiometricAvailable() async => false;
-}
-
-class _FakeFilePicker extends FilePicker {
-  _FakeFilePicker({required this.result});
-
-  final FilePickerResult? result;
-
-  @override
-  Future<FilePickerResult?> pickFiles({
-    String? dialogTitle,
-    String? initialDirectory,
-    FileType type = FileType.any,
-    List<String>? allowedExtensions,
-    Function(FilePickerStatus)? onFileLoading,
-    bool allowCompression = false,
-    int compressionQuality = 0,
-    bool allowMultiple = false,
-    bool withData = false,
-    bool withReadStream = false,
-    bool lockParentWindow = false,
-    bool readSequential = false,
-  }) async => result;
-}
-
-class _FakeSecureTransferService extends SecureTransferService {
-  _FakeSecureTransferService(
-    super.db,
-    super.keyRepository,
-    super.hostRepository, {
-    required this.payload,
-  });
-
-  final TransferPayload payload;
-  int importCallCount = 0;
-
-  @override
-  Future<TransferPayload> decryptPayload({
-    required String encodedPayload,
-    required String transferPassphrase,
-  }) async => payload;
-
-  @override
-  MigrationPreview previewMigrationPayload(TransferPayload payload) =>
-      MigrationPreview(
-        settingsCount: 0,
-        hostCount: (payload.data['hosts'] as List).length,
-        keyCount: (payload.data['keys'] as List).length,
-        groupCount: (payload.data['groups'] as List).length,
-        snippetCount: (payload.data['snippets'] as List).length,
-        snippetFolderCount: (payload.data['snippetFolders'] as List).length,
-        portForwardCount: (payload.data['portForwards'] as List).length,
-        knownHostCount: (payload.data['knownHosts'] as List).length,
-      );
-
-  @override
-  Future<void> importFullMigrationPayload({
-    required TransferPayload payload,
-    required MigrationImportMode mode,
-  }) async {
-    importCallCount += 1;
-  }
-}
-
-class _StaticThemeModeNotifier extends ThemeModeNotifier {
-  @override
-  ThemeMode build() => ThemeMode.system;
-}
-
-class _StaticFontSizeNotifier extends FontSizeNotifier {
-  @override
-  double build() => 14;
-}
-
-class _StaticFontFamilyNotifier extends FontFamilyNotifier {
-  @override
-  String build() => 'System Monospace';
-}
-
-class _StaticCursorStyleNotifier extends CursorStyleNotifier {
-  @override
-  String build() => 'block';
-}
-
-class _StaticBellSoundNotifier extends BellSoundNotifier {
-  @override
-  bool build() => true;
-}
-
-class _StaticTerminalThemeSettingsNotifier
-    extends TerminalThemeSettingsNotifier {
-  @override
-  TerminalThemeSettings build() => const TerminalThemeSettings(
-    lightThemeId: 'github-light',
-    darkThemeId: 'dracula',
-  );
 }


### PR DESCRIPTION
## Summary

- refresh the shared host/key/group presentation providers after full migration imports from both the settings flow and the incoming transfer flow
- centralize that invalidation so the hosts view refreshes immediately instead of staying in a stale broken state until restart
- add a widget regression for the settings import path plus an integration regression validated on Android and iOS devices

## Testing

- `flutter analyze`
- `flutter test`
- `flutter test integration_test/settings_import_refresh_validation_test.dart -d emulator-5554 --flavor production`
- `flutter test integration_test/settings_import_refresh_validation_test.dart -d 96C81AA7-D8AB-4F45-AE1B-F2FAF825567A --flavor production`
