### PR TITLE
fix: block soft-keyboard backspace/delete key events to prevent IME double-processing

### DIFF
--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -169,6 +169,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   bool _touchSequenceHadMultiplePointers = false;
   bool _skipNextTouchKeyboardRequest = false;
   bool _sawImeComposition = false;
+  bool _softKeyboardShown = false;
   bool _isProcessingEditingValue = false;
   bool _lastProcessedUserSelectionWasValid = false;
   bool _lastProcessedSelectionWasCollapsed = true;
@@ -364,15 +365,19 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       return KeyEventResult.ignored;
     }
 
-    // When an IME connection is active, block text-modifying key events
+    // When the soft keyboard is shown, block text-modifying key events
     // (backspace/delete). On Android, the soft keyboard can dispatch a key
     // event AND an IME updateEditingValue for the same keystroke. Letting
     // both through double-processes the deletion, desyncing _lastSentText
     // from the terminal and jumbling later IME replacements. The IME path
     // (marker-damage or committed delta) handles backspace/delete reliably
-    // on its own, so we only let these keys through when there is no IME
-    // connection (e.g. hardware-only keyboard with no soft keyboard shown).
-    if (hasInputConnection &&
+    // on its own.
+    //
+    // Gate on _softKeyboardShown rather than hasInputConnection because
+    // the connection can be attached without showing the keyboard (e.g.
+    // tapToShowKeyboard: false), and in that case hardware-key deletions
+    // must still reach the terminal.
+    if (_softKeyboardShown &&
         !hasShortcutModifier &&
         (key == TerminalKey.backspace || key == TerminalKey.delete)) {
       return KeyEventResult.skipRemainingHandlers;
@@ -450,7 +455,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (!_shouldCreateInputConnection) return;
 
     if (hasInputConnection) {
-      if (show) _connection!.show();
+      if (show) {
+        _connection!.show();
+        _softKeyboardShown = true;
+      }
     } else {
       final config = TextInputConfiguration(
         // Keep these explicit because terminal IME behavior is central here.
@@ -467,6 +475,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       );
 
       _connection = TextInput.attach(this, config);
+      _softKeyboardShown = show;
       if (show) _connection!.show();
       _invalidatePendingEditingUpdates();
       _sawImeComposition = false;
@@ -486,6 +495,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (_connection != null && _connection!.attached) {
       _connection!.close();
       _connection = null;
+      _softKeyboardShown = false;
     }
     _invalidatePendingEditingUpdates();
     _sawImeComposition = false;
@@ -1233,6 +1243,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   @override
   void connectionClosed() {
     _connection = null;
+    _softKeyboardShown = false;
     _invalidatePendingEditingUpdates();
     _sawImeComposition = false;
     _lastSentText = '';

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -329,6 +329,17 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
           maxOffset,
         );
         return;
+      case TerminalKey.backspace:
+        if (_lastSentCursorOffset > 0 && _lastSentText.isNotEmpty) {
+          final graphemes = _lastSentText.characters.toList(growable: true);
+          final deleteIndex = _lastSentCursorOffset - 1;
+          if (deleteIndex < graphemes.length) {
+            graphemes.removeAt(deleteIndex);
+            _lastSentText = graphemes.join();
+            _lastSentCursorOffset = deleteIndex;
+          }
+        }
+        return;
       case TerminalKey.arrowUp:
       case TerminalKey.arrowDown:
         if (_lastSentText.isNotEmpty || _lastSentCursorOffset != 0) {

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -173,7 +173,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   bool _lastProcessedUserSelectionWasValid = false;
   bool _lastProcessedSelectionWasCollapsed = true;
   bool _trimLeadingSwipeSpaceAfterBufferClear = false;
-  bool _keyEventProcessedBackspace = false;
+  bool _keyEventProcessedDeletion = false;
   String _lastSentText = '';
   int _lastSentCursorOffset = 0;
   String? _pendingPerformedEnterText;
@@ -331,6 +331,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         );
         return;
       case TerminalKey.backspace:
+        _keyEventProcessedDeletion = true;
         if (_lastSentCursorOffset > 0 && _lastSentText.isNotEmpty) {
           final graphemes = _lastSentText.characters.toList(growable: true);
           final deleteIndex = _lastSentCursorOffset - 1;
@@ -338,17 +339,16 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
             graphemes.removeAt(deleteIndex);
             _lastSentText = graphemes.join();
             _lastSentCursorOffset = deleteIndex;
-            _keyEventProcessedBackspace = true;
           }
         }
         return;
       case TerminalKey.delete:
+        _keyEventProcessedDeletion = true;
         if (_lastSentText.isNotEmpty) {
           final graphemes = _lastSentText.characters.toList(growable: true);
           if (_lastSentCursorOffset < graphemes.length) {
             graphemes.removeAt(_lastSentCursorOffset);
             _lastSentText = graphemes.join();
-            _keyEventProcessedBackspace = true;
           }
         }
         return;
@@ -479,6 +479,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       if (show) _connection!.show();
       _invalidatePendingEditingUpdates();
       _sawImeComposition = false;
+      _keyEventProcessedDeletion = false;
       _lastProcessedUserSelectionWasValid = false;
       _lastProcessedSelectionWasCollapsed = true;
       _trimLeadingSwipeSpaceAfterBufferClear = false;
@@ -498,6 +499,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
     _invalidatePendingEditingUpdates();
     _sawImeComposition = false;
+    _keyEventProcessedDeletion = false;
     _lastProcessedUserSelectionWasValid = false;
     _lastProcessedSelectionWasCollapsed = true;
     _trimLeadingSwipeSpaceAfterBufferClear = false;
@@ -1106,8 +1108,8 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       // Clear the key-event backspace flag now that a committed update has
       // arrived. The marker-damage path below checks this flag before clearing
       // it; for all other committed paths the flag is stale and safe to reset.
-      final keyEventAlreadyProcessedBackspace = _keyEventProcessedBackspace;
-      _keyEventProcessedBackspace = false;
+      final keyEventAlreadyProcessedBackspace = _keyEventProcessedDeletion;
+      _keyEventProcessedDeletion = false;
 
       if (_editingPrefixLength(value.text) < _initEditingState.text.length) {
         if (keyEventAlreadyProcessedBackspace) {
@@ -1259,7 +1261,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _connection = null;
     _invalidatePendingEditingUpdates();
     _sawImeComposition = false;
-    _keyEventProcessedBackspace = false;
+    _keyEventProcessedDeletion = false;
     _lastSentText = '';
     _lastSentCursorOffset = 0;
     _pendingPerformedEnterText = null;

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -173,6 +173,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   bool _lastProcessedUserSelectionWasValid = false;
   bool _lastProcessedSelectionWasCollapsed = true;
   bool _trimLeadingSwipeSpaceAfterBufferClear = false;
+  bool _keyEventProcessedBackspace = false;
   String _lastSentText = '';
   int _lastSentCursorOffset = 0;
   String? _pendingPerformedEnterText;
@@ -329,6 +330,28 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
           maxOffset,
         );
         return;
+      case TerminalKey.backspace:
+        if (_lastSentCursorOffset > 0 && _lastSentText.isNotEmpty) {
+          final graphemes = _lastSentText.characters.toList(growable: true);
+          final deleteIndex = _lastSentCursorOffset - 1;
+          if (deleteIndex < graphemes.length) {
+            graphemes.removeAt(deleteIndex);
+            _lastSentText = graphemes.join();
+            _lastSentCursorOffset = deleteIndex;
+            _keyEventProcessedBackspace = true;
+          }
+        }
+        return;
+      case TerminalKey.delete:
+        if (_lastSentText.isNotEmpty) {
+          final graphemes = _lastSentText.characters.toList(growable: true);
+          if (_lastSentCursorOffset < graphemes.length) {
+            graphemes.removeAt(_lastSentCursorOffset);
+            _lastSentText = graphemes.join();
+            _keyEventProcessedBackspace = true;
+          }
+        }
+        return;
       case TerminalKey.arrowUp:
       case TerminalKey.arrowDown:
         if (_lastSentText.isNotEmpty || _lastSentCursorOffset != 0) {
@@ -362,18 +385,6 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     final key = keyToTerminalKey(event.logicalKey);
     if (key == null) {
       return KeyEventResult.ignored;
-    }
-
-    // When an IME connection is active, let the IME handle text-modifying keys
-    // (backspace/delete) via updateEditingValue so _lastSentText stays in sync.
-    // Without this guard, both the key event AND the IME update can each send a
-    // backspace to the terminal, causing a desync that jumbles later
-    // replacements (e.g. suggestion-bar taps producing "thitle" instead of
-    // "thistle").
-    if (hasInputConnection &&
-        !hasShortcutModifier &&
-        (key == TerminalKey.backspace || key == TerminalKey.delete)) {
-      return KeyEventResult.skipRemainingHandlers;
     }
 
     final handled = widget.terminal.keyInput(
@@ -1092,7 +1103,22 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         return;
       }
 
+      // Clear the key-event backspace flag now that a committed update has
+      // arrived. The marker-damage path below checks this flag before clearing
+      // it; for all other committed paths the flag is stale and safe to reset.
+      final keyEventAlreadyProcessedBackspace = _keyEventProcessedBackspace;
+      _keyEventProcessedBackspace = false;
+
       if (_editingPrefixLength(value.text) < _initEditingState.text.length) {
+        if (keyEventAlreadyProcessedBackspace) {
+          // A key event already sent the backspace to the terminal and updated
+          // _lastSentText. The marker damage is from the same keystroke that
+          // the key event already handled — skip the duplicate terminal input
+          // but still reset the editing state so the marker is restored.
+          _sawImeComposition = false;
+          _resetCommittedInputState();
+          return;
+        }
         final deletedCount = _textLengthInGraphemes(_lastSentText);
         final clearedBufferedInput = deletedCount > 0;
         _notifyUserInput();
@@ -1233,6 +1259,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _connection = null;
     _invalidatePendingEditingUpdates();
     _sawImeComposition = false;
+    _keyEventProcessedBackspace = false;
     _lastSentText = '';
     _lastSentCursorOffset = 0;
     _pendingPerformedEnterText = null;

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -173,7 +173,6 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   bool _lastProcessedUserSelectionWasValid = false;
   bool _lastProcessedSelectionWasCollapsed = true;
   bool _trimLeadingSwipeSpaceAfterBufferClear = false;
-  bool _keyEventProcessedDeletion = false;
   String _lastSentText = '';
   int _lastSentCursorOffset = 0;
   String? _pendingPerformedEnterText;
@@ -330,28 +329,6 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
           maxOffset,
         );
         return;
-      case TerminalKey.backspace:
-        _keyEventProcessedDeletion = true;
-        if (_lastSentCursorOffset > 0 && _lastSentText.isNotEmpty) {
-          final graphemes = _lastSentText.characters.toList(growable: true);
-          final deleteIndex = _lastSentCursorOffset - 1;
-          if (deleteIndex < graphemes.length) {
-            graphemes.removeAt(deleteIndex);
-            _lastSentText = graphemes.join();
-            _lastSentCursorOffset = deleteIndex;
-          }
-        }
-        return;
-      case TerminalKey.delete:
-        _keyEventProcessedDeletion = true;
-        if (_lastSentText.isNotEmpty) {
-          final graphemes = _lastSentText.characters.toList(growable: true);
-          if (_lastSentCursorOffset < graphemes.length) {
-            graphemes.removeAt(_lastSentCursorOffset);
-            _lastSentText = graphemes.join();
-          }
-        }
-        return;
       case TerminalKey.arrowUp:
       case TerminalKey.arrowDown:
         if (_lastSentText.isNotEmpty || _lastSentCursorOffset != 0) {
@@ -385,6 +362,20 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     final key = keyToTerminalKey(event.logicalKey);
     if (key == null) {
       return KeyEventResult.ignored;
+    }
+
+    // When an IME connection is active, block text-modifying key events
+    // (backspace/delete). On Android, the soft keyboard can dispatch a key
+    // event AND an IME updateEditingValue for the same keystroke. Letting
+    // both through double-processes the deletion, desyncing _lastSentText
+    // from the terminal and jumbling later IME replacements. The IME path
+    // (marker-damage or committed delta) handles backspace/delete reliably
+    // on its own, so we only let these keys through when there is no IME
+    // connection (e.g. hardware-only keyboard with no soft keyboard shown).
+    if (hasInputConnection &&
+        !hasShortcutModifier &&
+        (key == TerminalKey.backspace || key == TerminalKey.delete)) {
+      return KeyEventResult.skipRemainingHandlers;
     }
 
     final handled = widget.terminal.keyInput(
@@ -479,7 +470,6 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       if (show) _connection!.show();
       _invalidatePendingEditingUpdates();
       _sawImeComposition = false;
-      _keyEventProcessedDeletion = false;
       _lastProcessedUserSelectionWasValid = false;
       _lastProcessedSelectionWasCollapsed = true;
       _trimLeadingSwipeSpaceAfterBufferClear = false;
@@ -499,7 +489,6 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
     _invalidatePendingEditingUpdates();
     _sawImeComposition = false;
-    _keyEventProcessedDeletion = false;
     _lastProcessedUserSelectionWasValid = false;
     _lastProcessedSelectionWasCollapsed = true;
     _trimLeadingSwipeSpaceAfterBufferClear = false;
@@ -1105,22 +1094,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         return;
       }
 
-      // Clear the key-event backspace flag now that a committed update has
-      // arrived. The marker-damage path below checks this flag before clearing
-      // it; for all other committed paths the flag is stale and safe to reset.
-      final keyEventAlreadyProcessedBackspace = _keyEventProcessedDeletion;
-      _keyEventProcessedDeletion = false;
-
       if (_editingPrefixLength(value.text) < _initEditingState.text.length) {
-        if (keyEventAlreadyProcessedBackspace) {
-          // A key event already sent the backspace to the terminal and updated
-          // _lastSentText. The marker damage is from the same keystroke that
-          // the key event already handled — skip the duplicate terminal input
-          // but still reset the editing state so the marker is restored.
-          _sawImeComposition = false;
-          _resetCommittedInputState();
-          return;
-        }
         final deletedCount = _textLengthInGraphemes(_lastSentText);
         final clearedBufferedInput = deletedCount > 0;
         _notifyUserInput();
@@ -1261,7 +1235,6 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _connection = null;
     _invalidatePendingEditingUpdates();
     _sawImeComposition = false;
-    _keyEventProcessedDeletion = false;
     _lastSentText = '';
     _lastSentCursorOffset = 0;
     _pendingPerformedEnterText = null;

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -329,17 +329,6 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
           maxOffset,
         );
         return;
-      case TerminalKey.backspace:
-        if (_lastSentCursorOffset > 0 && _lastSentText.isNotEmpty) {
-          final graphemes = _lastSentText.characters.toList(growable: true);
-          final deleteIndex = _lastSentCursorOffset - 1;
-          if (deleteIndex < graphemes.length) {
-            graphemes.removeAt(deleteIndex);
-            _lastSentText = graphemes.join();
-            _lastSentCursorOffset = deleteIndex;
-          }
-        }
-        return;
       case TerminalKey.arrowUp:
       case TerminalKey.arrowDown:
         if (_lastSentText.isNotEmpty || _lastSentCursorOffset != 0) {
@@ -373,6 +362,18 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     final key = keyToTerminalKey(event.logicalKey);
     if (key == null) {
       return KeyEventResult.ignored;
+    }
+
+    // When an IME connection is active, let the IME handle text-modifying keys
+    // (backspace/delete) via updateEditingValue so _lastSentText stays in sync.
+    // Without this guard, both the key event AND the IME update can each send a
+    // backspace to the terminal, causing a desync that jumbles later
+    // replacements (e.g. suggestion-bar taps producing "thitle" instead of
+    // "thistle").
+    if (hasInputConnection &&
+        !hasShortcutModifier &&
+        (key == TerminalKey.backspace || key == TerminalKey.delete)) {
+      return KeyEventResult.skipRemainingHandlers;
     }
 
     final handled = widget.terminal.keyInput(

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -3916,6 +3916,149 @@ void main() {
       },
     );
 
+    testWidgets(
+      'tracks a hardware-key backspace so a later IME replacement stays correct',
+      (tester) async {
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add);
+        final focusNode = FocusNode();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TerminalTextInputHandler(
+                terminal: terminal,
+                focusNode: focusNode,
+                deleteDetection: true,
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        // Commit "this ".
+        tester.testTextInput.updateEditingValue(
+          _editingValue('this ', selectionOffset: 'this '.length),
+        );
+        await tester.pump();
+
+        expect(_terminalTextFromEvents(terminalOutput), 'this ');
+
+        // Simulate Android: hardware key event backspace arrives before the IME
+        // composing update, removing the trailing space.
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.backspace);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.backspace);
+        await tester.pump();
+
+        // The IME then sends the word back in composing mode (ignored).
+        tester.testTextInput.updateEditingValue(
+          const TextEditingValue(
+            text: '\u200B\u200Bthis',
+            selection: TextSelection.collapsed(offset: 6),
+            composing: TextRange(start: 2, end: 6),
+          ),
+        );
+        await tester.pump();
+
+        // Another hardware-key backspace removes the 's'.
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.backspace);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.backspace);
+        await tester.pump();
+
+        // IME sends composing "thi" (ignored).
+        tester.testTextInput.updateEditingValue(
+          const TextEditingValue(
+            text: '\u200B\u200Bthi',
+            selection: TextSelection.collapsed(offset: 5),
+            composing: TextRange(start: 2, end: 5),
+          ),
+        );
+        await tester.pump();
+
+        // User taps "thistle" from suggestion bar → IME commits "thistle ".
+        tester.testTextInput.updateEditingValue(
+          _editingValue('thistle ', selectionOffset: 'thistle '.length),
+        );
+        await tester.pump();
+
+        // Must produce "thistle ", not "thitle " or any other jumbled result.
+        expect(_terminalTextFromEvents(terminalOutput), 'thistle ');
+
+        focusNode.dispose();
+      },
+    );
+
+    testWidgets(
+      'tracks a hardware-key backspace at a mid-word cursor position',
+      (tester) async {
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add);
+        final focusNode = FocusNode();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TerminalTextInputHandler(
+                terminal: terminal,
+                focusNode: focusNode,
+                deleteDetection: true,
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        // Commit "hello".
+        tester.testTextInput.updateEditingValue(
+          _editingValue('hello', selectionOffset: 'hello'.length),
+        );
+        await tester.pump();
+
+        // Move cursor to position 3 (between 'l' and 'l').
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.pump();
+
+        terminalOutput.clear();
+
+        // Hardware-key backspace at cursor offset 3 removes the first 'l'.
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.backspace);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.backspace);
+        await tester.pump();
+
+        // IME sends committed update reflecting the deletion.
+        tester.testTextInput.updateEditingValue(
+          _editingValue('helo', selectionOffset: 'he'.length),
+        );
+        await tester.pump();
+
+        // Now type 'X' at cursor position 2.
+        tester.testTextInput.updateEditingValue(
+          _editingValue('heXlo', selectionOffset: 'heX'.length),
+        );
+        await tester.pump();
+
+        expect(
+          _terminalStateFromEvents(
+            terminalOutput,
+            initialText: 'hello',
+            initialCursorOffset: 'hel'.length,
+          ),
+          (text: 'heXlo', cursorOffset: 'heX'.length),
+        );
+
+        focusNode.dispose();
+      },
+    );
+
     testWidgets('keeps ctrl combos working while IME composition is active', (
       tester,
     ) async {

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -4071,6 +4071,52 @@ void main() {
       },
     );
 
+    testWidgets(
+      'allows hardware-key backspace when soft keyboard is not shown (tapToShowKeyboard: false)',
+      (tester) async {
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add);
+        final focusNode = FocusNode();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TerminalTextInputHandler(
+                terminal: terminal,
+                focusNode: focusNode,
+                deleteDetection: true,
+                tapToShowKeyboard: false,
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        // IME connection is attached but keyboard is not shown. Type via
+        // hardware keyboard simulation (commit through IME first to
+        // populate _lastSentText).
+        tester.testTextInput.updateEditingValue(
+          _editingValue('hello', selectionOffset: 'hello'.length),
+        );
+        await tester.pump();
+
+        expect(_terminalTextFromEvents(terminalOutput), 'hello');
+
+        // Hardware-key backspace should NOT be blocked because the soft
+        // keyboard is not shown — there's no IME to handle the deletion.
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.backspace);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.backspace);
+        await tester.pump();
+
+        expect(_terminalTextFromEvents(terminalOutput), 'hell');
+
+        focusNode.dispose();
+      },
+    );
+
     testWidgets('keeps ctrl combos working while IME composition is active', (
       tester,
     ) async {

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -3917,7 +3917,7 @@ void main() {
     );
 
     testWidgets(
-      'blocks hardware-key backspace when IME is active so suggestion replacement stays correct',
+      'tracks hardware-key backspace so a later IME suggestion replacement stays correct',
       (tester) async {
         final terminalOutput = <String>[];
         final terminal = Terminal(onOutput: terminalOutput.add);
@@ -3948,14 +3948,15 @@ void main() {
         expect(_terminalTextFromEvents(terminalOutput), 'this ');
 
         // Simulate Android: hardware key event backspace arrives before the IME
-        // composing update. With the fix, this key event is BLOCKED (not sent
-        // to terminal) because the IME connection is active.
+        // composing update (composing is still collapsed from the committed
+        // state). The key event sends \x7f to the terminal AND tracking
+        // updates _lastSentText from "this " to "this".
         await tester.sendKeyDownEvent(LogicalKeyboardKey.backspace);
         await tester.sendKeyUpEvent(LogicalKeyboardKey.backspace);
         await tester.pump();
 
-        // Terminal output should still be "this " — backspace was blocked.
-        expect(_terminalTextFromEvents(terminalOutput), 'this ');
+        // Terminal now shows "this" (space was deleted).
+        expect(_terminalTextFromEvents(terminalOutput), 'this');
 
         // The IME sends the word in composing mode (ignored as composing).
         tester.testTextInput.updateEditingValue(
@@ -3967,10 +3968,14 @@ void main() {
         );
         await tester.pump();
 
-        // Another hardware-key backspace — also blocked.
+        // Another hardware-key backspace during composing — blocked by the
+        // existing composing guard (all key events are blocked while composing
+        // is active). Terminal still shows "this".
         await tester.sendKeyDownEvent(LogicalKeyboardKey.backspace);
         await tester.sendKeyUpEvent(LogicalKeyboardKey.backspace);
         await tester.pump();
+
+        expect(_terminalTextFromEvents(terminalOutput), 'this');
 
         // IME sends composing "thi" (ignored).
         tester.testTextInput.updateEditingValue(
@@ -3983,8 +3988,8 @@ void main() {
         await tester.pump();
 
         // User taps "thistle" from suggestion bar → IME commits "thistle ".
-        // Since _lastSentText is still "this " (never desynced), the delta
-        // correctly replaces "this " with "thistle ".
+        // Since tracking kept _lastSentText = "this", the delta correctly
+        // computes: delete 0, append "tle " → terminal shows "thistle ".
         tester.testTextInput.updateEditingValue(
           _editingValue('thistle ', selectionOffset: 'thistle '.length),
         );
@@ -3998,7 +4003,7 @@ void main() {
     );
 
     testWidgets(
-      'blocks hardware-key backspace when IME is active at mid-word cursor',
+      'tracks hardware-key backspace at a mid-word cursor without double-processing the IME update',
       (tester) async {
         final terminalOutput = <String>[];
         final terminal = Terminal(onOutput: terminalOutput.add);
@@ -4035,16 +4040,15 @@ void main() {
 
         terminalOutput.clear();
 
-        // Hardware-key backspace — blocked by the IME guard, not sent to
-        // terminal.
+        // Hardware-key backspace at cursor offset 3 removes the first 'l'.
+        // Tracking: _lastSentText "hello" → "helo", cursor 3 → 2.
         await tester.sendKeyDownEvent(LogicalKeyboardKey.backspace);
         await tester.sendKeyUpEvent(LogicalKeyboardKey.backspace);
         await tester.pump();
 
-        // No terminal output from the blocked backspace.
-        expect(terminalOutput, isEmpty);
-
-        // IME sends committed update reflecting the deletion.
+        // IME sends committed update "helo" with cursor at 2.
+        // Since tracking already set _lastSentText = "helo", this is a
+        // same-text no-op — no duplicate backspace sent to terminal.
         tester.testTextInput.updateEditingValue(
           _editingValue('helo', selectionOffset: 'he'.length),
         );

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -3917,7 +3917,7 @@ void main() {
     );
 
     testWidgets(
-      'tracks hardware-key backspace so a later IME suggestion replacement stays correct',
+      'blocks key-event backspace when IME is active so suggestion replacement stays correct',
       (tester) async {
         final terminalOutput = <String>[];
         final terminal = Terminal(onOutput: terminalOutput.add);
@@ -3947,16 +3947,16 @@ void main() {
 
         expect(_terminalTextFromEvents(terminalOutput), 'this ');
 
-        // Simulate Android: hardware key event backspace arrives before the IME
-        // composing update (composing is still collapsed from the committed
-        // state). The key event sends \x7f to the terminal AND tracking
-        // updates _lastSentText from "this " to "this".
+        // Simulate Android: hardware key event backspace arrives before the
+        // IME composing update. With the blocking guard, the key event is
+        // swallowed (not sent to the terminal) because the IME connection
+        // is active.
         await tester.sendKeyDownEvent(LogicalKeyboardKey.backspace);
         await tester.sendKeyUpEvent(LogicalKeyboardKey.backspace);
         await tester.pump();
 
-        // Terminal now shows "this" (space was deleted).
-        expect(_terminalTextFromEvents(terminalOutput), 'this');
+        // Terminal still shows "this " — key-event backspace was blocked.
+        expect(_terminalTextFromEvents(terminalOutput), 'this ');
 
         // The IME sends the word in composing mode (ignored as composing).
         tester.testTextInput.updateEditingValue(
@@ -3968,14 +3968,11 @@ void main() {
         );
         await tester.pump();
 
-        // Another hardware-key backspace during composing — blocked by the
-        // existing composing guard (all key events are blocked while composing
-        // is active). Terminal still shows "this".
+        // Another hardware-key backspace during composing — also blocked
+        // (by the existing composing guard).
         await tester.sendKeyDownEvent(LogicalKeyboardKey.backspace);
         await tester.sendKeyUpEvent(LogicalKeyboardKey.backspace);
         await tester.pump();
-
-        expect(_terminalTextFromEvents(terminalOutput), 'this');
 
         // IME sends composing "thi" (ignored).
         tester.testTextInput.updateEditingValue(
@@ -3988,8 +3985,8 @@ void main() {
         await tester.pump();
 
         // User taps "thistle" from suggestion bar → IME commits "thistle ".
-        // Since tracking kept _lastSentText = "this", the delta correctly
-        // computes: delete 0, append "tle " → terminal shows "thistle ".
+        // Since _lastSentText was never desynced (key events were blocked),
+        // the delta correctly replaces "this " with "thistle ".
         tester.testTextInput.updateEditingValue(
           _editingValue('thistle ', selectionOffset: 'thistle '.length),
         );
@@ -4003,7 +4000,7 @@ void main() {
     );
 
     testWidgets(
-      'tracks hardware-key backspace at a mid-word cursor without double-processing the IME update',
+      'blocks key-event backspace when IME is active so committed update handles deletion alone',
       (tester) async {
         final terminalOutput = <String>[];
         final terminal = Terminal(onOutput: terminalOutput.add);
@@ -4040,15 +4037,16 @@ void main() {
 
         terminalOutput.clear();
 
-        // Hardware-key backspace at cursor offset 3 removes the first 'l'.
-        // Tracking: _lastSentText "hello" → "helo", cursor 3 → 2.
+        // Hardware-key backspace — blocked by the IME guard.
         await tester.sendKeyDownEvent(LogicalKeyboardKey.backspace);
         await tester.sendKeyUpEvent(LogicalKeyboardKey.backspace);
         await tester.pump();
 
-        // IME sends committed update "helo" with cursor at 2.
-        // Since tracking already set _lastSentText = "helo", this is a
-        // same-text no-op — no duplicate backspace sent to terminal.
+        // No terminal output from the blocked backspace.
+        expect(terminalOutput, isEmpty);
+
+        // IME sends committed update "helo" with cursor at 2 — this is the
+        // sole handler for the deletion.
         tester.testTextInput.updateEditingValue(
           _editingValue('helo', selectionOffset: 'he'.length),
         );

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -3917,7 +3917,7 @@ void main() {
     );
 
     testWidgets(
-      'tracks a hardware-key backspace so a later IME replacement stays correct',
+      'blocks hardware-key backspace when IME is active so suggestion replacement stays correct',
       (tester) async {
         final terminalOutput = <String>[];
         final terminal = Terminal(onOutput: terminalOutput.add);
@@ -3948,12 +3948,16 @@ void main() {
         expect(_terminalTextFromEvents(terminalOutput), 'this ');
 
         // Simulate Android: hardware key event backspace arrives before the IME
-        // composing update, removing the trailing space.
+        // composing update. With the fix, this key event is BLOCKED (not sent
+        // to terminal) because the IME connection is active.
         await tester.sendKeyDownEvent(LogicalKeyboardKey.backspace);
         await tester.sendKeyUpEvent(LogicalKeyboardKey.backspace);
         await tester.pump();
 
-        // The IME then sends the word back in composing mode (ignored).
+        // Terminal output should still be "this " — backspace was blocked.
+        expect(_terminalTextFromEvents(terminalOutput), 'this ');
+
+        // The IME sends the word in composing mode (ignored as composing).
         tester.testTextInput.updateEditingValue(
           const TextEditingValue(
             text: '\u200B\u200Bthis',
@@ -3963,7 +3967,7 @@ void main() {
         );
         await tester.pump();
 
-        // Another hardware-key backspace removes the 's'.
+        // Another hardware-key backspace — also blocked.
         await tester.sendKeyDownEvent(LogicalKeyboardKey.backspace);
         await tester.sendKeyUpEvent(LogicalKeyboardKey.backspace);
         await tester.pump();
@@ -3979,6 +3983,8 @@ void main() {
         await tester.pump();
 
         // User taps "thistle" from suggestion bar → IME commits "thistle ".
+        // Since _lastSentText is still "this " (never desynced), the delta
+        // correctly replaces "this " with "thistle ".
         tester.testTextInput.updateEditingValue(
           _editingValue('thistle ', selectionOffset: 'thistle '.length),
         );
@@ -3992,7 +3998,7 @@ void main() {
     );
 
     testWidgets(
-      'tracks a hardware-key backspace at a mid-word cursor position',
+      'blocks hardware-key backspace when IME is active at mid-word cursor',
       (tester) async {
         final terminalOutput = <String>[];
         final terminal = Terminal(onOutput: terminalOutput.add);
@@ -4029,10 +4035,14 @@ void main() {
 
         terminalOutput.clear();
 
-        // Hardware-key backspace at cursor offset 3 removes the first 'l'.
+        // Hardware-key backspace — blocked by the IME guard, not sent to
+        // terminal.
         await tester.sendKeyDownEvent(LogicalKeyboardKey.backspace);
         await tester.sendKeyUpEvent(LogicalKeyboardKey.backspace);
         await tester.pump();
+
+        // No terminal output from the blocked backspace.
+        expect(terminalOutput, isEmpty);
 
         // IME sends committed update reflecting the deletion.
         tester.testTextInput.updateEditingValue(


### PR DESCRIPTION
## Summary
- On Android, a soft-keyboard backspace/delete can dispatch **both** a key event and an IME `updateEditingValue` for the same keystroke. When both reach the terminal, the deletion is double-processed, desyncing `_lastSentText` from the terminal and causing later IME replacements (e.g. suggestion-bar taps) to produce jumbled text.
- Block `TerminalKey.backspace` and `TerminalKey.delete` in `_onKeyEvent` when the soft keyboard is shown (`_softKeyboardShown`), letting the IME's marker-damage or committed delta path handle deletions exclusively.
- Gate on `_softKeyboardShown` (not `hasInputConnection`) so hardware-key backspace still works when the connection is attached but the keyboard is hidden (e.g. `tapToShowKeyboard: false`).

## Test plan
- [x] Existing 107 tests pass
- [x] New test: key-event backspace blocked when soft keyboard is shown, IME suggestion replacement produces correct text
- [x] New test: IME committed update handles mid-word deletion alone when key event is blocked
- [x] New test: hardware-key backspace still works when `tapToShowKeyboard: false` (keyboard hidden, connection attached)
- [ ] Manual test on Android device with GBoard swipe typing: type "this ", backspace to "thi", tap "thistle" from suggestion bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)