### PR TITLE
fix: support prod iOS subscription ids

### DIFF
--- a/lib/domain/models/monetization.dart
+++ b/lib/domain/models/monetization.dart
@@ -6,10 +6,10 @@ abstract final class MonetizationProductIds {
   /// Google Play subscription product.
   static const androidPro = 'monkeyssh_pro';
 
-  /// App Store monthly subscription product.
+  /// App Store monthly subscription product for the preview app.
   static const iosMonthly = 'monkeyssh_pro_monthly';
 
-  /// App Store annual subscription product.
+  /// App Store annual subscription product for the preview app.
   static const iosAnnual = 'monkeyssh_pro_annual';
 
   /// App Store monthly subscription product for the production app.
@@ -29,8 +29,8 @@ abstract final class MonetizationProductIds {
 
   /// Product identifiers to query on the current platform.
   static Set<String> forPlatform(TargetPlatform platform) => switch (platform) {
-    TargetPlatform.android => {androidPro},
-    TargetPlatform.iOS => {
+    TargetPlatform.android => const {androidPro},
+    TargetPlatform.iOS => const {
       iosMonthly,
       iosAnnual,
       iosMonthlyProd,

--- a/lib/domain/models/monetization.dart
+++ b/lib/domain/models/monetization.dart
@@ -12,13 +12,30 @@ abstract final class MonetizationProductIds {
   /// App Store annual subscription product.
   static const iosAnnual = 'monkeyssh_pro_annual';
 
+  /// App Store monthly subscription product for the production app.
+  static const iosMonthlyProd = 'monkeyssh_pro_monthly_prod';
+
+  /// App Store annual subscription product for the production app.
+  static const iosAnnualProd = 'monkeyssh_pro_annual_prod';
+
   /// All recognized paid products across platforms.
-  static const allKnown = <String>{androidPro, iosMonthly, iosAnnual};
+  static const allKnown = <String>{
+    androidPro,
+    iosMonthly,
+    iosAnnual,
+    iosMonthlyProd,
+    iosAnnualProd,
+  };
 
   /// Product identifiers to query on the current platform.
   static Set<String> forPlatform(TargetPlatform platform) => switch (platform) {
     TargetPlatform.android => {androidPro},
-    TargetPlatform.iOS => {iosMonthly, iosAnnual},
+    TargetPlatform.iOS => {
+      iosMonthly,
+      iosAnnual,
+      iosMonthlyProd,
+      iosAnnualProd,
+    },
     _ => const {},
   };
 }

--- a/lib/presentation/screens/upgrade_screen.dart
+++ b/lib/presentation/screens/upgrade_screen.dart
@@ -93,6 +93,12 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
     _ => 'Pricing loads from your local storefront',
   };
 
+  String _storefrontLabel() => switch (defaultTargetPlatform) {
+    TargetPlatform.iOS => 'the App Store',
+    TargetPlatform.android => 'Google Play',
+    _ => 'your local storefront',
+  };
+
   Future<void> _purchasePro(String offerId) async {
     final messenger = ScaffoldMessenger.of(context);
     final result = await ref
@@ -168,7 +174,14 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
         ref.watch(monetizationStateProvider).asData?.value ??
         ref.read(monetizationServiceProvider).currentState;
     final isCatalogLoading = state.isLoading && state.offers.isEmpty;
-    final isBusy = isCatalogLoading || _restoreInProgress;
+    final isBusy = state.isLoading || _restoreInProgress;
+    final progressMessage = switch ((state.isLoading, _restoreInProgress)) {
+      (_, true) => 'Restoring purchases from ${_storefrontLabel()}...',
+      (true, false) when state.offers.isEmpty =>
+        'Loading plans from ${_storefrontLabel()}...',
+      (true, false) => 'Processing your request with ${_storefrontLabel()}...',
+      _ => null,
+    };
     final feature = widget.feature;
     final highlightedOffer = state.activeOffer ?? state.defaultOffer;
     final priceLabel =
@@ -214,6 +227,10 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
           if (feature != null) ...[
             const SizedBox(height: 20),
             _UpgradeReasonCard(feature: feature),
+          ],
+          if (progressMessage case final message?) ...[
+            const SizedBox(height: 20),
+            _UpgradeProgressBanner(message: message),
           ],
           const SizedBox(height: 24),
           Text('Included with Pro', style: theme.textTheme.titleMedium),
@@ -588,6 +605,45 @@ class _UpgradeBanner extends StatelessWidget {
       ),
     ),
   );
+}
+
+class _UpgradeProgressBanner extends StatelessWidget {
+  const _UpgradeProgressBanner({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      key: const ValueKey('store-progress-banner'),
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHigh,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            message,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurface,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 12),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(999),
+            child: const LinearProgressIndicator(minHeight: 4),
+          ),
+        ],
+      ),
+    );
+  }
 }
 
 class _UpgradeReasonCard extends StatelessWidget {

--- a/test/domain/services/monetization_service_test.dart
+++ b/test/domain/services/monetization_service_test.dart
@@ -33,6 +33,22 @@ void main() {
     registerFallbackValue(_FakePurchaseParam());
   });
 
+  test('queries both preview and prod App Store product IDs on iOS', () {
+    expect(MonetizationProductIds.forPlatform(TargetPlatform.iOS), {
+      MonetizationProductIds.iosMonthly,
+      MonetizationProductIds.iosAnnual,
+      MonetizationProductIds.iosMonthlyProd,
+      MonetizationProductIds.iosAnnualProd,
+    });
+    expect(
+      MonetizationProductIds.allKnown,
+      containsAll({
+        MonetizationProductIds.iosMonthlyProd,
+        MonetizationProductIds.iosAnnualProd,
+      }),
+    );
+  });
+
   group('buildMonetizationOffers', () {
     test('deduplicates Google Play base plans and keeps trial offers', () {
       final productDetails = GooglePlayProductDetails.fromProductDetails(

--- a/test/domain/services/monetization_service_test.dart
+++ b/test/domain/services/monetization_service_test.dart
@@ -34,12 +34,15 @@ void main() {
   });
 
   test('queries both preview and prod App Store product IDs on iOS', () {
-    expect(MonetizationProductIds.forPlatform(TargetPlatform.iOS), {
-      MonetizationProductIds.iosMonthly,
-      MonetizationProductIds.iosAnnual,
-      MonetizationProductIds.iosMonthlyProd,
-      MonetizationProductIds.iosAnnualProd,
-    });
+    expect(
+      MonetizationProductIds.forPlatform(TargetPlatform.iOS),
+      unorderedEquals([
+        MonetizationProductIds.iosMonthly,
+        MonetizationProductIds.iosAnnual,
+        MonetizationProductIds.iosMonthlyProd,
+        MonetizationProductIds.iosAnnualProd,
+      ]),
+    );
     expect(
       MonetizationProductIds.allKnown,
       containsAll({

--- a/test/widget/upgrade_screen_test.dart
+++ b/test/widget/upgrade_screen_test.dart
@@ -342,4 +342,51 @@ void main() {
     );
     expect(sharedIntroText.data, contains('monthly and annual'));
   });
+
+  testWidgets('shows inline store progress while processing loaded plans', (
+    tester,
+  ) async {
+    final service = _MockMonetizationService();
+    const state = MonetizationState(
+      billingAvailability: MonetizationBillingAvailability.available,
+      entitlements: MonetizationEntitlements.free(),
+      offers: [
+        MonetizationOffer(
+          id: 'monthly',
+          productId: 'monkeyssh_pro',
+          billingPeriod: MonetizationBillingPeriod.monthly,
+          planLabel: 'Monthly',
+          priceLabel: r'$4.99',
+          displayPriceLabel: r'$4.99 / month',
+          rawPrice: 4.99,
+          currencyCode: 'USD',
+          currencySymbol: r'$',
+        ),
+      ],
+      debugUnlockAvailable: false,
+      debugUnlocked: false,
+      isLoading: true,
+    );
+
+    when(() => service.currentState).thenReturn(state);
+    when(
+      () => service.purchaseOffer(any()),
+    ).thenAnswer(_cancelledPurchaseResult);
+    _stubRestorePurchases(service);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          monetizationServiceProvider.overrideWithValue(service),
+          monetizationStateProvider.overrideWith((ref) => Stream.value(state)),
+        ],
+        child: const MaterialApp(home: UpgradeScreen()),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('store-progress-banner')), findsOneWidget);
+    expect(find.textContaining('Processing your request with'), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary

- add prod-suffixed iOS subscription product IDs alongside the existing preview IDs
- query all recognized iOS subscription IDs so the private preview app and release app can share one codebase
- add regression coverage for the iOS product ID query set

## Testing

- `flutter analyze`
- `flutter test`
