### PR TITLE
feat: support Mac App Store billing

### DIFF
--- a/lib/domain/models/monetization.dart
+++ b/lib/domain/models/monetization.dart
@@ -6,16 +6,16 @@ abstract final class MonetizationProductIds {
   /// Google Play subscription product.
   static const androidPro = 'monkeyssh_pro';
 
-  /// App Store monthly subscription product for the preview app.
+  /// Apple App Store monthly subscription product for the preview app.
   static const iosMonthly = 'monkeyssh_pro_monthly';
 
-  /// App Store annual subscription product for the preview app.
+  /// Apple App Store annual subscription product for the preview app.
   static const iosAnnual = 'monkeyssh_pro_annual';
 
-  /// App Store monthly subscription product for the production app.
+  /// Apple App Store monthly subscription product for the production app.
   static const iosMonthlyProd = 'monkeyssh_pro_monthly_prod';
 
-  /// App Store annual subscription product for the production app.
+  /// Apple App Store annual subscription product for the production app.
   static const iosAnnualProd = 'monkeyssh_pro_annual_prod';
 
   /// All recognized paid products across platforms.
@@ -30,7 +30,7 @@ abstract final class MonetizationProductIds {
   /// Product identifiers to query on the current platform.
   static Set<String> forPlatform(TargetPlatform platform) => switch (platform) {
     TargetPlatform.android => const {androidPro},
-    TargetPlatform.iOS => const {
+    TargetPlatform.iOS || TargetPlatform.macOS => const {
       iosMonthly,
       iosAnnual,
       iosMonthlyProd,

--- a/lib/domain/services/monetization_service.dart
+++ b/lib/domain/services/monetization_service.dart
@@ -187,7 +187,7 @@ class MonetizationService {
     await initialize();
     if (!_supportsStoreBilling) {
       return const MonetizationActionResult.failure(
-        'Subscriptions are only available on iPhone and Android.',
+        'Subscriptions are only available through the App Store and Google Play.',
       );
     }
     await _tryRecoverStaleAndroidPurchaseAttempt();
@@ -264,7 +264,7 @@ class MonetizationService {
     await initialize();
     if (!_supportsStoreBilling) {
       return const MonetizationActionResult.failure(
-        'Restoring purchases is only available on iPhone and Android.',
+        'Restoring purchases is only available through the App Store and Google Play.',
       );
     }
     await _tryRecoverStaleAndroidPurchaseAttempt();
@@ -339,7 +339,8 @@ class MonetizationService {
 
   bool get _supportsStoreBilling =>
       defaultTargetPlatform == TargetPlatform.android ||
-      defaultTargetPlatform == TargetPlatform.iOS;
+      defaultTargetPlatform == TargetPlatform.iOS ||
+      defaultTargetPlatform == TargetPlatform.macOS;
 
   void _handlePurchaseUpdates(List<PurchaseDetails> purchases) {
     for (final purchase in purchases) {

--- a/lib/presentation/screens/upgrade_screen.dart
+++ b/lib/presentation/screens/upgrade_screen.dart
@@ -88,13 +88,14 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
   }
 
   String _pricingSourceLabel() => switch (defaultTargetPlatform) {
-    TargetPlatform.iOS => 'Pricing loads from the App Store',
+    TargetPlatform.iOS ||
+    TargetPlatform.macOS => 'Pricing loads from the App Store',
     TargetPlatform.android => 'Pricing loads from Google Play',
     _ => 'Pricing loads from your local storefront',
   };
 
   String _storefrontLabel() => switch (defaultTargetPlatform) {
-    TargetPlatform.iOS => 'the App Store',
+    TargetPlatform.iOS || TargetPlatform.macOS => 'the App Store',
     TargetPlatform.android => 'Google Play',
     _ => 'your local storefront',
   };
@@ -129,7 +130,7 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
   }
 
   Uri? _manageSubscriptionUrl() => switch (defaultTargetPlatform) {
-    TargetPlatform.iOS => Uri.parse(
+    TargetPlatform.iOS || TargetPlatform.macOS => Uri.parse(
       'https://apps.apple.com/account/subscriptions',
     ),
     TargetPlatform.android => Uri.parse(

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -5,8 +5,13 @@ PODS:
     - Flutter
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
+  - in_app_purchase_storekit (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - local_auth_darwin (0.0.1):
     - Flutter
+    - FlutterMacOS
+  - package_info_plus (0.0.1):
     - FlutterMacOS
   - pasteboard (0.0.1):
     - FlutterMacOS
@@ -19,7 +24,9 @@ DEPENDENCIES:
   - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
   - flutter_secure_storage_darwin (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - in_app_purchase_storekit (from `Flutter/ephemeral/.symlinks/plugins/in_app_purchase_storekit/darwin`)
   - local_auth_darwin (from `Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin`)
+  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - pasteboard (from `Flutter/ephemeral/.symlinks/plugins/pasteboard/macos`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
@@ -31,8 +38,12 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin
   FlutterMacOS:
     :path: Flutter/ephemeral
+  in_app_purchase_storekit:
+    :path: Flutter/ephemeral/.symlinks/plugins/in_app_purchase_storekit/darwin
   local_auth_darwin:
     :path: Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin
+  package_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   pasteboard:
     :path: Flutter/ephemeral/.symlinks/plugins/pasteboard/macos
   share_plus:
@@ -44,7 +55,9 @@ SPEC CHECKSUMS:
   file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  in_app_purchase_storekit: 22cca7d08eebca9babdf4d07d0baccb73325d3c8
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
+  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   pasteboard: b594eaf838d930b276d7a35a44a32b4f489170cb
   share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
   url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -275,6 +275,9 @@
 						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
+							com.apple.InAppPurchase = {
+								enabled = 1;
+							};
 							com.apple.Sandbox = {
 								enabled = 1;
 							};

--- a/test/domain/services/monetization_service_test.dart
+++ b/test/domain/services/monetization_service_test.dart
@@ -33,24 +33,36 @@ void main() {
     registerFallbackValue(_FakePurchaseParam());
   });
 
-  test('queries both preview and prod App Store product IDs on iOS', () {
-    expect(
-      MonetizationProductIds.forPlatform(TargetPlatform.iOS),
-      unorderedEquals([
-        MonetizationProductIds.iosMonthly,
-        MonetizationProductIds.iosAnnual,
-        MonetizationProductIds.iosMonthlyProd,
-        MonetizationProductIds.iosAnnualProd,
-      ]),
-    );
-    expect(
-      MonetizationProductIds.allKnown,
-      containsAll({
-        MonetizationProductIds.iosMonthlyProd,
-        MonetizationProductIds.iosAnnualProd,
-      }),
-    );
-  });
+  test(
+    'queries both preview and prod App Store product IDs on Apple platforms',
+    () {
+      expect(
+        MonetizationProductIds.forPlatform(TargetPlatform.iOS),
+        unorderedEquals([
+          MonetizationProductIds.iosMonthly,
+          MonetizationProductIds.iosAnnual,
+          MonetizationProductIds.iosMonthlyProd,
+          MonetizationProductIds.iosAnnualProd,
+        ]),
+      );
+      expect(
+        MonetizationProductIds.forPlatform(TargetPlatform.macOS),
+        unorderedEquals([
+          MonetizationProductIds.iosMonthly,
+          MonetizationProductIds.iosAnnual,
+          MonetizationProductIds.iosMonthlyProd,
+          MonetizationProductIds.iosAnnualProd,
+        ]),
+      );
+      expect(
+        MonetizationProductIds.allKnown,
+        containsAll({
+          MonetizationProductIds.iosMonthlyProd,
+          MonetizationProductIds.iosAnnualProd,
+        }),
+      );
+    },
+  );
 
   group('buildMonetizationOffers', () {
     test('deduplicates Google Play base plans and keeps trial offers', () {
@@ -352,6 +364,28 @@ void main() {
         isTrue,
       );
     });
+
+    test(
+      'macOS uses the Apple storefront path for billing availability',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+        final service = MonetizationService(
+          settings,
+          inAppPurchase: inAppPurchase,
+          allowDebugUnlock: false,
+        );
+        addTearDown(service.dispose);
+
+        await service.initialize();
+
+        expect(
+          service.currentState.billingAvailability,
+          MonetizationBillingAvailability.unavailable,
+        );
+      },
+    );
 
     test(
       'concurrent initialize calls wait for the same in-flight work',


### PR DESCRIPTION
## Summary

- enable StoreKit subscription purchase, restore, and manage-subscription flows on macOS via the App Store path
- query the Apple subscription product IDs on macOS and update upgrade-screen storefront copy accordingly
- enable the macOS Runner In-App Purchase capability and cover the Apple-platform billing path in tests

## Validation

- flutter analyze
- flutter test
- flutter build macos --debug --no-pub
