### PR TITLE
feat: add large-screen split views for hosts, connections, and files

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -303,7 +303,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         ),
       ],
     ),
-    body: _buildContent(),
+    body: _buildContent(preserveState: true),
     bottomNavigationBar: NavigationBar(
       selectedIndex: _selectedIndex,
       onDestinationSelected: (index) => setState(() => _selectedIndex = index),
@@ -435,7 +435,19 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     );
   }
 
-  Widget _buildContent() {
+  Widget _buildContent({bool preserveState = false}) {
+    if (preserveState) {
+      return IndexedStack(
+        index: _selectedIndex,
+        children: const [
+          _HostsPanel(),
+          _ConnectionsPanel(),
+          _KeysPanel(),
+          _SnippetsPanel(),
+        ],
+      );
+    }
+
     switch (_selectedIndex) {
       case 0:
         return const _HostsPanel();
@@ -588,6 +600,8 @@ class _HostsPanelState extends ConsumerState<_HostsPanel> {
                       Expanded(
                         child: _EmbeddedTerminalDetailPane(
                           target: _selectedTerminalTarget,
+                          onDisconnectRequested: () =>
+                              setState(() => _selectedTerminalTarget = null),
                           emptyTitle:
                               'Connect to a host to open the live terminal here.',
                           emptySubtitle:
@@ -901,6 +915,14 @@ class _HostRow extends ConsumerWidget {
     }
 
     if (connectionIds.length == 1) {
+      final onShowTerminalDetail = this.onShowTerminalDetail;
+      if (onShowTerminalDetail != null) {
+        onShowTerminalDetail((
+          hostId: host.id,
+          connectionId: connectionIds.first,
+        ));
+        return;
+      }
       if (context.mounted) {
         unawaited(
           context.push(
@@ -1315,6 +1337,10 @@ class _ConnectionsPanelState extends ConsumerState<_ConnectionsPanel> {
                                 hostId: detailConnection.hostId,
                                 connectionId: detailConnection.connectionId,
                               ),
+                        onDisconnectRequested: detailConnection == null
+                            ? null
+                            : () =>
+                                  setState(() => _selectedConnectionId = null),
                         emptyTitle:
                             'Select a connection to open the live terminal here.',
                         emptySubtitle:
@@ -1450,11 +1476,13 @@ class _EmbeddedTerminalDetailPane extends StatelessWidget {
     required this.target,
     required this.emptyTitle,
     required this.emptySubtitle,
+    this.onDisconnectRequested,
   });
 
   final _TerminalDetailTarget? target;
   final String emptyTitle;
   final String emptySubtitle;
+  final VoidCallback? onDisconnectRequested;
 
   @override
   Widget build(BuildContext context) {
@@ -1493,6 +1521,7 @@ class _EmbeddedTerminalDetailPane extends StatelessWidget {
       key: ValueKey<String>('detail-terminal-${target.connectionId}'),
       hostId: target.hostId,
       connectionId: target.connectionId,
+      onDisconnectRequested: onDisconnectRequested,
     );
   }
 }

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -537,8 +537,7 @@ class _HostsPanelState extends ConsumerState<_HostsPanel> {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final hostsAsync = ref.watch(allHostsProvider);
-    final useMasterDetail = shouldUseIpadLandscapeMasterDetail(
-      platform: theme.platform,
+    final useMasterDetail = shouldUseLargeScreenMasterDetail(
       orientation: MediaQuery.of(context).orientation,
       screenSize: MediaQuery.of(context).size,
     );
@@ -584,8 +583,8 @@ class _HostsPanelState extends ConsumerState<_HostsPanel> {
                 : useMasterDetail
                 ? Row(
                     children: [
-                      SizedBox(
-                        width: 380,
+                      Expanded(
+                        flex: 5,
                         child: _buildHostsList(
                           context,
                           ref,
@@ -598,6 +597,7 @@ class _HostsPanelState extends ConsumerState<_HostsPanel> {
                         color: colorScheme.outline.withAlpha(50),
                       ),
                       Expanded(
+                        flex: 7,
                         child: _EmbeddedTerminalDetailPane(
                           target: _selectedTerminalTarget,
                           onDisconnectRequested: () =>
@@ -1265,8 +1265,7 @@ class _ConnectionsPanelState extends ConsumerState<_ConnectionsPanel> {
     final connections = sessionsNotifier.getActiveConnections();
     final hosts = hostsAsync.asData?.value ?? <Host>[];
     final hostLookup = {for (final host in hosts) host.id: host};
-    final useMasterDetail = shouldUseIpadLandscapeMasterDetail(
-      platform: theme.platform,
+    final useMasterDetail = shouldUseLargeScreenMasterDetail(
       orientation: MediaQuery.of(context).orientation,
       screenSize: MediaQuery.of(context).size,
     );
@@ -1312,8 +1311,8 @@ class _ConnectionsPanelState extends ConsumerState<_ConnectionsPanel> {
               : useMasterDetail
               ? Row(
                   children: [
-                    SizedBox(
-                      width: 360,
+                    Expanded(
+                      flex: 4,
                       child: _buildConnectionsList(
                         context,
                         connections,
@@ -1330,6 +1329,7 @@ class _ConnectionsPanelState extends ConsumerState<_ConnectionsPanel> {
                       color: colorScheme.outline.withAlpha(50),
                     ),
                     Expanded(
+                      flex: 7,
                       child: _EmbeddedTerminalDetailPane(
                         target: detailConnection == null
                             ? null
@@ -1522,6 +1522,7 @@ class _EmbeddedTerminalDetailPane extends StatelessWidget {
       hostId: target.hostId,
       connectionId: target.connectionId,
       onDisconnectRequested: onDisconnectRequested,
+      showAppBar: false,
     );
   }
 }

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -23,6 +23,7 @@ import '../../domain/services/transfer_intent_service.dart';
 import '../providers/entity_list_providers.dart';
 import '../widgets/connection_attempt_dialog.dart';
 import '../widgets/connection_preview_snippet.dart';
+import '../widgets/ipad_landscape_layout.dart';
 import 'transfer_screen.dart';
 
 /// The main home screen - Termius-style sidebar layout.
@@ -1082,11 +1083,18 @@ class _ConnectionSelectionTile extends StatelessWidget {
   }
 }
 
-class _ConnectionsPanel extends ConsumerWidget {
+class _ConnectionsPanel extends ConsumerStatefulWidget {
   const _ConnectionsPanel();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_ConnectionsPanel> createState() => _ConnectionsPanelState();
+}
+
+class _ConnectionsPanelState extends ConsumerState<_ConnectionsPanel> {
+  int? _selectedConnectionId;
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final hostsAsync = ref.watch(allHostsProvider);
@@ -1099,6 +1107,29 @@ class _ConnectionsPanel extends ConsumerWidget {
     final connections = sessionsNotifier.getActiveConnections();
     final hosts = hostsAsync.asData?.value ?? <Host>[];
     final hostLookup = {for (final host in hosts) host.id: host};
+    final useMasterDetail = shouldUseIpadLandscapeMasterDetail(
+      platform: theme.platform,
+      orientation: MediaQuery.of(context).orientation,
+      screenSize: MediaQuery.of(context).size,
+    );
+    final selectedConnectionId =
+        connections.any(
+          (connection) => connection.connectionId == _selectedConnectionId,
+        )
+        ? _selectedConnectionId
+        : connections.isEmpty
+        ? null
+        : connections.first.connectionId;
+    ActiveConnection? selectedConnection;
+    if (selectedConnectionId != null) {
+      for (final connection in connections) {
+        if (connection.connectionId == selectedConnectionId) {
+          selectedConnection = connection;
+          break;
+        }
+      }
+    }
+    final detailConnection = selectedConnection;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -1120,73 +1151,165 @@ class _ConnectionsPanel extends ConsumerWidget {
         Expanded(
           child: connections.isEmpty
               ? _buildEmptyState(context)
-              : ListView.builder(
-                  padding: const EdgeInsets.symmetric(vertical: 4),
-                  itemCount: connections.length,
-                  itemBuilder: (context, index) {
-                    final connection = connections[index];
-                    final host = hostLookup[connection.hostId];
-                    final state =
-                        connectionStates[connection.connectionId] ??
-                        connection.state;
-                    final endpoint =
-                        '${connection.config.username}@'
-                        '${connection.config.hostname}:${connection.config.port}';
-                    final preview = connection.preview;
-                    final previewTheme = resolveConnectionPreviewTheme(
-                      brightness: theme.brightness,
-                      themeSettings: terminalThemeSettings,
-                      availableThemes: terminalThemes,
-                      lightThemeId:
-                          connection.terminalThemeLightId ??
-                          host?.terminalThemeLightId,
-                      darkThemeId:
-                          connection.terminalThemeDarkId ??
-                          host?.terminalThemeDarkId,
-                    );
-
-                    return ListTile(
-                      leading: Icon(
-                        Icons.terminal,
-                        color: state == SshConnectionState.connected
-                            ? colorScheme.primary
-                            : colorScheme.onSurfaceVariant,
+              : useMasterDetail
+              ? Row(
+                  children: [
+                    SizedBox(
+                      width: 360,
+                      child: _buildConnectionsList(
+                        context,
+                        connections,
+                        hostLookup,
+                        connectionStates,
+                        terminalThemeSettings,
+                        terminalThemes,
+                        selectedConnectionId: selectedConnectionId,
+                        useMasterDetail: true,
                       ),
-                      title: Text(host?.label ?? 'Host ${connection.hostId}'),
-                      subtitle: _ConnectionPreviewText(
-                        endpoint:
-                            '$endpoint  •  Connection #${connection.connectionId}',
-                        preview: preview,
-                        windowTitle: connection.windowTitle,
-                        iconName: connection.iconName,
-                        workingDirectory: connection.workingDirectory,
-                        shellStatus: connection.shellStatus,
-                        lastExitCode: connection.lastExitCode,
-                        terminalTheme: previewTheme,
+                    ),
+                    VerticalDivider(
+                      width: 1,
+                      color: colorScheme.outline.withAlpha(50),
+                    ),
+                    Expanded(
+                      child: _ConnectionDetailPane(
+                        connection: detailConnection,
+                        host: detailConnection == null
+                            ? null
+                            : hostLookup[detailConnection.hostId],
+                        state: detailConnection == null
+                            ? null
+                            : connectionStates[detailConnection.connectionId] ??
+                                  detailConnection.state,
+                        previewTheme: detailConnection == null
+                            ? null
+                            : resolveConnectionPreviewTheme(
+                                brightness: theme.brightness,
+                                themeSettings: terminalThemeSettings,
+                                availableThemes: terminalThemes,
+                                lightThemeId:
+                                    detailConnection.terminalThemeLightId ??
+                                    hostLookup[detailConnection.hostId]
+                                        ?.terminalThemeLightId,
+                                darkThemeId:
+                                    detailConnection.terminalThemeDarkId ??
+                                    hostLookup[detailConnection.hostId]
+                                        ?.terminalThemeDarkId,
+                              ),
+                        onOpenTerminal: detailConnection == null
+                            ? null
+                            : () => unawaited(
+                                context.push(
+                                  '/terminal/${detailConnection.hostId}'
+                                  '?connectionId=${detailConnection.connectionId}',
+                                ),
+                              ),
+                        onOpenFiles: detailConnection == null
+                            ? null
+                            : () => unawaited(
+                                context.push(
+                                  '/sftp/${detailConnection.hostId}'
+                                  '?connectionId=${detailConnection.connectionId}',
+                                ),
+                              ),
+                        onDisconnect: detailConnection == null
+                            ? null
+                            : () => ref
+                                  .read(activeSessionsProvider.notifier)
+                                  .disconnect(detailConnection.connectionId),
                       ),
-                      isThreeLine: preview?.trim().isNotEmpty ?? false,
-                      trailing: IconButton(
-                        icon: const Icon(Icons.close),
-                        tooltip: 'Disconnect',
-                        onPressed: () async {
-                          await ref
-                              .read(activeSessionsProvider.notifier)
-                              .disconnect(connection.connectionId);
-                        },
-                      ),
-                      onTap: () => unawaited(
-                        context.push(
-                          '/terminal/${connection.hostId}'
-                          '?connectionId=${connection.connectionId}',
-                        ),
-                      ),
-                    );
-                  },
+                    ),
+                  ],
+                )
+              : _buildConnectionsList(
+                  context,
+                  connections,
+                  hostLookup,
+                  connectionStates,
+                  terminalThemeSettings,
+                  terminalThemes,
+                  selectedConnectionId: selectedConnectionId,
+                  useMasterDetail: false,
                 ),
         ),
       ],
     );
   }
+
+  Widget _buildConnectionsList(
+    BuildContext context,
+    List<ActiveConnection> connections,
+    Map<int, Host> hostLookup,
+    Map<int, SshConnectionState> connectionStates,
+    TerminalThemeSettings terminalThemeSettings,
+    List<TerminalThemeData> terminalThemes, {
+    required int? selectedConnectionId,
+    required bool useMasterDetail,
+  }) => ListView.builder(
+    padding: const EdgeInsets.symmetric(vertical: 4),
+    itemCount: connections.length,
+    itemBuilder: (context, index) {
+      final connection = connections[index];
+      final host = hostLookup[connection.hostId];
+      final state =
+          connectionStates[connection.connectionId] ?? connection.state;
+      final endpoint =
+          '${connection.config.username}@'
+          '${connection.config.hostname}:${connection.config.port}';
+      final preview = connection.preview;
+      final previewTheme = resolveConnectionPreviewTheme(
+        brightness: Theme.of(context).brightness,
+        themeSettings: terminalThemeSettings,
+        availableThemes: terminalThemes,
+        lightThemeId:
+            connection.terminalThemeLightId ?? host?.terminalThemeLightId,
+        darkThemeId:
+            connection.terminalThemeDarkId ?? host?.terminalThemeDarkId,
+      );
+
+      return ListTile(
+        selected:
+            useMasterDetail && connection.connectionId == selectedConnectionId,
+        leading: Icon(
+          Icons.terminal,
+          color: state == SshConnectionState.connected
+              ? Theme.of(context).colorScheme.primary
+              : Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+        title: Text(host?.label ?? 'Host ${connection.hostId}'),
+        subtitle: _ConnectionPreviewText(
+          endpoint: '$endpoint  •  Connection #${connection.connectionId}',
+          preview: preview,
+          windowTitle: connection.windowTitle,
+          iconName: connection.iconName,
+          workingDirectory: connection.workingDirectory,
+          shellStatus: connection.shellStatus,
+          lastExitCode: connection.lastExitCode,
+          terminalTheme: previewTheme,
+        ),
+        isThreeLine: preview?.trim().isNotEmpty ?? false,
+        trailing: IconButton(
+          icon: const Icon(Icons.close),
+          tooltip: 'Disconnect',
+          onPressed: () async {
+            await ref
+                .read(activeSessionsProvider.notifier)
+                .disconnect(connection.connectionId);
+          },
+        ),
+        onTap: useMasterDetail
+            ? () => setState(
+                () => _selectedConnectionId = connection.connectionId,
+              )
+            : () => unawaited(
+                context.push(
+                  '/terminal/${connection.hostId}'
+                  '?connectionId=${connection.connectionId}',
+                ),
+              ),
+      );
+    },
+  );
 
   Widget _buildEmptyState(BuildContext context) {
     final theme = Theme.of(context);
@@ -1212,6 +1335,146 @@ class _ConnectionsPanel extends ConsumerWidget {
             'Open a host to create one',
             style: theme.textTheme.bodySmall?.copyWith(
               color: colorScheme.onSurface.withAlpha(100),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ConnectionDetailPane extends StatelessWidget {
+  const _ConnectionDetailPane({
+    required this.connection,
+    required this.host,
+    required this.state,
+    required this.previewTheme,
+    required this.onOpenTerminal,
+    required this.onOpenFiles,
+    required this.onDisconnect,
+  });
+
+  final ActiveConnection? connection;
+  final Host? host;
+  final SshConnectionState? state;
+  final TerminalThemeData? previewTheme;
+  final VoidCallback? onOpenTerminal;
+  final VoidCallback? onOpenFiles;
+  final Future<void> Function()? onDisconnect;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    if (connection == null) {
+      return Center(
+        child: Text(
+          'Select a connection to open it or browse its files.',
+          style: theme.textTheme.bodyLarge?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      );
+    }
+
+    final endpoint =
+        '${connection!.config.username}@'
+        '${connection!.config.hostname}:${connection!.config.port}';
+
+    return Padding(
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            host?.label ?? 'Host ${connection!.hostId}',
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '$endpoint  •  Connection #${connection!.connectionId}',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              FilledButton.icon(
+                onPressed: onOpenTerminal,
+                icon: const Icon(Icons.open_in_new),
+                label: const Text('Open terminal'),
+              ),
+              OutlinedButton.icon(
+                onPressed: onOpenFiles,
+                icon: const Icon(Icons.folder_open),
+                label: const Text('Browse files'),
+              ),
+              OutlinedButton.icon(
+                onPressed: onDisconnect == null
+                    ? null
+                    : () => unawaited(onDisconnect!.call()),
+                icon: const Icon(Icons.link_off),
+                label: const Text('Disconnect'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: colorScheme.surfaceContainerLow,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(color: colorScheme.outlineVariant),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Status',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(switch (state) {
+                  SshConnectionState.connected => 'Connected',
+                  SshConnectionState.connecting => 'Connecting',
+                  SshConnectionState.authenticating => 'Authenticating',
+                  SshConnectionState.disconnected => 'Disconnected',
+                  SshConnectionState.reconnecting => 'Reconnecting',
+                  SshConnectionState.error => 'Error',
+                  null => 'Unknown',
+                }, style: theme.textTheme.bodyMedium),
+              ],
+            ),
+          ),
+          const SizedBox(height: 20),
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(16),
+              child: ColoredBox(
+                color: colorScheme.surfaceContainerLowest,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: ConnectionPreviewSnippet(
+                    endpoint: endpoint,
+                    preview: connection!.preview,
+                    windowTitle: connection!.windowTitle,
+                    iconName: connection!.iconName,
+                    workingDirectory: connection!.workingDirectory,
+                    shellStatus: connection!.shellStatus,
+                    lastExitCode: connection!.lastExitCode,
+                    terminalTheme: previewTheme,
+                  ),
+                ),
+              ),
             ),
           ),
         ],

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -24,7 +24,10 @@ import '../providers/entity_list_providers.dart';
 import '../widgets/connection_attempt_dialog.dart';
 import '../widgets/connection_preview_snippet.dart';
 import '../widgets/ipad_landscape_layout.dart';
+import 'terminal_screen.dart';
 import 'transfer_screen.dart';
+
+typedef _TerminalDetailTarget = ({int hostId, int connectionId});
 
 /// The main home screen - Termius-style sidebar layout.
 class HomeScreen extends ConsumerStatefulWidget {
@@ -206,13 +209,77 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
   @override
   Widget build(BuildContext context) {
-    final screenWidth = MediaQuery.of(context).size.width;
+    final mediaQuery = MediaQuery.of(context);
+    final screenWidth = mediaQuery.size.width;
     final isWide = screenWidth >= _mobileBreakpoint;
+    final useIpadLandscapeLayout = shouldUseIpadLandscapeMasterDetail(
+      platform: Theme.of(context).platform,
+      orientation: mediaQuery.orientation,
+      screenSize: mediaQuery.size,
+    );
 
+    if (useIpadLandscapeLayout) {
+      return _buildIpadLandscapeLayout();
+    }
     return isWide ? _buildDesktopLayout() : _buildMobileLayout();
   }
 
   Widget _buildMobileLayout() => Scaffold(
+    appBar: AppBar(
+      title: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(6),
+            child: Image.asset(
+              'assets/icons/monkeyssh_icon.png',
+              width: 28,
+              height: 28,
+            ),
+          ),
+          const SizedBox(width: 8),
+          const Text('MonkeySSH'),
+        ],
+      ),
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.settings_outlined),
+          onPressed: () => context.push('/settings'),
+        ),
+      ],
+    ),
+    body: _buildContent(),
+    bottomNavigationBar: NavigationBar(
+      selectedIndex: _selectedIndex,
+      onDestinationSelected: (index) => setState(() => _selectedIndex = index),
+      labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
+      height: 65,
+      destinations: const [
+        NavigationDestination(
+          icon: Icon(Icons.dns_outlined),
+          selectedIcon: Icon(Icons.dns_rounded),
+          label: 'Hosts',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.link_outlined),
+          selectedIcon: Icon(Icons.link),
+          label: 'Connections',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.key_outlined),
+          selectedIcon: Icon(Icons.key_rounded),
+          label: 'Keys',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.code_outlined),
+          selectedIcon: Icon(Icons.code_rounded),
+          label: 'Snippets',
+        ),
+      ],
+    ),
+  );
+
+  Widget _buildIpadLandscapeLayout() => Scaffold(
     appBar: AppBar(
       title: Row(
         mainAxisSize: MainAxisSize.min,
@@ -443,14 +510,26 @@ class _NavItem extends StatelessWidget {
   }
 }
 
-class _HostsPanel extends ConsumerWidget {
+class _HostsPanel extends ConsumerStatefulWidget {
   const _HostsPanel();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_HostsPanel> createState() => _HostsPanelState();
+}
+
+class _HostsPanelState extends ConsumerState<_HostsPanel> {
+  _TerminalDetailTarget? _selectedTerminalTarget;
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final hostsAsync = ref.watch(allHostsProvider);
+    final useMasterDetail = shouldUseIpadLandscapeMasterDetail(
+      platform: theme.platform,
+      orientation: MediaQuery.of(context).orientation,
+      screenSize: MediaQuery.of(context).size,
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -490,7 +569,34 @@ class _HostsPanel extends ConsumerWidget {
             error: (e, _) => Center(child: Text('Error: $e')),
             data: (hosts) => hosts.isEmpty
                 ? _buildEmptyState(context)
-                : _buildHostsList(context, ref, hosts),
+                : useMasterDetail
+                ? Row(
+                    children: [
+                      SizedBox(
+                        width: 380,
+                        child: _buildHostsList(
+                          context,
+                          ref,
+                          hosts,
+                          useMasterDetail: true,
+                        ),
+                      ),
+                      VerticalDivider(
+                        width: 1,
+                        color: colorScheme.outline.withAlpha(50),
+                      ),
+                      Expanded(
+                        child: _EmbeddedTerminalDetailPane(
+                          target: _selectedTerminalTarget,
+                          emptyTitle:
+                              'Connect to a host to open the live terminal here.',
+                          emptySubtitle:
+                              'Use the host row or add-connection button to launch a session in the detail pane.',
+                        ),
+                      ),
+                    ],
+                  )
+                : _buildHostsList(context, ref, hosts, useMasterDetail: false),
           ),
         ),
       ],
@@ -538,21 +644,35 @@ class _HostsPanel extends ConsumerWidget {
   Widget _buildHostsList(
     BuildContext context,
     WidgetRef ref,
-    List<Host> hosts,
-  ) => ListView.builder(
+    List<Host> hosts, {
+    required bool useMasterDetail,
+  }) => ListView.builder(
     padding: const EdgeInsets.symmetric(vertical: 4),
     itemCount: hosts.length,
     itemBuilder: (context, index) {
       final host = hosts[index];
-      return _HostRow(host: host);
+      return _HostRow(
+        host: host,
+        isSelected:
+            useMasterDetail && _selectedTerminalTarget?.hostId == host.id,
+        onShowTerminalDetail: useMasterDetail
+            ? (target) => setState(() => _selectedTerminalTarget = target)
+            : null,
+      );
     },
   );
 }
 
 class _HostRow extends ConsumerWidget {
-  const _HostRow({required this.host});
+  const _HostRow({
+    required this.host,
+    this.isSelected = false,
+    this.onShowTerminalDetail,
+  });
 
   final Host host;
+  final bool isSelected;
+  final void Function(_TerminalDetailTarget target)? onShowTerminalDetail;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -609,7 +729,9 @@ class _HostRow extends ConsumerWidget {
         .toList(growable: false);
 
     return Material(
-      color: Colors.transparent,
+      color: isSelected
+          ? colorScheme.primaryContainer.withAlpha(80)
+          : Colors.transparent,
       child: InkWell(
         onTap: () => unawaited(_openHostConnection(context, ref)),
         child: Container(
@@ -862,6 +984,11 @@ class _HostRow extends ConsumerWidget {
 
     final selectedId = int.tryParse(selection.replaceFirst('connection:', ''));
     if (selectedId != null) {
+      final onShowTerminalDetail = this.onShowTerminalDetail;
+      if (onShowTerminalDetail != null) {
+        onShowTerminalDetail((hostId: host.id, connectionId: selectedId));
+        return;
+      }
       unawaited(context.push('/terminal/${host.id}?connectionId=$selectedId'));
     }
   }
@@ -874,6 +1001,15 @@ class _HostRow extends ConsumerWidget {
     }
 
     if (!result.success || result.connectionId == null) {
+      return;
+    }
+
+    final onShowTerminalDetail = this.onShowTerminalDetail;
+    if (onShowTerminalDetail != null) {
+      onShowTerminalDetail((
+        hostId: host.id,
+        connectionId: result.connectionId!,
+      ));
       return;
     }
 
@@ -1172,51 +1308,17 @@ class _ConnectionsPanelState extends ConsumerState<_ConnectionsPanel> {
                       color: colorScheme.outline.withAlpha(50),
                     ),
                     Expanded(
-                      child: _ConnectionDetailPane(
-                        connection: detailConnection,
-                        host: detailConnection == null
+                      child: _EmbeddedTerminalDetailPane(
+                        target: detailConnection == null
                             ? null
-                            : hostLookup[detailConnection.hostId],
-                        state: detailConnection == null
-                            ? null
-                            : connectionStates[detailConnection.connectionId] ??
-                                  detailConnection.state,
-                        previewTheme: detailConnection == null
-                            ? null
-                            : resolveConnectionPreviewTheme(
-                                brightness: theme.brightness,
-                                themeSettings: terminalThemeSettings,
-                                availableThemes: terminalThemes,
-                                lightThemeId:
-                                    detailConnection.terminalThemeLightId ??
-                                    hostLookup[detailConnection.hostId]
-                                        ?.terminalThemeLightId,
-                                darkThemeId:
-                                    detailConnection.terminalThemeDarkId ??
-                                    hostLookup[detailConnection.hostId]
-                                        ?.terminalThemeDarkId,
+                            : (
+                                hostId: detailConnection.hostId,
+                                connectionId: detailConnection.connectionId,
                               ),
-                        onOpenTerminal: detailConnection == null
-                            ? null
-                            : () => unawaited(
-                                context.push(
-                                  '/terminal/${detailConnection.hostId}'
-                                  '?connectionId=${detailConnection.connectionId}',
-                                ),
-                              ),
-                        onOpenFiles: detailConnection == null
-                            ? null
-                            : () => unawaited(
-                                context.push(
-                                  '/sftp/${detailConnection.hostId}'
-                                  '?connectionId=${detailConnection.connectionId}',
-                                ),
-                              ),
-                        onDisconnect: detailConnection == null
-                            ? null
-                            : () => ref
-                                  .read(activeSessionsProvider.notifier)
-                                  .disconnect(detailConnection.connectionId),
+                        emptyTitle:
+                            'Select a connection to open the live terminal here.',
+                        emptySubtitle:
+                            'The active session stays on the right while you browse connections on the left.',
                       ),
                     ),
                   ],
@@ -1343,142 +1445,54 @@ class _ConnectionsPanelState extends ConsumerState<_ConnectionsPanel> {
   }
 }
 
-class _ConnectionDetailPane extends StatelessWidget {
-  const _ConnectionDetailPane({
-    required this.connection,
-    required this.host,
-    required this.state,
-    required this.previewTheme,
-    required this.onOpenTerminal,
-    required this.onOpenFiles,
-    required this.onDisconnect,
+class _EmbeddedTerminalDetailPane extends StatelessWidget {
+  const _EmbeddedTerminalDetailPane({
+    required this.target,
+    required this.emptyTitle,
+    required this.emptySubtitle,
   });
 
-  final ActiveConnection? connection;
-  final Host? host;
-  final SshConnectionState? state;
-  final TerminalThemeData? previewTheme;
-  final VoidCallback? onOpenTerminal;
-  final VoidCallback? onOpenFiles;
-  final Future<void> Function()? onDisconnect;
+  final _TerminalDetailTarget? target;
+  final String emptyTitle;
+  final String emptySubtitle;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    if (connection == null) {
+    final target = this.target;
+    if (target == null) {
       return Center(
-        child: Text(
-          'Select a connection to open it or browse its files.',
-          style: theme.textTheme.bodyLarge?.copyWith(
-            color: colorScheme.onSurfaceVariant,
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.terminal, size: 72, color: colorScheme.outline),
+              const SizedBox(height: 16),
+              Text(
+                emptyTitle,
+                style: theme.textTheme.titleMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                emptySubtitle,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
           ),
-          textAlign: TextAlign.center,
         ),
       );
     }
 
-    final endpoint =
-        '${connection!.config.username}@'
-        '${connection!.config.hostname}:${connection!.config.port}';
-
-    return Padding(
-      padding: const EdgeInsets.all(20),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            host?.label ?? 'Host ${connection!.hostId}',
-            style: theme.textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            '$endpoint  •  Connection #${connection!.connectionId}',
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: colorScheme.onSurfaceVariant,
-            ),
-          ),
-          const SizedBox(height: 16),
-          Wrap(
-            spacing: 12,
-            runSpacing: 12,
-            children: [
-              FilledButton.icon(
-                onPressed: onOpenTerminal,
-                icon: const Icon(Icons.open_in_new),
-                label: const Text('Open terminal'),
-              ),
-              OutlinedButton.icon(
-                onPressed: onOpenFiles,
-                icon: const Icon(Icons.folder_open),
-                label: const Text('Browse files'),
-              ),
-              OutlinedButton.icon(
-                onPressed: onDisconnect == null
-                    ? null
-                    : () => unawaited(onDisconnect!.call()),
-                icon: const Icon(Icons.link_off),
-                label: const Text('Disconnect'),
-              ),
-            ],
-          ),
-          const SizedBox(height: 20),
-          Container(
-            width: double.infinity,
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: colorScheme.surfaceContainerLow,
-              borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: colorScheme.outlineVariant),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Status',
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Text(switch (state) {
-                  SshConnectionState.connected => 'Connected',
-                  SshConnectionState.connecting => 'Connecting',
-                  SshConnectionState.authenticating => 'Authenticating',
-                  SshConnectionState.disconnected => 'Disconnected',
-                  SshConnectionState.reconnecting => 'Reconnecting',
-                  SshConnectionState.error => 'Error',
-                  null => 'Unknown',
-                }, style: theme.textTheme.bodyMedium),
-              ],
-            ),
-          ),
-          const SizedBox(height: 20),
-          Expanded(
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(16),
-              child: ColoredBox(
-                color: colorScheme.surfaceContainerLowest,
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: ConnectionPreviewSnippet(
-                    endpoint: endpoint,
-                    preview: connection!.preview,
-                    windowTitle: connection!.windowTitle,
-                    iconName: connection!.iconName,
-                    workingDirectory: connection!.workingDirectory,
-                    shellStatus: connection!.shellStatus,
-                    lastExitCode: connection!.lastExitCode,
-                    terminalTheme: previewTheme,
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
+    return TerminalScreen(
+      key: ValueKey<String>('detail-terminal-${target.connectionId}'),
+      hostId: target.hostId,
+      connectionId: target.connectionId,
     );
   }
 }

--- a/lib/presentation/screens/remote_text_editor_screen.dart
+++ b/lib/presentation/screens/remote_text_editor_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -203,7 +204,7 @@ Widget buildRemoteTextEditorScreenForTesting({
   ScrollController? horizontalScrollController,
   TerminalThemeData? terminalTheme,
   Future<void> Function(String text)? onSaveRequested,
-  VoidCallback? onCloseRequested,
+  Future<void> Function()? onCloseRequested,
   String fontFamily = 'monospace',
   double initialFontSize = 14,
 }) => RemoteTextEditorScreen(
@@ -254,7 +255,7 @@ class RemoteTextEditorScreen extends StatefulWidget {
   final Future<void> Function(String text)? onSaveRequested;
 
   /// Called instead of popping the route when the user closes the editor.
-  final VoidCallback? onCloseRequested;
+  final Future<void> Function()? onCloseRequested;
 
   @override
   State<RemoteTextEditorScreen> createState() => _RemoteTextEditorScreenState();
@@ -282,12 +283,15 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
   double? _cachedMeasuredWidthTextScale;
   String? _cachedMeasuredWidthFontFamily;
   double? _cachedMeasuredWidthFontSize;
+  late String _lastSavedText;
+  bool _isSaving = false;
 
   @override
   void initState() {
     super.initState();
     _editorFocusNode = FocusNode();
     _fontSize = clampRemoteEditorFontSize(widget.initialFontSize);
+    _lastSavedText = widget.controller.text;
     _horizontalScrollController =
         widget.horizontalScrollController ?? ScrollController();
     _ownsHorizontalScrollController = widget.horizontalScrollController == null;
@@ -310,6 +314,7 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
       oldWidget.controller.removeListener(_handleControllerChanged);
       _ensureInitialSelectionIsVisibleFromStart(widget.controller);
       widget.controller.addListener(_handleControllerChanged);
+      _lastSavedText = widget.controller.text;
       _cachedText = null;
       _cachedSelection = null;
       _cachedMeasuredWidthText = null;
@@ -360,6 +365,8 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
   int get _lineCount => _cachedLineStartOffsets.length;
 
   ({int line, int column}) get _caretPosition => _cachedCaretPosition;
+
+  bool get _hasUnsavedChanges => widget.controller.text != _lastSavedText;
 
   void _refreshCachedMetrics() {
     final text = widget.controller.text;
@@ -573,6 +580,69 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
     return measuredWidth;
   }
 
+  Future<bool> _confirmDiscardChanges() async {
+    if (!_hasUnsavedChanges || !mounted) {
+      return true;
+    }
+    final discardChanges = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Discard changes?'),
+        content: Text(
+          'You have unsaved changes in "${widget.fileName}". Discard them?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Keep editing'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Discard'),
+          ),
+        ],
+      ),
+    );
+    return discardChanges ?? false;
+  }
+
+  Future<void> _handleCloseRequested() async {
+    if (!await _confirmDiscardChanges() || !mounted) {
+      return;
+    }
+    final onCloseRequested = widget.onCloseRequested;
+    if (onCloseRequested != null) {
+      await onCloseRequested();
+      return;
+    }
+    Navigator.pop(context);
+  }
+
+  Future<void> _handleSaveRequested() async {
+    if (_isSaving) {
+      return;
+    }
+    setState(() => _isSaving = true);
+    try {
+      final onSaveRequested = widget.onSaveRequested;
+      if (onSaveRequested != null) {
+        await onSaveRequested(widget.controller.text);
+        if (mounted) {
+          setState(() => _lastSavedText = widget.controller.text);
+        }
+        return;
+      }
+      if (!mounted) {
+        return;
+      }
+      Navigator.pop(context, widget.controller.text);
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -594,205 +664,206 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
           foregroundColor: colors.foreground,
         ),
       ),
-      child: Scaffold(
-        backgroundColor: colors.background,
-        appBar: AppBar(
-          automaticallyImplyLeading: widget.onCloseRequested == null,
-          leading: widget.onCloseRequested == null
-              ? null
-              : IconButton(
-                  onPressed: widget.onCloseRequested,
-                  icon: const Icon(Icons.close),
-                  tooltip: 'Close editor',
+      child: PopScope(
+        canPop: widget.onCloseRequested != null || !_hasUnsavedChanges,
+        onPopInvokedWithResult: (didPop, _) {
+          if (didPop || widget.onCloseRequested != null) {
+            return;
+          }
+          unawaited(_handleCloseRequested());
+        },
+        child: Scaffold(
+          backgroundColor: colors.background,
+          appBar: AppBar(
+            automaticallyImplyLeading: widget.onCloseRequested == null,
+            leading: widget.onCloseRequested == null
+                ? null
+                : IconButton(
+                    onPressed: _isSaving ? null : _handleCloseRequested,
+                    icon: const Icon(Icons.close),
+                    tooltip: 'Close editor',
+                  ),
+            title: Text('Edit ${widget.fileName}'),
+            actions: [
+              if (_showDesktopZoomButtons(theme.platform))
+                IconButton(
+                  onPressed: _fontSize <= _minRemoteEditorFontSize
+                      ? null
+                      : () => _changeFontSize(-_remoteEditorFontStep),
+                  icon: const Icon(Icons.zoom_out),
+                  tooltip: 'Zoom out',
                 ),
-          title: Text('Edit ${widget.fileName}'),
-          actions: [
-            if (_showDesktopZoomButtons(theme.platform))
               IconButton(
-                onPressed: _fontSize <= _minRemoteEditorFontSize
-                    ? null
-                    : () => _changeFontSize(-_remoteEditorFontStep),
-                icon: const Icon(Icons.zoom_out),
-                tooltip: 'Zoom out',
+                onPressed: () {
+                  setState(() {
+                    _wrapLines = !_wrapLines;
+                  });
+                  if (!_wrapLines) {
+                    _scheduleSelectionVisibilityUpdate();
+                  }
+                },
+                icon: Icon(_wrapLines ? Icons.wrap_text : Icons.segment),
+                tooltip: _wrapLines ? 'Disable line wrap' : 'Enable line wrap',
               ),
-            IconButton(
-              onPressed: () {
-                setState(() {
-                  _wrapLines = !_wrapLines;
-                });
-                if (!_wrapLines) {
-                  _scheduleSelectionVisibilityUpdate();
-                }
-              },
-              icon: Icon(_wrapLines ? Icons.wrap_text : Icons.segment),
-              tooltip: _wrapLines ? 'Disable line wrap' : 'Enable line wrap',
-            ),
-            if (_showDesktopZoomButtons(theme.platform))
-              IconButton(
-                onPressed: _fontSize >= _maxRemoteEditorFontSize
-                    ? null
-                    : () => _changeFontSize(_remoteEditorFontStep),
-                icon: const Icon(Icons.zoom_in),
-                tooltip: 'Zoom in',
+              if (_showDesktopZoomButtons(theme.platform))
+                IconButton(
+                  onPressed: _fontSize >= _maxRemoteEditorFontSize
+                      ? null
+                      : () => _changeFontSize(_remoteEditorFontStep),
+                  icon: const Icon(Icons.zoom_in),
+                  tooltip: 'Zoom in',
+                ),
+              TextButton(
+                onPressed: _isSaving ? null : _handleSaveRequested,
+                child: const Text('Save'),
               ),
-            TextButton(
-              onPressed: () async {
-                final onSaveRequested = widget.onSaveRequested;
-                if (onSaveRequested != null) {
-                  await onSaveRequested(widget.controller.text);
-                  return;
-                }
-                if (!mounted) {
-                  return;
-                }
-                Navigator.pop(context, widget.controller.text);
-              },
-              child: const Text('Save'),
-            ),
-          ],
-        ),
-        body: Padding(
-          padding: const EdgeInsets.all(12),
-          child: SizedBox.expand(
-            child: ClipRect(
-              key: _remoteTextEditorSurfaceKey,
-              child: ColoredBox(
-                color: colors.background,
-                child: Column(
-                  children: [
-                    Expanded(
-                      child: LayoutBuilder(
-                        builder: (context, constraints) {
-                          final gutterWidth = _wrapLines
-                              ? 0.0
-                              : _resolveGutterWidth(context, editorTextStyle);
-                          final viewportWidth =
-                              constraints.maxWidth > gutterWidth
-                              ? constraints.maxWidth - gutterWidth
-                              : 0.0;
-                          _updateEditorViewportWidth(viewportWidth);
+            ],
+          ),
+          body: Padding(
+            padding: const EdgeInsets.all(12),
+            child: SizedBox.expand(
+              child: ClipRect(
+                key: _remoteTextEditorSurfaceKey,
+                child: ColoredBox(
+                  color: colors.background,
+                  child: Column(
+                    children: [
+                      Expanded(
+                        child: LayoutBuilder(
+                          builder: (context, constraints) {
+                            final gutterWidth = _wrapLines
+                                ? 0.0
+                                : _resolveGutterWidth(context, editorTextStyle);
+                            final viewportWidth =
+                                constraints.maxWidth > gutterWidth
+                                ? constraints.maxWidth - gutterWidth
+                                : 0.0;
+                            _updateEditorViewportWidth(viewportWidth);
 
-                          final editor = TextField(
-                            controller: widget.controller,
-                            focusNode: _editorFocusNode,
-                            expands: true,
-                            maxLines: null,
-                            keyboardType: TextInputType.multiline,
-                            textAlignVertical: TextAlignVertical.top,
-                            style: editorTextStyle,
-                            scrollController: _editorScrollController,
-                            scrollPhysics: const ClampingScrollPhysics(),
-                            strutStyle: StrutStyle.fromTextStyle(
-                              editorTextStyle,
-                              forceStrutHeight: true,
-                            ),
-                            decoration: null,
-                          );
+                            final editor = TextField(
+                              controller: widget.controller,
+                              focusNode: _editorFocusNode,
+                              expands: true,
+                              maxLines: null,
+                              keyboardType: TextInputType.multiline,
+                              textAlignVertical: TextAlignVertical.top,
+                              style: editorTextStyle,
+                              scrollController: _editorScrollController,
+                              scrollPhysics: const ClampingScrollPhysics(),
+                              strutStyle: StrutStyle.fromTextStyle(
+                                editorTextStyle,
+                                forceStrutHeight: true,
+                              ),
+                              decoration: null,
+                            );
 
-                          final editorPane = _wrapLines
-                              ? SizedBox(
-                                  width: viewportWidth,
-                                  height: constraints.maxHeight,
-                                  child: editor,
-                                )
-                              : _buildNowrapEditorPane(
-                                  context,
-                                  constraints.maxHeight,
-                                  viewportWidth,
-                                  editorTextStyle,
-                                  editor,
-                                );
+                            final editorPane = _wrapLines
+                                ? SizedBox(
+                                    width: viewportWidth,
+                                    height: constraints.maxHeight,
+                                    child: editor,
+                                  )
+                                : _buildNowrapEditorPane(
+                                    context,
+                                    constraints.maxHeight,
+                                    viewportWidth,
+                                    editorTextStyle,
+                                    editor,
+                                  );
 
-                          return Padding(
-                            padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
-                            child: TerminalPinchZoomGestureHandler(
-                              onPinchStart: _handleEditorScaleStart,
-                              onPinchUpdate: _handleEditorScaleUpdate,
-                              onPinchEnd: _handleEditorScaleEnd,
-                              child: Row(
-                                children: [
-                                  if (!_wrapLines)
-                                    Container(
-                                      width: gutterWidth,
-                                      height: constraints.maxHeight,
-                                      padding: const EdgeInsets.only(
-                                        left: _remoteEditorGutterLeftPadding,
-                                        right: _remoteEditorGutterRightPadding,
-                                      ),
-                                      color: colors.gutterBackground,
-                                      child: IgnorePointer(
-                                        child: ListView.builder(
-                                          controller:
-                                              _lineNumberScrollController,
-                                          physics:
-                                              const NeverScrollableScrollPhysics(),
-                                          itemCount: _lineCount,
-                                          itemExtent: lineHeight,
-                                          itemBuilder: (context, index) =>
-                                              Align(
-                                                alignment:
-                                                    Alignment.centerRight,
-                                                child: Text(
-                                                  '${index + 1}',
-                                                  style: editorTextStyle
-                                                      .copyWith(
-                                                        color: colors
-                                                            .gutterForeground,
-                                                      ),
-                                                  strutStyle:
-                                                      StrutStyle.fromTextStyle(
-                                                        editorTextStyle,
-                                                        forceStrutHeight: true,
-                                                      ),
+                            return Padding(
+                              padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+                              child: TerminalPinchZoomGestureHandler(
+                                onPinchStart: _handleEditorScaleStart,
+                                onPinchUpdate: _handleEditorScaleUpdate,
+                                onPinchEnd: _handleEditorScaleEnd,
+                                child: Row(
+                                  children: [
+                                    if (!_wrapLines)
+                                      Container(
+                                        width: gutterWidth,
+                                        height: constraints.maxHeight,
+                                        padding: const EdgeInsets.only(
+                                          left: _remoteEditorGutterLeftPadding,
+                                          right:
+                                              _remoteEditorGutterRightPadding,
+                                        ),
+                                        color: colors.gutterBackground,
+                                        child: IgnorePointer(
+                                          child: ListView.builder(
+                                            controller:
+                                                _lineNumberScrollController,
+                                            physics:
+                                                const NeverScrollableScrollPhysics(),
+                                            itemCount: _lineCount,
+                                            itemExtent: lineHeight,
+                                            itemBuilder: (context, index) =>
+                                                Align(
+                                                  alignment:
+                                                      Alignment.centerRight,
+                                                  child: Text(
+                                                    '${index + 1}',
+                                                    style: editorTextStyle
+                                                        .copyWith(
+                                                          color: colors
+                                                              .gutterForeground,
+                                                        ),
+                                                    strutStyle:
+                                                        StrutStyle.fromTextStyle(
+                                                          editorTextStyle,
+                                                          forceStrutHeight:
+                                                              true,
+                                                        ),
+                                                  ),
                                                 ),
-                                              ),
+                                          ),
                                         ),
                                       ),
-                                    ),
-                                  Expanded(child: editorPane),
-                                ],
+                                    Expanded(child: editorPane),
+                                  ],
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                      Container(
+                        key: _remoteTextEditorStatusKey,
+                        width: double.infinity,
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 12,
+                        ),
+                        color: colors.statusBackground,
+                        child: Wrap(
+                          alignment: WrapAlignment.spaceBetween,
+                          runSpacing: 8,
+                          spacing: 16,
+                          children: [
+                            Text(
+                              'Line ${caretPosition.line}, Column ${caretPosition.column}',
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: colors.statusForeground,
+                                fontWeight: FontWeight.w600,
                               ),
                             ),
-                          );
-                        },
-                      ),
-                    ),
-                    Container(
-                      key: _remoteTextEditorStatusKey,
-                      width: double.infinity,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 12,
-                      ),
-                      color: colors.statusBackground,
-                      child: Wrap(
-                        alignment: WrapAlignment.spaceBetween,
-                        runSpacing: 8,
-                        spacing: 16,
-                        children: [
-                          Text(
-                            'Line ${caretPosition.line}, Column ${caretPosition.column}',
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: colors.statusForeground,
-                              fontWeight: FontWeight.w600,
+                            Text(
+                              _wrapLines ? 'Wrap on' : 'Wrap off',
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: colors.statusForeground,
+                              ),
                             ),
-                          ),
-                          Text(
-                            _wrapLines ? 'Wrap on' : 'Wrap off',
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: colors.statusForeground,
+                            Text(
+                              '${_fontSize.toStringAsFixed(0)} pt',
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: colors.statusForeground,
+                              ),
                             ),
-                          ),
-                          Text(
-                            '${_fontSize.toStringAsFixed(0)} pt',
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: colors.statusForeground,
-                            ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/presentation/screens/remote_text_editor_screen.dart
+++ b/lib/presentation/screens/remote_text_editor_screen.dart
@@ -202,6 +202,8 @@ Widget buildRemoteTextEditorScreenForTesting({
   required TextEditingController controller,
   ScrollController? horizontalScrollController,
   TerminalThemeData? terminalTheme,
+  Future<void> Function(String text)? onSaveRequested,
+  VoidCallback? onCloseRequested,
   String fontFamily = 'monospace',
   double initialFontSize = 14,
 }) => RemoteTextEditorScreen(
@@ -209,6 +211,8 @@ Widget buildRemoteTextEditorScreenForTesting({
   controller: controller,
   horizontalScrollController: horizontalScrollController,
   terminalTheme: terminalTheme,
+  onSaveRequested: onSaveRequested,
+  onCloseRequested: onCloseRequested,
   fontFamily: fontFamily,
   initialFontSize: initialFontSize,
 );
@@ -223,6 +227,8 @@ class RemoteTextEditorScreen extends StatefulWidget {
     required this.initialFontSize,
     this.horizontalScrollController,
     this.terminalTheme,
+    this.onSaveRequested,
+    this.onCloseRequested,
     super.key,
   });
 
@@ -243,6 +249,12 @@ class RemoteTextEditorScreen extends StatefulWidget {
 
   /// Optional terminal theme to adapt the editor surface to the connection.
   final TerminalThemeData? terminalTheme;
+
+  /// Called instead of popping the route when the user saves.
+  final Future<void> Function(String text)? onSaveRequested;
+
+  /// Called instead of popping the route when the user closes the editor.
+  final VoidCallback? onCloseRequested;
 
   @override
   State<RemoteTextEditorScreen> createState() => _RemoteTextEditorScreenState();
@@ -585,6 +597,14 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
       child: Scaffold(
         backgroundColor: colors.background,
         appBar: AppBar(
+          automaticallyImplyLeading: widget.onCloseRequested == null,
+          leading: widget.onCloseRequested == null
+              ? null
+              : IconButton(
+                  onPressed: widget.onCloseRequested,
+                  icon: const Icon(Icons.close),
+                  tooltip: 'Close editor',
+                ),
           title: Text('Edit ${widget.fileName}'),
           actions: [
             if (_showDesktopZoomButtons(theme.platform))
@@ -616,7 +636,17 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
                 tooltip: 'Zoom in',
               ),
             TextButton(
-              onPressed: () => Navigator.pop(context, widget.controller.text),
+              onPressed: () async {
+                final onSaveRequested = widget.onSaveRequested;
+                if (onSaveRequested != null) {
+                  await onSaveRequested(widget.controller.text);
+                  return;
+                }
+                if (!mounted) {
+                  return;
+                }
+                Navigator.pop(context, widget.controller.text);
+              },
               child: const Text('Save'),
             ),
           ],

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -169,7 +169,7 @@ class _SftpEditorDetailPaneContent extends _SftpDetailPaneContent {
     required this.terminalTheme,
     required this.fontFamily,
     required this.initialFontSize,
-  });
+  }) : savedText = controller.text;
 
   final String fileName;
   final String remotePath;
@@ -177,6 +177,9 @@ class _SftpEditorDetailPaneContent extends _SftpDetailPaneContent {
   final TerminalThemeData? terminalTheme;
   final String fontFamily;
   final double initialFontSize;
+  String savedText;
+
+  bool get hasUnsavedChanges => controller.text != savedText;
 
   @override
   void dispose() {
@@ -687,11 +690,20 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   }
 
   bool _usesMasterDetailLayout(BuildContext context) =>
-      shouldUseIpadLandscapeMasterDetail(
-        platform: Theme.of(context).platform,
+      shouldUseLargeScreenMasterDetail(
         orientation: MediaQuery.of(context).orientation,
         screenSize: MediaQuery.of(context).size,
       );
+
+  _SftpEditorDetailPaneContent? get _detailEditorPaneContent {
+    final detailPaneContent = _detailPaneContent;
+    return detailPaneContent is _SftpEditorDetailPaneContent
+        ? detailPaneContent
+        : null;
+  }
+
+  bool get _hasUnsavedDetailEditorChanges =>
+      _detailEditorPaneContent?.hasUnsavedChanges ?? false;
 
   void _setDetailPaneContent(_SftpDetailPaneContent? nextContent) {
     final previousContent = _detailPaneContent;
@@ -703,8 +715,38 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     }
   }
 
-  void _clearDetailPane() {
+  Future<bool> _confirmDiscardDetailPaneChanges() async {
+    final editorContent = _detailEditorPaneContent;
+    if (editorContent == null || !editorContent.hasUnsavedChanges || !mounted) {
+      return true;
+    }
+    final shouldDiscard = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Discard changes?'),
+        content: Text(
+          'You have unsaved changes in "${editorContent.fileName}". Discard them?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Keep editing'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Discard'),
+          ),
+        ],
+      ),
+    );
+    return shouldDiscard ?? false;
+  }
+
+  Future<void> _clearDetailPane() async {
     if (_detailPaneContent == null || !mounted) {
+      return;
+    }
+    if (!await _confirmDiscardDetailPaneChanges() || !mounted) {
       return;
     }
     setState(() => _setDetailPaneContent(null));
@@ -717,10 +759,17 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
 
   @override
   Widget build(BuildContext context) => PopScope(
-    canPop: _pathHistory.length <= 1,
-    onPopInvokedWithResult: (didPop, _) {
+    canPop: _pathHistory.length <= 1 && !_hasUnsavedDetailEditorChanges,
+    onPopInvokedWithResult: (didPop, _) async {
       if (!didPop && _pathHistory.length > 1) {
         unawaited(_goBack());
+        return;
+      }
+      if (!didPop && _hasUnsavedDetailEditorChanges) {
+        final navigator = Navigator.of(context);
+        if (await _confirmDiscardDetailPaneChanges() && mounted) {
+          navigator.pop();
+        }
       }
     },
     child: Scaffold(
@@ -781,7 +830,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         fileName: detailPaneContent.fileName,
         bytes: detailPaneContent.bytes,
         isSvg: detailPaneContent.isSvg,
-        onClose: _clearDetailPane,
+        onClose: () => unawaited(_clearDetailPane()),
       );
     }
     if (detailPaneContent is _SftpEditorDetailPaneContent) {
@@ -949,7 +998,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     );
   }
 
-  void _handleFileTap(SftpName file) {
+  Future<void> _handleFileTap(SftpName file) async {
     final useMasterDetailLayout = _usesMasterDetailLayout(context);
     switch (resolveSftpFileTapIntent(
       isDirectory: file.attr.isDirectory,
@@ -957,13 +1006,16 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     )) {
       case SftpFileTapIntent.navigate:
         if (useMasterDetailLayout) {
+          if (!await _confirmDiscardDetailPaneChanges()) {
+            return;
+          }
           setState(() => _setDetailPaneContent(null));
         }
-        unawaited(_navigateTo(_joinRemotePath(_currentPath, file.filename)));
+        await _navigateTo(_joinRemotePath(_currentPath, file.filename));
       case SftpFileTapIntent.preview:
-        unawaited(_previewImageFile(file));
+        await _previewImageFile(file);
       case SftpFileTapIntent.edit:
-        unawaited(_editTextFile(file));
+        await _editTextFile(file);
     }
   }
 
@@ -1350,6 +1402,9 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       }
 
       if (_usesMasterDetailLayout(context)) {
+        if (!await _confirmDiscardDetailPaneChanges() || !mounted) {
+          return;
+        }
         setState(() {
           _highlightCurrentFile(file.filename);
           _setDetailPaneContent(
@@ -1485,6 +1540,14 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         return;
       }
       if (_usesMasterDetailLayout(context)) {
+        if (!await _confirmDiscardDetailPaneChanges()) {
+          controller.dispose();
+          return;
+        }
+        if (!mounted) {
+          controller.dispose();
+          return;
+        }
         setState(() {
           _highlightCurrentFile(file.filename);
           _setDetailPaneContent(
@@ -1563,6 +1626,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       );
       await saveFile.writeBytes(Uint8List.fromList(utf8.encode(updatedText)));
       await _loadDirectory(_currentPath);
+      detailPaneContent.savedText = updatedText;
       if (!mounted) {
         return;
       }

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -696,8 +696,10 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   void _setDetailPaneContent(_SftpDetailPaneContent? nextContent) {
     final previousContent = _detailPaneContent;
     _detailPaneContent = nextContent;
-    if (!identical(previousContent, nextContent)) {
-      previousContent?.dispose();
+    if (!identical(previousContent, nextContent) && previousContent != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        previousContent.dispose();
+      });
     }
   }
 
@@ -706,6 +708,11 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       return;
     }
     setState(() => _setDetailPaneContent(null));
+  }
+
+  void _highlightCurrentFile(String fileName) {
+    _highlightedDirectoryPath = _currentPath;
+    _highlightedFileName = fileName;
   }
 
   @override
@@ -1343,15 +1350,16 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       }
 
       if (_usesMasterDetailLayout(context)) {
-        setState(
-          () => _setDetailPaneContent(
+        setState(() {
+          _highlightCurrentFile(file.filename);
+          _setDetailPaneContent(
             _SftpImageDetailPaneContent(
               fileName: file.filename,
               bytes: bytes,
               isSvg: isSvgFileName(file.filename),
             ),
-          ),
-        );
+          );
+        });
         return;
       }
 
@@ -1477,8 +1485,9 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         return;
       }
       if (_usesMasterDetailLayout(context)) {
-        setState(
-          () => _setDetailPaneContent(
+        setState(() {
+          _highlightCurrentFile(file.filename);
+          _setDetailPaneContent(
             _SftpEditorDetailPaneContent(
               fileName: file.filename,
               remotePath: remotePath,
@@ -1487,8 +1496,8 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
               fontFamily: fontFamily,
               initialFontSize: initialFontSize,
             ),
-          ),
-        );
+          );
+        });
         return;
       }
       final updated = await navigator.push<String>(
@@ -1543,25 +1552,40 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       return;
     }
 
-    final saveFile = await _sftp!.open(
-      detailPaneContent.remotePath,
-      mode:
-          SftpFileOpenMode.write |
-          SftpFileOpenMode.create |
-          SftpFileOpenMode.truncate,
-    );
+    SftpFile? saveFile;
     try {
+      saveFile = await _sftp!.open(
+        detailPaneContent.remotePath,
+        mode:
+            SftpFileOpenMode.write |
+            SftpFileOpenMode.create |
+            SftpFileOpenMode.truncate,
+      );
       await saveFile.writeBytes(Uint8List.fromList(utf8.encode(updatedText)));
+      await _loadDirectory(_currentPath);
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Saved "${detailPaneContent.fileName}"')),
+      );
+    } on Exception catch (error, stackTrace) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed to save "${detailPaneContent.fileName}".'),
+          ),
+        );
+      }
+      if (kDebugMode) {
+        debugPrint(
+          'Error saving remote file "${detailPaneContent.remotePath}": $error',
+        );
+        debugPrintStack(stackTrace: stackTrace);
+      }
     } finally {
-      await saveFile.close();
+      await saveFile?.close();
     }
-    await _loadDirectory(_currentPath);
-    if (!mounted) {
-      return;
-    }
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Saved "${detailPaneContent.fileName}"')),
-    );
   }
 
   String _joinRemotePath(String directory, String name) =>

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -12,12 +12,14 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:path/path.dart' as path;
 
 import '../../data/repositories/host_repository.dart';
+import '../../domain/models/terminal_theme.dart';
 import '../../domain/models/terminal_themes.dart';
 import '../../domain/services/remote_file_service.dart';
 import '../../domain/services/settings_service.dart';
 import '../../domain/services/ssh_service.dart';
 import '../../domain/services/terminal_theme_service.dart';
 import '../widgets/connection_preview_snippet.dart';
+import '../widgets/ipad_landscape_layout.dart';
 import '../widgets/syntax_highlight_controller.dart';
 import '../widgets/syntax_highlight_language.dart';
 import '../widgets/syntax_highlight_theme.dart';
@@ -141,6 +143,47 @@ SftpFileTapIntent resolveSftpFileTapIntent({
   return SftpFileTapIntent.edit;
 }
 
+abstract class _SftpDetailPaneContent {
+  const _SftpDetailPaneContent();
+
+  void dispose() {}
+}
+
+class _SftpImageDetailPaneContent extends _SftpDetailPaneContent {
+  const _SftpImageDetailPaneContent({
+    required this.fileName,
+    required this.bytes,
+    required this.isSvg,
+  });
+
+  final String fileName;
+  final Uint8List bytes;
+  final bool isSvg;
+}
+
+class _SftpEditorDetailPaneContent extends _SftpDetailPaneContent {
+  _SftpEditorDetailPaneContent({
+    required this.fileName,
+    required this.remotePath,
+    required this.controller,
+    required this.terminalTheme,
+    required this.fontFamily,
+    required this.initialFontSize,
+  });
+
+  final String fileName;
+  final String remotePath;
+  final TextEditingController controller;
+  final TerminalThemeData? terminalTheme;
+  final String fontFamily;
+  final double initialFontSize;
+
+  @override
+  void dispose() {
+    controller.dispose();
+  }
+}
+
 /// SFTP file browser screen.
 class SftpScreen extends ConsumerStatefulWidget {
   /// Creates a new [SftpScreen].
@@ -183,6 +226,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   String? _highlightedFileName;
   String? _homeDirectoryPath;
   String? _fallbackDirectoryPath;
+  _SftpDetailPaneContent? _detailPaneContent;
 
   @override
   void initState() {
@@ -213,6 +257,8 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   void dispose() {
     _breadcrumbScrollController.dispose();
     _fileListScrollController.dispose();
+    _detailPaneContent?.dispose();
+    _detailPaneContent = null;
     _sftp?.close();
     _sftp = null;
     super.dispose();
@@ -640,6 +686,28 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     return trimmedPath;
   }
 
+  bool _usesMasterDetailLayout(BuildContext context) =>
+      shouldUseIpadLandscapeMasterDetail(
+        platform: Theme.of(context).platform,
+        orientation: MediaQuery.of(context).orientation,
+        screenSize: MediaQuery.of(context).size,
+      );
+
+  void _setDetailPaneContent(_SftpDetailPaneContent? nextContent) {
+    final previousContent = _detailPaneContent;
+    _detailPaneContent = nextContent;
+    if (!identical(previousContent, nextContent)) {
+      previousContent?.dispose();
+    }
+  }
+
+  void _clearDetailPane() {
+    if (_detailPaneContent == null || !mounted) {
+      return;
+    }
+    setState(() => _setDetailPaneContent(null));
+  }
+
   @override
   Widget build(BuildContext context) => PopScope(
     canPop: _pathHistory.length <= 1,
@@ -664,18 +732,65 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
           ),
         ],
       ),
-      body: Column(
-        children: [
-          _buildBreadcrumbs(),
-          Expanded(child: _buildFileList()),
-        ],
-      ),
+      body: _usesMasterDetailLayout(context)
+          ? Row(
+              children: [
+                Expanded(
+                  flex: 5,
+                  child: Column(
+                    children: [
+                      _buildBreadcrumbs(),
+                      Expanded(child: _buildFileList()),
+                    ],
+                  ),
+                ),
+                VerticalDivider(
+                  width: 1,
+                  color: Theme.of(context).colorScheme.outlineVariant,
+                ),
+                Expanded(flex: 6, child: _buildDetailPane()),
+              ],
+            )
+          : Column(
+              children: [
+                _buildBreadcrumbs(),
+                Expanded(child: _buildFileList()),
+              ],
+            ),
       floatingActionButton: FloatingActionButton(
         onPressed: _showUploadDialog,
         child: const Icon(Icons.upload_file),
       ),
     ),
   );
+
+  Widget _buildDetailPane() {
+    final detailPaneContent = _detailPaneContent;
+    if (detailPaneContent == null) {
+      return _SftpDetailPlaceholder(hostLabel: _hostLabel);
+    }
+    if (detailPaneContent is _SftpImageDetailPaneContent) {
+      return _SftpImageDetailPane(
+        fileName: detailPaneContent.fileName,
+        bytes: detailPaneContent.bytes,
+        isSvg: detailPaneContent.isSvg,
+        onClose: _clearDetailPane,
+      );
+    }
+    if (detailPaneContent is _SftpEditorDetailPaneContent) {
+      return RemoteTextEditorScreen(
+        fileName: detailPaneContent.fileName,
+        controller: detailPaneContent.controller,
+        terminalTheme: detailPaneContent.terminalTheme,
+        fontFamily: detailPaneContent.fontFamily,
+        initialFontSize: detailPaneContent.initialFontSize,
+        onSaveRequested: (updatedText) =>
+            _saveDetailEditorText(detailPaneContent, updatedText),
+        onCloseRequested: _clearDetailPane,
+      );
+    }
+    return const SizedBox.shrink();
+  }
 
   Widget _buildBreadcrumbs() {
     final parts = _currentPath.split('/').where((p) => p.isNotEmpty).toList();
@@ -828,11 +943,15 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   }
 
   void _handleFileTap(SftpName file) {
+    final useMasterDetailLayout = _usesMasterDetailLayout(context);
     switch (resolveSftpFileTapIntent(
       isDirectory: file.attr.isDirectory,
       filename: file.filename,
     )) {
       case SftpFileTapIntent.navigate:
+        if (useMasterDetailLayout) {
+          setState(() => _setDetailPaneContent(null));
+        }
         unawaited(_navigateTo(_joinRemotePath(_currentPath, file.filename)));
       case SftpFileTapIntent.preview:
         unawaited(_previewImageFile(file));
@@ -1223,6 +1342,19 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         return;
       }
 
+      if (_usesMasterDetailLayout(context)) {
+        setState(
+          () => _setDetailPaneContent(
+            _SftpImageDetailPaneContent(
+              fileName: file.filename,
+              bytes: bytes,
+              isSvg: isSvgFileName(file.filename),
+            ),
+          ),
+        );
+        return;
+      }
+
       await Navigator.of(context).push<void>(
         MaterialPageRoute(
           fullscreenDialog: true,
@@ -1344,6 +1476,21 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         controller.dispose();
         return;
       }
+      if (_usesMasterDetailLayout(context)) {
+        setState(
+          () => _setDetailPaneContent(
+            _SftpEditorDetailPaneContent(
+              fileName: file.filename,
+              remotePath: remotePath,
+              controller: controller,
+              terminalTheme: editorTheme,
+              fontFamily: fontFamily,
+              initialFontSize: initialFontSize,
+            ),
+          ),
+        );
+        return;
+      }
       final updated = await navigator.push<String>(
         MaterialPageRoute(
           fullscreenDialog: true,
@@ -1386,6 +1533,35 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         ).showSnackBar(SnackBar(content: Text('Edit failed: $e')));
       }
     }
+  }
+
+  Future<void> _saveDetailEditorText(
+    _SftpEditorDetailPaneContent detailPaneContent,
+    String updatedText,
+  ) async {
+    if (_sftp == null) {
+      return;
+    }
+
+    final saveFile = await _sftp!.open(
+      detailPaneContent.remotePath,
+      mode:
+          SftpFileOpenMode.write |
+          SftpFileOpenMode.create |
+          SftpFileOpenMode.truncate,
+    );
+    try {
+      await saveFile.writeBytes(Uint8List.fromList(utf8.encode(updatedText)));
+    } finally {
+      await saveFile.close();
+    }
+    await _loadDirectory(_currentPath);
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Saved "${detailPaneContent.fileName}"')),
+    );
   }
 
   String _joinRemotePath(String directory, String name) =>
@@ -1503,6 +1679,94 @@ class _InfoRow extends StatelessWidget {
       ],
     ),
   );
+}
+
+class _SftpDetailPlaceholder extends StatelessWidget {
+  const _SftpDetailPlaceholder({this.hostLabel});
+
+  final String? hostLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.folder_open, size: 72, color: theme.colorScheme.outline),
+            const SizedBox(height: 16),
+            Text(
+              hostLabel == null
+                  ? 'Select a file to preview or edit it here.'
+                  : 'Select a file from ${hostLabel!} to preview or edit it here.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Directories stay on the left while images and editors open in this detail pane.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SftpImageDetailPane extends StatelessWidget {
+  const _SftpImageDetailPane({
+    required this.fileName,
+    required this.bytes,
+    required this.isSvg,
+    required this.onClose,
+  });
+
+  final String fileName;
+  final Uint8List bytes;
+  final bool isSvg;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final image = isSvg
+        ? SvgPicture.memory(bytes)
+        : Image.memory(bytes, fit: BoxFit.contain);
+    return Column(
+      children: [
+        Material(
+          color: theme.colorScheme.surfaceContainerLow,
+          child: ListTile(
+            leading: const Icon(Icons.image_outlined),
+            title: Text(fileName),
+            trailing: IconButton(
+              onPressed: onClose,
+              icon: const Icon(Icons.close),
+              tooltip: 'Close preview',
+            ),
+          ),
+        ),
+        Expanded(
+          child: ColoredBox(
+            color: Colors.black,
+            child: Center(
+              child: InteractiveViewer(
+                minScale: 0.5,
+                maxScale: 6,
+                child: Padding(padding: const EdgeInsets.all(24), child: image),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
 }
 
 class _RemoteImageViewerScreen extends StatelessWidget {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -965,13 +965,21 @@ bool didTerminalScrollPolicyChange({
 /// Terminal screen for SSH sessions.
 class TerminalScreen extends ConsumerStatefulWidget {
   /// Creates a new [TerminalScreen].
-  const TerminalScreen({required this.hostId, this.connectionId, super.key});
+  const TerminalScreen({
+    required this.hostId,
+    this.connectionId,
+    this.onDisconnectRequested,
+    super.key,
+  });
 
   /// The host ID to connect to.
   final int hostId;
 
   /// Optional existing connection ID to reuse.
   final int? connectionId;
+
+  /// Called after a manual disconnect instead of popping the current route.
+  final VoidCallback? onDisconnectRequested;
 
   @override
   ConsumerState<TerminalScreen> createState() => _TerminalScreenState();
@@ -1946,7 +1954,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       await _sessionsNotifier?.disconnect(connectionId);
     }
     if (mounted) {
-      Navigator.of(context).pop();
+      final onDisconnectRequested = widget.onDisconnectRequested;
+      if (onDisconnectRequested != null) {
+        onDisconnectRequested();
+      } else {
+        Navigator.of(context).pop();
+      }
     }
   }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -969,6 +969,7 @@ class TerminalScreen extends ConsumerStatefulWidget {
     required this.hostId,
     this.connectionId,
     this.onDisconnectRequested,
+    this.showAppBar = true,
     super.key,
   });
 
@@ -980,6 +981,9 @@ class TerminalScreen extends ConsumerStatefulWidget {
 
   /// Called after a manual disconnect instead of popping the current route.
   final VoidCallback? onDisconnectRequested;
+
+  /// Whether the terminal should render its full app bar chrome.
+  final bool showAppBar;
 
   @override
   ConsumerState<TerminalScreen> createState() => _TerminalScreenState();
@@ -2164,137 +2168,35 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
     final titleSubtitle = titleSubtitleSegments.join(' • ');
     final statusChips = _buildTerminalStatusChips(theme);
+    final appBarActions = _buildTerminalAppBarActions(
+      isMobile: isMobile,
+      systemKeyboardVisible: systemKeyboardVisible,
+      connectionState: connectionState,
+      statusChips: statusChips,
+    );
 
     return Scaffold(
-      appBar: AppBar(
-        title: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(_host?.label ?? 'Terminal'),
-            if (titleSubtitle.isNotEmpty)
-              Text(
-                titleSubtitle,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-              ),
-          ],
-        ),
-        bottom: !_showsTerminalMetadata || statusChips.isEmpty
-            ? null
-            : PreferredSize(
-                preferredSize: const Size.fromHeight(40),
-                child: Container(
-                  alignment: Alignment.centerLeft,
-                  width: double.infinity,
-                  padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
-                  child: SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    child: Row(
-                      children: statusChips
-                          .map(
-                            (chip) => Padding(
-                              padding: const EdgeInsets.only(right: 8),
-                              child: chip,
-                            ),
-                          )
-                          .toList(growable: false),
+      appBar: widget.showAppBar
+          ? AppBar(
+              title: _buildTerminalTitle(theme, titleSubtitle),
+              bottom: !_showsTerminalMetadata || statusChips.isEmpty
+                  ? null
+                  : PreferredSize(
+                      preferredSize: const Size.fromHeight(40),
+                      child: _buildTerminalStatusChipRow(statusChips),
                     ),
-                  ),
-                ),
-              ),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.folder_outlined),
-            onPressed:
-                _connectionId == null ||
-                    connectionState != SshConnectionState.connected
-                ? null
-                : _openConnectionFileBrowser,
-            tooltip: 'Browse files',
-          ),
-          if (isMobile)
-            IconButton(
-              icon: Icon(
-                systemKeyboardVisible
-                    ? Icons.keyboard_hide
-                    : Icons.keyboard_alt_outlined,
-              ),
-              onPressed: () => _toggleSystemKeyboard(systemKeyboardVisible),
-              tooltip: systemKeyboardVisible
-                  ? 'Hide system keyboard'
-                  : 'Show system keyboard',
-            ),
-          IconButton(
-            icon: Icon(
-              _showKeyboard ? Icons.space_bar : Icons.keyboard_outlined,
-            ),
-            onPressed: () => setState(() => _showKeyboard = !_showKeyboard),
-            tooltip: _showKeyboard ? 'Hide toolbar' : 'Show toolbar',
-          ),
-          PopupMenuButton<String>(
-            onSelected: _handleMenuAction,
-            itemBuilder: (context) => [
-              const PopupMenuItem(value: 'snippets', child: Text('Snippets')),
-              const PopupMenuItem(
-                value: 'change_theme',
-                child: Text('Change Theme'),
-              ),
-              if (statusChips.isNotEmpty)
-                PopupMenuItem(
-                  value: 'toggle_terminal_info',
-                  child: Text(
-                    _showsTerminalMetadata
-                        ? 'Hide Terminal Info'
-                        : 'Show Terminal Info',
-                  ),
-                ),
-              if (isMobile)
-                CheckedPopupMenuItem(
-                  value: 'toggle_tap_keyboard',
-                  checked: ref.read(tapToShowKeyboardNotifierProvider),
-                  child: const Text('Tap to Show Keyboard'),
-                ),
-              const PopupMenuDivider(),
-              if (!isMobile)
-                PopupMenuItem(
-                  value: 'native_select',
-                  child: Text(
-                    _isNativeSelectionMode
-                        ? 'Exit Native Selection'
-                        : 'Native Selection',
-                  ),
-                ),
-              if (_workingDirectoryPath != null)
-                const PopupMenuItem(
-                  value: 'copy_working_directory',
-                  child: Text('Copy Current Directory'),
-                ),
-              const PopupMenuItem(value: 'copy', child: Text('Copy')),
-              const PopupMenuItem(value: 'paste', child: Text('Paste')),
-              const PopupMenuItem(
-                value: 'paste_image',
-                child: Text('Paste Image'),
-              ),
-              const PopupMenuItem(
-                value: 'paste_file',
-                child: Text('Paste File'),
-              ),
-              const PopupMenuItem(value: 'clear', child: Text('Clear')),
-              const PopupMenuDivider(),
-              const PopupMenuItem(
-                value: 'disconnect',
-                child: Text('Disconnect'),
-              ),
-            ],
-          ),
-        ],
-      ),
+              actions: appBarActions,
+            )
+          : null,
       body: Column(
         children: [
+          if (!widget.showAppBar)
+            _EmbeddedTerminalHeader(
+              title: _host?.label ?? 'Terminal',
+              subtitle: titleSubtitle,
+              actions: appBarActions,
+              statusChips: _showsTerminalMetadata ? statusChips : const [],
+            ),
           Expanded(child: _buildTerminalView(terminalTheme, isMobile)),
           if (_showKeyboard &&
               !showsDisconnectedOverlay &&
@@ -2309,6 +2211,120 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       ),
     );
   }
+
+  Widget _buildTerminalTitle(ThemeData theme, String titleSubtitle) => Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      Text(_host?.label ?? 'Terminal'),
+      if (titleSubtitle.isNotEmpty)
+        Text(
+          titleSubtitle,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+    ],
+  );
+
+  Widget _buildTerminalStatusChipRow(List<Widget> statusChips) => Container(
+    alignment: Alignment.centerLeft,
+    width: double.infinity,
+    padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+    child: SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: statusChips
+            .map(
+              (chip) => Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: chip,
+              ),
+            )
+            .toList(growable: false),
+      ),
+    ),
+  );
+
+  List<Widget> _buildTerminalAppBarActions({
+    required bool isMobile,
+    required bool systemKeyboardVisible,
+    required SshConnectionState connectionState,
+    required List<Widget> statusChips,
+  }) => [
+    IconButton(
+      icon: const Icon(Icons.folder_outlined),
+      onPressed:
+          _connectionId == null ||
+              connectionState != SshConnectionState.connected
+          ? null
+          : _openConnectionFileBrowser,
+      tooltip: 'Browse files',
+    ),
+    if (isMobile)
+      IconButton(
+        icon: Icon(
+          systemKeyboardVisible
+              ? Icons.keyboard_hide
+              : Icons.keyboard_alt_outlined,
+        ),
+        onPressed: () => _toggleSystemKeyboard(systemKeyboardVisible),
+        tooltip: systemKeyboardVisible
+            ? 'Hide system keyboard'
+            : 'Show system keyboard',
+      ),
+    IconButton(
+      icon: Icon(_showKeyboard ? Icons.space_bar : Icons.keyboard_outlined),
+      onPressed: () => setState(() => _showKeyboard = !_showKeyboard),
+      tooltip: _showKeyboard ? 'Hide toolbar' : 'Show toolbar',
+    ),
+    PopupMenuButton<String>(
+      onSelected: _handleMenuAction,
+      itemBuilder: (context) => [
+        const PopupMenuItem(value: 'snippets', child: Text('Snippets')),
+        const PopupMenuItem(value: 'change_theme', child: Text('Change Theme')),
+        if (statusChips.isNotEmpty)
+          PopupMenuItem(
+            value: 'toggle_terminal_info',
+            child: Text(
+              _showsTerminalMetadata
+                  ? 'Hide Terminal Info'
+                  : 'Show Terminal Info',
+            ),
+          ),
+        if (isMobile)
+          CheckedPopupMenuItem(
+            value: 'toggle_tap_keyboard',
+            checked: ref.read(tapToShowKeyboardNotifierProvider),
+            child: const Text('Tap to Show Keyboard'),
+          ),
+        const PopupMenuDivider(),
+        if (!isMobile)
+          PopupMenuItem(
+            value: 'native_select',
+            child: Text(
+              _isNativeSelectionMode
+                  ? 'Exit Native Selection'
+                  : 'Native Selection',
+            ),
+          ),
+        if (_workingDirectoryPath != null)
+          const PopupMenuItem(
+            value: 'copy_working_directory',
+            child: Text('Copy Current Directory'),
+          ),
+        const PopupMenuItem(value: 'copy', child: Text('Copy')),
+        const PopupMenuItem(value: 'paste', child: Text('Paste')),
+        const PopupMenuItem(value: 'paste_image', child: Text('Paste Image')),
+        const PopupMenuItem(value: 'paste_file', child: Text('Paste File')),
+        const PopupMenuItem(value: 'clear', child: Text('Clear')),
+        const PopupMenuDivider(),
+        const PopupMenuItem(value: 'disconnect', child: Text('Disconnect')),
+      ],
+    ),
+  ];
 
   /// Toggles the system keyboard visibility on mobile platforms.
   void _toggleSystemKeyboard(bool isVisible) {
@@ -5082,6 +5098,86 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
               style: const TextStyle(fontFamily: 'monospace'),
             ),
           ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmbeddedTerminalHeader extends StatelessWidget {
+  const _EmbeddedTerminalHeader({
+    required this.title,
+    required this.subtitle,
+    required this.actions,
+    required this.statusChips,
+  });
+
+  final String title;
+  final String subtitle;
+  final List<Widget> actions;
+  final List<Widget> statusChips;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Material(
+      color: colorScheme.surfaceContainerLow,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 8, 6, 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleSmall,
+                      ),
+                      if (subtitle.isNotEmpty)
+                        Text(
+                          subtitle,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.labelSmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                ...actions,
+              ],
+            ),
+          ),
+          if (statusChips.isNotEmpty)
+            Container(
+              alignment: Alignment.centerLeft,
+              width: double.infinity,
+              padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: statusChips
+                      .map(
+                        (chip) => Padding(
+                          padding: const EdgeInsets.only(right: 8),
+                          child: chip,
+                        ),
+                      )
+                      .toList(growable: false),
+                ),
+              ),
+            ),
+          Divider(height: 1, color: colorScheme.outlineVariant),
         ],
       ),
     );

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2332,9 +2332,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           forceShowSystemKeyboard ||
           (showSystemKeyboard && ref.read(tapToShowKeyboardNotifierProvider));
       if (shouldShowKeyboard && _isMobilePlatform) {
-        unawaited(
-          SystemChannels.textInput.invokeMethod<void>('TextInput.show'),
-        );
+        _terminalTextInputController.requestKeyboard();
       }
     });
   }

--- a/lib/presentation/widgets/ipad_landscape_layout.dart
+++ b/lib/presentation/widgets/ipad_landscape_layout.dart
@@ -2,12 +2,22 @@ import 'package:flutter/widgets.dart';
 
 const _minimumIpadShortestSide = 744.0;
 
-/// Whether the current device should use the iPad landscape master-detail UI.
+/// Whether the current window should use the large-screen master-detail UI.
+bool shouldUseLargeScreenMasterDetail({
+  required Orientation orientation,
+  required Size screenSize,
+}) =>
+    orientation == Orientation.landscape &&
+    screenSize.shortestSide >= _minimumIpadShortestSide;
+
+/// Whether the current device should use the iPad-specific landscape shell.
 bool shouldUseIpadLandscapeMasterDetail({
   required TargetPlatform platform,
   required Orientation orientation,
   required Size screenSize,
 }) =>
     platform == TargetPlatform.iOS &&
-    orientation == Orientation.landscape &&
-    screenSize.shortestSide >= _minimumIpadShortestSide;
+    shouldUseLargeScreenMasterDetail(
+      orientation: orientation,
+      screenSize: screenSize,
+    );

--- a/lib/presentation/widgets/ipad_landscape_layout.dart
+++ b/lib/presentation/widgets/ipad_landscape_layout.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/widgets.dart';
+
+const _minimumIpadShortestSide = 744.0;
+
+/// Whether the current device should use the iPad landscape master-detail UI.
+bool shouldUseIpadLandscapeMasterDetail({
+  required TargetPlatform platform,
+  required Orientation orientation,
+  required Size screenSize,
+}) =>
+    platform == TargetPlatform.iOS &&
+    orientation == Orientation.landscape &&
+    screenSize.shortestSide >= _minimumIpadShortestSide;

--- a/test/widget/ipad_landscape_layout_test.dart
+++ b/test/widget/ipad_landscape_layout_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/presentation/widgets/ipad_landscape_layout.dart';
+
+void main() {
+  group('shouldUseIpadLandscapeMasterDetail', () {
+    test('enables master-detail on iPad landscape', () {
+      expect(
+        shouldUseIpadLandscapeMasterDetail(
+          platform: TargetPlatform.iOS,
+          orientation: Orientation.landscape,
+          screenSize: const Size(1194, 834),
+        ),
+        isTrue,
+      );
+    });
+
+    test('disables master-detail on iPad portrait', () {
+      expect(
+        shouldUseIpadLandscapeMasterDetail(
+          platform: TargetPlatform.iOS,
+          orientation: Orientation.portrait,
+          screenSize: const Size(834, 1194),
+        ),
+        isFalse,
+      );
+    });
+
+    test('disables master-detail on iPhone landscape widths', () {
+      expect(
+        shouldUseIpadLandscapeMasterDetail(
+          platform: TargetPlatform.iOS,
+          orientation: Orientation.landscape,
+          screenSize: const Size(932, 430),
+        ),
+        isFalse,
+      );
+    });
+
+    test('disables master-detail on Android tablets', () {
+      expect(
+        shouldUseIpadLandscapeMasterDetail(
+          platform: TargetPlatform.android,
+          orientation: Orientation.landscape,
+          screenSize: const Size(1280, 800),
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/widget/ipad_landscape_layout_test.dart
+++ b/test/widget/ipad_landscape_layout_test.dart
@@ -3,8 +3,60 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/presentation/widgets/ipad_landscape_layout.dart';
 
 void main() {
-  group('shouldUseIpadLandscapeMasterDetail', () {
+  group('shouldUseLargeScreenMasterDetail', () {
     test('enables master-detail on iPad landscape', () {
+      expect(
+        shouldUseLargeScreenMasterDetail(
+          orientation: Orientation.landscape,
+          screenSize: const Size(1194, 834),
+        ),
+        isTrue,
+      );
+    });
+
+    test('enables master-detail on Android tablets', () {
+      expect(
+        shouldUseLargeScreenMasterDetail(
+          orientation: Orientation.landscape,
+          screenSize: const Size(1280, 800),
+        ),
+        isTrue,
+      );
+    });
+
+    test('enables master-detail on desktop-sized windows', () {
+      expect(
+        shouldUseLargeScreenMasterDetail(
+          orientation: Orientation.landscape,
+          screenSize: const Size(1440, 900),
+        ),
+        isTrue,
+      );
+    });
+
+    test('disables master-detail on portrait tablets', () {
+      expect(
+        shouldUseLargeScreenMasterDetail(
+          orientation: Orientation.portrait,
+          screenSize: const Size(834, 1194),
+        ),
+        isFalse,
+      );
+    });
+
+    test('disables master-detail on phone landscape widths', () {
+      expect(
+        shouldUseLargeScreenMasterDetail(
+          orientation: Orientation.landscape,
+          screenSize: const Size(932, 430),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('shouldUseIpadLandscapeMasterDetail', () {
+    test('enables the iPad shell on iPad landscape', () {
       expect(
         shouldUseIpadLandscapeMasterDetail(
           platform: TargetPlatform.iOS,
@@ -15,7 +67,7 @@ void main() {
       );
     });
 
-    test('disables master-detail on iPad portrait', () {
+    test('disables the iPad shell on iPad portrait', () {
       expect(
         shouldUseIpadLandscapeMasterDetail(
           platform: TargetPlatform.iOS,
@@ -26,7 +78,7 @@ void main() {
       );
     });
 
-    test('disables master-detail on iPhone landscape widths', () {
+    test('disables the iPad shell on iPhone landscape widths', () {
       expect(
         shouldUseIpadLandscapeMasterDetail(
           platform: TargetPlatform.iOS,
@@ -37,7 +89,7 @@ void main() {
       );
     });
 
-    test('disables master-detail on Android tablets', () {
+    test('disables the iPad shell on Android tablets', () {
       expect(
         shouldUseIpadLandscapeMasterDetail(
           platform: TargetPlatform.android,

--- a/test/widget/sftp_screen_test.dart
+++ b/test/widget/sftp_screen_test.dart
@@ -238,5 +238,41 @@ void main() {
       expect(find.byTooltip('Zoom out'), findsNothing);
       expect(find.byTooltip('Zoom in'), findsNothing);
     });
+
+    testWidgets('uses close and save callbacks in embedded mode', (
+      tester,
+    ) async {
+      final controller = TextEditingController(text: 'alpha');
+      var closeCount = 0;
+      String? savedText;
+
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: buildRemoteTextEditorScreenForTesting(
+            fileName: 'notes.txt',
+            controller: controller,
+            onCloseRequested: () => closeCount++,
+            onSaveRequested: (text) async {
+              savedText = text;
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      controller.text = 'beta';
+      await tester.pump();
+
+      await tester.tap(find.byTooltip('Close editor'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(closeCount, 1);
+      expect(savedText, 'beta');
+    });
   });
 }

--- a/test/widget/sftp_screen_test.dart
+++ b/test/widget/sftp_screen_test.dart
@@ -253,7 +253,9 @@ void main() {
           home: buildRemoteTextEditorScreenForTesting(
             fileName: 'notes.txt',
             controller: controller,
-            onCloseRequested: () => closeCount++,
+            onCloseRequested: () async {
+              closeCount++;
+            },
             onSaveRequested: (text) async {
               savedText = text;
             },
@@ -268,11 +270,51 @@ void main() {
       await tester.tap(find.byTooltip('Close editor'));
       await tester.pumpAndSettle();
 
+      expect(find.text('Discard changes?'), findsOneWidget);
+
+      await tester.tap(find.text('Keep editing'));
+      await tester.pumpAndSettle();
+
+      expect(closeCount, 0);
+
+      await tester.tap(find.byTooltip('Close editor'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Discard'));
+      await tester.pumpAndSettle();
+
       await tester.tap(find.text('Save'));
       await tester.pumpAndSettle();
 
       expect(closeCount, 1);
       expect(savedText, 'beta');
+    });
+
+    testWidgets('closes immediately when there are no unsaved changes', (
+      tester,
+    ) async {
+      final controller = TextEditingController(text: 'alpha');
+      var closeCount = 0;
+
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: buildRemoteTextEditorScreenForTesting(
+            fileName: 'notes.txt',
+            controller: controller,
+            onCloseRequested: () async {
+              closeCount++;
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Close editor'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Discard changes?'), findsNothing);
+      expect(closeCount, 1);
     });
   });
 }


### PR DESCRIPTION
## Summary

- broaden the master-detail experience from iPad-only to large landscape screens, including desktop windows and Android tablets, while keeping the slimmer home shell iPad-specific
- add unsaved-change protection for the embedded remote editor so closing, leaving, or replacing the detail pane does not silently discard edits
- reduce duplicate terminal chrome in embedded detail panes with a compact in-pane header and replace fixed home split widths with responsive proportions

## Testing

- `dart format lib/presentation/screens/home_screen.dart lib/presentation/screens/remote_text_editor_screen.dart lib/presentation/screens/sftp_screen.dart lib/presentation/screens/terminal_screen.dart lib/presentation/widgets/ipad_landscape_layout.dart test/widget/ipad_landscape_layout_test.dart test/widget/sftp_screen_test.dart`
- `flutter analyze`
- `flutter test`
