### PR TITLE
feat: add monkey release codenames

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -11,6 +11,11 @@ on:
         required: true
         type: string
         description: 'Build number (integer, monotonically increasing)'
+      build-codename:
+        required: false
+        type: string
+        default: ''
+        description: 'Monkey codename for the current major version'
       pr-number:
         required: false
         type: string
@@ -425,6 +430,9 @@ jobs:
           PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
           AAB_PATH: ../build/app/outputs/bundle/${{ inputs.flavor }}Release/app-${{ inputs.flavor }}-release.aab
           ANDROID_VERSION_CODE: ${{ inputs.build-number }}
+          FLUTTY_BUILD_NAME: ${{ inputs.build-name }}
+          FLUTTY_VERSION_CODENAME: ${{ inputs.build-codename }}
+          FLUTTY_SOURCE_SHA: ${{ steps.resolved-source-sha.outputs.value }}
           BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
         run: |
           cd android
@@ -633,6 +641,9 @@ jobs:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          FLUTTY_BUILD_NAME: ${{ inputs.build-name }}
+          FLUTTY_VERSION_CODENAME: ${{ inputs.build-codename }}
+          FLUTTY_SOURCE_SHA: ${{ steps.resolved-source-sha.outputs.value }}
           BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
         run: |
           cd ios

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -120,19 +120,20 @@ jobs:
     outputs:
       build-name: ${{ steps.provided-version.outputs.build-name || steps.source-version.outputs.build-name }}
       build-number: ${{ steps.provided-version.outputs.build-number || steps.source-version.outputs.build-number }}
+      build-codename: ${{ steps.version-codename.outputs.build-codename }}
+      build-display: ${{ steps.version-codename.outputs.build-display }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          ref: ${{ needs.validate-pr.outputs.deploy-sha }}
+
       - name: Reuse requested build version
         id: provided-version
         if: inputs.preview-build-name != '' && inputs.preview-build-number != ''
         run: |
           echo "build-name=${{ inputs.preview-build-name }}" >> "$GITHUB_OUTPUT"
           echo "build-number=${{ inputs.preview-build-number }}" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: inputs.preview-build-name == '' || inputs.preview-build-number == ''
-        with:
-          persist-credentials: false
-          ref: ${{ needs.validate-pr.outputs.deploy-sha }}
 
       - name: Compute version
         id: source-version
@@ -144,6 +145,22 @@ jobs:
           echo "build-name=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "build-number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve codename
+        id: version-codename
+        env:
+          PROVIDED_BUILD_NAME: ${{ steps.provided-version.outputs.build-name }}
+          SOURCE_BUILD_NAME: ${{ steps.source-version.outputs.build-name }}
+        run: |
+          BUILD_NAME="${PROVIDED_BUILD_NAME:-$SOURCE_BUILD_NAME}"
+          BUILD_CODENAME=$(python3 scripts/version_codename.py "$BUILD_NAME")
+          BUILD_DISPLAY="$BUILD_NAME"
+          if [ -n "$BUILD_CODENAME" ]; then
+            BUILD_DISPLAY="$BUILD_NAME \"$BUILD_CODENAME\""
+          fi
+
+          echo "build-codename=${BUILD_CODENAME}" >> "$GITHUB_OUTPUT"
+          echo "build-display=${BUILD_DISPLAY}" >> "$GITHUB_OUTPUT"
+
   finalize-version:
     name: Finalize Deploy Version
     needs: [validate-pr, compute-version]
@@ -154,6 +171,8 @@ jobs:
     outputs:
       build-name: ${{ steps.finalize.outputs.build-name }}
       build-number: ${{ steps.finalize.outputs.build-number }}
+      build-codename: ${{ steps.finalize.outputs.build-codename }}
+      build-display: ${{ steps.finalize.outputs.build-display }}
       requested-build-name: ${{ steps.finalize.outputs.requested-build-name }}
       requested-build-number: ${{ steps.finalize.outputs.requested-build-number }}
       rebuild-required: ${{ steps.finalize.outputs.rebuild-required }}
@@ -168,6 +187,8 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const requestedBuildName = '${{ needs.compute-version.outputs.build-name }}'.trim();
+            const requestedBuildCodename = '${{ needs.compute-version.outputs.build-codename }}'.trim();
+            const requestedBuildDisplay = '${{ needs.compute-version.outputs.build-display }}'.trim();
             const requestedBuildNumber = '${{ needs.compute-version.outputs.build-number }}'.trim();
             const workflowIds = ['deploy-testflight.yml', 'develop.yml'];
             const markerArtifactPattern = /^private-deploy-build-number-(\d+)$/;
@@ -290,6 +311,8 @@ jobs:
 
             core.setOutput('build-name', requestedBuildName);
             core.setOutput('build-number', buildNumber);
+            core.setOutput('build-codename', requestedBuildCodename);
+            core.setOutput('build-display', requestedBuildDisplay);
             core.setOutput('requested-build-name', requestedBuildName);
             core.setOutput('requested-build-number', requestedBuildNumber);
             core.setOutput('rebuild-required', rebuildRequired);
@@ -562,7 +585,7 @@ jobs:
               '| **Status** | 🔒 Lock acquired — deploying |',
               `| **Requested by** | ${requestDetails} |`,
               `| **Preview SHA** | \`${deploySha}\` |`,
-              `| **Version** | \`${{ needs.finalize-version.outputs.build-name }}\` |`,
+              `| **Version** | \`${{ needs.finalize-version.outputs.build-display }}\` |`,
               `| **Build** | \`${{ needs.finalize-version.outputs.build-number }}\` |`,
               '| **Android Status** | ⏳ Deploying to Play internal |',
               '| **iOS Status** | ⏳ Uploading to TestFlight |',
@@ -587,9 +610,10 @@ jobs:
                `<!-- preview-deploy-request-comment-url:${requestCommentUrl} -->`,
                `<!-- preview-deploy-preview-comment-url:${previewCommentUrl} -->`,
                `<!-- preview-deploy-workflow-url:${runUrl} -->`,
-               `<!-- preview-deploy-source-sha:${deploySha} -->`,
-               `<!-- preview-deploy-build-name:${{ needs.finalize-version.outputs.build-name }} -->`,
-               `<!-- preview-deploy-build-number:${{ needs.finalize-version.outputs.build-number }} -->`,
+                `<!-- preview-deploy-source-sha:${deploySha} -->`,
+                `<!-- preview-deploy-build-name:${{ needs.finalize-version.outputs.build-name }} -->`,
+                `<!-- preview-deploy-build-codename:${{ needs.finalize-version.outputs.build-codename }} -->`,
+                `<!-- preview-deploy-build-number:${{ needs.finalize-version.outputs.build-number }} -->`,
                `<!-- preview-deploy-requested-build-number:${{ needs.finalize-version.outputs.requested-build-number }} -->`,
                `<!-- preview-deploy-rebuild-required:${{ needs.finalize-version.outputs.rebuild-required }} -->`,
             ]
@@ -624,6 +648,7 @@ jobs:
     with:
       build-name: ${{ needs.finalize-version.outputs.build-name }}
       build-number: ${{ needs.finalize-version.outputs.build-number }}
+      build-codename: ${{ needs.finalize-version.outputs.build-codename }}
       pr-number: ${{ inputs.pr-number }}
       pr-title: ${{ needs.validate-pr.outputs.pr-title }}
       flavor: private
@@ -910,7 +935,7 @@ jobs:
               `| **Requested by** | ${requestDetails} |`,
               deploySha ? `| **Preview SHA** | \`${deploySha}\` |` : null,
               '${{ needs.finalize-version.outputs.build-name }}'
-                ? `| **Version** | \`${{ needs.finalize-version.outputs.build-name }}\` |`
+                ? `| **Version** | \`${{ needs.finalize-version.outputs.build-display }}\` |`
                 : null,
               '${{ needs.finalize-version.outputs.build-number }}'
                 ? `| **Build** | \`${{ needs.finalize-version.outputs.build-number }}\` |`
@@ -938,9 +963,10 @@ jobs:
                `<!-- preview-deploy-request-comment-url:${requestCommentUrl} -->`,
                `<!-- preview-deploy-preview-comment-url:${previewCommentUrl} -->`,
                `<!-- preview-deploy-workflow-url:${runUrl} -->`,
-               `<!-- preview-deploy-source-sha:${deploySha} -->`,
-               `<!-- preview-deploy-build-name:${{ needs.finalize-version.outputs.build-name }} -->`,
-               `<!-- preview-deploy-build-number:${{ needs.finalize-version.outputs.build-number }} -->`,
+                `<!-- preview-deploy-source-sha:${deploySha} -->`,
+                `<!-- preview-deploy-build-name:${{ needs.finalize-version.outputs.build-name }} -->`,
+                `<!-- preview-deploy-build-codename:${{ needs.finalize-version.outputs.build-codename }} -->`,
+                `<!-- preview-deploy-build-number:${{ needs.finalize-version.outputs.build-number }} -->`,
                `<!-- preview-deploy-requested-build-number:${{ needs.finalize-version.outputs.requested-build-number }} -->`,
                `<!-- preview-deploy-rebuild-required:${{ needs.finalize-version.outputs.rebuild-required }} -->`,
             ]

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       build-name: ${{ steps.version.outputs.build-name }}
       build-number: ${{ steps.version.outputs.build-number }}
+      build-codename: ${{ steps.version.outputs.build-codename }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -35,9 +36,11 @@ jobs:
         run: |
           BASE_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | cut -d'+' -f1)
           BUILD_NUMBER=$(( $(date +%s) / 10 ))
+          BUILD_CODENAME=$(python3 scripts/version_codename.py "$BASE_VERSION")
 
           echo "build-name=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "build-number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "build-codename=${BUILD_CODENAME}" >> "$GITHUB_OUTPUT"
 
   deploy:
     name: Build & Deploy Private
@@ -46,6 +49,7 @@ jobs:
     with:
       build-name: ${{ needs.compute-version.outputs.build-name }}
       build-number: ${{ needs.compute-version.outputs.build-number }}
+      build-codename: ${{ needs.compute-version.outputs.build-codename }}
       flavor: private
       deploy-ios-to: testflight
       deploy-android-to: internal

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,6 +20,8 @@ jobs:
     outputs:
       build-name: ${{ steps.version.outputs.build-name }}
       build-number: ${{ steps.version.outputs.build-number }}
+      build-codename: ${{ steps.version.outputs.build-codename }}
+      build-display: ${{ steps.version.outputs.build-display }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -31,9 +33,16 @@ jobs:
         run: |
           BASE_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | cut -d'+' -f1)
           BUILD_NUMBER=$(( $(date +%s) / 10 ))
+          BUILD_CODENAME=$(python3 scripts/version_codename.py "$BASE_VERSION")
+          BUILD_DISPLAY="$BASE_VERSION"
+          if [ -n "$BUILD_CODENAME" ]; then
+            BUILD_DISPLAY="$BASE_VERSION \"$BUILD_CODENAME\""
+          fi
 
           echo "build-name=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "build-number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "build-codename=${BUILD_CODENAME}" >> "$GITHUB_OUTPUT"
+          echo "build-display=${BUILD_DISPLAY}" >> "$GITHUB_OUTPUT"
 
   comment-initial:
     name: PR Comment (Queued)
@@ -54,7 +63,7 @@ jobs:
 
             | | Details |
             |---|---|
-            | **Version** | `${{ needs.compute-version.outputs.build-name }}` (PR #${{ github.event.pull_request.number }}) |
+            | **Version** | `${{ needs.compute-version.outputs.build-display }}` (PR #${{ github.event.pull_request.number }}) |
             | **Build** | `${{ needs.compute-version.outputs.build-number }}` |
             | **Android Status** | ⏳ Building |
             | **iOS Status** | ⏳ Building |
@@ -71,6 +80,7 @@ jobs:
             > Build triggered by ${{ github.event.pull_request.head.sha }}
             <!-- preview-build-source-sha:${{ github.event.pull_request.head.sha }} -->
             <!-- preview-build-name:${{ needs.compute-version.outputs.build-name }} -->
+            <!-- preview-build-codename:${{ needs.compute-version.outputs.build-codename }} -->
             <!-- preview-build-number:${{ needs.compute-version.outputs.build-number }} -->
             <!-- preview-build-run-id:${{ github.run_id }} -->
 
@@ -82,6 +92,7 @@ jobs:
     with:
       build-name: ${{ needs.compute-version.outputs.build-name }}
       build-number: ${{ needs.compute-version.outputs.build-number }}
+      build-codename: ${{ needs.compute-version.outputs.build-codename }}
       pr-number: ${{ github.event.pull_request.number }}
       pr-title: ${{ github.event.pull_request.title }}
       flavor: private
@@ -100,6 +111,7 @@ jobs:
     with:
       build-name: ${{ needs.compute-version.outputs.build-name }}
       build-number: ${{ needs.compute-version.outputs.build-number }}
+      build-codename: ${{ needs.compute-version.outputs.build-codename }}
       pr-number: ${{ github.event.pull_request.number }}
       pr-title: ${{ github.event.pull_request.title }}
       flavor: private
@@ -185,7 +197,7 @@ jobs:
 
             | | Details |
             |---|---|
-            | **Version** | `${{ needs.compute-version.outputs.build-name }}` (PR #${{ github.event.pull_request.number }}) |
+            | **Version** | `${{ needs.compute-version.outputs.build-display }}` (PR #${{ github.event.pull_request.number }}) |
             | **Build** | `${{ needs.compute-version.outputs.build-number }}` |
             | **Android Status** | ${{ steps.preview-status.outputs.android-status }} |
             | **iOS Status** | ${{ steps.preview-status.outputs.ios-status }} |
@@ -202,6 +214,7 @@ jobs:
             > Build triggered by ${{ github.event.pull_request.head.sha }}
             <!-- preview-build-source-sha:${{ github.event.pull_request.head.sha }} -->
             <!-- preview-build-name:${{ needs.compute-version.outputs.build-name }} -->
+            <!-- preview-build-codename:${{ needs.compute-version.outputs.build-codename }} -->
             <!-- preview-build-number:${{ needs.compute-version.outputs.build-number }} -->
             <!-- preview-build-run-id:${{ github.run_id }} -->
 
@@ -280,7 +293,7 @@ jobs:
 
             | | Details |
             |---|---|
-            | **Version** | `${{ needs.compute-version.outputs.build-name }}` (PR #${{ github.event.pull_request.number }}) |
+            | **Version** | `${{ needs.compute-version.outputs.build-display }}` (PR #${{ github.event.pull_request.number }}) |
             | **Build** | `${{ needs.compute-version.outputs.build-number }}` |
             | **Android Status** | ${{ steps.preview-status.outputs.android-status }} |
             | **iOS Status** | ${{ steps.preview-status.outputs.ios-status }} |
@@ -297,5 +310,6 @@ jobs:
             > Build triggered by ${{ github.event.pull_request.head.sha }}
             <!-- preview-build-source-sha:${{ github.event.pull_request.head.sha }} -->
             <!-- preview-build-name:${{ needs.compute-version.outputs.build-name }} -->
+            <!-- preview-build-codename:${{ needs.compute-version.outputs.build-codename }} -->
             <!-- preview-build-number:${{ needs.compute-version.outputs.build-number }} -->
             <!-- preview-build-run-id:${{ github.run_id }} -->

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -18,6 +18,8 @@ jobs:
     outputs:
       build-name: ${{ steps.version.outputs.build-name }}
       build-number: ${{ steps.version.outputs.build-number }}
+      build-codename: ${{ steps.version.outputs.build-codename }}
+      build-display: ${{ steps.version.outputs.build-display }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -34,11 +36,18 @@ jobs:
 
           BUILD_NAME="$(printf '%s' "$VERSION_LINE" | sed 's/^version:[[:space:]]*//' | cut -d'+' -f1 | xargs)"
           BUILD_NUMBER=$(( $(date +%s) / 10 ))
+          BUILD_CODENAME=$(python3 scripts/version_codename.py "$BUILD_NAME")
+          BUILD_DISPLAY="$BUILD_NAME"
+          if [ -n "$BUILD_CODENAME" ]; then
+            BUILD_DISPLAY="$BUILD_NAME \"$BUILD_CODENAME\""
+          fi
 
           echo "build-name=${BUILD_NAME}" >> "$GITHUB_OUTPUT"
           echo "build-number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "build-codename=${BUILD_CODENAME}" >> "$GITHUB_OUTPUT"
+          echo "build-display=${BUILD_DISPLAY}" >> "$GITHUB_OUTPUT"
           echo "## Internal Release Info" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Version:** ${BUILD_NAME}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version:** ${BUILD_DISPLAY}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Build Number:** ${BUILD_NUMBER}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Flavor:** production" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Audience:** internal testers only" >> "$GITHUB_STEP_SUMMARY"
@@ -50,6 +59,7 @@ jobs:
     with:
       build-name: ${{ needs.compute-version.outputs.build-name }}
       build-number: ${{ needs.compute-version.outputs.build-number }}
+      build-codename: ${{ needs.compute-version.outputs.build-codename }}
       flavor: production
       deploy-ios-to: testflight
       deploy-android-to: internal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,13 @@ jobs:
     outputs:
       build-name: ${{ steps.version.outputs.build-name }}
       build-number: ${{ steps.version.outputs.build-number }}
+      build-codename: ${{ steps.version.outputs.build-codename }}
+      build-display: ${{ steps.version.outputs.build-display }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
       - name: Compute version
         id: version
         run: |
@@ -37,11 +43,18 @@ jobs:
           fi
 
           BUILD_NUMBER=$(( $(date +%s) / 10 ))
+          BUILD_CODENAME=$(python3 scripts/version_codename.py "$BUILD_NAME")
+          BUILD_DISPLAY="$BUILD_NAME"
+          if [ -n "$BUILD_CODENAME" ]; then
+            BUILD_DISPLAY="$BUILD_NAME \"$BUILD_CODENAME\""
+          fi
 
           echo "build-name=${BUILD_NAME}" >> "$GITHUB_OUTPUT"
           echo "build-number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "build-codename=${BUILD_CODENAME}" >> "$GITHUB_OUTPUT"
+          echo "build-display=${BUILD_DISPLAY}" >> "$GITHUB_OUTPUT"
           echo "## Release Info" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Version:** ${BUILD_NAME}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version:** ${BUILD_DISPLAY}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Build Number:** ${BUILD_NUMBER}" >> "$GITHUB_STEP_SUMMARY"
 
   deploy:
@@ -51,6 +64,7 @@ jobs:
     with:
       build-name: ${{ needs.compute-version.outputs.build-name }}
       build-number: ${{ needs.compute-version.outputs.build-number }}
+      build-codename: ${{ needs.compute-version.outputs.build-codename }}
       flavor: production
       deploy-ios-to: appstore
       deploy-android-to: production

--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ lib/
 
 See [docs/deployment.md](docs/deployment.md) for setting up automated deployment to TestFlight and Google Play.
 
+## Versioning
+
+MonkeySSH keeps the store-facing app version numeric (`major.minor.patch`) so App Store Connect and Google Play accept the build, and layers a monkey codename on top of each major version.
+
+- Major `0` starts the sequence with **Allen's Swamp Monkey**
+- Each later major advances alphabetically: **Baboon**, **Capuchin**, **Drill**, and so on
+- `X` is intentionally reserved until a real X codename is chosen
+
+The canonical codename table lives in `assets/version_codenames.json`, and release workflows plus the in-app About screen both read from that scheme.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -1,5 +1,9 @@
 default_platform(:android)
 
+require 'fileutils'
+require 'tmpdir'
+require_relative '../../scripts/preview_release_notes'
+
 platform :android do
   METADATA_DIRS = {
     'xyz.depollsoft.monkeyssh.private' => File.expand_path('metadata-private/android', __dir__),
@@ -62,6 +66,25 @@ platform :android do
     version_codes.include?(version_code)
   end
 
+  private_lane :prepared_metadata_path do |options|
+    base_metadata_path = options[:base_metadata_path]
+    version_code = options[:version_code].to_s
+    preview_notes = PreviewReleaseNotes.current
+
+    return [base_metadata_path, false] if preview_notes.nil? || version_code.empty?
+
+    tmpdir = Dir.mktmpdir('flutty-play-metadata')
+    if base_metadata_path && File.directory?(base_metadata_path)
+      FileUtils.cp_r(File.join(base_metadata_path, '.'), tmpdir)
+    end
+
+    changelog_dir = File.join(tmpdir, 'en-US', 'changelogs')
+    FileUtils.mkdir_p(changelog_dir)
+    File.write(File.join(changelog_dir, "#{version_code}.txt"), preview_notes)
+
+    [tmpdir, true]
+  end
+
   desc 'Upload flavor AAB to Play Store internal testing'
   lane :internal do |options|
     skip_meta = options[:skip_metadata].to_s == 'true'
@@ -85,6 +108,12 @@ platform :android do
           "Metadata sync requires a supported package_name. Expected one of: #{allowed_packages}",
         )
       end
+    upload_metadata_path = nil
+    remove_metadata_path = false
+    upload_metadata_path, remove_metadata_path = prepared_metadata_path(
+      base_metadata_path: meta_path,
+      version_code: version_code,
+    )
 
     clear_draft_releases(package_name: package, track: 'internal')
 
@@ -98,13 +127,15 @@ platform :android do
       track: 'internal',
       aab: ENV['AAB_PATH'] || default_aab,
       json_key_data: ENV['PLAY_STORE_SERVICE_ACCOUNT_JSON'],
-      metadata_path: meta_path,
+      metadata_path: upload_metadata_path,
       skip_upload_metadata: skip_meta,
       skip_upload_images: skip_meta,
       skip_upload_screenshots: true,
-      skip_upload_changelogs: skip_meta,
+      skip_upload_changelogs: upload_metadata_path.nil?,
       changes_not_sent_for_review: true,
     )
+  ensure
+    FileUtils.rm_rf(upload_metadata_path) if remove_metadata_path
   end
 
   desc 'Upload production flavor AAB to Play Store production'

--- a/assets/version_codenames.json
+++ b/assets/version_codenames.json
@@ -1,0 +1,137 @@
+{
+  "major_version_offset": 0,
+  "codenames": [
+    {
+      "major": 0,
+      "letter": "A",
+      "name": "Allen's Swamp Monkey"
+    },
+    {
+      "major": 1,
+      "letter": "B",
+      "name": "Baboon"
+    },
+    {
+      "major": 2,
+      "letter": "C",
+      "name": "Capuchin"
+    },
+    {
+      "major": 3,
+      "letter": "D",
+      "name": "Drill"
+    },
+    {
+      "major": 4,
+      "letter": "E",
+      "name": "Emperor Tamarin"
+    },
+    {
+      "major": 5,
+      "letter": "F",
+      "name": "Francois' Langur"
+    },
+    {
+      "major": 6,
+      "letter": "G",
+      "name": "Gelada"
+    },
+    {
+      "major": 7,
+      "letter": "H",
+      "name": "Howler Monkey"
+    },
+    {
+      "major": 8,
+      "letter": "I",
+      "name": "Indri"
+    },
+    {
+      "major": 9,
+      "letter": "J",
+      "name": "Japanese Macaque"
+    },
+    {
+      "major": 10,
+      "letter": "K",
+      "name": "Kipunji"
+    },
+    {
+      "major": 11,
+      "letter": "L",
+      "name": "Langur"
+    },
+    {
+      "major": 12,
+      "letter": "M",
+      "name": "Mandrill"
+    },
+    {
+      "major": 13,
+      "letter": "N",
+      "name": "Night Monkey"
+    },
+    {
+      "major": 14,
+      "letter": "O",
+      "name": "Orangutan"
+    },
+    {
+      "major": 15,
+      "letter": "P",
+      "name": "Proboscis Monkey"
+    },
+    {
+      "major": 16,
+      "letter": "Q",
+      "name": "Quiracoatan"
+    },
+    {
+      "major": 17,
+      "letter": "R",
+      "name": "Rhesus Macaque"
+    },
+    {
+      "major": 18,
+      "letter": "S",
+      "name": "Squirrel Monkey"
+    },
+    {
+      "major": 19,
+      "letter": "T",
+      "name": "Titi Monkey"
+    },
+    {
+      "major": 20,
+      "letter": "U",
+      "name": "Uakari"
+    },
+    {
+      "major": 21,
+      "letter": "V",
+      "name": "Vervet Monkey"
+    },
+    {
+      "major": 22,
+      "letter": "W",
+      "name": "Woolly Monkey"
+    },
+    {
+      "major": 23,
+      "letter": "X",
+      "name": null,
+      "reserved": true,
+      "note": "Reserved until an X codename is chosen."
+    },
+    {
+      "major": 24,
+      "letter": "Y",
+      "name": "Yellow Baboon"
+    },
+    {
+      "major": 25,
+      "letter": "Z",
+      "name": "Zanzibar Red Colobus"
+    }
+  ]
+}

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -3,6 +3,7 @@ default_platform(:ios)
 require 'fileutils'
 require 'shellwords'
 require 'tmpdir'
+require_relative '../../scripts/preview_release_notes'
 
 platform :ios do
   before_all do
@@ -106,6 +107,20 @@ platform :ios do
   private_lane :resolved_ipa_path do |options|
     provided_ipa_path = options[:ipa_path].to_s
     provided_ipa_path.empty? ? lane_context[SharedValues::IPA_OUTPUT_PATH] : provided_ipa_path
+  end
+
+  private_lane :testflight_release_notes do
+    preview_notes = PreviewReleaseNotes.current
+    return [nil, nil] if preview_notes.nil?
+
+    [
+      preview_notes,
+      {
+        'en-US' => {
+          whats_new: preview_notes,
+        },
+      },
+    ]
   end
 
   private_lane :resolved_profile_path do |options|
@@ -344,6 +359,7 @@ platform :ios do
     app_id = APP_IDS[scheme]
     skip_meta = options[:skip_metadata].to_s == 'true'
     provided_ipa_path = options[:ipa_path].to_s
+    changelog, localized_build_info = testflight_release_notes
 
     build_and_sign(scheme: scheme) if provided_ipa_path.empty?
 
@@ -355,6 +371,8 @@ platform :ios do
       skip_submission: false,
       distribute_external: false,
       uses_non_exempt_encryption: false,
+      changelog: changelog,
+      localized_build_info: localized_build_info,
     )
 
     sync_metadata(app_identifier: app_id) unless skip_meta

--- a/lib/app/app_metadata.dart
+++ b/lib/app/app_metadata.dart
@@ -1,11 +1,16 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 /// Default app name used while platform metadata is still loading.
 const defaultAppName = 'MonkeySSH';
+const _versionCodenameAssetPath = 'assets/version_codenames.json';
 
 const _pullRequestNumber = String.fromEnvironment('FLUTTY_PR_NUMBER');
 const _pullRequestTitle = String.fromEnvironment('FLUTTY_PR_TITLE');
+Future<Map<int, String>>? _versionCodenameLookup;
 
 /// Provides the current platform app name with a safe fallback.
 final appDisplayNameProvider = Provider<String>((ref) {
@@ -24,6 +29,7 @@ final appMetadataProvider = FutureProvider<AppMetadata>((ref) async {
     appName: normalizeAppName(packageInfo.appName),
     version: packageInfo.version,
     buildNumber: packageInfo.buildNumber,
+    versionCodename: await _resolveVersionCodename(packageInfo.version),
     pullRequestNumber: _normalizeBuildMetadata(_pullRequestNumber),
     pullRequestTitle: _normalizeBuildMetadata(_pullRequestTitle),
   );
@@ -42,6 +48,7 @@ class AppMetadata {
     required this.appName,
     required this.version,
     required this.buildNumber,
+    this.versionCodename,
     this.pullRequestNumber,
     this.pullRequestTitle,
   });
@@ -55,14 +62,27 @@ class AppMetadata {
   /// Platform build number for the current app bundle.
   final String buildNumber;
 
+  /// Monkey-themed codename associated with the current major version.
+  final String? versionCodename;
+
   /// Pull request number for preview-derived builds, when present.
   final String? pullRequestNumber;
 
   /// Pull request title for preview-derived builds, when present.
   final String? pullRequestTitle;
 
+  /// Human-visible version label including the major-version codename.
+  String get marketingVersionLabel {
+    final versionCodename = this.versionCodename;
+    if (versionCodename == null) {
+      return version;
+    }
+
+    return '$version "$versionCodename"';
+  }
+
   /// Combined version/build label for settings and license UI.
-  String get versionLabel => '$version ($buildNumber)';
+  String get versionLabel => '$marketingVersionLabel ($buildNumber)';
 
   /// Human-friendly pull request label for preview/TestFlight deploys.
   String? get pullRequestLabel {
@@ -87,6 +107,57 @@ String? _normalizeBuildMetadata(String value) {
   }
 
   return trimmedValue;
+}
+
+Future<String?> _resolveVersionCodename(String version) async {
+  final majorVersion = _parseMajorVersion(version);
+  if (majorVersion == null) {
+    return null;
+  }
+
+  final versionCodenameLookup = await (_versionCodenameLookup ??=
+      _loadVersionCodenameLookup());
+  return versionCodenameLookup[majorVersion];
+}
+
+Future<Map<int, String>> _loadVersionCodenameLookup() async {
+  final payload = jsonDecode(
+    await rootBundle.loadString(_versionCodenameAssetPath),
+  );
+  final result = <int, String>{};
+
+  if (payload case {'codenames': final List<dynamic> entries}) {
+    for (final entry in entries) {
+      if (entry is! Map<String, dynamic>) {
+        continue;
+      }
+
+      final majorVersion = entry['major'];
+      final name = entry['name'];
+      if (majorVersion is int && name is String) {
+        final normalizedName = name.trim();
+        if (normalizedName.isNotEmpty) {
+          result[majorVersion] = normalizedName;
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+int? _parseMajorVersion(String version) {
+  final trimmedVersion = version.trim();
+  if (trimmedVersion.isEmpty) {
+    return null;
+  }
+
+  final segments = trimmedVersion.split('.');
+  if (segments.isEmpty) {
+    return null;
+  }
+
+  return int.tryParse(segments.first);
 }
 
 /// Normalizes a platform app name and falls back to [defaultAppName].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -91,5 +91,6 @@ flutter:
   
   assets:
     - assets/icons/
+    - assets/version_codenames.json
   #   - assets/icons/
   #   - assets/fonts/

--- a/scripts/preview_release_notes.rb
+++ b/scripts/preview_release_notes.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module PreviewReleaseNotes
+  module_function
+
+  def current
+    pr_number = normalize(ENV['FLUTTY_PR_NUMBER'])
+    pr_title = normalize(ENV['FLUTTY_PR_TITLE'])
+    return nil if pr_number.nil? && pr_title.nil?
+
+    build_name = normalize(ENV['FLUTTY_BUILD_NAME'])
+    version_codename = normalize(ENV['FLUTTY_VERSION_CODENAME'])
+    source_sha = normalize(ENV['FLUTTY_SOURCE_SHA'])
+    repository = normalize(ENV['GITHUB_REPOSITORY'])
+    server_url = normalize(ENV['GITHUB_SERVER_URL']) || 'https://github.com'
+
+    lines = [headline(pr_number: pr_number, pr_title: pr_title)]
+    version_line = format_version(build_name: build_name, version_codename: version_codename)
+    lines << version_line if version_line
+
+    if repository && pr_number
+      lines << "PR: #{server_url}/#{repository}/pull/#{pr_number}"
+    end
+
+    lines << "Commit: #{source_sha[0, 7]}" if source_sha
+
+    lines.join("\n")
+  end
+
+  def headline(pr_number:, pr_title:)
+    return "PR ##{pr_number}: #{pr_title}" if pr_number && pr_title
+    return "PR ##{pr_number}" if pr_number
+
+    pr_title
+  end
+
+  def format_version(build_name:, version_codename:)
+    return nil if build_name.nil? && version_codename.nil?
+    return %(Version: #{build_name} "#{version_codename}") if build_name && version_codename
+    return "Version: #{build_name}" if build_name
+
+    "Codename: #{version_codename}"
+  end
+
+  def normalize(value)
+    trimmed = value.to_s.strip
+    trimmed.empty? ? nil : trimmed
+  end
+end

--- a/scripts/version_codename.py
+++ b/scripts/version_codename.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+
+def parse_major(version: str) -> int | None:
+    value = version.strip()
+    if not value:
+        return None
+
+    major_segment = value.split('.', 1)[0].strip()
+    if not major_segment:
+        return None
+
+    try:
+        return int(major_segment)
+    except ValueError:
+        return None
+
+
+def load_mapping() -> dict[int, str]:
+    mapping_path = pathlib.Path(__file__).resolve().parent.parent / 'assets' / 'version_codenames.json'
+    payload = json.loads(mapping_path.read_text(encoding='utf-8'))
+    result: dict[int, str] = {}
+
+    for entry in payload.get('codenames', []):
+        if not isinstance(entry, dict):
+            continue
+
+        major = entry.get('major')
+        name = entry.get('name')
+        if isinstance(major, int) and isinstance(name, str) and name.strip():
+            result[major] = name.strip()
+
+    return result
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print('usage: version_codename.py <version>', file=sys.stderr)
+        return 1
+
+    major = parse_major(sys.argv[1])
+    if major is None:
+        return 0
+
+    codename = load_mapping().get(major)
+    if codename:
+        print(codename)
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/test/app/app_metadata_test.dart
+++ b/test/app/app_metadata_test.dart
@@ -4,6 +4,8 @@ import 'package:monkeyssh/app/app_metadata.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('appMetadataProvider exposes the platform app name', () async {
     PackageInfo.setMockInitialValues(
       appName: 'MonkeySSH β',
@@ -19,6 +21,7 @@ void main() {
     final metadata = await container.read(appMetadataProvider.future);
 
     expect(metadata.appName, 'MonkeySSH β');
-    expect(metadata.versionLabel, '1.2.3 (456)');
+    expect(metadata.versionCodename, 'Baboon');
+    expect(metadata.versionLabel, '1.2.3 "Baboon" (456)');
   });
 }

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -209,7 +209,25 @@ void main() {
       final db = AppDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);
 
-      await _pumpSettingsScreen(tester, db: db);
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            appMetadataProvider.overrideWith(
+              (ref) async => const AppMetadata(
+                appName: 'MonkeySSH',
+                version: '0.1.1',
+                buildNumber: '123',
+                versionCodename: 'Allen\'s Swamp Monkey',
+              ),
+            ),
+            databaseProvider.overrideWithValue(db),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(MockAuthStateNotifier.new),
+          ],
+          child: const MaterialApp(home: SettingsScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
 
       await tester.scrollUntilVisible(
         find.text('App version'),
@@ -219,7 +237,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('App version'), findsOneWidget);
-      expect(find.text('0.1.1 (123)'), findsOneWidget);
+      expect(find.text('0.1.1 "Allen\'s Swamp Monkey" (123)'), findsOneWidget);
       expect(find.text('GitHub'), findsOneWidget);
       expect(find.text('Licenses'), findsOneWidget);
     });
@@ -236,6 +254,7 @@ void main() {
                 appName: 'MonkeySSH',
                 version: '0.1.1',
                 buildNumber: '123',
+                versionCodename: 'Allen\'s Swamp Monkey',
                 pullRequestNumber: '175',
                 pullRequestTitle: 'Show PR metadata in settings',
               ),


### PR DESCRIPTION
## Summary

- add a shared monkey codename table keyed by major version and surface it in app metadata/settings
- include the codename in release workflow summaries and preview/deploy comments while keeping store-facing version numbers numeric
- add PR preview release notes for Play internal and TestFlight using PR metadata plus version/codename context
