### PR TITLE
fix: resolve deploy build failures from codename PR

### DIFF
--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -182,14 +182,19 @@ jobs:
       - name: Keep deploy build number monotonic
         id: finalize
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          INPUT_BUILD_NAME: ${{ needs.compute-version.outputs.build-name }}
+          INPUT_BUILD_CODENAME: ${{ needs.compute-version.outputs.build-codename }}
+          INPUT_BUILD_DISPLAY: ${{ needs.compute-version.outputs.build-display }}
+          INPUT_BUILD_NUMBER: ${{ needs.compute-version.outputs.build-number }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const requestedBuildName = '${{ needs.compute-version.outputs.build-name }}'.trim();
-            const requestedBuildCodename = '${{ needs.compute-version.outputs.build-codename }}'.trim();
-            const requestedBuildDisplay = '${{ needs.compute-version.outputs.build-display }}'.trim();
-            const requestedBuildNumber = '${{ needs.compute-version.outputs.build-number }}'.trim();
+            const requestedBuildName = (process.env.INPUT_BUILD_NAME || '').trim();
+            const requestedBuildCodename = (process.env.INPUT_BUILD_CODENAME || '').trim();
+            const requestedBuildDisplay = (process.env.INPUT_BUILD_DISPLAY || '').trim();
+            const requestedBuildNumber = (process.env.INPUT_BUILD_NUMBER || '').trim();
             const workflowIds = ['deploy-testflight.yml', 'develop.yml'];
             const markerArtifactPattern = /^private-deploy-build-number-(\d+)$/;
             const legacyArtifactPattern = /^(?:android|ios)-private-.+-(\d+)$/;

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -41,7 +41,7 @@ platform :android do
         track.releases = track.releases.reject { |r| r.status == 'draft' }
         client.update_track(track_name, track)
         client.commit_current_edit!
-        return
+        next
       end
     end
     client.abort_current_edit
@@ -52,7 +52,7 @@ platform :android do
     track_name = options[:track]
     version_code = options[:version_code].to_s
 
-    return false if version_code.empty?
+    next false if version_code.empty?
 
     client = play_store_client(package_name: package)
     client.begin_edit(package_name: package)
@@ -71,7 +71,7 @@ platform :android do
     version_code = options[:version_code].to_s
     preview_notes = PreviewReleaseNotes.current
 
-    return [base_metadata_path, false] if preview_notes.nil? || version_code.empty?
+    next [base_metadata_path, false] if preview_notes.nil? || version_code.empty?
 
     tmpdir = Dir.mktmpdir('flutty-play-metadata')
     if base_metadata_path && File.directory?(base_metadata_path)

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -111,7 +111,7 @@ platform :ios do
 
   private_lane :testflight_release_notes do
     preview_notes = PreviewReleaseNotes.current
-    return [nil, nil] if preview_notes.nil?
+    next [nil, nil] if preview_notes.nil?
 
     [
       preview_notes,


### PR DESCRIPTION
## Summary

Fix three deploy build failures introduced by the build-labeling PR (#258):

### Fastfile LocalJumpError (Android + iOS)

Fastlane lanes are Ruby blocks/procs, not methods. Using return inside a block raises LocalJumpError: unexpected return. Changed to next which is the correct way to exit early from a block with a value.

**Android** (android/fastlane/Fastfile):
- clear_draft_releases: return to next (latent bug, only hit when drafts exist)
- track_contains_version_code: return false to next false (latent bug, only hit when version_code is empty)
- prepared_metadata_path: return [...] to next [...] (new code from #258)

**iOS** (ios/fastlane/Fastfile):
- testflight_release_notes: return [nil, nil] to next [nil, nil] (new code from #258)

### JS SyntaxError in deploy-testflight.yml

The finalize-version job interpolated build-codename and build-display directly into single-quoted JS strings. The current version resolves to codename Allen s Swamp Monkey -- the apostrophe breaks the JS string literal, producing SyntaxError: Unexpected identifier.

Fixed by passing values through environment variables (process.env) instead, which avoids string-quoting issues entirely.

## Failing runs
- [Deploy Private #130](https://github.com/depollsoft/MonkeySSH/actions/runs/24300469948) -- Android + iOS Fastlane failures
- [Deploy PR Preview #193](https://github.com/depollsoft/MonkeySSH/actions/runs/24309382131) -- JS syntax error in version finalization
