### PR TITLE
fix: stop Android transfer intents from routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Repository notes for agents
+
+- Use JDK 17 for Android/Gradle builds in this repo. JDK 25 fails in the Android/Kotlin toolchain with `IllegalArgumentException: 25.0.1`.
+- On macOS, set `JAVA_HOME="$(/usr/libexec/java_home -v 17)"` before running `flutter build ...` or `./gradlew ...` for Android.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:taskAffinity=""
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
@@ -12,6 +12,7 @@ import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 import java.io.ByteArrayOutputStream
+import java.util.Locale
 
 class MainActivity : FlutterActivity() {
     companion object {
@@ -40,6 +41,13 @@ class MainActivity : FlutterActivity() {
             return "/"
         }
         return super.getInitialRoute()
+    }
+
+    override fun shouldHandleDeeplinking(): Boolean {
+        if (isTransferIntent(intent)) {
+            return false
+        }
+        return super.shouldHandleDeeplinking()
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
@@ -119,8 +127,8 @@ class MainActivity : FlutterActivity() {
     }
 
     override fun onNewIntent(intent: Intent) {
-        super.onNewIntent(intent)
         setIntent(intent)
+        super.onNewIntent(intent)
         handleTransferIntent(intent)
     }
 
@@ -173,7 +181,8 @@ class MainActivity : FlutterActivity() {
             return
         }
 
-        val sourceUri = intent.data ?: return
+        val transferIntent = intent ?: return
+        val sourceUri = transferIntent.data ?: return
         try {
             pendingTransferPayload = contentResolver.openInputStream(sourceUri)?.use { stream ->
                 val buffer = ByteArray(8192)
@@ -201,10 +210,11 @@ class MainActivity : FlutterActivity() {
     }
 
     private fun isTransferIntent(intent: Intent?): Boolean {
-        if (intent?.action != Intent.ACTION_VIEW) {
+        val transferIntent = intent ?: return false
+        if (transferIntent.action != Intent.ACTION_VIEW) {
             return false
         }
-        val sourceUri = intent.data ?: return false
+        val sourceUri = transferIntent.data ?: return false
         val hasSupportedScheme = when (sourceUri.scheme) {
             "content", "file" -> true
             else -> false
@@ -212,11 +222,11 @@ class MainActivity : FlutterActivity() {
         if (!hasSupportedScheme) {
             return false
         }
-        val mimeType = intent.type?.lowercase()
+        val mimeType = transferIntent.type?.lowercase(Locale.ROOT)
         if (mimeType == MONKEYSSH_TRANSFER_MIME_TYPE) {
             return true
         }
-        val lastPathSegment = sourceUri.lastPathSegment?.lowercase()
+        val lastPathSegment = sourceUri.lastPathSegment?.lowercase(Locale.ROOT)
         return lastPathSegment?.endsWith(MONKEYSSH_TRANSFER_EXTENSION) == true
     }
 

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
@@ -17,6 +17,8 @@ class MainActivity : FlutterActivity() {
     companion object {
         private const val NOTIFICATION_PERMISSION_REQUEST_CODE = 1001
         private const val MAX_CLIPBOARD_CONTENT_URI_BYTES = 512 * 1024
+        private const val MONKEYSSH_TRANSFER_MIME_TYPE = "application/x-monkeyssh-transfer"
+        private const val MONKEYSSH_TRANSFER_EXTENSION = ".monkeysshx"
     }
 
     private val channel = "xyz.depollsoft.monkeyssh/ssh_service"
@@ -31,6 +33,13 @@ class MainActivity : FlutterActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         handleTransferIntent(intent)
+    }
+
+    override fun getInitialRoute(): String? {
+        if (isTransferIntent(intent)) {
+            return "/"
+        }
+        return super.getInitialRoute()
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
@@ -160,7 +169,7 @@ class MainActivity : FlutterActivity() {
     }
 
     private fun handleTransferIntent(intent: Intent?) {
-        if (intent?.action != Intent.ACTION_VIEW) {
+        if (!isTransferIntent(intent)) {
             return
         }
 
@@ -189,6 +198,26 @@ class MainActivity : FlutterActivity() {
     private fun notifyIncomingTransferPayload() {
         val payload = pendingTransferPayload ?: return
         transferMethodChannel?.invokeMethod("onIncomingTransferPayload", payload)
+    }
+
+    private fun isTransferIntent(intent: Intent?): Boolean {
+        if (intent?.action != Intent.ACTION_VIEW) {
+            return false
+        }
+        val sourceUri = intent.data ?: return false
+        val hasSupportedScheme = when (sourceUri.scheme) {
+            "content", "file" -> true
+            else -> false
+        }
+        if (!hasSupportedScheme) {
+            return false
+        }
+        val mimeType = intent.type?.lowercase()
+        if (mimeType == MONKEYSSH_TRANSFER_MIME_TYPE) {
+            return true
+        }
+        val lastPathSegment = sourceUri.lastPathSegment?.lowercase()
+        return lastPathSegment?.endsWith(MONKEYSSH_TRANSFER_EXTENSION) == true
     }
 
     private fun readClipboardContentUri(uri: Uri): Map<String, Any> {


### PR DESCRIPTION
## Summary

- stop Android transfer-file `ACTION_VIEW` launches from being treated as Flutter routes when the incoming URI is a `content://` or `file://` transfer file
- reuse the existing app task for Drive/file opens so Android doesn't create a second MonkeySSH instance in recents/back stack

## Testing

- `flutter analyze`
- `flutter test`
- `flutter build apk --debug` *(fails locally because the installed Java reports `25.0.1`, which the current Gradle/Kotlin toolchain rejects before app compilation)*
