### PR TITLE
fix: preserve split leading token after tmux chord

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -53,6 +53,18 @@ bool _isPromptReturnAsciiLetterOrDigit(int codeUnit) =>
     (codeUnit >= 0x41 && codeUnit <= 0x5A) ||
     (codeUnit >= 0x61 && codeUnit <= 0x7A);
 
+final _oscEscapeSequencePattern = RegExp(
+  '\x1B\\][^\x07\x1B]*(?:\x07|\x1B\\\\)',
+  dotAll: true,
+);
+final _csiEscapeSequencePattern = RegExp('\x1B\\[[0-?]*[ -/]*[@-~]');
+final _singleCharEscapeSequencePattern = RegExp('\x1B[@-_]');
+
+String _stripTerminalPromptEscapeSequences(String text) => text
+    .replaceAll(_oscEscapeSequencePattern, '')
+    .replaceAll(_csiEscapeSequencePattern, '')
+    .replaceAll(_singleCharEscapeSequencePattern, '');
+
 const _minTerminalFontSize = 8.0;
 const _maxTerminalFontSize = 32.0;
 const _terminalFollowOutputTolerance = 1.0;
@@ -2128,13 +2140,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   bool _shellOutputLooksLikePromptReturn(String data) {
-    if (data.isEmpty) {
+    final sanitizedData = _stripTerminalPromptEscapeSequences(data);
+    if (sanitizedData.isEmpty) {
       return false;
     }
 
-    var index = data.length - 1;
+    var index = sanitizedData.length - 1;
     while (index >= 0) {
-      final codeUnit = data.codeUnitAt(index);
+      final codeUnit = sanitizedData.codeUnitAt(index);
       if (codeUnit == 0x0A || codeUnit == 0x0D) {
         return false;
       }
@@ -2150,7 +2163,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     var visibleCodeUnitCount = 0;
     while (index >= 0) {
-      final codeUnit = data.codeUnitAt(index);
+      final codeUnit = sanitizedData.codeUnitAt(index);
       if (codeUnit == 0x0A || codeUnit == 0x0D) {
         break;
       }

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -1199,6 +1199,93 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     );
   }
 
+  String _trailingToken(String text) {
+    final graphemes = text.characters.toList(growable: false);
+    var tokenEnd = graphemes.length;
+    while (tokenEnd > 0 && _isWhitespaceGrapheme(graphemes[tokenEnd - 1])) {
+      tokenEnd--;
+    }
+    if (tokenEnd == 0) {
+      return '';
+    }
+
+    var tokenStart = tokenEnd;
+    while (tokenStart > 0 &&
+        !_isWhitespaceGrapheme(graphemes[tokenStart - 1])) {
+      tokenStart--;
+    }
+    return graphemes.sublist(tokenStart, tokenEnd).join();
+  }
+
+  ({String currentText, int? cursorOffset})? _normalizeSplitLeadingToken(
+    String currentText, {
+    int? cursorOffsetHint,
+  }) {
+    if (_lastSentText.isEmpty) {
+      return null;
+    }
+
+    final previousTrailingToken = _trailingToken(_lastSentText);
+    if (previousTrailingToken.characters.length < 2) {
+      return null;
+    }
+
+    final currentGraphemes = currentText.characters.toList(growable: false);
+    final tokenInfo = _leadingTokenInfo(currentGraphemes);
+    if (tokenInfo == null ||
+        tokenInfo.firstTokenGraphemes.length != 1 ||
+        tokenInfo.trailingGraphemes.isEmpty) {
+      return null;
+    }
+
+    var separatorLength = 0;
+    while (separatorLength < tokenInfo.trailingGraphemes.length &&
+        _isWhitespaceGrapheme(tokenInfo.trailingGraphemes[separatorLength])) {
+      separatorLength++;
+    }
+    if (separatorLength == 0 ||
+        separatorLength == tokenInfo.trailingGraphemes.length) {
+      return null;
+    }
+
+    var nextTokenEnd = separatorLength;
+    while (nextTokenEnd < tokenInfo.trailingGraphemes.length &&
+        !_isWhitespaceGrapheme(tokenInfo.trailingGraphemes[nextTokenEnd])) {
+      nextTokenEnd++;
+    }
+    if (nextTokenEnd == separatorLength) {
+      return null;
+    }
+
+    final mergedLeadingToken =
+        tokenInfo.firstTokenGraphemes.join() +
+        tokenInfo.trailingGraphemes
+            .sublist(separatorLength, nextTokenEnd)
+            .join();
+    final continuesPreviousTrailingToken =
+        mergedLeadingToken.startsWith(previousTrailingToken) ||
+        previousTrailingToken.startsWith(mergedLeadingToken);
+    if (!continuesPreviousTrailingToken) {
+      return null;
+    }
+
+    final separatorStart = tokenInfo.firstTokenEnd;
+    final separatorEnd = separatorStart + separatorLength;
+    final normalizedCursorOffset = cursorOffsetHint == null
+        ? null
+        : cursorOffsetHint <= separatorStart
+        ? cursorOffsetHint
+        : cursorOffsetHint <= separatorEnd
+        ? separatorStart
+        : cursorOffsetHint - separatorLength;
+    return (
+      currentText:
+          tokenInfo.firstTokenGraphemes.join() +
+          tokenInfo.trailingGraphemes.sublist(separatorLength).join(),
+      cursorOffset: normalizedCursorOffset,
+    );
+  }
+
   int _textLengthInGraphemes(String text) => text.characters.length;
 
   int _graphemeOffsetForCodeUnitOffset(String text, int codeUnitOffset) => text
@@ -1674,16 +1761,25 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         currentText,
         value,
       );
+      final normalizedSplitLeadingToken = _normalizeSplitLeadingToken(
+        currentText,
+        cursorOffsetHint: targetCursorOffset,
+      );
+      final splitNormalizedCurrentText =
+          normalizedSplitLeadingToken?.currentText ?? currentText;
+      final splitNormalizedTargetCursorOffset =
+          normalizedSplitLeadingToken?.cursorOffset ?? targetCursorOffset;
       final normalizedDeleteResetLeadingFragment =
           _normalizeDeleteResetLeadingFragment(
-            currentText,
-            cursorOffsetHint: targetCursorOffset,
+            splitNormalizedCurrentText,
+            cursorOffsetHint: splitNormalizedTargetCursorOffset,
           );
       final normalizedCurrentText =
-          normalizedDeleteResetLeadingFragment?.currentText ?? currentText;
+          normalizedDeleteResetLeadingFragment?.currentText ??
+          splitNormalizedCurrentText;
       final normalizedTargetCursorOffset =
           normalizedDeleteResetLeadingFragment?.cursorOffset ??
-          targetCursorOffset;
+          splitNormalizedTargetCursorOffset;
       if (normalizedCurrentText == _lastSentText) {
         final collapsedMoveAwayFromReplacement =
             !_lastProcessedSelectionWasCollapsed &&
@@ -1865,6 +1961,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         effectiveCurrentText,
         sourceValue:
             normalizedPendingEnter.strippedPendingEnter ||
+                normalizedSplitLeadingToken != null ||
                 normalizedDeleteResetLeadingFragment != null ||
                 effectiveCurrentText != normalizedCurrentText
             ? null

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -236,6 +236,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   bool _lastProcessedSelectionWasCollapsed = true;
   bool _trimLeadingSuggestionSpaceAfterDelete = false;
   bool _trimLeadingSwipeSpaceAfterBufferClear = false;
+  bool _allowSplitLeadingTokenNormalization = false;
   bool _clearImeAfterNextTouchCursorMove = false;
   bool _hasPendingPromptOutputImeReset = false;
   DateTime? _modifierChordResetTime;
@@ -481,6 +482,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
 
   void _clearImeBufferForFreshInput({
     bool armModifierChordWindow = false,
+    bool armSplitLeadingTokenNormalization = false,
     String? deleteResetBaselineText,
     int? deleteResetBaselineCursorOffset,
     String? deleteResetDeletedSuffixText,
@@ -506,6 +508,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
     _trimLeadingSuggestionSpaceAfterDelete = true;
     _trimLeadingSwipeSpaceAfterBufferClear = false;
+    _allowSplitLeadingTokenNormalization = armSplitLeadingTokenNormalization;
     _modifierChordResetTime = armModifierChordWindow
         ? _readModifierChordClock()
         : null;
@@ -529,7 +532,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         !_currentLineLooksLikePromptPrefix(textBeforeCursor)) {
       return;
     }
-    _clearImeBufferForFreshInput(flushPlatformContext: true);
+    _clearImeBufferForFreshInput(
+      flushPlatformContext: true,
+      armSplitLeadingTokenNormalization: true,
+    );
   }
 
   // -- Focus handling --
@@ -590,6 +596,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       _lastProcessedSelectionWasCollapsed = true;
       _trimLeadingSuggestionSpaceAfterDelete = false;
       _trimLeadingSwipeSpaceAfterBufferClear = false;
+      _allowSplitLeadingTokenNormalization = false;
       _hasPendingPromptOutputImeReset = false;
       _modifierChordResetTime = null;
       _clearPendingDeleteResetBaseline();
@@ -613,6 +620,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _lastProcessedSelectionWasCollapsed = true;
     _trimLeadingSuggestionSpaceAfterDelete = false;
     _trimLeadingSwipeSpaceAfterBufferClear = false;
+    _allowSplitLeadingTokenNormalization = false;
     _hasPendingPromptOutputImeReset = false;
     _modifierChordResetTime = null;
     _clearPendingDeleteResetBaseline();
@@ -900,6 +908,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _trimLeadingSuggestionSpaceAfterDelete = false;
     _trimLeadingSwipeSpaceAfterBufferClear = false;
     _clearImeAfterNextTouchCursorMove = false;
+    _allowSplitLeadingTokenNormalization = false;
     _modifierChordResetTime = null;
     if (clearPendingDeleteResetBaseline) {
       _clearPendingDeleteResetBaseline();
@@ -1221,7 +1230,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     String currentText, {
     int? cursorOffsetHint,
   }) {
-    if (_lastSentText.isEmpty) {
+    if (!_allowSplitLeadingTokenNormalization || _lastSentText.isEmpty) {
       return null;
     }
 
@@ -1231,6 +1240,13 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
 
     final currentGraphemes = currentText.characters.toList(growable: false);
+    final currentTextLength = currentGraphemes.length;
+    final previousTextLength = _textLengthInGraphemes(_lastSentText);
+    if (_lastSentCursorOffset != previousTextLength ||
+        cursorOffsetHint == null ||
+        cursorOffsetHint != currentTextLength) {
+      return null;
+    }
     final tokenInfo = _leadingTokenInfo(currentGraphemes);
     if (tokenInfo == null ||
         tokenInfo.firstTokenGraphemes.length != 1 ||
@@ -1269,11 +1285,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       return null;
     }
 
+    _allowSplitLeadingTokenNormalization = false;
     final separatorStart = tokenInfo.firstTokenEnd;
     final separatorEnd = separatorStart + separatorLength;
-    final normalizedCursorOffset = cursorOffsetHint == null
-        ? null
-        : cursorOffsetHint <= separatorStart
+    final normalizedCursorOffset = cursorOffsetHint <= separatorStart
         ? cursorOffsetHint
         : cursorOffsetHint <= separatorEnd
         ? separatorStart
@@ -1917,6 +1932,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         // shell's response to a control code is unpredictable.
         _clearImeBufferForFreshInput(
           armModifierChordWindow: wasModifiedSingleChar,
+          armSplitLeadingTokenNormalization: true,
         );
         _sawImeComposition = false;
         return;
@@ -2022,6 +2038,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _lastProcessedSelectionWasCollapsed = true;
     _trimLeadingSuggestionSpaceAfterDelete = false;
     _trimLeadingSwipeSpaceAfterBufferClear = false;
+    _allowSplitLeadingTokenNormalization = false;
     _modifierChordResetTime = null;
     _pendingEnterActionSuppressions = 0;
     _currentEditingState = _initEditingState.copyWith();

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -15,6 +15,7 @@ import 'terminal_key_input.dart';
 
 const _deleteDetectionMarker = '\u200B\u200B';
 final _leadingSwipeNewlineArtifactPattern = RegExp(r'^[\r\n]+ ?(?=\S)');
+final _splitLeadingTokenCandidatePattern = RegExp(r'^\s*\S\s+\S');
 const _enterCommitNewlineSequences = <String>['\r\n', '\n', '\r'];
 
 bool _isAsciiLetterOrDigitCodeUnit(int codeUnit) =>
@@ -1230,7 +1231,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     String currentText, {
     int? cursorOffsetHint,
   }) {
-    if (!_allowSplitLeadingTokenNormalization || _lastSentText.isEmpty) {
+    if (!_allowSplitLeadingTokenNormalization ||
+        _lastSentText.isEmpty ||
+        !_splitLeadingTokenCandidatePattern.hasMatch(currentText)) {
       return null;
     }
 
@@ -1288,6 +1291,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _allowSplitLeadingTokenNormalization = false;
     final separatorStart = tokenInfo.firstTokenEnd;
     final separatorEnd = separatorStart + separatorLength;
+    final leadingPrefix = currentGraphemes
+        .sublist(0, tokenInfo.firstTokenStart)
+        .join();
     final normalizedCursorOffset = cursorOffsetHint <= separatorStart
         ? cursorOffsetHint
         : cursorOffsetHint <= separatorEnd
@@ -1295,6 +1301,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         : cursorOffsetHint - separatorLength;
     return (
       currentText:
+          leadingPrefix +
           tokenInfo.firstTokenGraphemes.join() +
           tokenInfo.trailingGraphemes.sublist(separatorLength).join(),
       cursorOffset: normalizedCursorOffset,

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -270,6 +270,36 @@ void main() {
     );
 
     testWidgets(
+      'ANSI-styled prompt-like shell output reconnects the IME input client after keyboard input',
+      (tester) async {
+        await pumpScreen(tester);
+
+        tester.testTextInput.updateEditingValue(
+          _editingValue('ls', selectionOffset: 2),
+        );
+        await tester.pump();
+
+        await tester.testTextInput.receiveAction(TextInputAction.newline);
+        await tester.pump();
+
+        tester.testTextInput.log.clear();
+        shellStdoutController.add(
+          Uint8List.fromList(utf8.encode('\u001b[38;5;39m>\u001b[0m ')),
+        );
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(
+          tester.testTextInput.log.where(
+            (call) => call.method == 'TextInput.setClient',
+          ),
+          hasLength(1),
+        );
+        await tester.pump(const Duration(milliseconds: 200));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
       'non-prompt shell output does not reconnect the IME input client',
       (tester) async {
         await pumpScreen(tester);

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -7415,6 +7415,79 @@ void main() {
     );
 
     testWidgets(
+      'preserves leading indentation when a split token is normalized',
+      (tester) async {
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add);
+        final focusNode = FocusNode();
+        final controller = TerminalTextInputHandlerController();
+        var modifierActive = false;
+        var fakeNow = DateTime(2026);
+        debugSetModifierChordClock(() => fakeNow);
+        addTearDown(() => debugSetModifierChordClock(null));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TerminalTextInputHandler(
+                terminal: terminal,
+                focusNode: focusNode,
+                controller: controller,
+                deleteDetection: true,
+                resolveTextBeforeCursor: () => '>',
+                hasActiveToolbarModifier: () => modifierActive,
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        modifierActive = true;
+        tester.testTextInput.updateEditingValue(
+          _editingValue('b', selectionOffset: 1),
+        );
+        await tester.pump();
+        modifierActive = false;
+
+        fakeNow = fakeNow.add(const Duration(milliseconds: 100));
+        tester.testTextInput.updateEditingValue(
+          _editingValue('c', selectionOffset: 1),
+        );
+        await tester.pump();
+
+        terminalOutput.clear();
+        controller.handleExternalTerminalOutput();
+        await tester.pump();
+
+        tester.testTextInput.updateEditingValue(
+          _editingValue('  copilot', selectionOffset: '  copilot'.length),
+        );
+        await tester.pump();
+
+        terminalOutput.clear();
+
+        tester.testTextInput.updateEditingValue(
+          _editingValue('  c opilot ', selectionOffset: '  c opilot '.length),
+        );
+        await tester.pump();
+
+        expect(
+          _terminalStateFromEvents(
+            terminalOutput,
+            initialText: '  copilot',
+            initialCursorOffset: '  copilot'.length,
+          ),
+          (text: '  copilot ', cursorOffset: '  copilot '.length),
+        );
+
+        focusNode.dispose();
+      },
+    );
+
+    testWidgets(
       'does not reset after modifier chord when follow-up arrives after timeout',
       (tester) async {
         final terminalOutput = <String>[];

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -7361,6 +7361,60 @@ void main() {
     );
 
     testWidgets(
+      'preserves an intentional space inserted inside the first token',
+      (tester) async {
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add);
+        final focusNode = FocusNode();
+        final controller = TerminalTextInputHandlerController();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TerminalTextInputHandler(
+                terminal: terminal,
+                focusNode: focusNode,
+                controller: controller,
+                deleteDetection: true,
+                resolveTextBeforeCursor: () => '>',
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        controller.handleExternalTerminalOutput();
+        await tester.pump();
+
+        tester.testTextInput.updateEditingValue(
+          _editingValue('copilot', selectionOffset: 'copilot'.length),
+        );
+        await tester.pump();
+
+        terminalOutput.clear();
+
+        tester.testTextInput.updateEditingValue(
+          _editingValue('c opilot', selectionOffset: 2),
+        );
+        await tester.pump();
+
+        expect(
+          _terminalStateFromEvents(
+            terminalOutput,
+            initialText: 'copilot',
+            initialCursorOffset: 'copilot'.length,
+          ),
+          (text: 'c opilot', cursorOffset: 2),
+        );
+
+        focusNode.dispose();
+      },
+    );
+
+    testWidgets(
       'does not reset after modifier chord when follow-up arrives after timeout',
       (tester) async {
         final terminalOutput = <String>[];

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -7293,6 +7293,74 @@ void main() {
     );
 
     testWidgets(
+      'typing copilot after tmux Ctrl+b, c keeps the leading c when space is pressed',
+      (tester) async {
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add);
+        final focusNode = FocusNode();
+        final controller = TerminalTextInputHandlerController();
+        var modifierActive = false;
+        var fakeNow = DateTime(2026);
+        debugSetModifierChordClock(() => fakeNow);
+        addTearDown(() => debugSetModifierChordClock(null));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TerminalTextInputHandler(
+                terminal: terminal,
+                focusNode: focusNode,
+                controller: controller,
+                deleteDetection: true,
+                resolveTextBeforeCursor: () => '>',
+                hasActiveToolbarModifier: () => modifierActive,
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        modifierActive = true;
+        tester.testTextInput.updateEditingValue(
+          _editingValue('b', selectionOffset: 1),
+        );
+        await tester.pump();
+        modifierActive = false;
+
+        fakeNow = fakeNow.add(const Duration(milliseconds: 100));
+        tester.testTextInput.updateEditingValue(
+          _editingValue('c', selectionOffset: 1),
+        );
+        await tester.pump();
+
+        terminalOutput.clear();
+        tester.testTextInput.log.clear();
+        controller.handleExternalTerminalOutput();
+        await tester.pump();
+
+        for (var index = 1; index <= 'copilot'.length; index++) {
+          final text = 'copilot'.substring(0, index);
+          tester.testTextInput.updateEditingValue(
+            _editingValue(text, selectionOffset: index),
+          );
+          await tester.pump();
+        }
+
+        tester.testTextInput.updateEditingValue(
+          _editingValue('c opilot ', selectionOffset: 'c opilot '.length),
+        );
+        await tester.pump();
+
+        expect(_terminalTextFromEvents(terminalOutput), 'copilot ');
+
+        focusNode.dispose();
+      },
+    );
+
+    testWidgets(
       'does not reset after modifier chord when follow-up arrives after timeout',
       (tester) async {
         final terminalOutput = <String>[];


### PR DESCRIPTION
## Summary

- normalize split IME commits like `c opilot ` back into a continuation of the already-typed trailing token
- cover the tmux `Ctrl+b, c` mobile flow with a regression test that preserves `copilot ` when space is pressed
- keep the existing stale one-letter delete-reset fragment behavior intact for real delete-reset cases
