### PR TITLE
fix: improve Android background SSH survival

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,9 +4,10 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
     <application
         android:label="@string/app_name"
-        android:name="${applicationName}"
+        android:name=".MonkeySshApplication"
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="false"
         android:fullBackupContent="@xml/backup_rules"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -52,7 +52,8 @@
             android:name=".SshConnectionService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="dataSync" />
+            android:foregroundServiceType="dataSync"
+            android:stopWithTask="false" />
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
@@ -1,6 +1,7 @@
 package xyz.depollsoft.monkeyssh
 
 import android.Manifest
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -22,7 +23,6 @@ class MainActivity : FlutterActivity() {
         private const val MONKEYSSH_TRANSFER_EXTENSION = ".monkeysshx"
     }
 
-    private val channel = "xyz.depollsoft.monkeyssh/ssh_service"
     private val clipboardChannel = "xyz.depollsoft.monkeyssh/clipboard_content"
     private val transferChannel = "xyz.depollsoft.monkeyssh/transfer"
     private val maxTransferPayloadBytes = 10 * 1024 * 1024
@@ -33,8 +33,14 @@ class MainActivity : FlutterActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        SshServiceChannelHandler.attachActivity(this)
         handleTransferIntent(intent)
     }
+
+    override fun provideFlutterEngine(context: Context): FlutterEngine =
+        MonkeySshApplication.from(context).ensureSharedFlutterEngine()
+
+    override fun shouldDestroyEngineWithHost(): Boolean = false
 
     override fun getInitialRoute(): String? {
         if (isTransferIntent(intent)) {
@@ -52,37 +58,6 @@ class MainActivity : FlutterActivity() {
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
-
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channel)
-            .setMethodCallHandler { call, result ->
-                when (call.method) {
-                    "updateStatus" -> {
-                        val connectionCount = call.argument<Int>("connectionCount") ?: 0
-                        val connectedCount = call.argument<Int>("connectedCount") ?: 0
-                        SshConnectionService.updateStatus(
-                            context = this,
-                            status = SshConnectionService.ConnectionStatus(
-                                connectionCount = connectionCount,
-                                connectedCount = connectedCount
-                            ),
-                        )
-                        result.success(null)
-                    }
-                    "setForegroundState" -> {
-                        val isForeground = call.argument<Boolean>("isForeground") ?: true
-                        if (!isForeground && SshConnectionService.hasActiveConnections()) {
-                            ensureNotificationPermission()
-                        }
-                        SshConnectionService.setForegroundState(this, isForeground)
-                        result.success(null)
-                    }
-                    "stopService" -> {
-                        SshConnectionService.stop(this)
-                        result.success(null)
-                    }
-                    else -> result.notImplemented()
-                }
-            }
 
         clipboardMethodChannel = MethodChannel(
             flutterEngine.dartExecutor.binaryMessenger,
@@ -133,6 +108,7 @@ class MainActivity : FlutterActivity() {
     }
 
     override fun onDestroy() {
+        SshServiceChannelHandler.detachActivity(this)
         clipboardMethodChannel?.setMethodCallHandler(null)
         clipboardMethodChannel = null
         transferMethodChannel?.setMethodCallHandler(null)
@@ -154,7 +130,7 @@ class MainActivity : FlutterActivity() {
         }
     }
 
-    private fun ensureNotificationPermission() {
+    fun ensureNotificationPermission() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             return
         }

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
@@ -57,8 +57,6 @@ class MainActivity : FlutterActivity() {
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
-        super.configureFlutterEngine(flutterEngine)
-
         clipboardMethodChannel = MethodChannel(
             flutterEngine.dartExecutor.binaryMessenger,
             clipboardChannel,

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MonkeySshApplication.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MonkeySshApplication.kt
@@ -22,10 +22,10 @@ class MonkeySshApplication : Application() {
 
         val engine = FlutterEngine(this)
         GeneratedPluginRegistrant.registerWith(engine)
+        SshServiceChannelHandler.attachToEngine(engine, applicationContext)
         engine.dartExecutor.executeDartEntrypoint(
             DartExecutor.DartEntrypoint.createDefault()
         )
-        SshServiceChannelHandler.attachToEngine(engine, applicationContext)
         sharedFlutterEngine = engine
         return engine
     }

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MonkeySshApplication.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MonkeySshApplication.kt
@@ -1,0 +1,32 @@
+package xyz.depollsoft.monkeyssh
+
+import android.app.Application
+import android.content.Context
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.dart.DartExecutor
+import io.flutter.plugins.GeneratedPluginRegistrant
+
+class MonkeySshApplication : Application() {
+
+    companion object {
+        fun from(context: Context): MonkeySshApplication =
+            context.applicationContext as MonkeySshApplication
+    }
+
+    @Volatile
+    private var sharedFlutterEngine: FlutterEngine? = null
+
+    @Synchronized
+    fun ensureSharedFlutterEngine(): FlutterEngine {
+        sharedFlutterEngine?.let { return it }
+
+        val engine = FlutterEngine(this)
+        GeneratedPluginRegistrant.registerWith(engine)
+        engine.dartExecutor.executeDartEntrypoint(
+            DartExecutor.DartEntrypoint.createDefault()
+        )
+        SshServiceChannelHandler.attachToEngine(engine, applicationContext)
+        sharedFlutterEngine = engine
+        return engine
+    }
+}

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/SshConnectionService.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/SshConnectionService.kt
@@ -101,6 +101,7 @@ class SshConnectionService : Service() {
 
     override fun onCreate() {
         super.onCreate()
+        MonkeySshApplication.from(this).ensureSharedFlutterEngine()
         createNotificationChannel()
     }
 

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/SshConnectionService.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/SshConnectionService.kt
@@ -30,6 +30,8 @@ class SshConnectionService : Service() {
         const val NOTIFICATION_ID = 1
 
         private const val ACTION_SYNC = "xyz.depollsoft.monkeyssh.action.SYNC"
+        private const val ACTION_RESHOW_NOTIFICATION =
+            "xyz.depollsoft.monkeyssh.action.RESHOW_NOTIFICATION"
         private const val EXTRA_CONNECTION_COUNT = "connectionCount"
         private const val EXTRA_CONNECTED_COUNT = "connectedCount"
 
@@ -107,6 +109,8 @@ class SshConnectionService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.action == ACTION_SYNC) {
             latestStatus = extractStatus(intent) ?: latestStatus
+        } else if (intent?.action == ACTION_RESHOW_NOTIFICATION) {
+            Log.d(TAG, "Re-showing SSH foreground notification after dismissal")
         } else if (intent == null) {
             latestStatus = latestStatus ?: Companion.latestStatus
         }
@@ -187,6 +191,14 @@ class SshConnectionService : Service() {
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
         } else null
+        val reShowNotificationIntent = PendingIntent.getService(
+            this,
+            1,
+            Intent(this, SshConnectionService::class.java).apply {
+                action = ACTION_RESHOW_NOTIFICATION
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
 
         val title = if (status.connectionCount == 1) {
             "1 active SSH connection"
@@ -211,6 +223,7 @@ class SshConnectionService : Service() {
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setContentIntent(tapPendingIntent)
+            .setDeleteIntent(reShowNotificationIntent)
             .setSubText(summary)
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
             .setStyle(

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/SshConnectionService.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/SshConnectionService.kt
@@ -101,7 +101,6 @@ class SshConnectionService : Service() {
 
     override fun onCreate() {
         super.onCreate()
-        MonkeySshApplication.from(this).ensureSharedFlutterEngine()
         createNotificationChannel()
     }
 
@@ -159,6 +158,7 @@ class SshConnectionService : Service() {
             return
         }
 
+        MonkeySshApplication.from(this).ensureSharedFlutterEngine()
         latestStatus = status
         val manager = getSystemService(NotificationManager::class.java)
         val notification = buildNotification(status)

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/SshServiceChannelHandler.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/SshServiceChannelHandler.kt
@@ -1,11 +1,13 @@
 package xyz.depollsoft.monkeyssh
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.PowerManager
 import android.provider.Settings
+import android.util.Log
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -13,6 +15,7 @@ import java.lang.ref.WeakReference
 
 object SshServiceChannelHandler {
     private const val CHANNEL = "xyz.depollsoft.monkeyssh/ssh_service"
+    private const val TAG = "SshServiceChannel"
 
     private var currentActivityRef = WeakReference<MainActivity>(null)
     private var methodChannel: MethodChannel? = null
@@ -123,7 +126,14 @@ object SshServiceChannelHandler {
         return try {
             context.startActivity(launchIntent)
             true
-        } catch (_: SecurityException) {
+        } catch (error: SecurityException) {
+            Log.w(TAG, "Battery optimization settings launch denied", error)
+            false
+        } catch (error: ActivityNotFoundException) {
+            Log.w(TAG, "Battery optimization settings activity missing", error)
+            false
+        } catch (error: RuntimeException) {
+            Log.w(TAG, "Battery optimization settings launch failed", error)
             false
         }
     }

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/SshServiceChannelHandler.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/SshServiceChannelHandler.kt
@@ -1,0 +1,130 @@
+package xyz.depollsoft.monkeyssh
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
+import android.provider.Settings
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.lang.ref.WeakReference
+
+object SshServiceChannelHandler {
+    private const val CHANNEL = "xyz.depollsoft.monkeyssh/ssh_service"
+
+    private var currentActivityRef = WeakReference<MainActivity>(null)
+    private var methodChannel: MethodChannel? = null
+
+    fun attachToEngine(flutterEngine: FlutterEngine, applicationContext: Context) {
+        val messenger = flutterEngine.dartExecutor.binaryMessenger
+        if (methodChannel != null) {
+            return
+        }
+
+        methodChannel = MethodChannel(messenger, CHANNEL).apply {
+            setMethodCallHandler { call, result ->
+                handleMethodCall(
+                    call = call,
+                    result = result,
+                    applicationContext = applicationContext,
+                )
+            }
+        }
+    }
+
+    fun attachActivity(activity: MainActivity) {
+        currentActivityRef = WeakReference(activity)
+    }
+
+    fun detachActivity(activity: MainActivity) {
+        if (currentActivityRef.get() === activity) {
+            currentActivityRef.clear()
+        }
+    }
+
+    private fun handleMethodCall(
+        call: MethodCall,
+        result: MethodChannel.Result,
+        applicationContext: Context,
+    ) {
+        when (call.method) {
+            "updateStatus" -> {
+                val connectionCount = call.argument<Int>("connectionCount") ?: 0
+                val connectedCount = call.argument<Int>("connectedCount") ?: 0
+                SshConnectionService.updateStatus(
+                    context = applicationContext,
+                    status = SshConnectionService.ConnectionStatus(
+                        connectionCount = connectionCount,
+                        connectedCount = connectedCount,
+                    ),
+                )
+                result.success(null)
+            }
+            "setForegroundState" -> {
+                val isForeground = call.argument<Boolean>("isForeground") ?: true
+                if (!isForeground && SshConnectionService.hasActiveConnections()) {
+                    currentActivityRef.get()?.ensureNotificationPermission()
+                }
+                SshConnectionService.setForegroundState(applicationContext, isForeground)
+                result.success(null)
+            }
+            "stopService" -> {
+                SshConnectionService.stop(applicationContext)
+                result.success(null)
+            }
+            "isBatteryOptimizationIgnored" -> {
+                result.success(isBatteryOptimizationIgnored(applicationContext))
+            }
+            "requestDisableBatteryOptimization" -> {
+                result.success(requestDisableBatteryOptimization(applicationContext))
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun isBatteryOptimizationIgnored(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return true
+        }
+        val powerManager =
+            context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        return powerManager.isIgnoringBatteryOptimizations(context.packageName)
+    }
+
+    private fun requestDisableBatteryOptimization(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return false
+        }
+        if (isBatteryOptimizationIgnored(context)) {
+            return true
+        }
+
+        val requestIntent = Intent(
+            Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+            Uri.parse("package:${context.packageName}"),
+        )
+        if (launchSettingsIntent(context, requestIntent)) {
+            return true
+        }
+
+        return launchSettingsIntent(
+            context,
+            Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS),
+        )
+    }
+
+    private fun launchSettingsIntent(context: Context, intent: Intent): Boolean {
+        val launchIntent = intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        if (launchIntent.resolveActivity(context.packageManager) == null) {
+            return false
+        }
+        return try {
+            context.startActivity(launchIntent)
+            true
+        } catch (_: SecurityException) {
+            false
+        }
+    }
+}

--- a/lib/domain/services/background_ssh_service.dart
+++ b/lib/domain/services/background_ssh_service.dart
@@ -103,7 +103,7 @@ class BackgroundSshService {
   }
 
   /// Whether Android battery optimization is already disabled for the app.
-  static Future<bool> isBatteryOptimizationIgnored() async {
+  static Future<bool?> isBatteryOptimizationIgnored() async {
     if (!_supportsBatteryOptimizationControls) {
       return true;
     }
@@ -117,13 +117,13 @@ class BackgroundSshService {
         'Failed to read Android battery optimization status: '
         '${error.message ?? error.code}',
       );
-      return false;
+      return null;
     } on MissingPluginException catch (error) {
       debugPrint(
         'Failed to read Android battery optimization status: '
         '${error.message ?? 'missing plugin'}',
       );
-      return false;
+      return null;
     }
   }
 

--- a/lib/domain/services/background_ssh_service.dart
+++ b/lib/domain/services/background_ssh_service.dart
@@ -17,12 +17,24 @@ class BackgroundSshService {
   static bool get _supportsPlatform =>
       debugIsSupportedPlatformOverride ??
       (!kIsWeb && (Platform.isAndroid || Platform.isIOS));
+  static bool get _supportsBatteryOptimizationControls =>
+      debugIsAndroidPlatformOverride ?? (!kIsWeb && Platform.isAndroid);
 
   /// Overrides platform support checks in tests.
   ///
   /// Set to `null` to use the real runtime platform detection.
   @visibleForTesting
   static bool? debugIsSupportedPlatformOverride;
+
+  /// Overrides Android-only battery optimization support checks in tests.
+  ///
+  /// Set to `null` to use the real runtime platform detection.
+  @visibleForTesting
+  static bool? debugIsAndroidPlatformOverride;
+
+  /// Whether Android battery-optimization controls are available.
+  static bool get supportsBatteryOptimizationControls =>
+      _supportsBatteryOptimizationControls;
 
   /// Publish the latest active connection status to native background UI.
   static Future<void> updateStatus({
@@ -87,6 +99,56 @@ class BackgroundSshService {
         'Failed to stop background SSH status: '
         '${error.message ?? 'missing plugin'}',
       );
+    }
+  }
+
+  /// Whether Android battery optimization is already disabled for the app.
+  static Future<bool> isBatteryOptimizationIgnored() async {
+    if (!_supportsBatteryOptimizationControls) {
+      return true;
+    }
+    try {
+      return await _channel.invokeMethod<bool>(
+            'isBatteryOptimizationIgnored',
+          ) ??
+          false;
+    } on PlatformException catch (error) {
+      debugPrint(
+        'Failed to read Android battery optimization status: '
+        '${error.message ?? error.code}',
+      );
+      return false;
+    } on MissingPluginException catch (error) {
+      debugPrint(
+        'Failed to read Android battery optimization status: '
+        '${error.message ?? 'missing plugin'}',
+      );
+      return false;
+    }
+  }
+
+  /// Open Android settings so the user can disable battery optimization.
+  static Future<bool> requestDisableBatteryOptimization() async {
+    if (!_supportsBatteryOptimizationControls) {
+      return false;
+    }
+    try {
+      return await _channel.invokeMethod<bool>(
+            'requestDisableBatteryOptimization',
+          ) ??
+          false;
+    } on PlatformException catch (error) {
+      debugPrint(
+        'Failed to open Android battery optimization settings: '
+        '${error.message ?? error.code}',
+      );
+      return false;
+    } on MissingPluginException catch (error) {
+      debugPrint(
+        'Failed to open Android battery optimization settings: '
+        '${error.message ?? 'missing plugin'}',
+      );
+      return false;
     }
   }
 }

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -22,7 +22,7 @@ import '../widgets/terminal_theme_picker.dart';
 import 'transfer_screen.dart';
 
 /// Settings screen with appearance, security, terminal, import/export,
-/// background, and about sections.
+/// background and about sections.
 class SettingsScreen extends ConsumerWidget {
   /// Creates a new [SettingsScreen].
   const SettingsScreen({super.key});

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -10,6 +10,7 @@ import '../../app/routes.dart';
 import '../../domain/models/monetization.dart';
 import '../../domain/models/terminal_themes.dart';
 import '../../domain/services/auth_service.dart';
+import '../../domain/services/background_ssh_service.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/secure_transfer_service.dart';
 import '../../domain/services/settings_service.dart';
@@ -20,8 +21,8 @@ import '../widgets/premium_badge.dart';
 import '../widgets/terminal_theme_picker.dart';
 import 'transfer_screen.dart';
 
-/// Settings screen with appearance, security, terminal, import/export,
-/// and about sections.
+/// Settings screen with appearance, security, terminal, background,
+/// import/export, and about sections.
 class SettingsScreen extends ConsumerWidget {
   /// Creates a new [SettingsScreen].
   const SettingsScreen({super.key});
@@ -31,13 +32,15 @@ class SettingsScreen extends ConsumerWidget {
     appBar: AppBar(title: const Text('Settings')),
     body: ListView(
       padding: const EdgeInsets.only(top: 4, bottom: 32),
-      children: const [
-        _SubscriptionSection(),
-        _AppearanceSection(),
-        _SecuritySection(),
-        _TerminalSection(),
-        _ImportExportSection(),
-        _AboutSection(),
+      children: [
+        const _SubscriptionSection(),
+        const _AppearanceSection(),
+        const _SecuritySection(),
+        const _TerminalSection(),
+        const _ImportExportSection(),
+        if (BackgroundSshService.supportsBatteryOptimizationControls)
+          const _AndroidBackgroundSection(),
+        const _AboutSection(),
       ],
     ),
   );
@@ -836,6 +839,98 @@ class _AboutSection extends ConsumerWidget {
       ),
     );
   }
+}
+
+class _AndroidBackgroundSection extends ConsumerStatefulWidget {
+  const _AndroidBackgroundSection();
+
+  @override
+  ConsumerState<_AndroidBackgroundSection> createState() =>
+      _AndroidBackgroundSectionState();
+}
+
+class _AndroidBackgroundSectionState
+    extends ConsumerState<_AndroidBackgroundSection>
+    with WidgetsBindingObserver {
+  late Future<bool> _batteryOptimizationStatus;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _batteryOptimizationStatus =
+        BackgroundSshService.isBatteryOptimizationIgnored();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed || !mounted) {
+      return;
+    }
+    _refreshStatus();
+  }
+
+  void _refreshStatus() {
+    setState(() {
+      _batteryOptimizationStatus =
+          BackgroundSshService.isBatteryOptimizationIgnored();
+    });
+  }
+
+  Future<void> _requestBatteryOptimizationExemption() async {
+    final openedSettings =
+        await BackgroundSshService.requestDisableBatteryOptimization();
+    if (!mounted) {
+      return;
+    }
+    if (!openedSettings) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Could not open Android battery optimization settings'),
+        ),
+      );
+      return;
+    }
+    _refreshStatus();
+  }
+
+  @override
+  Widget build(BuildContext context) => FutureBuilder<bool>(
+    future: _batteryOptimizationStatus,
+    builder: (context, snapshot) {
+      final isDisabled = snapshot.data ?? false;
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const _SectionHeader(title: 'Background SSH'),
+          ListTile(
+            leading: Icon(
+              isDisabled
+                  ? Icons.battery_saver_outlined
+                  : Icons.battery_alert_outlined,
+            ),
+            title: const Text('Battery optimization'),
+            subtitle: Text(
+              isDisabled
+                  ? 'Disabled for MonkeySSH. Android is less likely to pause background SSH.'
+                  : 'Still enabled. Foreground notifications alone are not always enough on Android. Tap to allow MonkeySSH to request an exemption.',
+            ),
+            trailing: Text(
+              isDisabled ? 'Disabled' : 'Enabled',
+              style: Theme.of(context).textTheme.labelMedium,
+            ),
+            onTap: _requestBatteryOptimizationExemption,
+          ),
+        ],
+      );
+    },
+  );
 }
 
 class _ImportExportSection extends ConsumerWidget {

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -21,8 +21,8 @@ import '../widgets/premium_badge.dart';
 import '../widgets/terminal_theme_picker.dart';
 import 'transfer_screen.dart';
 
-/// Settings screen with appearance, security, terminal, background,
-/// import/export, and about sections.
+/// Settings screen with appearance, security, terminal, import/export,
+/// background, and about sections.
 class SettingsScreen extends ConsumerWidget {
   /// Creates a new [SettingsScreen].
   const SettingsScreen({super.key});
@@ -852,7 +852,7 @@ class _AndroidBackgroundSection extends ConsumerStatefulWidget {
 class _AndroidBackgroundSectionState
     extends ConsumerState<_AndroidBackgroundSection>
     with WidgetsBindingObserver {
-  late Future<bool> _batteryOptimizationStatus;
+  late Future<bool?> _batteryOptimizationStatus;
 
   @override
   void initState() {
@@ -901,31 +901,47 @@ class _AndroidBackgroundSectionState
   }
 
   @override
-  Widget build(BuildContext context) => FutureBuilder<bool>(
+  Widget build(BuildContext context) => FutureBuilder<bool?>(
     future: _batteryOptimizationStatus,
     builder: (context, snapshot) {
+      final isLoading = snapshot.connectionState != ConnectionState.done;
+      final isUnavailable = !isLoading && snapshot.data == null;
+      final hasResolvedStatus = snapshot.data != null && !isLoading;
       final isDisabled = snapshot.data ?? false;
+      final leadingIcon = isLoading
+          ? Icons.hourglass_top_outlined
+          : isUnavailable
+          ? Icons.error_outline
+          : isDisabled
+          ? Icons.battery_saver_outlined
+          : Icons.battery_alert_outlined;
+      final subtitle = isLoading
+          ? 'Checking Android battery optimization status...'
+          : isUnavailable
+          ? 'Could not determine battery optimization status right now.'
+          : isDisabled
+          ? 'Disabled for MonkeySSH. Android is less likely to pause background SSH.'
+          : 'Still enabled. Foreground notifications alone are not always enough on Android. Tap to allow MonkeySSH to request an exemption.';
+      final trailingText = hasResolvedStatus
+          ? (isDisabled ? 'Disabled' : 'Enabled')
+          : isUnavailable
+          ? 'Unavailable'
+          : 'Loading...';
       return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const _SectionHeader(title: 'Background SSH'),
           ListTile(
-            leading: Icon(
-              isDisabled
-                  ? Icons.battery_saver_outlined
-                  : Icons.battery_alert_outlined,
-            ),
+            leading: Icon(leadingIcon),
             title: const Text('Battery optimization'),
-            subtitle: Text(
-              isDisabled
-                  ? 'Disabled for MonkeySSH. Android is less likely to pause background SSH.'
-                  : 'Still enabled. Foreground notifications alone are not always enough on Android. Tap to allow MonkeySSH to request an exemption.',
-            ),
+            subtitle: Text(subtitle),
             trailing: Text(
-              isDisabled ? 'Disabled' : 'Enabled',
+              trailingText,
               style: Theme.of(context).textTheme.labelMedium,
             ),
-            onTap: _requestBatteryOptimizationExemption,
+            onTap: hasResolvedStatus
+                ? _requestBatteryOptimizationExemption
+                : null,
           ),
         ],
       );

--- a/test/domain/services/background_ssh_service_test.dart
+++ b/test/domain/services/background_ssh_service_test.dart
@@ -1,0 +1,78 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/services/background_ssh_service.dart';
+
+const _backgroundSshChannel = MethodChannel(
+  'xyz.depollsoft.monkeyssh/ssh_service',
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('BackgroundSshService battery optimization helpers', () {
+    late List<MethodCall> methodCalls;
+    var batteryOptimizationIgnored = false;
+    var openedBatterySettings = false;
+
+    setUp(() {
+      methodCalls = <MethodCall>[];
+      batteryOptimizationIgnored = false;
+      openedBatterySettings = false;
+      BackgroundSshService.debugIsAndroidPlatformOverride = true;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(_backgroundSshChannel, (call) async {
+            methodCalls.add(call);
+            return switch (call.method) {
+              'isBatteryOptimizationIgnored' => batteryOptimizationIgnored,
+              'requestDisableBatteryOptimization' => openedBatterySettings,
+              _ => null,
+            };
+          });
+    });
+
+    tearDown(() {
+      BackgroundSshService.debugIsAndroidPlatformOverride = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(_backgroundSshChannel, null);
+    });
+
+    test('isBatteryOptimizationIgnored queries the native channel', () async {
+      batteryOptimizationIgnored = true;
+
+      final result = await BackgroundSshService.isBatteryOptimizationIgnored();
+
+      expect(result, isTrue);
+      expect(methodCalls, hasLength(1));
+      expect(methodCalls.single.method, 'isBatteryOptimizationIgnored');
+    });
+
+    test(
+      'requestDisableBatteryOptimization opens the native settings flow',
+      () async {
+        openedBatterySettings = true;
+
+        final result =
+            await BackgroundSshService.requestDisableBatteryOptimization();
+
+        expect(result, isTrue);
+        expect(methodCalls, hasLength(1));
+        expect(methodCalls.single.method, 'requestDisableBatteryOptimization');
+      },
+    );
+
+    test('unsupported platforms skip the native channel', () async {
+      BackgroundSshService.debugIsAndroidPlatformOverride = false;
+
+      final isIgnored =
+          await BackgroundSshService.isBatteryOptimizationIgnored();
+      final opened =
+          await BackgroundSshService.requestDisableBatteryOptimization();
+
+      expect(isIgnored, isTrue);
+      expect(opened, isFalse);
+      expect(methodCalls, isEmpty);
+    });
+  });
+}

--- a/test/domain/services/background_ssh_service_test.dart
+++ b/test/domain/services/background_ssh_service_test.dart
@@ -49,6 +49,24 @@ void main() {
     });
 
     test(
+      'isBatteryOptimizationIgnored returns null when the channel fails',
+      () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(_backgroundSshChannel, (call) async {
+              methodCalls.add(call);
+              throw PlatformException(code: 'failed');
+            });
+
+        final result =
+            await BackgroundSshService.isBatteryOptimizationIgnored();
+
+        expect(result, isNull);
+        expect(methodCalls, hasLength(1));
+        expect(methodCalls.single.method, 'isBatteryOptimizationIgnored');
+      },
+    );
+
+    test(
       'requestDisableBatteryOptimization opens the native settings flow',
       () async {
         openedBatterySettings = true;

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -2,17 +2,23 @@
 
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/app/app_metadata.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/domain/services/auth_service.dart';
+import 'package:monkeyssh/domain/services/background_ssh_service.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/presentation/providers/entity_list_providers.dart';
 import 'package:monkeyssh/presentation/screens/settings_screen.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import '../support/settings_import_test_helpers.dart';
+
+const _backgroundSshChannel = MethodChannel(
+  'xyz.depollsoft.monkeyssh/ssh_service',
+);
 
 Future<void> _pumpSettingsScreen(
   WidgetTester tester, {
@@ -42,6 +48,22 @@ void main() {
         buildNumber: '123',
         buildSignature: '',
       );
+      BackgroundSshService.debugIsAndroidPlatformOverride = true;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            _backgroundSshChannel,
+            (call) async => switch (call.method) {
+              'isBatteryOptimizationIgnored' => false,
+              'requestDisableBatteryOptimization' => true,
+              _ => null,
+            },
+          );
+    });
+
+    tearDown(() {
+      BackgroundSshService.debugIsAndroidPlatformOverride = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(_backgroundSshChannel, null);
     });
 
     testWidgets('displays all sections', (tester) async {
@@ -69,6 +91,14 @@ void main() {
       );
       await tester.pumpAndSettle();
       expect(find.text('Import & Export'), findsOneWidget);
+
+      await tester.scrollUntilVisible(
+        find.text('Background SSH'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Background SSH'), findsOneWidget);
 
       await tester.scrollUntilVisible(
         find.text('About'),
@@ -272,6 +302,32 @@ void main() {
       expect(find.text('Change PIN'), findsOneWidget);
       expect(find.text('Biometric authentication'), findsOneWidget);
       expect(find.text('Auto-lock timeout'), findsOneWidget);
+    });
+
+    testWidgets('displays Android background reliability controls', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      await _pumpSettingsScreen(tester, db: db);
+
+      await tester.scrollUntilVisible(
+        find.text('Battery optimization'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Background SSH'), findsOneWidget);
+      expect(find.text('Battery optimization'), findsOneWidget);
+      expect(find.text('Enabled'), findsOneWidget);
+      expect(
+        find.textContaining(
+          'Foreground notifications alone are not always enough on Android.',
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('displays import and export actions', (tester) async {

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -386,14 +386,22 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.text('Loading...'), findsOneWidget);
+      final batteryOptimizationTile = find.widgetWithText(
+        ListTile,
+        'Battery optimization',
+      );
+      expect(
+        find.descendant(
+          of: batteryOptimizationTile,
+          matching: find.text('Loading...'),
+        ),
+        findsOneWidget,
+      );
       expect(
         find.text('Checking Android battery optimization status...'),
         findsOneWidget,
       );
-      final tile = tester.widget<ListTile>(
-        find.widgetWithText(ListTile, 'Battery optimization'),
-      );
+      final tile = tester.widget<ListTile>(batteryOptimizationTile);
       expect(tile.onTap, isNull);
 
       completer.complete(false);

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 // ignore_for_file: public_member_api_docs
 
 import 'package:drift/native.dart';
@@ -328,6 +330,92 @@ void main() {
         ),
         findsOneWidget,
       );
+    });
+
+    testWidgets('shows loading state before battery optimization resolves', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final completer = Completer<bool?>();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            _backgroundSshChannel,
+            (call) => switch (call.method) {
+              'isBatteryOptimizationIgnored' => completer.future,
+              'requestDisableBatteryOptimization' => Future<bool>.value(true),
+              _ => Future<Object?>.value(),
+            },
+          );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(MockAuthStateNotifier.new),
+          ],
+          child: const MaterialApp(home: SettingsScreen()),
+        ),
+      );
+      await tester.pump();
+
+      await tester.scrollUntilVisible(
+        find.text('Battery optimization'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pump();
+
+      expect(find.text('Loading...'), findsOneWidget);
+      expect(
+        find.text('Checking Android battery optimization status...'),
+        findsOneWidget,
+      );
+      final tile = tester.widget<ListTile>(
+        find.widgetWithText(ListTile, 'Battery optimization'),
+      );
+      expect(tile.onTap, isNull);
+
+      completer.complete(false);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('shows unavailable state when battery status cannot be read', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            _backgroundSshChannel,
+            (call) async => switch (call.method) {
+              'isBatteryOptimizationIgnored' => throw PlatformException(
+                code: 'failed',
+              ),
+              'requestDisableBatteryOptimization' => true,
+              _ => null,
+            },
+          );
+
+      await _pumpSettingsScreen(tester, db: db);
+
+      await tester.scrollUntilVisible(
+        find.text('Battery optimization'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Unavailable'), findsOneWidget);
+      expect(
+        find.text('Could not determine battery optimization status right now.'),
+        findsOneWidget,
+      );
+      final tile = tester.widget<ListTile>(
+        find.widgetWithText(ListTile, 'Battery optimization'),
+      );
+      expect(tile.onTap, isNull);
     });
 
     testWidgets('displays import and export actions', (tester) async {


### PR DESCRIPTION
## Summary

- add Android battery-optimization status/request controls and expose them in Settings under a new Background SSH section
- retain a shared `FlutterEngine` from `Application` and have `MainActivity` reuse it with `shouldDestroyEngineWithHost = false`
- have the SSH foreground service ensure the shared engine exists while background SSH is active, and move the SSH method channel onto an application-safe handler

## Validation

- `flutter analyze`
- `flutter test`
- `flutter build apk --debug --flavor production`
