### PR TITLE
feat: tmux-native window navigation and agent session history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,26 @@
 
 - Use JDK 17 for Android/Gradle builds in this repo. JDK 25 fails in the Android/Kotlin toolchain with `IllegalArgumentException: 25.0.1`.
 - On macOS, set `JAVA_HOME="$(/usr/libexec/java_home -v 17)"` before running `flutter build ...` or `./gradlew ...` for Android.
+
+## Manual testing: tmux navigation
+
+The tmux navigator feature requires a real SSH connection to a host running tmux. Use the setup script to create a local test environment:
+
+```bash
+# Set up local SSH + tmux test environment
+./scripts/setup_tmux_test_env.sh
+
+# Run the app in a simulator
+flutter run --device-id <simulator-id>
+
+# When done, tear down
+./scripts/setup_tmux_test_env.sh teardown
+```
+
+The script generates a temporary SSH key, authorizes it for localhost, and creates a tmux session with 3 windows. Follow the on-screen instructions to add a host in the app and test the navigator.
+
+### Key gotchas for tmux over SSH exec channels
+
+- **PATH**: SSH exec channels use a minimal PATH that excludes Homebrew. The tmux service sources `~/.profile`, `~/.bash_profile`, and `~/.zprofile` before running commands.
+- **Format strings**: tmux's `-F` option does **not** interpret `\t` as tab. Use `|` pipe delimiters instead.
+- **Environment variables**: Exec channels don't share the interactive shell's environment. Use `tmux list-sessions` / `tmux display-message` instead of `echo $TMUX`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,5 +23,5 @@ The script generates a temporary SSH key, authorizes it for localhost, and creat
 ### Key gotchas for tmux over SSH exec channels
 
 - **PATH**: SSH exec channels use a minimal PATH that excludes Homebrew. The tmux service sources `~/.profile`, `~/.bash_profile`, and `~/.zprofile` before running commands.
-- **Format strings**: tmux's `-F` option does **not** interpret `\t` as tab. Use `|` pipe delimiters instead.
+- **Format strings**: tmux's `-F` option does **not** interpret `\t` as tab. Use ASCII Unit Separator (`\x1f`) delimiters instead so window names and titles can still contain `|`.
 - **Environment variables**: Exec channels don't share the interactive shell's environment. Use `tmux list-sessions` / `tmux display-message` instead of `echo $TMUX`.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -63,6 +63,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -122,5 +123,6 @@ flutter {
 }
 
 dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
     implementation("eu.simonbinder:sqlite3-native-library:3.51.1")
 }

--- a/integration_test/tmux_bar_expand_validation_test.dart
+++ b/integration_test/tmux_bar_expand_validation_test.dart
@@ -1,0 +1,141 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:monkeyssh/app/app.dart';
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/data/repositories/key_repository.dart';
+import 'package:monkeyssh/domain/services/host_key_prompt_handler_provider.dart';
+import 'package:monkeyssh/domain/services/host_key_verification.dart';
+import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
+
+const _hostLabel = 'Local tmux validation';
+const _sshPort = String.fromEnvironment('FLUTTY_TMUX_BAR_SSH_PORT');
+const _sshUser = String.fromEnvironment('FLUTTY_TMUX_BAR_SSH_USER');
+const _sshPrivateKeyBase64 = String.fromEnvironment(
+  'FLUTTY_TMUX_BAR_SSH_KEY_B64',
+);
+const _sshPublicKeyBase64 = String.fromEnvironment(
+  'FLUTTY_TMUX_BAR_SSH_PUB_B64',
+);
+const _tmuxSessionName = String.fromEnvironment(
+  'FLUTTY_TMUX_BAR_SESSION',
+  defaultValue: 'MonkeySSH',
+);
+const _tmuxHandleBarKey = ValueKey<String>('tmux-handle-bar');
+
+String get _deviceReachableHost =>
+    Platform.isAndroid ? '10.0.2.2' : '127.0.0.1';
+
+Future<void> _pumpUntilFound(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 30),
+  Duration step = const Duration(milliseconds: 200),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(step);
+    if (finder.evaluate().isNotEmpty) {
+      return;
+    }
+  }
+
+  fail('Timed out waiting for finder: $finder');
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final binding = IntegrationTestWidgetsFlutterBinding.instance;
+
+  testWidgets('expands the tmux bar on device', (tester) async {
+    expect(_sshPort, isNotEmpty);
+    expect(_sshUser, isNotEmpty);
+    expect(_sshPrivateKeyBase64, isNotEmpty);
+    expect(_sshPublicKeyBase64, isNotEmpty);
+
+    await tester.binding.setSurfaceSize(const Size(430, 932));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final container = ProviderContainer(
+      overrides: [
+        hostKeyPromptHandlerProvider.overrideWithValue(
+          (_) async => HostKeyTrustDecision.trust,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final db = container.read(databaseProvider);
+    await db.customStatement('DELETE FROM known_hosts;');
+    await db.customStatement('DELETE FROM hosts;');
+    await db.customStatement('DELETE FROM ssh_keys;');
+
+    final keyId = await container
+        .read(keyRepositoryProvider)
+        .insert(
+          SshKeysCompanion.insert(
+            name: 'Temporary tmux validation key',
+            keyType: 'ed25519',
+            publicKey: utf8.decode(base64Decode(_sshPublicKeyBase64)),
+            privateKey: utf8.decode(base64Decode(_sshPrivateKeyBase64)),
+          ),
+        );
+
+    final hostId = await container
+        .read(hostRepositoryProvider)
+        .insert(
+          HostsCompanion.insert(
+            label: _hostLabel,
+            hostname: _deviceReachableHost,
+            port: Value(int.parse(_sshPort)),
+            username: _sshUser,
+            keyId: Value(keyId),
+            autoConnectRequiresConfirmation: const Value(false),
+            tmuxSessionName: const Value(_tmuxSessionName),
+          ),
+        );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(container: container, child: const FluttyApp()),
+    );
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+
+    final hostRow = find.byKey(ValueKey('home-host-$hostId'));
+    await _pumpUntilFound(tester, hostRow);
+
+    await tester.tap(hostRow);
+    await tester.pump();
+
+    await _pumpUntilFound(
+      tester,
+      find.byType(TerminalScreen),
+      timeout: const Duration(seconds: 20),
+    );
+    final handleBar = find.byKey(_tmuxHandleBarKey);
+    await _pumpUntilFound(tester, handleBar);
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    await binding.takeScreenshot('tmux-bar-collapsed');
+
+    await tester.tap(handleBar);
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+
+    await _pumpUntilFound(
+      tester,
+      find.text('New Window'),
+      timeout: const Duration(seconds: 15),
+    );
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    expect(find.text('New Window'), findsOneWidget);
+    await binding.takeScreenshot('tmux-bar-expanded');
+  });
+}

--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -37,12 +37,12 @@ PODS:
   - flutter_secure_storage_darwin (10.0.0):
     - Flutter
     - FlutterMacOS
+  - in_app_purchase_storekit (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - integration_test (0.0.1):
     - Flutter
   - local_auth_darwin (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - mobile_scanner (7.0.0):
     - Flutter
     - FlutterMacOS
   - package_info_plus (0.4.5):
@@ -62,9 +62,9 @@ DEPENDENCIES:
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
+  - in_app_purchase_storekit (from `.symlinks/plugins/in_app_purchase_storekit/darwin`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
-  - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - pasteboard (from `.symlinks/plugins/pasteboard/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
@@ -84,12 +84,12 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_secure_storage_darwin:
     :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
+  in_app_purchase_storekit:
+    :path: ".symlinks/plugins/in_app_purchase_storekit/darwin"
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
   local_auth_darwin:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
-  mobile_scanner:
-    :path: ".symlinks/plugins/mobile_scanner/darwin"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
   pasteboard:
@@ -105,9 +105,9 @@ SPEC CHECKSUMS:
   file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
+  in_app_purchase_storekit: 22cca7d08eebca9babdf4d07d0baccb73325d3c8
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
-  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   pasteboard: 3913b69d3f2be214970a8ae94e7e87fe76e47e98
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf

--- a/lib/data/database/database.dart
+++ b/lib/data/database/database.dart
@@ -80,6 +80,21 @@ class Hosts extends Table {
   BoolColumn get autoConnectRequiresConfirmation =>
       boolean().withDefault(const Constant(false))();
 
+  /// tmux session name to attach/create on connect.
+  ///
+  /// When set, the app generates a `tmux new-session -A -s <name>` command
+  /// instead of using [autoConnectCommand], and knows the session name
+  /// directly for window navigation.
+  TextColumn get tmuxSessionName => text().nullable()();
+
+  /// Working directory to use when starting a tmux session.
+  ///
+  /// Passed as `-c <dir>` to `tmux new-session`.
+  TextColumn get tmuxWorkingDirectory => text().nullable()();
+
+  /// Extra tmux flags appended to the generated `tmux new-session` command.
+  TextColumn get tmuxExtraFlags => text().nullable()();
+
   /// Display order within the hosts list.
   IntColumn get sortOrder => integer().withDefault(const Constant(0))();
 }
@@ -300,7 +315,7 @@ class AppDatabase extends _$AppDatabase {
   final AppleDatabaseFilePolicyApplier _appleDatabaseFilePolicyApplier;
 
   @override
-  int get schemaVersion => 6;
+  int get schemaVersion => 7;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -347,6 +362,18 @@ class AppDatabase extends _$AppDatabase {
             tableName: 'snippets',
             columnName: 'sort_order',
           );
+        }
+      }
+      if (from < 7) {
+        final hostColumnNames = await _readColumnNames('hosts');
+        if (!hostColumnNames.contains(hosts.tmuxSessionName.$name)) {
+          await m.addColumn(hosts, hosts.tmuxSessionName);
+        }
+        if (!hostColumnNames.contains(hosts.tmuxWorkingDirectory.$name)) {
+          await m.addColumn(hosts, hosts.tmuxWorkingDirectory);
+        }
+        if (!hostColumnNames.contains(hosts.tmuxExtraFlags.$name)) {
+          await m.addColumn(hosts, hosts.tmuxExtraFlags);
         }
       }
     },

--- a/lib/data/database/database.g.dart
+++ b/lib/data/database/database.g.dart
@@ -2262,6 +2262,39 @@ class $HostsTable extends Hosts with TableInfo<$HostsTable, Host> {
         ),
         defaultValue: const Constant(false),
       );
+  static const VerificationMeta _tmuxSessionNameMeta = const VerificationMeta(
+    'tmuxSessionName',
+  );
+  @override
+  late final GeneratedColumn<String> tmuxSessionName = GeneratedColumn<String>(
+    'tmux_session_name',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _tmuxWorkingDirectoryMeta =
+      const VerificationMeta('tmuxWorkingDirectory');
+  @override
+  late final GeneratedColumn<String> tmuxWorkingDirectory =
+      GeneratedColumn<String>(
+        'tmux_working_directory',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _tmuxExtraFlagsMeta = const VerificationMeta(
+    'tmuxExtraFlags',
+  );
+  @override
+  late final GeneratedColumn<String> tmuxExtraFlags = GeneratedColumn<String>(
+    'tmux_extra_flags',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _sortOrderMeta = const VerificationMeta(
     'sortOrder',
   );
@@ -2298,6 +2331,9 @@ class $HostsTable extends Hosts with TableInfo<$HostsTable, Host> {
     autoConnectCommand,
     autoConnectSnippetId,
     autoConnectRequiresConfirmation,
+    tmuxSessionName,
+    tmuxWorkingDirectory,
+    tmuxExtraFlags,
     sortOrder,
   ];
   @override
@@ -2471,6 +2507,33 @@ class $HostsTable extends Hosts with TableInfo<$HostsTable, Host> {
         ),
       );
     }
+    if (data.containsKey('tmux_session_name')) {
+      context.handle(
+        _tmuxSessionNameMeta,
+        tmuxSessionName.isAcceptableOrUnknown(
+          data['tmux_session_name']!,
+          _tmuxSessionNameMeta,
+        ),
+      );
+    }
+    if (data.containsKey('tmux_working_directory')) {
+      context.handle(
+        _tmuxWorkingDirectoryMeta,
+        tmuxWorkingDirectory.isAcceptableOrUnknown(
+          data['tmux_working_directory']!,
+          _tmuxWorkingDirectoryMeta,
+        ),
+      );
+    }
+    if (data.containsKey('tmux_extra_flags')) {
+      context.handle(
+        _tmuxExtraFlagsMeta,
+        tmuxExtraFlags.isAcceptableOrUnknown(
+          data['tmux_extra_flags']!,
+          _tmuxExtraFlagsMeta,
+        ),
+      );
+    }
     if (data.containsKey('sort_order')) {
       context.handle(
         _sortOrderMeta,
@@ -2574,6 +2637,18 @@ class $HostsTable extends Hosts with TableInfo<$HostsTable, Host> {
         DriftSqlType.bool,
         data['${effectivePrefix}auto_connect_requires_confirmation'],
       )!,
+      tmuxSessionName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}tmux_session_name'],
+      ),
+      tmuxWorkingDirectory: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}tmux_working_directory'],
+      ),
+      tmuxExtraFlags: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}tmux_extra_flags'],
+      ),
       sortOrder: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}sort_order'],
@@ -2654,6 +2729,21 @@ class Host extends DataClass implements Insertable<Host> {
   /// Whether auto-connect should require user review before it can run.
   final bool autoConnectRequiresConfirmation;
 
+  /// tmux session name to attach/create on connect.
+  ///
+  /// When set, the app generates a `tmux new-session -A -s <name>` command
+  /// instead of using [autoConnectCommand], and knows the session name
+  /// directly for window navigation.
+  final String? tmuxSessionName;
+
+  /// Working directory to use when starting a tmux session.
+  ///
+  /// Passed as `-c <dir>` to `tmux new-session`.
+  final String? tmuxWorkingDirectory;
+
+  /// Extra tmux flags appended to the generated `tmux new-session` command.
+  final String? tmuxExtraFlags;
+
   /// Display order within the hosts list.
   final int sortOrder;
   const Host({
@@ -2679,6 +2769,9 @@ class Host extends DataClass implements Insertable<Host> {
     this.autoConnectCommand,
     this.autoConnectSnippetId,
     required this.autoConnectRequiresConfirmation,
+    this.tmuxSessionName,
+    this.tmuxWorkingDirectory,
+    this.tmuxExtraFlags,
     required this.sortOrder,
   });
   @override
@@ -2734,6 +2827,15 @@ class Host extends DataClass implements Insertable<Host> {
     map['auto_connect_requires_confirmation'] = Variable<bool>(
       autoConnectRequiresConfirmation,
     );
+    if (!nullToAbsent || tmuxSessionName != null) {
+      map['tmux_session_name'] = Variable<String>(tmuxSessionName);
+    }
+    if (!nullToAbsent || tmuxWorkingDirectory != null) {
+      map['tmux_working_directory'] = Variable<String>(tmuxWorkingDirectory);
+    }
+    if (!nullToAbsent || tmuxExtraFlags != null) {
+      map['tmux_extra_flags'] = Variable<String>(tmuxExtraFlags);
+    }
     map['sort_order'] = Variable<int>(sortOrder);
     return map;
   }
@@ -2786,6 +2888,15 @@ class Host extends DataClass implements Insertable<Host> {
           ? const Value.absent()
           : Value(autoConnectSnippetId),
       autoConnectRequiresConfirmation: Value(autoConnectRequiresConfirmation),
+      tmuxSessionName: tmuxSessionName == null && nullToAbsent
+          ? const Value.absent()
+          : Value(tmuxSessionName),
+      tmuxWorkingDirectory: tmuxWorkingDirectory == null && nullToAbsent
+          ? const Value.absent()
+          : Value(tmuxWorkingDirectory),
+      tmuxExtraFlags: tmuxExtraFlags == null && nullToAbsent
+          ? const Value.absent()
+          : Value(tmuxExtraFlags),
       sortOrder: Value(sortOrder),
     );
   }
@@ -2830,6 +2941,11 @@ class Host extends DataClass implements Insertable<Host> {
       autoConnectRequiresConfirmation: serializer.fromJson<bool>(
         json['autoConnectRequiresConfirmation'],
       ),
+      tmuxSessionName: serializer.fromJson<String?>(json['tmuxSessionName']),
+      tmuxWorkingDirectory: serializer.fromJson<String?>(
+        json['tmuxWorkingDirectory'],
+      ),
+      tmuxExtraFlags: serializer.fromJson<String?>(json['tmuxExtraFlags']),
       sortOrder: serializer.fromJson<int>(json['sortOrder']),
     );
   }
@@ -2861,6 +2977,9 @@ class Host extends DataClass implements Insertable<Host> {
       'autoConnectRequiresConfirmation': serializer.toJson<bool>(
         autoConnectRequiresConfirmation,
       ),
+      'tmuxSessionName': serializer.toJson<String?>(tmuxSessionName),
+      'tmuxWorkingDirectory': serializer.toJson<String?>(tmuxWorkingDirectory),
+      'tmuxExtraFlags': serializer.toJson<String?>(tmuxExtraFlags),
       'sortOrder': serializer.toJson<int>(sortOrder),
     };
   }
@@ -2888,6 +3007,9 @@ class Host extends DataClass implements Insertable<Host> {
     Value<String?> autoConnectCommand = const Value.absent(),
     Value<int?> autoConnectSnippetId = const Value.absent(),
     bool? autoConnectRequiresConfirmation,
+    Value<String?> tmuxSessionName = const Value.absent(),
+    Value<String?> tmuxWorkingDirectory = const Value.absent(),
+    Value<String?> tmuxExtraFlags = const Value.absent(),
     int? sortOrder,
   }) => Host(
     id: id ?? this.id,
@@ -2925,6 +3047,15 @@ class Host extends DataClass implements Insertable<Host> {
         : this.autoConnectSnippetId,
     autoConnectRequiresConfirmation:
         autoConnectRequiresConfirmation ?? this.autoConnectRequiresConfirmation,
+    tmuxSessionName: tmuxSessionName.present
+        ? tmuxSessionName.value
+        : this.tmuxSessionName,
+    tmuxWorkingDirectory: tmuxWorkingDirectory.present
+        ? tmuxWorkingDirectory.value
+        : this.tmuxWorkingDirectory,
+    tmuxExtraFlags: tmuxExtraFlags.present
+        ? tmuxExtraFlags.value
+        : this.tmuxExtraFlags,
     sortOrder: sortOrder ?? this.sortOrder,
   );
   Host copyWithCompanion(HostsCompanion data) {
@@ -2970,6 +3101,15 @@ class Host extends DataClass implements Insertable<Host> {
           data.autoConnectRequiresConfirmation.present
           ? data.autoConnectRequiresConfirmation.value
           : this.autoConnectRequiresConfirmation,
+      tmuxSessionName: data.tmuxSessionName.present
+          ? data.tmuxSessionName.value
+          : this.tmuxSessionName,
+      tmuxWorkingDirectory: data.tmuxWorkingDirectory.present
+          ? data.tmuxWorkingDirectory.value
+          : this.tmuxWorkingDirectory,
+      tmuxExtraFlags: data.tmuxExtraFlags.present
+          ? data.tmuxExtraFlags.value
+          : this.tmuxExtraFlags,
       sortOrder: data.sortOrder.present ? data.sortOrder.value : this.sortOrder,
     );
   }
@@ -3001,6 +3141,9 @@ class Host extends DataClass implements Insertable<Host> {
           ..write(
             'autoConnectRequiresConfirmation: $autoConnectRequiresConfirmation, ',
           )
+          ..write('tmuxSessionName: $tmuxSessionName, ')
+          ..write('tmuxWorkingDirectory: $tmuxWorkingDirectory, ')
+          ..write('tmuxExtraFlags: $tmuxExtraFlags, ')
           ..write('sortOrder: $sortOrder')
           ..write(')'))
         .toString();
@@ -3030,6 +3173,9 @@ class Host extends DataClass implements Insertable<Host> {
     autoConnectCommand,
     autoConnectSnippetId,
     autoConnectRequiresConfirmation,
+    tmuxSessionName,
+    tmuxWorkingDirectory,
+    tmuxExtraFlags,
     sortOrder,
   ]);
   @override
@@ -3059,6 +3205,9 @@ class Host extends DataClass implements Insertable<Host> {
           other.autoConnectSnippetId == this.autoConnectSnippetId &&
           other.autoConnectRequiresConfirmation ==
               this.autoConnectRequiresConfirmation &&
+          other.tmuxSessionName == this.tmuxSessionName &&
+          other.tmuxWorkingDirectory == this.tmuxWorkingDirectory &&
+          other.tmuxExtraFlags == this.tmuxExtraFlags &&
           other.sortOrder == this.sortOrder);
 }
 
@@ -3085,6 +3234,9 @@ class HostsCompanion extends UpdateCompanion<Host> {
   final Value<String?> autoConnectCommand;
   final Value<int?> autoConnectSnippetId;
   final Value<bool> autoConnectRequiresConfirmation;
+  final Value<String?> tmuxSessionName;
+  final Value<String?> tmuxWorkingDirectory;
+  final Value<String?> tmuxExtraFlags;
   final Value<int> sortOrder;
   const HostsCompanion({
     this.id = const Value.absent(),
@@ -3109,6 +3261,9 @@ class HostsCompanion extends UpdateCompanion<Host> {
     this.autoConnectCommand = const Value.absent(),
     this.autoConnectSnippetId = const Value.absent(),
     this.autoConnectRequiresConfirmation = const Value.absent(),
+    this.tmuxSessionName = const Value.absent(),
+    this.tmuxWorkingDirectory = const Value.absent(),
+    this.tmuxExtraFlags = const Value.absent(),
     this.sortOrder = const Value.absent(),
   });
   HostsCompanion.insert({
@@ -3134,6 +3289,9 @@ class HostsCompanion extends UpdateCompanion<Host> {
     this.autoConnectCommand = const Value.absent(),
     this.autoConnectSnippetId = const Value.absent(),
     this.autoConnectRequiresConfirmation = const Value.absent(),
+    this.tmuxSessionName = const Value.absent(),
+    this.tmuxWorkingDirectory = const Value.absent(),
+    this.tmuxExtraFlags = const Value.absent(),
     this.sortOrder = const Value.absent(),
   }) : label = Value(label),
        hostname = Value(hostname),
@@ -3161,6 +3319,9 @@ class HostsCompanion extends UpdateCompanion<Host> {
     Expression<String>? autoConnectCommand,
     Expression<int>? autoConnectSnippetId,
     Expression<bool>? autoConnectRequiresConfirmation,
+    Expression<String>? tmuxSessionName,
+    Expression<String>? tmuxWorkingDirectory,
+    Expression<String>? tmuxExtraFlags,
     Expression<int>? sortOrder,
   }) {
     return RawValuesInsertable({
@@ -3192,6 +3353,10 @@ class HostsCompanion extends UpdateCompanion<Host> {
         'auto_connect_snippet_id': autoConnectSnippetId,
       if (autoConnectRequiresConfirmation != null)
         'auto_connect_requires_confirmation': autoConnectRequiresConfirmation,
+      if (tmuxSessionName != null) 'tmux_session_name': tmuxSessionName,
+      if (tmuxWorkingDirectory != null)
+        'tmux_working_directory': tmuxWorkingDirectory,
+      if (tmuxExtraFlags != null) 'tmux_extra_flags': tmuxExtraFlags,
       if (sortOrder != null) 'sort_order': sortOrder,
     });
   }
@@ -3219,6 +3384,9 @@ class HostsCompanion extends UpdateCompanion<Host> {
     Value<String?>? autoConnectCommand,
     Value<int?>? autoConnectSnippetId,
     Value<bool>? autoConnectRequiresConfirmation,
+    Value<String?>? tmuxSessionName,
+    Value<String?>? tmuxWorkingDirectory,
+    Value<String?>? tmuxExtraFlags,
     Value<int>? sortOrder,
   }) {
     return HostsCompanion(
@@ -3246,6 +3414,9 @@ class HostsCompanion extends UpdateCompanion<Host> {
       autoConnectRequiresConfirmation:
           autoConnectRequiresConfirmation ??
           this.autoConnectRequiresConfirmation,
+      tmuxSessionName: tmuxSessionName ?? this.tmuxSessionName,
+      tmuxWorkingDirectory: tmuxWorkingDirectory ?? this.tmuxWorkingDirectory,
+      tmuxExtraFlags: tmuxExtraFlags ?? this.tmuxExtraFlags,
       sortOrder: sortOrder ?? this.sortOrder,
     );
   }
@@ -3327,6 +3498,17 @@ class HostsCompanion extends UpdateCompanion<Host> {
         autoConnectRequiresConfirmation.value,
       );
     }
+    if (tmuxSessionName.present) {
+      map['tmux_session_name'] = Variable<String>(tmuxSessionName.value);
+    }
+    if (tmuxWorkingDirectory.present) {
+      map['tmux_working_directory'] = Variable<String>(
+        tmuxWorkingDirectory.value,
+      );
+    }
+    if (tmuxExtraFlags.present) {
+      map['tmux_extra_flags'] = Variable<String>(tmuxExtraFlags.value);
+    }
     if (sortOrder.present) {
       map['sort_order'] = Variable<int>(sortOrder.value);
     }
@@ -3360,6 +3542,9 @@ class HostsCompanion extends UpdateCompanion<Host> {
           ..write(
             'autoConnectRequiresConfirmation: $autoConnectRequiresConfirmation, ',
           )
+          ..write('tmuxSessionName: $tmuxSessionName, ')
+          ..write('tmuxWorkingDirectory: $tmuxWorkingDirectory, ')
+          ..write('tmuxExtraFlags: $tmuxExtraFlags, ')
           ..write('sortOrder: $sortOrder')
           ..write(')'))
         .toString();
@@ -6467,6 +6652,9 @@ typedef $$HostsTableCreateCompanionBuilder =
       Value<String?> autoConnectCommand,
       Value<int?> autoConnectSnippetId,
       Value<bool> autoConnectRequiresConfirmation,
+      Value<String?> tmuxSessionName,
+      Value<String?> tmuxWorkingDirectory,
+      Value<String?> tmuxExtraFlags,
       Value<int> sortOrder,
     });
 typedef $$HostsTableUpdateCompanionBuilder =
@@ -6493,6 +6681,9 @@ typedef $$HostsTableUpdateCompanionBuilder =
       Value<String?> autoConnectCommand,
       Value<int?> autoConnectSnippetId,
       Value<bool> autoConnectRequiresConfirmation,
+      Value<String?> tmuxSessionName,
+      Value<String?> tmuxWorkingDirectory,
+      Value<String?> tmuxExtraFlags,
       Value<int> sortOrder,
     });
 
@@ -6689,6 +6880,21 @@ class $$HostsTableFilterComposer extends Composer<_$AppDatabase, $HostsTable> {
 
   ColumnFilters<bool> get autoConnectRequiresConfirmation => $composableBuilder(
     column: $table.autoConnectRequiresConfirmation,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get tmuxSessionName => $composableBuilder(
+    column: $table.tmuxSessionName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get tmuxWorkingDirectory => $composableBuilder(
+    column: $table.tmuxWorkingDirectory,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get tmuxExtraFlags => $composableBuilder(
+    column: $table.tmuxExtraFlags,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -6915,6 +7121,21 @@ class $$HostsTableOrderingComposer
         builder: (column) => ColumnOrderings(column),
       );
 
+  ColumnOrderings<String> get tmuxSessionName => $composableBuilder(
+    column: $table.tmuxSessionName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get tmuxWorkingDirectory => $composableBuilder(
+    column: $table.tmuxWorkingDirectory,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get tmuxExtraFlags => $composableBuilder(
+    column: $table.tmuxExtraFlags,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get sortOrder => $composableBuilder(
     column: $table.sortOrder,
     builder: (column) => ColumnOrderings(column),
@@ -7090,6 +7311,21 @@ class $$HostsTableAnnotationComposer
         column: $table.autoConnectRequiresConfirmation,
         builder: (column) => column,
       );
+
+  GeneratedColumn<String> get tmuxSessionName => $composableBuilder(
+    column: $table.tmuxSessionName,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get tmuxWorkingDirectory => $composableBuilder(
+    column: $table.tmuxWorkingDirectory,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get tmuxExtraFlags => $composableBuilder(
+    column: $table.tmuxExtraFlags,
+    builder: (column) => column,
+  );
 
   GeneratedColumn<int> get sortOrder =>
       $composableBuilder(column: $table.sortOrder, builder: (column) => column);
@@ -7269,6 +7505,9 @@ class $$HostsTableTableManager
                 Value<int?> autoConnectSnippetId = const Value.absent(),
                 Value<bool> autoConnectRequiresConfirmation =
                     const Value.absent(),
+                Value<String?> tmuxSessionName = const Value.absent(),
+                Value<String?> tmuxWorkingDirectory = const Value.absent(),
+                Value<String?> tmuxExtraFlags = const Value.absent(),
                 Value<int> sortOrder = const Value.absent(),
               }) => HostsCompanion(
                 id: id,
@@ -7294,6 +7533,9 @@ class $$HostsTableTableManager
                 autoConnectSnippetId: autoConnectSnippetId,
                 autoConnectRequiresConfirmation:
                     autoConnectRequiresConfirmation,
+                tmuxSessionName: tmuxSessionName,
+                tmuxWorkingDirectory: tmuxWorkingDirectory,
+                tmuxExtraFlags: tmuxExtraFlags,
                 sortOrder: sortOrder,
               ),
           createCompanionCallback:
@@ -7321,6 +7563,9 @@ class $$HostsTableTableManager
                 Value<int?> autoConnectSnippetId = const Value.absent(),
                 Value<bool> autoConnectRequiresConfirmation =
                     const Value.absent(),
+                Value<String?> tmuxSessionName = const Value.absent(),
+                Value<String?> tmuxWorkingDirectory = const Value.absent(),
+                Value<String?> tmuxExtraFlags = const Value.absent(),
                 Value<int> sortOrder = const Value.absent(),
               }) => HostsCompanion.insert(
                 id: id,
@@ -7346,6 +7591,9 @@ class $$HostsTableTableManager
                 autoConnectSnippetId: autoConnectSnippetId,
                 autoConnectRequiresConfirmation:
                     autoConnectRequiresConfirmation,
+                tmuxSessionName: tmuxSessionName,
+                tmuxWorkingDirectory: tmuxWorkingDirectory,
+                tmuxExtraFlags: tmuxExtraFlags,
                 sortOrder: sortOrder,
               ),
           withReferenceMapper: (p0) => p0

--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -6,9 +6,6 @@ enum AgentLaunchTool {
   /// GitHub Copilot CLI.
   copilotCli,
 
-  /// Aider.
-  aider,
-
   /// OpenAI Codex CLI.
   codex,
 
@@ -25,7 +22,6 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
   String get label => switch (this) {
     AgentLaunchTool.claudeCode => 'Claude Code',
     AgentLaunchTool.copilotCli => 'Copilot CLI',
-    AgentLaunchTool.aider => 'Aider',
     AgentLaunchTool.codex => 'Codex',
     AgentLaunchTool.openCode => 'OpenCode',
     AgentLaunchTool.geminiCli => 'Gemini CLI',
@@ -35,7 +31,6 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
   String get commandName => switch (this) {
     AgentLaunchTool.claudeCode => 'claude',
     AgentLaunchTool.copilotCli => 'copilot',
-    AgentLaunchTool.aider => 'aider',
     AgentLaunchTool.codex => 'codex',
     AgentLaunchTool.openCode => 'opencode',
     AgentLaunchTool.geminiCli => 'gemini',
@@ -48,7 +43,6 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
     AgentLaunchTool.codex => true,
     AgentLaunchTool.openCode => true,
     AgentLaunchTool.geminiCli => true,
-    AgentLaunchTool.aider => true,
   };
 }
 

--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -8,6 +8,15 @@ enum AgentLaunchTool {
 
   /// Aider.
   aider,
+
+  /// OpenAI Codex CLI.
+  codex,
+
+  /// OpenCode CLI.
+  openCode,
+
+  /// Google Gemini CLI.
+  geminiCli,
 }
 
 /// Presentation helpers for [AgentLaunchTool].
@@ -17,6 +26,9 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
     AgentLaunchTool.claudeCode => 'Claude Code',
     AgentLaunchTool.copilotCli => 'Copilot CLI',
     AgentLaunchTool.aider => 'Aider',
+    AgentLaunchTool.codex => 'Codex',
+    AgentLaunchTool.openCode => 'OpenCode',
+    AgentLaunchTool.geminiCli => 'Gemini CLI',
   };
 
   /// Shell command used to launch this tool.
@@ -24,6 +36,19 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
     AgentLaunchTool.claudeCode => 'claude',
     AgentLaunchTool.copilotCli => 'copilot',
     AgentLaunchTool.aider => 'aider',
+    AgentLaunchTool.codex => 'codex',
+    AgentLaunchTool.openCode => 'opencode',
+    AgentLaunchTool.geminiCli => 'gemini',
+  };
+
+  /// Whether this tool supports session resume.
+  bool get supportsResume => switch (this) {
+    AgentLaunchTool.claudeCode => true,
+    AgentLaunchTool.copilotCli => true,
+    AgentLaunchTool.codex => true,
+    AgentLaunchTool.openCode => true,
+    AgentLaunchTool.geminiCli => true,
+    AgentLaunchTool.aider => true,
   };
 }
 

--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -6,6 +6,9 @@ enum AgentLaunchTool {
   /// GitHub Copilot CLI.
   copilotCli,
 
+  /// Aider.
+  aider,
+
   /// OpenAI Codex CLI.
   codex,
 
@@ -22,6 +25,7 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
   String get label => switch (this) {
     AgentLaunchTool.claudeCode => 'Claude Code',
     AgentLaunchTool.copilotCli => 'Copilot CLI',
+    AgentLaunchTool.aider => 'Aider',
     AgentLaunchTool.codex => 'Codex',
     AgentLaunchTool.openCode => 'OpenCode',
     AgentLaunchTool.geminiCli => 'Gemini CLI',
@@ -31,6 +35,7 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
   String get commandName => switch (this) {
     AgentLaunchTool.claudeCode => 'claude',
     AgentLaunchTool.copilotCli => 'copilot',
+    AgentLaunchTool.aider => 'aider',
     AgentLaunchTool.codex => 'codex',
     AgentLaunchTool.openCode => 'opencode',
     AgentLaunchTool.geminiCli => 'gemini',
@@ -40,6 +45,7 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
   bool get supportsResume => switch (this) {
     AgentLaunchTool.claudeCode => true,
     AgentLaunchTool.copilotCli => true,
+    AgentLaunchTool.aider => true,
     AgentLaunchTool.codex => true,
     AgentLaunchTool.openCode => true,
     AgentLaunchTool.geminiCli => true,
@@ -57,16 +63,22 @@ class AgentLaunchPreset {
   });
 
   /// Decodes an [AgentLaunchPreset] from JSON.
-  factory AgentLaunchPreset.fromJson(Map<String, dynamic> json) =>
-      AgentLaunchPreset(
-        tool: AgentLaunchTool.values.firstWhere(
-          (value) => value.name == json['tool'],
-          orElse: () => AgentLaunchTool.claudeCode,
-        ),
-        workingDirectory: _readTrimmedString(json['workingDirectory']),
-        tmuxSessionName: _readTrimmedString(json['tmuxSessionName']),
-        additionalArguments: _readTrimmedString(json['additionalArguments']),
-      );
+  factory AgentLaunchPreset.fromJson(Map<String, dynamic> json) {
+    final rawTool = _readTrimmedString(json['tool']);
+    final tool = AgentLaunchTool.values.firstWhere(
+      (value) => value.name == rawTool,
+      orElse: () => switch (rawTool) {
+        'aider' => AgentLaunchTool.aider,
+        _ => AgentLaunchTool.claudeCode,
+      },
+    );
+    return AgentLaunchPreset(
+      tool: tool,
+      workingDirectory: _readTrimmedString(json['workingDirectory']),
+      tmuxSessionName: _readTrimmedString(json['tmuxSessionName']),
+      additionalArguments: _readTrimmedString(json['additionalArguments']),
+    );
+  }
 
   /// Selected coding-agent CLI.
   final AgentLaunchTool tool;

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -74,17 +74,30 @@ class TmuxWindow {
     this.currentPath,
     this.flags,
     this.paneTitle,
+    this.idleSeconds,
   });
 
   /// Parses a [TmuxWindow] from a pipe-delimited tmux format string.
   ///
   /// Expected format (from `tmux list-windows -F`):
-  /// `index|name|active_flag|command|path|flags|pane_title`
+  /// `index|name|active_flag|command|path|flags|pane_title|activity_epoch`
   factory TmuxWindow.fromTmuxFormat(String line) {
     final parts = line.split('|');
     if (parts.length < 3) {
       throw FormatException('Invalid tmux window format: $line');
     }
+
+    // Compute idle seconds from window_activity epoch if available.
+    int? idleSeconds;
+    if (parts.length > 7) {
+      final activityEpoch = int.tryParse(parts[7]);
+      if (activityEpoch != null && activityEpoch > 0) {
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        idleSeconds = now - activityEpoch;
+        if (idleSeconds < 0) idleSeconds = 0;
+      }
+    }
+
     return TmuxWindow(
       index: int.tryParse(parts[0]) ?? 0,
       name: parts[1],
@@ -93,6 +106,7 @@ class TmuxWindow {
       currentPath: parts.length > 4 ? _nonEmpty(parts[4]) : null,
       flags: parts.length > 5 ? _nonEmpty(parts[5]) : null,
       paneTitle: parts.length > 6 ? _nonEmpty(parts[6]) : null,
+      idleSeconds: idleSeconds,
     );
   }
 
@@ -117,18 +131,34 @@ class TmuxWindow {
   /// The pane title set by the running application, if available.
   final String? paneTitle;
 
+  /// Seconds since last output activity in this window, if available.
+  final int? idleSeconds;
+
+  /// Idle threshold (seconds) above which a window is considered "waiting".
+  static const _idleThreshold = 15;
+
   /// Whether this window has a pending alert or bell.
   bool get hasAlert => flags != null && flags!.contains('#');
+
+  /// Whether the window appears to be idle (no output for a while).
+  ///
+  /// A CLI that has finished working and is waiting for the user to
+  /// return will have a high idle time while still showing as the
+  /// `currentCommand`.
+  bool get isIdle =>
+      idleSeconds != null && idleSeconds! > _idleThreshold && !isActive;
 
   /// A short display title — prefers paneTitle, falls back to name.
   String get displayTitle => paneTitle ?? name;
 
   /// A human-readable status label for display.
+  ///
+  /// Only returns a label for noteworthy states — the active window
+  /// is already visually highlighted via the index badge.
   String get statusLabel {
     if (hasAlert) return 'alert';
-    if (isActive) return 'active';
-    if (currentCommand != null) return 'running';
-    return 'idle';
+    if (isIdle) return 'waiting';
+    return '';
   }
 
   @override
@@ -146,7 +176,8 @@ class TmuxWindow {
           currentCommand == other.currentCommand &&
           currentPath == other.currentPath &&
           flags == other.flags &&
-          paneTitle == other.paneTitle;
+          paneTitle == other.paneTitle &&
+          idleSeconds == other.idleSeconds;
 
   @override
   int get hashCode => Object.hash(
@@ -157,6 +188,7 @@ class TmuxWindow {
     currentPath,
     flags,
     paneTitle,
+    idleSeconds,
   );
 }
 

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -292,14 +292,21 @@ String? parseTmuxSessionName(String? command) {
   // Match a shell argument: 'quoted', "quoted", or unquoted-word.
   const argPattern = r"""(?:'([^']*)'|"([^"]*)"|(\S+))""";
 
-  // Try -s <name> (new-session / new)
-  final sFlag = RegExp('-[A-Za-z]*s\\s+$argPattern').firstMatch(tmuxPart);
+  // Try -s <name> (new-session / new).
+  // Use a whitespace lookbehind so we match standalone flags like `-s`
+  // or combined flags like `-As`, but not subcommand suffixes like
+  // `list-sessions`.
+  final sFlag = RegExp(
+    '(?<=\\s)-[A-Za-z]*s\\s+$argPattern',
+  ).firstMatch(tmuxPart);
   if (sFlag != null) {
     return sFlag.group(1) ?? sFlag.group(2) ?? sFlag.group(3);
   }
 
   // Try -t <name> (attach / attach-session)
-  final tFlag = RegExp('-[A-Za-z]*t\\s+$argPattern').firstMatch(tmuxPart);
+  final tFlag = RegExp(
+    '(?<=\\s)-[A-Za-z]*t\\s+$argPattern',
+  ).firstMatch(tmuxPart);
   if (tFlag != null) {
     return tFlag.group(1) ?? tFlag.group(2) ?? tFlag.group(3);
   }

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -1,10 +1,3 @@
-/// Domain models for tmux session and window state.
-///
-/// These models represent the tmux state as queried over SSH exec channels.
-/// They deliberately avoid tmux implementation details in their public API,
-/// using user-friendly terminology ("windows" not "tmux windows").
-library;
-
 import 'package:flutter/foundation.dart';
 
 /// Represents a tmux session on a remote host.
@@ -98,7 +91,7 @@ class TmuxWindow {
     );
   }
 
-  /// The zero-based window index within the session.
+  /// The tmux-reported window index within the session.
   final int index;
 
   /// The window name (often set by the running program or user).

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -145,9 +145,11 @@ class TmuxWindow {
   ///
   /// A CLI that has finished working and is waiting for the user to
   /// return will have a high idle time while still showing as the
-  /// `currentCommand`.
-  bool get isIdle =>
-      idleSeconds != null && idleSeconds! > _idleThreshold && !isActive;
+  /// `currentCommand`, including when it is the currently selected window.
+  bool get isIdle => idleSeconds != null && idleSeconds! > _idleThreshold;
+
+  /// Whether the window appears to be actively running work.
+  bool get isRunning => !hasAlert && !isIdle;
 
   /// A short display title — prefers the richest usable tmux title.
   String get displayTitle {
@@ -192,12 +194,10 @@ class TmuxWindow {
 
   /// A human-readable status label for display.
   ///
-  /// Only returns a label for noteworthy states — the active window
-  /// is already visually highlighted via the index badge.
   String get statusLabel {
     if (hasAlert) return 'alert';
     if (isIdle) return 'waiting';
-    return '';
+    return 'running';
   }
 
   @override

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -72,12 +72,14 @@ class TmuxWindow {
     required this.isActive,
     this.currentCommand,
     this.currentPath,
+    this.flags,
+    this.paneTitle,
   });
 
   /// Parses a [TmuxWindow] from a pipe-delimited tmux format string.
   ///
   /// Expected format (from `tmux list-windows -F`):
-  /// `index|name|active_flag|current_command|current_path`
+  /// `index|name|active_flag|command|path|flags|pane_title`
   factory TmuxWindow.fromTmuxFormat(String line) {
     final parts = line.split('|');
     if (parts.length < 3) {
@@ -89,6 +91,8 @@ class TmuxWindow {
       isActive: parts[2] == '1',
       currentCommand: parts.length > 3 ? _nonEmpty(parts[3]) : null,
       currentPath: parts.length > 4 ? _nonEmpty(parts[4]) : null,
+      flags: parts.length > 5 ? _nonEmpty(parts[5]) : null,
+      paneTitle: parts.length > 6 ? _nonEmpty(parts[6]) : null,
     );
   }
 
@@ -107,8 +111,21 @@ class TmuxWindow {
   /// The working directory of the active pane, if available.
   final String? currentPath;
 
+  /// tmux window flags (`*` active, `-` last, `#` alert/bell, etc.).
+  final String? flags;
+
+  /// The pane title set by the running application, if available.
+  final String? paneTitle;
+
+  /// Whether this window has a pending alert or bell.
+  bool get hasAlert => flags != null && flags!.contains('#');
+
+  /// A short display title — prefers paneTitle, falls back to name.
+  String get displayTitle => paneTitle ?? name;
+
   /// A human-readable status label for display.
   String get statusLabel {
+    if (hasAlert) return 'alert';
     if (isActive) return 'active';
     if (currentCommand != null) return 'running';
     return 'idle';
@@ -117,7 +134,7 @@ class TmuxWindow {
   @override
   String toString() =>
       'TmuxWindow(index: $index, name: $name, active: $isActive, '
-      'command: $currentCommand)';
+      'command: $currentCommand, title: $paneTitle)';
 
   @override
   bool operator ==(Object other) =>
@@ -127,11 +144,20 @@ class TmuxWindow {
           name == other.name &&
           isActive == other.isActive &&
           currentCommand == other.currentCommand &&
-          currentPath == other.currentPath;
+          currentPath == other.currentPath &&
+          flags == other.flags &&
+          paneTitle == other.paneTitle;
 
   @override
-  int get hashCode =>
-      Object.hash(index, name, isActive, currentCommand, currentPath);
+  int get hashCode => Object.hash(
+    index,
+    name,
+    isActive,
+    currentCommand,
+    currentPath,
+    flags,
+    paneTitle,
+  );
 }
 
 /// Metadata for a recent AI coding tool session found on a remote host.

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -231,6 +231,18 @@ class ToolSessionInfo {
     return '${diff.inDays ~/ 7}w ago';
   }
 
+  /// A compact absolute + relative timestamp label for session lists.
+  String get lastUpdatedLabel {
+    if (lastActive == null) return '';
+    final localTime = lastActive!.toLocal();
+    final now = DateTime.now();
+    final month = _monthAbbreviations[localTime.month - 1];
+    final dateLabel = localTime.year == now.year
+        ? '$month ${localTime.day}'
+        : '$month ${localTime.day}, ${localTime.year}';
+    return '$dateLabel | $timeAgoLabel';
+  }
+
   @override
   String toString() =>
       'ToolSessionInfo(tool: $toolName, id: $sessionId, '
@@ -246,6 +258,21 @@ class ToolSessionInfo {
   @override
   int get hashCode => Object.hash(toolName, sessionId);
 }
+
+const _monthAbbreviations = <String>[
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
 
 String? _nonEmpty(String value) {
   final trimmed = value.trim();

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -20,14 +20,15 @@ class TmuxSession {
     if (parts.length < 3) {
       throw FormatException('Invalid tmux session format: $line');
     }
+    final activityEpoch = parts.length > 3 && parts[3].isNotEmpty
+        ? int.tryParse(parts[3])
+        : null;
     return TmuxSession(
       name: parts[0],
       windowCount: int.tryParse(parts[1]) ?? 0,
       isAttached: parts[2] == '1',
-      lastActivity: parts.length > 3
-          ? DateTime.fromMillisecondsSinceEpoch(
-              (int.tryParse(parts[3]) ?? 0) * 1000,
-            )
+      lastActivity: activityEpoch != null && activityEpoch > 0
+          ? DateTime.fromMillisecondsSinceEpoch(activityEpoch * 1000)
           : null,
     );
   }
@@ -73,7 +74,7 @@ class TmuxWindow {
     this.currentPath,
   });
 
-  /// Parses a [TmuxWindow] from a tab-delimited tmux format string.
+  /// Parses a [TmuxWindow] from a pipe-delimited tmux format string.
   ///
   /// Expected format (from `tmux list-windows -F`):
   /// `index|name|active_flag|current_command|current_path`

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -11,22 +11,25 @@ class TmuxSession {
     this.lastActivity,
   });
 
-  /// Parses a [TmuxSession] from a pipe-delimited tmux format string.
+  /// Parses a [TmuxSession] from a unit-separator-delimited tmux format
+  /// string.
   ///
   /// Expected format (from `tmux list-sessions -F`):
-  /// `session_name|window_count|attached_flag|activity_epoch`
+  /// `session_name\x1fwindow_count\x1fattached_flag\x1factivity_epoch`
   factory TmuxSession.fromTmuxFormat(String line) {
-    final parts = line.split('|');
-    if (parts.length < 3) {
+    final parts = line.split('\x1f');
+    // Fall back to pipe delimiter for compatibility with older callers.
+    final fields = parts.length >= 3 ? parts : line.split('|');
+    if (fields.length < 3) {
       throw FormatException('Invalid tmux session format: $line');
     }
-    final activityEpoch = parts.length > 3 && parts[3].isNotEmpty
-        ? int.tryParse(parts[3])
+    final activityEpoch = fields.length > 3 && fields[3].isNotEmpty
+        ? int.tryParse(fields[3])
         : null;
     return TmuxSession(
-      name: parts[0],
-      windowCount: int.tryParse(parts[1]) ?? 0,
-      isAttached: parts[2] == '1',
+      name: fields[0],
+      windowCount: int.tryParse(fields[1]) ?? 0,
+      isAttached: fields[2] == '1',
       lastActivity: activityEpoch != null && activityEpoch > 0
           ? DateTime.fromMillisecondsSinceEpoch(activityEpoch * 1000)
           : null,
@@ -77,20 +80,23 @@ class TmuxWindow {
     this.idleSeconds,
   });
 
-  /// Parses a [TmuxWindow] from a pipe-delimited tmux format string.
+  /// Parses a [TmuxWindow] from a unit-separator-delimited tmux format
+  /// string.
   ///
   /// Expected format (from `tmux list-windows -F`):
-  /// `index|name|active_flag|command|path|flags|pane_title|activity_epoch`
+  /// `index\x1fname\x1factive_flag\x1fcommand\x1fpath\x1fflags\x1fpane_title\x1factivity_epoch`
   factory TmuxWindow.fromTmuxFormat(String line) {
-    final parts = line.split('|');
-    if (parts.length < 3) {
+    final parts = line.split('\x1f');
+    // Fall back to pipe delimiter for compatibility with older callers.
+    final fields = parts.length >= 3 ? parts : line.split('|');
+    if (fields.length < 3) {
       throw FormatException('Invalid tmux window format: $line');
     }
 
     // Compute idle seconds from window_activity epoch if available.
     int? idleSeconds;
-    if (parts.length > 7) {
-      final activityEpoch = int.tryParse(parts[7]);
+    if (fields.length > 7) {
+      final activityEpoch = int.tryParse(fields[7]);
       if (activityEpoch != null && activityEpoch > 0) {
         final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
         idleSeconds = now - activityEpoch;
@@ -99,13 +105,13 @@ class TmuxWindow {
     }
 
     return TmuxWindow(
-      index: int.tryParse(parts[0]) ?? 0,
-      name: parts[1],
-      isActive: parts[2] == '1',
-      currentCommand: parts.length > 3 ? _nonEmpty(parts[3]) : null,
-      currentPath: parts.length > 4 ? _nonEmpty(parts[4]) : null,
-      flags: parts.length > 5 ? _nonEmpty(parts[5]) : null,
-      paneTitle: parts.length > 6 ? _nonEmpty(parts[6]) : null,
+      index: int.tryParse(fields[0]) ?? 0,
+      name: fields[1],
+      isActive: fields[2] == '1',
+      currentCommand: fields.length > 3 ? _nonEmpty(fields[3]) : null,
+      currentPath: fields.length > 4 ? _nonEmpty(fields[4]) : null,
+      flags: fields.length > 5 ? _nonEmpty(fields[5]) : null,
+      paneTitle: fields.length > 6 ? _nonEmpty(fields[6]) : null,
       idleSeconds: idleSeconds,
     );
   }

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -11,15 +11,12 @@ class TmuxSession {
     this.lastActivity,
   });
 
-  /// Parses a [TmuxSession] from a unit-separator-delimited tmux format
-  /// string.
+  /// Parses a [TmuxSession] from a pipe-delimited tmux format string.
   ///
   /// Expected format (from `tmux list-sessions -F`):
-  /// `session_name\x1fwindow_count\x1fattached_flag\x1factivity_epoch`
+  /// `session_name|window_count|attached_flag|activity_epoch`
   factory TmuxSession.fromTmuxFormat(String line) {
-    final parts = line.split('\x1f');
-    // Fall back to pipe delimiter for compatibility with older callers.
-    final fields = parts.length >= 3 ? parts : line.split('|');
+    final fields = line.split('|');
     if (fields.length < 3) {
       throw FormatException('Invalid tmux session format: $line');
     }
@@ -80,15 +77,12 @@ class TmuxWindow {
     this.idleSeconds,
   });
 
-  /// Parses a [TmuxWindow] from a unit-separator-delimited tmux format
-  /// string.
+  /// Parses a [TmuxWindow] from a pipe-delimited tmux format string.
   ///
   /// Expected format (from `tmux list-windows -F`):
-  /// `index\x1fname\x1factive_flag\x1fcommand\x1fpath\x1fflags\x1fpane_title\x1factivity_epoch`
+  /// `index|name|active_flag|command|path|flags|pane_title|activity_epoch`
   factory TmuxWindow.fromTmuxFormat(String line) {
-    final parts = line.split('\x1f');
-    // Fall back to pipe delimiter for compatibility with older callers.
-    final fields = parts.length >= 3 ? parts : line.split('|');
+    final fields = line.split('|');
     if (fields.length < 3) {
       throw FormatException('Invalid tmux window format: $line');
     }

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -306,14 +306,3 @@ String? parseTmuxSessionName(String? command) {
 
   return null;
 }
-
-/// Strips surrounding quotes from a shell argument.
-String _unquote(String value) {
-  if (value.length >= 2) {
-    if ((value.startsWith("'") && value.endsWith("'")) ||
-        (value.startsWith('"') && value.endsWith('"'))) {
-      return value.substring(1, value.length - 1);
-    }
-  }
-  return value;
-}

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -11,12 +11,12 @@ class TmuxSession {
     this.lastActivity,
   });
 
-  /// Parses a [TmuxSession] from a tab-delimited tmux format string.
+  /// Parses a [TmuxSession] from a pipe-delimited tmux format string.
   ///
   /// Expected format (from `tmux list-sessions -F`):
-  /// `session_name\twindow_count\tattached_flag\tactivity_epoch`
+  /// `session_name|window_count|attached_flag|activity_epoch`
   factory TmuxSession.fromTmuxFormat(String line) {
-    final parts = line.split('\t');
+    final parts = line.split('|');
     if (parts.length < 3) {
       throw FormatException('Invalid tmux session format: $line');
     }
@@ -76,9 +76,9 @@ class TmuxWindow {
   /// Parses a [TmuxWindow] from a tab-delimited tmux format string.
   ///
   /// Expected format (from `tmux list-windows -F`):
-  /// `index\tname\tactive_flag\tcurrent_command\tcurrent_path`
+  /// `index|name|active_flag|current_command|current_path`
   factory TmuxWindow.fromTmuxFormat(String line) {
-    final parts = line.split('\t');
+    final parts = line.split('|');
     if (parts.length < 3) {
       throw FormatException('Invalid tmux window format: $line');
     }

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -137,8 +137,9 @@ class TmuxWindow {
   /// Idle threshold (seconds) above which a window is considered "waiting".
   static const _idleThreshold = 15;
 
-  /// Whether this window has a pending alert or bell.
-  bool get hasAlert => flags != null && flags!.contains('#');
+  /// Whether this window has a pending alert, bell, or activity notification.
+  bool get hasAlert =>
+      flags != null && (flags!.contains('#') || flags!.contains('!'));
 
   /// Whether the window appears to be idle (no output for a while).
   ///

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -150,7 +150,26 @@ class TmuxWindow {
       idleSeconds != null && idleSeconds! > _idleThreshold && !isActive;
 
   /// A short display title — prefers paneTitle, falls back to name.
-  String get displayTitle => paneTitle ?? name;
+  String get displayTitle =>
+      _normalizedTmuxTitle(paneTitle) ??
+      _normalizedTmuxTitle(name, stripPlaceholderPrefix: true) ??
+      name;
+
+  /// Secondary context for the window title when both pane and window names
+  /// are useful and distinct.
+  String? get secondaryTitle {
+    final normalizedPaneTitle = _normalizedTmuxTitle(paneTitle);
+    final normalizedName = _normalizedTmuxTitle(
+      name,
+      stripPlaceholderPrefix: true,
+    );
+    if (normalizedPaneTitle == null ||
+        normalizedName == null ||
+        normalizedName == normalizedPaneTitle) {
+      return null;
+    }
+    return normalizedName;
+  }
 
   /// A human-readable status label for display.
   ///
@@ -277,6 +296,22 @@ const _monthAbbreviations = <String>[
 String? _nonEmpty(String value) {
   final trimmed = value.trim();
   return trimmed.isEmpty ? null : trimmed;
+}
+
+String? _normalizedTmuxTitle(
+  String? value, {
+  bool stripPlaceholderPrefix = false,
+}) {
+  final trimmed = value?.trim();
+  if (trimmed == null || trimmed.isEmpty) return null;
+
+  var normalized = trimmed;
+  if (stripPlaceholderPrefix) {
+    normalized = normalized.replaceFirst(RegExp(r'^_+\s*'), '').trimLeft();
+    normalized = normalized.replaceAll(RegExp(r'\s_+\s'), ' ').trim();
+  }
+
+  return normalized.isEmpty ? null : normalized;
 }
 
 // ── tmux command helpers ──────────────────────────────────────────────────

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -149,20 +149,39 @@ class TmuxWindow {
   bool get isIdle =>
       idleSeconds != null && idleSeconds! > _idleThreshold && !isActive;
 
-  /// A short display title — prefers paneTitle, falls back to name.
-  String get displayTitle =>
-      _normalizedTmuxTitle(paneTitle) ??
-      _normalizedTmuxTitle(name, stripPlaceholderPrefix: true) ??
-      name;
-
-  /// Secondary context for the window title when both pane and window names
-  /// are useful and distinct.
-  String? get secondaryTitle {
-    final normalizedPaneTitle = _normalizedTmuxTitle(paneTitle);
+  /// A short display title — prefers the richest usable tmux title.
+  String get displayTitle {
+    final normalizedPaneTitle = _normalizedTmuxTitle(
+      paneTitle,
+      stripPlaceholderPrefix: true,
+    );
     final normalizedName = _normalizedTmuxTitle(
       name,
       stripPlaceholderPrefix: true,
     );
+    if (normalizedPaneTitle == null) return normalizedName ?? name;
+    if (normalizedName == null) return normalizedPaneTitle;
+    if (_hasPlaceholderPrefix(name)) return normalizedPaneTitle;
+    if (_isDecoratedVariantOfTitle(name, normalizedPaneTitle)) {
+      return name.trim();
+    }
+    return normalizedPaneTitle;
+  }
+
+  /// Secondary context for the window title when both pane and window names
+  /// are useful and distinct.
+  String? get secondaryTitle {
+    final normalizedPaneTitle = _normalizedTmuxTitle(
+      paneTitle,
+      stripPlaceholderPrefix: true,
+    );
+    final normalizedName = _normalizedTmuxTitle(
+      name,
+      stripPlaceholderPrefix: true,
+    );
+    if (_isDecoratedVariantOfTitle(name, normalizedPaneTitle)) {
+      return null;
+    }
     if (normalizedPaneTitle == null ||
         normalizedName == null ||
         normalizedName == normalizedPaneTitle) {
@@ -313,6 +332,32 @@ String? _normalizedTmuxTitle(
 
   return normalized.isEmpty ? null : normalized;
 }
+
+bool _hasPlaceholderPrefix(String value) => value.trimLeft().startsWith('_');
+
+bool _isDecoratedVariantOfTitle(String rawTitle, String? plainTitle) {
+  if (plainTitle == null || plainTitle.isEmpty) return false;
+  final trimmed = rawTitle.trim();
+  if (trimmed.isEmpty || _hasPlaceholderPrefix(trimmed)) return false;
+  final stripped = _stripLeadingDecorativePrefix(trimmed);
+  return stripped.isNotEmpty && stripped == plainTitle && trimmed != plainTitle;
+}
+
+String _stripLeadingDecorativePrefix(String value) {
+  final characters = value.runes.toList(growable: false);
+  var startIndex = 0;
+  while (startIndex < characters.length &&
+      !_isAsciiLetterOrDigit(characters[startIndex])) {
+    startIndex++;
+  }
+  if (startIndex == 0 || startIndex >= characters.length) return value;
+  return String.fromCharCodes(characters.sublist(startIndex)).trimLeft();
+}
+
+bool _isAsciiLetterOrDigit(int rune) =>
+    (rune >= 0x30 && rune <= 0x39) ||
+    (rune >= 0x41 && rune <= 0x5A) ||
+    (rune >= 0x61 && rune <= 0x7A);
 
 // ── tmux command helpers ──────────────────────────────────────────────────
 

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -1,0 +1,200 @@
+/// Domain models for tmux session and window state.
+///
+/// These models represent the tmux state as queried over SSH exec channels.
+/// They deliberately avoid tmux implementation details in their public API,
+/// using user-friendly terminology ("windows" not "tmux windows").
+library;
+
+import 'package:flutter/foundation.dart';
+
+/// Represents a tmux session on a remote host.
+@immutable
+class TmuxSession {
+  /// Creates a new [TmuxSession].
+  const TmuxSession({
+    required this.name,
+    required this.windowCount,
+    required this.isAttached,
+    this.lastActivity,
+  });
+
+  /// Parses a [TmuxSession] from a tab-delimited tmux format string.
+  ///
+  /// Expected format (from `tmux list-sessions -F`):
+  /// `session_name\twindow_count\tattached_flag\tactivity_epoch`
+  factory TmuxSession.fromTmuxFormat(String line) {
+    final parts = line.split('\t');
+    if (parts.length < 3) {
+      throw FormatException('Invalid tmux session format: $line');
+    }
+    return TmuxSession(
+      name: parts[0],
+      windowCount: int.tryParse(parts[1]) ?? 0,
+      isAttached: parts[2] == '1',
+      lastActivity: parts.length > 3
+          ? DateTime.fromMillisecondsSinceEpoch(
+              (int.tryParse(parts[3]) ?? 0) * 1000,
+            )
+          : null,
+    );
+  }
+
+  /// The session name.
+  final String name;
+
+  /// Number of windows in this session.
+  final int windowCount;
+
+  /// Whether a client is currently viewing this session.
+  final bool isAttached;
+
+  /// When this session was last active.
+  final DateTime? lastActivity;
+
+  @override
+  String toString() =>
+      'TmuxSession(name: $name, windows: $windowCount, '
+      'attached: $isAttached)';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TmuxSession &&
+          name == other.name &&
+          windowCount == other.windowCount &&
+          isAttached == other.isAttached;
+
+  @override
+  int get hashCode => Object.hash(name, windowCount, isAttached);
+}
+
+/// Represents a single window within a tmux session.
+@immutable
+class TmuxWindow {
+  /// Creates a new [TmuxWindow].
+  const TmuxWindow({
+    required this.index,
+    required this.name,
+    required this.isActive,
+    this.currentCommand,
+    this.currentPath,
+  });
+
+  /// Parses a [TmuxWindow] from a tab-delimited tmux format string.
+  ///
+  /// Expected format (from `tmux list-windows -F`):
+  /// `index\tname\tactive_flag\tcurrent_command\tcurrent_path`
+  factory TmuxWindow.fromTmuxFormat(String line) {
+    final parts = line.split('\t');
+    if (parts.length < 3) {
+      throw FormatException('Invalid tmux window format: $line');
+    }
+    return TmuxWindow(
+      index: int.tryParse(parts[0]) ?? 0,
+      name: parts[1],
+      isActive: parts[2] == '1',
+      currentCommand: parts.length > 3 ? _nonEmpty(parts[3]) : null,
+      currentPath: parts.length > 4 ? _nonEmpty(parts[4]) : null,
+    );
+  }
+
+  /// The zero-based window index within the session.
+  final int index;
+
+  /// The window name (often set by the running program or user).
+  final String name;
+
+  /// Whether this is the currently active window in the session.
+  final bool isActive;
+
+  /// The command currently running in the active pane, if available.
+  final String? currentCommand;
+
+  /// The working directory of the active pane, if available.
+  final String? currentPath;
+
+  /// A human-readable status label for display.
+  String get statusLabel {
+    if (isActive) return 'active';
+    if (currentCommand != null) return 'running';
+    return 'idle';
+  }
+
+  @override
+  String toString() =>
+      'TmuxWindow(index: $index, name: $name, active: $isActive, '
+      'command: $currentCommand)';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TmuxWindow &&
+          index == other.index &&
+          name == other.name &&
+          isActive == other.isActive &&
+          currentCommand == other.currentCommand &&
+          currentPath == other.currentPath;
+
+  @override
+  int get hashCode =>
+      Object.hash(index, name, isActive, currentCommand, currentPath);
+}
+
+/// Metadata for a recent AI coding tool session found on a remote host.
+@immutable
+class ToolSessionInfo {
+  /// Creates a new [ToolSessionInfo].
+  const ToolSessionInfo({
+    required this.toolName,
+    required this.sessionId,
+    this.workingDirectory,
+    this.lastActive,
+    this.summary,
+  });
+
+  /// Human-readable tool name (e.g., "Claude Code", "Codex").
+  final String toolName;
+
+  /// Tool-specific session identifier used for resume commands.
+  final String sessionId;
+
+  /// The working directory this session was used in.
+  final String? workingDirectory;
+
+  /// When this session was last active.
+  final DateTime? lastActive;
+
+  /// A brief summary or title for the session, if available.
+  final String? summary;
+
+  /// How long ago this session was active, as a human-readable string.
+  String get timeAgoLabel {
+    if (lastActive == null) return '';
+    final diff = DateTime.now().difference(lastActive!);
+    if (diff.inMinutes < 1) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    if (diff.inDays < 7) return '${diff.inDays}d ago';
+    return '${diff.inDays ~/ 7}w ago';
+  }
+
+  @override
+  String toString() =>
+      'ToolSessionInfo(tool: $toolName, id: $sessionId, '
+      'lastActive: $lastActive)';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ToolSessionInfo &&
+          toolName == other.toolName &&
+          sessionId == other.sessionId;
+
+  @override
+  int get hashCode => Object.hash(toolName, sessionId);
+}
+
+String? _nonEmpty(String value) {
+  final trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -250,3 +250,70 @@ String? _nonEmpty(String value) {
   final trimmed = value.trim();
   return trimmed.isEmpty ? null : trimmed;
 }
+
+// ── tmux command helpers ──────────────────────────────────────────────────
+
+/// Builds a `tmux new-session` command from structured configuration.
+///
+/// Always uses `-A` (attach-or-create) so reconnecting reuses the session.
+String buildTmuxCommand({
+  required String sessionName,
+  String? workingDirectory,
+  String? extraFlags,
+}) {
+  final parts = <String>[
+    'tmux new-session -A',
+    "-s '${sessionName.replaceAll("'", "'\"'\"'")}'",
+    if (workingDirectory != null && workingDirectory.trim().isNotEmpty)
+      "-c '${workingDirectory.trim().replaceAll("'", "'\"'\"'")}'",
+    if (extraFlags != null && extraFlags.trim().isNotEmpty) extraFlags.trim(),
+  ];
+  return parts.join(' ');
+}
+
+/// Attempts to extract the tmux session name from a command string.
+///
+/// Handles common patterns:
+/// - `tmux new-session -A -s myproject`
+/// - `tmux new -As myproject`
+/// - `tmux a -t myproject`
+/// - `tmux attach -t myproject`
+///
+/// Returns `null` if the command doesn't appear to be a tmux invocation
+/// or the session name can't be parsed.
+String? parseTmuxSessionName(String? command) {
+  if (command == null || command.isEmpty) return null;
+
+  // Normalize: strip leading cd/env/path prefixes to find 'tmux ...'
+  final tmuxIdx = command.indexOf('tmux ');
+  if (tmuxIdx < 0) return null;
+  final tmuxPart = command.substring(tmuxIdx);
+
+  // Match a shell argument: 'quoted', "quoted", or unquoted-word.
+  const argPattern = r"""(?:'([^']*)'|"([^"]*)"|(\S+))""";
+
+  // Try -s <name> (new-session / new)
+  final sFlag = RegExp('-[A-Za-z]*s\\s+$argPattern').firstMatch(tmuxPart);
+  if (sFlag != null) {
+    return sFlag.group(1) ?? sFlag.group(2) ?? sFlag.group(3);
+  }
+
+  // Try -t <name> (attach / attach-session)
+  final tFlag = RegExp('-[A-Za-z]*t\\s+$argPattern').firstMatch(tmuxPart);
+  if (tFlag != null) {
+    return tFlag.group(1) ?? tFlag.group(2) ?? tFlag.group(3);
+  }
+
+  return null;
+}
+
+/// Strips surrounding quotes from a shell argument.
+String _unquote(String value) {
+  if (value.length >= 2) {
+    if ((value.startsWith("'") && value.endsWith("'")) ||
+        (value.startsWith('"') && value.endsWith('"'))) {
+      return value.substring(1, value.length - 1);
+    }
+  }
+  return value;
+}

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -56,6 +56,36 @@ int compareDiscoveredSessionsByRecency(ToolSessionInfo a, ToolSessionInfo b) {
   return (a.summary ?? '').compareTo(b.summary ?? '');
 }
 
+/// Discovered session results plus any tool histories that could not be read.
+class DiscoveredSessionsResult {
+  /// Creates a new [DiscoveredSessionsResult].
+  DiscoveredSessionsResult({
+    required Iterable<ToolSessionInfo> sessions,
+    Iterable<String> failedTools = const <String>[],
+  }) : sessions = List<ToolSessionInfo>.unmodifiable(sessions),
+       failedTools = Set<String>.unmodifiable(failedTools);
+
+  /// The sessions that were discovered successfully.
+  final List<ToolSessionInfo> sessions;
+
+  /// Tool names whose session history could not be loaded.
+  final Set<String> failedTools;
+
+  /// Whether any tool histories failed to load.
+  bool get hasFailures => failedTools.isNotEmpty;
+
+  /// A human-readable failure message for the UI.
+  String? get failureMessage {
+    if (failedTools.isEmpty) return null;
+    final orderedTools = failedTools.toList()..sort();
+    if (orderedTools.length == 1) {
+      return 'Could not load ${orderedTools.first} sessions.';
+    }
+    final lastTool = orderedTools.removeLast();
+    return 'Could not load ${orderedTools.join(', ')} and $lastTool sessions.';
+  }
+}
+
 String? _normalizeDiscoveredSessionSummary(
   ToolSessionInfo info, {
   String? activeWorkingDirectory,
@@ -134,6 +164,176 @@ String _truncateSessionIdValue(String id) {
   return '${id.substring(0, 8)}…';
 }
 
+String _summarizeSessionText(String value, {int maxLength = 80}) {
+  final firstMeaningfulLine = value
+      .split('\n')
+      .map((line) => line.trim())
+      .firstWhere((line) => line.isNotEmpty, orElse: () => value.trim());
+  final collapsed = firstMeaningfulLine.replaceAll(RegExp(r'\s+'), ' ').trim();
+  if (collapsed.length <= maxLength) return collapsed;
+  return '${collapsed.substring(0, maxLength - 3)}...';
+}
+
+/// Parses Copilot CLI workspace metadata from `workspace.yaml`.
+@visibleForTesting
+({String? summary, String? workingDirectory, DateTime? updatedAt})
+parseCopilotWorkspaceYamlMetadata(String raw) {
+  final lines = const LineSplitter().convert(raw);
+  String? summary;
+  String? workingDirectory;
+  DateTime? updatedAt;
+
+  for (var index = 0; index < lines.length; index++) {
+    final line = lines[index];
+
+    if (workingDirectory == null) {
+      final cwdMatch = RegExp(r'^cwd:\s*(.+)\s*$').firstMatch(line);
+      if (cwdMatch != null) {
+        workingDirectory = cwdMatch.group(1)!.trim();
+      }
+    }
+
+    if (updatedAt == null) {
+      final updatedAtMatch = RegExp(
+        r'^updated_at:\s*(.+)\s*$',
+      ).firstMatch(line);
+      if (updatedAtMatch != null) {
+        updatedAt = DateTime.tryParse(updatedAtMatch.group(1)!.trim());
+      }
+    }
+
+    if (summary != null) continue;
+    final summaryMatch = RegExp(r'^summary:\s*(.*)$').firstMatch(line);
+    if (summaryMatch == null) continue;
+
+    final inlineValue = summaryMatch.group(1)!.trimRight();
+    if (inlineValue.isEmpty) continue;
+    if (inlineValue == '|' ||
+        inlineValue == '|-' ||
+        inlineValue == '>' ||
+        inlineValue == '>-') {
+      final blockLines = <String>[];
+      while (index + 1 < lines.length) {
+        final nextLine = lines[index + 1];
+        if (!nextLine.startsWith('  ')) break;
+        index += 1;
+        blockLines.add(nextLine.substring(2));
+      }
+      final blockValue = blockLines.join('\n').trim();
+      if (blockValue.isNotEmpty) {
+        summary = _summarizeSessionText(blockValue);
+      }
+      continue;
+    }
+
+    final normalizedInlineValue = inlineValue.trim();
+    if (normalizedInlineValue.isNotEmpty) {
+      summary = _summarizeSessionText(normalizedInlineValue);
+    }
+  }
+
+  return (
+    summary: summary,
+    workingDirectory: workingDirectory,
+    updatedAt: updatedAt,
+  );
+}
+
+/// Parses Codex rollout metadata from the head of a rollout JSONL file.
+@visibleForTesting
+({
+  String? summary,
+  String? workingDirectory,
+  DateTime? updatedAt,
+  bool parsedAny,
+})
+parseCodexRolloutMetadata(String raw) {
+  String? summary;
+  String? workingDirectory;
+  DateTime? updatedAt;
+  var parsedAny = false;
+
+  for (final line in const LineSplitter().convert(raw)) {
+    final decoded = _tryDecodeJsonObject(line);
+    if (decoded == null) continue;
+    parsedAny = true;
+
+    final payload = _readMapField(decoded, 'payload');
+    workingDirectory ??=
+        _readStringField(payload, 'cwd') ?? _readStringField(decoded, 'cwd');
+    updatedAt ??= _parseDateTimeValue(decoded['timestamp']);
+
+    if (summary != null) continue;
+    if (_readStringField(decoded, 'type') != 'event_msg' ||
+        _readStringField(payload, 'type') != 'user_message') {
+      continue;
+    }
+
+    final message = _readStringField(payload, 'message');
+    if (message != null && message.trim().isNotEmpty) {
+      summary = _summarizeSessionText(message);
+    }
+  }
+
+  return (
+    summary: summary,
+    workingDirectory: workingDirectory,
+    updatedAt: updatedAt,
+    parsedAny: parsedAny,
+  );
+}
+
+/// Parses Gemini session metadata from a saved chat JSON file.
+@visibleForTesting
+({
+  String? sessionId,
+  String? summary,
+  String? workingDirectory,
+  DateTime? updatedAt,
+  bool isSubagent,
+  bool parsedAny,
+})
+parseGeminiSessionMetadata(
+  String raw, {
+  String? activeWorkingDirectory,
+  String? fallbackWorkingDirectory,
+}) {
+  final decoded = _decodeJsonOrJsonlObject(raw);
+  if (decoded == null) {
+    return (
+      sessionId: null,
+      summary: null,
+      workingDirectory: fallbackWorkingDirectory,
+      updatedAt: null,
+      isSubagent: false,
+      parsedAny: false,
+    );
+  }
+
+  final storedSummary = _readStringField(decoded, 'summary');
+  final summary = (storedSummary?.trim().isNotEmpty ?? false)
+      ? _summarizeSessionText(storedSummary!)
+      : _extractGeminiUserSummary(_readListField(decoded, 'messages'));
+  final directories = _readListField(decoded, 'directories');
+  final resolvedWorkingDirectory =
+      _resolveGeminiWorkingDirectory(
+        directories,
+        activeWorkingDirectory: activeWorkingDirectory,
+      ) ??
+      fallbackWorkingDirectory;
+
+  return (
+    sessionId: _readStringField(decoded, 'sessionId'),
+    summary: summary,
+    workingDirectory: resolvedWorkingDirectory,
+    updatedAt:
+        _parseDateTimeValue(decoded['lastUpdated']) ??
+        _parseDateTimeValue(decoded['startTime']),
+    isSubagent: _readStringField(decoded, 'kind') == 'subagent',
+    parsedAny: true,
+  );
+}
+
 /// Discovers recent AI coding tool sessions on remote hosts by scanning
 /// known session storage locations.
 ///
@@ -151,9 +351,13 @@ class AgentSessionDiscoveryService {
   /// noisy placeholder entries, and then sorted globally by recency.
   /// Limits to [maxPerTool] sessions per tool to keep results manageable.
   ///
+  /// Returns both the successfully parsed sessions and any tool histories that
+  /// could not be loaded, so the UI can distinguish parse failures from an
+  /// actually empty history.
+  ///
   /// When [workingDirectory] is available, sessions are filtered to that
   /// directory whenever the tool exposes enough path information to do so.
-  Future<List<ToolSessionInfo>> discoverSessions(
+  Future<DiscoveredSessionsResult> discoverSessions(
     SshSession session, {
     String? workingDirectory,
     int maxPerTool = 12,
@@ -166,34 +370,45 @@ class AgentSessionDiscoveryService {
       _discoverOpenCodeSessions(session, maxPerTool),
     ]);
 
-    final all =
-        results
-            .expand((list) => list)
-            .map(
-              (info) => normalizeDiscoveredSessionInfo(
-                info,
-                activeWorkingDirectory: workingDirectory,
-              ),
-            )
-            .whereType<ToolSessionInfo>()
-            .toList()
-          ..sort(compareDiscoveredSessionsByRecency);
+    final all = results
+        .expand((result) => result.sessions)
+        .map(
+          (info) => normalizeDiscoveredSessionInfo(
+            info,
+            activeWorkingDirectory: workingDirectory,
+          ),
+        )
+        .whereType<ToolSessionInfo>()
+        .toList();
 
     // Filter to sessions matching the working directory if provided.
     if (workingDirectory != null && workingDirectory.isNotEmpty) {
-      final filtered = all
-          .where(
-            (s) =>
-                _matchesWorkingDirectory(workingDirectory, s.workingDirectory),
-          )
-          .toList();
+      final filtered = _limitDiscoveredSessionsPerTool(
+        all
+            .where(
+              (s) => _matchesWorkingDirectory(
+                workingDirectory,
+                s.workingDirectory,
+              ),
+            )
+            .toList(),
+        maxPerTool,
+      );
       // Return filtered results if any match; otherwise return all so the UI
       // still has a fallback when the remote tool doesn't persist directory
       // metadata for its sessions.
-      if (filtered.isNotEmpty) return filtered;
+      if (filtered.isNotEmpty) {
+        return DiscoveredSessionsResult(
+          sessions: filtered,
+          failedTools: results.where((r) => r.hadError).map((r) => r.toolName),
+        );
+      }
     }
 
-    return all;
+    return DiscoveredSessionsResult(
+      sessions: _limitDiscoveredSessionsPerTool(all, maxPerTool),
+      failedTools: results.where((r) => r.hadError).map((r) => r.toolName),
+    );
   }
 
   /// Builds the shell command to resume a specific session.
@@ -224,7 +439,7 @@ class AgentSessionDiscoveryService {
   // Sessions: ~/.claude/projects/<path-hash>/*.jsonl
   // Index:    ~/.claude/history.jsonl
 
-  Future<List<ToolSessionInfo>> _discoverClaudeSessions(
+  Future<_ToolDiscoveryResult> _discoverClaudeSessions(
     SshSession session,
     String? workingDirectory,
     int max,
@@ -237,7 +452,9 @@ class AgentSessionDiscoveryService {
         session,
         'tail -n $tailCount ~/.claude/history.jsonl 2>/dev/null',
       );
-      if (output.trim().isEmpty) return const [];
+      if (output.trim().isEmpty) {
+        return const _ToolDiscoveryResult.success('Claude Code', []);
+      }
 
       final sessions = <ToolSessionInfo>[];
       final seenIds = <String>{};
@@ -322,72 +539,64 @@ class AgentSessionDiscoveryService {
           continue;
         }
       }
-      return sessions;
+      return _ToolDiscoveryResult.success('Claude Code', sessions);
     } on Object {
-      return const [];
+      return const _ToolDiscoveryResult.failure('Claude Code');
     }
   }
 
   // ── Codex CLI ──────────────────────────────────────────────────────────
   // Sessions: ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
 
-  Future<List<ToolSessionInfo>> _discoverCodexSessions(
+  Future<_ToolDiscoveryResult> _discoverCodexSessions(
     SshSession session,
     int max,
   ) async {
     try {
+      final scanLimit = max * 5;
       final output = await _exec(
         session,
         'find ~/.codex/sessions -name "rollout-*.jsonl" -type f '
-        '-exec ls -1t {} + 2>/dev/null | head -n $max',
+        '-exec ls -1t {} + 2>/dev/null | head -n $scanLimit',
       );
-      if (output.trim().isEmpty) return const [];
+      if (output.trim().isEmpty) {
+        return const _ToolDiscoveryResult.success('Codex', []);
+      }
 
+      final sessionIndex = await _readCodexSessionIndex(session, scanLimit);
       final sessions = <ToolSessionInfo>[];
+      var hadError = sessionIndex.hadError;
+
       for (final line in output.trim().split('\n')) {
         if (line.trim().isEmpty) continue;
         final filePath = line.trim();
         final fileName = filePath.split('/').last.replaceAll('.jsonl', '');
+        final threadId = _extractCodexThreadId(fileName);
+        final threadInfo = threadId != null
+            ? sessionIndex.entries[threadId]
+            : null;
 
-        // Read metadata from first line and first real user prompt.
-        String? summary;
+        var summary = threadInfo?.threadName;
         String? workingDirectory;
-        DateTime? lastActive;
-        try {
-          final meta = await _exec(
-            session,
-            'head -1 ${_shellQuote(filePath)} 2>/dev/null',
-          );
-          if (meta.trim().isNotEmpty) {
-            final decoded = jsonDecode(meta.trim());
-            if (decoded is Map<String, dynamic>) {
-              final payload =
-                  decoded['payload'] as Map<String, dynamic>? ?? decoded;
-              workingDirectory = payload['cwd'] as String?;
-              final ts = decoded['timestamp'] as String?;
-              if (ts != null) lastActive = DateTime.tryParse(ts);
-            }
-          }
-          lastActive ??= await _readModificationTime(session, filePath);
+        var lastActive = threadInfo?.updatedAt;
 
-          // Extract first prompt: skip session_meta, ignore environment/system
-          // context, and take the first short input_text payload.
-          final promptOutput = await _exec(
+        try {
+          final rolloutHead = await _exec(
             session,
-            'sed -n \'2,20p\' ${_shellQuote(filePath)} '
-            '| grep -oE \'"text":"[^"]{1,120}"\' '
-            '| grep -v \'"text":"<\' '
-            '| grep -v \'"text":"#\' '
-            '| head -1 '
-            '| sed \'s/"text":"//;s/"\$//\'',
+            'sed -n \'1,80p\' ${_shellQuote(filePath)} 2>/dev/null',
           );
-          final prompt = promptOutput.trim();
-          if (prompt.isNotEmpty) summary = prompt;
+          final metadata = parseCodexRolloutMetadata(rolloutHead);
+          if (rolloutHead.trim().isNotEmpty && !metadata.parsedAny) {
+            hadError = true;
+          }
+          summary ??= metadata.summary;
+          workingDirectory = metadata.workingDirectory;
+          lastActive ??= metadata.updatedAt;
         } on Object {
-          // Non-critical.
+          hadError = true;
         }
 
-        summary ??= _truncateId(fileName);
+        lastActive ??= await _readModificationTime(session, filePath);
 
         sessions.add(
           ToolSessionInfo(
@@ -395,70 +604,109 @@ class AgentSessionDiscoveryService {
             sessionId: fileName,
             workingDirectory: workingDirectory,
             lastActive: lastActive,
-            summary: summary,
+            summary: summary ?? _truncateId(fileName),
           ),
         );
       }
-      return sessions;
+      return _ToolDiscoveryResult.success(
+        'Codex',
+        sessions,
+        hadError: hadError,
+      );
     } on Object {
-      return const [];
+      return const _ToolDiscoveryResult.failure('Codex');
+    }
+  }
+
+  Future<_CodexSessionIndexResult> _readCodexSessionIndex(
+    SshSession session,
+    int scanLimit,
+  ) async {
+    try {
+      final output = await _exec(
+        session,
+        'tail -n ${scanLimit * 5} ~/.codex/session_index.jsonl 2>/dev/null',
+      );
+      if (output.trim().isEmpty) {
+        return const _CodexSessionIndexResult(entries: {});
+      }
+
+      final entries = <String, _CodexSessionIndexEntry>{};
+      var hadError = false;
+      for (final line in output.trim().split('\n').reversed) {
+        if (line.trim().isEmpty) continue;
+        final decoded = _tryDecodeJsonObject(line);
+        if (decoded == null) {
+          hadError = true;
+          continue;
+        }
+        final id = _readStringField(decoded, 'id');
+        if (id == null || id.isEmpty || entries.containsKey(id)) continue;
+        entries[id] = _CodexSessionIndexEntry(
+          threadName: _readStringField(decoded, 'thread_name'),
+          updatedAt: _parseDateTimeValue(decoded['updated_at']),
+        );
+      }
+      return _CodexSessionIndexResult(entries: entries, hadError: hadError);
+    } on Object {
+      return const _CodexSessionIndexResult(entries: {}, hadError: true);
     }
   }
 
   // ── Copilot CLI ────────────────────────────────────────────────────────
   // Sessions: ~/.copilot/session-state/<session-id>/
 
-  Future<List<ToolSessionInfo>> _discoverCopilotSessions(
+  Future<_ToolDiscoveryResult> _discoverCopilotSessions(
     SshSession session,
     int max,
   ) async {
     try {
+      final scanLimit = max * 5;
       final output = await _exec(
         session,
-        'ls -dt ~/.copilot/session-state/*/ 2>/dev/null | head -n $max',
+        'find ~/.copilot/session-state -mindepth 2 -maxdepth 2 '
+        '-name workspace.yaml -type f '
+        '-exec ls -1t {} + 2>/dev/null | head -n $scanLimit',
       );
-      if (output.trim().isEmpty) return const [];
+      if (output.trim().isEmpty) {
+        return const _ToolDiscoveryResult.success('Copilot CLI', []);
+      }
 
-      final sessionPaths = output
+      final workspacePaths = output
           .trim()
           .split('\n')
           .map((line) => line.trim())
           .where((line) => line.isNotEmpty)
           .toList(growable: false);
 
-      return Future.wait(
-        sessionPaths.map((dirPath) async {
+      var hadError = false;
+      final sessions = await Future.wait(
+        workspacePaths.map((workspacePath) async {
+          final dirPath = workspacePath.replaceFirst(
+            RegExp(r'/workspace\.yaml$'),
+            '/',
+          );
           final dirName = dirPath.split('/').where((s) => s.isNotEmpty).last;
-          final lastActive = await _readModificationTime(session, dirPath);
+          DateTime? lastActive;
 
           String? summary;
           String? workingDirectory;
           try {
             final yaml = await _exec(
               session,
-              'cat ${_shellQuote('${dirPath}workspace.yaml')} 2>/dev/null',
+              'cat ${_shellQuote(workspacePath)} 2>/dev/null',
             );
             if (yaml.trim().isNotEmpty) {
-              for (final yamlLine in yaml.split('\n')) {
-                final nameMatch = RegExp(r'^name:\s*(.+)').firstMatch(yamlLine);
-                if (nameMatch != null) {
-                  summary = nameMatch.group(1)!.trim();
-                }
-                final summaryMatch = RegExp(
-                  r'^summary:\s*(.+)',
-                ).firstMatch(yamlLine);
-                if (summaryMatch != null && summary == null) {
-                  summary = summaryMatch.group(1)!.trim();
-                }
-                final cwdMatch = RegExp(r'^cwd:\s*(.+)').firstMatch(yamlLine);
-                if (cwdMatch != null) {
-                  workingDirectory = cwdMatch.group(1)!.trim();
-                }
-              }
+              final metadata = parseCopilotWorkspaceYamlMetadata(yaml);
+              summary = metadata.summary;
+              workingDirectory = metadata.workingDirectory;
+              lastActive = metadata.updatedAt;
             }
           } on Object {
-            // Non-critical.
+            hadError = true;
           }
+
+          lastActive ??= await _readModificationTime(session, workspacePath);
 
           if (summary == null || summary.isEmpty) {
             try {
@@ -472,15 +720,13 @@ class AgentSessionDiscoveryService {
                       .replaceAll(RegExp(r'^#+\s*'), '')
                       .trim();
                   if (cleaned.isNotEmpty && cleaned.length > 3) {
-                    summary = cleaned.length > 80
-                        ? '${cleaned.substring(0, 77)}...'
-                        : cleaned;
+                    summary = _summarizeSessionText(cleaned);
                     break;
                   }
                 }
               }
             } on Object {
-              // Non-critical.
+              hadError = true;
             }
           }
 
@@ -493,8 +739,13 @@ class AgentSessionDiscoveryService {
           );
         }),
       );
+      return _ToolDiscoveryResult.success(
+        'Copilot CLI',
+        sessions,
+        hadError: hadError,
+      );
     } on Object {
-      return const [];
+      return const _ToolDiscoveryResult.failure('Copilot CLI');
     }
   }
 
@@ -504,7 +755,7 @@ class AgentSessionDiscoveryService {
   //   1. Title text (time ago) [session-uuid]
   // Falls back to scanning chat JSON files if the CLI is unavailable.
 
-  Future<List<ToolSessionInfo>> _discoverGeminiSessions(
+  Future<_ToolDiscoveryResult> _discoverGeminiSessions(
     SshSession session,
     String? workingDirectory,
     int max,
@@ -520,13 +771,18 @@ class AgentSessionDiscoveryService {
       );
       if (cliOutput.contains('[') && cliOutput.contains(']')) {
         final parsed = _parseGeminiCliOutput(cliOutput, workingDirectory);
-        if (parsed.isNotEmpty) return parsed.take(max).toList();
+        if (parsed.isNotEmpty) {
+          return _ToolDiscoveryResult.success(
+            'Gemini CLI',
+            parsed.take(max * 5).toList(),
+          );
+        }
       }
 
       // Fallback: scan chat JSON files directly.
       return _discoverGeminiSessionsFromFiles(session, workingDirectory, max);
     } on Object {
-      return const [];
+      return const _ToolDiscoveryResult.failure('Gemini CLI');
     }
   }
 
@@ -562,17 +818,21 @@ class AgentSessionDiscoveryService {
     return sessions;
   }
 
-  Future<List<ToolSessionInfo>> _discoverGeminiSessionsFromFiles(
+  Future<_ToolDiscoveryResult> _discoverGeminiSessionsFromFiles(
     SshSession session,
     String? workingDirectory,
     int max,
   ) async {
+    final scanLimit = max * 5;
     final output = await _exec(
       session,
-      'find ~/.gemini/tmp -name "*.json" -path "*/chats/*" -type f '
-      '-exec ls -1t {} + 2>/dev/null | head -n $max',
+      r'find ~/.gemini/tmp \( -name "session-*.json" -o -name "session-*.jsonl" \) '
+      '-path "*/chats/*" -type f '
+      '-exec ls -1t {} + 2>/dev/null | head -n $scanLimit',
     );
-    if (output.trim().isEmpty) return const [];
+    if (output.trim().isEmpty) {
+      return const _ToolDiscoveryResult.success('Gemini CLI', []);
+    }
 
     final sessionPaths = output
         .trim()
@@ -581,15 +841,19 @@ class AgentSessionDiscoveryService {
         .where((line) => line.isNotEmpty)
         .toList(growable: false);
 
-    return Future.wait(
+    var hadError = false;
+    final sessions = await Future.wait(
       sessionPaths.map((filePath) async {
-        final fileName = filePath.split('/').last.replaceAll('.json', '');
-        final lastActive = await _readModificationTime(session, filePath);
+        final fileName = filePath
+            .split('/')
+            .last
+            .replaceAll('.jsonl', '')
+            .replaceAll('.json', '');
 
         final pathParts = filePath.split('/');
         final chatsIdx = pathParts.indexOf('chats');
         final projectDir = chatsIdx > 0 ? pathParts[chatsIdx - 1] : null;
-        final sessionWorkingDirectory =
+        final fallbackWorkingDirectory =
             projectDir != null &&
                 workingDirectory != null &&
                 _pathLastSegment(workingDirectory) == projectDir
@@ -597,29 +861,51 @@ class AgentSessionDiscoveryService {
             : null;
 
         String? summary;
+        var sessionWorkingDirectory = fallbackWorkingDirectory;
+        DateTime? lastActive;
+        String? sessionId = fileName;
         try {
-          final firstMsg = await _exec(
+          final sessionRecord = await _exec(
             session,
-            'grep -o \'"text":"[^"]*"\' ${_shellQuote(filePath)} '
-            '| head -1 '
-            '| sed \'s/"text":"//;s/"\$//\'',
+            'cat ${_shellQuote(filePath)} 2>/dev/null',
           );
-          final text = firstMsg.trim();
-          if (text.isNotEmpty && text.length > 1) {
-            summary = text.length > 80 ? '${text.substring(0, 77)}...' : text;
+          final metadata = parseGeminiSessionMetadata(
+            sessionRecord,
+            activeWorkingDirectory: workingDirectory,
+            fallbackWorkingDirectory: fallbackWorkingDirectory,
+          );
+          if (sessionRecord.trim().isNotEmpty && !metadata.parsedAny) {
+            hadError = true;
+            return null;
+          }
+          if (metadata.isSubagent) return null;
+          summary = metadata.summary;
+          sessionWorkingDirectory = metadata.workingDirectory;
+          lastActive = metadata.updatedAt;
+          final discoveredSessionId = metadata.sessionId;
+          if (discoveredSessionId != null && discoveredSessionId.isNotEmpty) {
+            sessionId = discoveredSessionId;
           }
         } on Object {
-          // Non-critical.
+          hadError = true;
+          return null;
         }
+
+        lastActive ??= await _readModificationTime(session, filePath);
 
         return ToolSessionInfo(
           toolName: 'Gemini CLI',
-          sessionId: fileName,
+          sessionId: sessionId,
           workingDirectory: sessionWorkingDirectory,
           lastActive: lastActive,
           summary: summary ?? projectDir ?? _truncateId(fileName),
         );
       }),
+    );
+    return _ToolDiscoveryResult.success(
+      'Gemini CLI',
+      sessions.whereType<ToolSessionInfo>().toList(growable: false),
+      hadError: hadError,
     );
   }
 
@@ -628,18 +914,28 @@ class AgentSessionDiscoveryService {
   // It returns renamed titles, directory, and timestamps. Falls back to
   // the SQLite database or JSON files if the CLI is unavailable.
 
-  Future<List<ToolSessionInfo>> _discoverOpenCodeSessions(
+  Future<_ToolDiscoveryResult> _discoverOpenCodeSessions(
     SshSession session,
     int max,
   ) async {
     try {
+      final scanLimit = max * 5;
+      var hadError = false;
       // Preferred: use the CLI's own JSON output.
       final cliOutput = await _exec(
         session,
-        'opencode session list --format json -n $max 2>/dev/null',
+        'opencode session list --format json -n $scanLimit 2>/dev/null',
       );
       if (cliOutput.trim().startsWith('[')) {
-        return _parseOpenCodeCliJson(cliOutput);
+        try {
+          return _ToolDiscoveryResult.success(
+            'OpenCode',
+            _parseOpenCodeCliJson(cliOutput),
+          );
+        } on Object {
+          hadError = true;
+          // Fall through to the SQLite fallback.
+        }
       }
 
       // Fallback: query the SQLite database directly.
@@ -652,16 +948,21 @@ class AgentSessionDiscoveryService {
         "'SELECT id, title, directory, time_updated "
         'FROM session '
         'WHERE parent_id IS NULL '
+        'AND time_archived IS NULL '
         'ORDER BY time_updated DESC '
-        "LIMIT $max;' 2>/dev/null",
+        "LIMIT $scanLimit;' 2>/dev/null",
       );
       if (dbOutput.trim().isNotEmpty) {
-        return _parseOpenCodeDbOutput(dbOutput);
+        return _ToolDiscoveryResult.success(
+          'OpenCode',
+          _parseOpenCodeDbOutput(dbOutput),
+          hadError: hadError,
+        );
       }
 
-      return const [];
+      return _ToolDiscoveryResult.success('OpenCode', [], hadError: hadError);
     } on Object {
-      return const [];
+      return const _ToolDiscoveryResult.failure('OpenCode');
     }
   }
 
@@ -763,6 +1064,26 @@ class AgentSessionDiscoveryService {
   static String _shellQuote(String value) =>
       "'${value.replaceAll("'", "'\"'\"'")}'";
 
+  List<ToolSessionInfo> _limitDiscoveredSessionsPerTool(
+    List<ToolSessionInfo> sessions,
+    int maxPerTool,
+  ) {
+    final groupedSessions = <String, List<ToolSessionInfo>>{};
+    for (final session in sessions) {
+      groupedSessions
+          .putIfAbsent(session.toolName, () => <ToolSessionInfo>[])
+          .add(session);
+    }
+
+    final limited = <ToolSessionInfo>[];
+    for (final toolSessions in groupedSessions.values) {
+      toolSessions.sort(compareDiscoveredSessionsByRecency);
+      limited.addAll(toolSessions.take(maxPerTool));
+    }
+    limited.sort(compareDiscoveredSessionsByRecency);
+    return limited;
+  }
+
   static String? _firstNonEmpty(Iterable<String?> values) {
     for (final value in values) {
       if (value != null && value.isNotEmpty) return value;
@@ -781,6 +1102,148 @@ class AgentSessionDiscoveryService {
   }
 
   static String _truncateId(String id) => _truncateSessionIdValue(id);
+}
+
+class _ToolDiscoveryResult {
+  const _ToolDiscoveryResult.success(
+    this.toolName,
+    this.sessions, {
+    this.hadError = false,
+  });
+
+  const _ToolDiscoveryResult.failure(this.toolName)
+    : sessions = const <ToolSessionInfo>[],
+      hadError = true;
+
+  final String toolName;
+  final List<ToolSessionInfo> sessions;
+  final bool hadError;
+}
+
+class _CodexSessionIndexResult {
+  const _CodexSessionIndexResult({
+    required this.entries,
+    this.hadError = false,
+  });
+
+  final Map<String, _CodexSessionIndexEntry> entries;
+  final bool hadError;
+}
+
+class _CodexSessionIndexEntry {
+  const _CodexSessionIndexEntry({this.threadName, this.updatedAt});
+
+  final String? threadName;
+  final DateTime? updatedAt;
+}
+
+Map<String, dynamic>? _tryDecodeJsonObject(String raw) {
+  try {
+    final decoded = jsonDecode(raw);
+    if (decoded is Map<String, dynamic>) return decoded;
+  } on FormatException {
+    return null;
+  }
+  return null;
+}
+
+Map<String, dynamic>? _decodeJsonOrJsonlObject(String raw) {
+  final direct = _tryDecodeJsonObject(raw.trim());
+  if (direct != null) return direct;
+
+  Map<String, dynamic>? lastObject;
+  for (final line in const LineSplitter().convert(raw)) {
+    final decoded = _tryDecodeJsonObject(line.trim());
+    if (decoded == null) continue;
+    lastObject = decoded;
+    if (decoded.containsKey('sessionId') || decoded.containsKey('messages')) {
+      return decoded;
+    }
+  }
+  return lastObject;
+}
+
+Map<String, dynamic>? _readMapField(Map<String, dynamic>? map, String key) {
+  final value = map?[key];
+  if (value is Map<String, dynamic>) return value;
+  if (value is Map) {
+    return value.map(
+      (innerKey, innerValue) => MapEntry('$innerKey', innerValue),
+    );
+  }
+  return null;
+}
+
+List<dynamic>? _readListField(Map<String, dynamic>? map, String key) {
+  final value = map?[key];
+  return value is List ? value : null;
+}
+
+String? _readStringField(Map<String, dynamic>? map, String key) {
+  final value = map?[key];
+  return value is String ? value : null;
+}
+
+DateTime? _parseDateTimeValue(Object? value) {
+  if (value is String) return DateTime.tryParse(value);
+  if (value is int) return DateTime.fromMillisecondsSinceEpoch(value);
+  return null;
+}
+
+String? _extractCodexThreadId(String fileName) {
+  final match = RegExp(
+    r'([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$',
+  ).firstMatch(fileName);
+  return match?.group(1);
+}
+
+String? _extractGeminiUserSummary(List<dynamic>? messages) {
+  if (messages == null) return null;
+  for (final message in messages.whereType<Map>()) {
+    final messageMap = message.map((key, value) => MapEntry('$key', value));
+    if (_readStringField(messageMap, 'type') != 'user') continue;
+
+    final content = _readListField(messageMap, 'content');
+    if (content != null) {
+      for (final part in content.whereType<Map>()) {
+        final partMap = part.map((key, value) => MapEntry('$key', value));
+        final text = _readStringField(partMap, 'text');
+        if (text != null && text.trim().isNotEmpty) {
+          return _summarizeSessionText(text);
+        }
+      }
+    }
+
+    final displayContent = _readStringField(messageMap, 'displayContent');
+    if (displayContent != null && displayContent.trim().isNotEmpty) {
+      return _summarizeSessionText(displayContent);
+    }
+  }
+  return null;
+}
+
+String? _resolveGeminiWorkingDirectory(
+  List<dynamic>? directories, {
+  String? activeWorkingDirectory,
+}) {
+  final values = directories
+      ?.whereType<String>()
+      .map((value) => value.trim())
+      .where((value) => value.isNotEmpty)
+      .toList(growable: false);
+  if (values == null || values.isEmpty) return null;
+
+  if (activeWorkingDirectory != null && activeWorkingDirectory.isNotEmpty) {
+    for (final value in values) {
+      if (value == activeWorkingDirectory ||
+          _pathLastSegment(value) == _pathLastSegment(activeWorkingDirectory)) {
+        return value;
+      }
+    }
+  }
+
+  if (values.length == 1) return values.first;
+  return null;
 }
 
 /// Provider for [AgentSessionDiscoveryService].

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -18,8 +18,10 @@ class AgentSessionDiscoveryService {
   /// Discovers recent sessions across all supported tools for the given
   /// [workingDirectory] on the remote host.
   ///
-  /// Returns sessions sorted by most recent first. Limits to [maxPerTool]
-  /// sessions per tool to keep results manageable.
+  /// Each tool's sessions are discovered in most-recent-first order, then
+  /// the combined result is interleaved round-robin across tools so no
+  /// single tool dominates the list. Limits to [maxPerTool] sessions per
+  /// tool to keep results manageable.
   Future<List<ToolSessionInfo>> discoverSessions(
     SshSession session, {
     String? workingDirectory,
@@ -136,7 +138,7 @@ class AgentSessionDiscoveryService {
       final output = await _exec(
         session,
         'find ~/.codex/sessions -name "rollout-*.jsonl" -type f '
-        '2>/dev/null | xargs ls -1t 2>/dev/null | head -n $max',
+        '-exec ls -1t {} + 2>/dev/null | head -n $max',
       );
       if (output.trim().isEmpty) return const [];
 
@@ -206,7 +208,7 @@ class AgentSessionDiscoveryService {
       final output = await _exec(
         session,
         'find ~/.gemini/tmp -name "*.json" -path "*/chats/*" -type f '
-        '2>/dev/null | xargs ls -1t 2>/dev/null | head -n $max',
+        '-exec ls -1t {} + 2>/dev/null | head -n $max',
       );
       if (output.trim().isEmpty) return const [];
 

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -18,8 +18,14 @@ const _genericSessionSummaries = <String>{
 /// Filters noisy discovered sessions and fills in a better display summary
 /// when the tool only exposes a working directory.
 @visibleForTesting
-ToolSessionInfo? normalizeDiscoveredSessionInfo(ToolSessionInfo info) {
-  final normalizedSummary = _normalizeDiscoveredSessionSummary(info);
+ToolSessionInfo? normalizeDiscoveredSessionInfo(
+  ToolSessionInfo info, {
+  String? activeWorkingDirectory,
+}) {
+  final normalizedSummary = _normalizeDiscoveredSessionSummary(
+    info,
+    activeWorkingDirectory: activeWorkingDirectory,
+  );
   if (normalizedSummary == null) return null;
   return ToolSessionInfo(
     toolName: info.toolName,
@@ -50,16 +56,27 @@ int compareDiscoveredSessionsByRecency(ToolSessionInfo a, ToolSessionInfo b) {
   return (a.summary ?? '').compareTo(b.summary ?? '');
 }
 
-String? _normalizeDiscoveredSessionSummary(ToolSessionInfo info) {
+String? _normalizeDiscoveredSessionSummary(
+  ToolSessionInfo info, {
+  String? activeWorkingDirectory,
+}) {
   final normalizedSummary = _sanitizeSessionSummary(
     info.summary,
     sessionId: info.sessionId,
+    workingDirectory: info.workingDirectory,
   );
   if (normalizedSummary != null) return normalizedSummary;
-  return _directorySummaryFallback(info.workingDirectory);
+  return _directorySummaryFallback(
+    info.workingDirectory,
+    activeWorkingDirectory: activeWorkingDirectory,
+  );
 }
 
-String? _sanitizeSessionSummary(String? value, {required String sessionId}) {
+String? _sanitizeSessionSummary(
+  String? value, {
+  required String sessionId,
+  String? workingDirectory,
+}) {
   final trimmed = value?.trim();
   if (trimmed == null || trimmed.isEmpty) return null;
 
@@ -76,6 +93,12 @@ String? _sanitizeSessionSummary(String? value, {required String sessionId}) {
     return null;
   }
 
+  final workingDirectorySummary = _directorySummaryFallback(workingDirectory);
+  if (workingDirectorySummary != null &&
+      lowered == workingDirectorySummary.toLowerCase()) {
+    return null;
+  }
+
   final strippedSeparators = unquoted.replaceAll(
     RegExp(r'[\s\-_./\\[\](){}:;,*"`~]+'),
     '',
@@ -84,9 +107,20 @@ String? _sanitizeSessionSummary(String? value, {required String sessionId}) {
   return unquoted;
 }
 
-String? _directorySummaryFallback(String? workingDirectory) {
+String? _directorySummaryFallback(
+  String? workingDirectory, {
+  String? activeWorkingDirectory,
+}) {
   final trimmed = workingDirectory?.trim();
   if (trimmed == null || trimmed.isEmpty) return null;
+  if (activeWorkingDirectory != null &&
+      activeWorkingDirectory.isNotEmpty &&
+      AgentSessionDiscoveryService._matchesWorkingDirectory(
+        activeWorkingDirectory,
+        trimmed,
+      )) {
+    return null;
+  }
   final segment = _pathLastSegment(trimmed);
   if (segment.isEmpty || segment == '.' || segment == '~') return null;
   return segment;
@@ -135,7 +169,12 @@ class AgentSessionDiscoveryService {
     final all =
         results
             .expand((list) => list)
-            .map(normalizeDiscoveredSessionInfo)
+            .map(
+              (info) => normalizeDiscoveredSessionInfo(
+                info,
+                activeWorkingDirectory: workingDirectory,
+              ),
+            )
             .whereType<ToolSessionInfo>()
             .toList()
           ..sort(compareDiscoveredSessionsByRecency);

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -436,67 +436,118 @@ class AgentSessionDiscoveryService {
   }
 
   // ── OpenCode ───────────────────────────────────────────────────────────
-  // Sessions: ~/.local/share/opencode/storage/session/
-  // CLI: opencode session list
+  // Primary store: ~/.local/share/opencode/opencode.db (SQLite)
+  // The `session` table holds id, title, directory, and timestamps.
+  // JSON files under storage/session/ are a partial export and may not
+  // reflect renames, so we prefer the database.
 
   Future<List<ToolSessionInfo>> _discoverOpenCodeSessions(
     SshSession session,
     int max,
   ) async {
     try {
-      // List session JSON files directly (more reliable than dirs).
+      // Query the SQLite database directly — it's the source of truth.
       final output = await _exec(
         session,
-        'find ~/.local/share/opencode/storage/session -name "ses_*.json" '
-        '-type f -exec ls -1t {} + 2>/dev/null | head -n $max',
+        'sqlite3 -separator "|" '
+        '~/.local/share/opencode/opencode.db '
+        "'SELECT id, title, directory, time_updated "
+        'FROM session '
+        'WHERE parent_id IS NULL '
+        'ORDER BY time_updated DESC '
+        "LIMIT $max;' 2>/dev/null",
       );
-      if (output.trim().isEmpty) return const [];
 
-      final sessions = <ToolSessionInfo>[];
-      for (final line in output.trim().split('\n')) {
-        if (line.trim().isEmpty) continue;
-        final filePath = line.trim();
-        final fileName = filePath.split('/').last.replaceAll('.json', '');
-
-        // Read the session JSON for title and directory.
-        String? summary;
-        String? workingDirectory;
-        DateTime? lastActive;
-        try {
-          final content = await _exec(
-            session,
-            'head -c 500 ${_shellQuote(filePath)} 2>/dev/null',
-          );
-          if (content.trim().isNotEmpty) {
-            // Parse partial JSON — title/directory are near the top.
-            // Full parse may fail on truncated content, so extract fields.
-            final titleMatch = RegExp(
-              r'"title"\s*:\s*"([^"]*)"',
-            ).firstMatch(content);
-            final dirMatch = RegExp(
-              r'"directory"\s*:\s*"([^"]*)"',
-            ).firstMatch(content);
-            summary = titleMatch?.group(1);
-            workingDirectory = dirMatch?.group(1);
-          }
-        } on Object {
-          // Non-critical.
-        }
-
-        sessions.add(
-          ToolSessionInfo(
-            toolName: 'OpenCode',
-            sessionId: fileName,
-            workingDirectory: workingDirectory,
-            lastActive: lastActive,
-            summary: summary ?? _truncateId(fileName),
-          ),
-        );
+      if (output.trim().isNotEmpty) {
+        return _parseOpenCodeDbOutput(output);
       }
-      return sessions;
+
+      // Fallback: read JSON files if sqlite3 is not available.
+      return _discoverOpenCodeSessionsFromFiles(session, max);
     } on Object {
       return const [];
     }
+  }
+
+  List<ToolSessionInfo> _parseOpenCodeDbOutput(String output) {
+    final sessions = <ToolSessionInfo>[];
+    for (final line in output.trim().split('\n')) {
+      if (line.trim().isEmpty) continue;
+      final parts = line.split('|');
+      if (parts.length < 3) continue;
+
+      final id = parts[0].trim();
+      final title = parts[1].trim();
+      final directory = parts[2].trim();
+      DateTime? lastActive;
+      if (parts.length >= 4) {
+        final ts = int.tryParse(parts[3].trim());
+        if (ts != null) {
+          lastActive = DateTime.fromMillisecondsSinceEpoch(ts);
+        }
+      }
+
+      sessions.add(
+        ToolSessionInfo(
+          toolName: 'OpenCode',
+          sessionId: id,
+          workingDirectory: directory.isNotEmpty ? directory : null,
+          lastActive: lastActive,
+          summary: title.isNotEmpty ? title : _truncateId(id),
+        ),
+      );
+    }
+    return sessions;
+  }
+
+  Future<List<ToolSessionInfo>> _discoverOpenCodeSessionsFromFiles(
+    SshSession session,
+    int max,
+  ) async {
+    final output = await _exec(
+      session,
+      'find ~/.local/share/opencode/storage/session -name "ses_*.json" '
+      '-type f -exec ls -1t {} + 2>/dev/null | head -n $max',
+    );
+    if (output.trim().isEmpty) return const [];
+
+    final sessions = <ToolSessionInfo>[];
+    for (final line in output.trim().split('\n')) {
+      if (line.trim().isEmpty) continue;
+      final filePath = line.trim();
+      final fileName = filePath.split('/').last.replaceAll('.json', '');
+
+      String? summary;
+      String? workingDirectory;
+      try {
+        final content = await _exec(
+          session,
+          'head -c 500 ${_shellQuote(filePath)} 2>/dev/null',
+        );
+        if (content.trim().isNotEmpty) {
+          final titleMatch = RegExp(
+            r'"title"\s*:\s*"([^"]*)"',
+          ).firstMatch(content);
+          final dirMatch = RegExp(
+            r'"directory"\s*:\s*"([^"]*)"',
+          ).firstMatch(content);
+          summary = titleMatch?.group(1);
+          workingDirectory = dirMatch?.group(1);
+        }
+      } on Object {
+        // Non-critical.
+      }
+
+      sessions.add(
+        ToolSessionInfo(
+          toolName: 'OpenCode',
+          sessionId: fileName,
+          workingDirectory: workingDirectory,
+          summary: summary ?? _truncateId(fileName),
+        ),
+      );
+    }
+    return sessions;
   }
 
   // ── Helpers ────────────────────────────────────────────────────────────

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -15,6 +15,10 @@ const _genericSessionSummaries = <String>{
   'session',
 };
 
+const _profileSourcingPrefix =
+    '{ . ~/.profile; . ~/.bash_profile; . ~/.zprofile; } '
+    '>/dev/null 2>&1; ';
+
 /// Filters noisy discovered sessions and fills in a better display summary
 /// when the tool only exposes a working directory.
 @visibleForTesting
@@ -481,7 +485,7 @@ class AgentSessionDiscoveryService {
         return const _ToolDiscoveryResult.success('Claude Code', []);
       }
 
-      final sessions = <ToolSessionInfo>[];
+      final historyEntries = <Map<String, dynamic>>[];
       final seenIds = <String>{};
       for (final line in output.trim().split('\n').reversed) {
         if (line.trim().isEmpty) continue;
@@ -491,6 +495,18 @@ class AgentSessionDiscoveryService {
           final sessionId = decoded['sessionId'] as String? ?? '';
           if (sessionId.isEmpty || seenIds.contains(sessionId)) continue;
           seenIds.add(sessionId);
+          historyEntries.add(decoded);
+        } on Object {
+          // Ignore malformed lines.
+        }
+      }
+
+      final sessionFilesById = await _findClaudeSessionFiles(session, seenIds);
+      final sessions = <ToolSessionInfo>[];
+      for (final decoded in historyEntries) {
+        try {
+          final sessionId = decoded['sessionId'] as String? ?? '';
+          if (sessionId.isEmpty) continue;
 
           // timestamp may be int (epoch ms) or String (ISO 8601).
           DateTime? lastActive;
@@ -502,12 +518,7 @@ class AgentSessionDiscoveryService {
           }
 
           String? summary;
-          final sessionFile = await _exec(
-            session,
-            'find ~/.claude/projects -name ${_shellQuote('$sessionId.jsonl')} '
-            '-type f 2>/dev/null | head -1',
-          );
-          final sessionFilePath = sessionFile.trim();
+          final sessionFilePath = sessionFilesById[sessionId] ?? '';
           if (sessionFilePath.isNotEmpty) {
             lastActive ??= await _readModificationTime(
               session,
@@ -968,7 +979,7 @@ class AgentSessionDiscoveryService {
       // in session titles or directory paths.
       final dbOutput = await _exec(
         session,
-        r"sqlite3 -separator $'\x1f' "
+        r'SEP=$(printf "\037"); sqlite3 -separator "$SEP" '
         '~/.local/share/opencode/opencode.db '
         "'SELECT id, title, directory, time_updated "
         'FROM session '
@@ -1052,7 +1063,9 @@ class AgentSessionDiscoveryService {
   // ── Helpers ────────────────────────────────────────────────────────────
 
   Future<String> _exec(SshSession session, String command) async {
-    final execSession = await session.execute(command);
+    final execSession = await session.execute(
+      '$_profileSourcingPrefix$command',
+    );
     try {
       final results = await Future.wait([
         execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
@@ -1062,6 +1075,41 @@ class AgentSessionDiscoveryService {
     } finally {
       execSession.close();
     }
+  }
+
+  Future<Map<String, String>> _findClaudeSessionFiles(
+    SshSession session,
+    Iterable<String> sessionIds,
+  ) async {
+    final uniqueSessionIds = sessionIds
+        .where((id) => id.isNotEmpty)
+        .toSet()
+        .toList(growable: false);
+    if (uniqueSessionIds.isEmpty) {
+      return const <String, String>{};
+    }
+
+    final nameFilters = uniqueSessionIds
+        .map((id) => '-name ${_shellQuote('$id.jsonl')}')
+        .join(' -o ');
+    final output = await _exec(
+      session,
+      'find ~/.claude/projects -type f \\( $nameFilters \\) -print 2>/dev/null',
+    );
+
+    final filesById = <String, String>{};
+    for (final rawLine in output.split('\n')) {
+      final path = rawLine.trim();
+      if (path.isEmpty) continue;
+      final fileName = path.split('/').last;
+      if (!fileName.endsWith('.jsonl')) continue;
+      final sessionId = fileName.substring(
+        0,
+        fileName.length - '.jsonl'.length,
+      );
+      filesById.putIfAbsent(sessionId, () => path);
+    }
+    return filesById;
   }
 
   Future<DateTime?> _readModificationTime(

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -1,0 +1,296 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/tmux_state.dart';
+import 'ssh_service.dart';
+
+/// Discovers recent AI coding tool sessions on remote hosts by scanning
+/// known session storage locations.
+///
+/// Each tool stores session history differently. This service encapsulates
+/// the per-tool discovery logic and presents a unified list of
+/// [ToolSessionInfo] entries.
+class AgentSessionDiscoveryService {
+  /// Creates a new [AgentSessionDiscoveryService].
+  const AgentSessionDiscoveryService();
+
+  /// Discovers recent sessions across all supported tools for the given
+  /// [workingDirectory] on the remote host.
+  ///
+  /// Returns sessions sorted by most recent first. Limits to [maxPerTool]
+  /// sessions per tool to keep results manageable.
+  Future<List<ToolSessionInfo>> discoverSessions(
+    SshSession session, {
+    String? workingDirectory,
+    int maxPerTool = 5,
+  }) async {
+    final results = await Future.wait([
+      _discoverClaudeSessions(session, workingDirectory, maxPerTool),
+      _discoverCodexSessions(session, maxPerTool),
+      _discoverCopilotSessions(session, maxPerTool),
+      _discoverGeminiSessions(session, workingDirectory, maxPerTool),
+      _discoverOpenCodeSessions(session, maxPerTool),
+    ]);
+
+    final all = results.expand((list) => list).toList()
+      ..sort((a, b) {
+        final aTime = a.lastActive;
+        final bTime = b.lastActive;
+        if (aTime == null && bTime == null) return 0;
+        if (aTime == null) return 1;
+        if (bTime == null) return -1;
+        return bTime.compareTo(aTime);
+      });
+
+    return all;
+  }
+
+  /// Builds the shell command to resume a specific session.
+  String buildResumeCommand(ToolSessionInfo info) {
+    switch (info.toolName) {
+      case 'Claude Code':
+        return 'claude --resume ${_shellQuote(info.sessionId)}';
+      case 'Codex':
+        return 'codex resume';
+      case 'Copilot CLI':
+        return 'copilot --resume ${_shellQuote(info.sessionId)}';
+      case 'Gemini CLI':
+        return 'gemini --resume';
+      case 'OpenCode':
+        if (info.sessionId == '_continue') {
+          return 'opencode --continue';
+        }
+        return 'opencode --session ${_shellQuote(info.sessionId)}';
+      default:
+        return info.toolName.toLowerCase();
+    }
+  }
+
+  // ── Claude Code ────────────────────────────────────────────────────────
+  // Sessions: ~/.claude/projects/<path-hash>/*.jsonl
+  // Index:    ~/.claude/history.jsonl
+
+  Future<List<ToolSessionInfo>> _discoverClaudeSessions(
+    SshSession session,
+    String? workingDirectory,
+    int max,
+  ) async {
+    try {
+      // Try to read the global history index first.
+      final output = await _exec(
+        session,
+        'tail -n $max ~/.claude/history.jsonl 2>/dev/null',
+      );
+      if (output.trim().isEmpty) return const [];
+
+      final sessions = <ToolSessionInfo>[];
+      for (final line in output.trim().split('\n').reversed) {
+        if (line.trim().isEmpty) continue;
+        try {
+          final json = jsonDecode(line) as Map<String, dynamic>;
+          final sessionId = json['sessionId'] as String? ?? '';
+          if (sessionId.isEmpty) continue;
+
+          sessions.add(
+            ToolSessionInfo(
+              toolName: 'Claude Code',
+              sessionId: sessionId,
+              workingDirectory: json['directory'] as String?,
+              lastActive: json['timestamp'] != null
+                  ? DateTime.tryParse(json['timestamp'] as String)
+                  : null,
+              summary: json['title'] as String? ?? json['query'] as String?,
+            ),
+          );
+          if (sessions.length >= max) break;
+        } on FormatException {
+          continue;
+        }
+      }
+      return sessions;
+    } on Exception {
+      return const [];
+    }
+  }
+
+  // ── Codex CLI ──────────────────────────────────────────────────────────
+  // Sessions: ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+
+  Future<List<ToolSessionInfo>> _discoverCodexSessions(
+    SshSession session,
+    int max,
+  ) async {
+    try {
+      final output = await _exec(
+        session,
+        'find ~/.codex/sessions -name "rollout-*.jsonl" -type f '
+        '-printf "%T@\\t%p\\n" 2>/dev/null | sort -rn | head -n $max',
+      );
+      if (output.trim().isEmpty) return const [];
+
+      final sessions = <ToolSessionInfo>[];
+      for (final line in output.trim().split('\n')) {
+        final parts = line.split('\t');
+        if (parts.length < 2) continue;
+
+        final epochStr = parts[0];
+        final filePath = parts[1];
+        final epoch = double.tryParse(epochStr);
+        final fileName = filePath.split('/').last.replaceAll('.jsonl', '');
+
+        sessions.add(
+          ToolSessionInfo(
+            toolName: 'Codex',
+            sessionId: fileName,
+            lastActive: epoch != null
+                ? DateTime.fromMillisecondsSinceEpoch((epoch * 1000).toInt())
+                : null,
+            summary: fileName,
+          ),
+        );
+      }
+      return sessions;
+    } on Exception {
+      return const [];
+    }
+  }
+
+  // ── Copilot CLI ────────────────────────────────────────────────────────
+  // Sessions: ~/.copilot/session-state/<session-id>/
+
+  Future<List<ToolSessionInfo>> _discoverCopilotSessions(
+    SshSession session,
+    int max,
+  ) async {
+    try {
+      final output = await _exec(
+        session,
+        'ls -dt ~/.copilot/session-state/*/ 2>/dev/null | head -n $max',
+      );
+      if (output.trim().isEmpty) return const [];
+
+      final sessions = <ToolSessionInfo>[];
+      for (final line in output.trim().split('\n')) {
+        if (line.trim().isEmpty) continue;
+        // Extract session ID from directory path.
+        final dirName = line.trim().split('/').where((s) => s.isNotEmpty).last;
+
+        sessions.add(
+          ToolSessionInfo(
+            toolName: 'Copilot CLI',
+            sessionId: dirName,
+            summary: _truncateId(dirName),
+          ),
+        );
+      }
+      return sessions;
+    } on Exception {
+      return const [];
+    }
+  }
+
+  // ── Gemini CLI ─────────────────────────────────────────────────────────
+  // Sessions: ~/.gemini/tmp/<project_hash>/chats/*.json
+
+  Future<List<ToolSessionInfo>> _discoverGeminiSessions(
+    SshSession session,
+    String? workingDirectory,
+    int max,
+  ) async {
+    try {
+      final output = await _exec(
+        session,
+        'find ~/.gemini/tmp -name "*.json" -path "*/chats/*" -type f '
+        '-printf "%T@\\t%p\\n" 2>/dev/null | sort -rn | head -n $max',
+      );
+      if (output.trim().isEmpty) return const [];
+
+      final sessions = <ToolSessionInfo>[];
+      for (final line in output.trim().split('\n')) {
+        final parts = line.split('\t');
+        if (parts.length < 2) continue;
+
+        final epochStr = parts[0];
+        final filePath = parts[1];
+        final epoch = double.tryParse(epochStr);
+        final fileName = filePath.split('/').last.replaceAll('.json', '');
+
+        sessions.add(
+          ToolSessionInfo(
+            toolName: 'Gemini CLI',
+            sessionId: fileName,
+            lastActive: epoch != null
+                ? DateTime.fromMillisecondsSinceEpoch((epoch * 1000).toInt())
+                : null,
+            summary: _truncateId(fileName),
+          ),
+        );
+      }
+      return sessions;
+    } on Exception {
+      return const [];
+    }
+  }
+
+  // ── OpenCode ───────────────────────────────────────────────────────────
+  // Sessions: ~/.local/share/opencode/storage/session/
+  // CLI: opencode session list
+
+  Future<List<ToolSessionInfo>> _discoverOpenCodeSessions(
+    SshSession session,
+    int max,
+  ) async {
+    try {
+      // Try listing session directories by modification time.
+      final output = await _exec(
+        session,
+        'ls -dt ~/.local/share/opencode/storage/session/*/ 2>/dev/null '
+        '| head -n $max',
+      );
+      if (output.trim().isEmpty) return const [];
+
+      final sessions = <ToolSessionInfo>[];
+      for (final line in output.trim().split('\n')) {
+        if (line.trim().isEmpty) continue;
+        final dirName = line.trim().split('/').where((s) => s.isNotEmpty).last;
+
+        sessions.add(
+          ToolSessionInfo(
+            toolName: 'OpenCode',
+            sessionId: dirName,
+            summary: _truncateId(dirName),
+          ),
+        );
+      }
+      return sessions;
+    } on Exception {
+      return const [];
+    }
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────
+
+  Future<String> _exec(SshSession session, String command) async {
+    final execSession = await session.execute(command);
+    final stdout = await execSession.stdout
+        .cast<List<int>>()
+        .transform(utf8.decoder)
+        .join();
+    return stdout;
+  }
+
+  static String _shellQuote(String value) =>
+      "'${value.replaceAll("'", "'\"'\"'")}'";
+
+  static String _truncateId(String id) {
+    if (id.length <= 12) return id;
+    return '${id.substring(0, 8)}…';
+  }
+}
+
+/// Provider for [AgentSessionDiscoveryService].
+final agentSessionDiscoveryServiceProvider =
+    Provider<AgentSessionDiscoveryService>(
+      (ref) => const AgentSessionDiscoveryService(),
+    );

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -370,7 +370,10 @@ class AgentSessionDiscoveryService {
   }
 
   // ── Gemini CLI ─────────────────────────────────────────────────────────
-  // Sessions: ~/.gemini/tmp/<project_hash>/chats/*.json
+  // `gemini --list-sessions` outputs a human-readable list scoped to
+  // the current project. Each line looks like:
+  //   1. Title text (time ago) [session-uuid]
+  // Falls back to scanning chat JSON files if the CLI is unavailable.
 
   Future<List<ToolSessionInfo>> _discoverGeminiSessions(
     SshSession session,
@@ -378,76 +381,135 @@ class AgentSessionDiscoveryService {
     int max,
   ) async {
     try {
-      final output = await _exec(
+      // Preferred: use the CLI's own session list.
+      final cdPrefix = workingDirectory != null && workingDirectory.isNotEmpty
+          ? 'cd ${_shellQuote(workingDirectory)} && '
+          : '';
+      final cliOutput = await _exec(
         session,
-        'find ~/.gemini/tmp -name "*.json" -path "*/chats/*" -type f '
-        '-exec ls -1t {} + 2>/dev/null | head -n $max',
+        '${cdPrefix}gemini --list-sessions 2>/dev/null',
       );
-      if (output.trim().isEmpty) return const [];
-
-      final sessions = <ToolSessionInfo>[];
-      for (final line in output.trim().split('\n')) {
-        if (line.trim().isEmpty) continue;
-        final filePath = line.trim();
-        final fileName = filePath.split('/').last.replaceAll('.json', '');
-
-        // Extract project directory name from path.
-        // Path: ~/.gemini/tmp/<project_dir>/chats/<file>.json
-        final pathParts = filePath.split('/');
-        final chatsIdx = pathParts.indexOf('chats');
-        final projectDir = chatsIdx > 0 ? pathParts[chatsIdx - 1] : null;
-        final sessionWorkingDirectory =
-            projectDir != null &&
-                workingDirectory != null &&
-                _lastPathSegment(workingDirectory) == projectDir
-            ? workingDirectory
-            : null;
-
-        // Try to read the first user message as summary.
-        String? summary;
-        try {
-          final firstMsg = await _exec(
-            session,
-            'grep -o \'"text":"[^"]*"\' ${_shellQuote(filePath)} '
-            '| head -1 '
-            '| sed \'s/"text":"//;s/"\$//\'',
-          );
-          final text = firstMsg.trim();
-          if (text.isNotEmpty && text.length > 1) {
-            summary = text.length > 80 ? '${text.substring(0, 77)}...' : text;
-          }
-        } on Object {
-          // Non-critical.
-        }
-
-        sessions.add(
-          ToolSessionInfo(
-            toolName: 'Gemini CLI',
-            sessionId: fileName,
-            workingDirectory: sessionWorkingDirectory,
-            summary: summary ?? projectDir ?? _truncateId(fileName),
-          ),
-        );
+      if (cliOutput.contains('[') && cliOutput.contains(']')) {
+        final parsed = _parseGeminiCliOutput(cliOutput, workingDirectory);
+        if (parsed.isNotEmpty) return parsed.take(max).toList();
       }
-      return sessions;
+
+      // Fallback: scan chat JSON files directly.
+      return _discoverGeminiSessionsFromFiles(session, workingDirectory, max);
     } on Object {
       return const [];
     }
   }
 
+  /// Parses Gemini CLI `--list-sessions` text output.
+  ///
+  /// Each session line matches:
+  ///   `N. Title text (time ago) [session-uuid]`
+  static final _geminiSessionLinePattern = RegExp(
+    r'^\s*\d+\.\s+(.+?)\s+\([^)]+\)\s+\[([0-9a-f-]+)\]\s*$',
+  );
+
+  List<ToolSessionInfo> _parseGeminiCliOutput(
+    String output,
+    String? workingDirectory,
+  ) {
+    final sessions = <ToolSessionInfo>[];
+    for (final line in output.split('\n')) {
+      final match = _geminiSessionLinePattern.firstMatch(line);
+      if (match == null) continue;
+
+      final title = match.group(1)!.trim();
+      final id = match.group(2)!.trim();
+
+      sessions.add(
+        ToolSessionInfo(
+          toolName: 'Gemini CLI',
+          sessionId: id,
+          workingDirectory: workingDirectory,
+          summary: title.length > 80 ? '${title.substring(0, 77)}...' : title,
+        ),
+      );
+    }
+    return sessions;
+  }
+
+  Future<List<ToolSessionInfo>> _discoverGeminiSessionsFromFiles(
+    SshSession session,
+    String? workingDirectory,
+    int max,
+  ) async {
+    final output = await _exec(
+      session,
+      'find ~/.gemini/tmp -name "*.json" -path "*/chats/*" -type f '
+      '-exec ls -1t {} + 2>/dev/null | head -n $max',
+    );
+    if (output.trim().isEmpty) return const [];
+
+    final sessions = <ToolSessionInfo>[];
+    for (final line in output.trim().split('\n')) {
+      if (line.trim().isEmpty) continue;
+      final filePath = line.trim();
+      final fileName = filePath.split('/').last.replaceAll('.json', '');
+
+      final pathParts = filePath.split('/');
+      final chatsIdx = pathParts.indexOf('chats');
+      final projectDir = chatsIdx > 0 ? pathParts[chatsIdx - 1] : null;
+      final sessionWorkingDirectory =
+          projectDir != null &&
+              workingDirectory != null &&
+              _lastPathSegment(workingDirectory) == projectDir
+          ? workingDirectory
+          : null;
+
+      String? summary;
+      try {
+        final firstMsg = await _exec(
+          session,
+          'grep -o \'"text":"[^"]*"\' ${_shellQuote(filePath)} '
+          '| head -1 '
+          '| sed \'s/"text":"//;s/"\$//\'',
+        );
+        final text = firstMsg.trim();
+        if (text.isNotEmpty && text.length > 1) {
+          summary = text.length > 80 ? '${text.substring(0, 77)}...' : text;
+        }
+      } on Object {
+        // Non-critical.
+      }
+
+      sessions.add(
+        ToolSessionInfo(
+          toolName: 'Gemini CLI',
+          sessionId: fileName,
+          workingDirectory: sessionWorkingDirectory,
+          summary: summary ?? projectDir ?? _truncateId(fileName),
+        ),
+      );
+    }
+    return sessions;
+  }
+
   // ── OpenCode ───────────────────────────────────────────────────────────
-  // Primary store: ~/.local/share/opencode/opencode.db (SQLite)
-  // The `session` table holds id, title, directory, and timestamps.
-  // JSON files under storage/session/ are a partial export and may not
-  // reflect renames, so we prefer the database.
+  // `opencode session list --format json` is the cleanest source of truth.
+  // It returns renamed titles, directory, and timestamps. Falls back to
+  // the SQLite database or JSON files if the CLI is unavailable.
 
   Future<List<ToolSessionInfo>> _discoverOpenCodeSessions(
     SshSession session,
     int max,
   ) async {
     try {
-      // Query the SQLite database directly — it's the source of truth.
-      final output = await _exec(
+      // Preferred: use the CLI's own JSON output.
+      final cliOutput = await _exec(
+        session,
+        'opencode session list --format json -n $max 2>/dev/null',
+      );
+      if (cliOutput.trim().startsWith('[')) {
+        return _parseOpenCodeCliJson(cliOutput);
+      }
+
+      // Fallback: query the SQLite database directly.
+      final dbOutput = await _exec(
         session,
         'sqlite3 -separator "|" '
         '~/.local/share/opencode/opencode.db '
@@ -457,16 +519,39 @@ class AgentSessionDiscoveryService {
         'ORDER BY time_updated DESC '
         "LIMIT $max;' 2>/dev/null",
       );
-
-      if (output.trim().isNotEmpty) {
-        return _parseOpenCodeDbOutput(output);
+      if (dbOutput.trim().isNotEmpty) {
+        return _parseOpenCodeDbOutput(dbOutput);
       }
 
-      // Fallback: read JSON files if sqlite3 is not available.
-      return _discoverOpenCodeSessionsFromFiles(session, max);
+      return const [];
     } on Object {
       return const [];
     }
+  }
+
+  List<ToolSessionInfo> _parseOpenCodeCliJson(String raw) {
+    final decoded = jsonDecode(raw.trim());
+    if (decoded is! List) return const [];
+
+    return decoded.whereType<Map<String, dynamic>>().map((entry) {
+      final id = entry['id'] as String? ?? '';
+      final title = entry['title'] as String? ?? '';
+      final directory = entry['directory'] as String?;
+
+      DateTime? lastActive;
+      final updated = entry['updated'];
+      if (updated is int) {
+        lastActive = DateTime.fromMillisecondsSinceEpoch(updated);
+      }
+
+      return ToolSessionInfo(
+        toolName: 'OpenCode',
+        sessionId: id,
+        workingDirectory: directory,
+        lastActive: lastActive,
+        summary: title.isNotEmpty ? title : _truncateId(id),
+      );
+    }).toList();
   }
 
   List<ToolSessionInfo> _parseOpenCodeDbOutput(String output) {
@@ -494,56 +579,6 @@ class AgentSessionDiscoveryService {
           workingDirectory: directory.isNotEmpty ? directory : null,
           lastActive: lastActive,
           summary: title.isNotEmpty ? title : _truncateId(id),
-        ),
-      );
-    }
-    return sessions;
-  }
-
-  Future<List<ToolSessionInfo>> _discoverOpenCodeSessionsFromFiles(
-    SshSession session,
-    int max,
-  ) async {
-    final output = await _exec(
-      session,
-      'find ~/.local/share/opencode/storage/session -name "ses_*.json" '
-      '-type f -exec ls -1t {} + 2>/dev/null | head -n $max',
-    );
-    if (output.trim().isEmpty) return const [];
-
-    final sessions = <ToolSessionInfo>[];
-    for (final line in output.trim().split('\n')) {
-      if (line.trim().isEmpty) continue;
-      final filePath = line.trim();
-      final fileName = filePath.split('/').last.replaceAll('.json', '');
-
-      String? summary;
-      String? workingDirectory;
-      try {
-        final content = await _exec(
-          session,
-          'head -c 500 ${_shellQuote(filePath)} 2>/dev/null',
-        );
-        if (content.trim().isNotEmpty) {
-          final titleMatch = RegExp(
-            r'"title"\s*:\s*"([^"]*)"',
-          ).firstMatch(content);
-          final dirMatch = RegExp(
-            r'"directory"\s*:\s*"([^"]*)"',
-          ).firstMatch(content);
-          summary = titleMatch?.group(1);
-          workingDirectory = dirMatch?.group(1);
-        }
-      } on Object {
-        // Non-critical.
-      }
-
-      sessions.add(
-        ToolSessionInfo(
-          toolName: 'OpenCode',
-          sessionId: fileName,
-          workingDirectory: workingDirectory,
-          summary: summary ?? _truncateId(fileName),
         ),
       );
     }

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -1,9 +1,104 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/tmux_state.dart';
 import 'ssh_service.dart';
+
+const _genericSessionSummaries = <String>{
+  'untitled',
+  'unnamed',
+  'untitled session',
+  'new session',
+  'empty session',
+  'session',
+};
+
+/// Filters noisy discovered sessions and fills in a better display summary
+/// when the tool only exposes a working directory.
+@visibleForTesting
+ToolSessionInfo? normalizeDiscoveredSessionInfo(ToolSessionInfo info) {
+  final normalizedSummary = _normalizeDiscoveredSessionSummary(info);
+  if (normalizedSummary == null) return null;
+  return ToolSessionInfo(
+    toolName: info.toolName,
+    sessionId: info.sessionId,
+    workingDirectory: info.workingDirectory,
+    lastActive: info.lastActive,
+    summary: normalizedSummary,
+  );
+}
+
+/// Orders sessions from most to least recently updated, leaving untimestamped
+/// items at the end.
+@visibleForTesting
+int compareDiscoveredSessionsByRecency(ToolSessionInfo a, ToolSessionInfo b) {
+  final aTime = a.lastActive;
+  final bTime = b.lastActive;
+  if (aTime != null && bTime != null) {
+    final compare = bTime.compareTo(aTime);
+    if (compare != 0) return compare;
+  } else if (aTime != null) {
+    return -1;
+  } else if (bTime != null) {
+    return 1;
+  }
+
+  final toolCompare = a.toolName.compareTo(b.toolName);
+  if (toolCompare != 0) return toolCompare;
+  return (a.summary ?? '').compareTo(b.summary ?? '');
+}
+
+String? _normalizeDiscoveredSessionSummary(ToolSessionInfo info) {
+  final normalizedSummary = _sanitizeSessionSummary(
+    info.summary,
+    sessionId: info.sessionId,
+  );
+  if (normalizedSummary != null) return normalizedSummary;
+  return _directorySummaryFallback(info.workingDirectory);
+}
+
+String? _sanitizeSessionSummary(String? value, {required String sessionId}) {
+  final trimmed = value?.trim();
+  if (trimmed == null || trimmed.isEmpty) return null;
+
+  final unquoted = trimmed
+      .replaceAll(RegExp(r"""^["'`]+|["'`]+$"""), '')
+      .replaceAll(RegExp(r'\s+'), ' ')
+      .trim();
+  if (unquoted.isEmpty) return null;
+
+  final lowered = unquoted.toLowerCase();
+  if (_genericSessionSummaries.contains(lowered) ||
+      lowered == sessionId.toLowerCase() ||
+      lowered == _truncateSessionIdValue(sessionId).toLowerCase()) {
+    return null;
+  }
+
+  final strippedSeparators = unquoted.replaceAll(
+    RegExp(r'[\s\-_./\\[\](){}:;,*"`~]+'),
+    '',
+  );
+  if (strippedSeparators.isEmpty) return null;
+  return unquoted;
+}
+
+String? _directorySummaryFallback(String? workingDirectory) {
+  final trimmed = workingDirectory?.trim();
+  if (trimmed == null || trimmed.isEmpty) return null;
+  final segment = _pathLastSegment(trimmed);
+  if (segment.isEmpty || segment == '.' || segment == '~') return null;
+  return segment;
+}
+
+String _pathLastSegment(String path) =>
+    path.split('/').where((segment) => segment.isNotEmpty).lastOrNull ?? path;
+
+String _truncateSessionIdValue(String id) {
+  if (id.length <= 12) return id;
+  return '${id.substring(0, 8)}…';
+}
 
 /// Discovers recent AI coding tool sessions on remote hosts by scanning
 /// known session storage locations.
@@ -18,17 +113,16 @@ class AgentSessionDiscoveryService {
   /// Discovers recent sessions across all supported tools for the given
   /// [workingDirectory] on the remote host.
   ///
-  /// Each tool's sessions are discovered in most-recent-first order, then
-  /// the combined result is interleaved round-robin across tools so no
-  /// single tool dominates the list. Limits to [maxPerTool] sessions per
-  /// tool to keep results manageable.
+  /// Each tool's sessions are discovered separately, normalized to drop
+  /// noisy placeholder entries, and then sorted globally by recency.
+  /// Limits to [maxPerTool] sessions per tool to keep results manageable.
   ///
   /// When [workingDirectory] is available, sessions are filtered to that
   /// directory whenever the tool exposes enough path information to do so.
   Future<List<ToolSessionInfo>> discoverSessions(
     SshSession session, {
     String? workingDirectory,
-    int maxPerTool = 5,
+    int maxPerTool = 12,
   }) async {
     final results = await Future.wait([
       _discoverClaudeSessions(session, workingDirectory, maxPerTool),
@@ -38,26 +132,13 @@ class AgentSessionDiscoveryService {
       _discoverOpenCodeSessions(session, maxPerTool),
     ]);
 
-    // Interleave results from each tool in their original (mtime) order.
-    // Each tool's list is already sorted by most-recent-first from the
-    // remote commands. Interleaving round-robin keeps the combined list
-    // balanced across tools rather than pushing tools without timestamps
-    // to the bottom.
-    final all = <ToolSessionInfo>[];
-    final iterators = results
-        .where((list) => list.isNotEmpty)
-        .map((list) => list.iterator)
-        .toList();
-    var remaining = true;
-    while (remaining) {
-      remaining = false;
-      for (final it in iterators) {
-        if (it.moveNext()) {
-          all.add(it.current);
-          remaining = true;
-        }
-      }
-    }
+    final all =
+        results
+            .expand((list) => list)
+            .map(normalizeDiscoveredSessionInfo)
+            .whereType<ToolSessionInfo>()
+            .toList()
+          ..sort(compareDiscoveredSessionsByRecency);
 
     // Filter to sessions matching the working directory if provided.
     if (workingDirectory != null && workingDirectory.isNotEmpty) {
@@ -147,6 +228,10 @@ class AgentSessionDiscoveryService {
           );
           final sessionFilePath = sessionFile.trim();
           if (sessionFilePath.isNotEmpty) {
+            lastActive ??= await _readModificationTime(
+              session,
+              sessionFilePath,
+            );
             final customTitle = await _exec(
               session,
               'grep -o \'"customTitle":"[^"]*"\' '
@@ -244,6 +329,7 @@ class AgentSessionDiscoveryService {
               if (ts != null) lastActive = DateTime.tryParse(ts);
             }
           }
+          lastActive ??= await _readModificationTime(session, filePath);
 
           // Extract first prompt: skip session_meta, ignore environment/system
           // context, and take the first short input_text payload.
@@ -294,78 +380,80 @@ class AgentSessionDiscoveryService {
       );
       if (output.trim().isEmpty) return const [];
 
-      final sessions = <ToolSessionInfo>[];
-      for (final line in output.trim().split('\n')) {
-        if (line.trim().isEmpty) continue;
-        final dirPath = line.trim();
-        final dirName = dirPath.split('/').where((s) => s.isNotEmpty).last;
+      final sessionPaths = output
+          .trim()
+          .split('\n')
+          .map((line) => line.trim())
+          .where((line) => line.isNotEmpty)
+          .toList(growable: false);
 
-        // Read workspace.yaml for name, summary, and cwd.
-        String? summary;
-        String? workingDirectory;
-        try {
-          final yaml = await _exec(
-            session,
-            'cat ${_shellQuote('${dirPath}workspace.yaml')} 2>/dev/null',
-          );
-          if (yaml.trim().isNotEmpty) {
-            // Simple YAML field extraction (no dependency on yaml parser).
-            for (final yamlLine in yaml.split('\n')) {
-              final nameMatch = RegExp(r'^name:\s*(.+)').firstMatch(yamlLine);
-              if (nameMatch != null) {
-                summary = nameMatch.group(1)!.trim();
-              }
-              final summaryMatch = RegExp(
-                r'^summary:\s*(.+)',
-              ).firstMatch(yamlLine);
-              if (summaryMatch != null && summary == null) {
-                summary = summaryMatch.group(1)!.trim();
-              }
-              final cwdMatch = RegExp(r'^cwd:\s*(.+)').firstMatch(yamlLine);
-              if (cwdMatch != null) {
-                workingDirectory = cwdMatch.group(1)!.trim();
-              }
-            }
-          }
-        } on Object {
-          // Non-critical.
-        }
+      return Future.wait(
+        sessionPaths.map((dirPath) async {
+          final dirName = dirPath.split('/').where((s) => s.isNotEmpty).last;
+          final lastActive = await _readModificationTime(session, dirPath);
 
-        // Fall back to plan.md first line if no name/summary.
-        if (summary == null || summary.isEmpty) {
+          String? summary;
+          String? workingDirectory;
           try {
-            final planHead = await _exec(
+            final yaml = await _exec(
               session,
-              'head -3 ${_shellQuote('${dirPath}plan.md')} 2>/dev/null',
+              'cat ${_shellQuote('${dirPath}workspace.yaml')} 2>/dev/null',
             );
-            if (planHead.trim().isNotEmpty) {
-              for (final planLine in planHead.trim().split('\n')) {
-                final cleaned = planLine
-                    .replaceAll(RegExp(r'^#+\s*'), '')
-                    .trim();
-                if (cleaned.isNotEmpty && cleaned.length > 3) {
-                  summary = cleaned.length > 80
-                      ? '${cleaned.substring(0, 77)}...'
-                      : cleaned;
-                  break;
+            if (yaml.trim().isNotEmpty) {
+              for (final yamlLine in yaml.split('\n')) {
+                final nameMatch = RegExp(r'^name:\s*(.+)').firstMatch(yamlLine);
+                if (nameMatch != null) {
+                  summary = nameMatch.group(1)!.trim();
+                }
+                final summaryMatch = RegExp(
+                  r'^summary:\s*(.+)',
+                ).firstMatch(yamlLine);
+                if (summaryMatch != null && summary == null) {
+                  summary = summaryMatch.group(1)!.trim();
+                }
+                final cwdMatch = RegExp(r'^cwd:\s*(.+)').firstMatch(yamlLine);
+                if (cwdMatch != null) {
+                  workingDirectory = cwdMatch.group(1)!.trim();
                 }
               }
             }
           } on Object {
             // Non-critical.
           }
-        }
 
-        sessions.add(
-          ToolSessionInfo(
+          if (summary == null || summary.isEmpty) {
+            try {
+              final planHead = await _exec(
+                session,
+                'head -3 ${_shellQuote('${dirPath}plan.md')} 2>/dev/null',
+              );
+              if (planHead.trim().isNotEmpty) {
+                for (final planLine in planHead.trim().split('\n')) {
+                  final cleaned = planLine
+                      .replaceAll(RegExp(r'^#+\s*'), '')
+                      .trim();
+                  if (cleaned.isNotEmpty && cleaned.length > 3) {
+                    summary = cleaned.length > 80
+                        ? '${cleaned.substring(0, 77)}...'
+                        : cleaned;
+                    break;
+                  }
+                }
+              }
+            } on Object {
+              // Non-critical.
+            }
+          }
+
+          return ToolSessionInfo(
             toolName: 'Copilot CLI',
             sessionId: dirName,
             workingDirectory: workingDirectory,
+            lastActive: lastActive,
             summary: summary ?? _truncateId(dirName),
-          ),
-        );
-      }
-      return sessions;
+          );
+        }),
+      );
     } on Object {
       return const [];
     }
@@ -447,48 +535,53 @@ class AgentSessionDiscoveryService {
     );
     if (output.trim().isEmpty) return const [];
 
-    final sessions = <ToolSessionInfo>[];
-    for (final line in output.trim().split('\n')) {
-      if (line.trim().isEmpty) continue;
-      final filePath = line.trim();
-      final fileName = filePath.split('/').last.replaceAll('.json', '');
+    final sessionPaths = output
+        .trim()
+        .split('\n')
+        .map((line) => line.trim())
+        .where((line) => line.isNotEmpty)
+        .toList(growable: false);
 
-      final pathParts = filePath.split('/');
-      final chatsIdx = pathParts.indexOf('chats');
-      final projectDir = chatsIdx > 0 ? pathParts[chatsIdx - 1] : null;
-      final sessionWorkingDirectory =
-          projectDir != null &&
-              workingDirectory != null &&
-              _lastPathSegment(workingDirectory) == projectDir
-          ? workingDirectory
-          : null;
+    return Future.wait(
+      sessionPaths.map((filePath) async {
+        final fileName = filePath.split('/').last.replaceAll('.json', '');
+        final lastActive = await _readModificationTime(session, filePath);
 
-      String? summary;
-      try {
-        final firstMsg = await _exec(
-          session,
-          'grep -o \'"text":"[^"]*"\' ${_shellQuote(filePath)} '
-          '| head -1 '
-          '| sed \'s/"text":"//;s/"\$//\'',
-        );
-        final text = firstMsg.trim();
-        if (text.isNotEmpty && text.length > 1) {
-          summary = text.length > 80 ? '${text.substring(0, 77)}...' : text;
+        final pathParts = filePath.split('/');
+        final chatsIdx = pathParts.indexOf('chats');
+        final projectDir = chatsIdx > 0 ? pathParts[chatsIdx - 1] : null;
+        final sessionWorkingDirectory =
+            projectDir != null &&
+                workingDirectory != null &&
+                _pathLastSegment(workingDirectory) == projectDir
+            ? workingDirectory
+            : null;
+
+        String? summary;
+        try {
+          final firstMsg = await _exec(
+            session,
+            'grep -o \'"text":"[^"]*"\' ${_shellQuote(filePath)} '
+            '| head -1 '
+            '| sed \'s/"text":"//;s/"\$//\'',
+          );
+          final text = firstMsg.trim();
+          if (text.isNotEmpty && text.length > 1) {
+            summary = text.length > 80 ? '${text.substring(0, 77)}...' : text;
+          }
+        } on Object {
+          // Non-critical.
         }
-      } on Object {
-        // Non-critical.
-      }
 
-      sessions.add(
-        ToolSessionInfo(
+        return ToolSessionInfo(
           toolName: 'Gemini CLI',
           sessionId: fileName,
           workingDirectory: sessionWorkingDirectory,
+          lastActive: lastActive,
           summary: summary ?? projectDir ?? _truncateId(fileName),
-        ),
-      );
-    }
-    return sessions;
+        );
+      }),
+    );
   }
 
   // ── OpenCode ───────────────────────────────────────────────────────────
@@ -545,7 +638,9 @@ class AgentSessionDiscoveryService {
       DateTime? lastActive;
       final updated = entry['updated'];
       if (updated is int) {
-        lastActive = DateTime.fromMillisecondsSinceEpoch(updated);
+        lastActive = _dateTimeFromEpoch(updated);
+      } else if (updated is String) {
+        lastActive = DateTime.tryParse(updated);
       }
 
       return ToolSessionInfo(
@@ -572,7 +667,7 @@ class AgentSessionDiscoveryService {
       if (parts.length >= 4) {
         final ts = int.tryParse(parts[3].trim());
         if (ts != null) {
-          lastActive = DateTime.fromMillisecondsSinceEpoch(ts);
+          lastActive = _dateTimeFromEpoch(ts);
         }
       }
 
@@ -604,6 +699,28 @@ class AgentSessionDiscoveryService {
     }
   }
 
+  Future<DateTime?> _readModificationTime(
+    SshSession session,
+    String path,
+  ) async {
+    try {
+      final output = await _exec(
+        session,
+        '(stat -c %Y ${_shellQuote(path)} 2>/dev/null || '
+        'stat -f %m ${_shellQuote(path)} 2>/dev/null) | head -1',
+      );
+      final epoch = int.tryParse(output.trim());
+      if (epoch == null || epoch <= 0) return null;
+      return _dateTimeFromEpoch(epoch);
+    } on Object {
+      return null;
+    }
+  }
+
+  DateTime _dateTimeFromEpoch(int epoch) => DateTime.fromMillisecondsSinceEpoch(
+    epoch > 9999999999 ? epoch : epoch * 1000,
+  );
+
   static String _shellQuote(String value) =>
       "'${value.replaceAll("'", "'\"'\"'")}'";
 
@@ -620,17 +737,11 @@ class AgentSessionDiscoveryService {
   ) {
     if (sessionDirectory == null || sessionDirectory.isEmpty) return false;
     return sessionDirectory == expectedDirectory ||
-        _lastPathSegment(sessionDirectory) ==
-            _lastPathSegment(expectedDirectory);
+        _pathLastSegment(sessionDirectory) ==
+            _pathLastSegment(expectedDirectory);
   }
 
-  static String _lastPathSegment(String path) =>
-      path.split('/').where((segment) => segment.isNotEmpty).lastOrNull ?? path;
-
-  static String _truncateId(String id) {
-    if (id.length <= 12) return id;
-    return '${id.substring(0, 8)}…';
-  }
+  static String _truncateId(String id) => _truncateSessionIdValue(id);
 }
 
 /// Provider for [AgentSessionDiscoveryService].

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -64,24 +64,27 @@ class AgentSessionDiscoveryService {
   }
 
   /// Builds the shell command to resume a specific session.
+  ///
+  /// If the session has a [ToolSessionInfo.workingDirectory], the command
+  /// `cd`s there first so the CLI finds its project context.
   String buildResumeCommand(ToolSessionInfo info) {
-    switch (info.toolName) {
-      case 'Claude Code':
-        return 'claude --resume ${_shellQuote(info.sessionId)}';
-      case 'Codex':
-        return 'codex resume ${_shellQuote(info.sessionId)}';
-      case 'Copilot CLI':
-        return 'copilot --resume ${_shellQuote(info.sessionId)}';
-      case 'Gemini CLI':
-        return 'gemini --resume ${_shellQuote(info.sessionId)}';
-      case 'OpenCode':
-        if (info.sessionId == '_continue') {
-          return 'opencode --continue';
-        }
-        return 'opencode --session ${_shellQuote(info.sessionId)}';
-      default:
-        return info.toolName.toLowerCase();
+    final resume = switch (info.toolName) {
+      'Claude Code' => 'claude --resume ${_shellQuote(info.sessionId)}',
+      'Codex' => 'codex resume ${_shellQuote(info.sessionId)}',
+      'Copilot CLI' => 'copilot --resume ${_shellQuote(info.sessionId)}',
+      'Gemini CLI' => 'gemini --resume ${_shellQuote(info.sessionId)}',
+      'OpenCode' =>
+        info.sessionId == '_continue'
+            ? 'opencode --continue'
+            : 'opencode --session ${_shellQuote(info.sessionId)}',
+      _ => info.toolName.toLowerCase(),
+    };
+
+    final dir = info.workingDirectory;
+    if (dir != null && dir.isNotEmpty) {
+      return 'cd ${_shellQuote(dir)} && $resume';
     }
+    return resume;
   }
 
   // ── Claude Code ────────────────────────────────────────────────────────

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -22,6 +22,10 @@ class AgentSessionDiscoveryService {
   /// the combined result is interleaved round-robin across tools so no
   /// single tool dominates the list. Limits to [maxPerTool] sessions per
   /// tool to keep results manageable.
+  ///
+  /// The [workingDirectory] is passed to tools that support directory-scoped
+  /// session lookup (currently Claude Code and Gemini CLI pass it through
+  /// but do not yet filter by it — reserved for future use).
   Future<List<ToolSessionInfo>> discoverSessions(
     SshSession session, {
     String? workingDirectory,
@@ -101,23 +105,25 @@ class AgentSessionDiscoveryService {
       for (final line in output.trim().split('\n').reversed) {
         if (line.trim().isEmpty) continue;
         try {
-          final json = jsonDecode(line) as Map<String, dynamic>;
-          final sessionId = json['sessionId'] as String? ?? '';
+          final decoded = jsonDecode(line);
+          if (decoded is! Map<String, dynamic>) continue;
+          final sessionId = decoded['sessionId'] as String? ?? '';
           if (sessionId.isEmpty) continue;
 
           sessions.add(
             ToolSessionInfo(
               toolName: 'Claude Code',
               sessionId: sessionId,
-              workingDirectory: json['directory'] as String?,
-              lastActive: json['timestamp'] != null
-                  ? DateTime.tryParse(json['timestamp'] as String)
+              workingDirectory: decoded['directory'] as String?,
+              lastActive: decoded['timestamp'] != null
+                  ? DateTime.tryParse(decoded['timestamp'] as String)
                   : null,
-              summary: json['title'] as String? ?? json['query'] as String?,
+              summary:
+                  decoded['title'] as String? ?? decoded['query'] as String?,
             ),
           );
           if (sessions.length >= max) break;
-        } on FormatException {
+        } on Exception {
           continue;
         }
       }

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -33,15 +33,26 @@ class AgentSessionDiscoveryService {
       _discoverOpenCodeSessions(session, maxPerTool),
     ]);
 
-    final all = results.expand((list) => list).toList()
-      ..sort((a, b) {
-        final aTime = a.lastActive;
-        final bTime = b.lastActive;
-        if (aTime == null && bTime == null) return 0;
-        if (aTime == null) return 1;
-        if (bTime == null) return -1;
-        return bTime.compareTo(aTime);
-      });
+    // Interleave results from each tool in their original (mtime) order.
+    // Each tool's list is already sorted by most-recent-first from the
+    // remote commands. Interleaving round-robin keeps the combined list
+    // balanced across tools rather than pushing tools without timestamps
+    // to the bottom.
+    final all = <ToolSessionInfo>[];
+    final iterators = results
+        .where((list) => list.isNotEmpty)
+        .map((list) => list.iterator)
+        .toList();
+    var remaining = true;
+    while (remaining) {
+      remaining = false;
+      for (final it in iterators) {
+        if (it.moveNext()) {
+          all.add(it.current);
+          remaining = true;
+        }
+      }
+    }
 
     return all;
   }
@@ -52,11 +63,11 @@ class AgentSessionDiscoveryService {
       case 'Claude Code':
         return 'claude --resume ${_shellQuote(info.sessionId)}';
       case 'Codex':
-        return 'codex resume';
+        return 'codex resume ${_shellQuote(info.sessionId)}';
       case 'Copilot CLI':
         return 'copilot --resume ${_shellQuote(info.sessionId)}';
       case 'Gemini CLI':
-        return 'gemini --resume';
+        return 'gemini --resume ${_shellQuote(info.sessionId)}';
       case 'OpenCode':
         if (info.sessionId == '_continue') {
           return 'opencode --continue';

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -86,6 +86,17 @@ class DiscoveredSessionsResult {
   }
 }
 
+/// Whether a tool-level discovery issue should be surfaced to the UI.
+///
+/// Partial parse issues should stay silent when the tool still yielded usable
+/// sessions, so users only see a failure banner when a tool's history could not
+/// be loaded at all.
+@visibleForTesting
+bool shouldSurfaceDiscoveryFailure({
+  required bool hadError,
+  required int loadedSessionCount,
+}) => hadError && loadedSessionCount == 0;
+
 String? _normalizeDiscoveredSessionSummary(
   ToolSessionInfo info, {
   String? activeWorkingDirectory,
@@ -400,14 +411,28 @@ class AgentSessionDiscoveryService {
       if (filtered.isNotEmpty) {
         return DiscoveredSessionsResult(
           sessions: filtered,
-          failedTools: results.where((r) => r.hadError).map((r) => r.toolName),
+          failedTools: results
+              .where(
+                (r) => shouldSurfaceDiscoveryFailure(
+                  hadError: r.hadError,
+                  loadedSessionCount: r.sessions.length,
+                ),
+              )
+              .map((r) => r.toolName),
         );
       }
     }
 
     return DiscoveredSessionsResult(
       sessions: _limitDiscoveredSessionsPerTool(all, maxPerTool),
-      failedTools: results.where((r) => r.hadError).map((r) => r.toolName),
+      failedTools: results
+          .where(
+            (r) => shouldSurfaceDiscoveryFailure(
+              hadError: r.hadError,
+              loadedSessionCount: r.sessions.length,
+            ),
+          )
+          .map((r) => r.toolName),
     );
   }
 

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -125,27 +125,20 @@ class AgentSessionDiscoveryService {
       final output = await _exec(
         session,
         'find ~/.codex/sessions -name "rollout-*.jsonl" -type f '
-        '-printf "%T@\\t%p\\n" 2>/dev/null | sort -rn | head -n $max',
+        '2>/dev/null | xargs ls -1t 2>/dev/null | head -n $max',
       );
       if (output.trim().isEmpty) return const [];
 
       final sessions = <ToolSessionInfo>[];
       for (final line in output.trim().split('\n')) {
-        final parts = line.split('\t');
-        if (parts.length < 2) continue;
-
-        final epochStr = parts[0];
-        final filePath = parts[1];
-        final epoch = double.tryParse(epochStr);
+        if (line.trim().isEmpty) continue;
+        final filePath = line.trim();
         final fileName = filePath.split('/').last.replaceAll('.jsonl', '');
 
         sessions.add(
           ToolSessionInfo(
             toolName: 'Codex',
             sessionId: fileName,
-            lastActive: epoch != null
-                ? DateTime.fromMillisecondsSinceEpoch((epoch * 1000).toInt())
-                : null,
             summary: fileName,
           ),
         );
@@ -202,27 +195,20 @@ class AgentSessionDiscoveryService {
       final output = await _exec(
         session,
         'find ~/.gemini/tmp -name "*.json" -path "*/chats/*" -type f '
-        '-printf "%T@\\t%p\\n" 2>/dev/null | sort -rn | head -n $max',
+        '2>/dev/null | xargs ls -1t 2>/dev/null | head -n $max',
       );
       if (output.trim().isEmpty) return const [];
 
       final sessions = <ToolSessionInfo>[];
       for (final line in output.trim().split('\n')) {
-        final parts = line.split('\t');
-        if (parts.length < 2) continue;
-
-        final epochStr = parts[0];
-        final filePath = parts[1];
-        final epoch = double.tryParse(epochStr);
+        if (line.trim().isEmpty) continue;
+        final filePath = line.trim();
         final fileName = filePath.split('/').last.replaceAll('.json', '');
 
         sessions.add(
           ToolSessionInfo(
             toolName: 'Gemini CLI',
             sessionId: fileName,
-            lastActive: epoch != null
-                ? DateTime.fromMillisecondsSinceEpoch((epoch * 1000).toInt())
-                : null,
             summary: _truncateId(fileName),
           ),
         );
@@ -273,11 +259,11 @@ class AgentSessionDiscoveryService {
 
   Future<String> _exec(SshSession session, String command) async {
     final execSession = await session.execute(command);
-    final stdout = await execSession.stdout
-        .cast<List<int>>()
-        .transform(utf8.decoder)
-        .join();
-    return stdout;
+    final results = await Future.wait([
+      execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
+      execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
+    ]);
+    return results[0];
   }
 
   static String _shellQuote(String value) =>

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -511,9 +511,11 @@ class AgentSessionDiscoveryService {
       }
 
       // Fallback: query the SQLite database directly.
+      // Use ASCII Unit Separator (\x1f) to avoid collision with pipes
+      // in session titles or directory paths.
       final dbOutput = await _exec(
         session,
-        'sqlite3 -separator "|" '
+        r"sqlite3 -separator $'\x1f' "
         '~/.local/share/opencode/opencode.db '
         "'SELECT id, title, directory, time_updated "
         'FROM session '
@@ -560,7 +562,7 @@ class AgentSessionDiscoveryService {
     final sessions = <ToolSessionInfo>[];
     for (final line in output.trim().split('\n')) {
       if (line.trim().isEmpty) continue;
-      final parts = line.split('|');
+      final parts = line.split('\x1f');
       if (parts.length < 3) continue;
 
       final id = parts[0].trim();
@@ -591,11 +593,15 @@ class AgentSessionDiscoveryService {
 
   Future<String> _exec(SshSession session, String command) async {
     final execSession = await session.execute(command);
-    final results = await Future.wait([
-      execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
-      execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
-    ]).timeout(const Duration(seconds: 10), onTimeout: () => ['', '']);
-    return results[0];
+    try {
+      final results = await Future.wait([
+        execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
+        execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
+      ]).timeout(const Duration(seconds: 10), onTimeout: () => ['', '']);
+      return results[0];
+    } finally {
+      execSession.close();
+    }
   }
 
   static String _shellQuote(String value) =>

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -524,31 +524,14 @@ class AgentSessionDiscoveryService {
               session,
               sessionFilePath,
             );
-            final customTitle = await _exec(
+            final metadata = await _readClaudeSessionMetadata(
               session,
-              'grep -o \'"customTitle":"[^"]*"\' '
-              '${_shellQuote(sessionFilePath)} 2>/dev/null '
-              '| tail -1 '
-              '| sed \'s/"customTitle":"//;s/"\$//\'',
-            );
-            final agentName = await _exec(
-              session,
-              'grep -o \'"agentName":"[^"]*"\' '
-              '${_shellQuote(sessionFilePath)} 2>/dev/null '
-              '| tail -1 '
-              '| sed \'s/"agentName":"//;s/"\$//\'',
-            );
-            final lastPrompt = await _exec(
-              session,
-              'grep -o \'"lastPrompt":"[^"]*"\' '
-              '${_shellQuote(sessionFilePath)} 2>/dev/null '
-              '| tail -1 '
-              '| sed \'s/"lastPrompt":"//;s/"\$//\'',
+              sessionFilePath,
             );
             summary = _firstNonEmpty([
-              customTitle.trim(),
-              agentName.trim(),
-              lastPrompt.trim(),
+              metadata.customTitle,
+              metadata.agentName,
+              metadata.lastPrompt,
             ]);
           }
 
@@ -1128,6 +1111,47 @@ class AgentSessionDiscoveryService {
     } on Object {
       return null;
     }
+  }
+
+  Future<({String customTitle, String agentName, String lastPrompt})>
+  _readClaudeSessionMetadata(SshSession session, String path) async {
+    final output = await _exec(
+      session,
+      'awk '
+      '${_shellQuote(r'''
+match($0, /"customTitle":"([^"]*)"/, value) { customTitle = value[1] }
+match($0, /"agentName":"([^"]*)"/, value) { agentName = value[1] }
+match($0, /"lastPrompt":"([^"]*)"/, value) { lastPrompt = value[1] }
+END {
+  printf "customTitle=%s\nagentName=%s\nlastPrompt=%s\n", customTitle, agentName, lastPrompt
+}
+''')} '
+      '${_shellQuote(path)} 2>/dev/null',
+    );
+    var customTitle = '';
+    var agentName = '';
+    var lastPrompt = '';
+    for (final line in output.split('\n')) {
+      final separator = line.indexOf('=');
+      if (separator <= 0) {
+        continue;
+      }
+      final key = line.substring(0, separator);
+      final value = line.substring(separator + 1).trim();
+      switch (key) {
+        case 'customTitle':
+          customTitle = value;
+        case 'agentName':
+          agentName = value;
+        case 'lastPrompt':
+          lastPrompt = value;
+      }
+    }
+    return (
+      customTitle: customTitle,
+      agentName: agentName,
+      lastPrompt: lastPrompt,
+    );
   }
 
   DateTime _dateTimeFromEpoch(int epoch) => DateTime.fromMillisecondsSinceEpoch(

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -23,9 +23,8 @@ class AgentSessionDiscoveryService {
   /// single tool dominates the list. Limits to [maxPerTool] sessions per
   /// tool to keep results manageable.
   ///
-  /// The [workingDirectory] is passed to tools that support directory-scoped
-  /// session lookup (currently Claude Code and Gemini CLI pass it through
-  /// but do not yet filter by it — reserved for future use).
+  /// When [workingDirectory] is available, sessions are filtered to that
+  /// directory whenever the tool exposes enough path information to do so.
   Future<List<ToolSessionInfo>> discoverSessions(
     SshSession session, {
     String? workingDirectory,
@@ -65,12 +64,12 @@ class AgentSessionDiscoveryService {
       final filtered = all
           .where(
             (s) =>
-                s.workingDirectory == null ||
-                s.workingDirectory == workingDirectory,
+                _matchesWorkingDirectory(workingDirectory, s.workingDirectory),
           )
           .toList();
-      // Return filtered results if any match; otherwise return all
-      // so the UI isn't empty (user can still see sessions from other dirs).
+      // Return filtered results if any match; otherwise return all so the UI
+      // still has a fallback when the remote tool doesn't persist directory
+      // metadata for its sessions.
       if (filtered.isNotEmpty) return filtered;
     }
 
@@ -138,9 +137,45 @@ class AgentSessionDiscoveryService {
             lastActive = DateTime.tryParse(rawTs);
           }
 
-          // Use display text as summary, filtering out /exit commands.
+          String? summary;
+          final sessionFile = await _exec(
+            session,
+            'find ~/.claude/projects -name ${_shellQuote('$sessionId.jsonl')} '
+            '-type f 2>/dev/null | head -1',
+          );
+          final sessionFilePath = sessionFile.trim();
+          if (sessionFilePath.isNotEmpty) {
+            final customTitle = await _exec(
+              session,
+              'grep -o \'"customTitle":"[^"]*"\' '
+              '${_shellQuote(sessionFilePath)} 2>/dev/null '
+              '| tail -1 '
+              '| sed \'s/"customTitle":"//;s/"\$//\'',
+            );
+            final agentName = await _exec(
+              session,
+              'grep -o \'"agentName":"[^"]*"\' '
+              '${_shellQuote(sessionFilePath)} 2>/dev/null '
+              '| tail -1 '
+              '| sed \'s/"agentName":"//;s/"\$//\'',
+            );
+            final lastPrompt = await _exec(
+              session,
+              'grep -o \'"lastPrompt":"[^"]*"\' '
+              '${_shellQuote(sessionFilePath)} 2>/dev/null '
+              '| tail -1 '
+              '| sed \'s/"lastPrompt":"//;s/"\$//\'',
+            );
+            summary = _firstNonEmpty([
+              customTitle.trim(),
+              agentName.trim(),
+              lastPrompt.trim(),
+            ]);
+          }
+
+          // Fall back to history index fields.
           final display = decoded['display'] as String?;
-          final summary =
+          summary ??=
               decoded['title'] as String? ??
               decoded['query'] as String? ??
               (display != null && !display.startsWith('/') ? display : null);
@@ -188,7 +223,7 @@ class AgentSessionDiscoveryService {
         final filePath = line.trim();
         final fileName = filePath.split('/').last.replaceAll('.jsonl', '');
 
-        // Read the first line for session metadata (cwd + timestamp).
+        // Read metadata from first line and first real user prompt.
         String? summary;
         String? workingDirectory;
         DateTime? lastActive;
@@ -207,21 +242,25 @@ class AgentSessionDiscoveryService {
               if (ts != null) lastActive = DateTime.tryParse(ts);
             }
           }
+
+          // Extract first prompt: skip session_meta, ignore environment/system
+          // context, and take the first short input_text payload.
+          final promptOutput = await _exec(
+            session,
+            'sed -n \'2,20p\' ${_shellQuote(filePath)} '
+            '| grep -oE \'"text":"[^"]{1,120}"\' '
+            '| grep -v \'"text":"<\' '
+            '| grep -v \'"text":"#\' '
+            '| head -1 '
+            '| sed \'s/"text":"//;s/"\$//\'',
+          );
+          final prompt = promptOutput.trim();
+          if (prompt.isNotEmpty) summary = prompt;
         } on Object {
           // Non-critical.
         }
 
-        // Build a readable summary from date + project dir.
-        final dateMatch = RegExp(
-          r'rollout-(\d{4}-\d{2}-\d{2})',
-        ).firstMatch(fileName);
-        final dateStr = dateMatch?.group(1);
-        final projectName = workingDirectory?.split('/').last;
-        summary = <String>[
-          ?projectName,
-          ?dateStr,
-        ].join(' · ');
-        if (summary.isEmpty) summary = _truncateId(fileName);
+        summary ??= _truncateId(fileName);
 
         sessions.add(
           ToolSessionInfo(
@@ -256,24 +295,33 @@ class AgentSessionDiscoveryService {
       final sessions = <ToolSessionInfo>[];
       for (final line in output.trim().split('\n')) {
         if (line.trim().isEmpty) continue;
-        final dirName = line.trim().split('/').where((s) => s.isNotEmpty).last;
+        final dirPath = line.trim();
+        final dirName = dirPath.split('/').where((s) => s.isNotEmpty).last;
 
-        // Try to read the plan.md first line for a meaningful title.
+        // Read workspace.yaml for name, summary, and cwd.
         String? summary;
+        String? workingDirectory;
         try {
-          final planHead = await _exec(
+          final yaml = await _exec(
             session,
-            'head -5 ${_shellQuote('${line.trim()}plan.md')} 2>/dev/null',
+            'cat ${_shellQuote('${dirPath}workspace.yaml')} 2>/dev/null',
           );
-          if (planHead.trim().isNotEmpty) {
-            // Find first non-empty, non-heading line as the title.
-            for (final planLine in planHead.trim().split('\n')) {
-              final cleaned = planLine.replaceAll(RegExp(r'^#+\s*'), '').trim();
-              if (cleaned.isNotEmpty && cleaned.length > 3) {
-                summary = cleaned.length > 80
-                    ? '${cleaned.substring(0, 77)}...'
-                    : cleaned;
-                break;
+          if (yaml.trim().isNotEmpty) {
+            // Simple YAML field extraction (no dependency on yaml parser).
+            for (final yamlLine in yaml.split('\n')) {
+              final nameMatch = RegExp(r'^name:\s*(.+)').firstMatch(yamlLine);
+              if (nameMatch != null) {
+                summary = nameMatch.group(1)!.trim();
+              }
+              final summaryMatch = RegExp(
+                r'^summary:\s*(.+)',
+              ).firstMatch(yamlLine);
+              if (summaryMatch != null && summary == null) {
+                summary = summaryMatch.group(1)!.trim();
+              }
+              final cwdMatch = RegExp(r'^cwd:\s*(.+)').firstMatch(yamlLine);
+              if (cwdMatch != null) {
+                workingDirectory = cwdMatch.group(1)!.trim();
               }
             }
           }
@@ -281,10 +329,36 @@ class AgentSessionDiscoveryService {
           // Non-critical.
         }
 
+        // Fall back to plan.md first line if no name/summary.
+        if (summary == null || summary.isEmpty) {
+          try {
+            final planHead = await _exec(
+              session,
+              'head -3 ${_shellQuote('${dirPath}plan.md')} 2>/dev/null',
+            );
+            if (planHead.trim().isNotEmpty) {
+              for (final planLine in planHead.trim().split('\n')) {
+                final cleaned = planLine
+                    .replaceAll(RegExp(r'^#+\s*'), '')
+                    .trim();
+                if (cleaned.isNotEmpty && cleaned.length > 3) {
+                  summary = cleaned.length > 80
+                      ? '${cleaned.substring(0, 77)}...'
+                      : cleaned;
+                  break;
+                }
+              }
+            }
+          } on Object {
+            // Non-critical.
+          }
+        }
+
         sessions.add(
           ToolSessionInfo(
             toolName: 'Copilot CLI',
             sessionId: dirName,
+            workingDirectory: workingDirectory,
             summary: summary ?? _truncateId(dirName),
           ),
         );
@@ -317,17 +391,41 @@ class AgentSessionDiscoveryService {
         final filePath = line.trim();
         final fileName = filePath.split('/').last.replaceAll('.json', '');
 
-        // Extract project directory name from path for a meaningful label.
+        // Extract project directory name from path.
         // Path: ~/.gemini/tmp/<project_dir>/chats/<file>.json
         final pathParts = filePath.split('/');
         final chatsIdx = pathParts.indexOf('chats');
         final projectDir = chatsIdx > 0 ? pathParts[chatsIdx - 1] : null;
+        final sessionWorkingDirectory =
+            projectDir != null &&
+                workingDirectory != null &&
+                _lastPathSegment(workingDirectory) == projectDir
+            ? workingDirectory
+            : null;
+
+        // Try to read the first user message as summary.
+        String? summary;
+        try {
+          final firstMsg = await _exec(
+            session,
+            'grep -o \'"text":"[^"]*"\' ${_shellQuote(filePath)} '
+            '| head -1 '
+            '| sed \'s/"text":"//;s/"\$//\'',
+          );
+          final text = firstMsg.trim();
+          if (text.isNotEmpty && text.length > 1) {
+            summary = text.length > 80 ? '${text.substring(0, 77)}...' : text;
+          }
+        } on Object {
+          // Non-critical.
+        }
 
         sessions.add(
           ToolSessionInfo(
             toolName: 'Gemini CLI',
             sessionId: fileName,
-            summary: projectDir ?? _truncateId(fileName),
+            workingDirectory: sessionWorkingDirectory,
+            summary: summary ?? projectDir ?? _truncateId(fileName),
           ),
         );
       }
@@ -414,6 +512,26 @@ class AgentSessionDiscoveryService {
 
   static String _shellQuote(String value) =>
       "'${value.replaceAll("'", "'\"'\"'")}'";
+
+  static String? _firstNonEmpty(Iterable<String?> values) {
+    for (final value in values) {
+      if (value != null && value.isNotEmpty) return value;
+    }
+    return null;
+  }
+
+  static bool _matchesWorkingDirectory(
+    String expectedDirectory,
+    String? sessionDirectory,
+  ) {
+    if (sessionDirectory == null || sessionDirectory.isEmpty) return false;
+    return sessionDirectory == expectedDirectory ||
+        _lastPathSegment(sessionDirectory) ==
+            _lastPathSegment(expectedDirectory);
+  }
+
+  static String _lastPathSegment(String path) =>
+      path.split('/').where((segment) => segment.isNotEmpty).lastOrNull ?? path;
 
   static String _truncateId(String id) {
     if (id.length <= 12) return id;

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -102,33 +102,50 @@ class AgentSessionDiscoveryService {
       if (output.trim().isEmpty) return const [];
 
       final sessions = <ToolSessionInfo>[];
+      final seenIds = <String>{};
       for (final line in output.trim().split('\n').reversed) {
         if (line.trim().isEmpty) continue;
         try {
           final decoded = jsonDecode(line);
           if (decoded is! Map<String, dynamic>) continue;
           final sessionId = decoded['sessionId'] as String? ?? '';
-          if (sessionId.isEmpty) continue;
+          if (sessionId.isEmpty || seenIds.contains(sessionId)) continue;
+          seenIds.add(sessionId);
+
+          // timestamp may be int (epoch ms) or String (ISO 8601).
+          DateTime? lastActive;
+          final rawTs = decoded['timestamp'];
+          if (rawTs is int) {
+            lastActive = DateTime.fromMillisecondsSinceEpoch(rawTs);
+          } else if (rawTs is String) {
+            lastActive = DateTime.tryParse(rawTs);
+          }
+
+          // Use display text as summary, filtering out /exit commands.
+          final display = decoded['display'] as String?;
+          final summary =
+              decoded['title'] as String? ??
+              decoded['query'] as String? ??
+              (display != null && !display.startsWith('/') ? display : null);
 
           sessions.add(
             ToolSessionInfo(
               toolName: 'Claude Code',
               sessionId: sessionId,
-              workingDirectory: decoded['directory'] as String?,
-              lastActive: decoded['timestamp'] != null
-                  ? DateTime.tryParse(decoded['timestamp'] as String)
-                  : null,
-              summary:
-                  decoded['title'] as String? ?? decoded['query'] as String?,
+              workingDirectory:
+                  decoded['directory'] as String? ??
+                  decoded['project'] as String?,
+              lastActive: lastActive,
+              summary: summary,
             ),
           );
           if (sessions.length >= max) break;
-        } on Exception {
+        } on Object {
           continue;
         }
       }
       return sessions;
-    } on Exception {
+    } on Object {
       return const [];
     }
   }
@@ -163,7 +180,7 @@ class AgentSessionDiscoveryService {
         );
       }
       return sessions;
-    } on Exception {
+    } on Object {
       return const [];
     }
   }
@@ -197,7 +214,7 @@ class AgentSessionDiscoveryService {
         );
       }
       return sessions;
-    } on Exception {
+    } on Object {
       return const [];
     }
   }
@@ -233,7 +250,7 @@ class AgentSessionDiscoveryService {
         );
       }
       return sessions;
-    } on Exception {
+    } on Object {
       return const [];
     }
   }
@@ -269,7 +286,7 @@ class AgentSessionDiscoveryService {
         );
       }
       return sessions;
-    } on Exception {
+    } on Object {
       return const [];
     }
   }
@@ -281,7 +298,7 @@ class AgentSessionDiscoveryService {
     final results = await Future.wait([
       execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
       execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
-    ]);
+    ]).timeout(const Duration(seconds: 10), onTimeout: () => ['', '']);
     return results[0];
   }
 

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -60,6 +60,20 @@ class AgentSessionDiscoveryService {
       }
     }
 
+    // Filter to sessions matching the working directory if provided.
+    if (workingDirectory != null && workingDirectory.isNotEmpty) {
+      final filtered = all
+          .where(
+            (s) =>
+                s.workingDirectory == null ||
+                s.workingDirectory == workingDirectory,
+          )
+          .toList();
+      // Return filtered results if any match; otherwise return all
+      // so the UI isn't empty (user can still see sessions from other dirs).
+      if (filtered.isNotEmpty) return filtered;
+    }
+
     return all;
   }
 
@@ -174,11 +188,48 @@ class AgentSessionDiscoveryService {
         final filePath = line.trim();
         final fileName = filePath.split('/').last.replaceAll('.jsonl', '');
 
+        // Read the first line for session metadata (cwd + timestamp).
+        String? summary;
+        String? workingDirectory;
+        DateTime? lastActive;
+        try {
+          final meta = await _exec(
+            session,
+            'head -1 ${_shellQuote(filePath)} 2>/dev/null',
+          );
+          if (meta.trim().isNotEmpty) {
+            final decoded = jsonDecode(meta.trim());
+            if (decoded is Map<String, dynamic>) {
+              final payload =
+                  decoded['payload'] as Map<String, dynamic>? ?? decoded;
+              workingDirectory = payload['cwd'] as String?;
+              final ts = decoded['timestamp'] as String?;
+              if (ts != null) lastActive = DateTime.tryParse(ts);
+            }
+          }
+        } on Object {
+          // Non-critical.
+        }
+
+        // Build a readable summary from date + project dir.
+        final dateMatch = RegExp(
+          r'rollout-(\d{4}-\d{2}-\d{2})',
+        ).firstMatch(fileName);
+        final dateStr = dateMatch?.group(1);
+        final projectName = workingDirectory?.split('/').last;
+        summary = <String>[
+          ?projectName,
+          ?dateStr,
+        ].join(' · ');
+        if (summary.isEmpty) summary = _truncateId(fileName);
+
         sessions.add(
           ToolSessionInfo(
             toolName: 'Codex',
             sessionId: fileName,
-            summary: fileName,
+            workingDirectory: workingDirectory,
+            lastActive: lastActive,
+            summary: summary,
           ),
         );
       }
@@ -205,14 +256,36 @@ class AgentSessionDiscoveryService {
       final sessions = <ToolSessionInfo>[];
       for (final line in output.trim().split('\n')) {
         if (line.trim().isEmpty) continue;
-        // Extract session ID from directory path.
         final dirName = line.trim().split('/').where((s) => s.isNotEmpty).last;
+
+        // Try to read the plan.md first line for a meaningful title.
+        String? summary;
+        try {
+          final planHead = await _exec(
+            session,
+            'head -5 ${_shellQuote('${line.trim()}plan.md')} 2>/dev/null',
+          );
+          if (planHead.trim().isNotEmpty) {
+            // Find first non-empty, non-heading line as the title.
+            for (final planLine in planHead.trim().split('\n')) {
+              final cleaned = planLine.replaceAll(RegExp(r'^#+\s*'), '').trim();
+              if (cleaned.isNotEmpty && cleaned.length > 3) {
+                summary = cleaned.length > 80
+                    ? '${cleaned.substring(0, 77)}...'
+                    : cleaned;
+                break;
+              }
+            }
+          }
+        } on Object {
+          // Non-critical.
+        }
 
         sessions.add(
           ToolSessionInfo(
             toolName: 'Copilot CLI',
             sessionId: dirName,
-            summary: _truncateId(dirName),
+            summary: summary ?? _truncateId(dirName),
           ),
         );
       }
@@ -244,11 +317,17 @@ class AgentSessionDiscoveryService {
         final filePath = line.trim();
         final fileName = filePath.split('/').last.replaceAll('.json', '');
 
+        // Extract project directory name from path for a meaningful label.
+        // Path: ~/.gemini/tmp/<project_dir>/chats/<file>.json
+        final pathParts = filePath.split('/');
+        final chatsIdx = pathParts.indexOf('chats');
+        final projectDir = chatsIdx > 0 ? pathParts[chatsIdx - 1] : null;
+
         sessions.add(
           ToolSessionInfo(
             toolName: 'Gemini CLI',
             sessionId: fileName,
-            summary: _truncateId(fileName),
+            summary: projectDir ?? _truncateId(fileName),
           ),
         );
       }
@@ -267,24 +346,52 @@ class AgentSessionDiscoveryService {
     int max,
   ) async {
     try {
-      // Try listing session directories by modification time.
+      // List session JSON files directly (more reliable than dirs).
       final output = await _exec(
         session,
-        'ls -dt ~/.local/share/opencode/storage/session/*/ 2>/dev/null '
-        '| head -n $max',
+        'find ~/.local/share/opencode/storage/session -name "ses_*.json" '
+        '-type f -exec ls -1t {} + 2>/dev/null | head -n $max',
       );
       if (output.trim().isEmpty) return const [];
 
       final sessions = <ToolSessionInfo>[];
       for (final line in output.trim().split('\n')) {
         if (line.trim().isEmpty) continue;
-        final dirName = line.trim().split('/').where((s) => s.isNotEmpty).last;
+        final filePath = line.trim();
+        final fileName = filePath.split('/').last.replaceAll('.json', '');
+
+        // Read the session JSON for title and directory.
+        String? summary;
+        String? workingDirectory;
+        DateTime? lastActive;
+        try {
+          final content = await _exec(
+            session,
+            'head -c 500 ${_shellQuote(filePath)} 2>/dev/null',
+          );
+          if (content.trim().isNotEmpty) {
+            // Parse partial JSON — title/directory are near the top.
+            // Full parse may fail on truncated content, so extract fields.
+            final titleMatch = RegExp(
+              r'"title"\s*:\s*"([^"]*)"',
+            ).firstMatch(content);
+            final dirMatch = RegExp(
+              r'"directory"\s*:\s*"([^"]*)"',
+            ).firstMatch(content);
+            summary = titleMatch?.group(1);
+            workingDirectory = dirMatch?.group(1);
+          }
+        } on Object {
+          // Non-critical.
+        }
 
         sessions.add(
           ToolSessionInfo(
             toolName: 'OpenCode',
-            sessionId: dirName,
-            summary: _truncateId(dirName),
+            sessionId: fileName,
+            workingDirectory: workingDirectory,
+            lastActive: lastActive,
+            summary: summary ?? _truncateId(fileName),
           ),
         );
       }

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -110,10 +110,12 @@ class AgentSessionDiscoveryService {
     int max,
   ) async {
     try {
-      // Try to read the global history index first.
+      // Read more lines than needed to account for duplicate sessionIds
+      // (e.g. multiple history entries for the same active session).
+      final tailCount = max * 5;
       final output = await _exec(
         session,
-        'tail -n $max ~/.claude/history.jsonl 2>/dev/null',
+        'tail -n $tailCount ~/.claude/history.jsonl 2>/dev/null',
       );
       if (output.trim().isEmpty) return const [];
 

--- a/lib/domain/services/local_notification_service.dart
+++ b/lib/domain/services/local_notification_service.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Local notification channel used for tmux activity alerts.
+const tmuxAlertNotificationChannelId = 'tmux-alerts';
+
+/// Service for showing local notifications inside the app.
+class LocalNotificationService {
+  /// Creates a new [LocalNotificationService].
+  LocalNotificationService({FlutterLocalNotificationsPlugin? plugin})
+    : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
+
+  static const _tmuxAlertNotificationChannel = AndroidNotificationChannel(
+    tmuxAlertNotificationChannelId,
+    'tmux alerts',
+    description: 'Window activity alerts for tmux sessions.',
+    importance: Importance.high,
+  );
+
+  final FlutterLocalNotificationsPlugin _plugin;
+  Future<bool>? _initializeFuture;
+
+  /// Ensures the underlying notification plugin is initialized.
+  Future<bool> initialize() => _initializeFuture ??= _initializeInternal();
+
+  /// Shows or refreshes a tmux alert notification.
+  Future<void> showTmuxAlert({
+    required int notificationId,
+    required String title,
+    required String body,
+  }) async {
+    final didInitialize = await initialize();
+    if (!didInitialize) return;
+
+    const androidDetails = AndroidNotificationDetails(
+      tmuxAlertNotificationChannelId,
+      'tmux alerts',
+      channelDescription: 'Window activity alerts for tmux sessions.',
+      importance: Importance.high,
+      priority: Priority.high,
+      onlyAlertOnce: true,
+    );
+    const darwinDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentBadge: false,
+      presentSound: false,
+    );
+
+    try {
+      await _plugin.show(
+        notificationId,
+        title,
+        body,
+        const NotificationDetails(
+          android: androidDetails,
+          iOS: darwinDetails,
+          macOS: darwinDetails,
+        ),
+      );
+    } on MissingPluginException {
+      // Widget and unit tests don't register platform notification plugins.
+    }
+  }
+
+  /// Clears a previously shown tmux alert notification.
+  Future<void> clearTmuxAlert(int notificationId) async {
+    final didInitialize = await initialize();
+    if (!didInitialize) return;
+
+    try {
+      await _plugin.cancel(notificationId);
+    } on MissingPluginException {
+      // Widget and unit tests don't register platform notification plugins.
+    }
+  }
+
+  Future<bool> _initializeInternal() async {
+    if (kIsWeb) return false;
+
+    try {
+      const initializationSettings = InitializationSettings(
+        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+        iOS: DarwinInitializationSettings(),
+        macOS: DarwinInitializationSettings(),
+      );
+      await _plugin.initialize(initializationSettings);
+
+      final androidImplementation = _plugin
+          .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin
+          >();
+      await androidImplementation?.createNotificationChannel(
+        _tmuxAlertNotificationChannel,
+      );
+      await androidImplementation?.requestNotificationsPermission();
+
+      return true;
+    } on MissingPluginException {
+      return false;
+    }
+  }
+}
+
+/// Provides access to local notifications.
+final Provider<LocalNotificationService> localNotificationServiceProvider =
+    Provider<LocalNotificationService>((ref) => LocalNotificationService());

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -63,12 +63,12 @@ class TmuxService {
   /// Lists all tmux sessions on the remote host.
   Future<List<TmuxSession>> listSessions(SshSession session) async {
     try {
-      const fs = '\x1f'; // ASCII Unit Separator
       final output = await _exec(
         session,
+        'SEP=\$(printf \'\\x1f\'); '
         'tmux list-sessions -F '
-        "'#{session_name}$fs#{session_windows}$fs"
-        "#{session_attached}$fs#{session_activity}'",
+        r'"#{session_name}${SEP}#{session_windows}${SEP}'
+        r'#{session_attached}${SEP}#{session_activity}"',
       );
       return _parseLines(output, TmuxSession.fromTmuxFormat);
     } on Exception {
@@ -120,16 +120,17 @@ class TmuxService {
   ) async {
     try {
       final quotedName = _shellQuote(sessionName);
-      // Use ASCII Unit Separator (\x1f) as field delimiter so pipes,
-      // symbols, and emoji in window names / pane titles don't break
-      // parsing. The \x1f character is embedded literally via Dart.
-      const fs = '\x1f'; // ASCII Unit Separator
+      // Use ASCII Unit Separator as field delimiter so pipes, symbols,
+      // and emoji in window names / pane titles don't break parsing.
+      // Generate the separator via printf to avoid raw control chars
+      // in the command string.
       final output = await _exec(
         session,
+        'SEP=\$(printf \'\\x1f\'); '
         'tmux list-windows -t $quotedName -F '
-        "'#{window_index}$fs#{window_name}$fs#{window_active}$fs"
-        '#{pane_current_command}$fs#{pane_current_path}$fs'
-        "#{window_flags}$fs#{pane_title}$fs#{window_activity}'",
+        r'"#{window_index}${SEP}#{window_name}${SEP}#{window_active}${SEP}'
+        r'#{pane_current_command}${SEP}#{pane_current_path}${SEP}'
+        r'#{window_flags}${SEP}#{pane_title}${SEP}#{window_activity}"',
       );
       return _parseLines(output, TmuxWindow.fromTmuxFormat);
     } on Exception {

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -143,16 +143,27 @@ class TmuxService {
     String? name,
     String? workingDirectory,
   }) async {
+    // Create the window without a command — it gets a normal interactive
+    // login shell with full PATH, aliases, and profile scripts loaded.
     final parts = <String>[
       'tmux new-window -t ${_shellQuote(sessionName)}',
       if (workingDirectory != null && workingDirectory.trim().isNotEmpty)
         '-c ${_shellQuote(workingDirectory.trim())}',
       if (name != null && name.trim().isNotEmpty)
         '-n ${_shellQuote(name.trim())}',
-      if (command != null && command.trim().isNotEmpty)
-        _shellQuote(command.trim()),
     ];
     await _exec(session, parts.join(' '));
+
+    // If a command was requested, type it into the new window's shell.
+    // This ensures the command runs inside the login shell environment
+    // where CLI tools installed via Homebrew/nvm/etc. are available.
+    if (command != null && command.trim().isNotEmpty) {
+      _execFireAndForget(
+        session,
+        'tmux send-keys -t ${_shellQuote(sessionName)} '
+        '${_shellQuote(command.trim())} Enter',
+      );
+    }
   }
 
   /// Switches to window [windowIndex] in [sessionName] via exec channel.

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -63,11 +63,12 @@ class TmuxService {
   /// Lists all tmux sessions on the remote host.
   Future<List<TmuxSession>> listSessions(SshSession session) async {
     try {
+      const fs = '\x1f'; // ASCII Unit Separator
       final output = await _exec(
         session,
         'tmux list-sessions -F '
-        "'#{session_name}|#{session_windows}|"
-        "#{session_attached}|#{session_activity}'",
+        "'#{session_name}$fs#{session_windows}$fs"
+        "#{session_attached}$fs#{session_activity}'",
       );
       return _parseLines(output, TmuxSession.fromTmuxFormat);
     } on Exception {
@@ -119,12 +120,16 @@ class TmuxService {
   ) async {
     try {
       final quotedName = _shellQuote(sessionName);
+      // Use ASCII Unit Separator (\x1f) as field delimiter so pipes,
+      // symbols, and emoji in window names / pane titles don't break
+      // parsing. The \x1f character is embedded literally via Dart.
+      const fs = '\x1f'; // ASCII Unit Separator
       final output = await _exec(
         session,
         'tmux list-windows -t $quotedName -F '
-        "'#{window_index}|#{window_name}|#{window_active}|"
-        '#{pane_current_command}|#{pane_current_path}|'
-        "#{window_flags}|#{pane_title}|#{window_activity}'",
+        "'#{window_index}$fs#{window_name}$fs#{window_active}$fs"
+        '#{pane_current_command}$fs#{pane_current_path}$fs'
+        "#{window_flags}$fs#{pane_title}$fs#{window_activity}'",
       );
       return _parseLines(output, TmuxWindow.fromTmuxFormat);
     } on Exception {

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -20,8 +20,14 @@ class TmuxService {
   /// Cached tmux binary paths per SSH session (by connectionId).
   static final Map<int, String> _tmuxPathCache = {};
 
+  /// Cached profile source commands per SSH session.
+  static final Map<int, String> _profileSourceCache = {};
+
   /// Clears the cached tmux path for a connection.
-  void clearCache(int connectionId) => _tmuxPathCache.remove(connectionId);
+  void clearCache(int connectionId) {
+    _tmuxPathCache.remove(connectionId);
+    _profileSourceCache.remove(connectionId);
+  }
 
   // ── Detection ──────────────────────────────────────────────────────────
 
@@ -161,29 +167,39 @@ class TmuxService {
 
   // ── Helpers ────────────────────────────────────────────────────────────
 
+  /// Returns the profile source prefix for this session's login shell.
+  ///
+  /// Only sources the profile file appropriate for the user's shell:
+  /// - zsh: `~/.zprofile`
+  /// - bash: `~/.bash_profile` (falls back to `~/.profile`)
+  /// - sh/other: `~/.profile`
+  String _profilePrefix(int connectionId) {
+    final cached = _profileSourceCache[connectionId];
+    if (cached != null) return cached;
+    // Fallback — source all common profiles until shell is detected.
+    return '. ~/.profile 2>/dev/null; '
+        '. ~/.bash_profile 2>/dev/null; '
+        '. ~/.zprofile 2>/dev/null; ';
+  }
+
+  /// Wraps [command] with profile sourcing or cached path substitution.
+  String _wrapCommand(SshSession session, String command) {
+    final cachedPath = _tmuxPathCache[session.connectionId];
+    if (cachedPath != null) {
+      return command.replaceFirst('tmux ', '$cachedPath ');
+    }
+    return '${_profilePrefix(session.connectionId)}$command';
+  }
+
   /// Runs a command via SSH exec channel and returns stdout as a string.
   ///
-  /// SSH exec channels start with a minimal PATH that may not include
-  /// user-installed tools (e.g. Homebrew on macOS). The command is
-  /// wrapped to source common shell profiles first so tmux is found
-  /// regardless of install location.
+  /// Uses the cached tmux binary path when available; otherwise sources
+  /// the user's login shell profile to resolve the PATH.
   ///
   /// Drains both stdout and stderr to prevent SSH channel flow-control
   /// deadlocks, and awaits channel completion.
   Future<String> _exec(SshSession session, String command) async {
-    // If we have a cached tmux path, rewrite bare 'tmux' to the full path.
-    final cachedPath = _tmuxPathCache[session.connectionId];
-    final resolvedCommand = cachedPath != null
-        ? command.replaceFirst('tmux ', '$cachedPath ')
-        : command;
-
-    // Only source profiles if we don't have a cached path yet.
-    final wrappedCommand = cachedPath != null
-        ? resolvedCommand
-        : '. ~/.profile 2>/dev/null; '
-              '. ~/.bash_profile 2>/dev/null; '
-              '. ~/.zprofile 2>/dev/null; '
-              '$command';
+    final wrappedCommand = _wrapCommand(session, command);
     final execSession = await session.execute(wrappedCommand);
     final results = await Future.wait([
       execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
@@ -198,16 +214,7 @@ class TmuxService {
   /// visible immediately in the interactive terminal. Avoids the
   /// latency of draining stdout/stderr.
   void _execFireAndForget(SshSession session, String command) {
-    final cachedPath = _tmuxPathCache[session.connectionId];
-    final resolvedCommand = cachedPath != null
-        ? command.replaceFirst('tmux ', '$cachedPath ')
-        : command;
-    final wrappedCommand = cachedPath != null
-        ? resolvedCommand
-        : '. ~/.profile 2>/dev/null; '
-              '. ~/.bash_profile 2>/dev/null; '
-              '. ~/.zprofile 2>/dev/null; '
-              '$command';
+    final wrappedCommand = _wrapCommand(session, command);
     // Launch and ignore — the exec channel self-closes on completion.
     session.execute(wrappedCommand).then((exec) {
       // Drain streams to prevent backpressure, but don't wait.
@@ -216,26 +223,46 @@ class TmuxService {
     }).ignore();
   }
 
-  /// Resolves and caches the full path to the tmux binary.
+  /// Detects the user's login shell and resolves the tmux binary path.
+  ///
+  /// Caches both the shell-specific profile source command and the
+  /// full tmux path for subsequent calls.
   Future<void> _cacheTmuxPath(SshSession session) async {
     if (_tmuxPathCache.containsKey(session.connectionId)) return;
     try {
+      // Detect login shell and resolve tmux path in a single exec.
       final execSession = await session.execute(
-        '. ~/.profile 2>/dev/null; '
-        '. ~/.bash_profile 2>/dev/null; '
-        '. ~/.zprofile 2>/dev/null; '
+        // Print shell name, then source appropriate profile and find tmux.
+        r'SHELL_NAME=$(basename "$SHELL" 2>/dev/null || echo sh); '
+        r'case "$SHELL_NAME" in '
+        'zsh) . ~/.zprofile 2>/dev/null;; '
+        'bash) . ~/.bash_profile 2>/dev/null || . ~/.profile 2>/dev/null;; '
+        '*) . ~/.profile 2>/dev/null;; '
+        'esac; '
+        r'echo "$SHELL_NAME"; '
         'command -v tmux',
       );
       final results = await Future.wait([
         execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
         execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
       ]);
-      final path = results[0].trim();
-      if (path.isNotEmpty && path.startsWith('/')) {
-        _tmuxPathCache[session.connectionId] = path;
+      final lines = results[0].trim().split('\n');
+      if (lines.isNotEmpty) {
+        final shellName = lines[0].trim();
+        _profileSourceCache[session.connectionId] = switch (shellName) {
+          'zsh' => '. ~/.zprofile 2>/dev/null; ',
+          'bash' => '. ~/.bash_profile 2>/dev/null; ',
+          _ => '. ~/.profile 2>/dev/null; ',
+        };
+      }
+      if (lines.length > 1) {
+        final path = lines[1].trim();
+        if (path.isNotEmpty && path.startsWith('/')) {
+          _tmuxPathCache[session.connectionId] = path;
+        }
       }
     } on Object {
-      // Ignore — we'll fall back to profile sourcing.
+      // Ignore — we'll fall back to sourcing all profiles.
     }
   }
 

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -143,15 +143,13 @@ class TmuxService {
     String? name,
     String? workingDirectory,
   }) async {
-    // If no working directory was specified, inherit the current pane's
-    // working directory — this matches tmux's Ctrl+b,c behavior.
-    final cwd = workingDirectory ?? await _currentPaneCwd(session, sessionName);
-
-    // Create the window without a command — it gets a normal interactive
-    // login shell with full PATH, aliases, and profile scripts loaded.
+    // Don't pass -c unless an explicit workingDirectory was provided
+    // (e.g. resuming an AI session in a specific project). Without -c,
+    // tmux uses the session's default-directory — matching Ctrl+b,c.
     final parts = <String>[
       'tmux new-window -t ${_shellQuote(sessionName)}',
-      if (cwd != null && cwd.trim().isNotEmpty) '-c ${_shellQuote(cwd.trim())}',
+      if (workingDirectory != null && workingDirectory.trim().isNotEmpty)
+        '-c ${_shellQuote(workingDirectory.trim())}',
       if (name != null && name.trim().isNotEmpty)
         '-n ${_shellQuote(name.trim())}',
     ];
@@ -166,24 +164,6 @@ class TmuxService {
         'tmux send-keys -t ${_shellQuote(sessionName)} '
         '${_shellQuote(command.trim())} Enter',
       );
-    }
-  }
-
-  /// Returns the current pane's working directory via tmux.
-  Future<String?> _currentPaneCwd(
-    SshSession session,
-    String sessionName,
-  ) async {
-    try {
-      final output = await _exec(
-        session,
-        'tmux display-message -t ${_shellQuote(sessionName)} '
-        "-p '#{pane_current_path}'",
-      );
-      final path = output.trim();
-      return path.isNotEmpty ? path : null;
-    } on Object {
-      return null;
     }
   }
 

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -1,0 +1,157 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/tmux_state.dart';
+import 'ssh_service.dart';
+
+/// Introspects and controls tmux sessions on remote hosts via SSH exec
+/// channels.
+///
+/// All queries use `SshSession.execute()` to avoid interfering with the
+/// interactive shell. The results are parsed from tmux's `-F` format strings.
+class TmuxService {
+  /// Creates a new [TmuxService].
+  const TmuxService();
+
+  // ── Detection ──────────────────────────────────────────────────────────
+
+  /// Returns `true` if the connected shell appears to be inside a tmux
+  /// session.
+  ///
+  /// Checks by running `echo $TMUX` via an exec channel. A non-empty
+  /// response means tmux is active.
+  Future<bool> isTmuxActive(SshSession session) async {
+    try {
+      final output = await _exec(session, r'echo $TMUX');
+      return output.trim().isNotEmpty;
+    } on Exception {
+      return false;
+    }
+  }
+
+  /// Returns `true` if tmux is installed on the remote host.
+  Future<bool> isTmuxInstalled(SshSession session) async {
+    try {
+      final output = await _exec(session, 'which tmux');
+      return output.trim().isNotEmpty;
+    } on Exception {
+      return false;
+    }
+  }
+
+  // ── Session queries ────────────────────────────────────────────────────
+
+  /// Lists all tmux sessions on the remote host.
+  Future<List<TmuxSession>> listSessions(SshSession session) async {
+    try {
+      final output = await _exec(
+        session,
+        'tmux list-sessions -F '
+        "'#{session_name}\t#{session_windows}\t"
+        "#{session_attached}\t#{session_activity}'",
+      );
+      return _parseLines(output, TmuxSession.fromTmuxFormat);
+    } on Exception {
+      return const [];
+    }
+  }
+
+  /// Returns the name of the tmux session the interactive shell is
+  /// currently inside, or `null` if not in tmux.
+  Future<String?> currentSessionName(SshSession session) async {
+    try {
+      final output = await _exec(
+        session,
+        "tmux display-message -p '#{session_name}'",
+      );
+      final name = output.trim();
+      return name.isEmpty ? null : name;
+    } on Exception {
+      return null;
+    }
+  }
+
+  // ── Window queries ─────────────────────────────────────────────────────
+
+  /// Lists all windows in the given tmux [sessionName].
+  Future<List<TmuxWindow>> listWindows(
+    SshSession session,
+    String sessionName,
+  ) async {
+    try {
+      final quotedName = _shellQuote(sessionName);
+      final output = await _exec(
+        session,
+        'tmux list-windows -t $quotedName -F '
+        "'#{window_index}\t#{window_name}\t#{window_active}\t"
+        "#{pane_current_command}\t#{pane_current_path}'",
+      );
+      return _parseLines(output, TmuxWindow.fromTmuxFormat);
+    } on Exception {
+      return const [];
+    }
+  }
+
+  // ── Window mutations ───────────────────────────────────────────────────
+
+  /// Creates a new window in [sessionName], optionally running [command]
+  /// and/or setting a window [name].
+  Future<void> createWindow(
+    SshSession session,
+    String sessionName, {
+    String? command,
+    String? name,
+  }) async {
+    final parts = <String>[
+      'tmux new-window -t ${_shellQuote(sessionName)}',
+      if (name != null && name.trim().isNotEmpty)
+        '-n ${_shellQuote(name.trim())}',
+      if (command != null && command.trim().isNotEmpty)
+        _shellQuote(command.trim()),
+    ];
+    await _exec(session, parts.join(' '));
+  }
+
+  /// Builds the shell command to switch to window [windowIndex] in the
+  /// current tmux session.
+  ///
+  /// This returns the command string rather than executing it, because
+  /// window switching must be sent through the **interactive shell** (not
+  /// an exec channel) so that the terminal display updates.
+  String buildSelectWindowCommand(String sessionName, int windowIndex) =>
+      'tmux select-window -t ${_shellQuote(sessionName)}:$windowIndex';
+
+  // ── Helpers ────────────────────────────────────────────────────────────
+
+  Future<String> _exec(SshSession session, String command) async {
+    final execSession = await session.execute(command);
+    final stdout = await execSession.stdout
+        .cast<List<int>>()
+        .transform(utf8.decoder)
+        .join();
+    return stdout;
+  }
+
+  /// Parses non-empty lines from [output] using [parser].
+  List<T> _parseLines<T>(String output, T Function(String) parser) {
+    final lines = output.trim().split('\n');
+    final results = <T>[];
+    for (final line in lines) {
+      if (line.trim().isEmpty) continue;
+      try {
+        results.add(parser(line));
+      } on FormatException {
+        // Skip malformed lines.
+      }
+    }
+    return results;
+  }
+
+  /// Single-quotes a value for safe use in shell commands.
+  static String _shellQuote(String value) =>
+      "'${value.replaceAll("'", "'\"'\"'")}'";
+}
+
+/// Provider for [TmuxService].
+final tmuxServiceProvider = Provider<TmuxService>((ref) => const TmuxService());

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -49,8 +49,8 @@ class TmuxService {
       final output = await _exec(
         session,
         'tmux list-sessions -F '
-        "'#{session_name}\t#{session_windows}\t"
-        "#{session_attached}\t#{session_activity}'",
+        "'#{session_name}|#{session_windows}|"
+        "#{session_attached}|#{session_activity}'",
       );
       return _parseLines(output, TmuxSession.fromTmuxFormat);
     } on Exception {
@@ -103,8 +103,8 @@ class TmuxService {
       final output = await _exec(
         session,
         'tmux list-windows -t $quotedName -F '
-        "'#{window_index}\t#{window_name}\t#{window_active}\t"
-        "#{pane_current_command}\t#{pane_current_path}'",
+        "'#{window_index}|#{window_name}|#{window_active}|"
+        "#{pane_current_command}|#{pane_current_path}'",
       );
       return _parseLines(output, TmuxWindow.fromTmuxFormat);
     } on Exception {
@@ -152,10 +152,22 @@ class TmuxService {
 
   /// Runs a command via SSH exec channel and returns stdout as a string.
   ///
+  /// SSH exec channels start with a minimal PATH that may not include
+  /// user-installed tools (e.g. Homebrew on macOS). The command is
+  /// wrapped to source common shell profiles first so tmux is found
+  /// regardless of install location.
+  ///
   /// Drains both stdout and stderr to prevent SSH channel flow-control
   /// deadlocks, and awaits channel completion.
   Future<String> _exec(SshSession session, String command) async {
-    final execSession = await session.execute(command);
+    // Source the user's shell profile to pick up PATH additions (e.g.
+    // Homebrew, linuxbrew, nix, etc.) before running the actual command.
+    final wrappedCommand =
+        'source ~/.profile 2>/dev/null; '
+        'source ~/.bash_profile 2>/dev/null; '
+        'source ~/.zprofile 2>/dev/null; '
+        '$command';
+    final execSession = await session.execute(wrappedCommand);
     final results = await Future.wait([
       execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
       execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -104,7 +104,8 @@ class TmuxService {
         session,
         'tmux list-windows -t $quotedName -F '
         "'#{window_index}|#{window_name}|#{window_active}|"
-        "#{pane_current_command}|#{pane_current_path}'",
+        '#{pane_current_command}|#{pane_current_path}|'
+        "#{window_flags}|#{pane_title}'",
       );
       return _parseLines(output, TmuxWindow.fromTmuxFormat);
     } on Exception {

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -163,9 +163,9 @@ class TmuxService {
     // Source the user's shell profile to pick up PATH additions (e.g.
     // Homebrew, linuxbrew, nix, etc.) before running the actual command.
     final wrappedCommand =
-        'source ~/.profile 2>/dev/null; '
-        'source ~/.bash_profile 2>/dev/null; '
-        'source ~/.zprofile 2>/dev/null; '
+        '. ~/.profile 2>/dev/null; '
+        '. ~/.bash_profile 2>/dev/null; '
+        '. ~/.zprofile 2>/dev/null; '
         '$command';
     final execSession = await session.execute(wrappedCommand);
     final results = await Future.wait([

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -213,13 +213,22 @@ class TmuxService {
 
   /// Wraps [command] with profile sourcing or cached path substitution.
   String _wrapCommand(SshSession session, String command) {
+    final utf8Command = _forceUtf8TmuxCommand(command);
     final cachedPath = _tmuxPathCache[session.connectionId];
     final prefixedCommand = cachedPath != null
-        ? command.replaceFirst('tmux ', '$cachedPath ')
-        : command;
+        ? utf8Command.replaceFirst('tmux -u ', '$cachedPath -u ')
+        : utf8Command;
     // Always source the login-shell profile so locale- and PATH-related tmux
     // settings stay consistent even after the binary path is cached.
-    return '${_profilePrefix(session.connectionId)}$prefixedCommand';
+    return '${_profilePrefix(session.connectionId)}'
+        'export LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8; '
+        '$prefixedCommand';
+  }
+
+  String _forceUtf8TmuxCommand(String command) {
+    final trimmed = command.trimLeft();
+    if (!trimmed.startsWith('tmux ')) return command;
+    return command.replaceFirst('tmux ', 'tmux -u ');
   }
 
   /// Runs a command via SSH exec channel and returns stdout as a string.

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -16,14 +16,15 @@ class TmuxService {
 
   // ── Detection ──────────────────────────────────────────────────────────
 
-  /// Returns `true` if the connected shell appears to be inside a tmux
-  /// session.
+  /// Returns `true` if there is at least one tmux session running on the
+  /// remote host.
   ///
-  /// Checks by running `echo $TMUX` via an exec channel. A non-empty
-  /// response means tmux is active.
+  /// Uses `tmux list-sessions` rather than checking the `TMUX` environment
+  /// variable, because SSH exec channels do not share the interactive
+  /// shell's environment.
   Future<bool> isTmuxActive(SshSession session) async {
     try {
-      final output = await _exec(session, r'echo $TMUX');
+      final output = await _exec(session, 'tmux list-sessions 2>/dev/null');
       return output.trim().isNotEmpty;
     } on Exception {
       return false;
@@ -113,24 +114,35 @@ class TmuxService {
     await _exec(session, parts.join(' '));
   }
 
-  /// Builds the shell command to switch to window [windowIndex] in the
-  /// current tmux session.
+  /// Switches to window [windowIndex] in [sessionName] via exec channel.
   ///
-  /// This returns the command string rather than executing it, because
-  /// window switching must be sent through the **interactive shell** (not
-  /// an exec channel) so that the terminal display updates.
-  String buildSelectWindowCommand(String sessionName, int windowIndex) =>
-      'tmux select-window -t ${_shellQuote(sessionName)}:$windowIndex';
+  /// This is a tmux server operation — the server notifies all attached
+  /// clients of the change, so it works correctly regardless of which
+  /// channel sends the command.
+  Future<void> selectWindow(
+    SshSession session,
+    String sessionName,
+    int windowIndex,
+  ) async {
+    await _exec(
+      session,
+      'tmux select-window -t ${_shellQuote(sessionName)}:$windowIndex',
+    );
+  }
 
   // ── Helpers ────────────────────────────────────────────────────────────
 
+  /// Runs a command via SSH exec channel and returns stdout as a string.
+  ///
+  /// Drains both stdout and stderr to prevent SSH channel flow-control
+  /// deadlocks, and awaits channel completion.
   Future<String> _exec(SshSession session, String command) async {
     final execSession = await session.execute(command);
-    final stdout = await execSession.stdout
-        .cast<List<int>>()
-        .transform(utf8.decoder)
-        .join();
-    return stdout;
+    final results = await Future.wait([
+      execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
+      execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
+    ]);
+    return results[0];
   }
 
   /// Parses non-empty lines from [output] using [parser].

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -165,6 +165,17 @@ class TmuxService {
     );
   }
 
+  /// Closes a window in [sessionName] via exec channel.
+  ///
+  /// Uses fire-and-forget — if this was the last window, the tmux session
+  /// ends and the interactive shell exits naturally.
+  void killWindow(SshSession session, String sessionName, int windowIndex) {
+    _execFireAndForget(
+      session,
+      'tmux kill-window -t ${_shellQuote(sessionName)}:$windowIndex',
+    );
+  }
+
   // ── Helpers ────────────────────────────────────────────────────────────
 
   /// Returns the profile source prefix for this session's login shell.

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
 import 'dart:convert';
 
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/tmux_state.dart';
@@ -23,10 +26,19 @@ class TmuxService {
   /// Cached profile source commands per SSH session.
   static final Map<int, String> _profileSourceCache = {};
 
+  static final Map<_TmuxWindowWatchKey, _TmuxWindowChangeObserver>
+  _windowObservers = {};
+
   /// Clears the cached tmux path for a connection.
   void clearCache(int connectionId) {
     _tmuxPathCache.remove(connectionId);
     _profileSourceCache.remove(connectionId);
+    final observerKeys = _windowObservers.keys
+        .where((key) => key.connectionId == connectionId)
+        .toList(growable: false);
+    for (final key in observerKeys) {
+      unawaited(_windowObservers.remove(key)?.dispose());
+    }
   }
 
   // ── Detection ──────────────────────────────────────────────────────────
@@ -110,6 +122,19 @@ class TmuxService {
     }
   }
 
+  /// Returns `true` if [sessionName] exists on the remote tmux server.
+  Future<bool> hasSession(SshSession session, String sessionName) async {
+    try {
+      final output = await _exec(
+        session,
+        'tmux has-session -t ${_shellQuote(sessionName)} 2>/dev/null && printf 1',
+      );
+      return output.trim() == '1';
+    } on Exception {
+      return false;
+    }
+  }
+
   // ── Window queries ─────────────────────────────────────────────────────
 
   /// Lists all windows in the given tmux [sessionName].
@@ -130,6 +155,25 @@ class TmuxService {
     } on Exception {
       return const [];
     }
+  }
+
+  /// Watches tmux control-mode notifications that indicate window state
+  /// has changed for [sessionName].
+  Stream<void> watchWindowChanges(SshSession session, String sessionName) {
+    final key = _TmuxWindowWatchKey(
+      connectionId: session.connectionId,
+      sessionName: sessionName,
+    );
+    final observer = _windowObservers.putIfAbsent(
+      key,
+      () => _TmuxWindowChangeObserver(
+        service: this,
+        session: session,
+        sessionName: sessionName,
+        onDispose: () => _windowObservers.remove(key),
+      ),
+    );
+    return observer.stream;
   }
 
   // ── Window mutations ───────────────────────────────────────────────────
@@ -333,6 +377,232 @@ class TmuxService {
   /// Single-quotes a value for safe use in shell commands.
   static String _shellQuote(String value) =>
       "'${value.replaceAll("'", "'\"'\"'")}'";
+}
+
+const _tmuxWindowSubscriptionFormat =
+    '#{window_index}|#{window_name}|#{window_active}|'
+    '#{pane_current_command}|#{pane_current_path}|'
+    '#{window_flags}|#{pane_title}|#{window_activity}';
+
+const _tmuxControlModeClientFlags = 'read-only,ignore-size,no-output,wait-exit';
+
+/// Builds the tmux control-mode attach command used for live window updates.
+@visibleForTesting
+String buildTmuxControlModeAttachCommand(String sessionName) =>
+    'tmux -CC attach-session -f $_tmuxControlModeClientFlags '
+    '-t ${TmuxService._shellQuote(sessionName)}';
+
+/// Builds the tmux control-mode subscription command for window snapshots.
+@visibleForTesting
+String buildTmuxWindowSubscriptionCommand(String subscriptionName) =>
+    "refresh-client -B '$subscriptionName:@*:$_tmuxWindowSubscriptionFormat'";
+
+/// Returns whether a control-mode output [line] should trigger a window
+/// snapshot refresh for the observer using [subscriptionName].
+@visibleForTesting
+bool shouldReloadTmuxWindowsFromControlLine(
+  String line, {
+  required String subscriptionName,
+}) {
+  final trimmed = line.trim();
+  if (trimmed.isEmpty) return false;
+  if (trimmed.startsWith('%subscription-changed $subscriptionName ')) {
+    return true;
+  }
+
+  const notificationPrefixes = <String>[
+    '%session-changed ',
+    '%session-renamed ',
+    '%session-window-changed ',
+    '%sessions-changed',
+    '%unlinked-window-add ',
+    '%unlinked-window-close ',
+    '%unlinked-window-renamed ',
+    '%window-add ',
+    '%window-close ',
+    '%window-pane-changed ',
+    '%window-renamed ',
+  ];
+  return notificationPrefixes.any(trimmed.startsWith);
+}
+
+@immutable
+class _TmuxWindowWatchKey {
+  const _TmuxWindowWatchKey({
+    required this.connectionId,
+    required this.sessionName,
+  });
+
+  final int connectionId;
+  final String sessionName;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _TmuxWindowWatchKey &&
+          connectionId == other.connectionId &&
+          sessionName == other.sessionName;
+
+  @override
+  int get hashCode => Object.hash(connectionId, sessionName);
+}
+
+class _TmuxWindowChangeObserver {
+  _TmuxWindowChangeObserver({
+    required this.service,
+    required this.session,
+    required this.sessionName,
+    required this.onDispose,
+  }) : _controller = StreamController<void>.broadcast() {
+    _controller
+      ..onListen = _ensureStarted
+      ..onCancel = () => unawaited(dispose());
+  }
+
+  static const _eventDebounce = Duration(milliseconds: 150);
+
+  final TmuxService service;
+  final SshSession session;
+  final String sessionName;
+  final VoidCallback onDispose;
+  final StreamController<void> _controller;
+
+  StreamSubscription<String>? _stdoutSubscription;
+  StreamSubscription<String>? _stderrSubscription;
+  StreamSubscription<void>? _doneSubscription;
+  Timer? _debounceTimer;
+  Timer? _restartTimer;
+  SSHSession? _controlSession;
+  bool _starting = false;
+  bool _disposed = false;
+  int _restartAttempts = 0;
+
+  String get _subscriptionName =>
+      'flutty-${session.connectionId}-${sessionName.hashCode.abs()}';
+
+  Stream<void> get stream => _controller.stream;
+
+  Future<void> _ensureStarted() async {
+    if (_disposed || _starting || _controlSession != null) return;
+    _starting = true;
+    try {
+      await service._cacheTmuxPath(session);
+      final execSession = await session.execute(
+        service._wrapCommand(
+          session,
+          buildTmuxControlModeAttachCommand(sessionName),
+        ),
+      );
+      if (_disposed) {
+        execSession.close();
+        return;
+      }
+
+      _controlSession = execSession;
+      _stdoutSubscription = execSession.stdout
+          .cast<List<int>>()
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen(_handleStdoutLine, onError: _handleControlFailure);
+      _stderrSubscription = execSession.stderr
+          .cast<List<int>>()
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen(_handleStderrLine, onError: _handleControlFailure);
+      _doneSubscription = execSession.done.asStream().listen(
+        (_) => _handleControlClosed(),
+        onError: _handleControlFailure,
+      );
+      _configureControlSession();
+      _restartAttempts = 0;
+    } on Object catch (error, stackTrace) {
+      _handleControlFailure(error, stackTrace);
+    } finally {
+      _starting = false;
+    }
+  }
+
+  void _configureControlSession() {
+    final controlSession = _controlSession;
+    if (controlSession == null) return;
+    controlSession.write(
+      utf8.encode('${buildTmuxWindowSubscriptionCommand(_subscriptionName)}\n'),
+    );
+  }
+
+  void _handleStdoutLine(String line) {
+    if (_disposed) return;
+    final trimmed = line.trim();
+    if (trimmed.startsWith('%exit')) {
+      _handleControlClosed();
+      return;
+    }
+    if (!shouldReloadTmuxWindowsFromControlLine(
+      trimmed,
+      subscriptionName: _subscriptionName,
+    )) {
+      return;
+    }
+    _scheduleEvent();
+  }
+
+  void _handleStderrLine(String line) {
+    if (_disposed || line.trim().isEmpty) return;
+    _scheduleRestart();
+  }
+
+  void _scheduleEvent() {
+    if (_disposed) return;
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(_eventDebounce, () {
+      if (!_disposed && !_controller.isClosed) {
+        _controller.add(null);
+      }
+    });
+  }
+
+  void _handleControlFailure(Object error, StackTrace stackTrace) {
+    _scheduleRestart();
+  }
+
+  void _handleControlClosed() {
+    _cleanupControlSession();
+    _scheduleRestart();
+  }
+
+  void _scheduleRestart() {
+    if (_disposed || !_controller.hasListener) return;
+    _restartTimer?.cancel();
+    final cappedAttempt = _restartAttempts.clamp(0, 4);
+    final delay = Duration(seconds: 1 << cappedAttempt);
+    _restartAttempts += 1;
+    _restartTimer = Timer(delay, () => unawaited(_ensureStarted()));
+  }
+
+  void _cleanupControlSession() {
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    unawaited(_stdoutSubscription?.cancel());
+    unawaited(_stderrSubscription?.cancel());
+    unawaited(_doneSubscription?.cancel());
+    _stdoutSubscription = null;
+    _stderrSubscription = null;
+    _doneSubscription = null;
+    _controlSession?.close();
+    _controlSession = null;
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    _restartTimer?.cancel();
+    _restartTimer = null;
+    _cleanupControlSession();
+    if (!_controller.isClosed) {
+      await _controller.close();
+    }
+    onDispose();
+  }
 }
 
 /// Provider for [TmuxService].

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -252,7 +252,7 @@ class TmuxService {
         r'SHELL_NAME=$(basename "$SHELL" 2>/dev/null || echo sh); '
         r'case "$SHELL_NAME" in '
         'zsh) . ~/.zprofile 2>/dev/null;; '
-        'bash) . ~/.bash_profile 2>/dev/null || . ~/.profile 2>/dev/null;; '
+        'bash) . ~/.bash_profile 2>/dev/null; . ~/.profile 2>/dev/null;; '
         '*) . ~/.profile 2>/dev/null;; '
         'esac; '
         r'echo "$SHELL_NAME"; '
@@ -267,7 +267,7 @@ class TmuxService {
         final shellName = lines[0].trim();
         _profileSourceCache[session.connectionId] = switch (shellName) {
           'zsh' => '. ~/.zprofile 2>/dev/null; ',
-          'bash' => '. ~/.bash_profile 2>/dev/null; ',
+          'bash' => '. ~/.bash_profile 2>/dev/null; . ~/.profile 2>/dev/null; ',
           _ => '. ~/.profile 2>/dev/null; ',
         };
       }

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -143,12 +143,15 @@ class TmuxService {
     String? name,
     String? workingDirectory,
   }) async {
+    // If no working directory was specified, inherit the current pane's
+    // working directory — this matches tmux's Ctrl+b,c behavior.
+    final cwd = workingDirectory ?? await _currentPaneCwd(session, sessionName);
+
     // Create the window without a command — it gets a normal interactive
     // login shell with full PATH, aliases, and profile scripts loaded.
     final parts = <String>[
       'tmux new-window -t ${_shellQuote(sessionName)}',
-      if (workingDirectory != null && workingDirectory.trim().isNotEmpty)
-        '-c ${_shellQuote(workingDirectory.trim())}',
+      if (cwd != null && cwd.trim().isNotEmpty) '-c ${_shellQuote(cwd.trim())}',
       if (name != null && name.trim().isNotEmpty)
         '-n ${_shellQuote(name.trim())}',
     ];
@@ -163,6 +166,24 @@ class TmuxService {
         'tmux send-keys -t ${_shellQuote(sessionName)} '
         '${_shellQuote(command.trim())} Enter',
       );
+    }
+  }
+
+  /// Returns the current pane's working directory via tmux.
+  Future<String?> _currentPaneCwd(
+    SshSession session,
+    String sessionName,
+  ) async {
+    try {
+      final output = await _exec(
+        session,
+        'tmux display-message -t ${_shellQuote(sessionName)} '
+        "-p '#{pane_current_path}'",
+      );
+      final path = output.trim();
+      return path.isNotEmpty ? path : null;
+    } on Object {
+      return null;
     }
   }
 

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -10,9 +10,18 @@ import 'ssh_service.dart';
 ///
 /// All queries use `SshSession.execute()` to avoid interfering with the
 /// interactive shell. The results are parsed from tmux's `-F` format strings.
+///
+/// The tmux binary path is cached after first successful detection to
+/// avoid redundant profile sourcing on subsequent calls.
 class TmuxService {
   /// Creates a new [TmuxService].
   const TmuxService();
+
+  /// Cached tmux binary paths per SSH session (by connectionId).
+  static final Map<int, String> _tmuxPathCache = {};
+
+  /// Clears the cached tmux path for a connection.
+  void clearCache(int connectionId) => _tmuxPathCache.remove(connectionId);
 
   // ── Detection ──────────────────────────────────────────────────────────
 
@@ -24,6 +33,8 @@ class TmuxService {
   /// shell's environment.
   Future<bool> isTmuxActive(SshSession session) async {
     try {
+      // Cache the tmux binary path on first successful detection.
+      await _cacheTmuxPath(session);
       final output = await _exec(session, 'tmux list-sessions 2>/dev/null');
       return output.trim().isNotEmpty;
     } on Exception {
@@ -138,12 +149,11 @@ class TmuxService {
   /// This is a tmux server operation — the server notifies all attached
   /// clients of the change, so it works correctly regardless of which
   /// channel sends the command.
-  Future<void> selectWindow(
-    SshSession session,
-    String sessionName,
-    int windowIndex,
-  ) async {
-    await _exec(
+  ///
+  /// Uses fire-and-forget for instant response — the window switch is
+  /// visible immediately in the interactive terminal PTY.
+  void selectWindow(SshSession session, String sessionName, int windowIndex) {
+    _execFireAndForget(
       session,
       'tmux select-window -t ${_shellQuote(sessionName)}:$windowIndex',
     );
@@ -161,19 +171,72 @@ class TmuxService {
   /// Drains both stdout and stderr to prevent SSH channel flow-control
   /// deadlocks, and awaits channel completion.
   Future<String> _exec(SshSession session, String command) async {
-    // Source the user's shell profile to pick up PATH additions (e.g.
-    // Homebrew, linuxbrew, nix, etc.) before running the actual command.
-    final wrappedCommand =
-        '. ~/.profile 2>/dev/null; '
-        '. ~/.bash_profile 2>/dev/null; '
-        '. ~/.zprofile 2>/dev/null; '
-        '$command';
+    // If we have a cached tmux path, rewrite bare 'tmux' to the full path.
+    final cachedPath = _tmuxPathCache[session.connectionId];
+    final resolvedCommand = cachedPath != null
+        ? command.replaceFirst('tmux ', '$cachedPath ')
+        : command;
+
+    // Only source profiles if we don't have a cached path yet.
+    final wrappedCommand = cachedPath != null
+        ? resolvedCommand
+        : '. ~/.profile 2>/dev/null; '
+              '. ~/.bash_profile 2>/dev/null; '
+              '. ~/.zprofile 2>/dev/null; '
+              '$command';
     final execSession = await session.execute(wrappedCommand);
     final results = await Future.wait([
       execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
       execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
     ]);
     return results[0];
+  }
+
+  /// Fire-and-forget: sends a tmux command without waiting for output.
+  ///
+  /// Used for operations like `select-window` where the result is
+  /// visible immediately in the interactive terminal. Avoids the
+  /// latency of draining stdout/stderr.
+  void _execFireAndForget(SshSession session, String command) {
+    final cachedPath = _tmuxPathCache[session.connectionId];
+    final resolvedCommand = cachedPath != null
+        ? command.replaceFirst('tmux ', '$cachedPath ')
+        : command;
+    final wrappedCommand = cachedPath != null
+        ? resolvedCommand
+        : '. ~/.profile 2>/dev/null; '
+              '. ~/.bash_profile 2>/dev/null; '
+              '. ~/.zprofile 2>/dev/null; '
+              '$command';
+    // Launch and ignore — the exec channel self-closes on completion.
+    session.execute(wrappedCommand).then((exec) {
+      // Drain streams to prevent backpressure, but don't wait.
+      exec.stdout.drain<void>();
+      exec.stderr.drain<void>();
+    }).ignore();
+  }
+
+  /// Resolves and caches the full path to the tmux binary.
+  Future<void> _cacheTmuxPath(SshSession session) async {
+    if (_tmuxPathCache.containsKey(session.connectionId)) return;
+    try {
+      final execSession = await session.execute(
+        '. ~/.profile 2>/dev/null; '
+        '. ~/.bash_profile 2>/dev/null; '
+        '. ~/.zprofile 2>/dev/null; '
+        'command -v tmux',
+      );
+      final results = await Future.wait([
+        execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
+        execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
+      ]);
+      final path = results[0].trim();
+      if (path.isNotEmpty && path.startsWith('/')) {
+        _tmuxPathCache[session.connectionId] = path;
+      }
+    } on Object {
+      // Ignore — we'll fall back to profile sourcing.
+    }
   }
 
   /// Parses non-empty lines from [output] using [parser].

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -132,16 +132,19 @@ class TmuxService {
 
   // ── Window mutations ───────────────────────────────────────────────────
 
-  /// Creates a new window in [sessionName], optionally running [command]
-  /// and/or setting a window [name].
+  /// Creates a new window in [sessionName], optionally running [command],
+  /// setting a window [name], and/or starting in [workingDirectory].
   Future<void> createWindow(
     SshSession session,
     String sessionName, {
     String? command,
     String? name,
+    String? workingDirectory,
   }) async {
     final parts = <String>[
       'tmux new-window -t ${_shellQuote(sessionName)}',
+      if (workingDirectory != null && workingDirectory.trim().isNotEmpty)
+        '-c ${_shellQuote(workingDirectory.trim())}',
       if (name != null && name.trim().isNotEmpty)
         '-n ${_shellQuote(name.trim())}',
       if (command != null && command.trim().isNotEmpty)

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -96,12 +96,14 @@ class TmuxService {
       // Fall through to fallback.
     }
 
-    // Fallback — find the first attached session.
+    // Fallback — find attached sessions.
     try {
       final sessions = await listSessions(session);
       final attached = sessions.where((s) => s.isAttached).toList();
-      if (attached.isNotEmpty) return attached.first.name;
-      // If no attached session, tmux is running but user isn't in it.
+      if (attached.length == 1) return attached.first.name;
+      // Multiple attached sessions are ambiguous — we can't determine
+      // which one belongs to this terminal connection. Return null to
+      // avoid targeting the wrong session with destructive operations.
       return null;
     } on Exception {
       return null;
@@ -218,7 +220,7 @@ class TmuxService {
     final results = await Future.wait([
       execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
       execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
-    ]);
+    ]).timeout(const Duration(seconds: 10), onTimeout: () => ['', '']);
     return results[0];
   }
 
@@ -232,8 +234,8 @@ class TmuxService {
     // Launch and ignore — the exec channel self-closes on completion.
     session.execute(wrappedCommand).then((exec) {
       // Drain streams to prevent backpressure, but don't wait.
-      exec.stdout.drain<void>();
-      exec.stderr.drain<void>();
+      exec.stdout.drain<void>().ignore();
+      exec.stderr.drain<void>().ignore();
     }).ignore();
   }
 
@@ -259,7 +261,7 @@ class TmuxService {
       final results = await Future.wait([
         execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
         execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
-      ]);
+      ]).timeout(const Duration(seconds: 10), onTimeout: () => ['', '']);
       final lines = results[0].trim().split('\n');
       if (lines.isNotEmpty) {
         final shellName = lines[0].trim();

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -193,9 +193,10 @@ class TmuxService {
     final cached = _profileSourceCache[connectionId];
     if (cached != null) return cached;
     // Fallback — source all common profiles until shell is detected.
-    return '. ~/.profile 2>/dev/null; '
-        '. ~/.bash_profile 2>/dev/null; '
-        '. ~/.zprofile 2>/dev/null; ';
+    // Redirect stdout to avoid profile greeting/MOTD output corrupting
+    // our parsed command results.
+    return '{ . ~/.profile; . ~/.bash_profile; . ~/.zprofile; } '
+        '>/dev/null 2>&1; ';
   }
 
   /// Wraps [command] with profile sourcing or cached path substitution.
@@ -217,11 +218,15 @@ class TmuxService {
   Future<String> _exec(SshSession session, String command) async {
     final wrappedCommand = _wrapCommand(session, command);
     final execSession = await session.execute(wrappedCommand);
-    final results = await Future.wait([
-      execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
-      execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
-    ]).timeout(const Duration(seconds: 10), onTimeout: () => ['', '']);
-    return results[0];
+    try {
+      final results = await Future.wait([
+        execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
+        execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
+      ]).timeout(const Duration(seconds: 10), onTimeout: () => ['', '']);
+      return results[0];
+    } finally {
+      execSession.close();
+    }
   }
 
   /// Fire-and-forget: sends a tmux command without waiting for output.
@@ -247,35 +252,40 @@ class TmuxService {
     if (_tmuxPathCache.containsKey(session.connectionId)) return;
     try {
       // Detect login shell and resolve tmux path in a single exec.
+      // Redirect stdout from profile scripts to /dev/null so greetings,
+      // MOTD, or fortune output don't corrupt our parsed output.
       final execSession = await session.execute(
-        // Print shell name, then source appropriate profile and find tmux.
         r'SHELL_NAME=$(basename "$SHELL" 2>/dev/null || echo sh); '
         r'case "$SHELL_NAME" in '
-        'zsh) . ~/.zprofile 2>/dev/null;; '
-        'bash) . ~/.bash_profile 2>/dev/null; . ~/.profile 2>/dev/null;; '
-        '*) . ~/.profile 2>/dev/null;; '
+        'zsh) { . ~/.zprofile; } >/dev/null 2>&1;; '
+        'bash) { . ~/.bash_profile; . ~/.profile; } >/dev/null 2>&1;; '
+        '*) { . ~/.profile; } >/dev/null 2>&1;; '
         'esac; '
         r'echo "$SHELL_NAME"; '
         'command -v tmux',
       );
-      final results = await Future.wait([
-        execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
-        execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
-      ]).timeout(const Duration(seconds: 10), onTimeout: () => ['', '']);
-      final lines = results[0].trim().split('\n');
-      if (lines.isNotEmpty) {
-        final shellName = lines[0].trim();
-        _profileSourceCache[session.connectionId] = switch (shellName) {
-          'zsh' => '. ~/.zprofile 2>/dev/null; ',
-          'bash' => '. ~/.bash_profile 2>/dev/null; . ~/.profile 2>/dev/null; ',
-          _ => '. ~/.profile 2>/dev/null; ',
-        };
-      }
-      if (lines.length > 1) {
-        final path = lines[1].trim();
-        if (path.isNotEmpty && path.startsWith('/')) {
-          _tmuxPathCache[session.connectionId] = path;
+      try {
+        final results = await Future.wait([
+          execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
+          execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
+        ]).timeout(const Duration(seconds: 10), onTimeout: () => ['', '']);
+        final lines = results[0].trim().split('\n');
+        if (lines.isNotEmpty) {
+          final shellName = lines[0].trim();
+          _profileSourceCache[session.connectionId] = switch (shellName) {
+            'zsh' => '{ . ~/.zprofile; } >/dev/null 2>&1; ',
+            'bash' => '{ . ~/.bash_profile; . ~/.profile; } >/dev/null 2>&1; ',
+            _ => '{ . ~/.profile; } >/dev/null 2>&1; ',
+          };
         }
+        if (lines.length > 1) {
+          final path = lines[1].trim();
+          if (path.isNotEmpty && path.startsWith('/')) {
+            _tmuxPathCache[session.connectionId] = path;
+          }
+        }
+      } finally {
+        execSession.close();
       }
     } on Object {
       // Ignore — we'll fall back to sourcing all profiles.

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -129,6 +129,7 @@ class TmuxService {
   /// Returns `true` if [sessionName] exists on the remote tmux server.
   Future<bool> hasSession(SshSession session, String sessionName) async {
     try {
+      await _cacheTmuxPath(session);
       final output = await _exec(
         session,
         'tmux has-session -t ${_shellQuote(sessionName)} 2>/dev/null && printf 1',

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -65,10 +65,9 @@ class TmuxService {
     try {
       final output = await _exec(
         session,
-        'SEP=\$(printf \'\\037\'); '
         'tmux list-sessions -F '
-        r'"#{session_name}${SEP}#{session_windows}${SEP}'
-        r'#{session_attached}${SEP}#{session_activity}"',
+        "'#{session_name}|#{session_windows}|"
+        "#{session_attached}|#{session_activity}'",
       );
       return _parseLines(output, TmuxSession.fromTmuxFormat);
     } on Exception {
@@ -120,17 +119,12 @@ class TmuxService {
   ) async {
     try {
       final quotedName = _shellQuote(sessionName);
-      // Use ASCII Unit Separator as field delimiter so pipes, symbols,
-      // and emoji in window names / pane titles don't break parsing.
-      // Generate the separator via printf to avoid raw control chars
-      // in the command string.
       final output = await _exec(
         session,
-        'SEP=\$(printf \'\\037\'); '
         'tmux list-windows -t $quotedName -F '
-        r'"#{window_index}${SEP}#{window_name}${SEP}#{window_active}${SEP}'
-        r'#{pane_current_command}${SEP}#{pane_current_path}${SEP}'
-        r'#{window_flags}${SEP}#{pane_title}${SEP}#{window_activity}"',
+        "'#{window_index}|#{window_name}|#{window_active}|"
+        '#{pane_current_command}|#{pane_current_path}|'
+        "#{window_flags}|#{pane_title}|#{window_activity}'",
       );
       return _parseLines(output, TmuxWindow.fromTmuxFormat);
     } on Exception {

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -63,6 +63,10 @@ class TmuxService {
   /// Returns `true` if tmux is installed on the remote host.
   Future<bool> isTmuxInstalled(SshSession session) async {
     try {
+      final cachedTmuxPath = _tmuxPathCache[session.connectionId];
+      if (cachedTmuxPath != null && cachedTmuxPath.isNotEmpty) {
+        return true;
+      }
       final output = await _exec(session, 'which tmux');
       return output.trim().isNotEmpty;
     } on Exception {

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -122,7 +122,7 @@ class TmuxService {
         'tmux list-windows -t $quotedName -F '
         "'#{window_index}|#{window_name}|#{window_active}|"
         '#{pane_current_command}|#{pane_current_path}|'
-        "#{window_flags}|#{pane_title}'",
+        "#{window_flags}|#{pane_title}|#{window_activity}'",
       );
       return _parseLines(output, TmuxWindow.fromTmuxFormat);
     } on Exception {

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -58,16 +58,34 @@ class TmuxService {
     }
   }
 
-  /// Returns the name of the tmux session the interactive shell is
-  /// currently inside, or `null` if not in tmux.
+  /// Returns the name of the tmux session the user is most likely
+  /// interacting with, or `null` if no session can be identified.
+  ///
+  /// First tries `tmux display-message` (works when the exec shell
+  /// inherits the tmux context). If that fails, falls back to finding
+  /// the first attached session from `tmux list-sessions` — this covers
+  /// the common case where the interactive shell is inside tmux but the
+  /// exec channel is not.
   Future<String?> currentSessionName(SshSession session) async {
     try {
+      // Direct approach — works if the exec channel is inside tmux.
       final output = await _exec(
         session,
         "tmux display-message -p '#{session_name}'",
       );
       final name = output.trim();
-      return name.isEmpty ? null : name;
+      if (name.isNotEmpty) return name;
+    } on Exception {
+      // Fall through to fallback.
+    }
+
+    // Fallback — find the first attached session.
+    try {
+      final sessions = await listSessions(session);
+      final attached = sessions.where((s) => s.isAttached).toList();
+      if (attached.isNotEmpty) return attached.first.name;
+      // If no attached session, tmux is running but user isn't in it.
+      return null;
     } on Exception {
       return null;
     }

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -214,10 +214,12 @@ class TmuxService {
   /// Wraps [command] with profile sourcing or cached path substitution.
   String _wrapCommand(SshSession session, String command) {
     final cachedPath = _tmuxPathCache[session.connectionId];
-    if (cachedPath != null) {
-      return command.replaceFirst('tmux ', '$cachedPath ');
-    }
-    return '${_profilePrefix(session.connectionId)}$command';
+    final prefixedCommand = cachedPath != null
+        ? command.replaceFirst('tmux ', '$cachedPath ')
+        : command;
+    // Always source the login-shell profile so locale- and PATH-related tmux
+    // settings stay consistent even after the binary path is cached.
+    return '${_profilePrefix(session.connectionId)}$prefixedCommand';
   }
 
   /// Runs a command via SSH exec channel and returns stdout as a string.

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -65,7 +65,7 @@ class TmuxService {
     try {
       final output = await _exec(
         session,
-        'SEP=\$(printf \'\\x1f\'); '
+        'SEP=\$(printf \'\\037\'); '
         'tmux list-sessions -F '
         r'"#{session_name}${SEP}#{session_windows}${SEP}'
         r'#{session_attached}${SEP}#{session_activity}"',
@@ -126,7 +126,7 @@ class TmuxService {
       // in the command string.
       final output = await _exec(
         session,
-        'SEP=\$(printf \'\\x1f\'); '
+        'SEP=\$(printf \'\\037\'); '
         'tmux list-windows -t $quotedName -F '
         r'"#{window_index}${SEP}#{window_name}${SEP}#{window_active}${SEP}'
         r'#{pane_current_command}${SEP}#{pane_current_path}${SEP}'

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -46,7 +46,13 @@ class HomeScreen extends ConsumerStatefulWidget {
 class _HomeScreenState extends ConsumerState<HomeScreen>
     with WidgetsBindingObserver {
   int _selectedIndex = 0;
-  bool _hasAutoSwitchedToConnections = false;
+
+  /// Switches to the Connections tab so the user lands there when
+  /// returning from the terminal.
+  void switchToConnectionsTab() {
+    if (_selectedIndex != 1) setState(() => _selectedIndex = 1);
+  }
+
   StreamSubscription<String>? _incomingTransferSubscription;
   final Queue<String> _incomingTransferQueue = Queue<String>();
   String? _activeIncomingTransferPayload;
@@ -227,24 +233,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
   @override
   Widget build(BuildContext context) {
-    // Auto-switch to Connections tab once when first connection appears,
-    // so the user lands on Connections after connecting from Hosts.
-    // Does not repeat so the user can freely switch back to Hosts.
-    final connectionStates = ref.watch(activeSessionsProvider);
-    if (!_hasAutoSwitchedToConnections &&
-        _selectedIndex == 0 &&
-        connectionStates.isNotEmpty) {
-      _hasAutoSwitchedToConnections = true;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && _selectedIndex == 0) {
-          setState(() => _selectedIndex = 1);
-        }
-      });
-    }
-    if (connectionStates.isEmpty) {
-      _hasAutoSwitchedToConnections = false;
-    }
-
     final screenWidth = MediaQuery.of(context).size.width;
     final isWide = screenWidth >= _mobileBreakpoint;
 
@@ -900,6 +888,9 @@ class _HostRow extends ConsumerWidget {
 
     if (connectionIds.length == 1) {
       if (context.mounted) {
+        context
+            .findAncestorStateOfType<_HomeScreenState>()
+            ?.switchToConnectionsTab();
         unawaited(
           context.push(
             '/terminal/${host.id}?connectionId=${connectionIds.first}',
@@ -982,6 +973,9 @@ class _HostRow extends ConsumerWidget {
 
     final selectedId = int.tryParse(selection.replaceFirst('connection:', ''));
     if (selectedId != null) {
+      context
+          .findAncestorStateOfType<_HomeScreenState>()
+          ?.switchToConnectionsTab();
       unawaited(context.push('/terminal/${host.id}?connectionId=$selectedId'));
     }
   }
@@ -1015,6 +1009,11 @@ class _HostRow extends ConsumerWidget {
     unawaited(
       context.push('/terminal/${host.id}?connectionId=${result.connectionId}'),
     );
+    if (context.mounted) {
+      context
+          .findAncestorStateOfType<_HomeScreenState>()
+          ?.switchToConnectionsTab();
+    }
   }
 
   Future<void> _showContextMenu(

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2303,6 +2303,7 @@ class _TmuxConnectionBadge extends ConsumerStatefulWidget {
 class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
+  final Set<String> _expandedSessionTools = <String>{};
   String? _sessionName;
   bool _queried = false;
   bool _expanded = false;
@@ -2464,8 +2465,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                   ),
                 )
               else if (_recentSessions != null)
-                for (final session in _recentSessions!.take(5))
-                  _buildSessionRow(theme, session),
+                ..._groupSessions(_recentSessions!).entries.map(
+                  (entry) => _buildSessionGroup(theme, entry.key, entry.value),
+                ),
             ],
           ],
         ],
@@ -2521,10 +2523,13 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
 
     try {
       final discovery = ref.read(agentSessionDiscoveryServiceProvider);
-      final sessions = await discovery.discoverSessions(session, maxPerTool: 3);
+      final sessions = await discovery.discoverSessions(session, maxPerTool: 8);
       if (!mounted) return;
       setState(() {
         _recentSessions = sessions;
+        if (_expandedSessionTools.isEmpty && sessions.isNotEmpty) {
+          _expandedSessionTools.add(sessions.first.toolName);
+        }
         _isLoadingSessions = false;
       });
     } on Exception {
@@ -2557,21 +2562,95 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         .ignore();
   }
 
-  Widget _buildSessionRow(ThemeData theme, ToolSessionInfo info) {
-    final iconData = switch (info.toolName) {
-      'Claude Code' => Icons.auto_awesome,
-      'Codex' => Icons.code,
-      'Copilot CLI' => Icons.flight,
-      'Gemini CLI' => Icons.diamond_outlined,
-      'OpenCode' => Icons.terminal,
-      _ => Icons.smart_toy_outlined,
-    };
+  Map<String, List<ToolSessionInfo>> _groupSessions(
+    List<ToolSessionInfo> sessions,
+  ) {
+    final grouped = <String, List<ToolSessionInfo>>{};
+    for (final session in sessions) {
+      grouped
+          .putIfAbsent(session.toolName, () => <ToolSessionInfo>[])
+          .add(session);
+    }
+    return grouped;
+  }
+
+  Widget _buildSessionGroup(
+    ThemeData theme,
+    String toolName,
+    List<ToolSessionInfo> sessions,
+  ) {
+    final isExpanded = _expandedSessionTools.contains(toolName);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        InkWell(
+          onTap: () {
+            setState(() {
+              if (isExpanded) {
+                _expandedSessionTools.remove(toolName);
+              } else {
+                _expandedSessionTools.add(toolName);
+              }
+            });
+          },
+          borderRadius: BorderRadius.circular(6),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+            child: Row(
+              children: [
+                Icon(
+                  _toolIconData(toolName),
+                  size: 14,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    toolName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurface,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                Text(
+                  '${sessions.length}',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(width: 4),
+                Icon(
+                  isExpanded ? Icons.expand_less : Icons.expand_more,
+                  size: 14,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ],
+            ),
+          ),
+        ),
+        if (isExpanded)
+          for (final session in sessions)
+            _buildSessionRow(theme, session, indent: 20),
+      ],
+    );
+  }
+
+  Widget _buildSessionRow(
+    ThemeData theme,
+    ToolSessionInfo info, {
+    double indent = 0,
+  }) {
+    final iconData = _toolIconData(info.toolName);
 
     return InkWell(
       onTap: () => _resumeSession(info),
       borderRadius: BorderRadius.circular(6),
       child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 4),
+        padding: EdgeInsets.fromLTRB(4 + indent, 3, 4, 3),
         child: Row(
           children: [
             Icon(iconData, size: 14, color: theme.colorScheme.primary),
@@ -2599,6 +2678,15 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       ),
     );
   }
+
+  IconData _toolIconData(String toolName) => switch (toolName) {
+    'Claude Code' => Icons.auto_awesome,
+    'Codex' => Icons.code,
+    'Copilot CLI' => Icons.flight,
+    'Gemini CLI' => Icons.diamond_outlined,
+    'OpenCode' => Icons.terminal,
+    _ => Icons.smart_toy_outlined,
+  };
 
   Widget _buildWindowRow(ThemeData theme, TmuxWindow window) {
     final title = window.paneTitle ?? window.name;

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -16,12 +16,14 @@ import '../../data/repositories/snippet_repository.dart';
 import '../../domain/models/monetization.dart';
 import '../../domain/models/terminal_theme.dart';
 import '../../domain/models/terminal_themes.dart';
+import '../../domain/models/tmux_state.dart';
 import '../../domain/services/auth_service.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/secure_transfer_service.dart';
 import '../../domain/services/settings_service.dart';
 import '../../domain/services/ssh_service.dart';
 import '../../domain/services/terminal_theme_service.dart';
+import '../../domain/services/tmux_service.dart';
 import '../../domain/services/transfer_intent_service.dart';
 import '../providers/entity_list_providers.dart';
 import '../widgets/connection_attempt_dialog.dart';
@@ -1339,41 +1341,53 @@ class _ConnectionsPanel extends ConsumerWidget {
                               : null),
                     );
 
-                    return ListTile(
-                      leading: Icon(
-                        Icons.terminal,
-                        color: state == SshConnectionState.connected
-                            ? colorScheme.primary
-                            : colorScheme.onSurfaceVariant,
-                      ),
-                      title: Text(host?.label ?? 'Host ${connection.hostId}'),
-                      subtitle: _ConnectionPreviewText(
-                        endpoint:
-                            '$endpoint  •  Connection #${connection.connectionId}',
-                        preview: preview,
-                        windowTitle: connection.windowTitle,
-                        iconName: connection.iconName,
-                        workingDirectory: connection.workingDirectory,
-                        shellStatus: connection.shellStatus,
-                        lastExitCode: connection.lastExitCode,
-                        terminalTheme: previewTheme,
-                      ),
-                      isThreeLine: preview?.trim().isNotEmpty ?? false,
-                      trailing: IconButton(
-                        icon: const Icon(Icons.close),
-                        tooltip: 'Disconnect',
-                        onPressed: () async {
-                          await ref
-                              .read(activeSessionsProvider.notifier)
-                              .disconnect(connection.connectionId);
-                        },
-                      ),
-                      onTap: () => unawaited(
-                        context.push(
-                          '/terminal/${connection.hostId}'
-                          '?connectionId=${connection.connectionId}',
+                    return Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        ListTile(
+                          leading: Icon(
+                            Icons.terminal,
+                            color: state == SshConnectionState.connected
+                                ? colorScheme.primary
+                                : colorScheme.onSurfaceVariant,
+                          ),
+                          title: Text(
+                            host?.label ?? 'Host ${connection.hostId}',
+                          ),
+                          subtitle: _ConnectionPreviewText(
+                            endpoint:
+                                '$endpoint  •  Connection #${connection.connectionId}',
+                            preview: preview,
+                            windowTitle: connection.windowTitle,
+                            iconName: connection.iconName,
+                            workingDirectory: connection.workingDirectory,
+                            shellStatus: connection.shellStatus,
+                            lastExitCode: connection.lastExitCode,
+                            terminalTheme: previewTheme,
+                          ),
+                          isThreeLine: preview?.trim().isNotEmpty ?? false,
+                          trailing: IconButton(
+                            icon: const Icon(Icons.close),
+                            tooltip: 'Disconnect',
+                            onPressed: () async {
+                              await ref
+                                  .read(activeSessionsProvider.notifier)
+                                  .disconnect(connection.connectionId);
+                            },
+                          ),
+                          onTap: () => unawaited(
+                            context.push(
+                              '/terminal/${connection.hostId}'
+                              '?connectionId=${connection.connectionId}',
+                            ),
+                          ),
                         ),
-                      ),
+                        if (state == SshConnectionState.connected)
+                          _TmuxConnectionBadge(
+                            connectionId: connection.connectionId,
+                            hostId: connection.hostId,
+                          ),
+                      ],
                     );
                   },
                 ),
@@ -2253,5 +2267,117 @@ class _SnippetRow extends ConsumerWidget {
         ).showSnackBar(SnackBar(content: Text('Deleted "${snippet.name}"')));
       }
     }
+  }
+}
+
+/// Shows a compact tmux window badge below a connection tile.
+///
+/// Asynchronously queries tmux state for the given connection and displays
+/// a horizontal list of window name chips if tmux is active.
+class _TmuxConnectionBadge extends ConsumerStatefulWidget {
+  const _TmuxConnectionBadge({
+    required this.connectionId,
+    required this.hostId,
+  });
+
+  final int connectionId;
+  final int hostId;
+
+  @override
+  ConsumerState<_TmuxConnectionBadge> createState() =>
+      _TmuxConnectionBadgeState();
+}
+
+class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
+  List<TmuxWindow>? _windows;
+  bool _queried = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _queryTmux();
+  }
+
+  Future<void> _queryTmux() async {
+    final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
+    final session = sessionsNotifier.getSession(widget.connectionId);
+    if (session == null) return;
+
+    final tmux = ref.read(tmuxServiceProvider);
+    final active = await tmux.isTmuxActive(session);
+    if (!mounted || !active) {
+      if (mounted) setState(() => _queried = true);
+      return;
+    }
+
+    final sessionName = await tmux.currentSessionName(session);
+    if (!mounted || sessionName == null) {
+      if (mounted) setState(() => _queried = true);
+      return;
+    }
+
+    final windows = await tmux.listWindows(session, sessionName);
+    if (!mounted) return;
+    setState(() {
+      _windows = windows;
+      _queried = true;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_queried || _windows == null || _windows!.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final theme = Theme.of(context);
+    final windows = _windows!;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(56, 0, 16, 8),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            Icon(
+              Icons.window_outlined,
+              size: 14,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(width: 4),
+            Text(
+              'tmux:',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(width: 6),
+            for (final window in windows) ...[
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: window.isActive
+                      ? theme.colorScheme.primaryContainer
+                      : theme.colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  window.name,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: window.isActive
+                        ? theme.colorScheme.onPrimaryContainer
+                        : theme.colorScheme.onSurfaceVariant,
+                    fontWeight: window.isActive
+                        ? FontWeight.bold
+                        : FontWeight.normal,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 4),
+            ],
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2559,6 +2559,20 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         .getSession(widget.connectionId);
     if (session == null || _sessionName == null) return;
 
+    // Check if a window is already running this tool — switch to it
+    // instead of opening a duplicate.
+    final toolCmd = info.toolName.toLowerCase().split(' ').first;
+    final existingWindow = _windows?.where((w) {
+      final cmd = w.currentCommand?.toLowerCase() ?? '';
+      final winName = w.name.toLowerCase();
+      return cmd == toolCmd || winName == toolCmd;
+    }).firstOrNull;
+
+    if (existingWindow != null) {
+      _switchAndOpenWindow(existingWindow.index);
+      return;
+    }
+
     final discovery = ref.read(agentSessionDiscoveryServiceProvider);
     final command = discovery.buildResumeCommand(info);
     final tmux = ref.read(tmuxServiceProvider);

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2305,7 +2305,11 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   Future<void> _queryTmux() async {
     final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
     final session = sessionsNotifier.getSession(widget.connectionId);
-    if (session == null) return;
+    if (session == null) {
+      // Session not available yet; mark queried to avoid permanent spinner.
+      if (mounted) setState(() => _queried = true);
+      return;
+    }
 
     final tmux = ref.read(tmuxServiceProvider);
     final active = await tmux.isTmuxActive(session);

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1407,6 +1407,9 @@ class _ConnectionsPanel extends ConsumerWidget {
                             icon: const Icon(Icons.close),
                             tooltip: 'Disconnect',
                             onPressed: () async {
+                              ref
+                                  .read(tmuxServiceProvider)
+                                  .clearCache(connection.connectionId);
                               await ref
                                   .read(activeSessionsProvider.notifier)
                                   .disconnect(connection.connectionId);
@@ -2339,6 +2342,7 @@ class _TmuxConnectionBadge extends ConsumerStatefulWidget {
 class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   static const _initialSessionFetchLimit = 12;
   static const _sessionFetchStep = 12;
+  static const _tmuxQueryRetryDelay = Duration(seconds: 2);
 
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
@@ -2395,7 +2399,11 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         );
     }
 
-    if (_showSessions) {
+    if (!_hasAgentSessionAccess) {
+      _showSessions = false;
+    }
+
+    if (_showSessions && _hasAgentSessionAccess) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _loadRecentSessions();
       });
@@ -2414,30 +2422,54 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     }, identifier: _pageStorageIdentifier);
   }
 
+  bool get _hasAgentSessionAccess {
+    final monetizationState =
+        ref.read(monetizationStateProvider).asData?.value ??
+        ref.read(monetizationServiceProvider).currentState;
+    return monetizationState.allowsFeature(
+      MonetizationFeature.agentLaunchPresets,
+    );
+  }
+
+  Future<void> _retryTmuxQuery(int retries) async {
+    if (retries <= 0 || !mounted) {
+      if (mounted) {
+        setState(() => _queried = true);
+      }
+      return;
+    }
+    await Future<void>.delayed(_tmuxQueryRetryDelay);
+    if (mounted) {
+      await _queryTmux(retries: retries - 1);
+    }
+  }
+
+  Future<void> _handleLockedAiSessionsTap() => requireMonetizationFeatureAccess(
+    context: context,
+    ref: ref,
+    feature: MonetizationFeature.agentLaunchPresets,
+  );
+
   Future<void> _queryTmux({int retries = 3}) async {
     final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
     final session = sessionsNotifier.getSession(widget.connectionId);
     if (session == null) {
       // Session not available yet — retry after a delay so the badge
       // still appears for connections that finish establishing shortly.
-      if (retries > 0 && mounted) {
-        await Future<void>.delayed(const Duration(seconds: 2));
-        if (mounted) return _queryTmux(retries: retries - 1);
-      }
-      if (mounted) setState(() => _queried = true);
+      await _retryTmuxQuery(retries);
       return;
     }
 
     final tmux = ref.read(tmuxServiceProvider);
     final active = await tmux.isTmuxActive(session);
     if (!mounted || !active) {
-      if (mounted) setState(() => _queried = true);
+      await _retryTmuxQuery(retries);
       return;
     }
 
     final sessionName = await tmux.currentSessionName(session);
     if (!mounted || sessionName == null) {
-      if (mounted) setState(() => _queried = true);
+      await _retryTmuxQuery(retries);
       return;
     }
 
@@ -2491,6 +2523,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     }
 
     final theme = Theme.of(context);
+    final hasAgentSessionAccess = _hasAgentSessionAccess;
     final windows = _windows!;
     final alertCount = windows.where((w) => w.hasAlert).length;
 
@@ -2556,91 +2589,48 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
             const SizedBox(height: 4),
             for (final window in windows) _buildWindowRow(theme, window),
 
-            // Recent AI Sessions subsection.
             const SizedBox(height: 4),
-            GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: () {
-                setState(() => _showSessions = !_showSessions);
-                _persistUiState();
-                if (_showSessions) _loadRecentSessions();
-              },
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 2),
-                child: Row(
-                  children: [
-                    Icon(
-                      Icons.smart_toy_outlined,
-                      size: 12,
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
-                    const SizedBox(width: 4),
-                    Text(
-                      'AI Sessions',
-                      style: theme.textTheme.labelSmall?.copyWith(
+            if (hasAgentSessionAccess) ...[
+              // Recent AI Sessions subsection.
+              GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {
+                  setState(() => _showSessions = !_showSessions);
+                  _persistUiState();
+                  if (_showSessions) _loadRecentSessions();
+                },
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 6,
+                    horizontal: 2,
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.smart_toy_outlined,
+                        size: 12,
                         color: theme.colorScheme.onSurfaceVariant,
                       ),
-                    ),
-                    const Spacer(),
-                    Icon(
-                      _showSessions ? Icons.expand_less : Icons.expand_more,
-                      size: 14,
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
-                  ],
+                      const SizedBox(width: 4),
+                      Text(
+                        'AI Sessions',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      const Spacer(),
+                      Icon(
+                        _showSessions ? Icons.expand_less : Icons.expand_more,
+                        size: 14,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ],
+                  ),
                 ),
               ),
-            ),
-            if (_showSessions) ...[
-              if (_isLoadingSessions &&
-                  (_recentSessions == null || _recentSessions!.isEmpty))
-                const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 8),
-                  child: Center(
-                    child: SizedBox(
-                      width: 14,
-                      height: 14,
-                      child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-                    ),
-                  ),
-                )
-              else if (_sessionLoadError != null &&
-                  _recentSessions != null &&
-                  _recentSessions!.isEmpty)
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 4),
-                  child: Text(
-                    _sessionLoadError!,
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: theme.colorScheme.error,
-                    ),
-                  ),
-                )
-              else if (_recentSessions != null && _recentSessions!.isEmpty)
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 4),
-                  child: Text(
-                    'No recent sessions found',
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                )
-              else if (_recentSessions != null) ...[
-                if (_sessionLoadError != null)
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 4),
-                    child: Text(
-                      _sessionLoadError!,
-                      style: theme.textTheme.labelSmall?.copyWith(
-                        color: theme.colorScheme.error,
-                      ),
-                    ),
-                  ),
-                ..._groupSessions(_recentSessions!).entries.map(
-                  (entry) => _buildSessionGroup(theme, entry.key, entry.value),
-                ),
-                if (_isLoadingSessions)
+              if (_showSessions) ...[
+                if (_isLoadingSessions &&
+                    (_recentSessions == null || _recentSessions!.isEmpty))
                   const Padding(
                     padding: EdgeInsets.symmetric(vertical: 8),
                     child: Center(
@@ -2652,17 +2642,108 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                         ),
                       ),
                     ),
-                  ),
-                if (_canLoadMoreSessions)
+                  )
+                else if (_sessionLoadError != null &&
+                    _recentSessions != null &&
+                    _recentSessions!.isEmpty)
                   Padding(
-                    padding: const EdgeInsets.only(top: 2),
-                    child: TextButton(
-                      onPressed: _loadMoreSessions,
-                      child: const Text('Load more'),
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Text(
+                      _sessionLoadError!,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.error,
+                      ),
                     ),
+                  )
+                else if (_recentSessions != null && _recentSessions!.isEmpty)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Text(
+                      'No recent sessions found',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  )
+                else if (_recentSessions != null) ...[
+                  if (_sessionLoadError != null)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 4),
+                      child: Text(
+                        _sessionLoadError!,
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.error,
+                        ),
+                      ),
+                    ),
+                  ..._groupSessions(_recentSessions!).entries.map(
+                    (entry) =>
+                        _buildSessionGroup(theme, entry.key, entry.value),
                   ),
+                  if (_isLoadingSessions)
+                    const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 8),
+                      child: Center(
+                        child: SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator.adaptive(
+                            strokeWidth: 2,
+                          ),
+                        ),
+                      ),
+                    ),
+                  if (_canLoadMoreSessions)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 2),
+                      child: TextButton(
+                        onPressed: _loadMoreSessions,
+                        child: const Text('Load more'),
+                      ),
+                    ),
+                ],
               ],
-            ],
+            ] else
+              InkWell(
+                onTap: () => unawaited(_handleLockedAiSessionsTap()),
+                borderRadius: BorderRadius.circular(6),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 6,
+                    horizontal: 2,
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.smart_toy_outlined,
+                        size: 12,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        'AI Sessions',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      const SizedBox(width: 6),
+                      Icon(
+                        Icons.workspace_premium,
+                        size: 12,
+                        color: theme.colorScheme.primary,
+                      ),
+                      const Spacer(),
+                      Text(
+                        'Pro',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.primary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
           ],
         ],
       ),
@@ -2699,6 +2780,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   }
 
   Future<void> _loadRecentSessions({bool forceReload = false}) async {
+    if (!_hasAgentSessionAccess) {
+      return;
+    }
     if (_isLoadingSessions || (_recentSessions != null && !forceReload)) return;
     final previousCount = _recentSessions?.length ?? 0;
     setState(() {
@@ -2775,6 +2859,10 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   }
 
   void _resumeSession(ToolSessionInfo info) {
+    if (!_hasAgentSessionAccess) {
+      unawaited(_handleLockedAiSessionsTap());
+      return;
+    }
     final session = ref
         .read(activeSessionsProvider.notifier)
         .getSession(widget.connectionId);

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2793,27 +2793,39 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       child: Padding(
         padding: EdgeInsets.fromLTRB(6 + indent, 6, 6, 6),
         child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Icon(iconData, size: 14, color: theme.colorScheme.primary),
             const SizedBox(width: 6),
             Expanded(
-              child: Text(
-                info.summary ?? info.sessionId,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.onSurface,
-                ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    info.summary ?? info.sessionId,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurface,
+                    ),
+                  ),
+                  if (info.lastUpdatedLabel.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 2),
+                      child: Text(
+                        info.lastUpdatedLabel,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          fontSize: 10,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                ],
               ),
             ),
-            if (info.lastUpdatedLabel.isNotEmpty)
-              Text(
-                info.lastUpdatedLabel,
-                style: theme.textTheme.labelSmall?.copyWith(
-                  fontSize: 10,
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-              ),
           ],
         ),
       ),

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -17,6 +17,7 @@ import '../../domain/models/monetization.dart';
 import '../../domain/models/terminal_theme.dart';
 import '../../domain/models/terminal_themes.dart';
 import '../../domain/models/tmux_state.dart';
+import '../../domain/services/agent_session_discovery_service.dart';
 import '../../domain/services/auth_service.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/secure_transfer_service.dart';
@@ -2301,8 +2302,12 @@ class _TmuxConnectionBadge extends ConsumerStatefulWidget {
 
 class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   List<TmuxWindow>? _windows;
+  List<ToolSessionInfo>? _recentSessions;
+  String? _sessionName;
   bool _queried = false;
   bool _expanded = false;
+  bool _showSessions = false;
+  bool _isLoadingSessions = false;
 
   @override
   void initState() {
@@ -2336,6 +2341,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     if (!mounted) return;
     setState(() {
       _windows = windows;
+      _sessionName = sessionName;
       _queried = true;
     });
   }
@@ -2402,8 +2408,191 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
           if (_expanded) ...[
             const SizedBox(height: 4),
             for (final window in windows) _buildWindowRow(theme, window),
+
+            // Recent AI Sessions subsection.
+            const SizedBox(height: 4),
+            GestureDetector(
+              onTap: () {
+                setState(() => _showSessions = !_showSessions);
+                if (_showSessions) _loadRecentSessions();
+              },
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.smart_toy_outlined,
+                    size: 12,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    'AI Sessions',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const Spacer(),
+                  Icon(
+                    _showSessions ? Icons.expand_less : Icons.expand_more,
+                    size: 14,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ],
+              ),
+            ),
+            if (_showSessions) ...[
+              if (_isLoadingSessions)
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 8),
+                  child: Center(
+                    child: SizedBox(
+                      width: 14,
+                      height: 14,
+                      child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                    ),
+                  ),
+                )
+              else if (_recentSessions != null && _recentSessions!.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Text(
+                    'No recent sessions found',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                )
+              else if (_recentSessions != null)
+                for (final session in _recentSessions!.take(5))
+                  _buildSessionRow(theme, session),
+            ],
           ],
         ],
+      ),
+    );
+  }
+
+  void _closeWindow(int windowIndex) {
+    final session = ref
+        .read(activeSessionsProvider.notifier)
+        .getSession(widget.connectionId);
+    if (session == null || _sessionName == null) return;
+
+    ref
+        .read(tmuxServiceProvider)
+        .killWindow(session, _sessionName!, windowIndex);
+
+    // Optimistically remove from the list.
+    setState(() {
+      _windows = _windows?.where((w) => w.index != windowIndex).toList();
+    });
+  }
+
+  void _switchAndOpenWindow(int windowIndex) {
+    // Switch tmux to the target window before opening the terminal.
+    final session = ref
+        .read(activeSessionsProvider.notifier)
+        .getSession(widget.connectionId);
+    if (session != null && _sessionName != null) {
+      ref
+          .read(tmuxServiceProvider)
+          .selectWindow(session, _sessionName!, windowIndex);
+    }
+    widget.onTap();
+  }
+
+  Future<void> _loadRecentSessions() async {
+    if (_isLoadingSessions || _recentSessions != null) return;
+    setState(() => _isLoadingSessions = true);
+
+    final session = ref
+        .read(activeSessionsProvider.notifier)
+        .getSession(widget.connectionId);
+    if (session == null) {
+      if (mounted) {
+        setState(() {
+          _recentSessions = const [];
+          _isLoadingSessions = false;
+        });
+      }
+      return;
+    }
+
+    try {
+      final discovery = ref.read(agentSessionDiscoveryServiceProvider);
+      final sessions = await discovery.discoverSessions(session, maxPerTool: 3);
+      if (!mounted) return;
+      setState(() {
+        _recentSessions = sessions;
+        _isLoadingSessions = false;
+      });
+    } on Exception {
+      if (!mounted) return;
+      setState(() {
+        _recentSessions = const [];
+        _isLoadingSessions = false;
+      });
+    }
+  }
+
+  void _resumeSession(ToolSessionInfo info) {
+    final session = ref
+        .read(activeSessionsProvider.notifier)
+        .getSession(widget.connectionId);
+    if (session == null || _sessionName == null) return;
+
+    final discovery = ref.read(agentSessionDiscoveryServiceProvider);
+    final command = discovery.buildResumeCommand(info);
+    final tmux = ref.read(tmuxServiceProvider);
+    tmux
+        .createWindow(
+          session,
+          _sessionName!,
+          command: command,
+          name: info.toolName,
+        )
+        .then((_) => widget.onTap())
+        .ignore();
+  }
+
+  Widget _buildSessionRow(ThemeData theme, ToolSessionInfo info) {
+    final iconData = switch (info.toolName) {
+      'Claude Code' => Icons.auto_awesome,
+      'Codex' => Icons.code,
+      'Copilot CLI' => Icons.flight,
+      'Gemini CLI' => Icons.diamond_outlined,
+      'OpenCode' => Icons.terminal,
+      _ => Icons.smart_toy_outlined,
+    };
+
+    return InkWell(
+      onTap: () => _resumeSession(info),
+      borderRadius: BorderRadius.circular(6),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 4),
+        child: Row(
+          children: [
+            Icon(iconData, size: 14, color: theme.colorScheme.primary),
+            const SizedBox(width: 6),
+            Expanded(
+              child: Text(
+                info.summary ?? info.sessionId,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurface,
+                ),
+              ),
+            ),
+            if (info.timeAgoLabel.isNotEmpty)
+              Text(
+                info.timeAgoLabel,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  fontSize: 10,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }
@@ -2412,7 +2601,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     final title = window.paneTitle ?? window.name;
 
     return InkWell(
-      onTap: widget.onTap,
+      onTap: () => _switchAndOpenWindow(window.index),
       borderRadius: BorderRadius.circular(6),
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 4),
@@ -2465,6 +2654,15 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                       ? FontWeight.bold
                       : FontWeight.normal,
                 ),
+              ),
+            ),
+            // Close button.
+            GestureDetector(
+              onTap: () => _closeWindow(window.index),
+              child: Icon(
+                Icons.close,
+                size: 14,
+                color: theme.colorScheme.onSurfaceVariant,
               ),
             ),
           ],

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2316,11 +2316,16 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     _queryTmux();
   }
 
-  Future<void> _queryTmux() async {
+  Future<void> _queryTmux({int retries = 3}) async {
     final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
     final session = sessionsNotifier.getSession(widget.connectionId);
     if (session == null) {
-      // Session not available yet; mark queried to avoid permanent spinner.
+      // Session not available yet — retry after a delay so the badge
+      // still appears for connections that finish establishing shortly.
+      if (retries > 0 && mounted) {
+        await Future<void>.delayed(const Duration(seconds: 2));
+        if (mounted) return _queryTmux(retries: retries - 1);
+      }
       if (mounted) setState(() => _queried = true);
       return;
     }
@@ -2523,7 +2528,14 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
 
     try {
       final discovery = ref.read(agentSessionDiscoveryServiceProvider);
-      final sessions = await discovery.discoverSessions(session, maxPerTool: 8);
+      // Scope sessions to the active tmux window's working directory
+      // so results match the current project context.
+      final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
+      final sessions = await discovery.discoverSessions(
+        session,
+        workingDirectory: activeWindow?.currentPath,
+        maxPerTool: 8,
+      );
       if (!mounted) return;
       setState(() {
         _recentSessions = sessions;

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -32,6 +32,7 @@ import '../widgets/connection_preview_snippet.dart';
 import '../widgets/file_picker_helpers.dart';
 import '../widgets/premium_access.dart';
 import '../widgets/reorder_helpers.dart';
+import '../widgets/tmux_window_status_badge.dart';
 import 'transfer_screen.dart';
 
 /// The main home screen - Termius-style sidebar layout.
@@ -2342,6 +2343,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
   final Set<String> _expandedSessionTools = <String>{};
+  String? _sessionLoadError;
   String? _sessionName;
   bool _queried = false;
   bool _expanded = false;
@@ -2602,6 +2604,18 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                     ),
                   ),
                 )
+              else if (_sessionLoadError != null &&
+                  _recentSessions != null &&
+                  _recentSessions!.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Text(
+                    _sessionLoadError!,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.error,
+                    ),
+                  ),
+                )
               else if (_recentSessions != null && _recentSessions!.isEmpty)
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 4),
@@ -2613,6 +2627,16 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                   ),
                 )
               else if (_recentSessions != null) ...[
+                if (_sessionLoadError != null)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 4),
+                    child: Text(
+                      _sessionLoadError!,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.error,
+                      ),
+                    ),
+                  ),
                 ..._groupSessions(_recentSessions!).entries.map(
                   (entry) => _buildSessionGroup(theme, entry.key, entry.value),
                 ),
@@ -2677,7 +2701,10 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   Future<void> _loadRecentSessions({bool forceReload = false}) async {
     if (_isLoadingSessions || (_recentSessions != null && !forceReload)) return;
     final previousCount = _recentSessions?.length ?? 0;
-    setState(() => _isLoadingSessions = true);
+    setState(() {
+      _isLoadingSessions = true;
+      _sessionLoadError = null;
+    });
 
     final session = ref
         .read(activeSessionsProvider.notifier)
@@ -2698,20 +2725,21 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       // Scope sessions to the active tmux window's working directory
       // so results match the current project context.
       final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
-      final sessions = await discovery.discoverSessions(
+      final result = await discovery.discoverSessions(
         session,
         workingDirectory: activeWindow?.currentPath,
         maxPerTool: _sessionFetchLimit,
       );
       if (!mounted) return;
       setState(() {
-        _recentSessions = sessions;
-        if (_expandedSessionTools.isEmpty && sessions.isNotEmpty) {
-          _expandedSessionTools.add(sessions.first.toolName);
+        _recentSessions = result.sessions;
+        _sessionLoadError = result.failureMessage;
+        if (_expandedSessionTools.isEmpty && result.sessions.isNotEmpty) {
+          _expandedSessionTools.add(result.sessions.first.toolName);
         }
         _canLoadMoreSessions =
-            sessions.length > previousCount &&
-            _hasSessionGroupAtLimit(sessions);
+            result.sessions.length > previousCount &&
+            _hasSessionGroupAtLimit(result.sessions);
         _isLoadingSessions = false;
       });
       _persistUiState();
@@ -2719,6 +2747,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       if (!mounted) return;
       setState(() {
         _recentSessions = const [];
+        _sessionLoadError = 'Could not load recent AI sessions.';
         _canLoadMoreSessions = false;
         _isLoadingSessions = false;
       });
@@ -2963,6 +2992,10 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                       : FontWeight.normal,
                 ),
               ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(left: 6, right: 6),
+              child: TmuxWindowStatusBadge(window: window),
             ),
             // Close button.
             GestureDetector(

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -53,6 +53,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     if (_selectedIndex != 1) setState(() => _selectedIndex = 1);
   }
 
+  /// Switches back to the Hosts tab.
+  void switchToHostsTab() {
+    if (_selectedIndex != 0) setState(() => _selectedIndex = 0);
+  }
+
   StreamSubscription<String>? _incomingTransferSubscription;
   final Queue<String> _incomingTransferQueue = Queue<String>();
   String? _activeIncomingTransferPayload;
@@ -233,6 +238,22 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<Map<int, SshConnectionState>>(activeSessionsProvider, (
+      previous,
+      next,
+    ) {
+      final hadConnections = previous?.isNotEmpty ?? false;
+      if (!hadConnections || next.isNotEmpty || _selectedIndex != 1) {
+        return;
+      }
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || _selectedIndex != 1) {
+          return;
+        }
+        switchToHostsTab();
+      });
+    });
+
     final screenWidth = MediaQuery.of(context).size.width;
     final isWide = screenWidth >= _mobileBreakpoint;
 
@@ -2329,11 +2350,20 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   bool _canLoadMoreSessions = false;
   int _sessionFetchLimit = _initialSessionFetchLimit;
   bool _restoredUiState = false;
+  StreamSubscription<void>? _windowChangeSubscription;
+  bool _loadingWindows = false;
+  bool _pendingWindowReload = false;
 
   @override
   void initState() {
     super.initState();
     _queryTmux();
+  }
+
+  @override
+  void dispose() {
+    unawaited(_windowChangeSubscription?.cancel());
+    super.dispose();
   }
 
   @override
@@ -2409,13 +2439,47 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       return;
     }
 
-    final windows = await tmux.listWindows(session, sessionName);
-    if (!mounted) return;
-    setState(() {
-      _windows = windows;
-      _sessionName = sessionName;
-      _queried = true;
-    });
+    await _windowChangeSubscription?.cancel();
+    _windowChangeSubscription = tmux
+        .watchWindowChanges(session, sessionName)
+        .listen((_) {
+          if (!mounted) return;
+          _refreshTmuxWindows(session, sessionName);
+        });
+    await _refreshTmuxWindows(session, sessionName);
+  }
+
+  Future<void> _refreshTmuxWindows(
+    SshSession session,
+    String sessionName,
+  ) async {
+    if (_loadingWindows) {
+      _pendingWindowReload = true;
+      return;
+    }
+    _loadingWindows = true;
+    try {
+      final windows = await ref
+          .read(tmuxServiceProvider)
+          .listWindows(session, sessionName);
+      if (!mounted) return;
+      setState(() {
+        _windows = windows;
+        _sessionName = sessionName;
+        _queried = true;
+      });
+    } on Object {
+      if (!mounted) return;
+      setState(() {
+        _queried = true;
+      });
+    } finally {
+      _loadingWindows = false;
+      if (_pendingWindowReload) {
+        _pendingWindowReload = false;
+        unawaited(_refreshTmuxWindows(session, sessionName));
+      }
+    }
   }
 
   @override

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1384,6 +1384,9 @@ class _ConnectionsPanel extends ConsumerWidget {
                         ),
                         if (state == SshConnectionState.connected)
                           _TmuxConnectionBadge(
+                            key: ValueKey(
+                              'tmux-badge-${connection.connectionId}',
+                            ),
                             connectionId: connection.connectionId,
                             hostId: connection.hostId,
                           ),
@@ -2278,6 +2281,7 @@ class _TmuxConnectionBadge extends ConsumerStatefulWidget {
   const _TmuxConnectionBadge({
     required this.connectionId,
     required this.hostId,
+    super.key,
   });
 
   final int connectionId;

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1388,6 +1388,12 @@ class _ConnectionsPanel extends ConsumerWidget {
                               'tmux-badge-${connection.connectionId}',
                             ),
                             connectionId: connection.connectionId,
+                            onTap: () => unawaited(
+                              context.push(
+                                '/terminal/${connection.hostId}'
+                                '?connectionId=${connection.connectionId}',
+                              ),
+                            ),
                           ),
                       ],
                     );
@@ -2277,9 +2283,16 @@ class _SnippetRow extends ConsumerWidget {
 /// Asynchronously queries tmux state for the given connection and displays
 /// a horizontal list of window name chips if tmux is active.
 class _TmuxConnectionBadge extends ConsumerStatefulWidget {
-  const _TmuxConnectionBadge({required this.connectionId, super.key});
+  const _TmuxConnectionBadge({
+    required this.connectionId,
+    required this.onTap,
+    super.key,
+  });
 
   final int connectionId;
+
+  /// Called when the user taps a window chip — opens the terminal.
+  final VoidCallback onTap;
 
   @override
   ConsumerState<_TmuxConnectionBadge> createState() =>
@@ -2289,6 +2302,7 @@ class _TmuxConnectionBadge extends ConsumerStatefulWidget {
 class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   List<TmuxWindow>? _windows;
   bool _queried = false;
+  bool _expanded = false;
 
   @override
   void initState() {
@@ -2334,49 +2348,125 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
 
     final theme = Theme.of(context);
     final windows = _windows!;
+    final alertCount = windows.where((w) => w.hasAlert).length;
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(56, 0, 16, 8),
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Collapsed summary row — tap to expand/collapse.
+          GestureDetector(
+            onTap: () => setState(() => _expanded = !_expanded),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.window_outlined,
+                  size: 14,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  'tmux · ${windows.length} windows',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                if (alertCount > 0) ...[
+                  const SizedBox(width: 4),
+                  Icon(
+                    Icons.notifications_active,
+                    size: 12,
+                    color: theme.colorScheme.error,
+                  ),
+                  const SizedBox(width: 2),
+                  Text(
+                    '$alertCount',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.error,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
+                const Spacer(),
+                Icon(
+                  _expanded ? Icons.expand_less : Icons.expand_more,
+                  size: 16,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ],
+            ),
+          ),
+
+          // Expanded window list.
+          if (_expanded) ...[
+            const SizedBox(height: 4),
+            for (final window in windows) _buildWindowRow(theme, window),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildWindowRow(ThemeData theme, TmuxWindow window) {
+    final title = window.paneTitle ?? window.name;
+
+    return InkWell(
+      onTap: widget.onTap,
+      borderRadius: BorderRadius.circular(6),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 4),
         child: Row(
           children: [
-            Icon(
-              Icons.window_outlined,
-              size: 14,
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-            const SizedBox(width: 4),
-            Text(
-              'tmux:',
-              style: theme.textTheme.labelSmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
+            // Window index badge.
+            Container(
+              width: 20,
+              height: 20,
+              decoration: BoxDecoration(
+                color: window.isActive
+                    ? theme.colorScheme.primary
+                    : theme.colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              alignment: Alignment.center,
+              child: Text(
+                '${window.index}',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  fontSize: 10,
+                  color: window.isActive
+                      ? theme.colorScheme.onPrimary
+                      : theme.colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
             const SizedBox(width: 6),
-            for (final window in windows) ...[
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                decoration: BoxDecoration(
-                  color: window.isActive
-                      ? theme.colorScheme.primaryContainer
-                      : theme.colorScheme.surfaceContainerHighest,
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                child: Text(
-                  window.name,
-                  style: theme.textTheme.labelSmall?.copyWith(
-                    color: window.isActive
-                        ? theme.colorScheme.onPrimaryContainer
-                        : theme.colorScheme.onSurfaceVariant,
-                    fontWeight: window.isActive
-                        ? FontWeight.bold
-                        : FontWeight.normal,
-                  ),
+            // Alert icon.
+            if (window.hasAlert)
+              Padding(
+                padding: const EdgeInsets.only(right: 4),
+                child: Icon(
+                  Icons.notifications_active,
+                  size: 12,
+                  color: theme.colorScheme.error,
                 ),
               ),
-              const SizedBox(width: 4),
-            ],
+            // Title — truncated.
+            Expanded(
+              child: Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: window.isActive
+                      ? theme.colorScheme.primary
+                      : theme.colorScheme.onSurface,
+                  fontWeight: window.isActive
+                      ? FontWeight.bold
+                      : FontWeight.normal,
+                ),
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2559,20 +2559,6 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         .getSession(widget.connectionId);
     if (session == null || _sessionName == null) return;
 
-    // Check if a window is already running this tool — switch to it
-    // instead of opening a duplicate.
-    final toolCmd = info.toolName.toLowerCase().split(' ').first;
-    final existingWindow = _windows?.where((w) {
-      final cmd = w.currentCommand?.toLowerCase() ?? '';
-      final winName = w.name.toLowerCase();
-      return cmd == toolCmd || winName == toolCmd;
-    }).firstOrNull;
-
-    if (existingWindow != null) {
-      _switchAndOpenWindow(existingWindow.index);
-      return;
-    }
-
     final discovery = ref.read(agentSessionDiscoveryServiceProvider);
     final command = discovery.buildResumeCommand(info);
     final tmux = ref.read(tmuxServiceProvider);

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -46,6 +46,7 @@ class HomeScreen extends ConsumerStatefulWidget {
 class _HomeScreenState extends ConsumerState<HomeScreen>
     with WidgetsBindingObserver {
   int _selectedIndex = 0;
+  bool _hasAutoSwitchedToConnections = false;
   StreamSubscription<String>? _incomingTransferSubscription;
   final Queue<String> _incomingTransferQueue = Queue<String>();
   String? _activeIncomingTransferPayload;
@@ -226,16 +227,22 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
   @override
   Widget build(BuildContext context) {
-    // When returning from a terminal session, auto-switch to the
-    // Connections tab if there are active connections so the user
-    // can immediately see and manage windows/sessions.
+    // Auto-switch to Connections tab once when first connection appears,
+    // so the user lands on Connections after connecting from Hosts.
+    // Does not repeat so the user can freely switch back to Hosts.
     final connectionStates = ref.watch(activeSessionsProvider);
-    if (_selectedIndex == 0 && connectionStates.isNotEmpty) {
+    if (!_hasAutoSwitchedToConnections &&
+        _selectedIndex == 0 &&
+        connectionStates.isNotEmpty) {
+      _hasAutoSwitchedToConnections = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted && _selectedIndex == 0) {
           setState(() => _selectedIndex = 1);
         }
       });
+    }
+    if (connectionStates.isEmpty) {
+      _hasAutoSwitchedToConnections = false;
     }
 
     final screenWidth = MediaQuery.of(context).size.width;

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1388,7 +1388,6 @@ class _ConnectionsPanel extends ConsumerWidget {
                               'tmux-badge-${connection.connectionId}',
                             ),
                             connectionId: connection.connectionId,
-                            hostId: connection.hostId,
                           ),
                       ],
                     );
@@ -2278,14 +2277,9 @@ class _SnippetRow extends ConsumerWidget {
 /// Asynchronously queries tmux state for the given connection and displays
 /// a horizontal list of window name chips if tmux is active.
 class _TmuxConnectionBadge extends ConsumerStatefulWidget {
-  const _TmuxConnectionBadge({
-    required this.connectionId,
-    required this.hostId,
-    super.key,
-  });
+  const _TmuxConnectionBadge({required this.connectionId, super.key});
 
   final int connectionId;
-  final int hostId;
 
   @override
   ConsumerState<_TmuxConnectionBadge> createState() =>

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -226,6 +226,18 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
   @override
   Widget build(BuildContext context) {
+    // When returning from a terminal session, auto-switch to the
+    // Connections tab if there are active connections so the user
+    // can immediately see and manage windows/sessions.
+    final connectionStates = ref.watch(activeSessionsProvider);
+    if (_selectedIndex == 0 && connectionStates.isNotEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _selectedIndex == 0) {
+          setState(() => _selectedIndex = 1);
+        }
+      });
+    }
+
     final screenWidth = MediaQuery.of(context).size.width;
     final isWide = screenWidth >= _mobileBreakpoint;
 

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2551,6 +2551,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
           _sessionName!,
           command: command,
           name: info.toolName,
+          workingDirectory: info.workingDirectory,
         )
         .then((_) => widget.onTap())
         .ignore();

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2373,7 +2373,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                 ),
                 const SizedBox(width: 4),
                 Text(
-                  'tmux · ${windows.length} windows',
+                  _sessionName != null
+                      ? '$_sessionName · ${windows.length} windows'
+                      : 'tmux · ${windows.length} windows',
                   style: theme.textTheme.labelSmall?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -411,20 +411,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     );
   }
 
-  Widget _buildContent() {
-    switch (_selectedIndex) {
-      case 0:
-        return const HostsPanel();
-      case 1:
-        return const _ConnectionsPanel();
-      case 2:
-        return const _KeysPanel();
-      case 3:
-        return const SnippetsPanel();
-      default:
-        return const HostsPanel();
-    }
-  }
+  Widget _buildContent() => switch (_selectedIndex) {
+    0 => const HostsPanel(),
+    1 => const _ConnectionsPanel(),
+    2 => const _KeysPanel(),
+    3 => const SnippetsPanel(),
+    _ => const HostsPanel(),
+  };
 }
 
 class _NavItem extends StatelessWidget {
@@ -1250,6 +1243,9 @@ class _ConnectionSelectionTile extends StatelessWidget {
         ? endpoint
         : '$endpoint\nOpened ${_formatTime(createdAt!)}';
     return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      minTileHeight: 64,
+      minVerticalPadding: 10,
       leading: const Icon(Icons.terminal),
       title: Text('Connection #$connectionId'),
       subtitle: _ConnectionPreviewText(
@@ -2319,6 +2315,9 @@ class _TmuxConnectionBadge extends ConsumerStatefulWidget {
 }
 
 class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
+  static const _initialSessionFetchLimit = 12;
+  static const _sessionFetchStep = 12;
+
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
   final Set<String> _expandedSessionTools = <String>{};
@@ -2327,11 +2326,60 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   bool _expanded = false;
   bool _showSessions = false;
   bool _isLoadingSessions = false;
+  bool _canLoadMoreSessions = false;
+  int _sessionFetchLimit = _initialSessionFetchLimit;
+  bool _restoredUiState = false;
 
   @override
   void initState() {
     super.initState();
     _queryTmux();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_restoredUiState) return;
+    _restoredUiState = true;
+
+    final storedState = PageStorage.maybeOf(
+      context,
+    )?.readState(context, identifier: _pageStorageIdentifier);
+    if (storedState is! Map<Object?, Object?>) return;
+
+    _expanded = storedState['expanded'] as bool? ?? _expanded;
+    _showSessions = storedState['showSessions'] as bool? ?? _showSessions;
+    _sessionFetchLimit =
+        storedState['sessionFetchLimit'] as int? ?? _sessionFetchLimit;
+
+    final expandedSessionTools = storedState['expandedSessionTools'];
+    if (expandedSessionTools is List<Object?>) {
+      _expandedSessionTools
+        ..clear()
+        ..addAll(
+          expandedSessionTools.whereType<String>().where(
+            (toolName) => toolName.isNotEmpty,
+          ),
+        );
+    }
+
+    if (_showSessions) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _loadRecentSessions();
+      });
+    }
+  }
+
+  String get _pageStorageIdentifier =>
+      'tmux-badge-state-${widget.connectionId}';
+
+  void _persistUiState() {
+    PageStorage.maybeOf(context)?.writeState(context, <String, Object>{
+      'expanded': _expanded,
+      'showSessions': _showSessions,
+      'sessionFetchLimit': _sessionFetchLimit,
+      'expandedSessionTools': _expandedSessionTools.toList(growable: false),
+    }, identifier: _pageStorageIdentifier);
   }
 
   Future<void> _queryTmux({int retries = 3}) async {
@@ -2387,46 +2435,53 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         children: [
           // Collapsed summary row — tap to expand/collapse.
           GestureDetector(
-            onTap: () => setState(() => _expanded = !_expanded),
-            child: Row(
-              children: [
-                Icon(
-                  Icons.window_outlined,
-                  size: 14,
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-                const SizedBox(width: 4),
-                Text(
-                  _sessionName != null
-                      ? '$_sessionName · ${windows.length} windows'
-                      : 'tmux · ${windows.length} windows',
-                  style: theme.textTheme.labelSmall?.copyWith(
+            behavior: HitTestBehavior.opaque,
+            onTap: () {
+              setState(() => _expanded = !_expanded);
+              _persistUiState();
+            },
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 2),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.window_outlined,
+                    size: 14,
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
-                ),
-                if (alertCount > 0) ...[
                   const SizedBox(width: 4),
-                  Icon(
-                    Icons.notifications_active,
-                    size: 12,
-                    color: theme.colorScheme.error,
-                  ),
-                  const SizedBox(width: 2),
                   Text(
-                    '$alertCount',
+                    _sessionName != null
+                        ? '$_sessionName · ${windows.length} windows'
+                        : 'tmux · ${windows.length} windows',
                     style: theme.textTheme.labelSmall?.copyWith(
-                      color: theme.colorScheme.error,
-                      fontWeight: FontWeight.bold,
+                      color: theme.colorScheme.onSurfaceVariant,
                     ),
                   ),
+                  if (alertCount > 0) ...[
+                    const SizedBox(width: 4),
+                    Icon(
+                      Icons.notifications_active,
+                      size: 12,
+                      color: theme.colorScheme.error,
+                    ),
+                    const SizedBox(width: 2),
+                    Text(
+                      '$alertCount',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.error,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                  const Spacer(),
+                  Icon(
+                    _expanded ? Icons.expand_less : Icons.expand_more,
+                    size: 16,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
                 ],
-                const Spacer(),
-                Icon(
-                  _expanded ? Icons.expand_less : Icons.expand_more,
-                  size: 16,
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-              ],
+              ),
             ),
           ),
 
@@ -2438,35 +2493,41 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
             // Recent AI Sessions subsection.
             const SizedBox(height: 4),
             GestureDetector(
+              behavior: HitTestBehavior.opaque,
               onTap: () {
                 setState(() => _showSessions = !_showSessions);
+                _persistUiState();
                 if (_showSessions) _loadRecentSessions();
               },
-              child: Row(
-                children: [
-                  Icon(
-                    Icons.smart_toy_outlined,
-                    size: 12,
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                  const SizedBox(width: 4),
-                  Text(
-                    'AI Sessions',
-                    style: theme.textTheme.labelSmall?.copyWith(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 2),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.smart_toy_outlined,
+                      size: 12,
                       color: theme.colorScheme.onSurfaceVariant,
                     ),
-                  ),
-                  const Spacer(),
-                  Icon(
-                    _showSessions ? Icons.expand_less : Icons.expand_more,
-                    size: 14,
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                ],
+                    const SizedBox(width: 4),
+                    Text(
+                      'AI Sessions',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const Spacer(),
+                    Icon(
+                      _showSessions ? Icons.expand_less : Icons.expand_more,
+                      size: 14,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ],
+                ),
               ),
             ),
             if (_showSessions) ...[
-              if (_isLoadingSessions)
+              if (_isLoadingSessions &&
+                  (_recentSessions == null || _recentSessions!.isEmpty))
                 const Padding(
                   padding: EdgeInsets.symmetric(vertical: 8),
                   child: Center(
@@ -2487,10 +2548,32 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                     ),
                   ),
                 )
-              else if (_recentSessions != null)
+              else if (_recentSessions != null) ...[
                 ..._groupSessions(_recentSessions!).entries.map(
                   (entry) => _buildSessionGroup(theme, entry.key, entry.value),
                 ),
+                if (_isLoadingSessions)
+                  const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 8),
+                    child: Center(
+                      child: SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator.adaptive(
+                          strokeWidth: 2,
+                        ),
+                      ),
+                    ),
+                  ),
+                if (_canLoadMoreSessions)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: TextButton(
+                      onPressed: _loadMoreSessions,
+                      child: const Text('Load more'),
+                    ),
+                  ),
+              ],
             ],
           ],
         ],
@@ -2527,8 +2610,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     widget.onTap();
   }
 
-  Future<void> _loadRecentSessions() async {
-    if (_isLoadingSessions || _recentSessions != null) return;
+  Future<void> _loadRecentSessions({bool forceReload = false}) async {
+    if (_isLoadingSessions || (_recentSessions != null && !forceReload)) return;
+    final previousCount = _recentSessions?.length ?? 0;
     setState(() => _isLoadingSessions = true);
 
     final session = ref
@@ -2538,6 +2622,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       if (mounted) {
         setState(() {
           _recentSessions = const [];
+          _canLoadMoreSessions = false;
           _isLoadingSessions = false;
         });
       }
@@ -2552,7 +2637,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       final sessions = await discovery.discoverSessions(
         session,
         workingDirectory: activeWindow?.currentPath,
-        maxPerTool: 8,
+        maxPerTool: _sessionFetchLimit,
       );
       if (!mounted) return;
       setState(() {
@@ -2560,15 +2645,40 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         if (_expandedSessionTools.isEmpty && sessions.isNotEmpty) {
           _expandedSessionTools.add(sessions.first.toolName);
         }
+        _canLoadMoreSessions =
+            sessions.length > previousCount &&
+            _hasSessionGroupAtLimit(sessions);
         _isLoadingSessions = false;
       });
+      _persistUiState();
     } on Exception {
       if (!mounted) return;
       setState(() {
         _recentSessions = const [];
+        _canLoadMoreSessions = false;
         _isLoadingSessions = false;
       });
+      _persistUiState();
     }
+  }
+
+  void _loadMoreSessions() {
+    if (_isLoadingSessions) return;
+    setState(() => _sessionFetchLimit += _sessionFetchStep);
+    _persistUiState();
+    _loadRecentSessions(forceReload: true);
+  }
+
+  bool _hasSessionGroupAtLimit(List<ToolSessionInfo> sessions) {
+    final countsByTool = <String, int>{};
+    for (final session in sessions) {
+      countsByTool.update(
+        session.toolName,
+        (count) => count + 1,
+        ifAbsent: () => 1,
+      );
+    }
+    return countsByTool.values.any((count) => count >= _sessionFetchLimit);
   }
 
   void _resumeSession(ToolSessionInfo info) {
@@ -2623,10 +2733,11 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                 _expandedSessionTools.add(toolName);
               }
             });
+            _persistUiState();
           },
           borderRadius: BorderRadius.circular(6),
           child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+            padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 6),
             child: Row(
               children: [
                 Icon(
@@ -2680,7 +2791,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       onTap: () => _resumeSession(info),
       borderRadius: BorderRadius.circular(6),
       child: Padding(
-        padding: EdgeInsets.fromLTRB(4 + indent, 3, 4, 3),
+        padding: EdgeInsets.fromLTRB(6 + indent, 6, 6, 6),
         child: Row(
           children: [
             Icon(iconData, size: 14, color: theme.colorScheme.primary),
@@ -2695,9 +2806,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                 ),
               ),
             ),
-            if (info.timeAgoLabel.isNotEmpty)
+            if (info.lastUpdatedLabel.isNotEmpty)
               Text(
-                info.timeAgoLabel,
+                info.lastUpdatedLabel,
                 style: theme.textTheme.labelSmall?.copyWith(
                   fontSize: 10,
                   color: theme.colorScheme.onSurfaceVariant,
@@ -2719,19 +2830,19 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   };
 
   Widget _buildWindowRow(ThemeData theme, TmuxWindow window) {
-    final title = window.paneTitle ?? window.name;
+    final title = window.displayTitle;
 
     return InkWell(
       onTap: () => _switchAndOpenWindow(window.index),
       borderRadius: BorderRadius.circular(6),
       child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 4),
+        padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 6),
         child: Row(
           children: [
             // Window index badge.
             Container(
-              width: 20,
-              height: 20,
+              width: 22,
+              height: 22,
               decoration: BoxDecoration(
                 color: window.isActive
                     ? theme.colorScheme.primary

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -489,7 +489,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                           contentPadding: EdgeInsets.zero,
                           title: const Text('Use agent launch preset'),
                           subtitle: const Text(
-                            'Build a repeatable startup flow for Claude Code, Copilot CLI, or Aider.',
+                            'Build a repeatable startup flow for Claude Code, Copilot CLI, Codex, and more.',
                           ),
                           value: _useAgentLaunchPreset,
                           onChanged: hasAgentPresetAccess

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -15,6 +15,7 @@ import '../../domain/models/agent_launch_preset.dart';
 import '../../domain/models/auto_connect_command.dart';
 import '../../domain/models/monetization.dart';
 import '../../domain/models/terminal_themes.dart';
+import '../../domain/models/tmux_state.dart';
 import '../../domain/services/agent_launch_preset_service.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/secure_transfer_service.dart';
@@ -25,6 +26,18 @@ import '../widgets/premium_badge.dart';
 import '../widgets/terminal_text_style.dart';
 import '../widgets/terminal_theme_picker.dart';
 import 'transfer_screen.dart';
+
+enum _HostStartupMode { none, tmux, agent, customCommand, snippet }
+
+extension _HostStartupModePresentation on _HostStartupMode {
+  String get label => switch (this) {
+    _HostStartupMode.none => 'Do nothing',
+    _HostStartupMode.tmux => 'Open tmux session',
+    _HostStartupMode.agent => 'Launch coding agent',
+    _HostStartupMode.customCommand => 'Run custom command',
+    _HostStartupMode.snippet => 'Run saved snippet',
+  };
+}
 
 /// Screen for adding or editing a host.
 class HostEditScreen extends ConsumerStatefulWidget {
@@ -48,6 +61,9 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   late TextEditingController _passwordController;
   late TextEditingController _tagsController;
   late TextEditingController _autoConnectCommandController;
+  late TextEditingController _tmuxSessionController;
+  late TextEditingController _tmuxWorkingDirectoryController;
+  late TextEditingController _tmuxExtraFlagsController;
   late TextEditingController _agentWorkingDirectoryController;
   late TextEditingController _agentTmuxSessionController;
   late TextEditingController _agentArgumentsController;
@@ -59,9 +75,9 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   String? _selectedLightThemeId;
   String? _selectedDarkThemeId;
   String? _selectedFontFamily;
+  _HostStartupMode _selectedStartupMode = _HostStartupMode.none;
   AutoConnectCommandMode _selectedAutoConnectMode = AutoConnectCommandMode.none;
   AgentLaunchTool _selectedAgentLaunchTool = AgentLaunchTool.claudeCode;
-  bool _useAgentLaunchPreset = false;
   bool _isFavorite = false;
   bool _isLoading = false;
   bool _showPassword = false;
@@ -79,6 +95,9 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     _passwordController = TextEditingController();
     _tagsController = TextEditingController();
     _autoConnectCommandController = TextEditingController();
+    _tmuxSessionController = TextEditingController();
+    _tmuxWorkingDirectoryController = TextEditingController();
+    _tmuxExtraFlagsController = TextEditingController();
     _agentWorkingDirectoryController = TextEditingController();
     _agentTmuxSessionController = TextEditingController();
     _agentArgumentsController = TextEditingController();
@@ -118,10 +137,18 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       _selectedLightThemeId = host.terminalThemeLightId;
       _selectedDarkThemeId = host.terminalThemeDarkId;
       _selectedFontFamily = host.terminalFontFamily;
+      _tmuxSessionController.text = host.tmuxSessionName ?? '';
+      _tmuxWorkingDirectoryController.text = host.tmuxWorkingDirectory ?? '';
+      _tmuxExtraFlagsController.text = host.tmuxExtraFlags ?? '';
       _autoConnectCommandController.text = host.autoConnectCommand ?? '';
       _selectedAutoConnectMode = resolveAutoConnectCommandMode(
         command: host.autoConnectCommand,
         snippetId: host.autoConnectSnippetId,
+      );
+      _selectedStartupMode = _resolveStartupMode(
+        host: host,
+        preset: preset,
+        autoConnectMode: _selectedAutoConnectMode,
       );
       if (preset != null) {
         final presetCommand = buildAgentLaunchCommand(preset);
@@ -129,7 +156,6 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         _agentWorkingDirectoryController.text = preset.workingDirectory ?? '';
         _agentTmuxSessionController.text = preset.tmuxSessionName ?? '';
         _agentArgumentsController.text = preset.additionalArguments ?? '';
-        _useAgentLaunchPreset = true;
         if (_selectedAutoConnectMode == AutoConnectCommandMode.custom ||
             host.autoConnectCommand == presetCommand) {
           _autoConnectCommandController.text = presetCommand;
@@ -150,6 +176,9 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     _passwordController.dispose();
     _tagsController.dispose();
     _autoConnectCommandController.dispose();
+    _tmuxSessionController.dispose();
+    _tmuxWorkingDirectoryController.dispose();
+    _tmuxExtraFlagsController.dispose();
     _agentWorkingDirectoryController.dispose();
     _agentTmuxSessionController.dispose();
     _agentArgumentsController.dispose();
@@ -365,13 +394,19 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                   ),
                   const SizedBox(height: 24),
 
+                  _buildStartupSection(
+                    context: context,
+                    hasAutomationAccess: hasAutomationAccess,
+                    hasAgentPresetAccess: hasAgentPresetAccess,
+                    snippetsAsync: snippetsAsync,
+                  ),
+                  const SizedBox(height: 24),
+
                   // Advanced section
                   ExpansionTile(
                     key: const Key('host-advanced-tile'),
                     title: const Text('Advanced'),
-                    initiallyExpanded:
-                        _selectedJumpHostId != null ||
-                        _selectedAutoConnectMode != AutoConnectCommandMode.none,
+                    initiallyExpanded: _selectedJumpHostId != null,
                     children: [
                       const SizedBox(height: 8),
                       // Jump host dropdown
@@ -421,266 +456,6 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                           );
                         },
                       ),
-                      const SizedBox(height: 24),
-                      Text(
-                        'Auto-Run Command',
-                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                          color: Theme.of(context).colorScheme.primary,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      const PremiumBadge(),
-                      if (!hasAutomationAccess) ...[
-                        const SizedBox(height: 12),
-                        Container(
-                          width: double.infinity,
-                          padding: const EdgeInsets.all(12),
-                          decoration: BoxDecoration(
-                            color: Theme.of(
-                              context,
-                            ).colorScheme.surfaceContainerHighest,
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          child: Text(
-                            _selectedAutoConnectMode ==
-                                    AutoConnectCommandMode.none
-                                ? 'MonkeySSH Pro unlocks auto-run commands, saved snippets, and guided agent launch presets.'
-                                : 'This host keeps its saved Pro automation, but it will not run until MonkeySSH Pro is active again.',
-                            style: Theme.of(context).textTheme.bodySmall,
-                          ),
-                        ),
-                      ],
-                      const SizedBox(height: 12),
-                      DropdownButtonFormField<AutoConnectCommandMode>(
-                        // ignore: deprecated_member_use
-                        value: _selectedAutoConnectMode,
-                        decoration: const InputDecoration(
-                          labelText: 'After terminal connect',
-                          prefixIcon: Icon(Icons.play_circle_outline),
-                          helperText:
-                              'Optional command to run after connecting or reconnecting.',
-                        ),
-                        items: const [
-                          DropdownMenuItem(
-                            value: AutoConnectCommandMode.none,
-                            child: Text('Do nothing'),
-                          ),
-                          DropdownMenuItem(
-                            value: AutoConnectCommandMode.custom,
-                            child: Text('Run custom command'),
-                          ),
-                          DropdownMenuItem(
-                            value: AutoConnectCommandMode.snippet,
-                            child: Text('Run saved snippet'),
-                          ),
-                        ],
-                        onChanged: (value) {
-                          if (value == null) {
-                            return;
-                          }
-                          unawaited(_handleAutoConnectModeSelection(value));
-                        },
-                      ),
-                      if (_selectedAutoConnectMode ==
-                          AutoConnectCommandMode.custom) ...[
-                        const SizedBox(height: 16),
-                        SwitchListTile(
-                          contentPadding: EdgeInsets.zero,
-                          title: const Text('Use agent launch preset'),
-                          subtitle: const Text(
-                            'Build a repeatable startup flow for Claude Code, Copilot CLI, Codex, and more.',
-                          ),
-                          value: _useAgentLaunchPreset,
-                          onChanged: hasAgentPresetAccess
-                              ? (value) {
-                                  setState(() => _useAgentLaunchPreset = value);
-                                  if (value) {
-                                    _syncAutoConnectCommandFromPreset();
-                                  }
-                                }
-                              : null,
-                        ),
-                        if (_useAgentLaunchPreset) ...[
-                          const SizedBox(height: 12),
-                          Text(
-                            'Agent launch preset',
-                            style: Theme.of(context).textTheme.titleSmall,
-                          ),
-                          const SizedBox(height: 12),
-                          SegmentedButton<AgentLaunchTool>(
-                            segments: AgentLaunchTool.values
-                                .map(
-                                  (tool) => ButtonSegment<AgentLaunchTool>(
-                                    value: tool,
-                                    label: Text(tool.label),
-                                  ),
-                                )
-                                .toList(growable: false),
-                            selected: {_selectedAgentLaunchTool},
-                            onSelectionChanged: hasAgentPresetAccess
-                                ? (selection) {
-                                    setState(
-                                      () => _selectedAgentLaunchTool =
-                                          selection.first,
-                                    );
-                                    _syncAutoConnectCommandFromPreset();
-                                  }
-                                : null,
-                          ),
-                          const SizedBox(height: 12),
-                          TextFormField(
-                            controller: _agentWorkingDirectoryController,
-                            readOnly: !hasAgentPresetAccess,
-                            decoration: const InputDecoration(
-                              labelText: 'Working directory (optional)',
-                              hintText: '~/src/app',
-                              prefixIcon: Icon(Icons.folder_outlined),
-                            ),
-                            onChanged: hasAgentPresetAccess
-                                ? (_) => _syncAutoConnectCommandFromPreset()
-                                : null,
-                          ),
-                          const SizedBox(height: 12),
-                          TextFormField(
-                            controller: _agentTmuxSessionController,
-                            readOnly: !hasAgentPresetAccess,
-                            decoration: const InputDecoration(
-                              labelText: 'tmux session (optional)',
-                              hintText: 'app-agent',
-                              prefixIcon: Icon(Icons.view_carousel_outlined),
-                            ),
-                            onChanged: hasAgentPresetAccess
-                                ? (_) => _syncAutoConnectCommandFromPreset()
-                                : null,
-                          ),
-                          const SizedBox(height: 12),
-                          TextFormField(
-                            controller: _agentArgumentsController,
-                            readOnly: !hasAgentPresetAccess,
-                            decoration: const InputDecoration(
-                              labelText: 'Extra arguments (optional)',
-                              hintText: '--resume',
-                              prefixIcon: Icon(Icons.tune_outlined),
-                            ),
-                            onChanged: hasAgentPresetAccess
-                                ? (_) => _syncAutoConnectCommandFromPreset()
-                                : null,
-                          ),
-                          const SizedBox(height: 12),
-                        ],
-                        TextFormField(
-                          key: const Key('host-auto-connect-command-field'),
-                          controller: _autoConnectCommandController,
-                          decoration: InputDecoration(
-                            labelText: _useAgentLaunchPreset
-                                ? 'Generated command'
-                                : 'Custom command',
-                            hintText: defaultAutoConnectCommandSuggestion,
-                            helperText: _useAgentLaunchPreset
-                                ? 'Turn off the preset builder to edit the raw command directly.'
-                                : 'Suggested: tmux new -As MonkeySSH',
-                            prefixIcon: const Icon(Icons.terminal),
-                          ),
-                          minLines: 1,
-                          maxLines: 3,
-                          readOnly:
-                              _useAgentLaunchPreset || !hasAutomationAccess,
-                          autocorrect: false,
-                          validator: (value) {
-                            if (_selectedAutoConnectMode !=
-                                AutoConnectCommandMode.custom) {
-                              return null;
-                            }
-                            if (value == null || value.trim().isEmpty) {
-                              return 'Enter a command or choose "Do nothing"';
-                            }
-                            return null;
-                          },
-                        ),
-                      ],
-                      if (_selectedAutoConnectMode ==
-                          AutoConnectCommandMode.snippet) ...[
-                        const SizedBox(height: 16),
-                        snippetsAsync.when(
-                          loading: () => const LinearProgressIndicator(),
-                          error: (_, _) => const Text('Error loading snippets'),
-                          data: (snippets) {
-                            final selectedSnippetStillExists = snippets.any(
-                              (snippet) =>
-                                  snippet.id == _selectedAutoConnectSnippetId,
-                            );
-                            final effectiveSnippetId =
-                                selectedSnippetStillExists
-                                ? _selectedAutoConnectSnippetId
-                                : null;
-                            final selectedSnippet = effectiveSnippetId == null
-                                ? null
-                                : snippets.firstWhere(
-                                    (snippet) =>
-                                        snippet.id == effectiveSnippetId,
-                                  );
-                            return Column(
-                              children: [
-                                DropdownButtonFormField<int?>(
-                                  // ignore: deprecated_member_use
-                                  value: effectiveSnippetId,
-                                  decoration: const InputDecoration(
-                                    labelText: 'Snippet',
-                                    prefixIcon: Icon(Icons.code),
-                                    helperText:
-                                        'Variable prompts are not shown when a snippet runs automatically.',
-                                  ),
-                                  items: [
-                                    const DropdownMenuItem<int?>(
-                                      child: Text('Choose a snippet'),
-                                    ),
-                                    ...snippets.map(
-                                      (snippet) => DropdownMenuItem<int?>(
-                                        value: snippet.id,
-                                        child: Text(snippet.name),
-                                      ),
-                                    ),
-                                  ],
-                                  onChanged: hasAutomationAccess
-                                      ? (value) => setState(
-                                          () => _selectedAutoConnectSnippetId =
-                                              value,
-                                        )
-                                      : null,
-                                  validator: (value) {
-                                    if (_selectedAutoConnectMode !=
-                                        AutoConnectCommandMode.snippet) {
-                                      return null;
-                                    }
-                                    if (value == null) {
-                                      return 'Choose a snippet or select "Do nothing"';
-                                    }
-                                    return null;
-                                  },
-                                ),
-                                if (selectedSnippet != null) ...[
-                                  const SizedBox(height: 12),
-                                  Align(
-                                    alignment: Alignment.centerLeft,
-                                    child: Text(
-                                      selectedSnippet.command,
-                                      maxLines: 3,
-                                      overflow: TextOverflow.ellipsis,
-                                      style: FluttyTheme.monoStyle.copyWith(
-                                        fontSize: 12,
-                                        color: Theme.of(
-                                          context,
-                                        ).textTheme.bodySmall?.color,
-                                      ),
-                                    ),
-                                  ),
-                                ],
-                              ],
-                            );
-                          },
-                        ),
-                      ],
                       const SizedBox(height: 24),
                       // Terminal theme section
                       Row(
@@ -757,6 +532,410 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     );
   }
 
+  _HostStartupMode _resolveStartupMode({
+    required Host host,
+    required AgentLaunchPreset? preset,
+    required AutoConnectCommandMode autoConnectMode,
+  }) {
+    if (host.tmuxSessionName case final value? when value.trim().isNotEmpty) {
+      return _HostStartupMode.tmux;
+    }
+    if (preset != null) {
+      return _HostStartupMode.agent;
+    }
+    return switch (autoConnectMode) {
+      AutoConnectCommandMode.none => _HostStartupMode.none,
+      AutoConnectCommandMode.custom => _HostStartupMode.customCommand,
+      AutoConnectCommandMode.snippet => _HostStartupMode.snippet,
+    };
+  }
+
+  Widget _buildStartupSection({
+    required BuildContext context,
+    required bool hasAutomationAccess,
+    required bool hasAgentPresetAccess,
+    required AsyncValue<List<Snippet>> snippetsAsync,
+  }) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Wrap(
+          crossAxisAlignment: WrapCrossAlignment.center,
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            Text('Launch After Connect', style: theme.textTheme.titleMedium),
+            const PremiumBadge(),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Optionally open a tmux workspace, launch an agent with tmux window helpers, or run any shell command right after the terminal connects.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ),
+        if (!hasAutomationAccess) ...[
+          const SizedBox(height: 12),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: colorScheme.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Text(
+              _selectedStartupMode == _HostStartupMode.agent ||
+                      _selectedStartupMode == _HostStartupMode.customCommand ||
+                      _selectedStartupMode == _HostStartupMode.snippet
+                  ? 'This host keeps its saved Pro startup, but it will not run until MonkeySSH Pro is active again.'
+                  : 'Free hosts can still open tmux automatically. MonkeySSH Pro unlocks coding agents, custom commands, and saved snippets after connect.',
+              style: theme.textTheme.bodySmall,
+            ),
+          ),
+        ],
+        const SizedBox(height: 12),
+        DropdownButtonFormField<_HostStartupMode>(
+          key: const Key('host-startup-mode-field'),
+          // ignore: deprecated_member_use
+          value: _selectedStartupMode,
+          decoration: const InputDecoration(
+            labelText: 'Startup behavior',
+            prefixIcon: Icon(Icons.play_circle_outline),
+            helperText:
+                'Pick a startup flow for this host. tmux stays free; agent/custom/snippet flows require MonkeySSH Pro.',
+          ),
+          items: _HostStartupMode.values
+              .map(
+                (mode) => DropdownMenuItem<_HostStartupMode>(
+                  value: mode,
+                  child: Text(mode.label),
+                ),
+              )
+              .toList(growable: false),
+          onChanged: (value) {
+            if (value == null) {
+              return;
+            }
+            unawaited(_handleStartupModeSelection(value));
+          },
+        ),
+        switch (_selectedStartupMode) {
+          _HostStartupMode.none => const SizedBox.shrink(),
+          _HostStartupMode.tmux => _buildTmuxStartupFields(context),
+          _HostStartupMode.agent => _buildAgentStartupFields(
+            context,
+            hasAgentPresetAccess: hasAgentPresetAccess,
+          ),
+          _HostStartupMode.customCommand => _buildCustomCommandFields(
+            hasAutomationAccess: hasAutomationAccess,
+          ),
+          _HostStartupMode.snippet => _buildSnippetFields(
+            context,
+            snippetsAsync: snippetsAsync,
+            hasAutomationAccess: hasAutomationAccess,
+          ),
+        },
+      ],
+    );
+  }
+
+  Widget _buildTmuxStartupFields(BuildContext context) {
+    final preview = _tmuxSessionController.text.trim().isEmpty
+        ? null
+        : buildTmuxCommand(
+            sessionName: _tmuxSessionController.text.trim(),
+            workingDirectory: _tmuxWorkingDirectoryController.text.trim(),
+            extraFlags: _tmuxExtraFlagsController.text.trim(),
+          );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 16),
+        TextFormField(
+          key: const Key('host-tmux-session-field'),
+          controller: _tmuxSessionController,
+          decoration: const InputDecoration(
+            labelText: 'tmux session name',
+            hintText: 'workspace',
+            prefixIcon: Icon(Icons.view_carousel_outlined),
+            helperText:
+                'Creates or attaches to this tmux session without launching any extra command.',
+          ),
+          autocorrect: false,
+          onChanged: (_) => setState(() {}),
+          validator: (value) {
+            if (_selectedStartupMode != _HostStartupMode.tmux) {
+              return null;
+            }
+            if (value == null || value.trim().isEmpty) {
+              return 'Enter a tmux session name';
+            }
+            return null;
+          },
+        ),
+        const SizedBox(height: 12),
+        TextFormField(
+          key: const Key('host-tmux-working-directory-field'),
+          controller: _tmuxWorkingDirectoryController,
+          decoration: const InputDecoration(
+            labelText: 'Working directory (optional)',
+            hintText: '~/src/app',
+            prefixIcon: Icon(Icons.folder_outlined),
+          ),
+          autocorrect: false,
+          onChanged: (_) => setState(() {}),
+        ),
+        const SizedBox(height: 12),
+        TextFormField(
+          key: const Key('host-tmux-extra-flags-field'),
+          controller: _tmuxExtraFlagsController,
+          decoration: const InputDecoration(
+            labelText: 'Extra tmux flags (optional)',
+            hintText: '-f ~/.tmux.conf',
+            prefixIcon: Icon(Icons.tune_outlined),
+          ),
+          autocorrect: false,
+          onChanged: (_) => setState(() {}),
+        ),
+        if (preview != null) ...[
+          const SizedBox(height: 12),
+          Text(
+            'Generated command',
+            style: Theme.of(context).textTheme.titleSmall,
+          ),
+          const SizedBox(height: 8),
+          SelectableText(
+            preview,
+            style: FluttyTheme.monoStyle.copyWith(
+              fontSize: 12,
+              color: Theme.of(context).textTheme.bodySmall?.color,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildAgentStartupFields(
+    BuildContext context, {
+    required bool hasAgentPresetAccess,
+  }) {
+    final generatedCommand = buildAgentLaunchCommand(
+      _buildCurrentAgentLaunchPreset()!,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 16),
+        DropdownButtonFormField<AgentLaunchTool>(
+          key: const Key('host-agent-tool-field'),
+          // ignore: deprecated_member_use
+          value: _selectedAgentLaunchTool,
+          decoration: const InputDecoration(
+            labelText: 'Coding agent',
+            prefixIcon: Icon(Icons.smart_toy_outlined),
+            helperText:
+                'Launch an agent directly, or pair it with tmux so Flutty can show extra window navigation.',
+          ),
+          items: AgentLaunchTool.values
+              .map(
+                (tool) => DropdownMenuItem<AgentLaunchTool>(
+                  value: tool,
+                  child: Text(tool.label),
+                ),
+              )
+              .toList(growable: false),
+          onChanged: hasAgentPresetAccess
+              ? (value) {
+                  if (value == null) {
+                    return;
+                  }
+                  setState(() => _selectedAgentLaunchTool = value);
+                  _syncAutoConnectCommandFromPreset();
+                }
+              : null,
+        ),
+        const SizedBox(height: 12),
+        TextFormField(
+          key: const Key('host-agent-working-directory-field'),
+          controller: _agentWorkingDirectoryController,
+          readOnly: !hasAgentPresetAccess,
+          decoration: const InputDecoration(
+            labelText: 'Working directory (optional)',
+            hintText: '~/src/app',
+            prefixIcon: Icon(Icons.folder_outlined),
+          ),
+          autocorrect: false,
+          onChanged: hasAgentPresetAccess
+              ? (_) => _syncAutoConnectCommandFromPreset()
+              : null,
+        ),
+        const SizedBox(height: 12),
+        TextFormField(
+          key: const Key('host-agent-tmux-session-field'),
+          controller: _agentTmuxSessionController,
+          readOnly: !hasAgentPresetAccess,
+          decoration: const InputDecoration(
+            labelText: 'tmux session (optional)',
+            hintText: 'app-agent',
+            prefixIcon: Icon(Icons.view_carousel_outlined),
+            helperText:
+                'Add a tmux session to keep agent workspaces visible in the tmux bar.',
+          ),
+          autocorrect: false,
+          onChanged: hasAgentPresetAccess
+              ? (_) => _syncAutoConnectCommandFromPreset()
+              : null,
+        ),
+        const SizedBox(height: 12),
+        TextFormField(
+          key: const Key('host-agent-arguments-field'),
+          controller: _agentArgumentsController,
+          readOnly: !hasAgentPresetAccess,
+          decoration: const InputDecoration(
+            labelText: 'Extra arguments (optional)',
+            hintText: '--resume',
+            prefixIcon: Icon(Icons.tune_outlined),
+          ),
+          autocorrect: false,
+          onChanged: hasAgentPresetAccess
+              ? (_) => _syncAutoConnectCommandFromPreset()
+              : null,
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Generated command',
+          style: Theme.of(context).textTheme.titleSmall,
+        ),
+        const SizedBox(height: 8),
+        SelectableText(
+          generatedCommand,
+          style: FluttyTheme.monoStyle.copyWith(
+            fontSize: 12,
+            color: Theme.of(context).textTheme.bodySmall?.color,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCustomCommandFields({
+    required bool hasAutomationAccess,
+  }) => Column(
+    children: [
+      const SizedBox(height: 16),
+      TextFormField(
+        key: const Key('host-auto-connect-command-field'),
+        controller: _autoConnectCommandController,
+        decoration: const InputDecoration(
+          labelText: 'Custom command',
+          hintText: defaultAutoConnectCommandSuggestion,
+          helperText:
+              'Run any shell command after connect. Choose the tmux or agent modes above for extra window-aware behavior.',
+          prefixIcon: Icon(Icons.terminal),
+        ),
+        minLines: 1,
+        maxLines: 3,
+        readOnly: !hasAutomationAccess,
+        autocorrect: false,
+        validator: (value) {
+          if (_selectedStartupMode != _HostStartupMode.customCommand) {
+            return null;
+          }
+          if (value == null || value.trim().isEmpty) {
+            return 'Enter a command or choose "Do nothing"';
+          }
+          return null;
+        },
+      ),
+    ],
+  );
+
+  Widget _buildSnippetFields(
+    BuildContext context, {
+    required AsyncValue<List<Snippet>> snippetsAsync,
+    required bool hasAutomationAccess,
+  }) => Column(
+    children: [
+      const SizedBox(height: 16),
+      snippetsAsync.when(
+        loading: () => const LinearProgressIndicator(),
+        error: (_, _) => const Text('Error loading snippets'),
+        data: (snippets) {
+          final selectedSnippetStillExists = snippets.any(
+            (snippet) => snippet.id == _selectedAutoConnectSnippetId,
+          );
+          final effectiveSnippetId = selectedSnippetStillExists
+              ? _selectedAutoConnectSnippetId
+              : null;
+          final selectedSnippet = effectiveSnippetId == null
+              ? null
+              : snippets.firstWhere(
+                  (snippet) => snippet.id == effectiveSnippetId,
+                );
+          return Column(
+            children: [
+              DropdownButtonFormField<int?>(
+                key: const Key('host-auto-connect-snippet-field'),
+                // ignore: deprecated_member_use
+                value: effectiveSnippetId,
+                decoration: const InputDecoration(
+                  labelText: 'Snippet',
+                  prefixIcon: Icon(Icons.code),
+                  helperText:
+                      'Variable prompts are not shown when a snippet runs automatically.',
+                ),
+                items: [
+                  const DropdownMenuItem<int?>(child: Text('Choose a snippet')),
+                  ...snippets.map(
+                    (snippet) => DropdownMenuItem<int?>(
+                      value: snippet.id,
+                      child: Text(snippet.name),
+                    ),
+                  ),
+                ],
+                onChanged: hasAutomationAccess
+                    ? (value) =>
+                          setState(() => _selectedAutoConnectSnippetId = value)
+                    : null,
+                validator: (value) {
+                  if (_selectedStartupMode != _HostStartupMode.snippet) {
+                    return null;
+                  }
+                  if (value == null) {
+                    return 'Choose a snippet or select "Do nothing"';
+                  }
+                  return null;
+                },
+              ),
+              if (selectedSnippet != null) ...[
+                const SizedBox(height: 12),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    selectedSnippet.command,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                    style: FluttyTheme.monoStyle.copyWith(
+                      fontSize: 12,
+                      color: Theme.of(context).textTheme.bodySmall?.color,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          );
+        },
+      ),
+    ],
+  );
+
   Future<void> _saveHost() async {
     if (!_formKey.currentState!.validate()) return;
 
@@ -793,34 +972,97 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       final presetCommand = currentPreset == null
           ? null
           : buildAgentLaunchCommand(currentPreset);
-      final autoConnectCommand = switch (_selectedAutoConnectMode) {
-        AutoConnectCommandMode.none => null,
-        AutoConnectCommandMode.custom =>
-          _useAgentLaunchPreset && presetCommand != null
-              ? presetCommand
-              : _autoConnectCommandController.text.trim(),
-        AutoConnectCommandMode.snippet =>
-          selectedSnippet?.command ?? _autoConnectCommandController.text,
+      final tmuxSessionName = _tmuxSessionController.text.trim();
+      final tmuxWorkingDirectory = _tmuxWorkingDirectoryController.text.trim();
+      final tmuxExtraFlags = _tmuxExtraFlagsController.text.trim();
+
+      final normalizedTmuxSessionName = switch (_selectedStartupMode) {
+        _HostStartupMode.tmux =>
+          tmuxSessionName.isEmpty ? null : tmuxSessionName,
+        _HostStartupMode.none => null,
+        _ => hasAutomationAccess ? null : _existingHost?.tmuxSessionName,
       };
-      final normalizedAutoConnectCommand = hasAutomationAccess
-          ? (autoConnectCommand == null || autoConnectCommand.trim().isEmpty
+      final normalizedTmuxWorkingDirectory = switch (_selectedStartupMode) {
+        _HostStartupMode.tmux =>
+          tmuxWorkingDirectory.isEmpty ? null : tmuxWorkingDirectory,
+        _HostStartupMode.none => null,
+        _ => hasAutomationAccess ? null : _existingHost?.tmuxWorkingDirectory,
+      };
+      final normalizedTmuxExtraFlags = switch (_selectedStartupMode) {
+        _HostStartupMode.tmux => tmuxExtraFlags.isEmpty ? null : tmuxExtraFlags,
+        _HostStartupMode.none => null,
+        _ => hasAutomationAccess ? null : _existingHost?.tmuxExtraFlags,
+      };
+
+      String? normalizedAutoConnectCommand;
+      int? normalizedAutoConnectSnippetId;
+      late final bool autoConnectRequiresConfirmation;
+      switch (_selectedStartupMode) {
+        case _HostStartupMode.none:
+        case _HostStartupMode.tmux:
+          normalizedAutoConnectCommand = null;
+          normalizedAutoConnectSnippetId = null;
+          autoConnectRequiresConfirmation = false;
+        case _HostStartupMode.agent:
+          if (hasAutomationAccess) {
+            normalizedAutoConnectCommand =
+                presetCommand == null || presetCommand.trim().isEmpty
                 ? null
-                : autoConnectCommand)
-          : _existingHost?.autoConnectCommand;
-      final normalizedAutoConnectSnippetId = hasAutomationAccess
-          ? (_selectedAutoConnectMode == AutoConnectCommandMode.snippet &&
-                    selectedSnippet != null
-                ? selectedSnippet.id
-                : null)
-          : _existingHost?.autoConnectSnippetId;
-      final autoConnectRequiresConfirmation = _resolveAutoConnectConfirmation(
-        command: hasAutomationAccess
-            ? normalizedAutoConnectCommand
-            : _existingHost?.autoConnectCommand,
-        snippetId: hasAutomationAccess
-            ? normalizedAutoConnectSnippetId
-            : _existingHost?.autoConnectSnippetId,
-      );
+                : presetCommand;
+            normalizedAutoConnectSnippetId = null;
+            autoConnectRequiresConfirmation = _resolveAutoConnectConfirmation(
+              command: normalizedAutoConnectCommand,
+              snippetId: null,
+            );
+          } else {
+            normalizedAutoConnectCommand = _existingHost?.autoConnectCommand;
+            normalizedAutoConnectSnippetId =
+                _existingHost?.autoConnectSnippetId;
+            autoConnectRequiresConfirmation = _resolveAutoConnectConfirmation(
+              command: _existingHost?.autoConnectCommand,
+              snippetId: _existingHost?.autoConnectSnippetId,
+            );
+          }
+        case _HostStartupMode.customCommand:
+          if (hasAutomationAccess) {
+            final autoConnectCommand = _autoConnectCommandController.text
+                .trim();
+            normalizedAutoConnectCommand = autoConnectCommand.isEmpty
+                ? null
+                : autoConnectCommand;
+            normalizedAutoConnectSnippetId = null;
+            autoConnectRequiresConfirmation = _resolveAutoConnectConfirmation(
+              command: normalizedAutoConnectCommand,
+              snippetId: null,
+            );
+          } else {
+            normalizedAutoConnectCommand = _existingHost?.autoConnectCommand;
+            normalizedAutoConnectSnippetId =
+                _existingHost?.autoConnectSnippetId;
+            autoConnectRequiresConfirmation = _resolveAutoConnectConfirmation(
+              command: _existingHost?.autoConnectCommand,
+              snippetId: _existingHost?.autoConnectSnippetId,
+            );
+          }
+        case _HostStartupMode.snippet:
+          if (hasAutomationAccess) {
+            normalizedAutoConnectCommand =
+                selectedSnippet?.command ?? _autoConnectCommandController.text;
+            normalizedAutoConnectSnippetId = selectedSnippet?.id;
+            autoConnectRequiresConfirmation = _resolveAutoConnectConfirmation(
+              command: normalizedAutoConnectCommand,
+              snippetId: normalizedAutoConnectSnippetId,
+            );
+          } else {
+            normalizedAutoConnectCommand = _existingHost?.autoConnectCommand;
+            normalizedAutoConnectSnippetId =
+                _existingHost?.autoConnectSnippetId;
+            autoConnectRequiresConfirmation = _resolveAutoConnectConfirmation(
+              command: _existingHost?.autoConnectCommand,
+              snippetId: _existingHost?.autoConnectSnippetId,
+            );
+          }
+      }
       var savedHostId = widget.hostId;
 
       if (widget.hostId != null && _existingHost != null) {
@@ -841,6 +1083,9 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
           autoConnectCommand: drift.Value(normalizedAutoConnectCommand),
           autoConnectSnippetId: drift.Value(normalizedAutoConnectSnippetId),
           autoConnectRequiresConfirmation: autoConnectRequiresConfirmation,
+          tmuxSessionName: drift.Value(normalizedTmuxSessionName),
+          tmuxWorkingDirectory: drift.Value(normalizedTmuxWorkingDirectory),
+          tmuxExtraFlags: drift.Value(normalizedTmuxExtraFlags),
           isFavorite: _isFavorite,
         );
         await repo.update(updatedHost);
@@ -865,6 +1110,9 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
             autoConnectRequiresConfirmation: drift.Value(
               autoConnectRequiresConfirmation,
             ),
+            tmuxSessionName: drift.Value(normalizedTmuxSessionName),
+            tmuxWorkingDirectory: drift.Value(normalizedTmuxWorkingDirectory),
+            tmuxExtraFlags: drift.Value(normalizedTmuxExtraFlags),
             isFavorite: drift.Value(_isFavorite),
           ),
         );
@@ -872,13 +1120,17 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
 
       if (savedHostId != null) {
         final preset = _buildCurrentAgentLaunchPreset();
-        if (hasAutomationAccess &&
+        if (_selectedStartupMode == _HostStartupMode.agent &&
+            hasAutomationAccess &&
             hasAgentPresetAccess &&
-            _selectedAutoConnectMode == AutoConnectCommandMode.custom &&
-            _useAgentLaunchPreset &&
             preset != null) {
           await presetService.setPresetForHost(savedHostId, preset);
-        } else if (hasAutomationAccess && hasAgentPresetAccess) {
+        } else if (_selectedStartupMode == _HostStartupMode.none ||
+            _selectedStartupMode == _HostStartupMode.tmux ||
+            ((_selectedStartupMode == _HostStartupMode.customCommand ||
+                    _selectedStartupMode == _HostStartupMode.snippet) &&
+                hasAutomationAccess &&
+                hasAgentPresetAccess)) {
           await presetService.deletePresetForHost(savedHostId);
         }
       }
@@ -906,10 +1158,18 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     }
   }
 
-  Future<void> _handleAutoConnectModeSelection(
-    AutoConnectCommandMode value,
-  ) async {
-    if (value != AutoConnectCommandMode.none) {
+  Future<void> _handleStartupModeSelection(_HostStartupMode value) async {
+    if (value == _HostStartupMode.agent) {
+      final hasAccess = await requireMonetizationFeatureAccess(
+        context: context,
+        ref: ref,
+        feature: MonetizationFeature.agentLaunchPresets,
+      );
+      if (!hasAccess || !mounted) {
+        return;
+      }
+    } else if (value == _HostStartupMode.customCommand ||
+        value == _HostStartupMode.snippet) {
       final hasAccess = await requireMonetizationFeatureAccess(
         context: context,
         ref: ref,
@@ -921,12 +1181,20 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     }
 
     setState(() {
-      _selectedAutoConnectMode = value;
-      if (value != AutoConnectCommandMode.custom) {
-        _useAgentLaunchPreset = false;
+      _selectedStartupMode = value;
+      switch (value) {
+        case _HostStartupMode.none:
+        case _HostStartupMode.tmux:
+          _selectedAutoConnectMode = AutoConnectCommandMode.none;
+        case _HostStartupMode.agent:
+          _selectedAutoConnectMode = AutoConnectCommandMode.custom;
+        case _HostStartupMode.customCommand:
+          _selectedAutoConnectMode = AutoConnectCommandMode.custom;
+        case _HostStartupMode.snippet:
+          _selectedAutoConnectMode = AutoConnectCommandMode.snippet;
       }
     });
-    if (_useAgentLaunchPreset) {
+    if (value == _HostStartupMode.agent) {
       _syncAutoConnectCommandFromPreset();
     }
   }
@@ -1091,7 +1359,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   }
 
   AgentLaunchPreset? _buildCurrentAgentLaunchPreset() {
-    if (!_useAgentLaunchPreset) {
+    if (_selectedStartupMode != _HostStartupMode.agent) {
       return null;
     }
     return AgentLaunchPreset(

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -537,11 +537,11 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     required AgentLaunchPreset? preset,
     required AutoConnectCommandMode autoConnectMode,
   }) {
-    if (host.tmuxSessionName case final value? when value.trim().isNotEmpty) {
-      return _HostStartupMode.tmux;
-    }
     if (preset != null) {
       return _HostStartupMode.agent;
+    }
+    if (host.tmuxSessionName case final value? when value.trim().isNotEmpty) {
+      return _HostStartupMode.tmux;
     }
     return switch (autoConnectMode) {
       AutoConnectCommandMode.none => _HostStartupMode.none,

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2831,6 +2831,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     ref
         .read(tmuxServiceProvider)
         .selectWindow(session, sessionName, windowIndex);
+
+    // Clear stale working directory — it will be refreshed from
+    // OSC 7 or the next tmux query.
+    _tmuxWorkingDirectory = null;
   }
 
   /// Creates a new tmux window via exec channel, then switches to it.
@@ -2852,8 +2856,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       workingDirectory: workingDirectory,
     );
 
-    // After creating a new window, tmux automatically selects it.
-    // No explicit switch needed.
+    // Update cached working directory to the new window's directory.
+    _tmuxWorkingDirectory = workingDirectory;
   }
 
   /// Closes a tmux window via exec channel.
@@ -2946,6 +2950,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _doneSubscription = null;
     _shell = null;
     if (connectionId != null) {
+      ref.read(tmuxServiceProvider).clearCache(connectionId);
       await _sessionsNotifier?.disconnect(connectionId);
     }
     if (mounted) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -29,6 +29,7 @@ import '../../domain/models/monetization.dart';
 import '../../domain/models/terminal_theme.dart';
 import '../../domain/models/terminal_themes.dart';
 import '../../domain/models/tmux_state.dart';
+import '../../domain/services/agent_session_discovery_service.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/remote_clipboard_sync_service.dart';
 import '../../domain/services/remote_file_service.dart';
@@ -156,8 +157,12 @@ class _TmuxExpandableBar extends StatefulWidget {
 
 class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
   List<TmuxWindow>? _windows;
+  List<ToolSessionInfo>? _recentSessions;
+  final Set<String> _expandedSessionTools = <String>{};
   bool _expanded = false;
   bool _isLoading = true;
+  bool _isLoadingSessions = false;
+  bool _showSessions = false;
   double _dragOffset = 0;
   Timer? _syncTimer;
 
@@ -194,6 +199,43 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
       if (!mounted) return;
       if (_isLoading) setState(() => _isLoading = false);
     }
+  }
+
+  Future<void> _loadRecentSessions() async {
+    if (_isLoadingSessions || _recentSessions != null) return;
+    setState(() => _isLoadingSessions = true);
+
+    try {
+      final discovery = widget.ref.read(agentSessionDiscoveryServiceProvider);
+      final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
+      final sessions = await discovery.discoverSessions(
+        widget.session,
+        workingDirectory: activeWindow?.currentPath,
+      );
+      if (!mounted) return;
+      setState(() {
+        _recentSessions = sessions;
+        if (_expandedSessionTools.isEmpty && sessions.isNotEmpty) {
+          _expandedSessionTools.add(sessions.first.toolName);
+        }
+        _isLoadingSessions = false;
+      });
+    } on Exception {
+      if (!mounted) return;
+      setState(() {
+        _recentSessions = const [];
+        _isLoadingSessions = false;
+      });
+    }
+  }
+
+  void _resumeSession(ToolSessionInfo info) {
+    final discovery = widget.ref.read(agentSessionDiscoveryServiceProvider);
+    final command = discovery.buildResumeCommand(info);
+    setState(() => _expanded = false);
+    widget.onAction(
+      TmuxResumeSessionAction(command, workingDirectory: info.workingDirectory),
+    );
   }
 
   void _onVerticalDragUpdate(DragUpdateDetails details) {
@@ -366,8 +408,145 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
               });
             },
           ),
+          if (widget.isProUser) ...[
+            const Divider(height: 1),
+            _buildSessionsSection(theme),
+          ],
         ],
       ),
+    );
+  }
+
+  Widget _buildSessionsSection(ThemeData theme) => Column(
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      ListTile(
+        dense: true,
+        leading: Icon(
+          Icons.smart_toy_outlined,
+          size: 18,
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+        title: const Text('AI Sessions'),
+        trailing: Icon(
+          _showSessions ? Icons.expand_less : Icons.expand_more,
+          size: 18,
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+        onTap: () {
+          setState(() => _showSessions = !_showSessions);
+          if (_showSessions) _loadRecentSessions();
+        },
+      ),
+      if (_showSessions) ...[
+        if (_isLoadingSessions)
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 8),
+            child: Center(
+              child: SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+              ),
+            ),
+          )
+        else if (_recentSessions != null && _recentSessions!.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text(
+              'No recent sessions found',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          )
+        else if (_recentSessions != null)
+          ..._groupSessions(_recentSessions!).entries.map(
+            (entry) => _buildSessionGroup(theme, entry.key, entry.value),
+          ),
+      ],
+    ],
+  );
+
+  Map<String, List<ToolSessionInfo>> _groupSessions(
+    List<ToolSessionInfo> sessions,
+  ) {
+    final grouped = <String, List<ToolSessionInfo>>{};
+    for (final session in sessions) {
+      grouped
+          .putIfAbsent(session.toolName, () => <ToolSessionInfo>[])
+          .add(session);
+    }
+    return grouped;
+  }
+
+  Widget _buildSessionGroup(
+    ThemeData theme,
+    String toolName,
+    List<ToolSessionInfo> sessions,
+  ) {
+    final isExpanded = _expandedSessionTools.contains(toolName);
+    final iconData = switch (toolName) {
+      'Claude Code' => Icons.auto_awesome,
+      'Codex' => Icons.code,
+      'Copilot CLI' => Icons.flight,
+      'Gemini CLI' => Icons.diamond_outlined,
+      'OpenCode' => Icons.terminal,
+      _ => Icons.smart_toy_outlined,
+    };
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ListTile(
+          dense: true,
+          contentPadding: const EdgeInsets.only(left: 56, right: 16),
+          leading: Icon(iconData, size: 18, color: theme.colorScheme.primary),
+          title: Text(toolName),
+          subtitle: Text(
+            '${sessions.length} session${sessions.length == 1 ? '' : 's'}',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          trailing: Icon(
+            isExpanded ? Icons.expand_less : Icons.expand_more,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          onTap: () {
+            setState(() {
+              if (isExpanded) {
+                _expandedSessionTools.remove(toolName);
+              } else {
+                _expandedSessionTools.add(toolName);
+              }
+            });
+          },
+        ),
+        if (isExpanded)
+          for (final session in sessions)
+            ListTile(
+              dense: true,
+              contentPadding: const EdgeInsets.only(left: 72, right: 16),
+              title: Text(
+                session.summary ?? session.sessionId,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              subtitle: session.timeAgoLabel.isNotEmpty
+                  ? Text(
+                      session.timeAgoLabel,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    )
+                  : null,
+              trailing: TextButton(
+                onPressed: () => _resumeSession(session),
+                child: const Text('Resume'),
+              ),
+            ),
+      ],
     );
   }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -118,10 +118,9 @@ const _terminalFilePathVerificationExtensions = <String>[
 
 /// Expandable tmux bar that sits at the bottom of the terminal.
 ///
-/// Collapsed: a slim handle bar showing session name + drag pill.
-/// Expanded: smoothly grows upward to reveal window list + actions.
-/// When anchored in a stack, the expanded content overlays the terminal
-/// instead of shifting it upward.
+/// The handle bar is a normal Column child below the terminal so it
+/// doesn't cover content. When expanded, the window list overlays
+/// the terminal via a sibling [_TmuxExpandableOverlay] in a Stack.
 class _TmuxExpandableBar extends StatefulWidget {
   const _TmuxExpandableBar({
     required this.session,
@@ -129,6 +128,7 @@ class _TmuxExpandableBar extends StatefulWidget {
     required this.isProUser,
     required this.ref,
     required this.onAction,
+    super.key,
   });
 
   /// The active SSH session.
@@ -216,17 +216,14 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    // Compute extra height from drag for smooth tracking.
-    final dragExpansion = _dragOffset > 0 && !_expanded ? _dragOffset : 0.0;
 
+    // The handle bar sits in the normal layout flow (Column child).
+    // The expanded overlay is rendered by _TmuxExpandableOverlay in the
+    // parent Stack, reading state from this widget via a GlobalKey.
     return GestureDetector(
       onVerticalDragUpdate: _onVerticalDragUpdate,
       onVerticalDragEnd: _onVerticalDragEnd,
-      child: AnimatedContainer(
-        duration: _dragOffset > 0
-            ? Duration.zero
-            : const Duration(milliseconds: 300),
-        curve: Curves.easeOutCubic,
+      child: DecoratedBox(
         decoration: BoxDecoration(
           color: theme.colorScheme.surfaceContainerHighest,
           border: Border(
@@ -236,42 +233,13 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
             ),
           ),
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Handle bar — always visible.
-            _buildHandleBar(theme),
-            // Drag preview: show partial content during drag.
-            if (dragExpansion > 0)
-              SizedBox(
-                height: dragExpansion,
-                child: ClipRect(
-                  child: Align(
-                    alignment: Alignment.topCenter,
-                    child: _buildWindowList(theme),
-                  ),
-                ),
-              ),
-            // Expanded content.
-            AnimatedCrossFade(
-              duration: const Duration(milliseconds: 300),
-              sizeCurve: Curves.easeOutCubic,
-              crossFadeState: _expanded
-                  ? CrossFadeState.showSecond
-                  : CrossFadeState.showFirst,
-              firstChild: const SizedBox.shrink(),
-              secondChild: ConstrainedBox(
-                constraints: BoxConstraints(
-                  maxHeight: MediaQuery.sizeOf(context).height * 0.4,
-                ),
-                child: _buildWindowList(theme),
-              ),
-            ),
-          ],
-        ),
+        child: _buildHandleBar(theme),
       ),
     );
   }
+
+  /// Whether the overlay should be visible (expanded or being dragged).
+  bool get showOverlay => _expanded || _dragOffset > 0;
 
   Widget _buildHandleBar(ThemeData theme) => GestureDetector(
     onTap: () {
@@ -281,14 +249,14 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
       if (!wasExpanded) _loadWindows();
     },
     child: Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
       child: Stack(
         alignment: Alignment.center,
         children: [
           // Centered drag handle pill.
           Container(
-            width: 32,
-            height: 4,
+            width: 28,
+            height: 3,
             decoration: BoxDecoration(
               color: theme.colorScheme.onSurfaceVariant.withAlpha(80),
               borderRadius: BorderRadius.circular(2),
@@ -299,13 +267,14 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
             children: [
               Icon(
                 Icons.window_outlined,
-                size: 14,
+                size: 12,
                 color: theme.colorScheme.primary,
               ),
-              const SizedBox(width: 6),
+              const SizedBox(width: 4),
               Text(
                 widget.tmuxSessionName,
                 style: theme.textTheme.labelSmall?.copyWith(
+                  fontSize: 10,
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
               ),
@@ -315,7 +284,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
                 turns: _expanded ? 0.5 : 0,
                 child: Icon(
                   Icons.keyboard_arrow_up,
-                  size: 16,
+                  size: 14,
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
               ),
@@ -1696,6 +1665,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   String? _tmuxSessionName;
   bool _showTmuxBar = true;
   String? _tmuxWorkingDirectory;
+  final _tmuxBarKey = GlobalKey<_TmuxExpandableBarState>();
   final Map<String, _VerifiedTerminalPath> _verifiedTerminalPathCache =
       <String, _VerifiedTerminalPath>{};
   final ListQueue<String> _verifiedTerminalPathCacheOrder = ListQueue<String>();
@@ -2773,6 +2743,65 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
+  /// Builds the expanded tmux overlay that floats above the terminal.
+  ///
+  /// Reads state from the [_TmuxExpandableBarState] via [_tmuxBarKey].
+  Widget _buildTmuxOverlay(ThemeData theme) {
+    final barState = _tmuxBarKey.currentState;
+    if (barState == null) return const SizedBox.shrink();
+
+    final dragExpansion = barState._dragOffset > 0 && !barState._expanded
+        ? barState._dragOffset
+        : 0.0;
+
+    return AnimatedContainer(
+      duration: barState._dragOffset > 0
+          ? Duration.zero
+          : const Duration(milliseconds: 300),
+      curve: Curves.easeOutCubic,
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withAlpha(40),
+            blurRadius: 8,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (dragExpansion > 0)
+            SizedBox(
+              height: dragExpansion,
+              child: ClipRect(
+                child: Align(
+                  alignment: Alignment.topCenter,
+                  child: barState._buildWindowList(theme),
+                ),
+              ),
+            ),
+          AnimatedCrossFade(
+            duration: const Duration(milliseconds: 300),
+            sizeCurve: Curves.easeOutCubic,
+            crossFadeState: barState._expanded
+                ? CrossFadeState.showSecond
+                : CrossFadeState.showFirst,
+            firstChild: const SizedBox.shrink(),
+            secondChild: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.sizeOf(context).height * 0.4,
+              ),
+              child: barState._buildWindowList(theme),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   /// Builds a draggable tmux panel anchored to the bottom of the terminal.
   ///
   /// Collapsed, it shows a slim handle bar with the session name.
@@ -2795,6 +2824,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
 
     return _TmuxExpandableBar(
+      key: _tmuxBarKey,
       session: session,
       tmuxSessionName: _tmuxSessionName!,
       isProUser: isProUser,
@@ -3465,18 +3495,25 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 Positioned.fill(
                   child: _buildTerminalView(terminalTheme, isMobile),
                 ),
+                // Overlay: expanded window list floats above the terminal.
                 if (_isTmuxActive &&
                     _showTmuxBar &&
-                    connectionState == SshConnectionState.connected)
+                    connectionState == SshConnectionState.connected &&
+                    (_tmuxBarKey.currentState?.showOverlay ?? false))
                   Positioned(
                     left: 0,
                     right: 0,
                     bottom: 0,
-                    child: _buildTmuxExpandableBar(theme),
+                    child: _buildTmuxOverlay(theme),
                   ),
               ],
             ),
           ),
+          // Handle bar: sits below the terminal in normal layout flow.
+          if (_isTmuxActive &&
+              _showTmuxBar &&
+              connectionState == SshConnectionState.connected)
+            _buildTmuxExpandableBar(theme),
           if (_showKeyboardToolbar &&
               !showsDisconnectedOverlay &&
               (!_isNativeSelectionMode || _isMobilePlatform))

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -30,6 +30,7 @@ import '../../domain/models/terminal_theme.dart';
 import '../../domain/models/terminal_themes.dart';
 import '../../domain/models/tmux_state.dart';
 import '../../domain/services/agent_session_discovery_service.dart';
+import '../../domain/services/local_notification_service.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/remote_clipboard_sync_service.dart';
 import '../../domain/services/remote_file_service.dart';
@@ -191,6 +192,13 @@ class _TmuxExpandableBar extends StatefulWidget {
 
 class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     with SingleTickerProviderStateMixin {
+  static const _denseTileVisualDensity = VisualDensity(vertical: -2);
+  static const _denseTilePadding = EdgeInsets.symmetric(horizontal: 12);
+  static const _groupTilePadding = EdgeInsets.only(left: 52, right: 12);
+  static const _sessionTilePadding = EdgeInsets.only(left: 68, right: 12);
+  static const _initialSessionFetchLimit = 12;
+  static const _sessionFetchStep = 12;
+
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
   final Set<String> _expandedSessionTools = <String>{};
@@ -198,8 +206,10 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   bool _expanded = false;
   bool _isLoading = true;
   bool _isLoadingSessions = false;
+  bool _canLoadMoreSessions = false;
   bool _showSessions = false;
   double _dragOffset = 0;
+  int _sessionFetchLimit = _initialSessionFetchLimit;
   Timer? _syncTimer;
   late AnimationController _bounceController;
   late Animation<double> _bounceAnimation;
@@ -232,6 +242,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   @override
   void dispose() {
     _syncTimer?.cancel();
+    for (final windowIndex in _seenAlertWindows) {
+      _clearAlertNotification(windowIndex);
+    }
     _bounceController.dispose();
     super.dispose();
   }
@@ -257,10 +270,23 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         }
       }
 
-      // Clear seen alerts for windows that no longer have alerts.
-      _seenAlertWindows.removeWhere(
-        (idx) => !windows.any((w) => w.index == idx && w.hasAlert),
-      );
+      final activeAlerts = _seenAlertWindows
+          .where(
+            (idx) =>
+                windows.any((w) => w.index == idx && w.hasAlert && w.isActive),
+          )
+          .toList(growable: false);
+      for (final windowIndex in activeAlerts) {
+        _clearAlertNotification(windowIndex);
+      }
+
+      final clearedAlerts = _seenAlertWindows
+          .where((idx) => !windows.any((w) => w.index == idx && w.hasAlert))
+          .toList(growable: false);
+      for (final windowIndex in clearedAlerts) {
+        _seenAlertWindows.remove(windowIndex);
+        _clearAlertNotification(windowIndex);
+      }
 
       setState(() {
         _windows = windows;
@@ -272,8 +298,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     }
   }
 
-  Future<void> _loadRecentSessions() async {
-    if (_isLoadingSessions || _recentSessions != null) return;
+  Future<void> _loadRecentSessions({bool forceReload = false}) async {
+    if (_isLoadingSessions || (_recentSessions != null && !forceReload)) return;
+    final previousCount = _recentSessions?.length ?? 0;
     setState(() => _isLoadingSessions = true);
 
     try {
@@ -282,6 +309,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       final sessions = await discovery.discoverSessions(
         widget.session,
         workingDirectory: activeWindow?.currentPath,
+        maxPerTool: _sessionFetchLimit,
       );
       if (!mounted) return;
       setState(() {
@@ -289,15 +317,37 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         if (_expandedSessionTools.isEmpty && sessions.isNotEmpty) {
           _expandedSessionTools.add(sessions.first.toolName);
         }
+        _canLoadMoreSessions =
+            sessions.length > previousCount &&
+            _hasSessionGroupAtLimit(sessions);
         _isLoadingSessions = false;
       });
     } on Exception {
       if (!mounted) return;
       setState(() {
         _recentSessions = const [];
+        _canLoadMoreSessions = false;
         _isLoadingSessions = false;
       });
     }
+  }
+
+  void _loadMoreSessions() {
+    if (_isLoadingSessions) return;
+    setState(() => _sessionFetchLimit += _sessionFetchStep);
+    _loadRecentSessions(forceReload: true);
+  }
+
+  bool _hasSessionGroupAtLimit(List<ToolSessionInfo> sessions) {
+    final countsByTool = <String, int>{};
+    for (final session in sessions) {
+      countsByTool.update(
+        session.toolName,
+        (count) => count + 1,
+        ifAbsent: () => 1,
+      );
+    }
+    return countsByTool.values.any((count) => count >= _sessionFetchLimit);
   }
 
   void _resumeSession(ToolSessionInfo info) {
@@ -309,25 +359,50 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     );
   }
 
+  int _tmuxAlertNotificationId(int windowIndex) =>
+      Object.hash(widget.tmuxSessionName, windowIndex) & 0x7fffffff;
+
   void _sendAlertNotification(TmuxWindow window) {
-    // Haptic feedback on mobile.
     HapticFeedback.mediumImpact();
-    // TODO(tmux): Add local push notification via flutter_local_notifications
-    // so alerts are visible when the app is backgrounded.
+    final title = 'tmux alert · ${widget.tmuxSessionName}';
+    final name = window.displayTitle.trim();
+    final body = name.isEmpty ? 'Window ${window.index} needs attention' : name;
+    unawaited(
+      widget.ref
+          .read(localNotificationServiceProvider)
+          .showTmuxAlert(
+            notificationId: _tmuxAlertNotificationId(window.index),
+            title: title,
+            body: body,
+          ),
+    );
+  }
+
+  void _clearAlertNotification(int windowIndex) {
+    unawaited(
+      widget.ref
+          .read(localNotificationServiceProvider)
+          .clearTmuxAlert(_tmuxAlertNotificationId(windowIndex)),
+    );
   }
 
   void _onVerticalDragUpdate(DragUpdateDetails details) {
     setState(() {
-      _dragOffset -= details.delta.dy;
+      _dragOffset += _expanded ? details.delta.dy : -details.delta.dy;
       _dragOffset = _dragOffset.clamp(0.0, 300.0);
     });
   }
 
   void _onVerticalDragEnd(DragEndDetails details) {
     final velocity = details.primaryVelocity ?? 0;
-    final shouldExpand = velocity < -200 || (!_expanded && _dragOffset > 60);
+    final shouldExpand = !_expanded && (velocity < -200 || _dragOffset > 60);
+    final shouldCollapse = _expanded && (velocity > 200 || _dragOffset > 60);
     setState(() {
-      _expanded = shouldExpand;
+      if (shouldExpand) {
+        _expanded = true;
+      } else if (shouldCollapse) {
+        _expanded = false;
+      }
       _dragOffset = 0;
     });
     if (shouldExpand) _loadWindows();
@@ -336,7 +411,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final dragExpansion = _dragOffset > 0 && !_expanded ? _dragOffset : 0.0;
     final availableHeight = widget.availableHeight.isFinite
         ? widget.availableHeight
         : MediaQuery.sizeOf(context).height * 0.5;
@@ -351,9 +425,10 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       availableHeight,
       fallbackAvailableHeight: visibleViewportHeight * 0.5,
     );
+    final dragDistance = _dragOffset.clamp(0.0, maxContentHeight);
     final contentHeight = _expanded
-        ? maxContentHeight
-        : dragExpansion.clamp(0.0, maxContentHeight);
+        ? (maxContentHeight - dragDistance).clamp(0.0, maxContentHeight)
+        : dragDistance;
 
     return AnimatedBuilder(
       animation: _bounceAnimation,
@@ -477,10 +552,15 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           const Divider(height: 1),
           ListTile(
             dense: true,
+            visualDensity: _denseTileVisualDensity,
+            minTileHeight: 42,
+            contentPadding: _denseTilePadding,
+            horizontalTitleGap: 12,
+            minLeadingWidth: 20,
             leading: Icon(
               Icons.add_circle_outline,
               color: theme.colorScheme.primary,
-              size: 20,
+              size: 18,
             ),
             title: const Text('New Window'),
             onTap: () {
@@ -521,15 +601,20 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     children: [
       ListTile(
         dense: true,
+        visualDensity: _denseTileVisualDensity,
+        minTileHeight: 42,
+        contentPadding: _denseTilePadding,
+        horizontalTitleGap: 12,
+        minLeadingWidth: 18,
         leading: Icon(
           Icons.smart_toy_outlined,
-          size: 18,
+          size: 16,
           color: theme.colorScheme.onSurfaceVariant,
         ),
         title: const Text('AI Sessions'),
         trailing: Icon(
           _showSessions ? Icons.expand_less : Icons.expand_more,
-          size: 18,
+          size: 16,
           color: theme.colorScheme.onSurfaceVariant,
         ),
         onTap: () {
@@ -538,7 +623,8 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         },
       ),
       if (_showSessions) ...[
-        if (_isLoadingSessions)
+        if (_isLoadingSessions &&
+            (_recentSessions == null || _recentSessions!.isEmpty))
           const Padding(
             padding: EdgeInsets.symmetric(vertical: 8),
             child: Center(
@@ -559,10 +645,30 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
               ),
             ),
           )
-        else if (_recentSessions != null)
+        else if (_recentSessions != null) ...[
           ..._groupSessions(_recentSessions!).entries.map(
             (entry) => _buildSessionGroup(theme, entry.key, entry.value),
           ),
+          if (_isLoadingSessions)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 8),
+              child: Center(
+                child: SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                ),
+              ),
+            ),
+          if (_canLoadMoreSessions)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: TextButton(
+                onPressed: _loadMoreSessions,
+                child: const Text('Load more'),
+              ),
+            ),
+        ],
       ],
     ],
   );
@@ -599,8 +705,12 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       children: [
         ListTile(
           dense: true,
-          contentPadding: const EdgeInsets.only(left: 56, right: 16),
-          leading: Icon(iconData, size: 18, color: theme.colorScheme.primary),
+          visualDensity: _denseTileVisualDensity,
+          minVerticalPadding: 2,
+          contentPadding: _groupTilePadding,
+          horizontalTitleGap: 12,
+          minLeadingWidth: 18,
+          leading: Icon(iconData, size: 16, color: theme.colorScheme.primary),
           title: Text(toolName),
           subtitle: Text(
             '${sessions.length} session${sessions.length == 1 ? '' : 's'}',
@@ -626,15 +736,19 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           for (final session in sessions)
             ListTile(
               dense: true,
-              contentPadding: const EdgeInsets.only(left: 72, right: 16),
+              visualDensity: _denseTileVisualDensity,
+              minVerticalPadding: 2,
+              contentPadding: _sessionTilePadding,
+              horizontalTitleGap: 12,
+              minLeadingWidth: 18,
               title: Text(
                 session.summary ?? session.sessionId,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),
-              subtitle: session.timeAgoLabel.isNotEmpty
+              subtitle: session.lastUpdatedLabel.isNotEmpty
                   ? Text(
-                      session.timeAgoLabel,
+                      session.lastUpdatedLabel,
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: theme.colorScheme.onSurfaceVariant,
                       ),
@@ -642,6 +756,11 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
                   : null,
               trailing: TextButton(
                 onPressed: () => _resumeSession(session),
+                style: TextButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                ),
                 child: const Text('Resume'),
               ),
             ),
@@ -651,16 +770,24 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
 
   Widget _buildWindowTile(ThemeData theme, TmuxWindow window) {
     final isActive = window.isActive;
+    final secondaryTitle = window.displayTitle != window.name
+        ? window.name
+        : null;
 
     return ListTile(
       dense: true,
+      visualDensity: _denseTileVisualDensity,
+      minVerticalPadding: 2,
+      contentPadding: const EdgeInsets.only(left: 12, right: 4),
+      horizontalTitleGap: 10,
+      minLeadingWidth: 24,
       tileColor: isActive
           ? theme.colorScheme.primaryContainer.withAlpha(80)
           : null,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
       leading: Container(
-        width: 24,
-        height: 24,
+        width: 22,
+        height: 22,
         decoration: BoxDecoration(
           color: isActive
               ? theme.colorScheme.primary
@@ -679,16 +806,16 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         ),
       ),
       title: Text(
-        window.name,
+        window.displayTitle,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
         style: isActive
             ? theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600)
             : null,
       ),
-      subtitle: window.paneTitle != null
+      subtitle: secondaryTitle != null
           ? Text(
-              window.paneTitle!,
+              secondaryTitle,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: theme.textTheme.bodySmall?.copyWith(
@@ -703,6 +830,8 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           IconButton(
             icon: const Icon(Icons.close, size: 16),
             visualDensity: VisualDensity.compact,
+            constraints: const BoxConstraints.tightFor(width: 30, height: 30),
+            padding: EdgeInsets.zero,
             tooltip: 'Close window',
             onPressed: () {
               widget.onAction(TmuxCloseWindowAction(window.index));
@@ -1987,6 +2116,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _isTmuxActive = false;
   String? _tmuxSessionName;
   bool _showTmuxBar = true;
+  String? _tmuxLaunchWorkingDirectory;
   String? _tmuxWorkingDirectory;
   final Map<String, _VerifiedTerminalPath> _verifiedTerminalPathCache =
       <String, _VerifiedTerminalPath>{};
@@ -3025,6 +3155,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       setState(() {
         _isTmuxActive = false;
         _tmuxSessionName = null;
+        _tmuxLaunchWorkingDirectory = null;
         _tmuxWorkingDirectory = null;
       });
     }
@@ -3055,10 +3186,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       if (sessionName == null) return;
 
       // Get the active window's working directory for SFTP/path resolution.
+      var tmuxLaunchCwd = host?.tmuxWorkingDirectory;
       var tmuxCwd = host?.tmuxWorkingDirectory;
       try {
         final windows = await tmux.listWindows(session, sessionName);
         final activeWindow = windows.where((w) => w.isActive).firstOrNull;
+        tmuxLaunchCwd ??= activeWindow?.currentPath;
         tmuxCwd ??= activeWindow?.currentPath;
       } on Object {
         // Non-critical — path resolution will fall back to OSC 7.
@@ -3069,6 +3202,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       setState(() {
         _isTmuxActive = true;
         _tmuxSessionName = sessionName;
+        _tmuxLaunchWorkingDirectory = tmuxLaunchCwd;
         _tmuxWorkingDirectory = tmuxCwd;
       });
     } on Object {
@@ -3258,12 +3392,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (sessionName == null) return;
 
     final tmux = ref.read(tmuxServiceProvider);
+    final resolvedWorkingDirectory =
+        workingDirectory ??
+        (command != null && command.trim().isNotEmpty
+            ? (_tmuxLaunchWorkingDirectory ?? _host?.tmuxWorkingDirectory)
+            : null);
     await tmux.createWindow(
       session,
       sessionName,
       command: command,
       name: name,
-      workingDirectory: workingDirectory,
+      workingDirectory: resolvedWorkingDirectory,
     );
   }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -128,6 +128,7 @@ class _TmuxExpandableBar extends StatefulWidget {
     required this.isProUser,
     required this.ref,
     required this.onAction,
+    required this.onOverlayChanged,
     super.key,
   });
 
@@ -145,6 +146,9 @@ class _TmuxExpandableBar extends StatefulWidget {
 
   /// Callback for navigator actions.
   final Future<void> Function(TmuxNavigatorAction) onAction;
+
+  /// Called when the overlay visibility changes (expand/collapse/drag).
+  final VoidCallback onOverlayChanged;
 
   @override
   State<_TmuxExpandableBar> createState() => _TmuxExpandableBarState();
@@ -196,19 +200,23 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
   }
 
   void _onVerticalDragUpdate(DragUpdateDetails details) {
+    final wasDragging = _dragOffset > 0;
     setState(() {
       _dragOffset -= details.delta.dy;
       _dragOffset = _dragOffset.clamp(0.0, 300.0);
     });
+    if (wasDragging != (_dragOffset > 0)) widget.onOverlayChanged();
   }
 
   void _onVerticalDragEnd(DragEndDetails details) {
     final velocity = details.primaryVelocity ?? 0;
     final shouldExpand = velocity < -200 || (!_expanded && _dragOffset > 60);
+    final changed = _expanded != shouldExpand || _dragOffset > 0;
     setState(() {
       _expanded = shouldExpand;
       _dragOffset = 0;
     });
+    if (changed) widget.onOverlayChanged();
     // Refresh window list when expanding to get current active state.
     if (shouldExpand) _loadWindows();
   }
@@ -245,6 +253,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
     onTap: () {
       final wasExpanded = _expanded;
       setState(() => _expanded = !_expanded);
+      widget.onOverlayChanged();
       // Refresh window list when expanding to get current active state.
       if (!wasExpanded) _loadWindows();
     },
@@ -330,6 +339,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
             title: const Text('New Window'),
             onTap: () {
               setState(() => _expanded = false);
+              widget.onOverlayChanged();
               showModalBottomSheet<AgentLaunchTool?>(
                 context: context,
                 builder: (ctx) => TmuxToolPickerSheet(
@@ -1664,6 +1674,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _isTmuxActive = false;
   String? _tmuxSessionName;
   bool _showTmuxBar = true;
+  bool _tmuxOverlayVisible = false;
   String? _tmuxWorkingDirectory;
   final _tmuxBarKey = GlobalKey<_TmuxExpandableBarState>();
   final Map<String, _VerifiedTerminalPath> _verifiedTerminalPathCache =
@@ -2830,6 +2841,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       isProUser: isProUser,
       ref: ref,
       onAction: _handleTmuxAction,
+      onOverlayChanged: () {
+        final visible = _tmuxBarKey.currentState?.showOverlay ?? false;
+        if (visible != _tmuxOverlayVisible) {
+          setState(() => _tmuxOverlayVisible = visible);
+        }
+      },
     );
   }
 
@@ -3499,7 +3516,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 if (_isTmuxActive &&
                     _showTmuxBar &&
                     connectionState == SshConnectionState.connected &&
-                    (_tmuxBarKey.currentState?.showOverlay ?? false))
+                    _tmuxOverlayVisible)
                   Positioned(
                     left: 0,
                     right: 0,

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2334,16 +2334,26 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   /// Detects whether the connected session is inside tmux.
   ///
   /// Waits briefly for the auto-connect command to initialize, then
-  /// checks the TMUX environment variable via an exec channel. If tmux
-  /// is active, also queries the current session name.
+  /// checks for tmux sessions via an exec channel. If tmux is active,
+  /// also queries the current session name.
   Future<void> _detectTmux(SshSession session) async {
+    // Clear any stale tmux state from a previous connection.
+    if (mounted) {
+      setState(() {
+        _isTmuxActive = false;
+        _tmuxSessionName = null;
+      });
+    }
+
     // Give the auto-connect command (which may start tmux) time to init.
     await Future<void>.delayed(const Duration(seconds: 2));
     if (!mounted) return;
 
     final tmux = ref.read(tmuxServiceProvider);
     final active = await tmux.isTmuxActive(session);
-    if (!mounted || !active) return;
+    if (!mounted) return;
+
+    if (!active) return;
 
     final sessionName = await tmux.currentSessionName(session);
     if (!mounted) return;
@@ -2382,7 +2392,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     switch (action) {
       case TmuxSwitchWindowAction(:final windowIndex):
-        _sendTmuxSwitchCommand(windowIndex);
+        await _switchTmuxWindow(session, windowIndex);
       case TmuxNewWindowAction(:final command, :final windowName):
         await _createTmuxWindow(session, command: command, name: windowName);
       case TmuxResumeSessionAction(:final resumeCommand):
@@ -2390,15 +2400,18 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
-  /// Sends a tmux select-window command through the interactive shell.
-  void _sendTmuxSwitchCommand(int windowIndex) {
-    final shell = _shell;
+  /// Switches to a different tmux window via exec channel.
+  ///
+  /// Uses an exec channel (not the interactive shell) because
+  /// `tmux select-window` is a server operation — the tmux server
+  /// notifies all attached clients of the change. Writing to the PTY
+  /// would inject the command as input to whatever program is running.
+  Future<void> _switchTmuxWindow(SshSession session, int windowIndex) async {
     final sessionName = _tmuxSessionName;
-    if (shell == null || sessionName == null) return;
+    if (sessionName == null) return;
 
     final tmux = ref.read(tmuxServiceProvider);
-    final command = tmux.buildSelectWindowCommand(sessionName, windowIndex);
-    shell.write(utf8.encode('$command\n'));
+    await tmux.selectWindow(session, sessionName, windowIndex);
   }
 
   /// Creates a new tmux window via exec channel, then switches to it.

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2759,8 +2759,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _switchTmuxWindow(session, windowIndex);
       case TmuxNewWindowAction(:final command, :final windowName):
         await _createTmuxWindow(session, command: command, name: windowName);
-      case TmuxResumeSessionAction(:final resumeCommand):
-        await _createTmuxWindow(session, command: resumeCommand);
+      case TmuxResumeSessionAction(
+        :final resumeCommand,
+        :final workingDirectory,
+      ):
+        await _createTmuxWindow(
+          session,
+          command: resumeCommand,
+          workingDirectory: workingDirectory,
+        );
       case TmuxCloseWindowAction(:final windowIndex):
         _closeTmuxWindow(session, windowIndex);
     }
@@ -2797,8 +2804,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _switchTmuxWindow(session, windowIndex);
       case TmuxNewWindowAction(:final command, :final windowName):
         await _createTmuxWindow(session, command: command, name: windowName);
-      case TmuxResumeSessionAction(:final resumeCommand):
-        await _createTmuxWindow(session, command: resumeCommand);
+      case TmuxResumeSessionAction(
+        :final resumeCommand,
+        :final workingDirectory,
+      ):
+        await _createTmuxWindow(
+          session,
+          command: resumeCommand,
+          workingDirectory: workingDirectory,
+        );
       case TmuxCloseWindowAction(:final windowIndex):
         _closeTmuxWindow(session, windowIndex);
     }
@@ -2824,12 +2838,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     SshSession session, {
     String? command,
     String? name,
+    String? workingDirectory,
   }) async {
     final sessionName = _tmuxSessionName;
     if (sessionName == null) return;
 
     final tmux = ref.read(tmuxServiceProvider);
-    await tmux.createWindow(session, sessionName, command: command, name: name);
+    await tmux.createWindow(
+      session,
+      sessionName,
+      command: command,
+      name: name,
+      workingDirectory: workingDirectory,
+    );
 
     // After creating a new window, tmux automatically selects it.
     // No explicit switch needed.

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -388,10 +388,24 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
       mainAxisSize: MainAxisSize.min,
       children: [
         if (window.hasAlert)
-          Icon(
-            Icons.notifications_active,
-            size: 16,
-            color: theme.colorScheme.error,
+          Padding(
+            padding: const EdgeInsets.only(right: 4),
+            child: Icon(
+              Icons.notifications_active,
+              size: 16,
+              color: theme.colorScheme.error,
+            ),
+          )
+        else if (window.isIdle)
+          Padding(
+            padding: const EdgeInsets.only(right: 4),
+            child: Text(
+              'waiting',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.tertiary,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
           ),
         IconButton(
           icon: const Icon(Icons.close, size: 16),

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -119,9 +119,9 @@ const _terminalFilePathVerificationExtensions = <String>[
 /// Expandable tmux bar that sits at the bottom of the terminal.
 ///
 /// Collapsed: a slim handle bar showing session name + drag pill.
-/// Expanded: smoothly grows to reveal window list + actions.
-/// The bar always takes full width and pushes the terminal up,
-/// never overlaying it.
+/// Expanded: smoothly grows upward to reveal window list + actions.
+/// When anchored in a stack, the expanded content overlays the terminal
+/// instead of shifting it upward.
 class _TmuxExpandableBar extends StatefulWidget {
   const _TmuxExpandableBar({
     required this.session,
@@ -2776,8 +2776,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   /// Builds a draggable tmux panel anchored to the bottom of the terminal.
   ///
   /// Collapsed, it shows a slim handle bar with the session name.
-  /// Dragging up smoothly expands it into the full navigator — like
-  /// water droplets combining. Releasing snaps to collapsed or expanded.
+  /// Dragging up smoothly expands it into the full navigator without
+  /// changing the terminal's layout.
   Widget _buildTmuxExpandableBar(ThemeData theme) {
     final connectionId = _connectionId;
     if (connectionId == null || _tmuxSessionName == null) {
@@ -3459,11 +3459,24 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       ),
       body: Column(
         children: [
-          Expanded(child: _buildTerminalView(terminalTheme, isMobile)),
-          if (_isTmuxActive &&
-              _showTmuxBar &&
-              connectionState == SshConnectionState.connected)
-            _buildTmuxExpandableBar(theme),
+          Expanded(
+            child: Stack(
+              children: [
+                Positioned.fill(
+                  child: _buildTerminalView(terminalTheme, isMobile),
+                ),
+                if (_isTmuxActive &&
+                    _showTmuxBar &&
+                    connectionState == SshConnectionState.connected)
+                  Positioned(
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    child: _buildTmuxExpandableBar(theme),
+                  ),
+              ],
+            ),
+          ),
           if (_showKeyboardToolbar &&
               !showsDisconnectedOverlay &&
               (!_isNativeSelectionMode || _isMobilePlatform))

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3181,6 +3181,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   /// Creates a new tmux window via exec channel, then switches to it.
+  ///
+  /// Only passes `-c` when an explicit [workingDirectory] is provided
+  /// (e.g. resuming an AI session). Otherwise tmux uses its own
+  /// `default-directory` (where the session was started), matching
+  /// native `Ctrl+b, c` behavior.
   Future<void> _createTmuxWindow(
     SshSession session, {
     String? command,
@@ -3190,21 +3195,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final sessionName = _tmuxSessionName;
     if (sessionName == null) return;
 
-    // Fall back to the known tmux working directory so new windows
-    // open in the project folder, not the session start directory.
-    final cwd = workingDirectory ?? _tmuxWorkingDirectory;
-
     final tmux = ref.read(tmuxServiceProvider);
     await tmux.createWindow(
       session,
       sessionName,
       command: command,
       name: name,
-      workingDirectory: cwd,
+      workingDirectory: workingDirectory,
     );
-
-    // Update cached working directory to the new window's directory.
-    if (cwd != null) _tmuxWorkingDirectory = cwd;
   }
 
   /// Closes a tmux window via exec channel.

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -149,7 +149,7 @@ class _TmuxExpandableBar extends StatefulWidget {
 
   /// Height of the collapsed handle bar. The terminal adds this as
   /// bottom padding so the handle sits over empty space.
-  static const handleHeight = 28.0;
+  static const handleHeight = 22.0;
 
   @override
   State<_TmuxExpandableBar> createState() => _TmuxExpandableBarState();

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -448,7 +448,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       Object.hash(widget.tmuxSessionName, windowIndex) & 0x7fffffff;
 
   void _sendAlertNotification(TmuxWindow window) {
-    HapticFeedback.mediumImpact();
+    unawaited(HapticFeedback.mediumImpact());
     final title = 'tmux alert · ${widget.tmuxSessionName}';
     final name = window.displayTitle.trim();
     final body = name.isEmpty ? 'Window ${window.index} needs attention' : name;
@@ -563,49 +563,52 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       // Refresh window list when expanding to get current active state.
       if (!wasExpanded) _loadWindows();
     },
-    child: Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          // Centered drag handle pill.
-          Container(
-            width: 28,
-            height: 3,
-            decoration: BoxDecoration(
-              color: theme.colorScheme.onSurfaceVariant.withAlpha(80),
-              borderRadius: BorderRadius.circular(2),
+    child: SizedBox(
+      height: _TmuxExpandableBar.handleHeight,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            // Centered drag handle pill.
+            Container(
+              width: 28,
+              height: 3,
+              decoration: BoxDecoration(
+                color: theme.colorScheme.onSurfaceVariant.withAlpha(80),
+                borderRadius: BorderRadius.circular(2),
+              ),
             ),
-          ),
-          // Left-aligned session name, right-aligned chevron.
-          Row(
-            children: [
-              Icon(
-                Icons.window_outlined,
-                size: 12,
-                color: theme.colorScheme.primary,
-              ),
-              const SizedBox(width: 4),
-              Text(
-                widget.tmuxSessionName,
-                style: theme.textTheme.labelSmall?.copyWith(
-                  fontSize: 10,
-                  color: theme.colorScheme.onSurfaceVariant,
+            // Left-aligned session name, right-aligned chevron.
+            Row(
+              children: [
+                Icon(
+                  Icons.window_outlined,
+                  size: 12,
+                  color: theme.colorScheme.primary,
                 ),
-              ),
-              const Spacer(),
-              AnimatedRotation(
-                duration: const Duration(milliseconds: 300),
-                turns: _expanded ? 0.5 : 0,
-                child: Icon(
-                  Icons.keyboard_arrow_up,
-                  size: 14,
-                  color: theme.colorScheme.onSurfaceVariant,
+                const SizedBox(width: 4),
+                Text(
+                  widget.tmuxSessionName,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    fontSize: 10,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
                 ),
-              ),
-            ],
-          ),
-        ],
+                const Spacer(),
+                AnimatedRotation(
+                  duration: const Duration(milliseconds: 300),
+                  turns: _expanded ? 0.5 : 0,
+                  child: Icon(
+                    Icons.keyboard_arrow_up,
+                    size: 14,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     ),
   );
@@ -661,14 +664,15 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
                   },
                 ),
               ).then((tool) {
-                if (tool != null) {
-                  widget.onAction(
-                    TmuxNewWindowAction(
-                      command: tool.commandName,
-                      windowName: tool.commandName,
-                    ),
-                  );
+                if (!mounted || tool == null) {
+                  return;
                 }
+                widget.onAction(
+                  TmuxNewWindowAction(
+                    command: tool.commandName,
+                    windowName: tool.commandName,
+                  ),
+                );
               });
             },
           ),
@@ -3130,6 +3134,23 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         workingDirectory: host.tmuxWorkingDirectory,
         extraFlags: host.tmuxExtraFlags,
       );
+      final review = assessAutoConnectCommandExecution(
+        tmuxCommand,
+        importedNeedsReview: host.autoConnectRequiresConfirmation,
+      );
+      if (review.requiresReview) {
+        final decision = await _reviewImportedAutoConnectCommand(review);
+        if (!mounted || decision == _AutoConnectReviewDecision.skip) {
+          return;
+        }
+        if (decision == _AutoConnectReviewDecision.trustAndRun) {
+          final updatedHost = host.copyWith(
+            autoConnectRequiresConfirmation: false,
+          );
+          await ref.read(hostRepositoryProvider).update(updatedHost);
+          _host = updatedHost;
+        }
+      }
       shell.write(utf8.encode(formatAutoConnectCommandForShell(tmuxCommand)));
       return;
     }
@@ -3383,7 +3404,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           return Stack(
             children: [
               // Reserve actual layout space for the collapsed handle so the
-              // terminal viewport extends cleanly down to the bar boundary.
+              // terminal viewport ends exactly at the handle boundary.
               Positioned.fill(
                 child: ColoredBox(
                   color: terminalTheme.background,

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -200,26 +200,27 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
   }
 
   void _onVerticalDragUpdate(DragUpdateDetails details) {
-    final wasDragging = _dragOffset > 0;
     setState(() {
       _dragOffset -= details.delta.dy;
       _dragOffset = _dragOffset.clamp(0.0, 300.0);
     });
-    if (wasDragging != (_dragOffset > 0)) widget.onOverlayChanged();
+    // Update overlay visibility via notifier (no parent rebuild needed).
+    _syncOverlayNotifier();
   }
 
   void _onVerticalDragEnd(DragEndDetails details) {
     final velocity = details.primaryVelocity ?? 0;
     final shouldExpand = velocity < -200 || (!_expanded && _dragOffset > 60);
-    final changed = _expanded != shouldExpand || _dragOffset > 0;
     setState(() {
       _expanded = shouldExpand;
       _dragOffset = 0;
     });
-    if (changed) widget.onOverlayChanged();
+    _syncOverlayNotifier();
     // Refresh window list when expanding to get current active state.
     if (shouldExpand) _loadWindows();
   }
+
+  void _syncOverlayNotifier() => widget.onOverlayChanged();
 
   @override
   Widget build(BuildContext context) {
@@ -253,7 +254,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
     onTap: () {
       final wasExpanded = _expanded;
       setState(() => _expanded = !_expanded);
-      widget.onOverlayChanged();
+      _syncOverlayNotifier();
       // Refresh window list when expanding to get current active state.
       if (!wasExpanded) _loadWindows();
     },
@@ -339,7 +340,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
             title: const Text('New Window'),
             onTap: () {
               setState(() => _expanded = false);
-              widget.onOverlayChanged();
+              _syncOverlayNotifier();
               showModalBottomSheet<AgentLaunchTool?>(
                 context: context,
                 builder: (ctx) => TmuxToolPickerSheet(
@@ -1705,7 +1706,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _isTmuxActive = false;
   String? _tmuxSessionName;
   bool _showTmuxBar = true;
-  bool _tmuxOverlayVisible = false;
+  final _tmuxOverlayNotifier = ValueNotifier<bool>(false);
   String? _tmuxWorkingDirectory;
   final _tmuxBarKey = GlobalKey<_TmuxExpandableBarState>();
   final Map<String, _VerifiedTerminalPath> _verifiedTerminalPathCache =
@@ -2873,10 +2874,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       ref: ref,
       onAction: _handleTmuxAction,
       onOverlayChanged: () {
-        final visible = _tmuxBarKey.currentState?.showOverlay ?? false;
-        if (visible != _tmuxOverlayVisible) {
-          setState(() => _tmuxOverlayVisible = visible);
-        }
+        _tmuxOverlayNotifier.value =
+            _tmuxBarKey.currentState?.showOverlay ?? false;
       },
     );
   }
@@ -2981,17 +2980,21 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final sessionName = _tmuxSessionName;
     if (sessionName == null) return;
 
+    // Fall back to the known tmux working directory so new windows
+    // open in the project folder, not the session start directory.
+    final cwd = workingDirectory ?? _tmuxWorkingDirectory;
+
     final tmux = ref.read(tmuxServiceProvider);
     await tmux.createWindow(
       session,
       sessionName,
       command: command,
       name: name,
-      workingDirectory: workingDirectory,
+      workingDirectory: cwd,
     );
 
     // Update cached working directory to the new window's directory.
-    _tmuxWorkingDirectory = workingDirectory;
+    if (cwd != null) _tmuxWorkingDirectory = cwd;
   }
 
   /// Closes a tmux window via exec channel.
@@ -3151,6 +3154,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _shellStdoutSubscription?.cancel();
     _terminalFocusNode.dispose();
     _toolbarController.dispose();
+    _tmuxOverlayNotifier.dispose();
     super.dispose();
   }
 
@@ -3544,15 +3548,22 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                   child: _buildTerminalView(terminalTheme, isMobile),
                 ),
                 // Overlay: expanded window list floats above the terminal.
+                // Uses ValueListenableBuilder so the parent doesn't rebuild
+                // on drag updates — that would kill the gesture recognizer.
                 if (_isTmuxActive &&
                     _showTmuxBar &&
-                    connectionState == SshConnectionState.connected &&
-                    _tmuxOverlayVisible)
-                  Positioned(
-                    left: 0,
-                    right: 0,
-                    bottom: 0,
-                    child: _buildTmuxOverlay(theme),
+                    connectionState == SshConnectionState.connected)
+                  ValueListenableBuilder<bool>(
+                    valueListenable: _tmuxOverlayNotifier,
+                    builder: (context, visible, _) {
+                      if (!visible) return const SizedBox.shrink();
+                      return Positioned(
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        child: _buildTmuxOverlay(theme),
+                      );
+                    },
                   ),
               ],
             ),

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2337,6 +2337,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   /// checks for tmux sessions via an exec channel. If tmux is active,
   /// also queries the current session name.
   Future<void> _detectTmux(SshSession session) async {
+    // Capture the connection ID at the start so we can verify it hasn't
+    // changed after async gaps (user may have switched connections).
+    final capturedConnectionId = _connectionId;
+
     // Clear any stale tmux state from a previous connection.
     if (mounted) {
       setState(() {
@@ -2347,16 +2351,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     // Give the auto-connect command (which may start tmux) time to init.
     await Future<void>.delayed(const Duration(seconds: 2));
-    if (!mounted) return;
+    if (!mounted || _connectionId != capturedConnectionId) return;
 
     final tmux = ref.read(tmuxServiceProvider);
     final active = await tmux.isTmuxActive(session);
-    if (!mounted) return;
+    if (!mounted || _connectionId != capturedConnectionId) return;
 
     if (!active) return;
 
     final sessionName = await tmux.currentSessionName(session);
-    if (!mounted || sessionName == null) return;
+    if (!mounted || _connectionId != capturedConnectionId) return;
+    if (sessionName == null) return;
 
     setState(() {
       _isTmuxActive = true;
@@ -2766,14 +2771,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 ),
               ),
         actions: [
-          if (_isTmuxActive)
+          if (_isTmuxActive && connectionState == SshConnectionState.connected)
             IconButton(
               icon: const Icon(Icons.window_outlined),
-              onPressed:
-                  _connectionId == null ||
-                      connectionState != SshConnectionState.connected
-                  ? null
-                  : _openTmuxNavigator,
+              onPressed: _connectionId == null ? null : _openTmuxNavigator,
               tooltip: 'tmux windows',
             ),
           IconButton(

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2599,6 +2599,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
+    // If the host has structured tmux configuration, build the tmux command
+    // from it instead of using the custom auto-connect command.
+    final tmuxSession = host.tmuxSessionName;
+    if (tmuxSession != null && tmuxSession.isNotEmpty) {
+      final tmuxCommand = buildTmuxCommand(
+        sessionName: tmuxSession,
+        workingDirectory: host.tmuxWorkingDirectory,
+        extraFlags: host.tmuxExtraFlags,
+      );
+      shell.write(utf8.encode(formatAutoConnectCommandForShell(tmuxCommand)));
+      return;
+    }
+
     final mode = resolveAutoConnectCommandMode(
       command: host.autoConnectCommand,
       snippetId: host.autoConnectSnippetId,
@@ -2691,16 +2704,23 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
       if (!active) return;
 
-      final sessionName = await tmux.currentSessionName(session);
+      // Resolve session name using the best available source:
+      // 1. Host's structured tmux config (explicit session name)
+      // 2. Parsed from auto-connect command (-s flag)
+      // 3. tmux display-message / single-attached fallback
+      final host = _host;
+      var sessionName = host?.tmuxSessionName;
+      sessionName ??= parseTmuxSessionName(host?.autoConnectCommand);
+      sessionName ??= await tmux.currentSessionName(session);
       if (!mounted || _connectionId != capturedConnectionId) return;
       if (sessionName == null) return;
 
       // Get the active window's working directory for SFTP/path resolution.
-      String? tmuxCwd;
+      var tmuxCwd = host?.tmuxWorkingDirectory;
       try {
         final windows = await tmux.listWindows(session, sessionName);
         final activeWindow = windows.where((w) => w.isActive).firstOrNull;
-        tmuxCwd = activeWindow?.currentPath;
+        tmuxCwd ??= activeWindow?.currentPath;
       } on Object {
         // Non-critical — path resolution will fall back to OSC 7.
       }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -315,8 +315,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final dragExpansion = _dragOffset > 0 && !_expanded ? _dragOffset : 0.0;
-    final maxExpandedHeight = MediaQuery.sizeOf(context).height * 0.4;
-    final contentHeight = _expanded ? maxExpandedHeight : dragExpansion;
 
     return AnimatedBuilder(
       animation: _bounceAnimation,
@@ -327,34 +325,47 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       child: GestureDetector(
         onVerticalDragUpdate: _onVerticalDragUpdate,
         onVerticalDragEnd: _onVerticalDragEnd,
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: theme.colorScheme.surfaceContainerHighest,
-            border: Border(
-              top: BorderSide(
-                color: theme.colorScheme.outlineVariant,
-                width: 0.5,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            // Cap expanded height to available space minus the handle,
+            // so the popup doesn't overflow past the top of the terminal
+            // when the keyboard and toolbar are visible.
+            final availableHeight = constraints.maxHeight.isFinite
+                ? constraints.maxHeight - _TmuxExpandableBar.handleHeight
+                : MediaQuery.sizeOf(context).height * 0.4;
+            final maxContentHeight = availableHeight.clamp(0.0, 999.0);
+            final contentHeight = _expanded
+                ? maxContentHeight
+                : dragExpansion.clamp(0.0, maxContentHeight);
+
+            return DecoratedBox(
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest,
+                border: Border(
+                  top: BorderSide(
+                    color: theme.colorScheme.outlineVariant,
+                    width: 0.5,
+                  ),
+                ),
               ),
-            ),
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _buildHandleBar(theme),
-              // Use AnimatedContainer only for expand/collapse snap animation.
-              // During drag, height tracks the finger directly (duration: zero).
-              AnimatedContainer(
-                duration: _dragOffset > 0
-                    ? Duration.zero
-                    : const Duration(milliseconds: 300),
-                curve: Curves.easeOutCubic,
-                height: contentHeight,
-                child: contentHeight > 0
-                    ? ClipRect(child: _buildWindowList(theme))
-                    : const SizedBox.shrink(),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _buildHandleBar(theme),
+                  AnimatedContainer(
+                    duration: _dragOffset > 0
+                        ? Duration.zero
+                        : const Duration(milliseconds: 300),
+                    curve: Curves.easeOutCubic,
+                    height: contentHeight,
+                    child: contentHeight > 0
+                        ? ClipRect(child: _buildWindowList(theme))
+                        : const SizedBox.shrink(),
+                  ),
+                ],
               ),
-            ],
-          ),
+            );
+          },
         ),
       ),
     );

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -58,6 +58,24 @@ bool _isPromptReturnAsciiLetterOrDigit(int codeUnit) =>
     (codeUnit >= 0x41 && codeUnit <= 0x5A) ||
     (codeUnit >= 0x61 && codeUnit <= 0x7A);
 
+/// Resolves how much vertical space the tmux bar can safely expand into.
+@visibleForTesting
+double resolveTmuxBarMaxContentHeight(
+  double availableHeight, {
+  double handleHeight = 22,
+  double reservedPadding = 8,
+  double fallbackAvailableHeight = 0,
+}) {
+  final minimumExpandableHeight = handleHeight + reservedPadding;
+  final effectiveAvailableHeight = availableHeight > minimumExpandableHeight
+      ? availableHeight
+      : fallbackAvailableHeight;
+  return max(
+    0,
+    effectiveAvailableHeight - handleHeight - reservedPadding,
+  ).toDouble();
+}
+
 final _oscEscapeSequencePattern = RegExp(
   '\x1B\\][^\x07\x1B]*(?:\x07|\x1B\\\\)',
   dotAll: true,
@@ -139,6 +157,7 @@ class _TmuxExpandableBar extends StatefulWidget {
   const _TmuxExpandableBar({
     required this.session,
     required this.tmuxSessionName,
+    required this.availableHeight,
     required this.isProUser,
     required this.ref,
     required this.onAction,
@@ -149,6 +168,9 @@ class _TmuxExpandableBar extends StatefulWidget {
 
   /// The tmux session name.
   final String tmuxSessionName;
+
+  /// The available terminal height the bar can expand into.
+  final double availableHeight;
 
   /// Whether the user has Pro access.
   final bool isProUser;
@@ -315,15 +337,20 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final dragExpansion = _dragOffset > 0 && !_expanded ? _dragOffset : 0.0;
-    // Cap popup to available terminal area so it doesn't overflow.
-    final parentBox = context.findAncestorRenderObjectOfType<RenderBox>();
-    final terminalHeight =
-        parentBox?.size.height ?? MediaQuery.sizeOf(context).height * 0.5;
-    final maxContentHeight =
-        (terminalHeight - _TmuxExpandableBar.handleHeight - 8).clamp(
-          0.0,
-          999.0,
-        );
+    final availableHeight = widget.availableHeight.isFinite
+        ? widget.availableHeight
+        : MediaQuery.sizeOf(context).height * 0.5;
+    final mediaQuery = MediaQuery.of(context);
+    final visibleViewportHeight = max(
+      0,
+      mediaQuery.size.height -
+          mediaQuery.viewPadding.vertical -
+          mediaQuery.viewInsets.bottom,
+    );
+    final maxContentHeight = resolveTmuxBarMaxContentHeight(
+      availableHeight,
+      fallbackAvailableHeight: visibleViewportHeight * 0.5,
+    );
     final contentHeight = _expanded
         ? maxContentHeight
         : dragExpansion.clamp(0.0, maxContentHeight);
@@ -369,6 +396,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   }
 
   Widget _buildHandleBar(ThemeData theme) => GestureDetector(
+    key: const ValueKey('tmux-handle-bar'),
     onTap: () {
       final wasExpanded = _expanded;
       setState(() => _expanded = !_expanded);
@@ -2875,13 +2903,36 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
+    // Structured tmux attach is a first-class connection mode, not a generic
+    // automation command. Run it even when Pro-only auto-connect automation is
+    // unavailable so tmux-native navigation remains accessible.
+    final tmuxSession = host.tmuxSessionName;
+    if (tmuxSession != null && tmuxSession.isNotEmpty) {
+      final tmuxCommand = buildTmuxCommand(
+        sessionName: tmuxSession,
+        workingDirectory: host.tmuxWorkingDirectory,
+        extraFlags: host.tmuxExtraFlags,
+      );
+      shell.write(utf8.encode(formatAutoConnectCommandForShell(tmuxCommand)));
+      return;
+    }
+
     final hasAccess = await ref
         .read(monetizationServiceProvider)
         .canUseFeature(MonetizationFeature.autoConnectAutomation);
     if (!hasAccess) {
       if (mounted) {
+        const keyboardToolbarHeight = 96.0;
+        final bottomMargin =
+            MediaQuery.paddingOf(context).bottom +
+            (_showKeyboardToolbar ? keyboardToolbarHeight : 0) +
+            (_isTmuxActive && _showTmuxBar
+                ? _TmuxExpandableBar.handleHeight + 16
+                : 16);
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
+            behavior: SnackBarBehavior.floating,
+            margin: EdgeInsets.fromLTRB(16, 0, 16, bottomMargin),
             content: const Text(
               'MonkeySSH Pro unlocks auto-connect commands and snippets.',
             ),
@@ -2897,19 +2948,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           ),
         );
       }
-      return;
-    }
-
-    // If the host has structured tmux configuration, build the tmux command
-    // from it instead of using the custom auto-connect command.
-    final tmuxSession = host.tmuxSessionName;
-    if (tmuxSession != null && tmuxSession.isNotEmpty) {
-      final tmuxCommand = buildTmuxCommand(
-        sessionName: tmuxSession,
-        workingDirectory: host.tmuxWorkingDirectory,
-        extraFlags: host.tmuxExtraFlags,
-      );
-      shell.write(utf8.encode(formatAutoConnectCommandForShell(tmuxCommand)));
       return;
     }
 
@@ -3055,38 +3093,40 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _showTmuxBar &&
         connectionState == SshConnectionState.connected;
 
-    return Stack(
-      children: [
-        // Terminal with animated bottom padding that grows/shrinks
-        // smoothly when the tmux handle appears/disappears.
-        Positioned.fill(
-          child: AnimatedPadding(
-            duration: const Duration(milliseconds: 300),
-            curve: Curves.easeOutCubic,
-            padding: EdgeInsets.only(
-              bottom: showTmux ? _TmuxExpandableBar.handleHeight : 0,
+    return LayoutBuilder(
+      builder: (context, constraints) => Stack(
+        children: [
+          // Terminal with animated bottom padding that grows/shrinks
+          // smoothly when the tmux handle appears/disappears.
+          Positioned.fill(
+            child: AnimatedPadding(
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeOutCubic,
+              padding: EdgeInsets.only(
+                bottom: showTmux ? _TmuxExpandableBar.handleHeight : 0,
+              ),
+              child: _buildTerminalView(terminalTheme, isMobile),
             ),
-            child: _buildTerminalView(terminalTheme, isMobile),
           ),
-        ),
-        // Handle bar slides up from below via AnimatedPositioned.
-        Positioned(
-          left: 0,
-          right: 0,
-          bottom: showTmux ? 0 : -_TmuxExpandableBar.handleHeight,
-          child: AnimatedOpacity(
-            duration: const Duration(milliseconds: 300),
-            curve: Curves.easeOutCubic,
-            opacity: showTmux ? 1 : 0,
-            child: _buildTmuxExpandableBar(theme),
+          // Handle bar slides up from below via AnimatedPositioned.
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: showTmux ? 0 : -_TmuxExpandableBar.handleHeight,
+            child: AnimatedOpacity(
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeOutCubic,
+              opacity: showTmux ? 1 : 0,
+              child: _buildTmuxExpandableBar(theme, constraints.maxHeight),
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 
   /// Builds the tmux expandable bar overlaid at the bottom of the terminal.
-  Widget _buildTmuxExpandableBar(ThemeData theme) {
+  Widget _buildTmuxExpandableBar(ThemeData theme, double availableHeight) {
     final connectionId = _connectionId;
     if (connectionId == null || _tmuxSessionName == null) {
       return const SizedBox.shrink();
@@ -3105,6 +3145,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     return _TmuxExpandableBar(
       session: session,
       tmuxSessionName: _tmuxSessionName!,
+      availableHeight: availableHeight,
       isProUser: isProUser,
       ref: ref,
       onAction: _handleTmuxAction,

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -315,6 +315,18 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final dragExpansion = _dragOffset > 0 && !_expanded ? _dragOffset : 0.0;
+    // Cap popup to available terminal area so it doesn't overflow.
+    final parentBox = context.findAncestorRenderObjectOfType<RenderBox>();
+    final terminalHeight =
+        parentBox?.size.height ?? MediaQuery.sizeOf(context).height * 0.5;
+    final maxContentHeight =
+        (terminalHeight - _TmuxExpandableBar.handleHeight - 8).clamp(
+          0.0,
+          999.0,
+        );
+    final contentHeight = _expanded
+        ? maxContentHeight
+        : dragExpansion.clamp(0.0, maxContentHeight);
 
     return AnimatedBuilder(
       animation: _bounceAnimation,
@@ -325,47 +337,32 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       child: GestureDetector(
         onVerticalDragUpdate: _onVerticalDragUpdate,
         onVerticalDragEnd: _onVerticalDragEnd,
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            // Cap expanded height to available space minus the handle,
-            // so the popup doesn't overflow past the top of the terminal
-            // when the keyboard and toolbar are visible.
-            final availableHeight = constraints.maxHeight.isFinite
-                ? constraints.maxHeight - _TmuxExpandableBar.handleHeight
-                : MediaQuery.sizeOf(context).height * 0.4;
-            final maxContentHeight = availableHeight.clamp(0.0, 999.0);
-            final contentHeight = _expanded
-                ? maxContentHeight
-                : dragExpansion.clamp(0.0, maxContentHeight);
-
-            return DecoratedBox(
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surfaceContainerHighest,
-                border: Border(
-                  top: BorderSide(
-                    color: theme.colorScheme.outlineVariant,
-                    width: 0.5,
-                  ),
-                ),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceContainerHighest,
+            border: Border(
+              top: BorderSide(
+                color: theme.colorScheme.outlineVariant,
+                width: 0.5,
               ),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  _buildHandleBar(theme),
-                  AnimatedContainer(
-                    duration: _dragOffset > 0
-                        ? Duration.zero
-                        : const Duration(milliseconds: 300),
-                    curve: Curves.easeOutCubic,
-                    height: contentHeight,
-                    child: contentHeight > 0
-                        ? ClipRect(child: _buildWindowList(theme))
-                        : const SizedBox.shrink(),
-                  ),
-                ],
+            ),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildHandleBar(theme),
+              AnimatedContainer(
+                duration: _dragOffset > 0
+                    ? Duration.zero
+                    : const Duration(milliseconds: 300),
+                curve: Curves.easeOutCubic,
+                height: contentHeight,
+                child: contentHeight > 0
+                    ? ClipRect(child: _buildWindowList(theme))
+                    : const SizedBox.shrink(),
               ),
-            );
-          },
+            ],
+          ),
         ),
       ),
     );

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1659,6 +1659,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _isTmuxActive = false;
   String? _tmuxSessionName;
   bool _showTmuxBar = true;
+  String? _tmuxWorkingDirectory;
   final Map<String, _VerifiedTerminalPath> _verifiedTerminalPathCache =
       <String, _VerifiedTerminalPath>{};
   final ListQueue<String> _verifiedTerminalPathCacheOrder = ListQueue<String>();
@@ -1735,7 +1736,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       formatTerminalWorkingDirectoryLabel(_workingDirectory);
 
   String? get _workingDirectoryPath =>
-      resolveTerminalWorkingDirectoryPath(_workingDirectory);
+      resolveTerminalWorkingDirectoryPath(_workingDirectory) ??
+      _tmuxWorkingDirectory;
 
   TerminalShellStatus? get _shellStatus => _observedSession?.shellStatus;
 
@@ -2671,6 +2673,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       setState(() {
         _isTmuxActive = false;
         _tmuxSessionName = null;
+        _tmuxWorkingDirectory = null;
       });
     }
 
@@ -2692,9 +2695,22 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       if (!mounted || _connectionId != capturedConnectionId) return;
       if (sessionName == null) return;
 
+      // Get the active window's working directory for SFTP/path resolution.
+      String? tmuxCwd;
+      try {
+        final windows = await tmux.listWindows(session, sessionName);
+        final activeWindow = windows.where((w) => w.isActive).firstOrNull;
+        tmuxCwd = activeWindow?.currentPath;
+      } on Object {
+        // Non-critical — path resolution will fall back to OSC 7.
+      }
+
+      if (!mounted || _connectionId != capturedConnectionId) return;
+
       setState(() {
         _isTmuxActive = true;
         _tmuxSessionName = sessionName;
+        _tmuxWorkingDirectory = tmuxCwd;
       });
     } on Object {
       // Silently ignore — tmux detection is best-effort.
@@ -4040,10 +4056,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (connectionId == null) {
       return;
     }
+
+    // Pass the terminal's working directory (from OSC 7) as both the
+    // initial path and the working directory for relative path resolution.
+    final cwd = _workingDirectoryPath;
     context.pushNamed(
       Routes.sftp,
       pathParameters: {'hostId': widget.hostId.toString()},
-      queryParameters: {'connectionId': connectionId.toString()},
+      queryParameters: {
+        'connectionId': connectionId.toString(),
+        if (cwd != null) ...{'path': cwd, 'cwd': cwd},
+      },
     );
   }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -27,6 +27,7 @@ import '../../domain/models/auto_connect_command.dart';
 import '../../domain/models/monetization.dart';
 import '../../domain/models/terminal_theme.dart';
 import '../../domain/models/terminal_themes.dart';
+import '../../domain/models/tmux_state.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/remote_clipboard_sync_service.dart';
 import '../../domain/services/remote_file_service.dart';
@@ -113,6 +114,309 @@ const _terminalFilePathVerificationExtensions = <String>[
   'h',
   'm',
 ];
+
+/// Expandable tmux bar that sits at the bottom of the terminal.
+///
+/// Collapsed: a slim handle bar showing session name + drag pill.
+/// Expanded: smoothly grows to reveal window list + actions.
+/// The bar always takes full width and pushes the terminal up,
+/// never overlaying it.
+class _TmuxExpandableBar extends StatefulWidget {
+  const _TmuxExpandableBar({
+    required this.session,
+    required this.tmuxSessionName,
+    required this.isProUser,
+    required this.ref,
+    required this.onAction,
+  });
+
+  /// The active SSH session.
+  final SshSession session;
+
+  /// The tmux session name.
+  final String tmuxSessionName;
+
+  /// Whether the user has Pro access.
+  final bool isProUser;
+
+  /// Riverpod ref.
+  final WidgetRef ref;
+
+  /// Callback for navigator actions.
+  final Future<void> Function(TmuxNavigatorAction) onAction;
+
+  @override
+  State<_TmuxExpandableBar> createState() => _TmuxExpandableBarState();
+}
+
+class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
+  List<TmuxWindow>? _windows;
+  bool _expanded = false;
+  bool _isLoading = true;
+  double _dragOffset = 0;
+
+  TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
+
+  @override
+  void initState() {
+    super.initState();
+    _loadWindows();
+  }
+
+  Future<void> _loadWindows() async {
+    try {
+      final windows = await _tmux.listWindows(
+        widget.session,
+        widget.tmuxSessionName,
+      );
+      if (!mounted) return;
+      setState(() {
+        _windows = windows;
+        _isLoading = false;
+      });
+    } on Object {
+      if (!mounted) return;
+      setState(() => _isLoading = false);
+    }
+  }
+
+  void _onVerticalDragUpdate(DragUpdateDetails details) {
+    setState(() {
+      _dragOffset -= details.delta.dy;
+      _dragOffset = _dragOffset.clamp(0.0, 300.0);
+    });
+  }
+
+  void _onVerticalDragEnd(DragEndDetails details) {
+    final velocity = details.primaryVelocity ?? 0;
+    final shouldExpand = velocity < -200 || (!_expanded && _dragOffset > 60);
+    setState(() {
+      _expanded = shouldExpand;
+      _dragOffset = 0;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    // Compute extra height from drag for smooth tracking.
+    final dragExpansion = _dragOffset > 0 && !_expanded ? _dragOffset : 0.0;
+
+    return GestureDetector(
+      onVerticalDragUpdate: _onVerticalDragUpdate,
+      onVerticalDragEnd: _onVerticalDragEnd,
+      child: AnimatedContainer(
+        duration: _dragOffset > 0
+            ? Duration.zero
+            : const Duration(milliseconds: 300),
+        curve: Curves.easeOutCubic,
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerHighest,
+          border: Border(
+            top: BorderSide(
+              color: theme.colorScheme.outlineVariant,
+              width: 0.5,
+            ),
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Handle bar — always visible.
+            _buildHandleBar(theme),
+            // Drag preview: show partial content during drag.
+            if (dragExpansion > 0)
+              SizedBox(
+                height: dragExpansion,
+                child: ClipRect(
+                  child: Align(
+                    alignment: Alignment.topCenter,
+                    child: _buildWindowList(theme),
+                  ),
+                ),
+              ),
+            // Expanded content.
+            AnimatedCrossFade(
+              duration: const Duration(milliseconds: 300),
+              sizeCurve: Curves.easeOutCubic,
+              crossFadeState: _expanded
+                  ? CrossFadeState.showSecond
+                  : CrossFadeState.showFirst,
+              firstChild: const SizedBox.shrink(),
+              secondChild: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.sizeOf(context).height * 0.4,
+                ),
+                child: _buildWindowList(theme),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHandleBar(ThemeData theme) => GestureDetector(
+    onTap: () => setState(() => _expanded = !_expanded),
+    child: Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Row(
+        children: [
+          Icon(
+            Icons.window_outlined,
+            size: 14,
+            color: theme.colorScheme.primary,
+          ),
+          const SizedBox(width: 6),
+          Text(
+            widget.tmuxSessionName,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const Spacer(),
+          Container(
+            width: 32,
+            height: 4,
+            decoration: BoxDecoration(
+              color: theme.colorScheme.onSurfaceVariant.withAlpha(80),
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          const Spacer(),
+          AnimatedRotation(
+            duration: const Duration(milliseconds: 300),
+            turns: _expanded ? 0.5 : 0,
+            child: Icon(
+              Icons.keyboard_arrow_up,
+              size: 16,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+
+  Widget _buildWindowList(ThemeData theme) {
+    if (_isLoading) {
+      return const Padding(
+        padding: EdgeInsets.all(16),
+        child: Center(
+          child: SizedBox(
+            width: 20,
+            height: 20,
+            child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+          ),
+        ),
+      );
+    }
+
+    if (_windows == null || _windows!.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return SingleChildScrollView(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Divider(height: 1),
+          for (final window in _windows!) _buildWindowTile(theme, window),
+          const Divider(height: 1),
+          ListTile(
+            dense: true,
+            leading: Icon(
+              Icons.add_circle_outline,
+              color: theme.colorScheme.primary,
+              size: 20,
+            ),
+            title: const Text('New Window'),
+            onTap: _openTmuxNavigator,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _openTmuxNavigator() async {
+    final action = await showTmuxNavigator(
+      context: context,
+      ref: widget.ref,
+      session: widget.session,
+      tmuxSessionName: widget.tmuxSessionName,
+      isProUser: widget.isProUser,
+    );
+    if (action != null) {
+      await widget.onAction(action);
+    }
+  }
+
+  Widget _buildWindowTile(ThemeData theme, TmuxWindow window) => ListTile(
+    dense: true,
+    leading: Container(
+      width: 24,
+      height: 24,
+      decoration: BoxDecoration(
+        color: window.isActive
+            ? theme.colorScheme.primary
+            : theme.colorScheme.surfaceContainerHigh,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        '${window.index}',
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: window.isActive
+              ? theme.colorScheme.onPrimary
+              : theme.colorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    ),
+    title: Text(window.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+    subtitle: window.paneTitle != null
+        ? Text(
+            window.paneTitle!,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          )
+        : null,
+    trailing: Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (window.hasAlert)
+          Icon(
+            Icons.notifications_active,
+            size: 16,
+            color: theme.colorScheme.error,
+          ),
+        IconButton(
+          icon: const Icon(Icons.close, size: 16),
+          visualDensity: VisualDensity.compact,
+          tooltip: 'Close window',
+          onPressed: () {
+            widget.onAction(TmuxCloseWindowAction(window.index));
+            setState(() {
+              _windows = _windows
+                  ?.where((w) => w.index != window.index)
+                  .toList();
+            });
+          },
+        ),
+      ],
+    ),
+    selected: window.isActive,
+    onTap: window.isActive
+        ? () => setState(() => _expanded = false)
+        : () {
+            widget.onAction(TmuxSwitchWindowAction(window.index));
+            setState(() => _expanded = false);
+          },
+  );
+}
 
 class _ExtraKeysToggleKeycap extends StatelessWidget {
   const _ExtraKeysToggleKeycap({required this.isActive, super.key});
@@ -2383,60 +2687,54 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
-  /// Builds the slim tmux handle bar at the bottom of the terminal.
+  /// Builds a draggable tmux panel anchored to the bottom of the terminal.
   ///
-  /// Shows the current tmux session name and a drag handle. Tapping or
-  /// swiping up opens the full tmux navigator.
-  Widget _buildTmuxHandle(ThemeData theme) => GestureDetector(
-    onTap: _openTmuxNavigator,
-    onVerticalDragEnd: (details) {
-      // Swipe up to open.
-      if (details.primaryVelocity != null && details.primaryVelocity! < -100) {
-        _openTmuxNavigator();
-      }
-    },
-    child: Container(
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest,
-        border: Border(
-          top: BorderSide(color: theme.colorScheme.outlineVariant, width: 0.5),
-        ),
-      ),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-      child: Row(
-        children: [
-          Icon(
-            Icons.window_outlined,
-            size: 14,
-            color: theme.colorScheme.primary,
-          ),
-          const SizedBox(width: 6),
-          Text(
-            _tmuxSessionName ?? 'tmux',
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          ),
-          const Spacer(),
-          // Drag handle pill.
-          Container(
-            width: 32,
-            height: 4,
-            decoration: BoxDecoration(
-              color: theme.colorScheme.onSurfaceVariant.withAlpha(80),
-              borderRadius: BorderRadius.circular(2),
-            ),
-          ),
-          const Spacer(),
-          Icon(
-            Icons.keyboard_arrow_up,
-            size: 16,
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-        ],
-      ),
-    ),
-  );
+  /// Collapsed, it shows a slim handle bar with the session name.
+  /// Dragging up smoothly expands it into the full navigator — like
+  /// water droplets combining. Releasing snaps to collapsed or expanded.
+  Widget _buildTmuxExpandableBar(ThemeData theme) {
+    final connectionId = _connectionId;
+    if (connectionId == null || _tmuxSessionName == null) {
+      return const SizedBox.shrink();
+    }
+
+    final session = _sessionsNotifier?.getSession(connectionId);
+    if (session == null) return const SizedBox.shrink();
+
+    final monetizationState =
+        ref.read(monetizationStateProvider).asData?.value ??
+        ref.read(monetizationServiceProvider).currentState;
+    final isProUser = monetizationState.allowsFeature(
+      MonetizationFeature.agentLaunchPresets,
+    );
+
+    return _TmuxExpandableBar(
+      session: session,
+      tmuxSessionName: _tmuxSessionName!,
+      isProUser: isProUser,
+      ref: ref,
+      onAction: _handleTmuxAction,
+    );
+  }
+
+  /// Handles an action from the draggable tmux panel.
+  Future<void> _handleTmuxAction(TmuxNavigatorAction action) async {
+    final connectionId = _connectionId;
+    if (connectionId == null) return;
+    final session = _sessionsNotifier?.getSession(connectionId);
+    if (session == null) return;
+
+    switch (action) {
+      case TmuxSwitchWindowAction(:final windowIndex):
+        _switchTmuxWindow(session, windowIndex);
+      case TmuxNewWindowAction(:final command, :final windowName):
+        await _createTmuxWindow(session, command: command, name: windowName);
+      case TmuxResumeSessionAction(:final resumeCommand):
+        await _createTmuxWindow(session, command: resumeCommand);
+      case TmuxCloseWindowAction(:final windowIndex):
+        _closeTmuxWindow(session, windowIndex);
+    }
+  }
 
   /// Opens the tmux window navigator bottom sheet and handles the
   /// selected action.
@@ -3053,7 +3351,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           if (_isTmuxActive &&
               _showTmuxBar &&
               connectionState == SshConnectionState.connected)
-            _buildTmuxHandle(theme),
+            _buildTmuxExpandableBar(theme),
           if (_showKeyboardToolbar &&
               !showsDisconnectedOverlay &&
               (!_isNativeSelectionMode || _isMobilePlatform))

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -194,6 +194,8 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
       _expanded = shouldExpand;
       _dragOffset = 0;
     });
+    // Refresh window list when expanding to get current active state.
+    if (shouldExpand) _loadWindows();
   }
 
   @override
@@ -257,24 +259,18 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
   }
 
   Widget _buildHandleBar(ThemeData theme) => GestureDetector(
-    onTap: () => setState(() => _expanded = !_expanded),
+    onTap: () {
+      final wasExpanded = _expanded;
+      setState(() => _expanded = !_expanded);
+      // Refresh window list when expanding to get current active state.
+      if (!wasExpanded) _loadWindows();
+    },
     child: Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      child: Row(
+      child: Stack(
+        alignment: Alignment.center,
         children: [
-          Icon(
-            Icons.window_outlined,
-            size: 14,
-            color: theme.colorScheme.primary,
-          ),
-          const SizedBox(width: 6),
-          Text(
-            widget.tmuxSessionName,
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          ),
-          const Spacer(),
+          // Centered drag handle pill.
           Container(
             width: 32,
             height: 4,
@@ -283,15 +279,32 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
               borderRadius: BorderRadius.circular(2),
             ),
           ),
-          const Spacer(),
-          AnimatedRotation(
-            duration: const Duration(milliseconds: 300),
-            turns: _expanded ? 0.5 : 0,
-            child: Icon(
-              Icons.keyboard_arrow_up,
-              size: 16,
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
+          // Left-aligned session name, right-aligned chevron.
+          Row(
+            children: [
+              Icon(
+                Icons.window_outlined,
+                size: 14,
+                color: theme.colorScheme.primary,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                widget.tmuxSessionName,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const Spacer(),
+              AnimatedRotation(
+                duration: const Duration(milliseconds: 300),
+                turns: _expanded ? 0.5 : 0,
+                child: Icon(
+                  Icons.keyboard_arrow_up,
+                  size: 16,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
           ),
         ],
       ),
@@ -423,12 +436,11 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
       ],
     ),
     selected: window.isActive,
-    onTap: window.isActive
-        ? () => setState(() => _expanded = false)
-        : () {
-            widget.onAction(TmuxSwitchWindowAction(window.index));
-            setState(() => _expanded = false);
-          },
+    // Always issue the switch command — the active flag may be stale.
+    onTap: () {
+      widget.onAction(TmuxSwitchWindowAction(window.index));
+      setState(() => _expanded = false);
+    },
   );
 }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1340,6 +1340,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _showsTerminalMetadata = false;
   bool _isTmuxActive = false;
   String? _tmuxSessionName;
+  bool _showTmuxBar = true;
   final Map<String, _VerifiedTerminalPath> _verifiedTerminalPathCache =
       <String, _VerifiedTerminalPath>{};
   final ListQueue<String> _verifiedTerminalPathCacheOrder = ListQueue<String>();
@@ -2382,6 +2383,61 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
+  /// Builds the slim tmux handle bar at the bottom of the terminal.
+  ///
+  /// Shows the current tmux session name and a drag handle. Tapping or
+  /// swiping up opens the full tmux navigator.
+  Widget _buildTmuxHandle(ThemeData theme) => GestureDetector(
+    onTap: _openTmuxNavigator,
+    onVerticalDragEnd: (details) {
+      // Swipe up to open.
+      if (details.primaryVelocity != null && details.primaryVelocity! < -100) {
+        _openTmuxNavigator();
+      }
+    },
+    child: Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        border: Border(
+          top: BorderSide(color: theme.colorScheme.outlineVariant, width: 0.5),
+        ),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Row(
+        children: [
+          Icon(
+            Icons.window_outlined,
+            size: 14,
+            color: theme.colorScheme.primary,
+          ),
+          const SizedBox(width: 6),
+          Text(
+            _tmuxSessionName ?? 'tmux',
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const Spacer(),
+          // Drag handle pill.
+          Container(
+            width: 32,
+            height: 4,
+            decoration: BoxDecoration(
+              color: theme.colorScheme.onSurfaceVariant.withAlpha(80),
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          const Spacer(),
+          Icon(
+            Icons.keyboard_arrow_up,
+            size: 16,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ],
+      ),
+    ),
+  );
+
   /// Opens the tmux window navigator bottom sheet and handles the
   /// selected action.
   Future<void> _openTmuxNavigator() async {
@@ -2410,7 +2466,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     switch (action) {
       case TmuxSwitchWindowAction(:final windowIndex):
-        await _switchTmuxWindow(session, windowIndex);
+        _switchTmuxWindow(session, windowIndex);
       case TmuxNewWindowAction(:final command, :final windowName):
         await _createTmuxWindow(session, command: command, name: windowName);
       case TmuxResumeSessionAction(:final resumeCommand):
@@ -2424,12 +2480,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   /// `tmux select-window` is a server operation — the tmux server
   /// notifies all attached clients of the change. Writing to the PTY
   /// would inject the command as input to whatever program is running.
-  Future<void> _switchTmuxWindow(SshSession session, int windowIndex) async {
+  void _switchTmuxWindow(SshSession session, int windowIndex) {
     final sessionName = _tmuxSessionName;
     if (sessionName == null) return;
 
-    final tmux = ref.read(tmuxServiceProvider);
-    await tmux.selectWindow(session, sessionName, windowIndex);
+    ref
+        .read(tmuxServiceProvider)
+        .selectWindow(session, sessionName, windowIndex);
   }
 
   /// Creates a new tmux window via exec channel, then switches to it.
@@ -2869,6 +2926,22 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                     ],
                   ),
                 ),
+              if (_isTmuxActive)
+                PopupMenuItem(
+                  value: 'toggle_tmux_bar',
+                  child: Row(
+                    children: [
+                      Icon(
+                        _showTmuxBar
+                            ? Icons.window_outlined
+                            : Icons.window_rounded,
+                        size: 20,
+                      ),
+                      const SizedBox(width: 12),
+                      Text(_showTmuxBar ? 'Hide tmux Bar' : 'Show tmux Bar'),
+                    ],
+                  ),
+                ),
               if (isMobile)
                 CheckedPopupMenuItem(
                   value: 'toggle_tap_keyboard',
@@ -2965,6 +3038,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       body: Column(
         children: [
           Expanded(child: _buildTerminalView(terminalTheme, isMobile)),
+          if (_isTmuxActive &&
+              _showTmuxBar &&
+              connectionState == SshConnectionState.connected)
+            _buildTmuxHandle(theme),
           if (_showKeyboardToolbar &&
               !showsDisconnectedOverlay &&
               (!_isNativeSelectionMode || _isMobilePlatform))
@@ -3656,6 +3733,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         break;
       case 'toggle_terminal_info':
         setState(() => _showsTerminalMetadata = !_showsTerminalMetadata);
+        break;
+      case 'toggle_tmux_bar':
+        setState(() => _showTmuxBar = !_showTmuxBar);
         break;
       case 'toggle_tap_keyboard':
         final notifier = ref.read(tapToShowKeyboardNotifierProvider.notifier);

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2471,6 +2471,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         await _createTmuxWindow(session, command: command, name: windowName);
       case TmuxResumeSessionAction(:final resumeCommand):
         await _createTmuxWindow(session, command: resumeCommand);
+      case TmuxCloseWindowAction(:final windowIndex):
+        _closeTmuxWindow(session, windowIndex);
     }
   }
 
@@ -2503,6 +2505,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     // After creating a new window, tmux automatically selects it.
     // No explicit switch needed.
+  }
+
+  /// Closes a tmux window via exec channel.
+  void _closeTmuxWindow(SshSession session, int windowIndex) {
+    final sessionName = _tmuxSessionName;
+    if (sessionName == null) return;
+
+    ref.read(tmuxServiceProvider).killWindow(session, sessionName, windowIndex);
   }
 
   void _handleTrackedConnectionStateChange(

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -367,84 +367,115 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
     );
   }
 
-  Widget _buildWindowTile(ThemeData theme, TmuxWindow window) => ListTile(
-    dense: true,
-    leading: Container(
-      width: 24,
-      height: 24,
-      decoration: BoxDecoration(
-        color: window.isActive
-            ? theme.colorScheme.primary
-            : theme.colorScheme.surfaceContainerHigh,
-        borderRadius: BorderRadius.circular(6),
-      ),
-      alignment: Alignment.center,
-      child: Text(
-        '${window.index}',
-        style: theme.textTheme.labelSmall?.copyWith(
-          color: window.isActive
-              ? theme.colorScheme.onPrimary
-              : theme.colorScheme.onSurfaceVariant,
-          fontWeight: FontWeight.bold,
+  Widget _buildWindowTile(ThemeData theme, TmuxWindow window) {
+    final isActive = window.isActive;
+
+    return ListTile(
+      dense: true,
+      tileColor: isActive
+          ? theme.colorScheme.primaryContainer.withAlpha(80)
+          : null,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      leading: Container(
+        width: 24,
+        height: 24,
+        decoration: BoxDecoration(
+          color: isActive
+              ? theme.colorScheme.primary
+              : theme.colorScheme.surfaceContainerHigh,
+          borderRadius: BorderRadius.circular(6),
         ),
-      ),
-    ),
-    title: Text(window.name, maxLines: 1, overflow: TextOverflow.ellipsis),
-    subtitle: window.paneTitle != null
-        ? Text(
-            window.paneTitle!,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          )
-        : null,
-    trailing: Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        if (window.hasAlert)
-          Padding(
-            padding: const EdgeInsets.only(right: 4),
-            child: Icon(
-              Icons.notifications_active,
-              size: 16,
-              color: theme.colorScheme.error,
-            ),
-          )
-        else if (window.isIdle)
-          Padding(
-            padding: const EdgeInsets.only(right: 4),
-            child: Text(
-              'waiting',
-              style: theme.textTheme.labelSmall?.copyWith(
-                color: theme.colorScheme.tertiary,
-                fontStyle: FontStyle.italic,
-              ),
-            ),
+        alignment: Alignment.center,
+        child: Text(
+          '${window.index}',
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: isActive
+                ? theme.colorScheme.onPrimary
+                : theme.colorScheme.onSurfaceVariant,
+            fontWeight: FontWeight.bold,
           ),
-        IconButton(
-          icon: const Icon(Icons.close, size: 16),
-          visualDensity: VisualDensity.compact,
-          tooltip: 'Close window',
-          onPressed: () {
-            widget.onAction(TmuxCloseWindowAction(window.index));
-            setState(() {
-              _windows = _windows
-                  ?.where((w) => w.index != window.index)
-                  .toList();
-            });
-          },
         ),
-      ],
-    ),
-    selected: window.isActive,
-    // Always issue the switch command — the active flag may be stale.
-    onTap: () {
-      widget.onAction(TmuxSwitchWindowAction(window.index));
-      setState(() => _expanded = false);
-    },
-  );
+      ),
+      title: Text(
+        window.name,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: isActive
+            ? theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600)
+            : null,
+      ),
+      subtitle: window.paneTitle != null
+          ? Text(
+              window.paneTitle!,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            )
+          : null,
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _windowStatusIcon(theme, window),
+          IconButton(
+            icon: const Icon(Icons.close, size: 16),
+            visualDensity: VisualDensity.compact,
+            tooltip: 'Close window',
+            onPressed: () {
+              widget.onAction(TmuxCloseWindowAction(window.index));
+              setState(() {
+                _windows = _windows
+                    ?.where((w) => w.index != window.index)
+                    .toList();
+              });
+            },
+          ),
+        ],
+      ),
+      onTap: isActive
+          ? () => setState(() => _expanded = false)
+          : () {
+              widget.onAction(TmuxSwitchWindowAction(window.index));
+              setState(() => _expanded = false);
+            },
+    );
+  }
+
+  Widget _windowStatusIcon(ThemeData theme, TmuxWindow window) {
+    if (window.hasAlert) {
+      return Padding(
+        padding: const EdgeInsets.only(right: 4),
+        child: Icon(
+          Icons.notifications_active,
+          size: 16,
+          color: theme.colorScheme.error,
+        ),
+      );
+    }
+    if (window.isIdle) {
+      return Padding(
+        padding: const EdgeInsets.only(right: 4),
+        child: Icon(
+          Icons.hourglass_bottom,
+          size: 14,
+          color: theme.colorScheme.tertiary,
+        ),
+      );
+    }
+    if (!window.isActive) {
+      // Running — not idle, not alert.
+      return Padding(
+        padding: const EdgeInsets.only(right: 4),
+        child: Icon(
+          Icons.play_arrow,
+          size: 16,
+          color: theme.colorScheme.primary.withAlpha(160),
+        ),
+      );
+    }
+    return const SizedBox.shrink();
+  }
 }
 
 class _ExtraKeysToggleKeycap extends StatelessWidget {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -67,14 +67,20 @@ double resolveTmuxBarMaxContentHeight(
   double reservedPadding = 8,
   double fallbackAvailableHeight = 0,
 }) {
+  const maxHeightFactor = 0.68;
+  const maxHeightCap = 400.0;
   final minimumExpandableHeight = handleHeight + reservedPadding;
   final effectiveAvailableHeight = availableHeight > minimumExpandableHeight
       ? availableHeight
       : fallbackAvailableHeight;
-  return max(
+  final rawHeight = max(
     0,
     effectiveAvailableHeight - handleHeight - reservedPadding,
   ).toDouble();
+  return min(
+    rawHeight,
+    min(effectiveAvailableHeight * maxHeightFactor, maxHeightCap),
+  );
 }
 
 final _oscEscapeSequencePattern = RegExp(
@@ -770,9 +776,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
 
   Widget _buildWindowTile(ThemeData theme, TmuxWindow window) {
     final isActive = window.isActive;
-    final secondaryTitle = window.displayTitle != window.name
-        ? window.name
-        : null;
+    final secondaryTitle = window.secondaryTitle;
 
     return ListTile(
       dense: true,

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -34,6 +34,7 @@ import '../../domain/services/settings_service.dart';
 import '../../domain/services/ssh_service.dart';
 import '../../domain/services/terminal_hyperlink_tracker.dart';
 import '../../domain/services/terminal_theme_service.dart';
+import '../../domain/services/tmux_service.dart';
 import '../widgets/keyboard_toolbar.dart';
 import '../widgets/monkey_terminal_view.dart';
 import '../widgets/premium_access.dart';
@@ -41,6 +42,7 @@ import '../widgets/terminal_pinch_zoom_gesture_handler.dart';
 import '../widgets/terminal_text_input_handler.dart';
 import '../widgets/terminal_text_style.dart';
 import '../widgets/terminal_theme_picker.dart';
+import '../widgets/tmux_window_navigator.dart';
 
 bool _isPromptReturnWhitespaceCodeUnit(int codeUnit) =>
     codeUnit == 0x20 ||
@@ -1336,6 +1338,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   TerminalHyperlinkTracker? _terminalHyperlinkTracker;
   SshSession? _observedSession;
   bool _showsTerminalMetadata = false;
+  bool _isTmuxActive = false;
+  String? _tmuxSessionName;
   final Map<String, _VerifiedTerminalPath> _verifiedTerminalPathCache =
       <String, _VerifiedTerminalPath>{};
   final ListQueue<String> _verifiedTerminalPathCacheOrder = ListQueue<String>();
@@ -2067,6 +2071,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       // Start port forwards
       await _startPortForwards(session);
       await _runAutoConnectCommand();
+
+      // Detect tmux after the auto-connect command has had time to start.
+      // A small delay ensures tmux has initialized if the auto-connect
+      // command launches a tmux session.
+      unawaited(_detectTmux(session));
     } on Object catch (e) {
       if (!mounted) return;
       setState(() {
@@ -2320,6 +2329,92 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         ref.read(snippetRepositoryProvider).incrementUsage(resolvedSnippetId),
       );
     }
+  }
+
+  /// Detects whether the connected session is inside tmux.
+  ///
+  /// Waits briefly for the auto-connect command to initialize, then
+  /// checks the TMUX environment variable via an exec channel. If tmux
+  /// is active, also queries the current session name.
+  Future<void> _detectTmux(SshSession session) async {
+    // Give the auto-connect command (which may start tmux) time to init.
+    await Future<void>.delayed(const Duration(seconds: 2));
+    if (!mounted) return;
+
+    final tmux = ref.read(tmuxServiceProvider);
+    final active = await tmux.isTmuxActive(session);
+    if (!mounted || !active) return;
+
+    final sessionName = await tmux.currentSessionName(session);
+    if (!mounted) return;
+
+    setState(() {
+      _isTmuxActive = true;
+      _tmuxSessionName = sessionName;
+    });
+  }
+
+  /// Opens the tmux window navigator bottom sheet and handles the
+  /// selected action.
+  Future<void> _openTmuxNavigator() async {
+    final connectionId = _connectionId;
+    if (connectionId == null || _tmuxSessionName == null) return;
+
+    final session = _sessionsNotifier?.getSession(connectionId);
+    if (session == null) return;
+
+    final monetizationState =
+        ref.read(monetizationStateProvider).asData?.value ??
+        ref.read(monetizationServiceProvider).currentState;
+    final isProUser = monetizationState.allowsFeature(
+      MonetizationFeature.agentLaunchPresets,
+    );
+
+    final action = await showTmuxNavigator(
+      context: context,
+      ref: ref,
+      session: session,
+      tmuxSessionName: _tmuxSessionName!,
+      isProUser: isProUser,
+    );
+
+    if (!mounted || action == null) return;
+
+    switch (action) {
+      case TmuxSwitchWindowAction(:final windowIndex):
+        _sendTmuxSwitchCommand(windowIndex);
+      case TmuxNewWindowAction(:final command, :final windowName):
+        await _createTmuxWindow(session, command: command, name: windowName);
+      case TmuxResumeSessionAction(:final resumeCommand):
+        await _createTmuxWindow(session, command: resumeCommand);
+    }
+  }
+
+  /// Sends a tmux select-window command through the interactive shell.
+  void _sendTmuxSwitchCommand(int windowIndex) {
+    final shell = _shell;
+    final sessionName = _tmuxSessionName;
+    if (shell == null || sessionName == null) return;
+
+    final tmux = ref.read(tmuxServiceProvider);
+    final command = tmux.buildSelectWindowCommand(sessionName, windowIndex);
+    shell.write(utf8.encode('$command\n'));
+  }
+
+  /// Creates a new tmux window via exec channel, then switches to it.
+  Future<void> _createTmuxWindow(
+    SshSession session, {
+    String? command,
+    String? name,
+  }) async {
+    final sessionName = _tmuxSessionName;
+    if (sessionName == null) return;
+
+    final tmux = ref.read(tmuxServiceProvider);
+    await tmux.createWindow(session, sessionName, command: command, name: name);
+
+    // After creating a new window, tmux automatically selects it.
+    // No explicit switch needed.
   }
 
   void _handleTrackedConnectionStateChange(
@@ -2658,6 +2753,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 ),
               ),
         actions: [
+          if (_isTmuxActive)
+            IconButton(
+              icon: const Icon(Icons.window_outlined),
+              onPressed:
+                  _connectionId == null ||
+                      connectionState != SshConnectionState.connected
+                  ? null
+                  : _openTmuxNavigator,
+              tooltip: 'tmux windows',
+            ),
           IconButton(
             icon: const Icon(Icons.folder_outlined),
             onPressed:

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -118,9 +118,9 @@ const _terminalFilePathVerificationExtensions = <String>[
 
 /// Expandable tmux bar that sits at the bottom of the terminal.
 ///
-/// The handle bar is a normal Column child below the terminal so it
-/// doesn't cover content. When expanded, the window list overlays
-/// the terminal via a sibling [_TmuxExpandableOverlay] in a Stack.
+/// Collapsed: a slim handle bar showing session name + drag pill.
+/// Expanded: grows upward, pushing the terminal content up via padding.
+/// The entire bar (handle + expanded content) is a single Column child.
 class _TmuxExpandableBar extends StatefulWidget {
   const _TmuxExpandableBar({
     required this.session,
@@ -128,8 +128,6 @@ class _TmuxExpandableBar extends StatefulWidget {
     required this.isProUser,
     required this.ref,
     required this.onAction,
-    required this.onOverlayChanged,
-    super.key,
   });
 
   /// The active SSH session.
@@ -146,9 +144,6 @@ class _TmuxExpandableBar extends StatefulWidget {
 
   /// Callback for navigator actions.
   final Future<void> Function(TmuxNavigatorAction) onAction;
-
-  /// Called when the overlay visibility changes (expand/collapse/drag).
-  final VoidCallback onOverlayChanged;
 
   @override
   State<_TmuxExpandableBar> createState() => _TmuxExpandableBarState();
@@ -167,7 +162,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
   void initState() {
     super.initState();
     _loadWindows();
-    // Continuously sync window state every 5 seconds.
     _syncTimer = Timer.periodic(
       const Duration(seconds: 5),
       (_) => _loadWindows(),
@@ -193,8 +187,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
       });
     } on Object {
       if (!mounted) return;
-      // Only clear loading on first load failure — don't wipe existing data
-      // on periodic refresh failures.
       if (_isLoading) setState(() => _isLoading = false);
     }
   }
@@ -204,8 +196,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
       _dragOffset -= details.delta.dy;
       _dragOffset = _dragOffset.clamp(0.0, 300.0);
     });
-    // Update overlay visibility via notifier (no parent rebuild needed).
-    _syncOverlayNotifier();
   }
 
   void _onVerticalDragEnd(DragEndDetails details) {
@@ -215,24 +205,22 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
       _expanded = shouldExpand;
       _dragOffset = 0;
     });
-    _syncOverlayNotifier();
-    // Refresh window list when expanding to get current active state.
     if (shouldExpand) _loadWindows();
   }
-
-  void _syncOverlayNotifier() => widget.onOverlayChanged();
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final dragExpansion = _dragOffset > 0 && !_expanded ? _dragOffset : 0.0;
 
-    // The handle bar sits in the normal layout flow (Column child).
-    // The expanded overlay is rendered by _TmuxExpandableOverlay in the
-    // parent Stack, reading state from this widget via a GlobalKey.
     return GestureDetector(
       onVerticalDragUpdate: _onVerticalDragUpdate,
       onVerticalDragEnd: _onVerticalDragEnd,
-      child: DecoratedBox(
+      child: AnimatedContainer(
+        duration: _dragOffset > 0
+            ? Duration.zero
+            : const Duration(milliseconds: 300),
+        curve: Curves.easeOutCubic,
         decoration: BoxDecoration(
           color: theme.colorScheme.surfaceContainerHighest,
           border: Border(
@@ -242,19 +230,44 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
             ),
           ),
         ),
-        child: _buildHandleBar(theme),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _buildHandleBar(theme),
+            if (dragExpansion > 0)
+              SizedBox(
+                height: dragExpansion,
+                child: ClipRect(
+                  child: Align(
+                    alignment: Alignment.topCenter,
+                    child: _buildWindowList(theme),
+                  ),
+                ),
+              ),
+            AnimatedCrossFade(
+              duration: const Duration(milliseconds: 300),
+              sizeCurve: Curves.easeOutCubic,
+              crossFadeState: _expanded
+                  ? CrossFadeState.showSecond
+                  : CrossFadeState.showFirst,
+              firstChild: const SizedBox.shrink(),
+              secondChild: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.sizeOf(context).height * 0.4,
+                ),
+                child: _buildWindowList(theme),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
-
-  /// Whether the overlay should be visible (expanded or being dragged).
-  bool get showOverlay => _expanded || _dragOffset > 0;
 
   Widget _buildHandleBar(ThemeData theme) => GestureDetector(
     onTap: () {
       final wasExpanded = _expanded;
       setState(() => _expanded = !_expanded);
-      _syncOverlayNotifier();
       // Refresh window list when expanding to get current active state.
       if (!wasExpanded) _loadWindows();
     },
@@ -340,7 +353,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
             title: const Text('New Window'),
             onTap: () {
               setState(() => _expanded = false);
-              _syncOverlayNotifier();
               showModalBottomSheet<AgentLaunchTool?>(
                 context: context,
                 builder: (ctx) => TmuxToolPickerSheet(
@@ -1706,9 +1718,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _isTmuxActive = false;
   String? _tmuxSessionName;
   bool _showTmuxBar = true;
-  final _tmuxOverlayNotifier = ValueNotifier<bool>(false);
   String? _tmuxWorkingDirectory;
-  final _tmuxBarKey = GlobalKey<_TmuxExpandableBarState>();
   final Map<String, _VerifiedTerminalPath> _verifiedTerminalPathCache =
       <String, _VerifiedTerminalPath>{};
   final ListQueue<String> _verifiedTerminalPathCacheOrder = ListQueue<String>();
@@ -2786,70 +2796,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
-  /// Builds the expanded tmux overlay that floats above the terminal.
-  ///
-  /// Reads state from the [_TmuxExpandableBarState] via [_tmuxBarKey].
-  Widget _buildTmuxOverlay(ThemeData theme) {
-    final barState = _tmuxBarKey.currentState;
-    if (barState == null) return const SizedBox.shrink();
-
-    final dragExpansion = barState._dragOffset > 0 && !barState._expanded
-        ? barState._dragOffset
-        : 0.0;
-
-    return AnimatedContainer(
-      duration: barState._dragOffset > 0
-          ? Duration.zero
-          : const Duration(milliseconds: 300),
-      curve: Curves.easeOutCubic,
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest,
-        borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withAlpha(40),
-            blurRadius: 8,
-            offset: const Offset(0, -2),
-          ),
-        ],
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (dragExpansion > 0)
-            SizedBox(
-              height: dragExpansion,
-              child: ClipRect(
-                child: Align(
-                  alignment: Alignment.topCenter,
-                  child: barState._buildWindowList(theme),
-                ),
-              ),
-            ),
-          AnimatedCrossFade(
-            duration: const Duration(milliseconds: 300),
-            sizeCurve: Curves.easeOutCubic,
-            crossFadeState: barState._expanded
-                ? CrossFadeState.showSecond
-                : CrossFadeState.showFirst,
-            firstChild: const SizedBox.shrink(),
-            secondChild: ConstrainedBox(
-              constraints: BoxConstraints(
-                maxHeight: MediaQuery.sizeOf(context).height * 0.4,
-              ),
-              child: barState._buildWindowList(theme),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  /// Builds a draggable tmux panel anchored to the bottom of the terminal.
-  ///
-  /// Collapsed, it shows a slim handle bar with the session name.
-  /// Dragging up smoothly expands it into the full navigator without
-  /// changing the terminal's layout.
+  /// Builds the tmux expandable bar as a Column child below the terminal.
   Widget _buildTmuxExpandableBar(ThemeData theme) {
     final connectionId = _connectionId;
     if (connectionId == null || _tmuxSessionName == null) {
@@ -2867,16 +2814,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
 
     return _TmuxExpandableBar(
-      key: _tmuxBarKey,
       session: session,
       tmuxSessionName: _tmuxSessionName!,
       isProUser: isProUser,
       ref: ref,
       onAction: _handleTmuxAction,
-      onOverlayChanged: () {
-        _tmuxOverlayNotifier.value =
-            _tmuxBarKey.currentState?.showOverlay ?? false;
-      },
     );
   }
 
@@ -3154,7 +3096,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _shellStdoutSubscription?.cancel();
     _terminalFocusNode.dispose();
     _toolbarController.dispose();
-    _tmuxOverlayNotifier.dispose();
     super.dispose();
   }
 
@@ -3541,34 +3482,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       ),
       body: Column(
         children: [
-          Expanded(
-            child: Stack(
-              children: [
-                Positioned.fill(
-                  child: _buildTerminalView(terminalTheme, isMobile),
-                ),
-                // Overlay: expanded window list floats above the terminal.
-                // Uses ValueListenableBuilder so the parent doesn't rebuild
-                // on drag updates — that would kill the gesture recognizer.
-                if (_isTmuxActive &&
-                    _showTmuxBar &&
-                    connectionState == SshConnectionState.connected)
-                  ValueListenableBuilder<bool>(
-                    valueListenable: _tmuxOverlayNotifier,
-                    builder: (context, visible, _) {
-                      if (!visible) return const SizedBox.shrink();
-                      return Positioned(
-                        left: 0,
-                        right: 0,
-                        bottom: 0,
-                        child: _buildTmuxOverlay(theme),
-                      );
-                    },
-                  ),
-              ],
-            ),
-          ),
-          // Handle bar: sits below the terminal in normal layout flow.
+          Expanded(child: _buildTerminalView(terminalTheme, isMobile)),
           if (_isTmuxActive &&
               _showTmuxBar &&
               connectionState == SshConnectionState.connected)

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2356,7 +2356,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (!active) return;
 
     final sessionName = await tmux.currentSessionName(session);
-    if (!mounted) return;
+    if (!mounted || sessionName == null) return;
 
     setState(() {
       _isTmuxActive = true;

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -47,6 +47,7 @@ import '../widgets/terminal_text_input_handler.dart';
 import '../widgets/terminal_text_style.dart';
 import '../widgets/terminal_theme_picker.dart';
 import '../widgets/tmux_window_navigator.dart';
+import '../widgets/tmux_window_status_badge.dart';
 
 bool _isPromptReturnWhitespaceCodeUnit(int codeUnit) =>
     codeUnit == 0x20 ||
@@ -250,6 +251,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   List<ToolSessionInfo>? _recentSessions;
   final Set<String> _expandedSessionTools = <String>{};
   final Set<int> _seenAlertWindows = <int>{};
+  String? _sessionLoadError;
   bool _expanded = false;
   bool _isLoading = true;
   bool _isLoadingSessions = false;
@@ -379,31 +381,36 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   Future<void> _loadRecentSessions({bool forceReload = false}) async {
     if (_isLoadingSessions || (_recentSessions != null && !forceReload)) return;
     final previousCount = _recentSessions?.length ?? 0;
-    setState(() => _isLoadingSessions = true);
+    setState(() {
+      _isLoadingSessions = true;
+      _sessionLoadError = null;
+    });
 
     try {
       final discovery = widget.ref.read(agentSessionDiscoveryServiceProvider);
       final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
-      final sessions = await discovery.discoverSessions(
+      final result = await discovery.discoverSessions(
         widget.session,
         workingDirectory: activeWindow?.currentPath,
         maxPerTool: _sessionFetchLimit,
       );
       if (!mounted) return;
       setState(() {
-        _recentSessions = sessions;
-        if (_expandedSessionTools.isEmpty && sessions.isNotEmpty) {
-          _expandedSessionTools.add(sessions.first.toolName);
+        _recentSessions = result.sessions;
+        _sessionLoadError = result.failureMessage;
+        if (_expandedSessionTools.isEmpty && result.sessions.isNotEmpty) {
+          _expandedSessionTools.add(result.sessions.first.toolName);
         }
         _canLoadMoreSessions =
-            sessions.length > previousCount &&
-            _hasSessionGroupAtLimit(sessions);
+            result.sessions.length > previousCount &&
+            _hasSessionGroupAtLimit(result.sessions);
         _isLoadingSessions = false;
       });
     } on Exception {
       if (!mounted) return;
       setState(() {
         _recentSessions = const [];
+        _sessionLoadError = 'Could not load recent AI sessions.';
         _canLoadMoreSessions = false;
         _isLoadingSessions = false;
       });
@@ -713,6 +720,18 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
               ),
             ),
           )
+        else if (_sessionLoadError != null &&
+            _recentSessions != null &&
+            _recentSessions!.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text(
+              _sessionLoadError!,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.error,
+              ),
+            ),
+          )
         else if (_recentSessions != null && _recentSessions!.isEmpty)
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -724,6 +743,16 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
             ),
           )
         else if (_recentSessions != null) ...[
+          if (_sessionLoadError != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Text(
+                _sessionLoadError!,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+              ),
+            ),
           ..._groupSessions(_recentSessions!).entries.map(
             (entry) => _buildSessionGroup(theme, entry.key, entry.value),
           ),
@@ -902,7 +931,10 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _windowStatusIcon(theme, window),
+          Padding(
+            padding: const EdgeInsets.only(right: 6),
+            child: TmuxWindowStatusBadge(window: window),
+          ),
           IconButton(
             icon: const Icon(Icons.close, size: 16),
             visualDensity: VisualDensity.compact,
@@ -927,41 +959,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
               setState(() => _expanded = false);
             },
     );
-  }
-
-  Widget _windowStatusIcon(ThemeData theme, TmuxWindow window) {
-    if (window.hasAlert) {
-      return Padding(
-        padding: const EdgeInsets.only(right: 4),
-        child: Icon(
-          Icons.notifications_active,
-          size: 16,
-          color: theme.colorScheme.error,
-        ),
-      );
-    }
-    if (window.isIdle) {
-      return Padding(
-        padding: const EdgeInsets.only(right: 4),
-        child: Icon(
-          Icons.hourglass_bottom,
-          size: 14,
-          color: theme.colorScheme.tertiary,
-        ),
-      );
-    }
-    if (!window.isActive) {
-      // Running — not idle, not alert.
-      return Padding(
-        padding: const EdgeInsets.only(right: 4),
-        child: Icon(
-          Icons.play_arrow,
-          size: 16,
-          color: theme.colorScheme.primary.withAlpha(160),
-        ),
-      );
-    }
-    return const SizedBox.shrink();
   }
 }
 
@@ -3379,9 +3376,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
               // Drive the terminal inset and the handle reveal from the same
               // animated value so the bar stays visually locked to the padding.
               Positioned.fill(
-                child: Padding(
-                  padding: EdgeInsets.only(bottom: animatedBottomPadding),
-                  child: _buildTerminalView(terminalTheme, isMobile),
+                child: ColoredBox(
+                  color: terminalTheme.background,
+                  child: Padding(
+                    padding: EdgeInsets.only(bottom: animatedBottomPadding),
+                    child: _buildTerminalView(terminalTheme, isMobile),
+                  ),
                 ),
               ),
               if (showTmux || animatedBottomPadding > 0)

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -23,6 +23,7 @@ import '../../data/database/database.dart';
 import '../../data/repositories/host_repository.dart';
 import '../../data/repositories/port_forward_repository.dart';
 import '../../data/repositories/snippet_repository.dart';
+import '../../domain/models/agent_launch_preset.dart';
 import '../../domain/models/auto_connect_command.dart';
 import '../../domain/models/monetization.dart';
 import '../../domain/models/terminal_theme.dart';
@@ -154,6 +155,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
   bool _expanded = false;
   bool _isLoading = true;
   double _dragOffset = 0;
+  Timer? _syncTimer;
 
   TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
 
@@ -161,6 +163,17 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
   void initState() {
     super.initState();
     _loadWindows();
+    // Continuously sync window state every 5 seconds.
+    _syncTimer = Timer.periodic(
+      const Duration(seconds: 5),
+      (_) => _loadWindows(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _syncTimer?.cancel();
+    super.dispose();
   }
 
   Future<void> _loadWindows() async {
@@ -176,7 +189,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
       });
     } on Object {
       if (!mounted) return;
-      setState(() => _isLoading = false);
+      // Only clear loading on first load failure — don't wipe existing data
+      // on periodic refresh failures.
+      if (_isLoading) setState(() => _isLoading = false);
     }
   }
 
@@ -344,24 +359,33 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
               size: 20,
             ),
             title: const Text('New Window'),
-            onTap: _openTmuxNavigator,
+            onTap: () {
+              setState(() => _expanded = false);
+              showModalBottomSheet<AgentLaunchTool?>(
+                context: context,
+                builder: (ctx) => TmuxToolPickerSheet(
+                  isProUser: widget.isProUser,
+                  onToolSelected: (tool) => Navigator.pop(ctx, tool),
+                  onEmptyWindow: () {
+                    Navigator.pop(ctx);
+                    widget.onAction(const TmuxNewWindowAction());
+                  },
+                ),
+              ).then((tool) {
+                if (tool != null) {
+                  widget.onAction(
+                    TmuxNewWindowAction(
+                      command: tool.commandName,
+                      windowName: tool.commandName,
+                    ),
+                  );
+                }
+              });
+            },
           ),
         ],
       ),
     );
-  }
-
-  Future<void> _openTmuxNavigator() async {
-    final action = await showTmuxNavigator(
-      context: context,
-      ref: widget.ref,
-      session: widget.session,
-      tmuxSessionName: widget.tmuxSessionName,
-      isProUser: widget.isProUser,
-    );
-    if (action != null) {
-      await widget.onAction(action);
-    }
   }
 
   Widget _buildWindowTile(ThemeData theme, TmuxWindow window) => ListTile(

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1059,9 +1059,9 @@ enum _AutoConnectReviewDecision { skip, runOnce, trustAndRun }
 
 /// Padding around the terminal viewport.
 ///
-/// Keep the terminal flush with the bottom edge so status lines from tools like
-/// tmux use the full available height in every keyboard and toolbar state.
-const terminalViewportPadding = EdgeInsets.fromLTRB(8, 8, 8, 0);
+/// Keep the terminal flush with the bottom and side edges so status lines from
+/// tools like tmux can use the full available width and height.
+const terminalViewportPadding = EdgeInsets.fromLTRB(0, 8, 0, 0);
 
 /// Clamps a terminal font size into the supported zoom range.
 @visibleForTesting
@@ -1106,6 +1106,18 @@ String trimTerminalSelectionText(String text) =>
 @visibleForTesting
 double selectionActionsBottomOffset(MediaQueryData mediaQuery) =>
     _selectionActionsBottomPadding + mediaQuery.padding.bottom;
+
+/// Keeps the Pro upsell snackbar tucked just above the visible bottom chrome.
+@visibleForTesting
+double upgradeSnackBarBottomMargin(
+  MediaQueryData mediaQuery, {
+  bool showKeyboardToolbar = false,
+  double keyboardToolbarHeight = 96,
+  double baseSpacing = 16,
+}) =>
+    mediaQuery.padding.bottom +
+    (showKeyboardToolbar ? keyboardToolbarHeight : 0) +
+    baseSpacing;
 
 /// Resolves the transient indicator label for a terminal double-tap Tab gesture.
 @visibleForTesting
@@ -3127,13 +3139,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         .canUseFeature(MonetizationFeature.autoConnectAutomation);
     if (!hasAccess) {
       if (mounted) {
-        const keyboardToolbarHeight = 96.0;
-        final bottomMargin =
-            MediaQuery.paddingOf(context).bottom +
-            (_showKeyboardToolbar ? keyboardToolbarHeight : 0) +
-            (_isTmuxActive && _showTmuxBar
-                ? _TmuxExpandableBar.handleHeight + 16
-                : 16);
+        final bottomMargin = upgradeSnackBarBottomMargin(
+          MediaQuery.of(context),
+          showKeyboardToolbar: _showKeyboardToolbar,
+        );
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             behavior: SnackBarBehavior.floating,
@@ -3373,14 +3382,18 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
           return Stack(
             children: [
-              // Drive the terminal inset and the handle reveal from the same
-              // animated value so the bar stays visually locked to the padding.
+              // Reserve actual layout space for the collapsed handle so the
+              // terminal viewport extends cleanly down to the bar boundary.
               Positioned.fill(
                 child: ColoredBox(
                   color: terminalTheme.background,
-                  child: Padding(
-                    padding: EdgeInsets.only(bottom: animatedBottomPadding),
-                    child: _buildTerminalView(terminalTheme, isMobile),
+                  child: Column(
+                    children: [
+                      Expanded(
+                        child: _buildTerminalView(terminalTheme, isMobile),
+                      ),
+                      SizedBox(height: animatedBottomPadding),
+                    ],
                   ),
                 ),
               ),

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -83,6 +83,47 @@ double resolveTmuxBarMaxContentHeight(
   );
 }
 
+const _tmuxBarRevealDuration = Duration(milliseconds: 300);
+const _tmuxDetectionRetrySchedule = <Duration>[
+  Duration.zero,
+  Duration(milliseconds: 150),
+  Duration(milliseconds: 350),
+  Duration(milliseconds: 700),
+  Duration(milliseconds: 1400),
+];
+
+/// Resolves the retry schedule used for tmux detection after connect.
+@visibleForTesting
+List<Duration> resolveTmuxDetectionRetrySchedule({bool skipDelay = false}) =>
+    skipDelay ? const <Duration>[Duration.zero] : _tmuxDetectionRetrySchedule;
+
+/// Resolves the tmux session name we can infer before remote verification.
+@visibleForTesting
+String? resolvePreferredTmuxSessionName({
+  String? structuredSessionName,
+  String? autoConnectCommand,
+}) => structuredSessionName ?? parseTmuxSessionName(autoConnectCommand);
+
+/// Resolves the tmux bar's vertical offset from the animated bottom padding.
+@visibleForTesting
+double resolveTmuxBarRevealBottomOffset(
+  double terminalBottomPadding, {
+  double handleHeight = 22,
+}) => terminalBottomPadding - handleHeight;
+
+/// Resolves the tmux bar's reveal opacity from the animated bottom padding.
+@visibleForTesting
+double resolveTmuxBarRevealOpacity(
+  double terminalBottomPadding, {
+  double handleHeight = 22,
+}) {
+  if (handleHeight <= 0) {
+    return terminalBottomPadding > 0 ? 1 : 0;
+  }
+
+  return (terminalBottomPadding / handleHeight).clamp(0.0, 1.0);
+}
+
 final _oscEscapeSequencePattern = RegExp(
   '\x1B\\][^\x07\x1B]*(?:\x07|\x1B\\\\)',
   dotAll: true,
@@ -216,9 +257,11 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   bool _showSessions = false;
   double _dragOffset = 0;
   int _sessionFetchLimit = _initialSessionFetchLimit;
-  Timer? _syncTimer;
+  StreamSubscription<void>? _windowChangeSubscription;
   late AnimationController _bounceController;
   late Animation<double> _bounceAnimation;
+  bool _loadingWindows = false;
+  bool _pendingWindowReload = false;
 
   TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
 
@@ -239,15 +282,24 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           CurvedAnimation(parent: _bounceController, curve: Curves.easeInOut),
         );
     _loadWindows();
-    _syncTimer = Timer.periodic(
-      const Duration(seconds: 5),
-      (_) => _loadWindows(),
-    );
+    _subscribeToWindowChanges();
+  }
+
+  @override
+  void didUpdateWidget(covariant _TmuxExpandableBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.session.connectionId == widget.session.connectionId &&
+        oldWidget.tmuxSessionName == widget.tmuxSessionName) {
+      return;
+    }
+    _windowChangeSubscription?.cancel();
+    _subscribeToWindowChanges();
+    _loadWindows();
   }
 
   @override
   void dispose() {
-    _syncTimer?.cancel();
+    _windowChangeSubscription?.cancel();
     for (final windowIndex in _seenAlertWindows) {
       _clearAlertNotification(windowIndex);
     }
@@ -255,7 +307,21 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     super.dispose();
   }
 
+  void _subscribeToWindowChanges() {
+    _windowChangeSubscription = _tmux
+        .watchWindowChanges(widget.session, widget.tmuxSessionName)
+        .listen((_) {
+          if (!mounted) return;
+          _loadWindows();
+        });
+  }
+
   Future<void> _loadWindows() async {
+    if (_loadingWindows) {
+      _pendingWindowReload = true;
+      return;
+    }
+    _loadingWindows = true;
     try {
       final windows = await _tmux.listWindows(
         widget.session,
@@ -301,6 +367,12 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     } on Object {
       if (!mounted) return;
       if (_isLoading) setState(() => _isLoading = false);
+    } finally {
+      _loadingWindows = false;
+      if (_pendingWindowReload) {
+        _pendingWindowReload = false;
+        unawaited(_loadWindows());
+      }
     }
   }
 
@@ -2122,6 +2194,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _showTmuxBar = true;
   String? _tmuxLaunchWorkingDirectory;
   String? _tmuxWorkingDirectory;
+  int _tmuxDetectionGeneration = 0;
   final Map<String, _VerifiedTerminalPath> _verifiedTerminalPathCache =
       <String, _VerifiedTerminalPath>{};
   final ListQueue<String> _verifiedTerminalPathCacheOrder = ListQueue<String>();
@@ -2856,6 +2929,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _isConnecting = false;
       });
       _restoreTerminalFocus();
+      _primeTmuxStateFromHost();
 
       // Start port forwards
       await _startPortForwards(session);
@@ -3144,70 +3218,127 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
+  void _primeTmuxStateFromHost() {
+    final host = _host;
+    final preferredSessionName = resolvePreferredTmuxSessionName(
+      structuredSessionName: host?.tmuxSessionName,
+      autoConnectCommand: host?.autoConnectCommand,
+    );
+    if (!mounted || preferredSessionName == null) {
+      return;
+    }
+
+    final preferredWorkingDirectory = host?.tmuxWorkingDirectory;
+    setState(() {
+      _isTmuxActive = true;
+      _tmuxSessionName = preferredSessionName;
+      _tmuxLaunchWorkingDirectory = preferredWorkingDirectory;
+      _tmuxWorkingDirectory = preferredWorkingDirectory;
+    });
+  }
+
   /// Detects whether the connected session is inside tmux.
   ///
-  /// Waits briefly for the auto-connect command to initialize, then
-  /// checks for tmux sessions via an exec channel. If tmux is active,
-  /// also queries the current session name.
+  /// Starts with any structured tmux configuration immediately, then retries
+  /// discovery until the shell-side attach command has settled.
   Future<void> _detectTmux(SshSession session, {bool skipDelay = false}) async {
     // Capture the connection ID at the start so we can verify it hasn't
     // changed after async gaps (user may have switched connections).
     final capturedConnectionId = _connectionId;
+    final detectionGeneration = ++_tmuxDetectionGeneration;
+    final host = _host;
+    final preferredSessionName = resolvePreferredTmuxSessionName(
+      structuredSessionName: host?.tmuxSessionName,
+      autoConnectCommand: host?.autoConnectCommand,
+    );
+    final preferredWorkingDirectory = host?.tmuxWorkingDirectory;
 
-    // Clear any stale tmux state from a previous connection.
     if (mounted) {
+      setState(() {
+        _isTmuxActive = preferredSessionName != null;
+        _tmuxSessionName = preferredSessionName;
+        _tmuxLaunchWorkingDirectory = preferredWorkingDirectory;
+        _tmuxWorkingDirectory = preferredWorkingDirectory;
+      });
+    }
+
+    try {
+      final tmux = ref.read(tmuxServiceProvider);
+      final retrySchedule = resolveTmuxDetectionRetrySchedule(
+        skipDelay: skipDelay,
+      );
+
+      for (final delay in retrySchedule) {
+        if (delay > Duration.zero) {
+          await Future<void>.delayed(delay);
+          if (!mounted ||
+              _connectionId != capturedConnectionId ||
+              detectionGeneration != _tmuxDetectionGeneration) {
+            return;
+          }
+        }
+
+        final active = preferredSessionName != null
+            ? await tmux.hasSession(session, preferredSessionName)
+            : await tmux.isTmuxActive(session);
+        if (!mounted ||
+            _connectionId != capturedConnectionId ||
+            detectionGeneration != _tmuxDetectionGeneration) {
+          return;
+        }
+        if (!active) {
+          continue;
+        }
+
+        var sessionName = preferredSessionName;
+        sessionName ??= await tmux.currentSessionName(session);
+        if (!mounted ||
+            _connectionId != capturedConnectionId ||
+            detectionGeneration != _tmuxDetectionGeneration) {
+          return;
+        }
+        if (sessionName == null) {
+          continue;
+        }
+
+        // Get the active window's working directory for SFTP/path resolution.
+        var tmuxLaunchCwd = preferredWorkingDirectory;
+        var tmuxCwd = preferredWorkingDirectory;
+        try {
+          final windows = await tmux.listWindows(session, sessionName);
+          final activeWindow = windows.where((w) => w.isActive).firstOrNull;
+          tmuxLaunchCwd ??= activeWindow?.currentPath;
+          tmuxCwd ??= activeWindow?.currentPath;
+        } on Object {
+          // Non-critical — path resolution will fall back to OSC 7.
+        }
+
+        if (!mounted ||
+            _connectionId != capturedConnectionId ||
+            detectionGeneration != _tmuxDetectionGeneration) {
+          return;
+        }
+
+        setState(() {
+          _isTmuxActive = true;
+          _tmuxSessionName = sessionName;
+          _tmuxLaunchWorkingDirectory = tmuxLaunchCwd;
+          _tmuxWorkingDirectory = tmuxCwd;
+        });
+        return;
+      }
+
+      if (!mounted ||
+          _connectionId != capturedConnectionId ||
+          detectionGeneration != _tmuxDetectionGeneration) {
+        return;
+      }
+
       setState(() {
         _isTmuxActive = false;
         _tmuxSessionName = null;
         _tmuxLaunchWorkingDirectory = null;
         _tmuxWorkingDirectory = null;
-      });
-    }
-
-    // Give the auto-connect command (which may start tmux) time to init.
-    // Skip the delay when re-opening an already-connected terminal.
-    if (!skipDelay) {
-      await Future<void>.delayed(const Duration(seconds: 2));
-      if (!mounted || _connectionId != capturedConnectionId) return;
-    }
-
-    try {
-      final tmux = ref.read(tmuxServiceProvider);
-      final active = await tmux.isTmuxActive(session);
-      if (!mounted || _connectionId != capturedConnectionId) return;
-
-      if (!active) return;
-
-      // Resolve session name using the best available source:
-      // 1. Host's structured tmux config (explicit session name)
-      // 2. Parsed from auto-connect command (-s flag)
-      // 3. tmux display-message / single-attached fallback
-      final host = _host;
-      var sessionName = host?.tmuxSessionName;
-      sessionName ??= parseTmuxSessionName(host?.autoConnectCommand);
-      sessionName ??= await tmux.currentSessionName(session);
-      if (!mounted || _connectionId != capturedConnectionId) return;
-      if (sessionName == null) return;
-
-      // Get the active window's working directory for SFTP/path resolution.
-      var tmuxLaunchCwd = host?.tmuxWorkingDirectory;
-      var tmuxCwd = host?.tmuxWorkingDirectory;
-      try {
-        final windows = await tmux.listWindows(session, sessionName);
-        final activeWindow = windows.where((w) => w.isActive).firstOrNull;
-        tmuxLaunchCwd ??= activeWindow?.currentPath;
-        tmuxCwd ??= activeWindow?.currentPath;
-      } on Object {
-        // Non-critical — path resolution will fall back to OSC 7.
-      }
-
-      if (!mounted || _connectionId != capturedConnectionId) return;
-
-      setState(() {
-        _isTmuxActive = true;
-        _tmuxSessionName = sessionName;
-        _tmuxLaunchWorkingDirectory = tmuxLaunchCwd;
-        _tmuxWorkingDirectory = tmuxCwd;
       });
     } on Object {
       // Silently ignore — tmux detection is best-effort.
@@ -3230,35 +3361,47 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _isTmuxActive &&
         _showTmuxBar &&
         connectionState == SshConnectionState.connected;
+    final targetBottomPadding = showTmux
+        ? _TmuxExpandableBar.handleHeight
+        : 0.0;
 
     return LayoutBuilder(
-      builder: (context, constraints) => Stack(
-        children: [
-          // Terminal with animated bottom padding that grows/shrinks
-          // smoothly when the tmux handle appears/disappears.
-          Positioned.fill(
-            child: AnimatedPadding(
-              duration: const Duration(milliseconds: 300),
-              curve: Curves.easeOutCubic,
-              padding: EdgeInsets.only(
-                bottom: showTmux ? _TmuxExpandableBar.handleHeight : 0,
+      builder: (context, constraints) => TweenAnimationBuilder<double>(
+        tween: Tween<double>(end: targetBottomPadding),
+        duration: _tmuxBarRevealDuration,
+        curve: Curves.easeOutCubic,
+        child: _buildTmuxExpandableBar(theme, constraints.maxHeight),
+        builder: (context, animatedBottomPadding, child) {
+          final barOpacity = resolveTmuxBarRevealOpacity(animatedBottomPadding);
+
+          return Stack(
+            children: [
+              // Drive the terminal inset and the handle reveal from the same
+              // animated value so the bar stays visually locked to the padding.
+              Positioned.fill(
+                child: Padding(
+                  padding: EdgeInsets.only(bottom: animatedBottomPadding),
+                  child: _buildTerminalView(terminalTheme, isMobile),
+                ),
               ),
-              child: _buildTerminalView(terminalTheme, isMobile),
-            ),
-          ),
-          // Handle bar slides up from below via AnimatedPositioned.
-          Positioned(
-            left: 0,
-            right: 0,
-            bottom: showTmux ? 0 : -_TmuxExpandableBar.handleHeight,
-            child: AnimatedOpacity(
-              duration: const Duration(milliseconds: 300),
-              curve: Curves.easeOutCubic,
-              opacity: showTmux ? 1 : 0,
-              child: _buildTmuxExpandableBar(theme, constraints.maxHeight),
-            ),
-          ),
-        ],
+              if (showTmux || animatedBottomPadding > 0)
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: resolveTmuxBarRevealBottomOffset(
+                    animatedBottomPadding,
+                  ),
+                  child: IgnorePointer(
+                    ignoring: barOpacity == 0,
+                    child: Opacity(
+                      opacity: barOpacity,
+                      child: child ?? const SizedBox.shrink(),
+                    ),
+                  ),
+                ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -155,22 +155,39 @@ class _TmuxExpandableBar extends StatefulWidget {
   State<_TmuxExpandableBar> createState() => _TmuxExpandableBarState();
 }
 
-class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
+class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
+    with SingleTickerProviderStateMixin {
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
   final Set<String> _expandedSessionTools = <String>{};
+  final Set<int> _seenAlertWindows = <int>{};
   bool _expanded = false;
   bool _isLoading = true;
   bool _isLoadingSessions = false;
   bool _showSessions = false;
   double _dragOffset = 0;
   Timer? _syncTimer;
+  late AnimationController _bounceController;
+  late Animation<double> _bounceAnimation;
 
   TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
 
   @override
   void initState() {
     super.initState();
+    _bounceController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    );
+    _bounceAnimation =
+        TweenSequence<double>([
+          TweenSequenceItem(tween: Tween(begin: 0, end: -6), weight: 1),
+          TweenSequenceItem(tween: Tween(begin: -6, end: 0), weight: 1),
+          TweenSequenceItem(tween: Tween(begin: 0, end: -3), weight: 1),
+          TweenSequenceItem(tween: Tween(begin: -3, end: 0), weight: 1),
+        ]).animate(
+          CurvedAnimation(parent: _bounceController, curve: Curves.easeInOut),
+        );
     _loadWindows();
     _syncTimer = Timer.periodic(
       const Duration(seconds: 5),
@@ -181,6 +198,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
   @override
   void dispose() {
     _syncTimer?.cancel();
+    _bounceController.dispose();
     super.dispose();
   }
 
@@ -191,6 +209,25 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
         widget.tmuxSessionName,
       );
       if (!mounted) return;
+
+      // Detect new alerts that weren't in the previous window list.
+      final newAlerts = windows.where(
+        (w) =>
+            w.hasAlert && !w.isActive && !_seenAlertWindows.contains(w.index),
+      );
+      if (newAlerts.isNotEmpty) {
+        unawaited(_bounceController.forward(from: 0));
+        for (final w in newAlerts) {
+          _seenAlertWindows.add(w.index);
+          _sendAlertNotification(w);
+        }
+      }
+
+      // Clear seen alerts for windows that no longer have alerts.
+      _seenAlertWindows.removeWhere(
+        (idx) => !windows.any((w) => w.index == idx && w.hasAlert),
+      );
+
       setState(() {
         _windows = windows;
         _isLoading = false;
@@ -238,6 +275,13 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
     );
   }
 
+  void _sendAlertNotification(TmuxWindow window) {
+    // Haptic feedback on mobile.
+    HapticFeedback.mediumImpact();
+    // TODO(tmux): Add local push notification via flutter_local_notifications
+    // so alerts are visible when the app is backgrounded.
+  }
+
   void _onVerticalDragUpdate(DragUpdateDetails details) {
     setState(() {
       _dragOffset -= details.delta.dy;
@@ -262,36 +306,43 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
     final maxExpandedHeight = MediaQuery.sizeOf(context).height * 0.4;
     final contentHeight = _expanded ? maxExpandedHeight : dragExpansion;
 
-    return GestureDetector(
-      onVerticalDragUpdate: _onVerticalDragUpdate,
-      onVerticalDragEnd: _onVerticalDragEnd,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: theme.colorScheme.surfaceContainerHighest,
-          border: Border(
-            top: BorderSide(
-              color: theme.colorScheme.outlineVariant,
-              width: 0.5,
+    return AnimatedBuilder(
+      animation: _bounceAnimation,
+      builder: (context, child) => Transform.translate(
+        offset: Offset(0, _bounceAnimation.value),
+        child: child,
+      ),
+      child: GestureDetector(
+        onVerticalDragUpdate: _onVerticalDragUpdate,
+        onVerticalDragEnd: _onVerticalDragEnd,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceContainerHighest,
+            border: Border(
+              top: BorderSide(
+                color: theme.colorScheme.outlineVariant,
+                width: 0.5,
+              ),
             ),
           ),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _buildHandleBar(theme),
-            // Use AnimatedContainer only for expand/collapse snap animation.
-            // During drag, height tracks the finger directly (duration: zero).
-            AnimatedContainer(
-              duration: _dragOffset > 0
-                  ? Duration.zero
-                  : const Duration(milliseconds: 300),
-              curve: Curves.easeOutCubic,
-              height: contentHeight,
-              child: contentHeight > 0
-                  ? ClipRect(child: _buildWindowList(theme))
-                  : const SizedBox.shrink(),
-            ),
-          ],
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildHandleBar(theme),
+              // Use AnimatedContainer only for expand/collapse snap animation.
+              // During drag, height tracks the finger directly (duration: zero).
+              AnimatedContainer(
+                duration: _dragOffset > 0
+                    ? Duration.zero
+                    : const Duration(milliseconds: 300),
+                curve: Curves.easeOutCubic,
+                height: contentHeight,
+                child: contentHeight > 0
+                    ? ClipRect(child: _buildWindowList(theme))
+                    : const SizedBox.shrink(),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2028,6 +2028,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _isConnecting = false;
         });
         _restoreTerminalFocus();
+
+        // Detect tmux on existing sessions too (may not have been detected
+        // yet if the terminal was opened before tmux started).
+        if (!_isTmuxActive) {
+          unawaited(_detectTmux(session, skipDelay: true));
+        }
         return;
       }
 
@@ -2336,7 +2342,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   /// Waits briefly for the auto-connect command to initialize, then
   /// checks for tmux sessions via an exec channel. If tmux is active,
   /// also queries the current session name.
-  Future<void> _detectTmux(SshSession session) async {
+  Future<void> _detectTmux(SshSession session, {bool skipDelay = false}) async {
     // Capture the connection ID at the start so we can verify it hasn't
     // changed after async gaps (user may have switched connections).
     final capturedConnectionId = _connectionId;
@@ -2350,23 +2356,30 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
 
     // Give the auto-connect command (which may start tmux) time to init.
-    await Future<void>.delayed(const Duration(seconds: 2));
-    if (!mounted || _connectionId != capturedConnectionId) return;
+    // Skip the delay when re-opening an already-connected terminal.
+    if (!skipDelay) {
+      await Future<void>.delayed(const Duration(seconds: 2));
+      if (!mounted || _connectionId != capturedConnectionId) return;
+    }
 
-    final tmux = ref.read(tmuxServiceProvider);
-    final active = await tmux.isTmuxActive(session);
-    if (!mounted || _connectionId != capturedConnectionId) return;
+    try {
+      final tmux = ref.read(tmuxServiceProvider);
+      final active = await tmux.isTmuxActive(session);
+      if (!mounted || _connectionId != capturedConnectionId) return;
 
-    if (!active) return;
+      if (!active) return;
 
-    final sessionName = await tmux.currentSessionName(session);
-    if (!mounted || _connectionId != capturedConnectionId) return;
-    if (sessionName == null) return;
+      final sessionName = await tmux.currentSessionName(session);
+      if (!mounted || _connectionId != capturedConnectionId) return;
+      if (sessionName == null) return;
 
-    setState(() {
-      _isTmuxActive = true;
-      _tmuxSessionName = sessionName;
-    });
+      setState(() {
+        _isTmuxActive = true;
+        _tmuxSessionName = sessionName;
+      });
+    } on Object {
+      // Silently ignore — tmux detection is best-effort.
+    }
   }
 
   /// Opens the tmux window navigator bottom sheet and handles the

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -217,15 +217,13 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final dragExpansion = _dragOffset > 0 && !_expanded ? _dragOffset : 0.0;
+    final maxExpandedHeight = MediaQuery.sizeOf(context).height * 0.4;
+    final contentHeight = _expanded ? maxExpandedHeight : dragExpansion;
 
     return GestureDetector(
       onVerticalDragUpdate: _onVerticalDragUpdate,
       onVerticalDragEnd: _onVerticalDragEnd,
-      child: AnimatedContainer(
-        duration: _dragOffset > 0
-            ? Duration.zero
-            : const Duration(milliseconds: 300),
-        curve: Curves.easeOutCubic,
+      child: DecoratedBox(
         decoration: BoxDecoration(
           color: theme.colorScheme.surfaceContainerHighest,
           border: Border(
@@ -239,29 +237,17 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar> {
           mainAxisSize: MainAxisSize.min,
           children: [
             _buildHandleBar(theme),
-            if (dragExpansion > 0)
-              SizedBox(
-                height: dragExpansion,
-                child: ClipRect(
-                  child: Align(
-                    alignment: Alignment.topCenter,
-                    child: _buildWindowList(theme),
-                  ),
-                ),
-              ),
-            AnimatedCrossFade(
-              duration: const Duration(milliseconds: 300),
-              sizeCurve: Curves.easeOutCubic,
-              crossFadeState: _expanded
-                  ? CrossFadeState.showSecond
-                  : CrossFadeState.showFirst,
-              firstChild: const SizedBox.shrink(),
-              secondChild: ConstrainedBox(
-                constraints: BoxConstraints(
-                  maxHeight: MediaQuery.sizeOf(context).height * 0.4,
-                ),
-                child: _buildWindowList(theme),
-              ),
+            // Use AnimatedContainer only for expand/collapse snap animation.
+            // During drag, height tracks the finger directly (duration: zero).
+            AnimatedContainer(
+              duration: _dragOffset > 0
+                  ? Duration.zero
+                  : const Duration(milliseconds: 300),
+              curve: Curves.easeOutCubic,
+              height: contentHeight,
+              child: contentHeight > 0
+                  ? ClipRect(child: _buildWindowList(theme))
+                  : const SizedBox.shrink(),
             ),
           ],
         ),
@@ -2820,21 +2806,30 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     return Stack(
       children: [
+        // Terminal with animated bottom padding that grows/shrinks
+        // smoothly when the tmux handle appears/disappears.
         Positioned.fill(
-          child: Padding(
+          child: AnimatedPadding(
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeOutCubic,
             padding: EdgeInsets.only(
               bottom: showTmux ? _TmuxExpandableBar.handleHeight : 0,
             ),
             child: _buildTerminalView(terminalTheme, isMobile),
           ),
         ),
-        if (showTmux)
-          Positioned(
-            left: 0,
-            right: 0,
-            bottom: 0,
+        // Handle bar slides up from below via AnimatedPositioned.
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: showTmux ? 0 : -_TmuxExpandableBar.handleHeight,
+          child: AnimatedOpacity(
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeOutCubic,
+            opacity: showTmux ? 1 : 0,
             child: _buildTmuxExpandableBar(theme),
           ),
+        ),
       ],
     );
   }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2851,7 +2851,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 ),
               ),
         actions: [
-          if (_isTmuxActive && connectionState == SshConnectionState.connected)
+          if (_isTmuxActive &&
+              !_showTmuxBar &&
+              connectionState == SshConnectionState.connected)
             IconButton(
               icon: const Icon(Icons.window_outlined),
               onPressed: _connectionId == null ? null : _openTmuxNavigator,

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -116,11 +116,12 @@ const _terminalFilePathVerificationExtensions = <String>[
   'm',
 ];
 
-/// Expandable tmux bar that sits at the bottom of the terminal.
+/// Expandable tmux bar overlaid at the bottom of the terminal.
 ///
-/// Collapsed: a slim handle bar showing session name + drag pill.
-/// Expanded: grows upward, pushing the terminal content up via padding.
-/// The entire bar (handle + expanded content) is a single Column child.
+/// Collapsed: a slim handle bar sitting over bottom padding in the terminal.
+/// Expanded: slides up over the terminal content.
+/// The handle height matches the terminal's bottom padding so it never
+/// covers actual terminal content when collapsed.
 class _TmuxExpandableBar extends StatefulWidget {
   const _TmuxExpandableBar({
     required this.session,
@@ -144,6 +145,10 @@ class _TmuxExpandableBar extends StatefulWidget {
 
   /// Callback for navigator actions.
   final Future<void> Function(TmuxNavigatorAction) onAction;
+
+  /// Height of the collapsed handle bar. The terminal adds this as
+  /// bottom padding so the handle sits over empty space.
+  static const handleHeight = 28.0;
 
   @override
   State<_TmuxExpandableBar> createState() => _TmuxExpandableBarState();
@@ -2796,7 +2801,45 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
-  /// Builds the tmux expandable bar as a Column child below the terminal.
+  /// Wraps the terminal view in a Stack with the tmux bar overlaid.
+  ///
+  /// When tmux is active, the terminal gets bottom padding equal to the
+  /// handle bar height so the collapsed handle sits over empty space.
+  /// When expanded, the bar slides up over the terminal content.
+  /// When tmux is not active, the terminal fills the entire space.
+  Widget _buildTerminalWithTmuxBar(
+    TerminalThemeData terminalTheme,
+    bool isMobile,
+    ThemeData theme,
+    SshConnectionState connectionState,
+  ) {
+    final showTmux =
+        _isTmuxActive &&
+        _showTmuxBar &&
+        connectionState == SshConnectionState.connected;
+
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: Padding(
+            padding: EdgeInsets.only(
+              bottom: showTmux ? _TmuxExpandableBar.handleHeight : 0,
+            ),
+            child: _buildTerminalView(terminalTheme, isMobile),
+          ),
+        ),
+        if (showTmux)
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: _buildTmuxExpandableBar(theme),
+          ),
+      ],
+    );
+  }
+
+  /// Builds the tmux expandable bar overlaid at the bottom of the terminal.
   Widget _buildTmuxExpandableBar(ThemeData theme) {
     final connectionId = _connectionId;
     if (connectionId == null || _tmuxSessionName == null) {
@@ -3482,11 +3525,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       ),
       body: Column(
         children: [
-          Expanded(child: _buildTerminalView(terminalTheme, isMobile)),
-          if (_isTmuxActive &&
-              _showTmuxBar &&
-              connectionState == SshConnectionState.connected)
-            _buildTmuxExpandableBar(theme),
+          Expanded(
+            child: _buildTerminalWithTmuxBar(
+              terminalTheme,
+              isMobile,
+              theme,
+              connectionState,
+            ),
+          ),
           if (_showKeyboardToolbar &&
               !showsDisconnectedOverlay &&
               (!_isNativeSelectionMode || _isMobilePlatform))

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -30,13 +30,20 @@ import 'package:xterm/src/ui/terminal_text_style.dart';
 import 'package:xterm/src/ui/terminal_theme.dart';
 import 'package:xterm/src/ui/themes.dart';
 
-/// Safe-area padding that the terminal renderer should respect.
+/// Terminal render padding.
 ///
-/// Keep the top and horizontal insets so text does not sit under cutouts, but
-/// let the terminal use the full available height instead of reserving the
-/// bottom home-indicator inset as an extra blank row.
-EdgeInsets resolveTerminalRenderPadding(MediaQueryData mediaQuery) =>
-    mediaQuery.padding.copyWith(bottom: 0);
+/// Keep horizontal cutout insets in landscape, but avoid adding extra blank
+/// rows at the bottom or side gutters in portrait.
+EdgeInsets resolveTerminalRenderPadding(MediaQueryData mediaQuery) {
+  final isLandscape = mediaQuery.size.width > mediaQuery.size.height;
+  if (!isLandscape) {
+    return EdgeInsets.zero;
+  }
+  return EdgeInsets.only(
+    left: mediaQuery.padding.left,
+    right: mediaQuery.padding.right,
+  );
+}
 
 /// Adapted xterm terminal view with a trackpad scroll fix for alt-buffer apps.
 class MonkeyTerminalView extends StatefulWidget {

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -487,10 +487,11 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     bool flushPlatformContext = false,
   }) {
     if (flushPlatformContext && hasInputConnection) {
-      _closeInputConnectionIfNeeded();
-      if (widget.focusNode.hasFocus) {
-        _openInputConnection();
-      }
+      // Reset the editing state in-place rather than closing/reopening
+      // the input connection. Closing triggers a keyboard dismiss+reshow
+      // flicker on iPad.
+      _currentEditingState = _initEditingState.copyWith();
+      _connection!.setEditingState(_currentEditingState);
     }
     _invalidatePendingEditingUpdates();
     _resetCommittedInputState(clearPendingDeleteResetBaseline: false);

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -64,6 +67,15 @@ class TmuxResumeSessionAction extends TmuxNavigatorAction {
   final String resumeCommand;
 }
 
+/// Close a tmux window.
+class TmuxCloseWindowAction extends TmuxNavigatorAction {
+  /// Creates a new [TmuxCloseWindowAction].
+  const TmuxCloseWindowAction(this.windowIndex);
+
+  /// The window index to close.
+  final int windowIndex;
+}
+
 class _TmuxNavigatorSheet extends StatefulWidget {
   const _TmuxNavigatorSheet({
     required this.session,
@@ -90,6 +102,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
+  Set<AgentLaunchTool>? _installedTools;
   bool _isLoadingWindows = true;
   bool _isLoadingSessions = false;
   bool _showRecentSessions = false;
@@ -117,6 +130,8 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         _windows = windows;
         _isLoadingWindows = false;
       });
+      // Detect installed CLIs in parallel (non-blocking).
+      unawaited(_detectInstalledTools());
     } on Exception catch (e) {
       if (!mounted) return;
       setState(() {
@@ -125,6 +140,41 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       });
     }
   }
+
+  Future<void> _detectInstalledTools() async {
+    try {
+      final output = await widget.session.execute(
+        'command -v claude copilot codex gemini opencode 2>/dev/null'
+        ' || true',
+      );
+      final stdout = await output.stdout
+          .cast<List<int>>()
+          .transform(utf8.decoder)
+          .join();
+      await output.stderr.cast<List<int>>().transform(utf8.decoder).join();
+      if (!mounted) return;
+
+      final paths = stdout.trim().split('\n').where((l) => l.isNotEmpty);
+      final installed = <AgentLaunchTool>{};
+      for (final path in paths) {
+        final bin = path.split('/').last;
+        final tool = _toolForBinary(bin);
+        if (tool != null) installed.add(tool);
+      }
+      setState(() => _installedTools = installed);
+    } on Object {
+      // Ignore — show all tools if detection fails.
+    }
+  }
+
+  static AgentLaunchTool? _toolForBinary(String bin) => switch (bin) {
+    'claude' => AgentLaunchTool.claudeCode,
+    'copilot' => AgentLaunchTool.copilotCli,
+    'codex' => AgentLaunchTool.codex,
+    'gemini' => AgentLaunchTool.geminiCli,
+    'opencode' => AgentLaunchTool.openCode,
+    _ => null,
+  };
 
   Future<void> _loadRecentSessions() async {
     if (_isLoadingSessions || _recentSessions != null) return;
@@ -156,6 +206,10 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     Navigator.pop(context, TmuxSwitchWindowAction(windowIndex));
   }
 
+  void _closeWindow(int windowIndex) {
+    Navigator.pop(context, TmuxCloseWindowAction(windowIndex));
+  }
+
   void _createNewWindow({String? command, String? name}) {
     Navigator.pop(
       context,
@@ -173,6 +227,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       context: context,
       builder: (context) => _ToolPickerSheet(
         isProUser: widget.isProUser,
+        installedTools: _installedTools,
         onToolSelected: (tool) {
           Navigator.pop(context);
           _createNewWindow(command: tool.commandName, name: tool.commandName);
@@ -323,20 +378,19 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
                 color: theme.colorScheme.error,
               ),
             ),
-          Text(
-            window.statusLabel,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: window.hasAlert
-                  ? theme.colorScheme.error
-                  : isActive
-                  ? theme.colorScheme.primary
-                  : theme.colorScheme.onSurfaceVariant,
-            ),
+          IconButton(
+            icon: const Icon(Icons.close, size: 16),
+            visualDensity: VisualDensity.compact,
+            tooltip: 'Close window',
+            onPressed: () => _closeWindow(window.index),
           ),
         ],
       ),
       selected: isActive,
-      onTap: isActive ? null : () => _switchToWindow(window.index),
+      // Active window: dismiss. Other windows: switch.
+      onTap: isActive
+          ? () => Navigator.pop(context)
+          : () => _switchToWindow(window.index),
     );
   }
 
@@ -455,14 +509,16 @@ class _ToolPickerSheet extends StatelessWidget {
     required this.isProUser,
     required this.onToolSelected,
     required this.onEmptyWindow,
+    this.installedTools,
   });
 
   final bool isProUser;
+  final Set<AgentLaunchTool>? installedTools;
   final void Function(AgentLaunchTool tool) onToolSelected;
   final VoidCallback onEmptyWindow;
 
-  /// Tools shown in the picker (excludes Aider for the navigator).
-  static const _navigatorTools = [
+  /// All tools that can be shown in the picker.
+  static const _allTools = [
     AgentLaunchTool.claudeCode,
     AgentLaunchTool.copilotCli,
     AgentLaunchTool.codex,
@@ -473,6 +529,10 @@ class _ToolPickerSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    // Show only installed tools, or all if detection hasn't completed.
+    final tools = installedTools != null
+        ? _allTools.where((t) => installedTools!.contains(t)).toList()
+        : _allTools;
 
     return SafeArea(
       child: SingleChildScrollView(
@@ -484,7 +544,7 @@ class _ToolPickerSheet extends StatelessWidget {
               padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
               child: Text('New Window', style: theme.textTheme.titleMedium),
             ),
-            for (final tool in _navigatorTools)
+            for (final tool in tools)
               ListTile(
                 leading: _ToolPickerSheet._iconForTool(tool, theme),
                 title: Text(tool.label),

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -10,6 +11,15 @@ import '../../domain/services/agent_session_discovery_service.dart';
 import '../../domain/services/ssh_service.dart';
 import '../../domain/services/tmux_service.dart';
 import '../widgets/premium_badge.dart';
+
+const _tmuxNavigatorDenseVisualDensity = VisualDensity(vertical: -2);
+const _tmuxNavigatorTilePadding = EdgeInsets.symmetric(horizontal: 16);
+const _tmuxNavigatorGroupTilePadding = EdgeInsets.only(left: 16, right: 16);
+const _tmuxNavigatorSessionTilePadding = EdgeInsets.only(left: 56, right: 12);
+const _tmuxNavigatorMaxHeightFactor = 0.56;
+const _tmuxNavigatorMaxHeightCap = 520.0;
+const _tmuxToolPickerMaxHeightFactor = 0.42;
+const _tmuxToolPickerMaxHeightCap = 360.0;
 
 /// Shows the tmux window navigator bottom sheet.
 ///
@@ -259,12 +269,15 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final screenHeight = MediaQuery.sizeOf(context).height;
+    final maxSheetHeight = math.min(
+      screenHeight * _tmuxNavigatorMaxHeightFactor,
+      _tmuxNavigatorMaxHeightCap,
+    );
 
     return SafeArea(
       child: ConstrainedBox(
-        constraints: BoxConstraints(
-          maxHeight: MediaQuery.sizeOf(context).height * 0.7,
-        ),
+        constraints: BoxConstraints(maxHeight: maxSheetHeight),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -323,9 +336,15 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
             // New Window button
             ListTile(
+              visualDensity: _tmuxNavigatorDenseVisualDensity,
+              minTileHeight: 42,
+              contentPadding: _tmuxNavigatorTilePadding,
+              horizontalTitleGap: 12,
+              minLeadingWidth: 20,
               leading: Icon(
                 Icons.add_circle_outline,
                 color: theme.colorScheme.primary,
+                size: 18,
               ),
               title: const Text('New Window'),
               dense: true,
@@ -348,16 +367,24 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   Widget _buildWindowTile(TmuxWindow window) {
     final theme = Theme.of(context);
     final isActive = window.isActive;
+    final secondaryTitle = window.displayTitle != window.name
+        ? window.name
+        : null;
 
     return ListTile(
       dense: true,
+      visualDensity: _tmuxNavigatorDenseVisualDensity,
+      minVerticalPadding: 2,
+      contentPadding: const EdgeInsets.only(left: 16, right: 4),
+      horizontalTitleGap: 10,
+      minLeadingWidth: 28,
       tileColor: isActive
           ? theme.colorScheme.primaryContainer.withAlpha(80)
           : null,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
       leading: Container(
-        width: 28,
-        height: 28,
+        width: 24,
+        height: 24,
         decoration: BoxDecoration(
           color: isActive
               ? theme.colorScheme.primary
@@ -376,16 +403,16 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         ),
       ),
       title: Text(
-        window.name,
+        window.displayTitle,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
         style: isActive
             ? theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600)
             : null,
       ),
-      subtitle: window.paneTitle != null
+      subtitle: secondaryTitle != null
           ? Text(
-              window.paneTitle!,
+              secondaryTitle,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: theme.textTheme.bodySmall?.copyWith(
@@ -400,6 +427,8 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
           IconButton(
             icon: const Icon(Icons.close, size: 16),
             visualDensity: VisualDensity.compact,
+            constraints: const BoxConstraints.tightFor(width: 30, height: 30),
+            padding: EdgeInsets.zero,
             tooltip: 'Close window',
             onPressed: () => _closeWindow(window.index),
           ),
@@ -456,8 +485,14 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       children: [
         ListTile(
           dense: true,
+          visualDensity: _tmuxNavigatorDenseVisualDensity,
+          minTileHeight: 42,
+          contentPadding: _tmuxNavigatorTilePadding,
+          horizontalTitleGap: 12,
+          minLeadingWidth: 18,
           leading: Icon(
             _showRecentSessions ? Icons.expand_less : Icons.expand_more,
+            size: 18,
             color: theme.colorScheme.onSurfaceVariant,
           ),
           title: Row(
@@ -539,6 +574,11 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       children: [
         ListTile(
           dense: true,
+          visualDensity: _tmuxNavigatorDenseVisualDensity,
+          minVerticalPadding: 2,
+          contentPadding: _tmuxNavigatorGroupTilePadding,
+          horizontalTitleGap: 12,
+          minLeadingWidth: 20,
           leading: _toolIcon(toolName, theme),
           title: Text(toolName),
           subtitle: Text(
@@ -565,7 +605,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
           ...sessions.map(
             (session) => _buildSessionTile(
               session,
-              contentPadding: const EdgeInsets.only(left: 56, right: 16),
+              contentPadding: _tmuxNavigatorSessionTilePadding,
             ),
           ),
       ],
@@ -580,8 +620,12 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
     return ListTile(
       dense: true,
+      visualDensity: _tmuxNavigatorDenseVisualDensity,
+      minVerticalPadding: 2,
       contentPadding: contentPadding,
       leading: _toolIcon(info.toolName, theme),
+      horizontalTitleGap: 12,
+      minLeadingWidth: 20,
       title: Text(
         info.summary ?? info.sessionId,
         maxLines: 1,
@@ -597,6 +641,11 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       ),
       trailing: TextButton(
         onPressed: () => _resumeSession(info),
+        style: TextButton.styleFrom(
+          visualDensity: VisualDensity.compact,
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+        ),
         child: const Text('Resume'),
       ),
     );
@@ -652,40 +701,59 @@ class TmuxToolPickerSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final screenHeight = MediaQuery.sizeOf(context).height;
+    final maxSheetHeight = math.min(
+      screenHeight * _tmuxToolPickerMaxHeightFactor,
+      _tmuxToolPickerMaxHeightCap,
+    );
     // Show only installed tools, or all if detection hasn't completed.
     final tools = installedTools != null
         ? _allTools.where((t) => installedTools!.contains(t)).toList()
         : _allTools;
 
     return SafeArea(
-      child: SingleChildScrollView(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-              child: Text('New Window', style: theme.textTheme.titleMedium),
-            ),
-            for (final tool in tools)
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: maxSheetHeight),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                child: Text('New Window', style: theme.textTheme.titleMedium),
+              ),
+              for (final tool in tools)
+                ListTile(
+                  visualDensity: _tmuxNavigatorDenseVisualDensity,
+                  minTileHeight: 42,
+                  contentPadding: _tmuxNavigatorTilePadding,
+                  horizontalTitleGap: 12,
+                  minLeadingWidth: 20,
+                  leading: TmuxToolPickerSheet._iconForTool(tool, theme),
+                  title: Text(tool.label),
+                  trailing: !isProUser ? const PremiumBadge() : null,
+                  enabled: isProUser,
+                  onTap: () => onToolSelected(tool),
+                ),
+              const Divider(height: 1),
               ListTile(
-                leading: TmuxToolPickerSheet._iconForTool(tool, theme),
-                title: Text(tool.label),
-                trailing: !isProUser ? const PremiumBadge() : null,
-                enabled: isProUser,
-                onTap: () => onToolSelected(tool),
+                visualDensity: _tmuxNavigatorDenseVisualDensity,
+                minTileHeight: 42,
+                contentPadding: _tmuxNavigatorTilePadding,
+                horizontalTitleGap: 12,
+                minLeadingWidth: 20,
+                leading: Icon(
+                  Icons.terminal,
+                  color: theme.colorScheme.onSurfaceVariant,
+                  size: 18,
+                ),
+                title: const Text('Empty window'),
+                onTap: onEmptyWindow,
               ),
-            const Divider(height: 1),
-            ListTile(
-              leading: Icon(
-                Icons.terminal,
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-              title: const Text('Empty window'),
-              onTap: onEmptyWindow,
-            ),
-            const SizedBox(height: 8),
-          ],
+              const SizedBox(height: 8),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -184,72 +184,86 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     final theme = Theme.of(context);
 
     return SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Header
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 16, 8, 0),
-            child: Row(
-              children: [
-                Icon(
-                  Icons.window_outlined,
-                  size: 20,
-                  color: theme.colorScheme.primary,
-                ),
-                const SizedBox(width: 8),
-                Text('Windows', style: theme.textTheme.titleMedium),
-                const Spacer(),
-                IconButton(
-                  icon: const Icon(Icons.close, size: 20),
-                  onPressed: () => Navigator.pop(context),
-                  visualDensity: VisualDensity.compact,
-                ),
-              ],
-            ),
-          ),
-
-          const SizedBox(height: 4),
-
-          // Window list
-          if (_isLoadingWindows)
-            const Padding(
-              padding: EdgeInsets.all(24),
-              child: Center(child: CircularProgressIndicator.adaptive()),
-            )
-          else if (_error != null)
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.sizeOf(context).height * 0.7,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header
             Padding(
-              padding: const EdgeInsets.all(16),
-              child: Text(
-                'Could not load windows: $_error',
-                style: TextStyle(color: theme.colorScheme.error),
+              padding: const EdgeInsets.fromLTRB(16, 16, 8, 0),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.window_outlined,
+                    size: 20,
+                    color: theme.colorScheme.primary,
+                  ),
+                  const SizedBox(width: 8),
+                  Text('Windows', style: theme.textTheme.titleMedium),
+                  const Spacer(),
+                  IconButton(
+                    icon: const Icon(Icons.close, size: 20),
+                    onPressed: () => Navigator.pop(context),
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ],
               ),
-            )
-          else if (_windows != null && _windows!.isNotEmpty)
-            ..._windows!.map(_buildWindowTile),
-
-          const Divider(height: 1),
-
-          // New Window button
-          ListTile(
-            leading: Icon(
-              Icons.add_circle_outline,
-              color: theme.colorScheme.primary,
             ),
-            title: const Text('New Window'),
-            dense: true,
-            onTap: _showNewWindowPicker,
-          ),
 
-          // Recent AI Sessions (collapsed by default)
-          if (widget.isProUser) ...[
+            const SizedBox(height: 4),
+
+            // Scrollable window list
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  if (_isLoadingWindows)
+                    const Padding(
+                      padding: EdgeInsets.all(24),
+                      child: Center(
+                        child: CircularProgressIndicator.adaptive(),
+                      ),
+                    )
+                  else if (_error != null)
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Text(
+                        'Could not load windows: $_error',
+                        style: TextStyle(color: theme.colorScheme.error),
+                      ),
+                    )
+                  else if (_windows != null && _windows!.isNotEmpty)
+                    ..._windows!.map(_buildWindowTile),
+                ],
+              ),
+            ),
+
             const Divider(height: 1),
-            _buildRecentSessionsSection(theme),
-          ],
 
-          const SizedBox(height: 8),
-        ],
+            // New Window button
+            ListTile(
+              leading: Icon(
+                Icons.add_circle_outline,
+                color: theme.colorScheme.primary,
+              ),
+              title: const Text('New Window'),
+              dense: true,
+              onTap: _showNewWindowPicker,
+            ),
+
+            // Recent AI Sessions (collapsed by default)
+            if (widget.isProUser) ...[
+              const Divider(height: 1),
+              _buildRecentSessionsSection(theme),
+            ],
+
+            const SizedBox(height: 8),
+          ],
+        ),
       ),
     );
   }

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -382,6 +382,17 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
                 size: 16,
                 color: theme.colorScheme.error,
               ),
+            )
+          else if (window.isIdle)
+            Padding(
+              padding: const EdgeInsets.only(right: 4),
+              child: Text(
+                'waiting',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.tertiary,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
             ),
           IconButton(
             icon: const Icon(Icons.close, size: 16),

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -301,13 +301,39 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         ),
       ),
       title: Text(window.name, maxLines: 1, overflow: TextOverflow.ellipsis),
-      trailing: Text(
-        window.statusLabel,
-        style: theme.textTheme.bodySmall?.copyWith(
-          color: isActive
-              ? theme.colorScheme.primary
-              : theme.colorScheme.onSurfaceVariant,
-        ),
+      subtitle: window.paneTitle != null
+          ? Text(
+              window.paneTitle!,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            )
+          : null,
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (window.hasAlert)
+            Padding(
+              padding: const EdgeInsets.only(right: 4),
+              child: Icon(
+                Icons.notifications_active,
+                size: 16,
+                color: theme.colorScheme.error,
+              ),
+            ),
+          Text(
+            window.statusLabel,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: window.hasAlert
+                  ? theme.colorScheme.error
+                  : isActive
+                  ? theme.colorScheme.primary
+                  : theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
       ),
       selected: isActive,
       onTap: isActive ? null : () => _switchToWindow(window.index),

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -150,8 +150,13 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       final stdout = await output.stdout
           .cast<List<int>>()
           .transform(utf8.decoder)
-          .join();
-      await output.stderr.cast<List<int>>().transform(utf8.decoder).join();
+          .join()
+          .timeout(const Duration(seconds: 5), onTimeout: () => '');
+      await output.stderr
+          .cast<List<int>>()
+          .transform(utf8.decoder)
+          .join()
+          .timeout(const Duration(seconds: 5), onTimeout: () => '');
       if (!mounted) return;
 
       final paths = stdout.trim().split('\n').where((l) => l.isNotEmpty);

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -431,33 +431,35 @@ class _ToolPickerSheet extends StatelessWidget {
     final theme = Theme.of(context);
 
     return SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-            child: Text('New Window', style: theme.textTheme.titleMedium),
-          ),
-          for (final tool in _navigatorTools)
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+              child: Text('New Window', style: theme.textTheme.titleMedium),
+            ),
+            for (final tool in _navigatorTools)
+              ListTile(
+                leading: _ToolPickerSheet._iconForTool(tool, theme),
+                title: Text(tool.label),
+                trailing: !isProUser ? const PremiumBadge() : null,
+                enabled: isProUser,
+                onTap: () => onToolSelected(tool),
+              ),
+            const Divider(height: 1),
             ListTile(
-              leading: _ToolPickerSheet._iconForTool(tool, theme),
-              title: Text(tool.label),
-              trailing: !isProUser ? const PremiumBadge() : null,
-              enabled: isProUser,
-              onTap: () => onToolSelected(tool),
+              leading: Icon(
+                Icons.terminal,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              title: const Text('Empty window'),
+              onTap: onEmptyWindow,
             ),
-          const Divider(height: 1),
-          ListTile(
-            leading: Icon(
-              Icons.terminal,
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-            title: const Text('Empty window'),
-            onTap: onEmptyWindow,
-          ),
-          const SizedBox(height: 8),
-        ],
+            const SizedBox(height: 8),
+          ],
+        ),
       ),
     );
   }

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -396,7 +396,9 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         overflow: TextOverflow.ellipsis,
       ),
       subtitle: Text(
-        '${info.toolName} · ${info.timeAgoLabel}',
+        info.timeAgoLabel.isNotEmpty
+            ? '${info.toolName} · ${info.timeAgoLabel}'
+            : info.toolName,
         style: theme.textTheme.bodySmall?.copyWith(
           color: theme.colorScheme.onSurfaceVariant,
         ),

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -1,0 +1,463 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/models/agent_launch_preset.dart';
+import '../../domain/models/tmux_state.dart';
+import '../../domain/services/agent_session_discovery_service.dart';
+import '../../domain/services/ssh_service.dart';
+import '../../domain/services/tmux_service.dart';
+import '../widgets/premium_badge.dart';
+
+/// Shows the tmux window navigator bottom sheet.
+///
+/// Returns the action the user selected, or `null` if dismissed.
+Future<TmuxNavigatorAction?> showTmuxNavigator({
+  required BuildContext context,
+  required WidgetRef ref,
+  required SshSession session,
+  required String tmuxSessionName,
+  required bool isProUser,
+}) => showModalBottomSheet<TmuxNavigatorAction>(
+  context: context,
+  isScrollControlled: true,
+  builder: (context) => _TmuxNavigatorSheet(
+    session: session,
+    tmuxSessionName: tmuxSessionName,
+    isProUser: isProUser,
+    ref: ref,
+  ),
+);
+
+/// An action selected from the tmux navigator.
+sealed class TmuxNavigatorAction {
+  /// Creates a new [TmuxNavigatorAction].
+  const TmuxNavigatorAction();
+}
+
+/// Switch the current terminal to a different tmux window.
+class TmuxSwitchWindowAction extends TmuxNavigatorAction {
+  /// Creates a new [TmuxSwitchWindowAction].
+  const TmuxSwitchWindowAction(this.windowIndex);
+
+  /// The window index to switch to.
+  final int windowIndex;
+}
+
+/// Create a new tmux window, optionally running a command.
+class TmuxNewWindowAction extends TmuxNavigatorAction {
+  /// Creates a new [TmuxNewWindowAction].
+  const TmuxNewWindowAction({this.command, this.windowName});
+
+  /// Optional command to run in the new window.
+  final String? command;
+
+  /// Optional name for the new window.
+  final String? windowName;
+}
+
+/// Resume an AI tool session in a new tmux window.
+class TmuxResumeSessionAction extends TmuxNavigatorAction {
+  /// Creates a new [TmuxResumeSessionAction].
+  const TmuxResumeSessionAction(this.resumeCommand);
+
+  /// The full resume command to run.
+  final String resumeCommand;
+}
+
+class _TmuxNavigatorSheet extends StatefulWidget {
+  const _TmuxNavigatorSheet({
+    required this.session,
+    required this.tmuxSessionName,
+    required this.isProUser,
+    required this.ref,
+  });
+
+  final SshSession session;
+  final String tmuxSessionName;
+  final bool isProUser;
+  final WidgetRef ref;
+
+  @override
+  State<_TmuxNavigatorSheet> createState() => _TmuxNavigatorSheetState();
+}
+
+class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
+  List<TmuxWindow>? _windows;
+  List<ToolSessionInfo>? _recentSessions;
+  bool _isLoadingWindows = true;
+  bool _isLoadingSessions = false;
+  bool _showRecentSessions = false;
+  String? _error;
+
+  TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
+
+  AgentSessionDiscoveryService get _discovery =>
+      widget.ref.read(agentSessionDiscoveryServiceProvider);
+
+  @override
+  void initState() {
+    super.initState();
+    _loadWindows();
+  }
+
+  Future<void> _loadWindows() async {
+    try {
+      final windows = await _tmux.listWindows(
+        widget.session,
+        widget.tmuxSessionName,
+      );
+      if (!mounted) return;
+      setState(() {
+        _windows = windows;
+        _isLoadingWindows = false;
+      });
+    } on Exception catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _isLoadingWindows = false;
+      });
+    }
+  }
+
+  Future<void> _loadRecentSessions() async {
+    if (_isLoadingSessions || _recentSessions != null) return;
+    setState(() => _isLoadingSessions = true);
+
+    try {
+      // Get working directory from the active window if available.
+      final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
+      final sessions = await _discovery.discoverSessions(
+        widget.session,
+        workingDirectory: activeWindow?.currentPath,
+        maxPerTool: 3,
+      );
+      if (!mounted) return;
+      setState(() {
+        _recentSessions = sessions;
+        _isLoadingSessions = false;
+      });
+    } on Exception {
+      if (!mounted) return;
+      setState(() {
+        _recentSessions = const [];
+        _isLoadingSessions = false;
+      });
+    }
+  }
+
+  void _switchToWindow(int windowIndex) {
+    Navigator.pop(context, TmuxSwitchWindowAction(windowIndex));
+  }
+
+  void _createNewWindow({String? command, String? name}) {
+    Navigator.pop(
+      context,
+      TmuxNewWindowAction(command: command, windowName: name),
+    );
+  }
+
+  void _resumeSession(ToolSessionInfo info) {
+    final command = _discovery.buildResumeCommand(info);
+    Navigator.pop(context, TmuxResumeSessionAction(command));
+  }
+
+  void _showNewWindowPicker() {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (context) => _ToolPickerSheet(
+        isProUser: widget.isProUser,
+        onToolSelected: (tool) {
+          Navigator.pop(context);
+          _createNewWindow(command: tool.commandName, name: tool.commandName);
+        },
+        onEmptyWindow: () {
+          Navigator.pop(context);
+          _createNewWindow();
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 8, 0),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.window_outlined,
+                  size: 20,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Text('Windows', style: theme.textTheme.titleMedium),
+                const Spacer(),
+                IconButton(
+                  icon: const Icon(Icons.close, size: 20),
+                  onPressed: () => Navigator.pop(context),
+                  visualDensity: VisualDensity.compact,
+                ),
+              ],
+            ),
+          ),
+
+          const SizedBox(height: 4),
+
+          // Window list
+          if (_isLoadingWindows)
+            const Padding(
+              padding: EdgeInsets.all(24),
+              child: Center(child: CircularProgressIndicator.adaptive()),
+            )
+          else if (_error != null)
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(
+                'Could not load windows: $_error',
+                style: TextStyle(color: theme.colorScheme.error),
+              ),
+            )
+          else if (_windows != null && _windows!.isNotEmpty)
+            ..._windows!.map(_buildWindowTile),
+
+          const Divider(height: 1),
+
+          // New Window button
+          ListTile(
+            leading: Icon(
+              Icons.add_circle_outline,
+              color: theme.colorScheme.primary,
+            ),
+            title: const Text('New Window'),
+            dense: true,
+            onTap: _showNewWindowPicker,
+          ),
+
+          // Recent AI Sessions (collapsed by default)
+          if (widget.isProUser) ...[
+            const Divider(height: 1),
+            _buildRecentSessionsSection(theme),
+          ],
+
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildWindowTile(TmuxWindow window) {
+    final theme = Theme.of(context);
+    final isActive = window.isActive;
+
+    return ListTile(
+      dense: true,
+      leading: Container(
+        width: 28,
+        height: 28,
+        decoration: BoxDecoration(
+          color: isActive
+              ? theme.colorScheme.primary
+              : theme.colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(6),
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          '${window.index}',
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: isActive
+                ? theme.colorScheme.onPrimary
+                : theme.colorScheme.onSurfaceVariant,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+      title: Text(window.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+      trailing: Text(
+        window.statusLabel,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: isActive
+              ? theme.colorScheme.primary
+              : theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+      selected: isActive,
+      onTap: isActive ? null : () => _switchToWindow(window.index),
+    );
+  }
+
+  Widget _buildRecentSessionsSection(ThemeData theme) => Column(
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      ListTile(
+        dense: true,
+        leading: Icon(
+          _showRecentSessions ? Icons.expand_less : Icons.expand_more,
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+        title: Row(
+          children: [
+            const Text('Recent AI Sessions'),
+            if (_recentSessions != null && _recentSessions!.isNotEmpty) ...[
+              const SizedBox(width: 6),
+              Text(
+                '(${_recentSessions!.length})',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+            const Spacer(),
+            const PremiumBadge(),
+          ],
+        ),
+        onTap: () {
+          setState(() => _showRecentSessions = !_showRecentSessions);
+          if (_showRecentSessions) {
+            _loadRecentSessions();
+          }
+        },
+      ),
+      if (_showRecentSessions) ...[
+        if (_isLoadingSessions)
+          const Padding(
+            padding: EdgeInsets.all(16),
+            child: Center(
+              child: SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+              ),
+            ),
+          )
+        else if (_recentSessions != null && _recentSessions!.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text(
+              'No recent AI sessions found on this host.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          )
+        else if (_recentSessions != null)
+          ...(_recentSessions!.take(5).map(_buildSessionTile)),
+      ],
+    ],
+  );
+
+  Widget _buildSessionTile(ToolSessionInfo info) {
+    final theme = Theme.of(context);
+
+    return ListTile(
+      dense: true,
+      leading: _toolIcon(info.toolName, theme),
+      title: Text(
+        info.summary ?? info.sessionId,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        '${info.toolName} · ${info.timeAgoLabel}',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+      trailing: TextButton(
+        onPressed: () => _resumeSession(info),
+        child: const Text('Resume'),
+      ),
+    );
+  }
+
+  Widget _toolIcon(String toolName, ThemeData theme) {
+    final iconData = switch (toolName) {
+      'Claude Code' => Icons.auto_awesome,
+      'Codex' => Icons.code,
+      'Copilot CLI' => Icons.flight,
+      'Gemini CLI' => Icons.diamond_outlined,
+      'OpenCode' => Icons.terminal,
+      _ => Icons.smart_toy_outlined,
+    };
+
+    return Icon(iconData, size: 20, color: theme.colorScheme.primary);
+  }
+}
+
+class _ToolPickerSheet extends StatelessWidget {
+  const _ToolPickerSheet({
+    required this.isProUser,
+    required this.onToolSelected,
+    required this.onEmptyWindow,
+  });
+
+  final bool isProUser;
+  final void Function(AgentLaunchTool tool) onToolSelected;
+  final VoidCallback onEmptyWindow;
+
+  /// Tools shown in the picker (excludes Aider for the navigator).
+  static const _navigatorTools = [
+    AgentLaunchTool.claudeCode,
+    AgentLaunchTool.copilotCli,
+    AgentLaunchTool.codex,
+    AgentLaunchTool.geminiCli,
+    AgentLaunchTool.openCode,
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text('New Window', style: theme.textTheme.titleMedium),
+          ),
+          for (final tool in _navigatorTools)
+            ListTile(
+              leading: _ToolPickerSheet._iconForTool(tool, theme),
+              title: Text(tool.label),
+              trailing: !isProUser ? const PremiumBadge() : null,
+              enabled: isProUser,
+              onTap: () => onToolSelected(tool),
+            ),
+          const Divider(height: 1),
+          ListTile(
+            leading: Icon(
+              Icons.terminal,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            title: const Text('Empty window'),
+            onTap: onEmptyWindow,
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+
+  static Widget _iconForTool(AgentLaunchTool tool, ThemeData theme) {
+    final iconData = switch (tool) {
+      AgentLaunchTool.claudeCode => Icons.auto_awesome,
+      AgentLaunchTool.copilotCli => Icons.flight,
+      AgentLaunchTool.codex => Icons.code,
+      AgentLaunchTool.geminiCli => Icons.diamond_outlined,
+      AgentLaunchTool.openCode => Icons.terminal,
+      AgentLaunchTool.aider => Icons.smart_toy_outlined,
+    };
+
+    return Icon(iconData, color: theme.colorScheme.primary);
+  }
+}

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -146,7 +146,11 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
   Future<void> _detectInstalledTools() async {
     try {
+      // Source shell profiles so CLIs in Homebrew/nvm/etc. paths are found.
       final output = await widget.session.execute(
+        '. ~/.profile 2>/dev/null; '
+        '. ~/.bash_profile 2>/dev/null; '
+        '. ~/.zprofile 2>/dev/null; '
         'command -v claude copilot codex gemini opencode 2>/dev/null'
         ' || true',
       );
@@ -236,7 +240,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   void _showNewWindowPicker() {
     showModalBottomSheet<void>(
       context: context,
-      builder: (context) => _ToolPickerSheet(
+      builder: (context) => TmuxToolPickerSheet(
         isProUser: widget.isProUser,
         installedTools: _installedTools,
         onToolSelected: (tool) {
@@ -526,17 +530,28 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   }
 }
 
-class _ToolPickerSheet extends StatelessWidget {
-  const _ToolPickerSheet({
+/// Bottom sheet for picking an AI coding tool to launch in a new tmux window.
+class TmuxToolPickerSheet extends StatelessWidget {
+  /// Creates a new [TmuxToolPickerSheet].
+  const TmuxToolPickerSheet({
     required this.isProUser,
     required this.onToolSelected,
     required this.onEmptyWindow,
     this.installedTools,
+    super.key,
   });
 
+  /// Whether the user has Pro access.
   final bool isProUser;
+
+  /// Tools detected as installed on the remote host, or `null` if not yet
+  /// detected (shows all tools).
   final Set<AgentLaunchTool>? installedTools;
+
+  /// Called when the user selects a tool.
   final void Function(AgentLaunchTool tool) onToolSelected;
+
+  /// Called when the user selects an empty window.
   final VoidCallback onEmptyWindow;
 
   /// All tools that can be shown in the picker.
@@ -568,7 +583,7 @@ class _ToolPickerSheet extends StatelessWidget {
             ),
             for (final tool in tools)
               ListTile(
-                leading: _ToolPickerSheet._iconForTool(tool, theme),
+                leading: TmuxToolPickerSheet._iconForTool(tool, theme),
                 title: Text(tool.label),
                 trailing: !isProUser ? const PremiumBadge() : null,
                 enabled: isProUser,

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -351,6 +351,10 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
     return ListTile(
       dense: true,
+      tileColor: isActive
+          ? theme.colorScheme.primaryContainer.withAlpha(80)
+          : null,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
       leading: Container(
         width: 28,
         height: 28,
@@ -371,7 +375,14 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
           ),
         ),
       ),
-      title: Text(window.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+      title: Text(
+        window.name,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: isActive
+            ? theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600)
+            : null,
+      ),
       subtitle: window.paneTitle != null
           ? Text(
               window.paneTitle!,
@@ -385,26 +396,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (window.hasAlert)
-            Padding(
-              padding: const EdgeInsets.only(right: 4),
-              child: Icon(
-                Icons.notifications_active,
-                size: 16,
-                color: theme.colorScheme.error,
-              ),
-            )
-          else if (window.isIdle)
-            Padding(
-              padding: const EdgeInsets.only(right: 4),
-              child: Text(
-                'waiting',
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.tertiary,
-                  fontStyle: FontStyle.italic,
-                ),
-              ),
-            ),
+          _windowStatusIcon(theme, window),
           IconButton(
             icon: const Icon(Icons.close, size: 16),
             visualDensity: VisualDensity.compact,
@@ -413,12 +405,46 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
           ),
         ],
       ),
-      selected: isActive,
       // Active window: dismiss. Other windows: switch.
       onTap: isActive
           ? () => Navigator.pop(context)
           : () => _switchToWindow(window.index),
     );
+  }
+
+  /// Returns a status icon for the window's current state.
+  Widget _windowStatusIcon(ThemeData theme, TmuxWindow window) {
+    if (window.hasAlert) {
+      return Padding(
+        padding: const EdgeInsets.only(right: 4),
+        child: Icon(
+          Icons.notifications_active,
+          size: 16,
+          color: theme.colorScheme.error,
+        ),
+      );
+    }
+    if (window.isIdle) {
+      return Padding(
+        padding: const EdgeInsets.only(right: 4),
+        child: Icon(
+          Icons.hourglass_bottom,
+          size: 14,
+          color: theme.colorScheme.tertiary,
+        ),
+      );
+    }
+    if (!window.isActive) {
+      return Padding(
+        padding: const EdgeInsets.only(right: 4),
+        child: Icon(
+          Icons.play_arrow,
+          size: 16,
+          color: theme.colorScheme.primary.withAlpha(160),
+        ),
+      );
+    }
+    return const SizedBox.shrink();
   }
 
   Widget _buildRecentSessionsSection(ThemeData theme) {

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -82,6 +82,12 @@ class _TmuxNavigatorSheet extends StatefulWidget {
 }
 
 class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
+  /// Maximum number of recent sessions to show per tool.
+  static const _maxSessionsPerTool = 3;
+
+  /// Maximum total recent sessions to display.
+  static const _maxVisibleSessions = 5;
+
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
   bool _isLoadingWindows = true;
@@ -130,7 +136,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       final sessions = await _discovery.discoverSessions(
         widget.session,
         workingDirectory: activeWindow?.currentPath,
-        maxPerTool: 3,
+        maxPerTool: _maxSessionsPerTool,
       );
       if (!mounted) return;
       setState(() {
@@ -308,65 +314,75 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     );
   }
 
-  Widget _buildRecentSessionsSection(ThemeData theme) => Column(
-    mainAxisSize: MainAxisSize.min,
-    children: [
-      ListTile(
-        dense: true,
-        leading: Icon(
-          _showRecentSessions ? Icons.expand_less : Icons.expand_more,
-          color: theme.colorScheme.onSurfaceVariant,
+  Widget _buildRecentSessionsSection(ThemeData theme) {
+    final visibleCount = _recentSessions == null
+        ? 0
+        : _recentSessions!.length > _maxVisibleSessions
+        ? _maxVisibleSessions
+        : _recentSessions!.length;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ListTile(
+          dense: true,
+          leading: Icon(
+            _showRecentSessions ? Icons.expand_less : Icons.expand_more,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          title: Row(
+            children: [
+              const Text('Recent AI Sessions'),
+              if (visibleCount > 0) ...[
+                const SizedBox(width: 6),
+                Text(
+                  '($visibleCount)',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+              const Spacer(),
+              const PremiumBadge(),
+            ],
+          ),
+          onTap: () {
+            setState(() => _showRecentSessions = !_showRecentSessions);
+            if (_showRecentSessions) {
+              _loadRecentSessions();
+            }
+          },
         ),
-        title: Row(
-          children: [
-            const Text('Recent AI Sessions'),
-            if (_recentSessions != null && _recentSessions!.isNotEmpty) ...[
-              const SizedBox(width: 6),
-              Text(
-                '(${_recentSessions!.length})',
+        if (_showRecentSessions) ...[
+          if (_isLoadingSessions)
+            const Padding(
+              padding: EdgeInsets.all(16),
+              child: Center(
+                child: SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                ),
+              ),
+            )
+          else if (_recentSessions != null && _recentSessions!.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Text(
+                'No recent AI sessions found on this host.',
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
               ),
-            ],
-            const Spacer(),
-            const PremiumBadge(),
-          ],
-        ),
-        onTap: () {
-          setState(() => _showRecentSessions = !_showRecentSessions);
-          if (_showRecentSessions) {
-            _loadRecentSessions();
-          }
-        },
-      ),
-      if (_showRecentSessions) ...[
-        if (_isLoadingSessions)
-          const Padding(
-            padding: EdgeInsets.all(16),
-            child: Center(
-              child: SizedBox(
-                width: 20,
-                height: 20,
-                child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-              ),
-            ),
-          )
-        else if (_recentSessions != null && _recentSessions!.isEmpty)
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Text(
-              'No recent AI sessions found on this host.',
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
-          )
-        else if (_recentSessions != null)
-          ...(_recentSessions!.take(5).map(_buildSessionTile)),
+            )
+          else if (_recentSessions != null)
+            ...(_recentSessions!
+                .take(_maxVisibleSessions)
+                .map(_buildSessionTile)),
+        ],
       ],
-    ],
-  );
+    );
+  }
 
   Widget _buildSessionTile(ToolSessionInfo info) {
     final theme = Theme.of(context);

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -98,14 +98,12 @@ class _TmuxNavigatorSheet extends StatefulWidget {
 
 class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   /// Maximum number of recent sessions to show per tool.
-  static const _maxSessionsPerTool = 3;
-
-  /// Maximum total recent sessions to display.
-  static const _maxVisibleSessions = 5;
+  static const _maxSessionsPerTool = 8;
 
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
   Set<AgentLaunchTool>? _installedTools;
+  final Set<String> _expandedSessionTools = <String>{};
   bool _isLoadingWindows = true;
   bool _isLoadingSessions = false;
   bool _showRecentSessions = false;
@@ -203,6 +201,9 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       if (!mounted) return;
       setState(() {
         _recentSessions = sessions;
+        if (_expandedSessionTools.isEmpty && sessions.isNotEmpty) {
+          _expandedSessionTools.add(sessions.first.toolName);
+        }
         _isLoadingSessions = false;
       });
     } on Exception {
@@ -421,11 +422,8 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   }
 
   Widget _buildRecentSessionsSection(ThemeData theme) {
-    final visibleCount = _recentSessions == null
-        ? 0
-        : _recentSessions!.length > _maxVisibleSessions
-        ? _maxVisibleSessions
-        : _recentSessions!.length;
+    final visibleCount = _recentSessions?.length ?? 0;
+    final groupedSessions = _groupSessions(_recentSessions);
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -482,19 +480,81 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
               ),
             )
           else if (_recentSessions != null)
-            ...(_recentSessions!
-                .take(_maxVisibleSessions)
-                .map(_buildSessionTile)),
+            ...groupedSessions.entries.map(
+              (entry) => _buildSessionGroup(theme, entry.key, entry.value),
+            ),
         ],
       ],
     );
   }
 
-  Widget _buildSessionTile(ToolSessionInfo info) {
+  Map<String, List<ToolSessionInfo>> _groupSessions(
+    List<ToolSessionInfo>? sessions,
+  ) {
+    final grouped = <String, List<ToolSessionInfo>>{};
+    if (sessions == null) return grouped;
+    for (final session in sessions) {
+      grouped
+          .putIfAbsent(session.toolName, () => <ToolSessionInfo>[])
+          .add(session);
+    }
+    return grouped;
+  }
+
+  Widget _buildSessionGroup(
+    ThemeData theme,
+    String toolName,
+    List<ToolSessionInfo> sessions,
+  ) {
+    final isExpanded = _expandedSessionTools.contains(toolName);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ListTile(
+          dense: true,
+          leading: _toolIcon(toolName, theme),
+          title: Text(toolName),
+          subtitle: Text(
+            '${sessions.length} session${sessions.length == 1 ? '' : 's'}',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          trailing: Icon(
+            isExpanded ? Icons.expand_less : Icons.expand_more,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          onTap: () {
+            setState(() {
+              if (isExpanded) {
+                _expandedSessionTools.remove(toolName);
+              } else {
+                _expandedSessionTools.add(toolName);
+              }
+            });
+          },
+        ),
+        if (isExpanded)
+          ...sessions.map(
+            (session) => _buildSessionTile(
+              session,
+              contentPadding: const EdgeInsets.only(left: 56, right: 16),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildSessionTile(
+    ToolSessionInfo info, {
+    EdgeInsetsGeometry? contentPadding,
+  }) {
     final theme = Theme.of(context);
 
     return ListTile(
       dense: true,
+      contentPadding: contentPadding,
       leading: _toolIcon(info.toolName, theme),
       title: Text(
         info.summary ?? info.sessionId,

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -182,40 +182,45 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
   Future<void> _detectInstalledTools() async {
     try {
-      // Source shell profiles so CLIs in Homebrew/nvm/etc. paths are found.
-      final output = await widget.session.execute(
-        '. ~/.profile 2>/dev/null; '
-        '. ~/.bash_profile 2>/dev/null; '
-        '. ~/.zprofile 2>/dev/null; '
-        'command -v claude copilot codex gemini opencode 2>/dev/null'
+      // Source shell profiles so CLIs in Homebrew/nvm/etc. paths are found,
+      // while silencing profile output so only `command -v` results are parsed.
+      final execSession = await widget.session.execute(
+        '{ . ~/.profile; . ~/.bash_profile; . ~/.zprofile; } '
+        '>/dev/null 2>&1; '
+        'command -v aider claude copilot codex gemini opencode 2>/dev/null'
         ' || true',
       );
-      final stdout = await output.stdout
-          .cast<List<int>>()
-          .transform(utf8.decoder)
-          .join()
-          .timeout(const Duration(seconds: 5), onTimeout: () => '');
-      await output.stderr
-          .cast<List<int>>()
-          .transform(utf8.decoder)
-          .join()
-          .timeout(const Duration(seconds: 5), onTimeout: () => '');
-      if (!mounted) return;
+      try {
+        final stdout = await execSession.stdout
+            .cast<List<int>>()
+            .transform(utf8.decoder)
+            .join()
+            .timeout(const Duration(seconds: 5), onTimeout: () => '');
+        await execSession.stderr
+            .cast<List<int>>()
+            .transform(utf8.decoder)
+            .join()
+            .timeout(const Duration(seconds: 5), onTimeout: () => '');
+        if (!mounted) return;
 
-      final paths = stdout.trim().split('\n').where((l) => l.isNotEmpty);
-      final installed = <AgentLaunchTool>{};
-      for (final path in paths) {
-        final bin = path.split('/').last;
-        final tool = _toolForBinary(bin);
-        if (tool != null) installed.add(tool);
+        final paths = stdout.trim().split('\n').where((l) => l.isNotEmpty);
+        final installed = <AgentLaunchTool>{};
+        for (final path in paths) {
+          final bin = path.split('/').last;
+          final tool = _toolForBinary(bin);
+          if (tool != null) installed.add(tool);
+        }
+        setState(() => _installedTools = installed);
+      } finally {
+        execSession.close();
       }
-      setState(() => _installedTools = installed);
     } on Object {
       // Ignore — show all tools if detection fails.
     }
   }
 
   static AgentLaunchTool? _toolForBinary(String bin) => switch (bin) {
+    'aider' => AgentLaunchTool.aider,
     'claude' => AgentLaunchTool.claudeCode,
     'copilot' => AgentLaunchTool.copilotCli,
     'codex' => AgentLaunchTool.codex,
@@ -716,6 +721,7 @@ class TmuxToolPickerSheet extends StatelessWidget {
 
   /// All tools that can be shown in the picker.
   static const _allTools = [
+    AgentLaunchTool.aider,
     AgentLaunchTool.claudeCode,
     AgentLaunchTool.copilotCli,
     AgentLaunchTool.codex,
@@ -786,6 +792,7 @@ class TmuxToolPickerSheet extends StatelessWidget {
 
   static Widget _iconForTool(AgentLaunchTool tool, ThemeData theme) {
     final iconData = switch (tool) {
+      AgentLaunchTool.aider => Icons.chat_bubble_outline,
       AgentLaunchTool.claudeCode => Icons.auto_awesome,
       AgentLaunchTool.copilotCli => Icons.flight,
       AgentLaunchTool.codex => Icons.code,

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -11,6 +11,7 @@ import '../../domain/services/agent_session_discovery_service.dart';
 import '../../domain/services/ssh_service.dart';
 import '../../domain/services/tmux_service.dart';
 import '../widgets/premium_badge.dart';
+import 'tmux_window_status_badge.dart';
 
 const _tmuxNavigatorDenseVisualDensity = VisualDensity(vertical: -2);
 const _tmuxNavigatorTilePadding = EdgeInsets.symmetric(horizontal: 16);
@@ -108,7 +109,7 @@ class _TmuxNavigatorSheet extends StatefulWidget {
 
 class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   /// Maximum number of recent sessions to show per tool.
-  static const _maxSessionsPerTool = 8;
+  static const _maxSessionsPerTool = 16;
 
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
@@ -118,6 +119,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   bool _isLoadingWindows = true;
   bool _isLoadingSessions = false;
   bool _showRecentSessions = false;
+  String? _sessionLoadError;
   String? _error;
   bool _loadingWindows = false;
   bool _pendingWindowReload = false;
@@ -224,21 +226,25 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
   Future<void> _loadRecentSessions() async {
     if (_isLoadingSessions || _recentSessions != null) return;
-    setState(() => _isLoadingSessions = true);
+    setState(() {
+      _isLoadingSessions = true;
+      _sessionLoadError = null;
+    });
 
     try {
       // Get working directory from the active window if available.
       final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
-      final sessions = await _discovery.discoverSessions(
+      final result = await _discovery.discoverSessions(
         widget.session,
         workingDirectory: activeWindow?.currentPath,
         maxPerTool: _maxSessionsPerTool,
       );
       if (!mounted) return;
       setState(() {
-        _recentSessions = sessions;
-        if (_expandedSessionTools.isEmpty && sessions.isNotEmpty) {
-          _expandedSessionTools.add(sessions.first.toolName);
+        _recentSessions = result.sessions;
+        _sessionLoadError = result.failureMessage;
+        if (_expandedSessionTools.isEmpty && result.sessions.isNotEmpty) {
+          _expandedSessionTools.add(result.sessions.first.toolName);
         }
         _isLoadingSessions = false;
       });
@@ -246,6 +252,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       if (!mounted) return;
       setState(() {
         _recentSessions = const [];
+        _sessionLoadError = 'Could not load recent AI sessions.';
         _isLoadingSessions = false;
       });
     }
@@ -447,7 +454,10 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _windowStatusIcon(theme, window),
+          Padding(
+            padding: const EdgeInsets.only(right: 6),
+            child: TmuxWindowStatusBadge(window: window),
+          ),
           IconButton(
             icon: const Icon(Icons.close, size: 16),
             visualDensity: VisualDensity.compact,
@@ -463,41 +473,6 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
           ? () => Navigator.pop(context)
           : () => _switchToWindow(window.index),
     );
-  }
-
-  /// Returns a status icon for the window's current state.
-  Widget _windowStatusIcon(ThemeData theme, TmuxWindow window) {
-    if (window.hasAlert) {
-      return Padding(
-        padding: const EdgeInsets.only(right: 4),
-        child: Icon(
-          Icons.notifications_active,
-          size: 16,
-          color: theme.colorScheme.error,
-        ),
-      );
-    }
-    if (window.isIdle) {
-      return Padding(
-        padding: const EdgeInsets.only(right: 4),
-        child: Icon(
-          Icons.hourglass_bottom,
-          size: 14,
-          color: theme.colorScheme.tertiary,
-        ),
-      );
-    }
-    if (!window.isActive) {
-      return Padding(
-        padding: const EdgeInsets.only(right: 4),
-        child: Icon(
-          Icons.play_arrow,
-          size: 16,
-          color: theme.colorScheme.primary.withAlpha(160),
-        ),
-      );
-    }
-    return const SizedBox.shrink();
   }
 
   Widget _buildRecentSessionsSection(ThemeData theme) {
@@ -554,6 +529,18 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
                 ),
               ),
             )
+          else if (_sessionLoadError != null &&
+              _recentSessions != null &&
+              _recentSessions!.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Text(
+                _sessionLoadError!,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+              ),
+            )
           else if (_recentSessions != null && _recentSessions!.isEmpty)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -564,10 +551,24 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
                 ),
               ),
             )
-          else if (_recentSessions != null)
+          else if (_recentSessions != null) ...[
+            if (_sessionLoadError != null)
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                child: Text(
+                  _sessionLoadError!,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.error,
+                  ),
+                ),
+              ),
             ...groupedSessions.entries.map(
               (entry) => _buildSessionGroup(theme, entry.key, entry.value),
             ),
+          ],
         ],
       ],
     );

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -114,10 +114,13 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   List<ToolSessionInfo>? _recentSessions;
   Set<AgentLaunchTool>? _installedTools;
   final Set<String> _expandedSessionTools = <String>{};
+  StreamSubscription<void>? _windowChangeSubscription;
   bool _isLoadingWindows = true;
   bool _isLoadingSessions = false;
   bool _showRecentSessions = false;
   String? _error;
+  bool _loadingWindows = false;
+  bool _pendingWindowReload = false;
 
   TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
 
@@ -127,10 +130,27 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   @override
   void initState() {
     super.initState();
+    _windowChangeSubscription = _tmux
+        .watchWindowChanges(widget.session, widget.tmuxSessionName)
+        .listen((_) {
+          if (!mounted) return;
+          _loadWindows();
+        });
     _loadWindows();
   }
 
+  @override
+  void dispose() {
+    _windowChangeSubscription?.cancel();
+    super.dispose();
+  }
+
   Future<void> _loadWindows() async {
+    if (_loadingWindows) {
+      _pendingWindowReload = true;
+      return;
+    }
+    _loadingWindows = true;
     try {
       final windows = await _tmux.listWindows(
         widget.session,
@@ -149,6 +169,12 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         _error = e.toString();
         _isLoadingWindows = false;
       });
+    } finally {
+      _loadingWindows = false;
+      if (_pendingWindowReload) {
+        _pendingWindowReload = false;
+        unawaited(_loadWindows());
+      }
     }
   }
 

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -61,10 +61,13 @@ class TmuxNewWindowAction extends TmuxNavigatorAction {
 /// Resume an AI tool session in a new tmux window.
 class TmuxResumeSessionAction extends TmuxNavigatorAction {
   /// Creates a new [TmuxResumeSessionAction].
-  const TmuxResumeSessionAction(this.resumeCommand);
+  const TmuxResumeSessionAction(this.resumeCommand, {this.workingDirectory});
 
   /// The full resume command to run.
   final String resumeCommand;
+
+  /// The working directory to start in.
+  final String? workingDirectory;
 }
 
 /// Close a tmux window.
@@ -224,7 +227,10 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
   void _resumeSession(ToolSessionInfo info) {
     final command = _discovery.buildResumeCommand(info);
-    Navigator.pop(context, TmuxResumeSessionAction(command));
+    Navigator.pop(
+      context,
+      TmuxResumeSessionAction(command, workingDirectory: info.workingDirectory),
+    );
   }
 
   void _showNewWindowPicker() {

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -16,10 +16,10 @@ const _tmuxNavigatorDenseVisualDensity = VisualDensity(vertical: -2);
 const _tmuxNavigatorTilePadding = EdgeInsets.symmetric(horizontal: 16);
 const _tmuxNavigatorGroupTilePadding = EdgeInsets.only(left: 16, right: 16);
 const _tmuxNavigatorSessionTilePadding = EdgeInsets.only(left: 56, right: 12);
-const _tmuxNavigatorMaxHeightFactor = 0.56;
-const _tmuxNavigatorMaxHeightCap = 520.0;
-const _tmuxToolPickerMaxHeightFactor = 0.42;
-const _tmuxToolPickerMaxHeightCap = 360.0;
+const _tmuxNavigatorMaxHeightFactor = 0.48;
+const _tmuxNavigatorMaxHeightCap = 440.0;
+const _tmuxToolPickerMaxHeightFactor = 0.36;
+const _tmuxToolPickerMaxHeightCap = 320.0;
 
 /// Shows the tmux window navigator bottom sheet.
 ///
@@ -367,9 +367,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   Widget _buildWindowTile(TmuxWindow window) {
     final theme = Theme.of(context);
     final isActive = window.isActive;
-    final secondaryTitle = window.displayTitle != window.name
-        ? window.name
-        : null;
+    final secondaryTitle = window.secondaryTitle;
 
     return ListTile(
       dense: true,
@@ -632,8 +630,8 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         overflow: TextOverflow.ellipsis,
       ),
       subtitle: Text(
-        info.timeAgoLabel.isNotEmpty
-            ? '${info.toolName} · ${info.timeAgoLabel}'
+        info.lastUpdatedLabel.isNotEmpty
+            ? info.lastUpdatedLabel
             : info.toolName,
         style: theme.textTheme.bodySmall?.copyWith(
           color: theme.colorScheme.onSurfaceVariant,

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -698,7 +698,6 @@ class TmuxToolPickerSheet extends StatelessWidget {
       AgentLaunchTool.codex => Icons.code,
       AgentLaunchTool.geminiCli => Icons.diamond_outlined,
       AgentLaunchTool.openCode => Icons.terminal,
-      AgentLaunchTool.aider => Icons.smart_toy_outlined,
     };
 
     return Icon(iconData, color: theme.colorScheme.primary);

--- a/lib/presentation/widgets/tmux_window_status_badge.dart
+++ b/lib/presentation/widgets/tmux_window_status_badge.dart
@@ -48,21 +48,21 @@ class TmuxWindowStatusBadge extends StatelessWidget {
     if (window.hasAlert) {
       return _TmuxWindowStatusVisual(
         icon: Icons.notifications_active,
-        foregroundColor: theme.colorScheme.error,
-        backgroundColor: theme.colorScheme.errorContainer.withAlpha(150),
+        foregroundColor: theme.colorScheme.onErrorContainer,
+        backgroundColor: theme.colorScheme.errorContainer,
       );
     }
     if (window.isIdle) {
       return _TmuxWindowStatusVisual(
         icon: Icons.hourglass_bottom,
-        foregroundColor: theme.colorScheme.tertiary,
-        backgroundColor: theme.colorScheme.tertiaryContainer.withAlpha(170),
+        foregroundColor: theme.colorScheme.onTertiaryContainer,
+        backgroundColor: theme.colorScheme.tertiaryContainer,
       );
     }
     return _TmuxWindowStatusVisual(
       icon: Icons.play_arrow,
-      foregroundColor: theme.colorScheme.primary,
-      backgroundColor: theme.colorScheme.primaryContainer.withAlpha(170),
+      foregroundColor: theme.colorScheme.onPrimaryContainer,
+      backgroundColor: theme.colorScheme.primaryContainer,
     );
   }
 }

--- a/lib/presentation/widgets/tmux_window_status_badge.dart
+++ b/lib/presentation/widgets/tmux_window_status_badge.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/models/tmux_state.dart';
+
+/// Compact status badge for a tmux window.
+class TmuxWindowStatusBadge extends StatelessWidget {
+  /// Creates a new [TmuxWindowStatusBadge].
+  const TmuxWindowStatusBadge({required this.window, super.key});
+
+  /// The tmux window whose status is being displayed.
+  final TmuxWindow window;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final visual = _statusVisual(theme, window);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: visual.backgroundColor,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(visual.icon, size: 12, color: visual.foregroundColor),
+            const SizedBox(width: 3),
+            Text(
+              window.statusLabel,
+              style: theme.textTheme.labelSmall?.copyWith(
+                fontSize: 10,
+                color: visual.foregroundColor,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static _TmuxWindowStatusVisual _statusVisual(
+    ThemeData theme,
+    TmuxWindow window,
+  ) {
+    if (window.hasAlert) {
+      return _TmuxWindowStatusVisual(
+        icon: Icons.notifications_active,
+        foregroundColor: theme.colorScheme.error,
+        backgroundColor: theme.colorScheme.errorContainer.withAlpha(150),
+      );
+    }
+    if (window.isIdle) {
+      return _TmuxWindowStatusVisual(
+        icon: Icons.hourglass_bottom,
+        foregroundColor: theme.colorScheme.tertiary,
+        backgroundColor: theme.colorScheme.tertiaryContainer.withAlpha(170),
+      );
+    }
+    return _TmuxWindowStatusVisual(
+      icon: Icons.play_arrow,
+      foregroundColor: theme.colorScheme.primary,
+      backgroundColor: theme.colorScheme.primaryContainer.withAlpha(170),
+    );
+  }
+}
+
+class _TmuxWindowStatusVisual {
+  const _TmuxWindowStatusVisual({
+    required this.icon,
+    required this.foregroundColor,
+    required this.backgroundColor,
+  });
+
+  final IconData icon;
+  final Color foregroundColor;
+  final Color backgroundColor;
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import file_picker
+import flutter_local_notifications
 import flutter_secure_storage_darwin
 import in_app_purchase_storekit
 import local_auth_darwin
@@ -16,6 +17,7 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   InAppPurchasePlugin.register(with: registry.registrar(forPlugin: "InAppPurchasePlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -347,6 +347,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "19ffb0a8bb7407875555e5e98d7343a633bb73707bae6c6a5f37c90014077875"
+      url: "https://pub.dev"
+    source: hosted
+    version: "19.5.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -1196,6 +1228,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.15"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   flutter_svg: ^2.2.4
   google_fonts: ^8.0.2
+  flutter_local_notifications: ^19.4.2
   
   # Utilities
   uuid: ^4.5.3

--- a/scripts/setup_tmux_test_env.sh
+++ b/scripts/setup_tmux_test_env.sh
@@ -29,6 +29,16 @@ TMUX_SESSION="monkeyssh-test"
 AUTH_KEYS="$HOME/.ssh/authorized_keys"
 MARKER="# monkeyssh-tmux-test"
 
+restore_auth_keys_permissions() {
+    local mode
+    mode="$(stat -f '%Lp' "$AUTH_KEYS" 2>/dev/null || true)"
+    if [ -n "$mode" ]; then
+        chmod "$mode" "$AUTH_KEYS"
+    else
+        chmod 600 "$AUTH_KEYS"
+    fi
+}
+
 teardown() {
     echo "🧹 Tearing down tmux test environment..."
 
@@ -42,6 +52,7 @@ teardown() {
     if [ -f "$AUTH_KEYS" ] && grep -q "$MARKER" "$AUTH_KEYS"; then
         grep -v "$MARKER" "$AUTH_KEYS" > "${AUTH_KEYS}.tmp"
         mv "${AUTH_KEYS}.tmp" "$AUTH_KEYS"
+        restore_auth_keys_permissions
         echo "   Removed test key from authorized_keys"
     fi
 
@@ -67,8 +78,7 @@ if ! command -v tmux &>/dev/null; then
     exit 1
 fi
 
-if ! ssh -o BatchMode=yes -o ConnectTimeout=2 localhost "echo ok" &>/dev/null && \
-   ! sudo systemsetup -getremotelogin 2>/dev/null | grep -q "On"; then
+if ! ssh -o BatchMode=yes -o ConnectTimeout=2 localhost "echo ok" &>/dev/null; then
     echo "❌ Remote Login (SSH) is not enabled or not accessible."
     echo "   Enable via: System Settings → General → Sharing → Remote Login"
     exit 1
@@ -92,6 +102,7 @@ chmod 700 "$HOME/.ssh"
 if [ -f "$AUTH_KEYS" ] && grep -q "$MARKER" "$AUTH_KEYS"; then
     grep -v "$MARKER" "$AUTH_KEYS" > "${AUTH_KEYS}.tmp"
     mv "${AUTH_KEYS}.tmp" "$AUTH_KEYS"
+    restore_auth_keys_permissions
 fi
 
 # Add new key with marker comment

--- a/scripts/setup_tmux_test_env.sh
+++ b/scripts/setup_tmux_test_env.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Sets up a local SSH + tmux environment for manual testing of the
+# tmux navigation feature in the iOS Simulator.
+#
+# Prerequisites:
+#   - macOS with Remote Login enabled (System Settings → General → Sharing)
+#   - tmux installed (brew install tmux)
+#   - An iOS Simulator booted (xcrun simctl list devices booted)
+#
+# Usage:
+#   ./scripts/setup_tmux_test_env.sh          # set up everything
+#   ./scripts/setup_tmux_test_env.sh teardown  # clean up
+#
+# What it does:
+#   1. Generates a temporary ed25519 SSH key pair
+#   2. Adds the public key to ~/.ssh/authorized_keys
+#   3. Verifies SSH connectivity to localhost
+#   4. Creates a tmux session with sample windows
+#   5. Prints instructions for manual testing in the app
+#
+# After setup, add a host in MonkeySSH pointing to localhost with the
+# generated key, connect, and the tmux navigator should detect the
+# running tmux session.
+
+set -euo pipefail
+
+KEY_PATH="/tmp/monkeyssh_tmux_test_key"
+TMUX_SESSION="monkeyssh-test"
+AUTH_KEYS="$HOME/.ssh/authorized_keys"
+MARKER="# monkeyssh-tmux-test"
+
+teardown() {
+    echo "🧹 Tearing down tmux test environment..."
+
+    # Kill tmux session
+    if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+        tmux kill-session -t "$TMUX_SESSION"
+        echo "   Killed tmux session '$TMUX_SESSION'"
+    fi
+
+    # Remove test key from authorized_keys
+    if [ -f "$AUTH_KEYS" ] && grep -q "$MARKER" "$AUTH_KEYS"; then
+        grep -v "$MARKER" "$AUTH_KEYS" > "${AUTH_KEYS}.tmp"
+        mv "${AUTH_KEYS}.tmp" "$AUTH_KEYS"
+        echo "   Removed test key from authorized_keys"
+    fi
+
+    # Remove key files
+    rm -f "$KEY_PATH" "${KEY_PATH}.pub"
+    echo "   Removed key files"
+
+    echo "✅ Teardown complete."
+}
+
+if [ "${1:-}" = "teardown" ]; then
+    teardown
+    exit 0
+fi
+
+echo "🔧 Setting up tmux test environment..."
+echo ""
+
+# ── Step 1: Check prerequisites ──────────────────────────────────────
+
+if ! command -v tmux &>/dev/null; then
+    echo "❌ tmux not found. Install with: brew install tmux"
+    exit 1
+fi
+
+if ! ssh -o BatchMode=yes -o ConnectTimeout=2 localhost "echo ok" &>/dev/null && \
+   ! sudo systemsetup -getremotelogin 2>/dev/null | grep -q "On"; then
+    echo "❌ Remote Login (SSH) is not enabled or not accessible."
+    echo "   Enable via: System Settings → General → Sharing → Remote Login"
+    exit 1
+fi
+
+# ── Step 2: Generate SSH key ─────────────────────────────────────────
+
+if [ -f "$KEY_PATH" ]; then
+    echo "   Using existing test key at $KEY_PATH"
+else
+    ssh-keygen -t ed25519 -f "$KEY_PATH" -N "" -C "monkeyssh-tmux-test" -q
+    echo "   Generated test key: $KEY_PATH"
+fi
+
+# ── Step 3: Authorize the key ────────────────────────────────────────
+
+mkdir -p "$HOME/.ssh"
+chmod 700 "$HOME/.ssh"
+
+# Remove any previous test key
+if [ -f "$AUTH_KEYS" ] && grep -q "$MARKER" "$AUTH_KEYS"; then
+    grep -v "$MARKER" "$AUTH_KEYS" > "${AUTH_KEYS}.tmp"
+    mv "${AUTH_KEYS}.tmp" "$AUTH_KEYS"
+fi
+
+# Add new key with marker comment
+echo "$(cat "${KEY_PATH}.pub") $MARKER" >> "$AUTH_KEYS"
+chmod 600 "$AUTH_KEYS"
+echo "   Added test key to authorized_keys"
+
+# ── Step 4: Verify SSH connectivity ──────────────────────────────────
+
+if ssh -i "$KEY_PATH" -o StrictHostKeyChecking=no -o BatchMode=yes \
+    localhost "echo ok" &>/dev/null; then
+    echo "   SSH connectivity verified ✓"
+else
+    echo "❌ Cannot SSH to localhost with the test key."
+    echo "   Check that Remote Login is enabled and allows your user."
+    teardown
+    exit 1
+fi
+
+# ── Step 5: Create tmux session ──────────────────────────────────────
+
+if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+    tmux kill-session -t "$TMUX_SESSION"
+fi
+
+tmux new-session -d -s "$TMUX_SESSION" -n "shell"
+tmux send-keys -t "$TMUX_SESSION:shell" "echo 'Welcome to MonkeySSH test environment'" Enter
+
+tmux new-window -t "$TMUX_SESSION" -n "editor"
+tmux send-keys -t "$TMUX_SESSION:editor" "echo 'Editor window — try running vim or nano'" Enter
+
+tmux new-window -t "$TMUX_SESSION" -n "logs"
+tmux send-keys -t "$TMUX_SESSION:logs" "echo 'Logs window — try running tail -f'" Enter
+
+tmux select-window -t "$TMUX_SESSION:shell"
+
+echo "   Created tmux session '$TMUX_SESSION' with 3 windows"
+
+# ── Done ─────────────────────────────────────────────────────────────
+
+WINDOW_COUNT=$(tmux list-windows -t "$TMUX_SESSION" | wc -l | tr -d ' ')
+
+echo ""
+echo "✅ Test environment ready!"
+echo ""
+echo "┌─────────────────────────────────────────────────────────┐"
+echo "│  SSH Host:     localhost                                │"
+echo "│  Username:     $(printf '%-39s' "$USER")│"
+echo "│  Port:         22                                       │"
+echo "│  Key:          $KEY_PATH"
+echo "│  tmux session: $TMUX_SESSION ($WINDOW_COUNT windows)"
+echo "└─────────────────────────────────────────────────────────┘"
+echo ""
+echo "To test in MonkeySSH:"
+echo "  1. Run the app:  flutter run"
+echo "  2. Add a new host:"
+echo "     • Label:    Local tmux"
+echo "     • Hostname: localhost"
+echo "     • Username: $USER"
+echo "     • Import key from: $KEY_PATH"
+echo "     • Auto-connect: tmux new-session -A -s $TMUX_SESSION"
+echo "  3. Tap the host to connect"
+echo "  4. Look for the tmux icon (⊞) in the toolbar"
+echo "  5. Tap it to open the tmux navigator"
+echo ""
+echo "To tear down:  ./scripts/setup_tmux_test_env.sh teardown"

--- a/test/domain/models/agent_launch_preset_test.dart
+++ b/test/domain/models/agent_launch_preset_test.dart
@@ -20,7 +20,7 @@ void main() {
 
     test('builds a tmux command with quoted values', () {
       const preset = AgentLaunchPreset(
-        tool: AgentLaunchTool.aider,
+        tool: AgentLaunchTool.codex,
         workingDirectory: '~/src/app',
         tmuxSessionName: 'nightly review',
         additionalArguments: '--yes-always',
@@ -29,7 +29,7 @@ void main() {
       expect(
         buildAgentLaunchCommand(preset),
         'tmux new-session -A -s \'nightly review\' -c '
-        '"\$HOME/src/app" \'aider --yes-always\'',
+        '"\$HOME/src/app" \'codex --yes-always\'',
       );
     });
 

--- a/test/domain/models/agent_launch_preset_test.dart
+++ b/test/domain/models/agent_launch_preset_test.dart
@@ -28,8 +28,38 @@ void main() {
 
       expect(
         buildAgentLaunchCommand(preset),
-        'tmux new-session -A -s \'nightly review\' -c "\$HOME/src/app" \'aider --yes-always\'',
+        'tmux new-session -A -s \'nightly review\' -c '
+        '"\$HOME/src/app" \'aider --yes-always\'',
       );
+    });
+
+    test('builds command for codex tool', () {
+      const preset = AgentLaunchPreset(
+        tool: AgentLaunchTool.codex,
+        workingDirectory: '~/project',
+      );
+
+      expect(buildAgentLaunchCommand(preset), r'cd "$HOME/project" && codex');
+    });
+
+    test('builds command for openCode tool', () {
+      const preset = AgentLaunchPreset(
+        tool: AgentLaunchTool.openCode,
+        workingDirectory: '~/work',
+        tmuxSessionName: 'oc-session',
+      );
+
+      expect(
+        buildAgentLaunchCommand(preset),
+        "tmux new-session -A -s 'oc-session' -c "
+        '"\$HOME/work" \'opencode\'',
+      );
+    });
+
+    test('builds command for geminiCli tool', () {
+      const preset = AgentLaunchPreset(tool: AgentLaunchTool.geminiCli);
+
+      expect(buildAgentLaunchCommand(preset), 'gemini');
     });
   });
 
@@ -47,5 +77,62 @@ void main() {
     expect(decoded.workingDirectory, preset.workingDirectory);
     expect(decoded.tmuxSessionName, preset.tmuxSessionName);
     expect(decoded.additionalArguments, preset.additionalArguments);
+  });
+
+  test('round-trips new tool enum values through json', () {
+    for (final tool in [
+      AgentLaunchTool.codex,
+      AgentLaunchTool.openCode,
+      AgentLaunchTool.geminiCli,
+    ]) {
+      final preset = AgentLaunchPreset(tool: tool);
+      final decoded = AgentLaunchPreset.fromJson(preset.toJson());
+      expect(decoded.tool, tool, reason: '${tool.name} round-trip failed');
+    }
+  });
+
+  group('AgentLaunchTool presentation', () {
+    test('all tools have labels', () {
+      for (final tool in AgentLaunchTool.values) {
+        expect(tool.label, isNotEmpty, reason: '${tool.name} missing label');
+      }
+    });
+
+    test('all tools have command names', () {
+      for (final tool in AgentLaunchTool.values) {
+        expect(
+          tool.commandName,
+          isNotEmpty,
+          reason: '${tool.name} missing commandName',
+        );
+      }
+    });
+
+    test('new tool labels are correct', () {
+      expect(AgentLaunchTool.codex.label, 'Codex');
+      expect(AgentLaunchTool.openCode.label, 'OpenCode');
+      expect(AgentLaunchTool.geminiCli.label, 'Gemini CLI');
+    });
+
+    test('new tool command names are correct', () {
+      expect(AgentLaunchTool.codex.commandName, 'codex');
+      expect(AgentLaunchTool.openCode.commandName, 'opencode');
+      expect(AgentLaunchTool.geminiCli.commandName, 'gemini');
+    });
+
+    test('supportsResume returns true for all tools', () {
+      for (final tool in AgentLaunchTool.values) {
+        expect(
+          tool.supportsResume,
+          isTrue,
+          reason: '${tool.name} should support resume',
+        );
+      }
+    });
+  });
+
+  test('fromJson falls back to claudeCode for unknown tool name', () {
+    final preset = AgentLaunchPreset.fromJson({'tool': 'unknownTool'});
+    expect(preset.tool, AgentLaunchTool.claudeCode);
   });
 }

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -78,6 +78,29 @@ void main() {
       expect(window.displayTitle, 'bash');
     });
 
+    test('strips placeholder underscores from emoji-mangled window names', () {
+      const window = TmuxWindow(
+        index: 1,
+        name: '__ test-emoji',
+        isActive: false,
+      );
+
+      expect(window.displayTitle, 'test-emoji');
+      expect(window.secondaryTitle, isNull);
+    });
+
+    test('exposes secondaryTitle when pane title differs from window name', () {
+      const window = TmuxWindow(
+        index: 1,
+        name: 'claude',
+        isActive: false,
+        paneTitle: '✨ Editing main.dart',
+      );
+
+      expect(window.displayTitle, '✨ Editing main.dart');
+      expect(window.secondaryTitle, 'claude');
+    });
+
     test('handles empty command and path', () {
       const line = '1|shell|0||';
       final window = TmuxWindow.fromTmuxFormat(line);

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -191,6 +191,32 @@ void main() {
       expect(info.timeAgoLabel, '');
     });
 
+    test('lastUpdatedLabel includes date and relative time', () {
+      final now = DateTime.now();
+      final lastActive = now.subtract(const Duration(hours: 5));
+      final info = ToolSessionInfo(
+        toolName: 'Claude Code',
+        sessionId: '6',
+        lastActive: lastActive,
+      );
+
+      final month = const [
+        'Jan',
+        'Feb',
+        'Mar',
+        'Apr',
+        'May',
+        'Jun',
+        'Jul',
+        'Aug',
+        'Sep',
+        'Oct',
+        'Nov',
+        'Dec',
+      ][lastActive.month - 1];
+      expect(info.lastUpdatedLabel, '$month ${lastActive.day} | 5h ago');
+    });
+
     test('equality uses toolName and sessionId', () {
       const a = ToolSessionInfo(
         toolName: 'Claude Code',

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -50,7 +50,7 @@ void main() {
 
   group('TmuxWindow', () {
     test('parses from tmux format string with all fields', () {
-      const line = '0|vim|1|vim|/home/user/project';
+      const line = '0|vim|1|vim|/home/user/project|*|Editing main.dart';
       final window = TmuxWindow.fromTmuxFormat(line);
 
       expect(window.index, 0);
@@ -58,6 +58,10 @@ void main() {
       expect(window.isActive, true);
       expect(window.currentCommand, 'vim');
       expect(window.currentPath, '/home/user/project');
+      expect(window.flags, '*');
+      expect(window.paneTitle, 'Editing main.dart');
+      expect(window.displayTitle, 'Editing main.dart');
+      expect(window.hasAlert, false);
     });
 
     test('parses with minimal fields', () {
@@ -69,6 +73,9 @@ void main() {
       expect(window.isActive, false);
       expect(window.currentCommand, isNull);
       expect(window.currentPath, isNull);
+      expect(window.flags, isNull);
+      expect(window.paneTitle, isNull);
+      expect(window.displayTitle, 'bash');
     });
 
     test('handles empty command and path', () {
@@ -77,6 +84,14 @@ void main() {
 
       expect(window.currentCommand, isNull);
       expect(window.currentPath, isNull);
+    });
+
+    test('detects alert flag', () {
+      const line = '3|build|0|make|/tmp|#|Building project';
+      final window = TmuxWindow.fromTmuxFormat(line);
+
+      expect(window.hasAlert, true);
+      expect(window.statusLabel, 'alert');
     });
 
     test('throws on too few fields', () {

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -1,0 +1,187 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/models/tmux_state.dart';
+
+void main() {
+  group('TmuxSession', () {
+    test('parses from tmux format string', () {
+      const line = 'dev\t3\t1\t1712930000';
+      final session = TmuxSession.fromTmuxFormat(line);
+
+      expect(session.name, 'dev');
+      expect(session.windowCount, 3);
+      expect(session.isAttached, true);
+      expect(session.lastActivity, isNotNull);
+    });
+
+    test('parses unattached session', () {
+      const line = 'build\t1\t0\t1712920000';
+      final session = TmuxSession.fromTmuxFormat(line);
+
+      expect(session.name, 'build');
+      expect(session.windowCount, 1);
+      expect(session.isAttached, false);
+    });
+
+    test('handles missing activity field', () {
+      const line = 'test\t2\t0';
+      final session = TmuxSession.fromTmuxFormat(line);
+
+      expect(session.name, 'test');
+      expect(session.windowCount, 2);
+      expect(session.lastActivity, isNull);
+    });
+
+    test('throws on too few fields', () {
+      expect(() => TmuxSession.fromTmuxFormat('bad\t1'), throwsFormatException);
+    });
+
+    test('equality works correctly', () {
+      const a = TmuxSession(name: 'dev', windowCount: 3, isAttached: true);
+      const b = TmuxSession(name: 'dev', windowCount: 3, isAttached: true);
+      const c = TmuxSession(name: 'prod', windowCount: 1, isAttached: false);
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+      expect(a.hashCode, b.hashCode);
+    });
+  });
+
+  group('TmuxWindow', () {
+    test('parses from tmux format string with all fields', () {
+      const line = '0\tvim\t1\tvim\t/home/user/project';
+      final window = TmuxWindow.fromTmuxFormat(line);
+
+      expect(window.index, 0);
+      expect(window.name, 'vim');
+      expect(window.isActive, true);
+      expect(window.currentCommand, 'vim');
+      expect(window.currentPath, '/home/user/project');
+    });
+
+    test('parses with minimal fields', () {
+      const line = '2\tbash\t0';
+      final window = TmuxWindow.fromTmuxFormat(line);
+
+      expect(window.index, 2);
+      expect(window.name, 'bash');
+      expect(window.isActive, false);
+      expect(window.currentCommand, isNull);
+      expect(window.currentPath, isNull);
+    });
+
+    test('handles empty command and path', () {
+      const line = '1\tshell\t0\t\t';
+      final window = TmuxWindow.fromTmuxFormat(line);
+
+      expect(window.currentCommand, isNull);
+      expect(window.currentPath, isNull);
+    });
+
+    test('throws on too few fields', () {
+      expect(() => TmuxWindow.fromTmuxFormat('0\tvim'), throwsFormatException);
+    });
+
+    test('statusLabel returns correct values', () {
+      const active = TmuxWindow(index: 0, name: 'vim', isActive: true);
+      const running = TmuxWindow(
+        index: 1,
+        name: 'build',
+        isActive: false,
+        currentCommand: 'make',
+      );
+      const idle = TmuxWindow(index: 2, name: 'bash', isActive: false);
+
+      expect(active.statusLabel, 'active');
+      expect(running.statusLabel, 'running');
+      expect(idle.statusLabel, 'idle');
+    });
+
+    test('equality works correctly', () {
+      const a = TmuxWindow(index: 0, name: 'vim', isActive: true);
+      const b = TmuxWindow(index: 0, name: 'vim', isActive: true);
+      const c = TmuxWindow(index: 1, name: 'bash', isActive: false);
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+  });
+
+  group('ToolSessionInfo', () {
+    test('constructs with all fields', () {
+      final info = ToolSessionInfo(
+        toolName: 'Claude Code',
+        sessionId: 'abc123',
+        workingDirectory: '/home/user/project',
+        lastActive: DateTime(2026, 4, 12),
+        summary: 'Fix auth middleware',
+      );
+
+      expect(info.toolName, 'Claude Code');
+      expect(info.sessionId, 'abc123');
+      expect(info.summary, 'Fix auth middleware');
+    });
+
+    test('timeAgoLabel formats correctly', () {
+      final now = DateTime.now();
+
+      final justNow = ToolSessionInfo(
+        toolName: 'Claude Code',
+        sessionId: '1',
+        lastActive: now,
+      );
+      expect(justNow.timeAgoLabel, 'just now');
+
+      final minutesAgo = ToolSessionInfo(
+        toolName: 'Claude Code',
+        sessionId: '2',
+        lastActive: now.subtract(const Duration(minutes: 30)),
+      );
+      expect(minutesAgo.timeAgoLabel, '30m ago');
+
+      final hoursAgo = ToolSessionInfo(
+        toolName: 'Claude Code',
+        sessionId: '3',
+        lastActive: now.subtract(const Duration(hours: 5)),
+      );
+      expect(hoursAgo.timeAgoLabel, '5h ago');
+
+      final daysAgo = ToolSessionInfo(
+        toolName: 'Claude Code',
+        sessionId: '4',
+        lastActive: now.subtract(const Duration(days: 3)),
+      );
+      expect(daysAgo.timeAgoLabel, '3d ago');
+
+      final weeksAgo = ToolSessionInfo(
+        toolName: 'Claude Code',
+        sessionId: '5',
+        lastActive: now.subtract(const Duration(days: 14)),
+      );
+      expect(weeksAgo.timeAgoLabel, '2w ago');
+    });
+
+    test('timeAgoLabel returns empty when lastActive is null', () {
+      const info = ToolSessionInfo(toolName: 'Codex', sessionId: '1');
+      expect(info.timeAgoLabel, '');
+    });
+
+    test('equality uses toolName and sessionId', () {
+      const a = ToolSessionInfo(
+        toolName: 'Claude Code',
+        sessionId: 'abc',
+        summary: 'session A',
+      );
+      const b = ToolSessionInfo(
+        toolName: 'Claude Code',
+        sessionId: 'abc',
+        summary: 'different summary',
+      );
+      const c = ToolSessionInfo(toolName: 'Codex', sessionId: 'abc');
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+  });
+}

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -6,7 +6,7 @@ import 'package:monkeyssh/domain/models/tmux_state.dart';
 void main() {
   group('TmuxSession', () {
     test('parses from tmux format string', () {
-      const line = 'dev\t3\t1\t1712930000';
+      const line = 'dev|3|1|1712930000';
       final session = TmuxSession.fromTmuxFormat(line);
 
       expect(session.name, 'dev');
@@ -16,7 +16,7 @@ void main() {
     });
 
     test('parses unattached session', () {
-      const line = 'build\t1\t0\t1712920000';
+      const line = 'build|1|0|1712920000';
       final session = TmuxSession.fromTmuxFormat(line);
 
       expect(session.name, 'build');
@@ -25,7 +25,7 @@ void main() {
     });
 
     test('handles missing activity field', () {
-      const line = 'test\t2\t0';
+      const line = 'test|2|0';
       final session = TmuxSession.fromTmuxFormat(line);
 
       expect(session.name, 'test');
@@ -34,7 +34,7 @@ void main() {
     });
 
     test('throws on too few fields', () {
-      expect(() => TmuxSession.fromTmuxFormat('bad\t1'), throwsFormatException);
+      expect(() => TmuxSession.fromTmuxFormat('bad|1'), throwsFormatException);
     });
 
     test('equality works correctly', () {
@@ -50,7 +50,7 @@ void main() {
 
   group('TmuxWindow', () {
     test('parses from tmux format string with all fields', () {
-      const line = '0\tvim\t1\tvim\t/home/user/project';
+      const line = '0|vim|1|vim|/home/user/project';
       final window = TmuxWindow.fromTmuxFormat(line);
 
       expect(window.index, 0);
@@ -61,7 +61,7 @@ void main() {
     });
 
     test('parses with minimal fields', () {
-      const line = '2\tbash\t0';
+      const line = '2|bash|0';
       final window = TmuxWindow.fromTmuxFormat(line);
 
       expect(window.index, 2);
@@ -72,7 +72,7 @@ void main() {
     });
 
     test('handles empty command and path', () {
-      const line = '1\tshell\t0\t\t';
+      const line = '1|shell|0||';
       final window = TmuxWindow.fromTmuxFormat(line);
 
       expect(window.currentCommand, isNull);
@@ -80,7 +80,7 @@ void main() {
     });
 
     test('throws on too few fields', () {
-      expect(() => TmuxWindow.fromTmuxFormat('0\tvim'), throwsFormatException);
+      expect(() => TmuxWindow.fromTmuxFormat('0|vim'), throwsFormatException);
     });
 
     test('statusLabel returns correct values', () {

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -243,6 +243,14 @@ void main() {
       expect(parseTmuxSessionName('htop'), isNull);
     });
 
+    test('returns null for tmux subcommands containing flag-like suffixes', () {
+      expect(parseTmuxSessionName('tmux list-sessions'), isNull);
+      expect(
+        parseTmuxSessionName('tmux list-sessions -F #{session_name}'),
+        isNull,
+      );
+    });
+
     test('returns null for null/empty', () {
       expect(parseTmuxSessionName(null), isNull);
       expect(parseTmuxSessionName(''), isNull);

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -163,12 +163,21 @@ void main() {
         currentCommand: 'claude',
         idleSeconds: 120,
       );
+      const activeWaiting = TmuxWindow(
+        index: 4,
+        name: 'codex',
+        isActive: true,
+        currentCommand: 'codex',
+        idleSeconds: 120,
+      );
 
-      expect(active.statusLabel, '');
-      expect(running.statusLabel, '');
-      expect(idle.statusLabel, '');
+      expect(active.statusLabel, 'running');
+      expect(running.statusLabel, 'running');
+      expect(idle.statusLabel, 'running');
       expect(waiting.statusLabel, 'waiting');
       expect(waiting.isIdle, true);
+      expect(activeWaiting.statusLabel, 'waiting');
+      expect(activeWaiting.isIdle, true);
     });
 
     test('equality works correctly', () {

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -107,10 +107,19 @@ void main() {
         currentCommand: 'make',
       );
       const idle = TmuxWindow(index: 2, name: 'bash', isActive: false);
+      const waiting = TmuxWindow(
+        index: 3,
+        name: 'claude',
+        isActive: false,
+        currentCommand: 'claude',
+        idleSeconds: 120,
+      );
 
-      expect(active.statusLabel, 'active');
-      expect(running.statusLabel, 'running');
-      expect(idle.statusLabel, 'idle');
+      expect(active.statusLabel, '');
+      expect(running.statusLabel, '');
+      expect(idle.statusLabel, '');
+      expect(waiting.statusLabel, 'waiting');
+      expect(waiting.isIdle, true);
     });
 
     test('equality works correctly', () {

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -101,6 +101,32 @@ void main() {
       expect(window.secondaryTitle, 'claude');
     });
 
+    test(
+      'prefers decorated window name when pane title is the plain version',
+      () {
+        const window = TmuxWindow(
+          index: 1,
+          name: '🔥 test-emoji',
+          isActive: false,
+          paneTitle: 'test-emoji',
+        );
+
+        expect(window.displayTitle, '🔥 test-emoji');
+        expect(window.secondaryTitle, isNull);
+      },
+    );
+
+    test('drops placeholder underscore pane title in favor of plain title', () {
+      const window = TmuxWindow(
+        index: 1,
+        name: 'test-session-setup',
+        isActive: false,
+        paneTitle: '_ Test session setup',
+      );
+
+      expect(window.displayTitle, 'Test session setup');
+    });
+
     test('handles empty command and path', () {
       const line = '1|shell|0||';
       final window = TmuxWindow.fromTmuxFormat(line);

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -208,4 +208,78 @@ void main() {
       expect(a, isNot(equals(c)));
     });
   });
+
+  group('parseTmuxSessionName', () {
+    test('parses -s flag from new-session', () {
+      expect(
+        parseTmuxSessionName('tmux new-session -A -s myproject'),
+        'myproject',
+      );
+    });
+
+    test('parses combined -As flag', () {
+      expect(parseTmuxSessionName('tmux new -As MonkeySSH'), 'MonkeySSH');
+    });
+
+    test('parses -t flag from attach', () {
+      expect(parseTmuxSessionName('tmux attach -t dev'), 'dev');
+    });
+
+    test('parses quoted session name', () {
+      expect(
+        parseTmuxSessionName("tmux new-session -A -s 'my project'"),
+        'my project',
+      );
+    });
+
+    test('parses with cd prefix', () {
+      expect(
+        parseTmuxSessionName('cd /home/user && tmux new -As work'),
+        'work',
+      );
+    });
+
+    test('returns null for non-tmux command', () {
+      expect(parseTmuxSessionName('htop'), isNull);
+    });
+
+    test('returns null for null/empty', () {
+      expect(parseTmuxSessionName(null), isNull);
+      expect(parseTmuxSessionName(''), isNull);
+    });
+  });
+
+  group('buildTmuxCommand', () {
+    test('builds basic command', () {
+      expect(
+        buildTmuxCommand(sessionName: 'dev'),
+        "tmux new-session -A -s 'dev'",
+      );
+    });
+
+    test('includes working directory', () {
+      expect(
+        buildTmuxCommand(sessionName: 'dev', workingDirectory: '/home/user'),
+        "tmux new-session -A -s 'dev' -c '/home/user'",
+      );
+    });
+
+    test('includes extra flags', () {
+      expect(
+        buildTmuxCommand(sessionName: 'dev', extraFlags: '-x 200 -y 50'),
+        "tmux new-session -A -s 'dev' -x 200 -y 50",
+      );
+    });
+
+    test('includes all options', () {
+      expect(
+        buildTmuxCommand(
+          sessionName: 'dev',
+          workingDirectory: '/tmp',
+          extraFlags: '-n editor',
+        ),
+        "tmux new-session -A -s 'dev' -c '/tmp' -n editor",
+      );
+    });
+  });
 }

--- a/test/domain/services/agent_launch_preset_service_test.dart
+++ b/test/domain/services/agent_launch_preset_service_test.dart
@@ -39,7 +39,7 @@ void main() {
   });
 
   test('deletes a stored host preset', () async {
-    const preset = AgentLaunchPreset(tool: AgentLaunchTool.aider);
+    const preset = AgentLaunchPreset(tool: AgentLaunchTool.codex);
 
     await service.setPresetForHost(7, preset);
     await service.deletePresetForHost(7);

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -98,4 +98,110 @@ void main() {
       ]);
     });
   });
+
+  group('parseCopilotWorkspaceYamlMetadata', () {
+    test('reads multiline summary blocks and updated_at timestamps', () {
+      final metadata = parseCopilotWorkspaceYamlMetadata('''
+id: example
+cwd: /Users/depoll/Code/flutty
+summary: |-
+  Fix Handlebar Jitter And Tmux Animation
+  With extra detail on the next line
+updated_at: 2026-04-14T01:02:03.000Z
+''');
+
+      expect(metadata.summary, 'Fix Handlebar Jitter And Tmux Animation');
+      expect(metadata.workingDirectory, '/Users/depoll/Code/flutty');
+      expect(metadata.updatedAt, DateTime.parse('2026-04-14T01:02:03.000Z'));
+    });
+
+    test('normalizes inline summary text to a single display line', () {
+      final metadata = parseCopilotWorkspaceYamlMetadata('''
+summary:   Add   PR preview   commit list   
+cwd: /tmp/demo
+''');
+
+      expect(metadata.summary, 'Add PR preview commit list');
+      expect(metadata.workingDirectory, '/tmp/demo');
+      expect(metadata.updatedAt, isNull);
+    });
+  });
+
+  group('DiscoveredSessionsResult', () {
+    test('formats a readable failure message', () {
+      final result = DiscoveredSessionsResult(
+        sessions: const [],
+        failedTools: const {'Codex', 'Gemini CLI'},
+      );
+
+      expect(
+        result.failureMessage,
+        'Could not load Codex and Gemini CLI sessions.',
+      );
+    });
+  });
+
+  group('parseCodexRolloutMetadata', () {
+    test('prefers the structured user_message event over input_text noise', () {
+      final metadata = parseCodexRolloutMetadata('''
+{"timestamp":"2026-04-12T21:07:44.781Z","type":"session_meta","cwd":"/Users/depoll/Code/flutty"}
+{"timestamp":"2026-04-12T21:07:45.000Z","type":"response_item","payload":{"type":"message","content":[{"type":"input_text","text":"<permissions instructions>"}]}}
+{"timestamp":"2026-04-12T21:07:48.390Z","type":"event_msg","payload":{"type":"user_message","message":"rename this session","images":[]}}
+''');
+
+      expect(metadata.parsedAny, isTrue);
+      expect(metadata.workingDirectory, '/Users/depoll/Code/flutty');
+      expect(metadata.summary, 'rename this session');
+      expect(metadata.updatedAt, DateTime.parse('2026-04-12T21:07:44.781Z'));
+    });
+  });
+
+  group('parseGeminiSessionMetadata', () {
+    test('uses stored summary and lastUpdated for main sessions', () {
+      final metadata = parseGeminiSessionMetadata('''
+{
+  "sessionId": "bc1ced23-25ac-4971-8f30-8af35ce2f2f1",
+  "summary": "List available commands.",
+  "lastUpdated": "2026-04-12T21:29:53.292Z",
+  "kind": "main",
+  "messages": []
+}
+''', fallbackWorkingDirectory: '/Users/depoll/Code/flutty');
+
+      expect(metadata.parsedAny, isTrue);
+      expect(metadata.isSubagent, isFalse);
+      expect(metadata.sessionId, 'bc1ced23-25ac-4971-8f30-8af35ce2f2f1');
+      expect(metadata.summary, 'List available commands.');
+      expect(metadata.workingDirectory, '/Users/depoll/Code/flutty');
+      expect(metadata.updatedAt, DateTime.parse('2026-04-12T21:29:53.292Z'));
+    });
+
+    test('falls back to the first user message and filters subagents', () {
+      final metadata = parseGeminiSessionMetadata(
+        '''
+{
+  "sessionId": "session-1",
+  "kind": "subagent",
+  "messages": [
+    {
+      "type": "info",
+      "content": "Gemini update available"
+    },
+    {
+      "type": "user",
+      "content": [{"text": "can i rename this session?"}]
+    }
+  ]
+}
+''',
+        activeWorkingDirectory: '/Users/depoll/Code/flutty',
+        fallbackWorkingDirectory: '/Users/depoll/Code/flutty',
+      );
+
+      expect(metadata.parsedAny, isTrue);
+      expect(metadata.isSubagent, isTrue);
+      expect(metadata.summary, 'can i rename this session?');
+      expect(metadata.workingDirectory, '/Users/depoll/Code/flutty');
+    });
+  });
 }

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -141,6 +141,22 @@ cwd: /tmp/demo
     });
   });
 
+  group('shouldSurfaceDiscoveryFailure', () {
+    test('reports tools that failed to load any sessions', () {
+      expect(
+        shouldSurfaceDiscoveryFailure(hadError: true, loadedSessionCount: 0),
+        isTrue,
+      );
+    });
+
+    test('suppresses partial failures when sessions still loaded', () {
+      expect(
+        shouldSurfaceDiscoveryFailure(hadError: true, loadedSessionCount: 3),
+        isFalse,
+      );
+    });
+  });
+
   group('parseCodexRolloutMetadata', () {
     test('prefers the structured user_message event over input_text noise', () {
       final metadata = parseCodexRolloutMetadata('''

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/models/tmux_state.dart';
+import 'package:monkeyssh/domain/services/agent_session_discovery_service.dart';
+
+void main() {
+  group('normalizeDiscoveredSessionInfo', () {
+    test('drops unnamed sessions without usable fallback context', () {
+      const info = ToolSessionInfo(
+        toolName: 'Copilot CLI',
+        sessionId: '12345678-1234-1234-1234-1234567890ab',
+        summary: '12345678…',
+      );
+
+      expect(normalizeDiscoveredSessionInfo(info), isNull);
+    });
+
+    test('falls back to working directory name when title is missing', () {
+      const info = ToolSessionInfo(
+        toolName: 'Copilot CLI',
+        sessionId: '12345678-1234-1234-1234-1234567890ab',
+        workingDirectory: '/Users/depoll/Code/flutty',
+      );
+
+      final normalized = normalizeDiscoveredSessionInfo(info);
+      expect(normalized, isNotNull);
+      expect(normalized!.summary, 'flutty');
+    });
+  });
+
+  group('compareDiscoveredSessionsByRecency', () {
+    test('sorts newest first and leaves untimestamped sessions last', () {
+      final sessions = [
+        ToolSessionInfo(
+          toolName: 'OpenCode',
+          sessionId: '3',
+          summary: 'older',
+          lastActive: DateTime(2026, 4, 10),
+        ),
+        const ToolSessionInfo(
+          toolName: 'Copilot CLI',
+          sessionId: '2',
+          summary: 'no timestamp',
+        ),
+        ToolSessionInfo(
+          toolName: 'Claude Code',
+          sessionId: '1',
+          summary: 'newest',
+          lastActive: DateTime(2026, 4, 12),
+        ),
+      ];
+
+      final sortedSessions = sessions.toList()
+        ..sort(compareDiscoveredSessionsByRecency);
+
+      expect(sortedSessions.map((session) => session.sessionId), [
+        '1',
+        '3',
+        '2',
+      ]);
+    });
+  });
+}

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -25,6 +25,45 @@ void main() {
       expect(normalized, isNotNull);
       expect(normalized!.summary, 'flutty');
     });
+
+    test(
+      'drops project-name-only summaries in current working directory view',
+      () {
+        const info = ToolSessionInfo(
+          toolName: 'Copilot CLI',
+          sessionId: '12345678-1234-1234-1234-1234567890ab',
+          workingDirectory: '/Users/depoll/Code/flutty',
+          summary: 'flutty',
+        );
+
+        expect(
+          normalizeDiscoveredSessionInfo(
+            info,
+            activeWorkingDirectory: '/Users/depoll/Code/flutty',
+          ),
+          isNull,
+        );
+      },
+    );
+
+    test(
+      'drops directory fallback when the active working directory already matches',
+      () {
+        const info = ToolSessionInfo(
+          toolName: 'Gemini CLI',
+          sessionId: 'abcdef',
+          workingDirectory: '/Users/depoll/Code/flutty',
+        );
+
+        expect(
+          normalizeDiscoveredSessionInfo(
+            info,
+            activeWorkingDirectory: '/Users/depoll/Code/flutty',
+          ),
+          isNull,
+        );
+      },
+    );
   });
 
   group('compareDiscoveredSessionsByRecency', () {

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/services/tmux_service.dart';
+
+void main() {
+  group('control mode command builders', () {
+    test(
+      'attach command starts tmux in control mode with safe client flags',
+      () {
+        expect(
+          buildTmuxControlModeAttachCommand('dev\'s session'),
+          'tmux -CC attach-session -f '
+          'read-only,ignore-size,no-output,wait-exit '
+          "-t 'dev'\"'\"'s session'",
+        );
+      },
+    );
+
+    test(
+      'subscription command watches all windows in the attached session',
+      () {
+        expect(
+          buildTmuxWindowSubscriptionCommand('flutty-1-42'),
+          'refresh-client -B '
+          "'flutty-1-42:@*:"
+          '#{window_index}|#{window_name}|#{window_active}|'
+          '#{pane_current_command}|#{pane_current_path}|'
+          "#{window_flags}|#{pane_title}|#{window_activity}'",
+        );
+      },
+    );
+  });
+
+  group('shouldReloadTmuxWindowsFromControlLine', () {
+    const subscriptionName = 'flutty-1-42';
+
+    test('returns true for matching subscription notifications', () {
+      expect(
+        shouldReloadTmuxWindowsFromControlLine(
+          r'%subscription-changed flutty-1-42 $1 @1 1 %1 : updated',
+          subscriptionName: subscriptionName,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for other subscriptions', () {
+      expect(
+        shouldReloadTmuxWindowsFromControlLine(
+          r'%subscription-changed other-subscription $1 @1 1 %1 : updated',
+          subscriptionName: subscriptionName,
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns true for window lifecycle notifications', () {
+      expect(
+        shouldReloadTmuxWindowsFromControlLine(
+          '%window-renamed @1 🔥 test-emoji',
+          subscriptionName: subscriptionName,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldReloadTmuxWindowsFromControlLine(
+          '%window-close @1',
+          subscriptionName: subscriptionName,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldReloadTmuxWindowsFromControlLine(
+          r'%session-window-changed $1 @1',
+          subscriptionName: subscriptionName,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for control block markers and noise', () {
+      expect(
+        shouldReloadTmuxWindowsFromControlLine(
+          '%begin 1 2 0',
+          subscriptionName: subscriptionName,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldReloadTmuxWindowsFromControlLine(
+          '%output %1 hello',
+          subscriptionName: subscriptionName,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldReloadTmuxWindowsFromControlLine(
+          '',
+          subscriptionName: subscriptionName,
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -290,9 +290,9 @@ void main() {
 
         expect(
           tester.testTextInput.log.where(
-            (call) => call.method == 'TextInput.setClient',
+            (call) => call.method == 'TextInput.setEditingState',
           ),
-          hasLength(1),
+          hasLength(greaterThanOrEqualTo(1)),
         );
         await tester.pump(const Duration(milliseconds: 200));
       },

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -260,9 +260,9 @@ void main() {
 
         expect(
           tester.testTextInput.log.where(
-            (call) => call.method == 'TextInput.setClient',
+            (call) => call.method == 'TextInput.setEditingState',
           ),
-          hasLength(1),
+          hasLength(greaterThanOrEqualTo(1)),
         );
         await tester.pump(const Duration(milliseconds: 200));
       },

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -32,6 +32,57 @@ class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
   ActiveConnection? getActiveConnection(int connectionId) => null;
 }
 
+class _MutableActiveSessionsNotifier extends ActiveSessionsNotifier {
+  _MutableActiveSessionsNotifier({
+    List<ActiveConnection> initialConnections = const <ActiveConnection>[],
+  }) {
+    _connections.addEntries(
+      initialConnections.map(
+        (connection) => MapEntry(connection.connectionId, connection),
+      ),
+    );
+  }
+
+  final Map<int, ActiveConnection> _connections = <int, ActiveConnection>{};
+
+  @override
+  Map<int, SshConnectionState> build() => {
+    for (final connection in _connections.values)
+      connection.connectionId: connection.state,
+  };
+
+  @override
+  ConnectionAttemptStatus? getConnectionAttempt(int hostId) => null;
+
+  @override
+  List<int> getConnectionsForHost(int hostId) => _connections.values
+      .where((connection) => connection.hostId == hostId)
+      .map((connection) => connection.connectionId)
+      .toList(growable: false);
+
+  @override
+  ActiveConnection? getActiveConnection(int connectionId) =>
+      _connections[connectionId];
+
+  @override
+  List<ActiveConnection> getActiveConnections() =>
+      _connections.values.toList(growable: false);
+
+  void setActiveConnections(List<ActiveConnection> connections) {
+    _connections
+      ..clear()
+      ..addEntries(
+        connections.map(
+          (connection) => MapEntry(connection.connectionId, connection),
+        ),
+      );
+    state = {
+      for (final connection in connections)
+        connection.connectionId: connection.state,
+    };
+  }
+}
+
 Host _buildHost({
   required int id,
   required String label,
@@ -74,6 +125,22 @@ Snippet _buildSnippet({
   createdAt: DateTime(2026),
   usageCount: 0,
   sortOrder: sortOrder,
+);
+
+ActiveConnection _buildActiveConnection({
+  required int connectionId,
+  required int hostId,
+  SshConnectionState state = SshConnectionState.connected,
+}) => ActiveConnection(
+  connectionId: connectionId,
+  hostId: hostId,
+  state: state,
+  createdAt: DateTime(2026),
+  config: const SshConnectionConfig(
+    hostname: 'alpha.example.com',
+    port: 22,
+    username: 'root',
+  ),
 );
 
 // These tests are skipped because the HomeScreen uses StreamProviders
@@ -355,5 +422,46 @@ void main() {
       ),
       findsOneWidget,
     );
+  });
+
+  testWidgets('returns to Hosts when the last active connection disappears', (
+    tester,
+  ) async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final sessionsNotifier = _MutableActiveSessionsNotifier(
+      initialConnections: [
+        _buildActiveConnection(
+          connectionId: 7,
+          hostId: 1,
+          state: SshConnectionState.connecting,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      buildMobileHomeScreen(
+        db: db,
+        overrides: [
+          activeSessionsProvider.overrideWith(() => sessionsNotifier),
+          allHostsProvider.overrideWith(
+            (ref) =>
+                Stream.value([_buildHost(id: 1, label: 'Alpha', sortOrder: 0)]),
+          ),
+        ],
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    await tester.tap(find.text('Connections').first);
+    await tester.pump();
+    expect(find.text('No active connections'), findsNothing);
+
+    sessionsNotifier.setActiveConnections(const <ActiveConnection>[]);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('No active connections'), findsNothing);
   });
 }

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -15,7 +15,9 @@ import 'package:monkeyssh/data/repositories/key_repository.dart';
 import 'package:monkeyssh/data/repositories/port_forward_repository.dart';
 import 'package:monkeyssh/data/repositories/snippet_repository.dart';
 import 'package:monkeyssh/data/security/secret_encryption_service.dart';
+import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
 import 'package:monkeyssh/domain/models/monetization.dart';
+import 'package:monkeyssh/domain/services/agent_launch_preset_service.dart';
 import 'package:monkeyssh/domain/services/monetization_service.dart';
 import 'package:monkeyssh/presentation/screens/host_edit_screen.dart';
 
@@ -127,6 +129,9 @@ class _FakePortForwardRepository extends PortForwardRepository {
 
 class _MockMonetizationService extends Mock implements MonetizationService {}
 
+class _MockAgentLaunchPresetService extends Mock
+    implements AgentLaunchPresetService {}
+
 const _proMonetizationState = MonetizationState(
   billingAvailability: MonetizationBillingAvailability.available,
   entitlements: MonetizationEntitlements.pro(),
@@ -147,6 +152,10 @@ MonetizationService _buildProMonetizationService() {
 }
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(const AgentLaunchPreset(tool: AgentLaunchTool.codex));
+  });
+
   group('HostEditScreen', () {
     testWidgets(
       'preserves imported auto-connect review when saving unrelated edits',
@@ -347,6 +356,102 @@ void main() {
       expect(hostRepository.updatedHost!.tmuxWorkingDirectory, '~/src/app');
       expect(hostRepository.updatedHost!.tmuxExtraFlags, '-f ~/.tmux.conf');
     });
+
+    testWidgets(
+      'prefers an existing agent preset over legacy tmux startup fields',
+      (tester) async {
+        final database = AppDatabase.forTesting(NativeDatabase.memory());
+        final encryptionService = SecretEncryptionService.forTesting();
+        addTearDown(database.close);
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await tester.binding.setSurfaceSize(const Size(420, 900));
+
+        final hostRepository = _FakeHostRepository(
+          host: _testHost(
+            id: 1,
+            label: 'Legacy Mixed Host',
+            autoConnectRequiresConfirmation: false,
+            tmuxSessionName: 'workspace',
+          ),
+          database: database,
+          encryptionService: encryptionService,
+        );
+        final presetService = _MockAgentLaunchPresetService();
+        const preset = AgentLaunchPreset(
+          tool: AgentLaunchTool.codex,
+          tmuxSessionName: 'agent-session',
+        );
+        when(
+          () => presetService.getPresetForHost(1),
+        ).thenAnswer((_) async => preset);
+        when(
+          () => presetService.setPresetForHost(1, any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => presetService.deletePresetForHost(1),
+        ).thenAnswer((_) async {});
+
+        final router = GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) =>
+                  const Scaffold(body: SizedBox.shrink()),
+            ),
+            GoRoute(
+              path: '/edit',
+              builder: (context, state) => const HostEditScreen(hostId: 1),
+            ),
+          ],
+        );
+        addTearDown(router.dispose);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              databaseProvider.overrideWithValue(database),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              agentLaunchPresetServiceProvider.overrideWithValue(presetService),
+              keyRepositoryProvider.overrideWithValue(
+                _FakeKeyRepository(
+                  database: database,
+                  encryptionService: encryptionService,
+                ),
+              ),
+              snippetRepositoryProvider.overrideWithValue(
+                _FakeSnippetRepository(snippets: const [], database: database),
+              ),
+              portForwardRepositoryProvider.overrideWithValue(
+                _FakePortForwardRepository(database: database),
+              ),
+            ],
+            child: MaterialApp.router(routerConfig: router),
+          ),
+        );
+
+        unawaited(router.push('/edit'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(find.byKey(const Key('host-agent-tool-field')), findsOneWidget);
+        expect(find.byKey(const Key('host-tmux-session-field')), findsNothing);
+
+        await tester.scrollUntilVisible(
+          find.byKey(const Key('host-save-button')),
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.tap(find.byKey(const Key('host-save-button')));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        verify(() => presetService.setPresetForHost(1, any())).called(1);
+        verifyNever(() => presetService.deletePresetForHost(1));
+      },
+    );
 
     testWidgets(
       'clears imported auto-connect review after replacing the command',

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -25,6 +25,9 @@ Host _testHost({
   required bool autoConnectRequiresConfirmation,
   String? autoConnectCommand,
   int? autoConnectSnippetId,
+  String? tmuxSessionName,
+  String? tmuxWorkingDirectory,
+  String? tmuxExtraFlags,
 }) => Host(
   id: id,
   label: label,
@@ -37,6 +40,9 @@ Host _testHost({
   autoConnectCommand: autoConnectCommand,
   autoConnectSnippetId: autoConnectSnippetId,
   autoConnectRequiresConfirmation: autoConnectRequiresConfirmation,
+  tmuxSessionName: tmuxSessionName,
+  tmuxWorkingDirectory: tmuxWorkingDirectory,
+  tmuxExtraFlags: tmuxExtraFlags,
   sortOrder: 0,
 );
 
@@ -148,6 +154,8 @@ void main() {
         final database = AppDatabase.forTesting(NativeDatabase.memory());
         final encryptionService = SecretEncryptionService.forTesting();
         addTearDown(database.close);
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await tester.binding.setSurfaceSize(const Size(420, 900));
 
         final hostRepository = _FakeHostRepository(
           host: _testHost(
@@ -224,11 +232,16 @@ void main() {
 
         final formScroll = find.byType(Scrollable).first;
         await tester.scrollUntilVisible(
-          find.text('Save Changes'),
+          find.byKey(const Key('host-save-button')),
           200,
           scrollable: formScroll,
         );
-        await tester.tap(find.text('Save Changes'));
+        final saveButton = find.byKey(
+          const Key('host-save-button'),
+          skipOffstage: false,
+        );
+        await tester.ensureVisible(saveButton);
+        await tester.tap(saveButton, warnIfMissed: false);
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 
@@ -242,6 +255,98 @@ void main() {
         );
       },
     );
+
+    testWidgets('saves tmux startup without a custom command', (tester) async {
+      final database = AppDatabase.forTesting(NativeDatabase.memory());
+      final encryptionService = SecretEncryptionService.forTesting();
+      addTearDown(database.close);
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.binding.setSurfaceSize(const Size(420, 900));
+
+      final hostRepository = _FakeHostRepository(
+        host: _testHost(
+          id: 1,
+          label: 'Imported Host',
+          autoConnectRequiresConfirmation: false,
+          tmuxSessionName: 'old-workspace',
+        ),
+        database: database,
+        encryptionService: encryptionService,
+      );
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) =>
+                const Scaffold(body: SizedBox.shrink()),
+          ),
+          GoRoute(
+            path: '/edit',
+            builder: (context, state) => const HostEditScreen(hostId: 1),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(database),
+            hostRepositoryProvider.overrideWithValue(hostRepository),
+            keyRepositoryProvider.overrideWithValue(
+              _FakeKeyRepository(
+                database: database,
+                encryptionService: encryptionService,
+              ),
+            ),
+            snippetRepositoryProvider.overrideWithValue(
+              _FakeSnippetRepository(snippets: const [], database: database),
+            ),
+            portForwardRepositoryProvider.overrideWithValue(
+              _FakePortForwardRepository(database: database),
+            ),
+          ],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+
+      unawaited(router.push('/edit'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      await tester.enterText(
+        find.byKey(const Key('host-tmux-session-field')),
+        'workspace',
+      );
+      await tester.enterText(
+        find.byKey(const Key('host-tmux-working-directory-field')),
+        '~/src/app',
+      );
+      await tester.enterText(
+        find.byKey(const Key('host-tmux-extra-flags-field')),
+        '-f ~/.tmux.conf',
+      );
+
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('host-save-button')),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.tap(find.byKey(const Key('host-save-button')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(hostRepository.updatedHost, isNotNull);
+      expect(hostRepository.updatedHost!.autoConnectCommand, isNull);
+      expect(hostRepository.updatedHost!.autoConnectSnippetId, isNull);
+      expect(
+        hostRepository.updatedHost!.autoConnectRequiresConfirmation,
+        isFalse,
+      );
+      expect(hostRepository.updatedHost!.tmuxSessionName, 'workspace');
+      expect(hostRepository.updatedHost!.tmuxWorkingDirectory, '~/src/app');
+      expect(hostRepository.updatedHost!.tmuxExtraFlags, '-f ~/.tmux.conf');
+    });
 
     testWidgets(
       'clears imported auto-connect review after replacing the command',
@@ -387,22 +492,10 @@ void main() {
 
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
-      await tester.scrollUntilVisible(
-        find.byKey(const Key('host-advanced-tile')),
-        200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      await tester.ensureVisible(find.byKey(const Key('host-advanced-tile')));
-      await tester.tap(
-        find.byKey(const Key('host-advanced-tile')),
-        warnIfMissed: false,
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
 
       expect(
         find.text(
-          'MonkeySSH Pro unlocks auto-run commands, saved snippets, and guided agent launch presets.',
+          'Free hosts can still open tmux automatically. MonkeySSH Pro unlocks coding agents, custom commands, and saved snippets after connect.',
         ),
         findsOneWidget,
       );
@@ -450,18 +543,6 @@ void main() {
         ),
       );
 
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
-      await tester.scrollUntilVisible(
-        find.byKey(const Key('host-advanced-tile')),
-        200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      await tester.ensureVisible(find.byKey(const Key('host-advanced-tile')));
-      await tester.tap(
-        find.byKey(const Key('host-advanced-tile')),
-        warnIfMissed: false,
-      );
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
       await tester.scrollUntilVisible(

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -6,27 +6,35 @@ import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
 
 void main() {
   group('resolveTerminalRenderPadding', () {
-    test('drops only the bottom safe-area inset', () {
+    test('keeps portrait terminal rendering edge-to-edge', () {
       const mediaQuery = MediaQueryData(
+        size: Size(390, 844),
         padding: EdgeInsets.fromLTRB(12, 18, 16, 34),
       );
 
-      expect(
-        resolveTerminalRenderPadding(mediaQuery),
-        const EdgeInsets.fromLTRB(12, 18, 16, 0),
-      );
+      expect(resolveTerminalRenderPadding(mediaQuery), EdgeInsets.zero);
     });
 
-    test('keeps keyboard-open bottom inset cleared', () {
+    test('stays edge-to-edge in portrait when the keyboard is visible', () {
       const mediaQuery = MediaQueryData(
+        size: Size(390, 844),
         padding: EdgeInsets.fromLTRB(12, 18, 16, 0),
         viewPadding: EdgeInsets.fromLTRB(12, 18, 16, 34),
         viewInsets: EdgeInsets.fromLTRB(0, 0, 0, 320),
       );
 
+      expect(resolveTerminalRenderPadding(mediaQuery), EdgeInsets.zero);
+    });
+
+    test('keeps horizontal cutout padding in landscape', () {
+      const mediaQuery = MediaQueryData(
+        size: Size(844, 390),
+        padding: EdgeInsets.fromLTRB(44, 0, 34, 21),
+      );
+
       expect(
         resolveTerminalRenderPadding(mediaQuery),
-        const EdgeInsets.fromLTRB(12, 18, 16, 0),
+        const EdgeInsets.only(left: 44, right: 34),
       );
     });
   });

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -26,5 +26,51 @@ void main() {
         closeTo(217.6, 0.01),
       );
     });
+
+    test('tmux bar reveal stays aligned with terminal padding', () {
+      expect(resolveTmuxBarRevealBottomOffset(0), -22);
+      expect(resolveTmuxBarRevealBottomOffset(11), -11);
+      expect(resolveTmuxBarRevealBottomOffset(22), 0);
+
+      expect(resolveTmuxBarRevealOpacity(-10), 0);
+      expect(resolveTmuxBarRevealOpacity(0), 0);
+      expect(resolveTmuxBarRevealOpacity(11), 0.5);
+      expect(resolveTmuxBarRevealOpacity(22), 1);
+      expect(resolveTmuxBarRevealOpacity(40), 1);
+    });
+
+    test(
+      'tmux detection retries immediately instead of waiting two seconds',
+      () {
+        expect(resolveTmuxDetectionRetrySchedule(), const <Duration>[
+          Duration.zero,
+          Duration(milliseconds: 150),
+          Duration(milliseconds: 350),
+          Duration(milliseconds: 700),
+          Duration(milliseconds: 1400),
+        ]);
+        expect(
+          resolveTmuxDetectionRetrySchedule(skipDelay: true),
+          const <Duration>[Duration.zero],
+        );
+      },
+    );
+
+    test('resolves preferred tmux session name before remote verification', () {
+      expect(
+        resolvePreferredTmuxSessionName(
+          structuredSessionName: 'workspace',
+          autoConnectCommand: 'tmux attach -t ignored',
+        ),
+        'workspace',
+      );
+      expect(
+        resolvePreferredTmuxSessionName(
+          autoConnectCommand: 'tmux new-session -A -s parsed-session',
+        ),
+        'parsed-session',
+      );
+      expect(resolvePreferredTmuxSessionName(), isNull);
+    });
   });
 }

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -19,11 +19,11 @@ void main() {
     });
 
     test('tmux bar expansion uses the available terminal height', () {
-      expect(resolveTmuxBarMaxContentHeight(320), 290);
+      expect(resolveTmuxBarMaxContentHeight(320), closeTo(217.6, 0.01));
       expect(resolveTmuxBarMaxContentHeight(24), 0);
       expect(
         resolveTmuxBarMaxContentHeight(0, fallbackAvailableHeight: 320),
-        290,
+        closeTo(217.6, 0.01),
       );
     });
   });

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -4,18 +4,25 @@ import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 
 void main() {
   group('terminal layout helpers', () {
-    test(
-      'keeps horizontal and top breathing room without wasting bottom rows',
-      () {
-        expect(terminalViewportPadding, const EdgeInsets.fromLTRB(8, 8, 8, 0));
-        expect(terminalViewportPadding.bottom, 0);
-      },
-    );
+    test('keeps the terminal full width without wasting bottom rows', () {
+      expect(terminalViewportPadding, const EdgeInsets.fromLTRB(0, 8, 0, 0));
+      expect(terminalViewportPadding.bottom, 0);
+    });
 
     test('positions selection actions above the bottom safe area', () {
       const mediaQuery = MediaQueryData(padding: EdgeInsets.only(bottom: 34));
 
       expect(selectionActionsBottomOffset(mediaQuery), 46);
+    });
+
+    test('positions the upsell snackbar above visible bottom chrome only', () {
+      const mediaQuery = MediaQueryData(padding: EdgeInsets.only(bottom: 34));
+
+      expect(upgradeSnackBarBottomMargin(mediaQuery), 50);
+      expect(
+        upgradeSnackBarBottomMargin(mediaQuery, showKeyboardToolbar: true),
+        146,
+      );
     });
 
     test('tmux bar expansion uses the available terminal height', () {

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -17,5 +17,14 @@ void main() {
 
       expect(selectionActionsBottomOffset(mediaQuery), 46);
     });
+
+    test('tmux bar expansion uses the available terminal height', () {
+      expect(resolveTmuxBarMaxContentHeight(320), 290);
+      expect(resolveTmuxBarMaxContentHeight(24), 0);
+      expect(
+        resolveTmuxBarMaxContentHeight(0, fallbackAvailableHeight: 320),
+        290,
+      );
+    });
   });
 }

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -1510,9 +1510,9 @@ void main() {
 
         expect(
           tester.testTextInput.log.where(
-            (call) => call.method == 'TextInput.setClient',
+            (call) => call.method == 'TextInput.setEditingState',
           ),
-          hasLength(1),
+          hasLength(greaterThanOrEqualTo(1)),
         );
 
         await _commitSwipeText(tester, '$_deleteDetectionMarker world');

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -19,6 +19,7 @@ void main() {
         name: 'claude',
         isActive: false,
         currentCommand: 'claude',
+        idleSeconds: 120,
       ),
       const TmuxWindow(index: 2, name: 'bash', isActive: false),
       const TmuxWindow(
@@ -40,9 +41,8 @@ void main() {
       expect(find.text('claude'), findsOneWidget);
       expect(find.text('bash'), findsOneWidget);
       expect(find.text('htop'), findsOneWidget);
-      expect(find.text('active'), findsOneWidget);
-      expect(find.text('running'), findsNWidgets(2));
-      expect(find.text('idle'), findsOneWidget);
+      // Only "waiting" shows as a status — active/running are silent.
+      expect(find.text('waiting'), findsOneWidget);
     });
 
     testWidgets('renders tmux badge with window chips', (tester) async {

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -42,7 +42,7 @@ void main() {
       expect(find.text('claude'), findsOneWidget);
       expect(find.text('bash'), findsOneWidget);
       expect(find.text('htop'), findsOneWidget);
-      // Only "waiting" shows as a status — active/running are silent.
+      expect(find.text('running'), findsNWidgets(3));
       expect(find.text('waiting'), findsOneWidget);
     });
 

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -1,0 +1,191 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/models/tmux_state.dart';
+
+void main() {
+  group('tmux navigator UI', () {
+    final windows = [
+      const TmuxWindow(
+        index: 0,
+        name: 'vim',
+        isActive: true,
+        currentCommand: 'vim',
+        currentPath: '/home/user/project',
+      ),
+      const TmuxWindow(
+        index: 1,
+        name: 'claude',
+        isActive: false,
+        currentCommand: 'claude',
+      ),
+      const TmuxWindow(index: 2, name: 'bash', isActive: false),
+      const TmuxWindow(
+        index: 3,
+        name: 'htop',
+        isActive: false,
+        currentCommand: 'htop',
+      ),
+    ];
+
+    testWidgets('renders window list with correct statuses', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: _MockWindowList(windows: windows)),
+        ),
+      );
+
+      expect(find.text('vim'), findsOneWidget);
+      expect(find.text('claude'), findsOneWidget);
+      expect(find.text('bash'), findsOneWidget);
+      expect(find.text('htop'), findsOneWidget);
+      expect(find.text('active'), findsOneWidget);
+      expect(find.text('running'), findsNWidgets(2));
+      expect(find.text('idle'), findsOneWidget);
+    });
+
+    testWidgets('renders tmux badge with window chips', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            colorSchemeSeed: const Color(0xFF00796B),
+            useMaterial3: true,
+          ),
+          home: Scaffold(body: _MockTmuxBadge(windows: windows.sublist(0, 3))),
+        ),
+      );
+
+      expect(find.text('tmux:'), findsOneWidget);
+      expect(find.text('vim'), findsOneWidget);
+      expect(find.text('claude'), findsOneWidget);
+      expect(find.text('bash'), findsOneWidget);
+    });
+
+    testWidgets('recent session tile shows time ago', (tester) async {
+      final session = ToolSessionInfo(
+        toolName: 'Claude Code',
+        sessionId: 'abc123',
+        summary: 'Fix auth middleware',
+        lastActive: DateTime.now().subtract(const Duration(hours: 2)),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ListTile(
+              title: Text(session.summary!),
+              subtitle: Text('${session.toolName} · ${session.timeAgoLabel}'),
+              trailing: TextButton(
+                onPressed: () {},
+                child: const Text('Resume'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Fix auth middleware'), findsOneWidget);
+      expect(find.text('Claude Code · 2h ago'), findsOneWidget);
+      expect(find.text('Resume'), findsOneWidget);
+    });
+  });
+}
+
+class _MockWindowList extends StatelessWidget {
+  const _MockWindowList({required this.windows});
+  final List<TmuxWindow> windows;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView(
+      children: windows
+          .map(
+            (w) => ListTile(
+              dense: true,
+              leading: Container(
+                width: 28,
+                height: 28,
+                decoration: BoxDecoration(
+                  color: w.isActive
+                      ? theme.colorScheme.primary
+                      : theme.colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  '${w.index}',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: w.isActive
+                        ? theme.colorScheme.onPrimary
+                        : theme.colorScheme.onSurfaceVariant,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              title: Text(w.name),
+              trailing: Text(w.statusLabel),
+              selected: w.isActive,
+            ),
+          )
+          .toList(),
+    );
+  }
+}
+
+class _MockTmuxBadge extends StatelessWidget {
+  const _MockTmuxBadge({required this.windows});
+  final List<TmuxWindow> windows;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(56, 0, 16, 8),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            Icon(
+              Icons.window_outlined,
+              size: 14,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(width: 4),
+            Text(
+              'tmux:',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(width: 6),
+            for (final window in windows) ...[
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: window.isActive
+                      ? theme.colorScheme.primaryContainer
+                      : theme.colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  window.name,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: window.isActive
+                        ? theme.colorScheme.onPrimaryContainer
+                        : theme.colorScheme.onSurfaceVariant,
+                    fontWeight: window.isActive
+                        ? FontWeight.bold
+                        : FontWeight.normal,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 4),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -13,6 +13,7 @@ void main() {
         isActive: true,
         currentCommand: 'vim',
         currentPath: '/home/user/project',
+        paneTitle: '✨ Editing main.dart',
       ),
       const TmuxWindow(
         index: 1,
@@ -37,7 +38,7 @@ void main() {
         ),
       );
 
-      expect(find.text('vim'), findsOneWidget);
+      expect(find.text('✨ Editing main.dart'), findsOneWidget);
       expect(find.text('claude'), findsOneWidget);
       expect(find.text('bash'), findsOneWidget);
       expect(find.text('htop'), findsOneWidget);
@@ -57,7 +58,7 @@ void main() {
       );
 
       expect(find.text('tmux:'), findsOneWidget);
-      expect(find.text('vim'), findsOneWidget);
+      expect(find.text('✨ Editing main.dart'), findsOneWidget);
       expect(find.text('claude'), findsOneWidget);
       expect(find.text('bash'), findsOneWidget);
     });
@@ -124,7 +125,7 @@ class _MockWindowList extends StatelessWidget {
                   ),
                 ),
               ),
-              title: Text(w.name),
+              title: Text(w.displayTitle),
               trailing: Text(w.statusLabel),
               selected: w.isActive,
             ),
@@ -170,7 +171,7 @@ class _MockTmuxBadge extends StatelessWidget {
                   borderRadius: BorderRadius.circular(4),
                 ),
                 child: Text(
-                  window.name,
+                  window.displayTitle,
                   style: theme.textTheme.labelSmall?.copyWith(
                     color: window.isActive
                         ? theme.colorScheme.onPrimaryContainer

--- a/test/widget/tmux_window_status_badge_test.dart
+++ b/test/widget/tmux_window_status_badge_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/models/tmux_state.dart';
+import 'package:monkeyssh/presentation/widgets/tmux_window_status_badge.dart';
+
+void main() {
+  group('TmuxWindowStatusBadge', () {
+    testWidgets('shows waiting for the active idle window', (tester) async {
+      const window = TmuxWindow(
+        index: 0,
+        name: 'claude',
+        isActive: true,
+        currentCommand: 'claude',
+        idleSeconds: 120,
+      );
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Center(child: TmuxWindowStatusBadge(window: window)),
+          ),
+        ),
+      );
+
+      expect(find.text('waiting'), findsOneWidget);
+      expect(find.byIcon(Icons.hourglass_bottom), findsOneWidget);
+    });
+
+    testWidgets('shows running for the active window by default', (
+      tester,
+    ) async {
+      const window = TmuxWindow(index: 0, name: 'vim', isActive: true);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Center(child: TmuxWindowStatusBadge(window: window)),
+          ),
+        ),
+      );
+
+      expect(find.text('running'), findsOneWidget);
+      expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+    });
+  });
+}

--- a/test/widget/tmux_window_status_badge_test.dart
+++ b/test/widget/tmux_window_status_badge_test.dart
@@ -42,5 +42,40 @@ void main() {
       expect(find.text('running'), findsOneWidget);
       expect(find.byIcon(Icons.play_arrow), findsOneWidget);
     });
+
+    testWidgets('uses high-contrast container colors for alert badges', (
+      tester,
+    ) async {
+      const scheme = ColorScheme.light(
+        errorContainer: Color(0xFF112233),
+        onErrorContainer: Color(0xFFF1E2D3),
+      );
+      const window = TmuxWindow(
+        index: 2,
+        name: 'logs',
+        isActive: false,
+        flags: '#!',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(colorScheme: scheme),
+          home: const Scaffold(
+            body: Center(child: TmuxWindowStatusBadge(window: window)),
+          ),
+        ),
+      );
+
+      final badge = tester.widget<DecoratedBox>(
+        find.byType(DecoratedBox).first,
+      );
+      final decoration = badge.decoration as BoxDecoration;
+      final icon = tester.widget<Icon>(find.byIcon(Icons.notifications_active));
+      final text = tester.widget<Text>(find.text('alert'));
+
+      expect(decoration.color, scheme.errorContainer);
+      expect(icon.color, scheme.onErrorContainer);
+      expect(text.style?.color, scheme.onErrorContainer);
+    });
   });
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -11,6 +11,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_local_notifications_windows
   jni
 )
 


### PR DESCRIPTION
## Summary

First-class tmux integration that surfaces tmux windows as native UI elements, with easy launching and resuming of AI coding tool sessions.

Closes #261

## What is new

### In-terminal tmux navigator (bottom sheet)
- Detects tmux via SSH exec channel (TMUX env var check after connection)
- Shows tmux icon in terminal toolbar when tmux is active  
- Bottom sheet lists all windows with index, name, and status (active/running/idle)
- Tap a window to switch current terminal (tmux select-window)
- New Window picker for launching agent tools (Claude, Copilot, Codex, Gemini, OpenCode) or empty windows
- Collapsed Recent AI Sessions section (Pro-gated, shows max 3)

### Connections panel enrichment
- tmux badge on connected hosts showing window names as compact chips
- Active window highlighted with primary color
- Asynchronously queries tmux state per connection

### Agent session discovery (5 CLIs)
- Claude Code from ~/.claude/history.jsonl - resume with claude --resume
- Codex from ~/.codex/sessions/ - resume with codex resume
- Copilot CLI from ~/.copilot/session-state/ - resume with copilot --resume
- Gemini CLI from ~/.gemini/tmp/*/chats/ - resume with gemini --resume
- OpenCode from ~/.local/share/opencode/storage/session/ - resume with opencode --continue

### Extended tool support
- Added codex, openCode, geminiCli to AgentLaunchTool enum
- All tools have labels, command names, and supportsResume flag

## Design decisions

Informed by independent UX critique from Opus 4.6 and GPT 5.4:

- No separate Workspaces tab (overlaps Connections, often empty)
- Consistent tap behavior (tap always switches current terminal)
- No multi-shell refactoring in v1 (SshSession is 1:1)
- Progressive disclosure (only show UI for things that exist)
- Free tmux nav; Pro for agent launch/resume

## Testing

- flutter analyze: 0 issues
- flutter test: 1202 passed, 11 skipped, 0 failed
- Built and launched in iOS Simulator (iPhone 16e): no crashes
- Manual testing with real SSH+tmux needed for navigator/badge features
