### PR TITLE
fix: restore write permissions for deploy comment updates

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -173,6 +173,8 @@ on:
 permissions:
   actions: read
   contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   build-android:


### PR DESCRIPTION
## Summary

Restores write permissions for the deploy comment update jobs in `build-deploy.yml`.

## Problem

Since commit a1d086d, every "Deploy PR Preview" run fails with:

```
HttpError: Resource not accessible by integration (403)
```

on the "Update Android Deploy Comment" and "Update iOS Deploy Comment" jobs.

That commit removed job-level `permissions: { issues: write, pull-requests: write }` from these jobs to fix a startup_failure in callers that don't grant write access (release, develop, preview). However, the reusable workflow's top-level permissions only grant `actions: read` and `contents: read`, leaving the comment update jobs with no write permissions at all.

## Fix

Add `issues: write` and `pull-requests: write` to the **workflow-level** permissions block in `build-deploy.yml`. For reusable workflows, effective permissions are the intersection of caller and called:

- `deploy-testflight.yml` (grants write) → comment jobs get write ✅
- `release.yml` / `develop.yml` / `preview.yml` (read-only) → effective is `none`, but **no startup_failure** since it's a workflow-level declaration. The comment jobs are skipped by their `if` guards anyway (`update-pr-deploy-comment` defaults to `false`).

## Impact

- Fixes 20+ consecutive "Deploy PR Preview" failures
- No impact on release, develop, or preview workflows (they don't pass `update-pr-deploy-comment: true`)
