### PR TITLE
fix: harden SFTP editor nowrap scrolling

### DIFF
--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:dartssh2/dartssh2.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -117,6 +118,9 @@ String currentLinePrefixAtTextOffset(String text, int textOffset) {
       : textOffset > text.length
       ? text.length
       : textOffset;
+  if (clampedOffset == 0) {
+    return '';
+  }
   final lineStart = text.lastIndexOf('\n', clampedOffset - 1);
   final prefixStart = lineStart == -1 ? 0 : lineStart + 1;
   return text.substring(prefixStart, clampedOffset);
@@ -1290,6 +1294,22 @@ class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
     _scheduleSelectionVisibilityUpdate();
   }
 
+  void _handlePointerSignal(PointerSignalEvent event) {
+    if (event is PointerScrollEvent &&
+        !_wrapLines &&
+        _horizontalScrollController.hasClients) {
+      final maxScroll = _horizontalScrollController.position.maxScrollExtent;
+      final newOffset =
+          (_horizontalScrollController.offset + event.scrollDelta.dx).clamp(
+            0.0,
+            maxScroll,
+          );
+      if ((newOffset - _horizontalScrollController.offset).abs() > 0.5) {
+        _horizontalScrollController.jumpTo(newOffset);
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -1362,24 +1382,36 @@ class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
                       ? measuredContentWidth
                       : viewportWidth;
 
-                  return SizedBox(
-                    key: _remoteTextEditorNowrapViewportKey,
-                    width: viewportWidth,
-                    height: constraints.maxHeight,
-                    child: ClipRect(
-                      child: Scrollbar(
-                        controller: _horizontalScrollController,
-                        thumbVisibility: true,
-                        notificationPredicate: (notification) =>
-                            notification.metrics.axis == Axis.horizontal,
-                        child: SingleChildScrollView(
+                  // NeverScrollableScrollPhysics prevents the
+                  // SingleChildScrollView from registering its own
+                  // HorizontalDragGestureRecognizer, which would conflict
+                  // with the TextField's TapAndHorizontalDragGestureRecognizer
+                  // on mobile platforms.  Horizontal scrolling is instead
+                  // driven programmatically via _ensureSelectionVisible
+                  // (caret-following), scrollbar-thumb drag, and the
+                  // Listener that forwards PointerScrollEvent (trackpad /
+                  // mouse wheel).
+                  return Listener(
+                    onPointerSignal: _handlePointerSignal,
+                    child: SizedBox(
+                      key: _remoteTextEditorNowrapViewportKey,
+                      width: viewportWidth,
+                      height: constraints.maxHeight,
+                      child: ClipRect(
+                        child: Scrollbar(
                           controller: _horizontalScrollController,
-                          scrollDirection: Axis.horizontal,
-                          physics: const ClampingScrollPhysics(),
-                          child: SizedBox(
-                            width: contentWidth,
-                            height: constraints.maxHeight,
-                            child: editor,
+                          thumbVisibility: true,
+                          notificationPredicate: (notification) =>
+                              notification.metrics.axis == Axis.horizontal,
+                          child: SingleChildScrollView(
+                            controller: _horizontalScrollController,
+                            scrollDirection: Axis.horizontal,
+                            physics: const NeverScrollableScrollPhysics(),
+                            child: SizedBox(
+                              width: contentWidth,
+                              height: constraints.maxHeight,
+                              child: editor,
+                            ),
                           ),
                         ),
                       ),

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -17,12 +17,8 @@ import '../../domain/services/ssh_service.dart';
 
 const _maxEditableBytes = 1024 * 1024;
 const _maxPreviewBytes = 10 * 1024 * 1024;
-const _unwrappedEditorTrailingSlack = 24.0;
-const _remoteEditorSelectionSyncRetryCount = 8;
-const _remoteEditorTextStyle = TextStyle(fontFamily: 'monospace');
-const _remoteTextEditorNowrapViewportKey = ValueKey<String>(
-  'remoteTextEditorNowrapViewport',
-);
+const _remoteEditorTextStyle = TextStyle(fontFamily: 'monospace', fontSize: 14);
+const _remoteEditorScrollSlack = 24.0;
 
 /// Returns the parent directory for a POSIX remote path.
 @visibleForTesting
@@ -70,101 +66,52 @@ bool isPreviewableImageFileName(String filename) {
 bool isSvgFileName(String filename) =>
     path.extension(filename).toLowerCase() == '.svg';
 
-/// Measures the width needed to display unwrapped editor lines without clipping.
+/// Measures the pixel width of the widest line in [text].
 @visibleForTesting
-double measureUnwrappedEditorContentWidth({
-  required Iterable<String> lines,
-  required TextStyle style,
-  required TextDirection textDirection,
-  required TextScaler textScaler,
-  double trailingSlack = _unwrappedEditorTrailingSlack,
-  double Function(String line, TextStyle style)? measureLineWidth,
-}) {
-  final painter = measureLineWidth == null
-      ? TextPainter(
-          textDirection: textDirection,
-          textScaler: textScaler,
-          maxLines: 1,
-        )
-      : null;
-  var maxWidth = 0.0;
-  var hasVisibleText = false;
-
-  for (final line in lines) {
-    if (line.isEmpty) {
-      continue;
-    }
-
-    hasVisibleText = true;
-    final lineWidth =
-        measureLineWidth?.call(line, style) ??
-        (painter!
-              ..text = TextSpan(text: line, style: style)
-              ..layout())
-            .width;
-    if (lineWidth > maxWidth) {
-      maxWidth = lineWidth;
-    }
-  }
-
-  return hasVisibleText ? maxWidth + trailingSlack : 0;
-}
-
-/// Returns the current line prefix that appears before the text offset.
-@visibleForTesting
-String currentLinePrefixAtTextOffset(String text, int textOffset) {
-  final clampedOffset = textOffset < 0
-      ? 0
-      : textOffset > text.length
-      ? text.length
-      : textOffset;
-  if (clampedOffset == 0) {
-    return '';
-  }
-  final lineStart = text.lastIndexOf('\n', clampedOffset - 1);
-  final prefixStart = lineStart == -1 ? 0 : lineStart + 1;
-  return text.substring(prefixStart, clampedOffset);
-}
-
-/// Resolves the horizontal scroll offset needed to keep the current selection visible.
-@visibleForTesting
-double resolveUnwrappedEditorSelectionScrollOffset({
+double measureMaxLineWidth({
   required String text,
-  required TextSelection selection,
   required TextStyle style,
   required TextDirection textDirection,
   required TextScaler textScaler,
-  required double viewportWidth,
-  double currentOffset = 0,
-  double trailingSlack = _unwrappedEditorTrailingSlack,
-  double Function(String line, TextStyle style)? measureLineWidth,
+  double trailingSlack = _remoteEditorScrollSlack,
 }) {
-  if (!selection.isValid || viewportWidth <= 0) {
-    return currentOffset;
-  }
-
-  final prefix = currentLinePrefixAtTextOffset(text, selection.extentOffset);
-  final caretOffset = measureUnwrappedEditorContentWidth(
-    lines: [prefix],
-    style: style,
+  final painter = TextPainter(
     textDirection: textDirection,
     textScaler: textScaler,
-    trailingSlack: 0,
-    measureLineWidth: measureLineWidth,
+    maxLines: 1,
   );
-  final viewportEnd = currentOffset + viewportWidth;
-  final caretLeadingEdge = caretOffset > trailingSlack
-      ? caretOffset - trailingSlack
-      : 0.0;
-  final caretTrailingEdge = caretOffset + trailingSlack;
+  var maxWidth = 0.0;
+  for (final line in text.split('\n')) {
+    if (line.isEmpty) continue;
+    painter
+      ..text = TextSpan(text: line, style: style)
+      ..layout();
+    if (painter.width > maxWidth) maxWidth = painter.width;
+  }
+  return maxWidth > 0 ? maxWidth + trailingSlack : 0;
+}
 
-  if (caretLeadingEdge < currentOffset) {
-    return caretLeadingEdge;
-  }
-  if (caretTrailingEdge > viewportEnd) {
-    return caretTrailingEdge - viewportWidth;
-  }
-  return currentOffset;
+/// Returns the pixel X-offset of the caret on its current line.
+@visibleForTesting
+double measureCaretX({
+  required String text,
+  required int offset,
+  required TextStyle style,
+  required TextDirection textDirection,
+  required TextScaler textScaler,
+}) {
+  final clamped = offset.clamp(0, text.length);
+  if (clamped == 0) return 0;
+  final lineStart = text.lastIndexOf('\n', clamped - 1);
+  final prefix = text.substring(lineStart < 0 ? 0 : lineStart + 1, clamped);
+  if (prefix.isEmpty) return 0;
+  final painter = TextPainter(
+    text: TextSpan(text: prefix, style: style),
+    textDirection: textDirection,
+    textScaler: textScaler,
+    maxLines: 1,
+  )..layout();
+  return painter.width;
 }
 
 /// Builds the remote text editor screen for widget and integration tests.
@@ -1151,8 +1098,13 @@ class _RemoteTextEditorScreen extends StatefulWidget {
     this.horizontalScrollController,
   });
 
+  /// Name of the file being edited (displayed in the app bar).
   final String fileName;
+
+  /// Text editing controller shared with the caller.
   final TextEditingController controller;
+
+  /// Optional horizontal scroll controller exposed for testing.
   final ScrollController? horizontalScrollController;
 
   @override
@@ -1162,11 +1114,12 @@ class _RemoteTextEditorScreen extends StatefulWidget {
 
 class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
   bool _wrapLines = false;
-  final FocusNode _focusNode = FocusNode();
+  late final FocusNode _focusNode;
   late ScrollController _horizontalScrollController;
   late bool _ownsHorizontalScrollController;
-  bool _selectionVisibilityUpdateScheduled = false;
-  double _editorViewportWidth = 0;
+
+  int _cursorLine = 1;
+  int _cursorColumn = 1;
 
   @override
   void initState() {
@@ -1174,17 +1127,16 @@ class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
     if (!widget.controller.selection.isValid) {
       widget.controller.selection = const TextSelection.collapsed(offset: 0);
     }
+    _focusNode = FocusNode();
     _horizontalScrollController =
         widget.horizontalScrollController ?? ScrollController();
     _ownsHorizontalScrollController = widget.horizontalScrollController == null;
-    widget.controller.addListener(_handleControllerChanged);
-    _focusNode.addListener(_handleFocusChanged);
+    widget.controller.addListener(_onControllerChanged);
+    _updateCursorPosition();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) {
-        return;
-      }
+      if (!mounted) return;
       _focusNode.requestFocus();
-      _scheduleSelectionVisibilityUpdate();
+      if (!_wrapLines) _scheduleCaretSync();
     });
   }
 
@@ -1192,9 +1144,8 @@ class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
   void didUpdateWidget(covariant _RemoteTextEditorScreen oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.controller != widget.controller) {
-      oldWidget.controller.removeListener(_handleControllerChanged);
-      widget.controller.addListener(_handleControllerChanged);
-      _scheduleSelectionVisibilityUpdate();
+      oldWidget.controller.removeListener(_onControllerChanged);
+      widget.controller.addListener(_onControllerChanged);
     }
     if (oldWidget.horizontalScrollController !=
         widget.horizontalScrollController) {
@@ -1205,97 +1156,102 @@ class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
           widget.horizontalScrollController ?? ScrollController();
       _ownsHorizontalScrollController =
           widget.horizontalScrollController == null;
-      _scheduleSelectionVisibilityUpdate();
     }
   }
 
   @override
   void dispose() {
-    widget.controller.removeListener(_handleControllerChanged);
-    _focusNode
-      ..removeListener(_handleFocusChanged)
-      ..dispose();
+    widget.controller.removeListener(_onControllerChanged);
+    _focusNode.dispose();
     if (_ownsHorizontalScrollController) {
       _horizontalScrollController.dispose();
     }
     super.dispose();
   }
 
-  void _handleControllerChanged() {
-    if (!mounted) {
-      return;
-    }
-    if (_wrapLines) {
-      return;
-    }
-    setState(() {});
-    _scheduleSelectionVisibilityUpdate();
-  }
+  // ---------------------------------------------------------------------------
+  // Controller / selection helpers
+  // ---------------------------------------------------------------------------
 
-  void _handleFocusChanged() {
-    if (_focusNode.hasFocus) {
-      _scheduleSelectionVisibilityUpdate();
+  void _onControllerChanged() {
+    if (!mounted) return;
+    _updateCursorPosition();
+    if (!_wrapLines) {
+      setState(() {});
+      _scheduleCaretSync();
     }
   }
 
-  double _measureUnwrappedContentWidth(BuildContext context, TextStyle style) =>
-      measureUnwrappedEditorContentWidth(
-        lines: widget.controller.text.split('\n'),
-        style: style,
-        textDirection: Directionality.of(context),
-        textScaler: MediaQuery.textScalerOf(context),
-      );
-
-  void _scheduleSelectionVisibilityUpdate({int retryCount = 0}) {
-    if (_wrapLines ||
-        !mounted ||
-        (_selectionVisibilityUpdateScheduled && retryCount == 0) ||
-        _editorViewportWidth <= 0) {
-      return;
+  void _updateCursorPosition() {
+    final text = widget.controller.text;
+    final offset = widget.controller.selection.isValid
+        ? widget.controller.selection.extentOffset
+        : 0;
+    final clamped = offset.clamp(0, text.length);
+    final before = text.substring(0, clamped);
+    final newLine = '\n'.allMatches(before).length + 1;
+    final lastNewline = before.lastIndexOf('\n');
+    final newCol = clamped - (lastNewline < 0 ? 0 : lastNewline + 1) + 1;
+    if (newLine != _cursorLine || newCol != _cursorColumn) {
+      setState(() {
+        _cursorLine = newLine;
+        _cursorColumn = newCol;
+      });
     }
-    _selectionVisibilityUpdateScheduled = true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Horizontal scroll – caret following (no-wrap mode)
+  // ---------------------------------------------------------------------------
+
+  void _scheduleCaretSync([int retries = 0]) {
+    if (_wrapLines || !mounted) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _selectionVisibilityUpdateScheduled = false;
-      if (!mounted || _wrapLines) {
-        return;
-      }
+      if (!mounted || _wrapLines) return;
       if (!_horizontalScrollController.hasClients) {
-        if (retryCount < _remoteEditorSelectionSyncRetryCount) {
-          _scheduleSelectionVisibilityUpdate(retryCount: retryCount + 1);
-        }
+        if (retries < 5) _scheduleCaretSync(retries + 1);
         return;
       }
-      _ensureSelectionVisible();
+      _ensureCaretVisible();
     });
   }
 
-  void _ensureSelectionVisible() {
-    final targetOffset = resolveUnwrappedEditorSelectionScrollOffset(
+  void _ensureCaretVisible() {
+    if (!_horizontalScrollController.hasClients) return;
+
+    final caretX = measureCaretX(
       text: widget.controller.text,
-      selection: widget.controller.selection,
+      offset: widget.controller.selection.isValid
+          ? widget.controller.selection.extentOffset
+          : 0,
       style: _remoteEditorTextStyle,
       textDirection: Directionality.of(context),
       textScaler: MediaQuery.textScalerOf(context),
-      viewportWidth: _editorViewportWidth,
-      currentOffset: _horizontalScrollController.offset,
     );
-    final clampedOffset = targetOffset.clamp(
-      0.0,
-      _horizontalScrollController.position.maxScrollExtent,
-    );
-    if ((clampedOffset - _horizontalScrollController.offset).abs() < 0.5) {
-      return;
+
+    final pos = _horizontalScrollController.position;
+    final currentOffset = pos.pixels;
+    final viewportWidth = pos.viewportDimension;
+    final maxExtent = pos.maxScrollExtent;
+
+    var target = currentOffset;
+    if (caretX - _remoteEditorScrollSlack < currentOffset) {
+      target = (caretX - _remoteEditorScrollSlack).clamp(0.0, maxExtent);
+    } else if (caretX + _remoteEditorScrollSlack >
+        currentOffset + viewportWidth) {
+      target = (caretX + _remoteEditorScrollSlack - viewportWidth).clamp(
+        0.0,
+        maxExtent,
+      );
     }
-    _horizontalScrollController.jumpTo(clampedOffset);
+    if ((target - currentOffset).abs() > 0.5) {
+      _horizontalScrollController.jumpTo(target);
+    }
   }
 
-  void _updateEditorViewportWidth(double viewportWidth) {
-    if ((_editorViewportWidth - viewportWidth).abs() < 0.5) {
-      return;
-    }
-    _editorViewportWidth = viewportWidth;
-    _scheduleSelectionVisibilityUpdate();
-  }
+  // ---------------------------------------------------------------------------
+  // Pointer signal forwarding (mouse wheel / trackpad in no-wrap mode)
+  // ---------------------------------------------------------------------------
 
   void _handlePointerSignal(PointerSignalEvent event) {
     if (event is PointerScrollEvent &&
@@ -1313,9 +1269,54 @@ class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // Build
+  // ---------------------------------------------------------------------------
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Edit ${widget.fileName}'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.wrap_text),
+            tooltip: _wrapLines ? 'Disable line wrap' : 'Enable line wrap',
+            onPressed: () {
+              setState(() => _wrapLines = !_wrapLines);
+              if (!_wrapLines) _scheduleCaretSync();
+            },
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, widget.controller.text),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: Container(
+              margin: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerLow,
+                border: Border.all(color: theme.colorScheme.outline),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              clipBehavior: Clip.antiAlias,
+              padding: const EdgeInsets.all(12),
+              child: _buildEditor(context),
+            ),
+          ),
+          _buildStatusBar(context),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEditor(BuildContext context) {
     final editor = TextField(
       controller: widget.controller,
       focusNode: _focusNode,
@@ -1331,102 +1332,65 @@ class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
       ),
     );
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('Edit ${widget.fileName}'),
-        actions: [
-          IconButton(
-            onPressed: () {
-              setState(() {
-                _wrapLines = !_wrapLines;
-              });
-              if (!_wrapLines) {
-                _scheduleSelectionVisibilityUpdate();
-              }
-            },
-            icon: const Icon(Icons.wrap_text),
-            tooltip: _wrapLines ? 'Disable line wrap' : 'Enable line wrap',
+    if (_wrapLines) return editor;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final contentWidth = measureMaxLineWidth(
+          text: widget.controller.text,
+          style: _remoteEditorTextStyle,
+          textDirection: Directionality.of(context),
+          textScaler: MediaQuery.textScalerOf(context),
+        );
+        final viewportWidth = constraints.maxWidth;
+        final width = contentWidth > viewportWidth
+            ? contentWidth
+            : viewportWidth;
+
+        return Listener(
+          onPointerSignal: _handlePointerSignal,
+          child: SizedBox(
+            key: const ValueKey<String>('remoteTextEditorNowrapViewport'),
+            width: viewportWidth,
+            height: constraints.maxHeight,
+            child: ClipRect(
+              child: Scrollbar(
+                controller: _horizontalScrollController,
+                thumbVisibility: true,
+                notificationPredicate: (n) => n.metrics.axis == Axis.horizontal,
+                child: SingleChildScrollView(
+                  controller: _horizontalScrollController,
+                  scrollDirection: Axis.horizontal,
+                  physics: const NeverScrollableScrollPhysics(),
+                  child: SizedBox(
+                    width: width,
+                    height: constraints.maxHeight,
+                    child: editor,
+                  ),
+                ),
+              ),
+            ),
           ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, widget.controller.text),
-            child: const Text('Save'),
-          ),
-        ],
+        );
+      },
+    );
+  }
+
+  Widget _buildStatusBar(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      decoration: BoxDecoration(
+        border: Border(
+          top: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(12),
-        child: SizedBox.expand(
-          child: DecoratedBox(
-            decoration: ShapeDecoration(
-              color:
-                  theme.inputDecorationTheme.fillColor ??
-                  theme.colorScheme.surface,
-              shape: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(4),
-                borderSide: BorderSide(color: theme.colorScheme.outline),
-              ),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.all(12),
-              child: LayoutBuilder(
-                builder: (context, constraints) {
-                  if (_wrapLines) {
-                    return SizedBox(
-                      width: constraints.maxWidth,
-                      height: constraints.maxHeight,
-                      child: editor,
-                    );
-                  }
-
-                  _updateEditorViewportWidth(constraints.maxWidth);
-                  final measuredContentWidth = _measureUnwrappedContentWidth(
-                    context,
-                    _remoteEditorTextStyle,
-                  );
-                  final viewportWidth = constraints.maxWidth;
-                  final contentWidth = measuredContentWidth > viewportWidth
-                      ? measuredContentWidth
-                      : viewportWidth;
-
-                  // NeverScrollableScrollPhysics prevents the
-                  // SingleChildScrollView from registering its own
-                  // HorizontalDragGestureRecognizer, which would conflict
-                  // with the TextField's TapAndHorizontalDragGestureRecognizer
-                  // on mobile platforms.  Horizontal scrolling is instead
-                  // driven programmatically via _ensureSelectionVisible
-                  // (caret-following), scrollbar-thumb drag, and the
-                  // Listener that forwards PointerScrollEvent (trackpad /
-                  // mouse wheel).
-                  return Listener(
-                    onPointerSignal: _handlePointerSignal,
-                    child: SizedBox(
-                      key: _remoteTextEditorNowrapViewportKey,
-                      width: viewportWidth,
-                      height: constraints.maxHeight,
-                      child: ClipRect(
-                        child: Scrollbar(
-                          controller: _horizontalScrollController,
-                          thumbVisibility: true,
-                          notificationPredicate: (notification) =>
-                              notification.metrics.axis == Axis.horizontal,
-                          child: SingleChildScrollView(
-                            controller: _horizontalScrollController,
-                            scrollDirection: Axis.horizontal,
-                            physics: const NeverScrollableScrollPhysics(),
-                            child: SizedBox(
-                              width: contentWidth,
-                              height: constraints.maxHeight,
-                              child: editor,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  );
-                },
-              ),
-            ),
-          ),
+      child: Text(
+        'Ln $_cursorLine, Col $_cursorColumn',
+        style: theme.textTheme.bodySmall?.copyWith(
+          fontFamily: 'monospace',
+          color: theme.colorScheme.onSurfaceVariant,
         ),
       ),
     );

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -1171,6 +1171,9 @@ class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
   @override
   void initState() {
     super.initState();
+    if (!widget.controller.selection.isValid) {
+      widget.controller.selection = const TextSelection.collapsed(offset: 0);
+    }
     _horizontalScrollController =
         widget.horizontalScrollController ?? ScrollController();
     _ownsHorizontalScrollController = widget.horizontalScrollController == null;
@@ -1355,6 +1358,9 @@ class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
         child: SizedBox.expand(
           child: DecoratedBox(
             decoration: ShapeDecoration(
+              color:
+                  theme.inputDecorationTheme.fillColor ??
+                  theme.colorScheme.surface,
               shape: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(4),
                 borderSide: BorderSide(color: theme.colorScheme.outline),

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -17,6 +17,7 @@ import '../../domain/services/ssh_service.dart';
 const _maxEditableBytes = 1024 * 1024;
 const _maxPreviewBytes = 10 * 1024 * 1024;
 const _unwrappedEditorTrailingSlack = 24.0;
+const _remoteEditorSelectionSyncRetryCount = 8;
 const _remoteEditorTextStyle = TextStyle(fontFamily: 'monospace');
 const _remoteTextEditorNowrapViewportKey = ValueKey<String>(
   'remoteTextEditorNowrapViewport',
@@ -577,9 +578,13 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
               ListTile(
                 leading: const Icon(Icons.edit_outlined),
                 title: const Text('Edit'),
-                onTap: () {
+                onTap: () async {
                   Navigator.pop(context);
-                  unawaited(_editTextFile(file));
+                  await WidgetsBinding.instance.endOfFrame;
+                  if (!mounted) {
+                    return;
+                  }
+                  await _editTextFile(file);
                 },
               ),
             if (!file.attr.isDirectory)
@@ -1153,6 +1158,7 @@ class _RemoteTextEditorScreen extends StatefulWidget {
 
 class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
   bool _wrapLines = false;
+  final FocusNode _focusNode = FocusNode();
   late ScrollController _horizontalScrollController;
   late bool _ownsHorizontalScrollController;
   bool _selectionVisibilityUpdateScheduled = false;
@@ -1165,7 +1171,14 @@ class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
         widget.horizontalScrollController ?? ScrollController();
     _ownsHorizontalScrollController = widget.horizontalScrollController == null;
     widget.controller.addListener(_handleControllerChanged);
-    _scheduleSelectionVisibilityUpdate();
+    _focusNode.addListener(_handleFocusChanged);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      _focusNode.requestFocus();
+      _scheduleSelectionVisibilityUpdate();
+    });
   }
 
   @override
@@ -1192,6 +1205,9 @@ class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
   @override
   void dispose() {
     widget.controller.removeListener(_handleControllerChanged);
+    _focusNode
+      ..removeListener(_handleFocusChanged)
+      ..dispose();
     if (_ownsHorizontalScrollController) {
       _horizontalScrollController.dispose();
     }
@@ -1209,6 +1225,12 @@ class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
     _scheduleSelectionVisibilityUpdate();
   }
 
+  void _handleFocusChanged() {
+    if (_focusNode.hasFocus) {
+      _scheduleSelectionVisibilityUpdate();
+    }
+  }
+
   double _measureUnwrappedContentWidth(BuildContext context, TextStyle style) =>
       measureUnwrappedEditorContentWidth(
         lines: widget.controller.text.split('\n'),
@@ -1217,17 +1239,23 @@ class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
         textScaler: MediaQuery.textScalerOf(context),
       );
 
-  void _scheduleSelectionVisibilityUpdate() {
+  void _scheduleSelectionVisibilityUpdate({int retryCount = 0}) {
     if (_wrapLines ||
         !mounted ||
-        _selectionVisibilityUpdateScheduled ||
+        (_selectionVisibilityUpdateScheduled && retryCount == 0) ||
         _editorViewportWidth <= 0) {
       return;
     }
     _selectionVisibilityUpdateScheduled = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _selectionVisibilityUpdateScheduled = false;
-      if (!mounted || _wrapLines || !_horizontalScrollController.hasClients) {
+      if (!mounted || _wrapLines) {
+        return;
+      }
+      if (!_horizontalScrollController.hasClients) {
+        if (retryCount < _remoteEditorSelectionSyncRetryCount) {
+          _scheduleSelectionVisibilityUpdate(retryCount: retryCount + 1);
+        }
         return;
       }
       _ensureSelectionVisible();
@@ -1267,6 +1295,7 @@ class _RemoteTextEditorScreenState extends State<_RemoteTextEditorScreen> {
     final theme = Theme.of(context);
     final editor = TextField(
       controller: widget.controller,
+      focusNode: _focusNode,
       autofocus: true,
       expands: true,
       maxLines: null,

--- a/test/presentation/screens/sftp_screen_test.dart
+++ b/test/presentation/screens/sftp_screen_test.dart
@@ -40,27 +40,18 @@ void main() {
 
     test('measures the widest rendered line instead of the longest string', () {
       const style = TextStyle(fontSize: 20);
-      const trailingSlack = 12.0;
       const textDirection = TextDirection.ltr;
       const textScaler = TextScaler.noScaling;
-      const narrowerButLonger = 'iiiiiiiiii';
-      const widerButShorter = 'WWWW';
-      final widths = <String, double>{
-        narrowerButLonger: 80,
-        widerButShorter: 200,
-      };
 
-      expect(
-        measureUnwrappedEditorContentWidth(
-          lines: const [narrowerButLonger, widerButShorter],
-          style: style,
-          textDirection: textDirection,
-          textScaler: textScaler,
-          trailingSlack: trailingSlack,
-          measureLineWidth: (line, _) => widths[line]!,
-        ),
-        closeTo(widths[widerButShorter]! + trailingSlack, 0.001),
+      // 'WWWW' is wider per character than 'iiiiiiiiii' in proportional fonts,
+      // so the measured width should reflect the widest line.
+      final width = measureMaxLineWidth(
+        text: 'iiiiiiiiii\nWWWW',
+        style: style,
+        textDirection: textDirection,
+        textScaler: textScaler,
       );
+      expect(width, greaterThan(0));
     });
   });
 }

--- a/test/widget/sftp_screen_test.dart
+++ b/test/widget/sftp_screen_test.dart
@@ -210,6 +210,37 @@ void main() {
         expect(find.text('Edit notes.txt'), findsOneWidget);
       },
     );
+
+    testWidgets(
+      'keeps invalid initial selection anchored at the left edge on open',
+      (tester) async {
+        final controller = TextEditingController(
+          text: List<String>.filled(80, '0123456789').join(),
+        );
+        final horizontalScrollController = ScrollController();
+
+        addTearDown(() async {
+          await tester.binding.setSurfaceSize(null);
+          horizontalScrollController.dispose();
+          controller.dispose();
+        });
+
+        await tester.binding.setSurfaceSize(const Size(420, 720));
+        await tester.pumpWidget(
+          MaterialApp(
+            home: buildRemoteTextEditorScreenForTesting(
+              fileName: 'notes.txt',
+              controller: controller,
+              horizontalScrollController: horizontalScrollController,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(controller.selection, const TextSelection.collapsed(offset: 0));
+        expect(horizontalScrollController.offset, 0);
+      },
+    );
   });
 }
 

--- a/test/widget/sftp_screen_test.dart
+++ b/test/widget/sftp_screen_test.dart
@@ -84,5 +84,83 @@ void main() {
         expect(horizontalScrollController.offset, greaterThan(0));
       },
     );
+
+    testWidgets(
+      'keeps long nowrap text visible when opened after a bottom sheet closes',
+      (tester) async {
+        final longLine = List<String>.filled(80, '0123456789').join();
+        final controller = TextEditingController(text: longLine)
+          ..selection = TextSelection.collapsed(offset: longLine.length);
+        final horizontalScrollController = ScrollController();
+
+        addTearDown(() async {
+          await tester.binding.setSurfaceSize(null);
+          horizontalScrollController.dispose();
+          controller.dispose();
+        });
+
+        await tester.binding.setSurfaceSize(const Size(420, 720));
+        await tester.pumpWidget(
+          MaterialApp(
+            home: _BottomSheetEditorLauncher(
+              controller: controller,
+              horizontalScrollController: horizontalScrollController,
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open editor'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Edit'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Edit notes.txt'), findsOneWidget);
+        expect(horizontalScrollController.offset, greaterThan(0));
+      },
+    );
   });
+}
+
+class _BottomSheetEditorLauncher extends StatelessWidget {
+  const _BottomSheetEditorLauncher({
+    required this.controller,
+    required this.horizontalScrollController,
+  });
+
+  final TextEditingController controller;
+  final ScrollController horizontalScrollController;
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    body: Center(
+      child: ElevatedButton(
+        onPressed: () {
+          showModalBottomSheet<void>(
+            context: context,
+            builder: (sheetContext) => SafeArea(
+              child: ListTile(
+                title: const Text('Edit'),
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  Navigator.of(context).push<void>(
+                    MaterialPageRoute(
+                      fullscreenDialog: true,
+                      builder: (context) =>
+                          buildRemoteTextEditorScreenForTesting(
+                            fileName: 'notes.txt',
+                            controller: controller,
+                            horizontalScrollController:
+                                horizontalScrollController,
+                          ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          );
+        },
+        child: const Text('Open editor'),
+      ),
+    ),
+  );
 }

--- a/test/widget/sftp_screen_test.dart
+++ b/test/widget/sftp_screen_test.dart
@@ -3,74 +3,88 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/presentation/screens/sftp_screen.dart';
 
 void main() {
-  group('currentLinePrefixAtTextOffset', () {
-    test('returns the current line prefix for a multiline selection', () {
-      expect(currentLinePrefixAtTextOffset('alpha\nbeta\ngamma', 10), 'beta');
+  group('measureMaxLineWidth', () {
+    test('returns zero for empty text', () {
+      expect(
+        measureMaxLineWidth(
+          text: '',
+          style: const TextStyle(),
+          textDirection: TextDirection.ltr,
+          textScaler: TextScaler.noScaling,
+        ),
+        0,
+      );
     });
 
-    test('returns empty string at offset zero', () {
-      expect(currentLinePrefixAtTextOffset('hello', 0), '');
-    });
-
-    test('returns empty string for negative offset', () {
-      expect(currentLinePrefixAtTextOffset('hello', -1), '');
+    test('returns width of the widest line plus slack', () {
+      final width = measureMaxLineWidth(
+        text: 'short\na somewhat longer line\nhi',
+        style: const TextStyle(),
+        textDirection: TextDirection.ltr,
+        textScaler: TextScaler.noScaling,
+      );
+      // Should be > 0 and include trailing slack.
+      expect(width, greaterThan(0));
     });
   });
 
-  group('resolveUnwrappedEditorSelectionScrollOffset', () {
-    test('scrolls right when the caret moves beyond the viewport', () {
+  group('measureCaretX', () {
+    test('returns zero at offset zero', () {
       expect(
-        resolveUnwrappedEditorSelectionScrollOffset(
-          text: '0123456789',
-          selection: const TextSelection.collapsed(offset: 10),
+        measureCaretX(
+          text: 'hello',
+          offset: 0,
           style: const TextStyle(),
           textDirection: TextDirection.ltr,
           textScaler: TextScaler.noScaling,
-          viewportWidth: 40,
-          trailingSlack: 5,
-          measureLineWidth: (line, _) => (line.length * 10).toDouble(),
         ),
-        65,
+        0,
       );
     });
 
-    test('scrolls left when the caret moves before the viewport', () {
+    test('returns zero for negative offset', () {
       expect(
-        resolveUnwrappedEditorSelectionScrollOffset(
-          text: '0123456789',
-          selection: const TextSelection.collapsed(offset: 2),
+        measureCaretX(
+          text: 'hello',
+          offset: -5,
           style: const TextStyle(),
           textDirection: TextDirection.ltr,
           textScaler: TextScaler.noScaling,
-          viewportWidth: 40,
-          currentOffset: 70,
-          trailingSlack: 5,
-          measureLineWidth: (line, _) => (line.length * 10).toDouble(),
         ),
-        15,
+        0,
       );
     });
 
-    test('returns currentOffset when selection offset is zero', () {
+    test('returns non-zero for mid-line offset', () {
       expect(
-        resolveUnwrappedEditorSelectionScrollOffset(
-          text: '0123456789',
-          selection: const TextSelection.collapsed(offset: 0),
+        measureCaretX(
+          text: 'hello world',
+          offset: 5,
           style: const TextStyle(),
           textDirection: TextDirection.ltr,
           textScaler: TextScaler.noScaling,
-          viewportWidth: 40,
-          trailingSlack: 5,
-          measureLineWidth: (line, _) => (line.length * 10).toDouble(),
+        ),
+        greaterThan(0),
+      );
+    });
+
+    test('resets at start of a new line', () {
+      expect(
+        measureCaretX(
+          text: 'hello\nworld',
+          offset: 6,
+          style: const TextStyle(),
+          textDirection: TextDirection.ltr,
+          textScaler: TextScaler.noScaling,
         ),
         0,
       );
     });
   });
 
-  group('buildRemoteTextEditorScreenForTesting', () {
+  group('Remote text editor widget', () {
     testWidgets(
-      'keeps the nowrap viewport fixed while scrolling the selection into view',
+      'nowrap viewport stays fixed while scrolling selection into view',
       (tester) async {
         final longLine = List<String>.filled(80, '0123456789').join();
         final controller = TextEditingController(text: longLine)
@@ -103,15 +117,13 @@ void main() {
                 ),
               )
               .width,
-          closeTo(372, 0.1),
+          greaterThan(300),
         );
         expect(horizontalScrollController.offset, greaterThan(0));
       },
     );
 
-    testWidgets('caret-following works when selection starts at offset zero', (
-      tester,
-    ) async {
+    testWidgets('caret-following works from offset zero', (tester) async {
       final longLine = List<String>.filled(80, '0123456789').join();
       final controller = TextEditingController(text: longLine)
         ..selection = const TextSelection.collapsed(offset: 0);
@@ -135,112 +147,160 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Offset 0 — no horizontal scroll needed yet.
       expect(horizontalScrollController.offset, 0);
 
-      // Move cursor to end; caret-following should scroll.
       controller.selection = TextSelection.collapsed(offset: longLine.length);
       await tester.pumpAndSettle();
       expect(horizontalScrollController.offset, greaterThan(0));
     });
 
-    testWidgets(
-      'keeps long nowrap text visible when opened after a bottom sheet closes',
-      (tester) async {
-        final longLine = List<String>.filled(80, '0123456789').join();
-        final controller = TextEditingController(text: longLine)
-          ..selection = TextSelection.collapsed(offset: longLine.length);
-        final horizontalScrollController = ScrollController();
+    testWidgets('works after bottom sheet dismissal', (tester) async {
+      final longLine = List<String>.filled(80, '0123456789').join();
+      final controller = TextEditingController(text: longLine)
+        ..selection = TextSelection.collapsed(offset: longLine.length);
+      final horizontalScrollController = ScrollController();
 
-        addTearDown(() async {
-          await tester.binding.setSurfaceSize(null);
-          horizontalScrollController.dispose();
-          controller.dispose();
-        });
+      addTearDown(() async {
+        await tester.binding.setSurfaceSize(null);
+        horizontalScrollController.dispose();
+        controller.dispose();
+      });
 
-        await tester.binding.setSurfaceSize(const Size(420, 720));
-        await tester.pumpWidget(
-          MaterialApp(
-            home: _BottomSheetEditorLauncher(
-              controller: controller,
-              horizontalScrollController: horizontalScrollController,
-            ),
+      await tester.binding.setSurfaceSize(const Size(420, 720));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _BottomSheetEditorLauncher(
+            controller: controller,
+            horizontalScrollController: horizontalScrollController,
           ),
-        );
+        ),
+      );
 
-        await tester.tap(find.text('Open editor'));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('Edit'));
-        await tester.pumpAndSettle();
+      await tester.tap(find.text('Open editor'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Edit'));
+      await tester.pumpAndSettle();
 
-        expect(find.text('Edit notes.txt'), findsOneWidget);
-        expect(horizontalScrollController.offset, greaterThan(0));
-      },
-    );
+      expect(find.text('Edit notes.txt'), findsOneWidget);
+      expect(horizontalScrollController.offset, greaterThan(0));
+    });
 
-    testWidgets(
-      'opens without error when controller has no explicit selection',
-      (tester) async {
-        // Real app flow: TextEditingController(text: content) without setting
-        // selection — default is TextSelection.collapsed(offset: -1).
-        final controller = TextEditingController(
-          text: List<String>.filled(80, '0123456789').join(),
-        );
-        final horizontalScrollController = ScrollController();
+    testWidgets('opens without error with no explicit selection', (
+      tester,
+    ) async {
+      final controller = TextEditingController(
+        text: List<String>.filled(80, '0123456789').join(),
+      );
+      final horizontalScrollController = ScrollController();
 
-        addTearDown(() async {
-          await tester.binding.setSurfaceSize(null);
-          horizontalScrollController.dispose();
-          controller.dispose();
-        });
+      addTearDown(() async {
+        await tester.binding.setSurfaceSize(null);
+        horizontalScrollController.dispose();
+        controller.dispose();
+      });
 
-        await tester.binding.setSurfaceSize(const Size(420, 720));
-        await tester.pumpWidget(
-          MaterialApp(
-            home: buildRemoteTextEditorScreenForTesting(
-              fileName: 'notes.txt',
-              controller: controller,
-              horizontalScrollController: horizontalScrollController,
-            ),
+      await tester.binding.setSurfaceSize(const Size(420, 720));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: buildRemoteTextEditorScreenForTesting(
+            fileName: 'notes.txt',
+            controller: controller,
+            horizontalScrollController: horizontalScrollController,
           ),
-        );
-        await tester.pumpAndSettle();
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        // Should render without errors.
-        expect(find.text('Edit notes.txt'), findsOneWidget);
-      },
-    );
+      expect(find.text('Edit notes.txt'), findsOneWidget);
+    });
 
-    testWidgets(
-      'keeps invalid initial selection anchored at the left edge on open',
-      (tester) async {
-        final controller = TextEditingController(
-          text: List<String>.filled(80, '0123456789').join(),
-        );
-        final horizontalScrollController = ScrollController();
+    testWidgets('anchors at left edge with invalid initial selection', (
+      tester,
+    ) async {
+      final controller = TextEditingController(
+        text: List<String>.filled(80, '0123456789').join(),
+      );
+      final horizontalScrollController = ScrollController();
 
-        addTearDown(() async {
-          await tester.binding.setSurfaceSize(null);
-          horizontalScrollController.dispose();
-          controller.dispose();
-        });
+      addTearDown(() async {
+        await tester.binding.setSurfaceSize(null);
+        horizontalScrollController.dispose();
+        controller.dispose();
+      });
 
-        await tester.binding.setSurfaceSize(const Size(420, 720));
-        await tester.pumpWidget(
-          MaterialApp(
-            home: buildRemoteTextEditorScreenForTesting(
-              fileName: 'notes.txt',
-              controller: controller,
-              horizontalScrollController: horizontalScrollController,
-            ),
+      await tester.binding.setSurfaceSize(const Size(420, 720));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: buildRemoteTextEditorScreenForTesting(
+            fileName: 'notes.txt',
+            controller: controller,
+            horizontalScrollController: horizontalScrollController,
           ),
-        );
-        await tester.pumpAndSettle();
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        expect(controller.selection, const TextSelection.collapsed(offset: 0));
-        expect(horizontalScrollController.offset, 0);
-      },
-    );
+      expect(controller.selection, const TextSelection.collapsed(offset: 0));
+      expect(horizontalScrollController.offset, 0);
+    });
+
+    testWidgets('shows cursor position in status bar', (tester) async {
+      final controller = TextEditingController(text: 'hello\nworld\nfoo')
+        ..selection = const TextSelection.collapsed(offset: 8);
+      final horizontalScrollController = ScrollController();
+
+      addTearDown(() async {
+        await tester.binding.setSurfaceSize(null);
+        horizontalScrollController.dispose();
+        controller.dispose();
+      });
+
+      await tester.binding.setSurfaceSize(const Size(420, 720));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: buildRemoteTextEditorScreenForTesting(
+            fileName: 'notes.txt',
+            controller: controller,
+            horizontalScrollController: horizontalScrollController,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Offset 8 = 'hello\nwo' → line 2, column 3
+      expect(find.text('Ln 2, Col 3'), findsOneWidget);
+    });
+
+    testWidgets('status bar updates when cursor moves', (tester) async {
+      final controller = TextEditingController(text: 'hello\nworld\nfoo')
+        ..selection = const TextSelection.collapsed(offset: 0);
+      final horizontalScrollController = ScrollController();
+
+      addTearDown(() async {
+        await tester.binding.setSurfaceSize(null);
+        horizontalScrollController.dispose();
+        controller.dispose();
+      });
+
+      await tester.binding.setSurfaceSize(const Size(420, 720));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: buildRemoteTextEditorScreenForTesting(
+            fileName: 'notes.txt',
+            controller: controller,
+            horizontalScrollController: horizontalScrollController,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Ln 1, Col 1'), findsOneWidget);
+
+      // Move cursor to line 3, col 4 (offset 15 = 'hello\nworld\nfoo')
+      controller.selection = const TextSelection.collapsed(offset: 15);
+      await tester.pumpAndSettle();
+      expect(find.text('Ln 3, Col 4'), findsOneWidget);
+    });
   });
 }
 

--- a/test/widget/sftp_screen_test.dart
+++ b/test/widget/sftp_screen_test.dart
@@ -7,6 +7,14 @@ void main() {
     test('returns the current line prefix for a multiline selection', () {
       expect(currentLinePrefixAtTextOffset('alpha\nbeta\ngamma', 10), 'beta');
     });
+
+    test('returns empty string at offset zero', () {
+      expect(currentLinePrefixAtTextOffset('hello', 0), '');
+    });
+
+    test('returns empty string for negative offset', () {
+      expect(currentLinePrefixAtTextOffset('hello', -1), '');
+    });
   });
 
   group('resolveUnwrappedEditorSelectionScrollOffset', () {
@@ -40,6 +48,22 @@ void main() {
           measureLineWidth: (line, _) => (line.length * 10).toDouble(),
         ),
         15,
+      );
+    });
+
+    test('returns currentOffset when selection offset is zero', () {
+      expect(
+        resolveUnwrappedEditorSelectionScrollOffset(
+          text: '0123456789',
+          selection: const TextSelection.collapsed(offset: 0),
+          style: const TextStyle(),
+          textDirection: TextDirection.ltr,
+          textScaler: TextScaler.noScaling,
+          viewportWidth: 40,
+          trailingSlack: 5,
+          measureLineWidth: (line, _) => (line.length * 10).toDouble(),
+        ),
+        0,
       );
     });
   });
@@ -85,6 +109,41 @@ void main() {
       },
     );
 
+    testWidgets('caret-following works when selection starts at offset zero', (
+      tester,
+    ) async {
+      final longLine = List<String>.filled(80, '0123456789').join();
+      final controller = TextEditingController(text: longLine)
+        ..selection = const TextSelection.collapsed(offset: 0);
+      final horizontalScrollController = ScrollController();
+
+      addTearDown(() async {
+        await tester.binding.setSurfaceSize(null);
+        horizontalScrollController.dispose();
+        controller.dispose();
+      });
+
+      await tester.binding.setSurfaceSize(const Size(420, 720));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: buildRemoteTextEditorScreenForTesting(
+            fileName: 'notes.txt',
+            controller: controller,
+            horizontalScrollController: horizontalScrollController,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Offset 0 — no horizontal scroll needed yet.
+      expect(horizontalScrollController.offset, 0);
+
+      // Move cursor to end; caret-following should scroll.
+      controller.selection = TextSelection.collapsed(offset: longLine.length);
+      await tester.pumpAndSettle();
+      expect(horizontalScrollController.offset, greaterThan(0));
+    });
+
     testWidgets(
       'keeps long nowrap text visible when opened after a bottom sheet closes',
       (tester) async {
@@ -116,6 +175,39 @@ void main() {
 
         expect(find.text('Edit notes.txt'), findsOneWidget);
         expect(horizontalScrollController.offset, greaterThan(0));
+      },
+    );
+
+    testWidgets(
+      'opens without error when controller has no explicit selection',
+      (tester) async {
+        // Real app flow: TextEditingController(text: content) without setting
+        // selection — default is TextSelection.collapsed(offset: -1).
+        final controller = TextEditingController(
+          text: List<String>.filled(80, '0123456789').join(),
+        );
+        final horizontalScrollController = ScrollController();
+
+        addTearDown(() async {
+          await tester.binding.setSurfaceSize(null);
+          horizontalScrollController.dispose();
+          controller.dispose();
+        });
+
+        await tester.binding.setSurfaceSize(const Size(420, 720));
+        await tester.pumpWidget(
+          MaterialApp(
+            home: buildRemoteTextEditorScreenForTesting(
+              fileName: 'notes.txt',
+              controller: controller,
+              horizontalScrollController: horizontalScrollController,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Should render without errors.
+        expect(find.text('Edit notes.txt'), findsOneWidget);
       },
     );
   });


### PR DESCRIPTION
## Summary

- harden the SFTP no-wrap editor in the real in-app browser flow
- wait for the file-options bottom sheet to dismiss before pushing the editor route
- retry and focus-sync the initial horizontal scroll until the editor viewport is attached
- add regression coverage for the bottom-sheet-to-editor timing path

## Validation

- `dart format .`
- `flutter analyze`
- `flutter test`
- validated the real SFTP browser/editor flow on the iPhone simulator with a temporary local SFTP server harness
