### PR TITLE
fix: remove spurious terminal viewport margins

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1063,9 +1063,9 @@ enum _AutoConnectReviewDecision { skip, runOnce, trustAndRun }
 
 /// Padding around the terminal viewport.
 ///
-/// Keep the terminal flush with the bottom and side edges so status lines from
-/// tools like tmux can use the full available width and height.
-const terminalViewportPadding = EdgeInsets.fromLTRB(0, 8, 0, 0);
+/// Keep the terminal flush with the viewport edges so status lines from tools
+/// like tmux can use the full available width and height.
+const terminalViewportPadding = EdgeInsets.zero;
 
 /// Clamps a terminal font size into the supported zoom range.
 @visibleForTesting

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -4,8 +4,8 @@ import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 
 void main() {
   group('terminal layout helpers', () {
-    test('keeps the terminal full width without wasting bottom rows', () {
-      expect(terminalViewportPadding, const EdgeInsets.fromLTRB(0, 8, 0, 0));
+    test('keeps the terminal flush with the viewport edges', () {
+      expect(terminalViewportPadding, EdgeInsets.zero);
       expect(terminalViewportPadding.bottom, 0);
     });
 


### PR DESCRIPTION
## Summary

- remove the hardcoded terminal viewport inset so the terminal renders flush to the screen edges
- update the layout test to cover the edge-to-edge viewport padding
