### PR TITLE
feat: add PR commit list to preview build comments

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -409,32 +409,47 @@ jobs:
 
       - name: Fetch PR commits
         if: inputs.pr-number != ''
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr-number }}
         run: |
           python3 << 'SCRIPT'
-          import json, os, uuid, urllib.request
+          import json, os, sys, uuid, urllib.request
 
-          token = os.environ['GH_TOKEN']
-          repo = os.environ['GITHUB_REPOSITORY']
-          pr = os.environ['PR_NUMBER']
-          url = f'https://api.github.com/repos/{repo}/pulls/{pr}/commits?per_page=100'
-          req = urllib.request.Request(url, headers={
-              'Authorization': f'Bearer {token}',
-              'Accept': 'application/vnd.github+json',
-          })
-          commits = json.loads(urllib.request.urlopen(req).read())
-          lines = []
-          for c in reversed(commits):
-              sha = c['sha'][:7]
-              msg = c['commit']['message'].split('\n')[0]
-              lines.append(f'{sha} {msg}')
-          delim = f'FLUTTY_EOF_{uuid.uuid4().hex}'
-          with open(os.environ['GITHUB_ENV'], 'a') as f:
-              f.write(f'FLUTTY_PR_COMMITS<<{delim}\n')
-              f.write('\n'.join(lines))
-              f.write(f'\n{delim}\n')
+          try:
+              token = os.environ['GH_TOKEN']
+              repo = os.environ['GITHUB_REPOSITORY']
+              pr = os.environ['PR_NUMBER']
+              base_url = f'https://api.github.com/repos/{repo}/pulls/{pr}/commits'
+              headers = {
+                  'Authorization': f'Bearer {token}',
+                  'Accept': 'application/vnd.github+json',
+              }
+              commits = []
+              page = 1
+              while True:
+                  url = f'{base_url}?per_page=100&page={page}'
+                  req = urllib.request.Request(url, headers=headers)
+                  data = json.loads(urllib.request.urlopen(req).read())
+                  if not data:
+                      break
+                  commits.extend(data)
+                  if len(data) < 100:
+                      break
+                  page += 1
+              lines = []
+              for c in reversed(commits):
+                  sha = c['sha'][:7]
+                  msg = c['commit']['message'].split('\n')[0]
+                  lines.append(f'{sha} {msg}')
+              delim = f'FLUTTY_EOF_{uuid.uuid4().hex}'
+              with open(os.environ['GITHUB_ENV'], 'a') as f:
+                  f.write(f'FLUTTY_PR_COMMITS<<{delim}\n')
+                  f.write('\n'.join(lines))
+                  f.write(f'\n{delim}\n')
+          except Exception as e:
+              print(f'Warning: failed to fetch PR commits: {e}', file=sys.stderr)
           SCRIPT
 
       - name: Setup Ruby for Play deployment
@@ -665,32 +680,47 @@ jobs:
 
       - name: Fetch PR commits
         if: inputs.pr-number != ''
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr-number }}
         run: |
           python3 << 'SCRIPT'
-          import json, os, uuid, urllib.request
+          import json, os, sys, uuid, urllib.request
 
-          token = os.environ['GH_TOKEN']
-          repo = os.environ['GITHUB_REPOSITORY']
-          pr = os.environ['PR_NUMBER']
-          url = f'https://api.github.com/repos/{repo}/pulls/{pr}/commits?per_page=100'
-          req = urllib.request.Request(url, headers={
-              'Authorization': f'Bearer {token}',
-              'Accept': 'application/vnd.github+json',
-          })
-          commits = json.loads(urllib.request.urlopen(req).read())
-          lines = []
-          for c in reversed(commits):
-              sha = c['sha'][:7]
-              msg = c['commit']['message'].split('\n')[0]
-              lines.append(f'{sha} {msg}')
-          delim = f'FLUTTY_EOF_{uuid.uuid4().hex}'
-          with open(os.environ['GITHUB_ENV'], 'a') as f:
-              f.write(f'FLUTTY_PR_COMMITS<<{delim}\n')
-              f.write('\n'.join(lines))
-              f.write(f'\n{delim}\n')
+          try:
+              token = os.environ['GH_TOKEN']
+              repo = os.environ['GITHUB_REPOSITORY']
+              pr = os.environ['PR_NUMBER']
+              base_url = f'https://api.github.com/repos/{repo}/pulls/{pr}/commits'
+              headers = {
+                  'Authorization': f'Bearer {token}',
+                  'Accept': 'application/vnd.github+json',
+              }
+              commits = []
+              page = 1
+              while True:
+                  url = f'{base_url}?per_page=100&page={page}'
+                  req = urllib.request.Request(url, headers=headers)
+                  data = json.loads(urllib.request.urlopen(req).read())
+                  if not data:
+                      break
+                  commits.extend(data)
+                  if len(data) < 100:
+                      break
+                  page += 1
+              lines = []
+              for c in reversed(commits):
+                  sha = c['sha'][:7]
+                  msg = c['commit']['message'].split('\n')[0]
+                  lines.append(f'{sha} {msg}')
+              delim = f'FLUTTY_EOF_{uuid.uuid4().hex}'
+              with open(os.environ['GITHUB_ENV'], 'a') as f:
+                  f.write(f'FLUTTY_PR_COMMITS<<{delim}\n')
+                  f.write('\n'.join(lines))
+                  f.write(f'\n{delim}\n')
+          except Exception as e:
+              print(f'Warning: failed to fetch PR commits: {e}', file=sys.stderr)
           SCRIPT
 
       - name: Archive, sign & deploy via Fastlane

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -428,6 +428,7 @@ jobs:
               }
               commits = []
               page = 1
+              max_commits = 100
               while True:
                   url = f'{base_url}?per_page=100&page={page}'
                   req = urllib.request.Request(url, headers=headers)
@@ -435,9 +436,10 @@ jobs:
                   if not data:
                       break
                   commits.extend(data)
-                  if len(data) < 100:
+                  if len(data) < 100 or len(commits) >= max_commits:
                       break
                   page += 1
+              commits = commits[:max_commits]
               lines = []
               for c in reversed(commits):
                   sha = c['sha'][:7]
@@ -699,6 +701,7 @@ jobs:
               }
               commits = []
               page = 1
+              max_commits = 100
               while True:
                   url = f'{base_url}?per_page=100&page={page}'
                   req = urllib.request.Request(url, headers=headers)
@@ -706,9 +709,10 @@ jobs:
                   if not data:
                       break
                   commits.extend(data)
-                  if len(data) < 100:
+                  if len(data) < 100 or len(commits) >= max_commits:
                       break
                   page += 1
+              commits = commits[:max_commits]
               lines = []
               for c in reversed(commits):
                   sha = c['sha'][:7]

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -173,6 +173,7 @@ on:
 permissions:
   actions: read
   contents: read
+  pull-requests: read
 
 jobs:
   build-android:
@@ -406,6 +407,36 @@ jobs:
           name: android-apk-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
           path: build/app/outputs/flutter-apk/app-${{ inputs.flavor }}-debug.apk
 
+      - name: Fetch PR commits
+        if: inputs.pr-number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr-number }}
+        run: |
+          python3 << 'SCRIPT'
+          import json, os, uuid, urllib.request
+
+          token = os.environ['GH_TOKEN']
+          repo = os.environ['GITHUB_REPOSITORY']
+          pr = os.environ['PR_NUMBER']
+          url = f'https://api.github.com/repos/{repo}/pulls/{pr}/commits?per_page=100'
+          req = urllib.request.Request(url, headers={
+              'Authorization': f'Bearer {token}',
+              'Accept': 'application/vnd.github+json',
+          })
+          commits = json.loads(urllib.request.urlopen(req).read())
+          lines = []
+          for c in reversed(commits):
+              sha = c['sha'][:7]
+              msg = c['commit']['message'].split('\n')[0]
+              lines.append(f'{sha} {msg}')
+          delim = f'FLUTTY_EOF_{uuid.uuid4().hex}'
+          with open(os.environ['GITHUB_ENV'], 'a') as f:
+              f.write(f'FLUTTY_PR_COMMITS<<{delim}\n')
+              f.write('\n'.join(lines))
+              f.write(f'\n{delim}\n')
+          SCRIPT
+
       - name: Setup Ruby for Play deployment
         if: inputs.deploy-android-to != 'none' && inputs.run-android-deploy
         uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1.299.0
@@ -631,6 +662,36 @@ jobs:
           run-id: ${{ inputs.ios-reuse-run-id }}
           name: ${{ inputs.ios-reuse-ipa-artifact-name }}
           path: build/ios/ipa
+
+      - name: Fetch PR commits
+        if: inputs.pr-number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr-number }}
+        run: |
+          python3 << 'SCRIPT'
+          import json, os, uuid, urllib.request
+
+          token = os.environ['GH_TOKEN']
+          repo = os.environ['GITHUB_REPOSITORY']
+          pr = os.environ['PR_NUMBER']
+          url = f'https://api.github.com/repos/{repo}/pulls/{pr}/commits?per_page=100'
+          req = urllib.request.Request(url, headers={
+              'Authorization': f'Bearer {token}',
+              'Accept': 'application/vnd.github+json',
+          })
+          commits = json.loads(urllib.request.urlopen(req).read())
+          lines = []
+          for c in reversed(commits):
+              sha = c['sha'][:7]
+              msg = c['commit']['message'].split('\n')[0]
+              lines.append(f'{sha} {msg}')
+          delim = f'FLUTTY_EOF_{uuid.uuid4().hex}'
+          with open(os.environ['GITHUB_ENV'], 'a') as f:
+              f.write(f'FLUTTY_PR_COMMITS<<{delim}\n')
+              f.write('\n'.join(lines))
+              f.write(f'\n{delim}\n')
+          SCRIPT
 
       - name: Archive, sign & deploy via Fastlane
         if: inputs.deploy-ios-to != 'none'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   actions: read
   contents: read
+  pull-requests: read
 
 jobs:
   compute-version:
@@ -22,6 +23,7 @@ jobs:
       build-number: ${{ steps.version.outputs.build-number }}
       build-codename: ${{ steps.version.outputs.build-codename }}
       build-display: ${{ steps.version.outputs.build-display }}
+      commits-list: ${{ steps.commits.outputs.list }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -43,6 +45,28 @@ jobs:
           echo "build-number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "build-codename=${BUILD_CODENAME}" >> "$GITHUB_OUTPUT"
           echo "build-display=${BUILD_DISPLAY}" >> "$GITHUB_OUTPUT"
+
+      - name: List PR commits
+        id: commits
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ github.event.pull_request.number }},
+              per_page: 100,
+            });
+            commits.reverse();
+            const lines = commits.map(c => {
+              const sha = c.sha.substring(0, 7);
+              const msg = c.commit.message.split('\n')[0];
+              return `- \`${sha}\` ${msg}`;
+            });
+            const count = commits.length;
+            const summary = `${count} commit${count !== 1 ? 's' : ''} (newest first)`;
+            const body = lines.join('\n');
+            core.setOutput('list', `### Commits\n\n<details>\n<summary>${summary}</summary>\n\n${body}\n\n</details>`);
 
   comment-initial:
     name: PR Comment (Queued)
@@ -76,6 +100,8 @@ jobs:
 
             ### Promote
             Comment `/deploy` on this PR to deploy the current PR head to TestFlight and the Play Store internal track. The deploy workflow reuses these unsigned preview intermediates when their build number is still deployable; otherwise it rebuilds with a newer build number before uploading.
+
+            ${{ needs.compute-version.outputs.commits-list }}
 
             > Build triggered by ${{ github.event.pull_request.head.sha }}
             <!-- preview-build-source-sha:${{ github.event.pull_request.head.sha }} -->
@@ -211,6 +237,8 @@ jobs:
             ### Promote
             Comment `/deploy` on this PR to deploy the current PR head to TestFlight and the Play Store internal track. The deploy workflow reuses these unsigned preview intermediates when their build number is still deployable; otherwise it rebuilds with a newer build number before uploading.
 
+            ${{ needs.compute-version.outputs.commits-list }}
+
             > Build triggered by ${{ github.event.pull_request.head.sha }}
             <!-- preview-build-source-sha:${{ github.event.pull_request.head.sha }} -->
             <!-- preview-build-name:${{ needs.compute-version.outputs.build-name }} -->
@@ -306,6 +334,8 @@ jobs:
 
             ### Promote
             Comment `/deploy` on this PR to deploy the current PR head to TestFlight and the Play Store internal track. The deploy workflow reuses these unsigned preview intermediates when their build number is still deployable; otherwise it rebuilds with a newer build number before uploading.
+
+            ${{ needs.compute-version.outputs.commits-list }}
 
             > Build triggered by ${{ github.event.pull_request.head.sha }}
             <!-- preview-build-source-sha:${{ github.event.pull_request.head.sha }} -->

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -48,9 +48,17 @@ jobs:
 
       - name: List PR commits
         id: commits
+        continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
+            const MAX_DISPLAY = 25;
+            const sanitize = (s) => s
+              .replace(/&/g, '&amp;')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;')
+              .replace(/@/g, '@\u200b');
+
             const commits = await github.paginate(github.rest.pulls.listCommits, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -58,11 +66,15 @@ jobs:
               per_page: 100,
             });
             commits.reverse();
-            const lines = commits.map(c => {
+            const displayed = commits.slice(0, MAX_DISPLAY);
+            const lines = displayed.map(c => {
               const sha = c.sha.substring(0, 7);
-              const msg = c.commit.message.split('\n')[0];
+              const msg = sanitize(c.commit.message.split('\n')[0]);
               return `- \`${sha}\` ${msg}`;
             });
+            if (commits.length > MAX_DISPLAY) {
+              lines.push(`- *... and ${commits.length - MAX_DISPLAY} more*`);
+            }
             const count = commits.length;
             const summary = `${count} commit${count !== 1 ? 's' : ''} (newest first)`;
             const body = lines.join('\n');

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -59,23 +59,25 @@ jobs:
               .replace(/>/g, '&gt;')
               .replace(/@/g, '@\u200b');
 
-            const commits = await github.paginate(github.rest.pulls.listCommits, {
+            const count = ${{ github.event.pull_request.commits }};
+            const lastPage = Math.max(1, Math.ceil(count / 100));
+            const { data: page } = await github.rest.pulls.listCommits({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: ${{ github.event.pull_request.number }},
               per_page: 100,
+              page: lastPage,
             });
-            commits.reverse();
-            const displayed = commits.slice(0, MAX_DISPLAY);
+            page.reverse();
+            const displayed = page.slice(0, MAX_DISPLAY);
             const lines = displayed.map(c => {
               const sha = c.sha.substring(0, 7);
               const msg = sanitize(c.commit.message.split('\n')[0]);
               return `- \`${sha}\` ${msg}`;
             });
-            if (commits.length > MAX_DISPLAY) {
-              lines.push(`- *... and ${commits.length - MAX_DISPLAY} more*`);
+            if (count > displayed.length) {
+              lines.push(`- *... and ${count - displayed.length} more*`);
             }
-            const count = commits.length;
             const summary = `${count} commit${count !== 1 ? 's' : ''} (newest first)`;
             const body = lines.join('\n');
             core.setOutput('list', `### Commits\n\n<details>\n<summary>${summary}</summary>\n\n${body}\n\n</details>`);

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -69,7 +69,7 @@ platform :android do
   private_lane :prepared_metadata_path do |options|
     base_metadata_path = options[:base_metadata_path]
     version_code = options[:version_code].to_s
-    preview_notes = PreviewReleaseNotes.current
+    preview_notes = PreviewReleaseNotes.current(max_length: 500)
 
     next [base_metadata_path, false] if preview_notes.nil? || version_code.empty?
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -110,7 +110,7 @@ platform :ios do
   end
 
   private_lane :testflight_release_notes do
-    preview_notes = PreviewReleaseNotes.current
+    preview_notes = PreviewReleaseNotes.current(max_length: 4000)
     next [nil, nil] if preview_notes.nil?
 
     [

--- a/scripts/preview_release_notes.rb
+++ b/scripts/preview_release_notes.rb
@@ -3,7 +3,7 @@
 module PreviewReleaseNotes
   module_function
 
-  def current
+  def current(max_length: nil)
     pr_number = normalize(ENV['FLUTTY_PR_NUMBER'])
     pr_title = normalize(ENV['FLUTTY_PR_TITLE'])
     return nil if pr_number.nil? && pr_title.nil?
@@ -13,6 +13,7 @@ module PreviewReleaseNotes
     source_sha = normalize(ENV['FLUTTY_SOURCE_SHA'])
     repository = normalize(ENV['GITHUB_REPOSITORY'])
     server_url = normalize(ENV['GITHUB_SERVER_URL']) || 'https://github.com'
+    pr_commits = normalize(ENV['FLUTTY_PR_COMMITS'])
 
     lines = [headline(pr_number: pr_number, pr_title: pr_title)]
     version_line = format_version(build_name: build_name, version_codename: version_codename)
@@ -24,7 +25,9 @@ module PreviewReleaseNotes
 
     lines << "Commit: #{source_sha[0, 7]}" if source_sha
 
-    lines.join("\n")
+    header = lines.join("\n")
+
+    append_commits(header, pr_commits, max_length: max_length)
   end
 
   def headline(pr_number:, pr_title:)
@@ -40,6 +43,38 @@ module PreviewReleaseNotes
     return "Version: #{build_name}" if build_name
 
     "Codename: #{version_codename}"
+  end
+
+  def append_commits(header, raw_commits, max_length:)
+    return header if raw_commits.nil?
+
+    commit_lines = raw_commits.split("\n").reject(&:empty?)
+    return header if commit_lines.empty?
+
+    result = "#{header}\n\nCommits:"
+    included = 0
+
+    commit_lines.each_with_index do |line, index|
+      entry = "\n- #{line}"
+      remaining = commit_lines.length - index - 1
+      suffix = remaining.positive? ? "\n... and #{remaining} more" : ''
+
+      candidate = result + entry
+      if max_length.nil? || (candidate + suffix).length <= max_length
+        result = candidate
+        included += 1
+      else
+        break
+      end
+    end
+
+    return header if included.zero?
+
+    if included < commit_lines.length
+      result += "\n... and #{commit_lines.length - included} more"
+    end
+
+    result
   end
 
   def normalize(value)

--- a/scripts/preview_release_notes.rb
+++ b/scripts/preview_release_notes.rb
@@ -27,7 +27,8 @@ module PreviewReleaseNotes
 
     header = lines.join("\n")
 
-    append_commits(header, pr_commits, max_length: max_length)
+    result = append_commits(header, pr_commits, max_length: max_length)
+    enforce_limit(result, max_length)
   end
 
   def headline(pr_number:, pr_title:)
@@ -75,6 +76,14 @@ module PreviewReleaseNotes
     end
 
     result
+  end
+
+  def enforce_limit(text, max_length)
+    return text if max_length.nil? || text.length <= max_length
+
+    truncated = text[0, max_length]
+    last_newline = truncated.rindex("\n")
+    last_newline ? truncated[0, last_newline] : truncated
   end
 
   def normalize(value)


### PR DESCRIPTION
## Summary

Adds a **Commits** section showing all PR commits (newest first) with abbreviated SHA and one-line message to:

1. **PR preview build comment** — collapsible section in the sticky comment
2. **TestFlight release notes** — "What to Test" field (up to 4000 chars)
3. **Play Store changelog** — internal track release notes (up to 500 chars)

### How it works

**PR comment** (`preview.yml`):
- A `List PR commits` step in `compute-version` uses `actions/github-script` to fetch commits from the GitHub API (single-page fetch using PR commit count, not full pagination)
- Sanitizes HTML entities and `@` mentions to prevent rendering issues and notification spam
- Caps display at 25 commits with "... and N more"
- Wrapped in a collapsible `<details>` tag

**Store release notes** (`build-deploy.yml` + `preview_release_notes.rb`):
- A `Fetch PR commits` step in both Android and iOS jobs fetches commits via `python3`+`urllib` (no `gh` CLI dependency for runner compatibility)
- Passes them to Fastlane as `FLUTTY_PR_COMMITS` env var
- `PreviewReleaseNotes.current(max_length:)` appends commits with platform-aware truncation:
  - Android/Play Store: 500 chars → shows as many commits as fit
  - iOS/TestFlight: 4000 chars → room for full list
- `enforce_limit` guarantees the final string never exceeds `max_length`

### Resilience

- All commit-fetch steps use `continue-on-error: true` + error handling
- If the API call fails, release notes and PR comments degrade gracefully (no commit section, everything else works)
- Python scripts cap at 100 commits to bound `GITHUB_ENV` size
