### PR TITLE
fix: use product name for iOS bundle metadata

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>$(APP_DISPLAY_NAME)</string>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(APP_DISPLAY_NAME)</string>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -50,14 +50,14 @@
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>$(APP_DISPLAY_NAME) needs photo library access to select files for transfer.</string>
+	<string>$(PRODUCT_NAME) needs photo library access to select files for transfer.</string>
 	<key>NSCameraUsageDescription</key>
-	<string>$(APP_DISPLAY_NAME) needs camera access to scan sync recovery key QR codes.</string>
+	<string>$(PRODUCT_NAME) needs camera access to scan sync recovery key QR codes.</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
 			<key>CFBundleTypeName</key>
-			<string>$(APP_DISPLAY_NAME) Transfer Package</string>
+			<string>$(PRODUCT_NAME) Transfer Package</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>LSHandlerRank</key>
@@ -69,7 +69,7 @@
 		</dict>
 		<dict>
 			<key>CFBundleTypeName</key>
-			<string>$(APP_DISPLAY_NAME) Sync Vault</string>
+			<string>$(PRODUCT_NAME) Sync Vault</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>LSHandlerRank</key>
@@ -86,7 +86,7 @@
 			<key>UTTypeIdentifier</key>
 			<string>xyz.depollsoft.monkeyssh.transfer</string>
 			<key>UTTypeDescription</key>
-			<string>$(APP_DISPLAY_NAME) Transfer Package</string>
+			<string>$(PRODUCT_NAME) Transfer Package</string>
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.data</string>
@@ -105,7 +105,7 @@
 			<key>UTTypeIdentifier</key>
 			<string>xyz.depollsoft.monkeyssh.sync-vault</string>
 			<key>UTTypeDescription</key>
-			<string>$(APP_DISPLAY_NAME) Sync Vault</string>
+			<string>$(PRODUCT_NAME) Sync Vault</string>
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.data</string>


### PR DESCRIPTION
## Summary

Fix the iOS Runner bundle metadata so the private flavor resolves a non-empty bundle name during build.

## Changes

- replace the undefined `APP_DISPLAY_NAME` placeholder in `ios/Runner/Info.plist`
- use the existing flavor-specific `PRODUCT_NAME` for bundle name, display name, and related Info.plist strings
- keep the private build resolving to `MonkeySSH β` in the built app bundle

## Validation

- `dart format .`
- `flutter analyze`
- `flutter test`
- `flutter build ios --flavor private --release --no-codesign`
