### PR TITLE
fix: publish ipa and apk workflow artifacts

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -409,13 +409,32 @@ jobs:
           name: android-unsigned-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
           path: build/app/outputs/bundle/${{ inputs.flavor }}Release/app-${{ inputs.flavor }}-release.aab
 
+      - name: Prepare APK artifact
+        id: prepare-apk-artifact
+        env:
+          TARGET_APK_NAME: android-apk-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}.apk
+        run: |
+          SOURCE_APK_PATH=$(find build/app/outputs/flutter-apk -maxdepth 1 -name '*.apk' -print -quit)
+          if [ -z "$SOURCE_APK_PATH" ]; then
+            echo "Expected an APK under build/app/outputs/flutter-apk, but none was found."
+            find build/app/outputs/flutter-apk -maxdepth 4 -print || true
+            exit 1
+          fi
+
+          SOURCE_APK_PATH="$(python3 -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "$SOURCE_APK_PATH")"
+          TARGET_APK_PATH="$(python3 -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "build/app/outputs/flutter-apk/$TARGET_APK_NAME")"
+          if [ "$SOURCE_APK_PATH" != "$TARGET_APK_PATH" ]; then
+            cp "$SOURCE_APK_PATH" "$TARGET_APK_PATH"
+          fi
+
+          echo "artifact-path=$TARGET_APK_PATH" >> "$GITHUB_OUTPUT"
+
       - name: Upload APK artifact
         id: upload-apk
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: android-apk-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
-          path: build/app/outputs/flutter-apk/*.apk
-          compression-level: 0
+          path: ${{ steps.prepare-apk-artifact.outputs.artifact-path }}
+          archive: false
 
       - name: Fetch PR commits
         if: inputs.pr-number != ''
@@ -648,6 +667,27 @@ jobs:
             output_ipa_path:"$ADHOC_IPA_PATH"
           rm -f ../build/ios/ipa/Runner-unsigned.ipa
 
+      - name: Prepare ad hoc IPA artifact
+        id: prepare-adhoc-ipa-artifact
+        if: inputs.build-ios-adhoc-ipa && inputs.ios-reuse-ipa-artifact-name == '' && inputs.deploy-ios-to == 'none'
+        env:
+          TARGET_IPA_NAME: ios-adhoc-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}.ipa
+        run: |
+          SOURCE_IPA_PATH=$(find build/ios/ipa -maxdepth 1 -name '*.ipa' -print -quit)
+          if [ -z "$SOURCE_IPA_PATH" ]; then
+            echo "Expected an IPA under build/ios/ipa, but none was found."
+            find build/ios/ipa -maxdepth 4 -print || true
+            exit 1
+          fi
+
+          SOURCE_IPA_PATH="$(python3 -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "$SOURCE_IPA_PATH")"
+          TARGET_IPA_PATH="$(python3 -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "build/ios/ipa/$TARGET_IPA_NAME")"
+          if [ "$SOURCE_IPA_PATH" != "$TARGET_IPA_PATH" ]; then
+            cp "$SOURCE_IPA_PATH" "$TARGET_IPA_PATH"
+          fi
+
+          echo "artifact-path=$TARGET_IPA_PATH" >> "$GITHUB_OUTPUT"
+
       - name: Download reusable IPA artifact
         if: inputs.ios-reuse-ipa-artifact-name != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -768,23 +808,26 @@ jobs:
           fi
 
           FINAL_IPA_PATH="$(python3 -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "$FINAL_IPA_PATH")"
+          ARTIFACT_IPA_PATH="$(python3 -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "../build/ios/ipa/ios-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}.ipa")"
+          if [ "$FINAL_IPA_PATH" != "$ARTIFACT_IPA_PATH" ]; then
+            cp "$FINAL_IPA_PATH" "$ARTIFACT_IPA_PATH"
+            FINAL_IPA_PATH="$ARTIFACT_IPA_PATH"
+          fi
           echo "artifact-path=$FINAL_IPA_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Upload signed IPA artifact
         if: inputs.deploy-ios-to != 'none'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ios-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
           path: ${{ steps.prepare-deploy-ipa.outputs.artifact-path }}
-          compression-level: 0
+          archive: false
 
       - name: Upload ad hoc IPA artifact
         if: inputs.build-ios-adhoc-ipa && inputs.ios-reuse-ipa-artifact-name == '' && inputs.deploy-ios-to == 'none'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ios-adhoc-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
-          path: build/ios/ipa/*.ipa
-          compression-level: 0
+          path: ${{ steps.prepare-adhoc-ipa-artifact.outputs.artifact-path }}
+          archive: false
 
   deploy-status-summary:
     name: Summarize Deploy Status

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -60,11 +60,11 @@ on:
         type: boolean
         default: false
         description: 'Whether to build an unsigned Android release bundle artifact'
-      build-ios-unsigned-ipa:
+      build-ios-adhoc-ipa:
         required: false
         type: boolean
         default: false
-        description: 'Whether to package an unsigned iOS IPA artifact'
+        description: 'Whether to build an ad hoc signed iOS IPA artifact'
       run-android-deploy:
         required: false
         type: boolean
@@ -115,11 +115,11 @@ on:
         type: string
         default: ''
         description: 'Artifact name for a reusable iOS IPA'
-      ios-reuse-ipa-is-unsigned:
+      ios-reuse-ipa-needs-resign:
         required: false
         type: boolean
         default: false
-        description: 'Whether the reusable iOS IPA must be signed in this workflow'
+        description: 'Whether the reusable iOS IPA must be re-signed in this workflow'
       ios-reuse-source-sha:
         required: false
         type: string
@@ -587,7 +587,7 @@ jobs:
         run: flutter pub get
 
       - name: Setup code signing
-        if: inputs.deploy-ios-to != 'none' && (inputs.ios-reuse-ipa-artifact-name == '' || inputs.ios-reuse-ipa-is-unsigned)
+        if: (inputs.deploy-ios-to != 'none' || inputs.build-ios-adhoc-ipa) && (inputs.ios-reuse-ipa-artifact-name == '' || inputs.ios-reuse-ipa-needs-resign)
         env:
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
@@ -598,11 +598,12 @@ jobs:
           BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
         run: |
           cd ios
-          if [ "${{ inputs.flavor }}" = "private" ]; then
-            bundle exec fastlane setup_signing app_identifier:xyz.depollsoft.monkeyssh.private
-          else
-            bundle exec fastlane setup_signing app_identifier:xyz.depollsoft.monkeyssh
+          SCHEME="${{ inputs.flavor == 'private' && 'Private' || 'Production' }}"
+          DISTRIBUTION_TYPE='appstore'
+          if [ "${{ inputs.build-ios-adhoc-ipa }}" = 'true' ] && [ "${{ inputs.deploy-ios-to }}" = 'none' ]; then
+            DISTRIBUTION_TYPE='adhoc'
           fi
+          bundle exec fastlane setup_signing scheme:"$SCHEME" distribution_type:"$DISTRIBUTION_TYPE"
 
       - name: Build iOS
         if: inputs.ios-reuse-ipa-artifact-name == ''
@@ -623,9 +624,30 @@ jobs:
             --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
             --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE"
 
-      - name: Package unsigned IPA
-        if: inputs.build-ios-unsigned-ipa && inputs.ios-reuse-ipa-artifact-name == '' && inputs.deploy-ios-to == 'none'
+      - name: Package source IPA
+        if: inputs.build-ios-adhoc-ipa && inputs.ios-reuse-ipa-artifact-name == '' && inputs.deploy-ios-to == 'none'
         run: bash scripts/package_unsigned_ipa.sh
+
+      - name: Sign ad hoc IPA
+        if: inputs.build-ios-adhoc-ipa && inputs.ios-reuse-ipa-artifact-name == '' && inputs.deploy-ios-to == 'none'
+        env:
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
+        run: |
+          cd ios
+          SCHEME="${{ inputs.flavor == 'private' && 'Private' || 'Production' }}"
+          ADHOC_IPA_PATH="$(python3 -c 'import os; print(os.path.abspath("../build/ios/ipa/Runner-adhoc.ipa"))')"
+          bundle exec fastlane resign_ipa \
+            scheme:"$SCHEME" \
+            distribution_type:adhoc \
+            source_ipa_path:"../build/ios/ipa/Runner-unsigned.ipa" \
+            output_ipa_path:"$ADHOC_IPA_PATH"
+          rm -f ../build/ios/ipa/Runner-unsigned.ipa
 
       - name: Download reusable IPA artifact
         if: inputs.ios-reuse-ipa-artifact-name != ''
@@ -712,15 +734,16 @@ jobs:
             REUSED_IPA_PATH="$(python3 -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "$REUSED_IPA_PATH")"
           fi
 
-          if [ "${{ inputs.ios-reuse-ipa-is-unsigned }}" = 'true' ]; then
+          if [ "${{ inputs.ios-reuse-ipa-needs-resign }}" = 'true' ]; then
             if [ -z "$REUSED_IPA_PATH" ]; then
-              echo "ios-reuse-ipa-is-unsigned requires a reusable IPA artifact to be downloaded first."
+              echo "ios-reuse-ipa-needs-resign requires a reusable IPA artifact to be downloaded first."
               exit 1
             fi
             SIGNED_IPA_PATH="$(python3 -c 'import os; print(os.path.abspath("../build/ios/ipa/resigned-${{ inputs.flavor }}.ipa"))')"
             bundle exec fastlane resign_ipa \
               scheme:"$SCHEME" \
-              unsigned_ipa_path:"$REUSED_IPA_PATH" \
+              distribution_type:appstore \
+              source_ipa_path:"$REUSED_IPA_PATH" \
               output_ipa_path:"$SIGNED_IPA_PATH"
             REUSED_IPA_PATH="$SIGNED_IPA_PATH"
           fi
@@ -756,12 +779,12 @@ jobs:
           path: ${{ steps.prepare-deploy-ipa.outputs.artifact-path }}
           compression-level: 0
 
-      - name: Upload unsigned IPA artifact
-        if: inputs.build-ios-unsigned-ipa && inputs.ios-reuse-ipa-artifact-name == '' && inputs.deploy-ios-to == 'none'
+      - name: Upload ad hoc IPA artifact
+        if: inputs.build-ios-adhoc-ipa && inputs.ios-reuse-ipa-artifact-name == '' && inputs.deploy-ios-to == 'none'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ios-unsigned-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
-          path: build/ios/ipa/Runner-unsigned.ipa
+          name: ios-adhoc-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
+          path: build/ios/ipa/*.ipa
           compression-level: 0
 
   deploy-status-summary:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -436,6 +436,13 @@ jobs:
           path: ${{ steps.prepare-apk-artifact.outputs.artifact-path }}
           archive: false
 
+      - name: Upload ZIP-wrapped APK artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: android-apk-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
+          path: ${{ steps.prepare-apk-artifact.outputs.artifact-path }}
+          compression-level: 0
+
       - name: Fetch PR commits
         if: inputs.pr-number != ''
         continue-on-error: true

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -224,7 +224,7 @@ jobs:
           fi
 
       - name: Checkout requested source ref for Android build
-        if: inputs.source-ref != '' && inputs.android-reuse-aab-artifact-name == ''
+        if: inputs.source-ref != '' && (inputs.android-reuse-aab-artifact-name == '' || inputs.android-reuse-apk-artifact-name == '')
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
@@ -232,13 +232,13 @@ jobs:
           fetch-depth: 1
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        if: inputs.android-reuse-aab-artifact-name == '' || (inputs.deploy-android-to != 'none' && inputs.android-reuse-aab-is-unsigned)
+        if: inputs.android-reuse-aab-artifact-name == '' || inputs.android-reuse-apk-artifact-name == '' || (inputs.deploy-android-to != 'none' && inputs.android-reuse-aab-is-unsigned)
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        if: inputs.android-reuse-aab-artifact-name == ''
+        if: inputs.android-reuse-aab-artifact-name == '' || inputs.android-reuse-apk-artifact-name == ''
         with:
           path: |
             ~/.gradle/caches
@@ -247,18 +247,18 @@ jobs:
           restore-keys: gradle-${{ runner.os }}-
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
-        if: inputs.android-reuse-aab-artifact-name == ''
+        if: inputs.android-reuse-aab-artifact-name == '' || inputs.android-reuse-apk-artifact-name == ''
         with:
           flutter-version: '3.x'
           channel: 'stable'
           cache: true
 
       - name: Install dependencies
-        if: inputs.android-reuse-aab-artifact-name == ''
+        if: inputs.android-reuse-aab-artifact-name == '' || inputs.android-reuse-apk-artifact-name == ''
         run: flutter pub get
 
       - name: Validate Android signing secrets
-        if: inputs.deploy-android-to != 'none' && (inputs.android-reuse-aab-artifact-name == '' || inputs.android-reuse-aab-is-unsigned)
+        if: inputs.deploy-android-to != 'none' && (inputs.android-reuse-aab-artifact-name == '' || inputs.android-reuse-apk-artifact-name == '' || inputs.android-reuse-aab-is-unsigned)
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
@@ -283,7 +283,7 @@ jobs:
           fi
 
       - name: Decode keystore
-        if: inputs.deploy-android-to != 'none' && (inputs.android-reuse-aab-artifact-name == '' || inputs.android-reuse-aab-is-unsigned)
+        if: inputs.deploy-android-to != 'none' && (inputs.android-reuse-aab-artifact-name == '' || inputs.android-reuse-apk-artifact-name == '' || inputs.android-reuse-aab-is-unsigned)
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
@@ -291,7 +291,7 @@ jobs:
           echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > android/app/upload-keystore.jks
 
       - name: Create key.properties
-        if: inputs.deploy-android-to != 'none' && inputs.android-reuse-aab-artifact-name == ''
+        if: inputs.deploy-android-to != 'none' && (inputs.android-reuse-aab-artifact-name == '' || inputs.android-reuse-apk-artifact-name == '')
         env:
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
@@ -331,12 +331,23 @@ jobs:
             --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE"
 
       - name: Build debug APK
-        if: inputs.deploy-android-to == 'none'
+        if: inputs.deploy-android-to == 'none' && inputs.android-reuse-apk-artifact-name == ''
         run: |
           flutter build apk \
             --flavor ${{ inputs.flavor }} \
             --debug \
             --no-tree-shake-icons \
+            --build-name=${{ inputs.build-name }} \
+            --build-number=${{ inputs.build-number }} \
+            --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
+            --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE"
+
+      - name: Build release APK
+        if: inputs.deploy-android-to != 'none' && inputs.android-reuse-apk-artifact-name == ''
+        run: |
+          flutter build apk \
+            --flavor ${{ inputs.flavor }} \
+            --release \
             --build-name=${{ inputs.build-name }} \
             --build-number=${{ inputs.build-number }} \
             --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
@@ -402,11 +413,11 @@ jobs:
 
       - name: Upload APK artifact
         id: upload-apk
-        if: inputs.deploy-android-to == 'none'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: android-apk-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
-          path: build/app/outputs/flutter-apk/app-${{ inputs.flavor }}-debug.apk
+          path: build/app/outputs/flutter-apk/*.apk
+          compression-level: 0
 
       - name: Fetch PR commits
         if: inputs.pr-number != ''
@@ -614,63 +625,7 @@ jobs:
 
       - name: Package unsigned IPA
         if: inputs.build-ios-unsigned-ipa && inputs.ios-reuse-ipa-artifact-name == '' && inputs.deploy-ios-to == 'none'
-        run: |
-          APP_PATH=$(find build/ios/iphoneos -maxdepth 1 -name '*.app' -type d -print -quit)
-          if [ -z "$APP_PATH" ]; then
-            echo 'Expected a built .app bundle under build/ios/iphoneos, but none was found.'
-            ls -la build/ios/iphoneos || true
-            exit 1
-          fi
-          APP_BUNDLE_NAME=$(basename "$APP_PATH")
-
-          bundle_executable_path() {
-            local bundle_path="$1"
-            local info_plist="$bundle_path/Info.plist"
-            if [ ! -f "$info_plist" ]; then
-              echo "Expected Info.plist at $info_plist" >&2
-              return 1
-            fi
-
-            /usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$info_plist"
-          }
-
-          add_swift_scan_args() {
-            local bundle_path="$1"
-            local executable_name
-            executable_name=$(bundle_executable_path "$bundle_path")
-            SWIFT_SCAN_ARGS+=("--scan-executable" "$bundle_path/$executable_name")
-
-            if [ -d "$bundle_path/Frameworks" ]; then
-              SWIFT_SCAN_ARGS+=("--scan-folder" "$bundle_path/Frameworks")
-            fi
-          }
-
-          rm -rf build/ios/unsigned
-          mkdir -p build/ios/unsigned/Payload build/ios/ipa
-          ditto "$APP_PATH" "build/ios/unsigned/Payload/$APP_BUNDLE_NAME"
-
-          SWIFT_SUPPORT_DIR=build/ios/unsigned/SwiftSupport/iphoneos
-          mkdir -p "$SWIFT_SUPPORT_DIR"
-          declare -a SWIFT_SCAN_ARGS=()
-          add_swift_scan_args "build/ios/unsigned/Payload/$APP_BUNDLE_NAME"
-          if [ -d "build/ios/unsigned/Payload/$APP_BUNDLE_NAME/PlugIns" ]; then
-            while IFS= read -r -d '' APPEX_PATH; do
-              add_swift_scan_args "$APPEX_PATH"
-            done < <(find "build/ios/unsigned/Payload/$APP_BUNDLE_NAME/PlugIns" -mindepth 1 -maxdepth 1 -name '*.appex' -type d -print0)
-          fi
-          xcrun swift-stdlib-tool --copy --platform iphoneos --destination "$SWIFT_SUPPORT_DIR" "${SWIFT_SCAN_ARGS[@]}"
-          if ! find "$SWIFT_SUPPORT_DIR" -type f | grep -q .; then
-            rm -rf build/ios/unsigned/SwiftSupport
-          fi
-
-          (
-            cd build/ios/unsigned
-            ZIP_INPUTS=(Payload)
-            if [ -d SwiftSupport ]; then
-              ZIP_INPUTS+=(SwiftSupport)
-            fi
-            zip -qry ../ipa/Runner-unsigned.ipa "${ZIP_INPUTS[@]}"
-          )
+        run: bash scripts/package_unsigned_ipa.sh
 
       - name: Download reusable IPA artifact
         if: inputs.ios-reuse-ipa-artifact-name != ''
@@ -729,6 +684,7 @@ jobs:
           SCRIPT
 
       - name: Archive, sign & deploy via Fastlane
+        id: prepare-deploy-ipa
         if: inputs.deploy-ios-to != 'none'
         env:
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
@@ -779,12 +735,26 @@ jobs:
             bundle exec fastlane build_ipa scheme:"$SCHEME"
           fi
 
+          FINAL_IPA_PATH="$REUSED_IPA_PATH"
+          if [ -z "$FINAL_IPA_PATH" ]; then
+            FINAL_IPA_PATH=$(find ../build/ios/ipa -maxdepth 1 -name '*.ipa' -print -quit)
+            if [ -z "$FINAL_IPA_PATH" ]; then
+              echo "Expected a signed IPA artifact after Fastlane completed."
+              find ../build/ios/ipa -maxdepth 4 -print || true
+              exit 1
+            fi
+          fi
+
+          FINAL_IPA_PATH="$(python3 -c 'import os, sys; print(os.path.abspath(sys.argv[1]))' "$FINAL_IPA_PATH")"
+          echo "artifact-path=$FINAL_IPA_PATH" >> "$GITHUB_OUTPUT"
+
       - name: Upload signed IPA artifact
-        if: inputs.deploy-ios-to != 'none' && inputs.ios-reuse-ipa-artifact-name == ''
+        if: inputs.deploy-ios-to != 'none'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ios-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
-          path: build/ios/ipa/*.ipa
+          path: ${{ steps.prepare-deploy-ipa.outputs.artifact-path }}
+          compression-level: 0
 
       - name: Upload unsigned IPA artifact
         if: inputs.build-ios-unsigned-ipa && inputs.ios-reuse-ipa-artifact-name == '' && inputs.deploy-ios-to == 'none'
@@ -792,6 +762,7 @@ jobs:
         with:
           name: ios-unsigned-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
           path: build/ios/ipa/Runner-unsigned.ipa
+          compression-level: 0
 
   deploy-status-summary:
     name: Summarize Deploy Status

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -173,8 +173,6 @@ on:
 permissions:
   actions: read
   contents: read
-  issues: write
-  pull-requests: write
 
 jobs:
   build-android:
@@ -868,6 +866,9 @@ jobs:
     needs: [build-android]
     if: always() && inputs.update-pr-deploy-comment && inputs.pr-number != '' && inputs.build-android && inputs.run-android-deploy && inputs.deploy-android-to != 'none'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Update Android status row
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -930,6 +931,9 @@ jobs:
     needs: [build-ios]
     if: always() && inputs.update-pr-deploy-comment && inputs.pr-number != '' && inputs.build-ios && inputs.run-ios-deploy && inputs.deploy-ios-to != 'none'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Update iOS status row
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -639,11 +639,12 @@ jobs:
         run: |
           cd ios
           SCHEME="${{ inputs.flavor == 'private' && 'Private' || 'Production' }}"
+          SOURCE_IPA_PATH="$(python3 -c 'import os; print(os.path.abspath("../build/ios/ipa/Runner-unsigned.ipa"))')"
           ADHOC_IPA_PATH="$(python3 -c 'import os; print(os.path.abspath("../build/ios/ipa/Runner-adhoc.ipa"))')"
           bundle exec fastlane resign_ipa \
             scheme:"$SCHEME" \
             distribution_type:adhoc \
-            source_ipa_path:"../build/ios/ipa/Runner-unsigned.ipa" \
+            source_ipa_path:"$SOURCE_IPA_PATH" \
             output_ipa_path:"$ADHOC_IPA_PATH"
           rm -f ../build/ios/ipa/Runner-unsigned.ipa
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,11 +249,14 @@ jobs:
       - name: Build iOS (no codesign)
         run: flutter build ios --flavor production --release --no-codesign --no-tree-shake-icons --split-debug-info=.debug-info
 
-      - name: Upload iOS build
+      - name: Package unsigned IPA
+        run: bash scripts/package_unsigned_ipa.sh
+
+      - name: Upload iOS IPA
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ios-build
-          path: build/ios/iphoneos/MonkeySSH.app
+          name: ios-ipa
+          path: build/ios/ipa/Runner-unsigned.ipa
           compression-level: 0
           retention-days: 5
 

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -354,6 +354,7 @@ jobs:
               '${{ needs.finalize-version.outputs.rebuild-required }}' === 'true';
             const workflowId = 'preview.yml';
             const requiredArtifactNames = [
+              `android-apk-private-${buildName}-${buildNumber}`,
               `android-unsigned-private-${buildName}-${buildNumber}`,
               `ios-unsigned-private-${buildName}-${buildNumber}`,
             ];
@@ -662,6 +663,7 @@ jobs:
       deploy-android-to: internal
       android-reuse-run-id: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.resolve-preview-artifacts.outputs.preview-run-id || '' }}
       android-reuse-aab-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('android-unsigned-{0}-{1}-{2}', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
+      android-reuse-apk-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('android-apk-{0}-{1}-{2}', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
       android-reuse-aab-is-unsigned: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' }}
       android-reuse-source-sha: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.validate-pr.outputs.deploy-sha || '' }}
       ios-reuse-run-id: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.resolve-preview-artifacts.outputs.preview-run-id || '' }}

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -356,7 +356,7 @@ jobs:
             const requiredArtifactNames = [
               `android-apk-private-${buildName}-${buildNumber}`,
               `android-unsigned-private-${buildName}-${buildNumber}`,
-              `ios-unsigned-private-${buildName}-${buildNumber}`,
+              `ios-adhoc-private-${buildName}-${buildNumber}`,
             ];
             const waitStatuses = new Set(['queued', 'in_progress', 'requested', 'waiting']);
             const maxWaitAttempts = 40;
@@ -580,7 +580,7 @@ jobs:
               rebuildRequired
                 ? `| **Artifacts** | Rebuilding deploy artifacts in this run because requested preview build \`${{ needs.finalize-version.outputs.requested-build-number }}\` is not newer than the highest recent private deploy build \`${{ needs.finalize-version.outputs.previous-private-deploy-build-number }}\` |`
                 : '${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts }}' === 'true'
-                ? `| **Artifacts** | Reusing unsigned preview intermediates from run #${{ needs.resolve-preview-artifacts.outputs.preview-run-id }} |`
+                ? `| **Artifacts** | Reusing preview Android intermediates and re-signing the preview ad hoc IPA from run #${{ needs.resolve-preview-artifacts.outputs.preview-run-id }} |`
                 : '| **Artifacts** | Preview intermediates unavailable, so this run is building deploy artifacts from source |';
 
             const body = [
@@ -667,8 +667,8 @@ jobs:
       android-reuse-aab-is-unsigned: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' }}
       android-reuse-source-sha: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.validate-pr.outputs.deploy-sha || '' }}
       ios-reuse-run-id: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.resolve-preview-artifacts.outputs.preview-run-id || '' }}
-      ios-reuse-ipa-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('ios-unsigned-{0}-{1}-{2}', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
-      ios-reuse-ipa-is-unsigned: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' }}
+      ios-reuse-ipa-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('ios-adhoc-{0}-{1}-{2}', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
+      ios-reuse-ipa-needs-resign: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' }}
       ios-reuse-source-sha: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.validate-pr.outputs.deploy-sha || '' }}
       update-pr-deploy-comment: true
     secrets:
@@ -823,7 +823,7 @@ jobs:
               rebuildRequired
                 ? `| **Artifacts** | Built fresh deploy artifacts in this run because requested preview build \`${{ needs.finalize-version.outputs.requested-build-number }}\` was not newer than the highest recent private deploy build \`${{ needs.finalize-version.outputs.previous-private-deploy-build-number }}\` |`
                 : '${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts }}' === 'true'
-                ? `| **Artifacts** | Reused unsigned preview intermediates from run #${{ needs.resolve-preview-artifacts.outputs.preview-run-id }} |`
+                ? `| **Artifacts** | Reused preview Android intermediates and re-signed the preview ad hoc IPA from run #${{ needs.resolve-preview-artifacts.outputs.preview-run-id }} |`
                 : '| **Artifacts** | Built fresh deploy artifacts in this run because matching preview intermediates were unavailable |';
 
             const syncRequestCommentReaction = async (targetReaction) => {

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -354,9 +354,9 @@ jobs:
               '${{ needs.finalize-version.outputs.rebuild-required }}' === 'true';
             const workflowId = 'preview.yml';
             const requiredArtifactNames = [
-              `android-apk-private-${buildName}-${buildNumber}`,
+              `android-apk-private-${buildName}-${buildNumber}.apk`,
               `android-unsigned-private-${buildName}-${buildNumber}`,
-              `ios-adhoc-private-${buildName}-${buildNumber}`,
+              `ios-adhoc-private-${buildName}-${buildNumber}.ipa`,
             ];
             const waitStatuses = new Set(['queued', 'in_progress', 'requested', 'waiting']);
             const maxWaitAttempts = 40;
@@ -663,11 +663,11 @@ jobs:
       deploy-android-to: internal
       android-reuse-run-id: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.resolve-preview-artifacts.outputs.preview-run-id || '' }}
       android-reuse-aab-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('android-unsigned-{0}-{1}-{2}', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
-      android-reuse-apk-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('android-apk-{0}-{1}-{2}', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
+      android-reuse-apk-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('android-apk-{0}-{1}-{2}.apk', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
       android-reuse-aab-is-unsigned: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' }}
       android-reuse-source-sha: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.validate-pr.outputs.deploy-sha || '' }}
       ios-reuse-run-id: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.resolve-preview-artifacts.outputs.preview-run-id || '' }}
-      ios-reuse-ipa-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('ios-adhoc-{0}-{1}-{2}', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
+      ios-reuse-ipa-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('ios-adhoc-{0}-{1}-{2}.ipa', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
       ios-reuse-ipa-needs-resign: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' }}
       ios-reuse-source-sha: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.validate-pr.outputs.deploy-sha || '' }}
       update-pr-deploy-comment: true

--- a/.github/workflows/preview-deploy-command.yml
+++ b/.github/workflows/preview-deploy-command.yml
@@ -319,7 +319,7 @@ jobs:
                previewSha,
                previewCommentUrl,
                state: 'queued',
-               note: '> Duplicate requests stay locked out while this deploy is queued or running. The deploy workflow waits for matching unsigned preview intermediates for this SHA, then signs and uploads them without recompiling source when they are available.',
+                note: '> Duplicate requests stay locked out while this deploy is queued or running. The deploy workflow waits for matching preview Android intermediates and the preview ad hoc IPA for this SHA, then re-signs and uploads them without recompiling source when they are available.',
                requestKey,
              });
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,7 +12,8 @@ concurrency:
 permissions:
   actions: read
   contents: read
-  pull-requests: read
+  issues: write
+  pull-requests: write
 
 jobs:
   compute-version:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -133,6 +133,7 @@ jobs:
       actions: read
       contents: read
       issues: write
+      pull-requests: write
     uses: ./.github/workflows/build-deploy.yml
     with:
       build-name: ${{ needs.compute-version.outputs.build-name }}
@@ -156,6 +157,7 @@ jobs:
       actions: read
       contents: read
       issues: write
+      pull-requests: write
     uses: ./.github/workflows/build-deploy.yml
     with:
       build-name: ${{ needs.compute-version.outputs.build-name }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -109,11 +109,11 @@ jobs:
             ### Install
             | Platform | Link |
             |----------|------|
-            | 🍎 **iOS** | Available after a PR preview deploy |
+            | 🍎 **iOS (Ad Hoc IPA)** | [View workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
             | 🤖 **Android (APK)** | [View workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
 
             ### Promote
-            Comment `/deploy` on this PR to deploy the current PR head to TestFlight and the Play Store internal track. The deploy workflow reuses these unsigned preview intermediates when their build number is still deployable; otherwise it rebuilds with a newer build number before uploading.
+            Comment `/deploy` on this PR to deploy the current PR head to TestFlight and the Play Store internal track. The deploy workflow reuses the preview Android intermediates and re-signs the preview ad hoc iOS IPA when their build number is still deployable; otherwise it rebuilds with a newer build number before uploading.
 
             ${{ needs.compute-version.outputs.commits-list }}
 
@@ -160,7 +160,14 @@ jobs:
       deploy-android-to: none
       build-ios: true
       build-android: false
-      build-ios-unsigned-ipa: true
+      build-ios-adhoc-ipa: true
+    secrets:
+      MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+      APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
 
   comment-android:
     name: PR Comment (Android)
@@ -215,6 +222,9 @@ jobs:
             const apkArtifact = artifacts.find((artifact) =>
               artifact.name.startsWith('android-apk-private-'),
             );
+            const ipaArtifact = artifacts.find((artifact) =>
+              artifact.name.startsWith('ios-adhoc-private-'),
+            );
             let androidLink = `[View workflow run](${runUrl})`;
             if (androidJob && androidJob.status === 'completed') {
               if (androidJob.conclusion === 'success' && apkArtifact) {
@@ -223,9 +233,18 @@ jobs:
                 androidLink = 'N/A (build skipped for fork PR)';
               }
             }
+            let iosLink = `[View workflow run](${runUrl})`;
+            if (iosJob && iosJob.status === 'completed') {
+              if (iosJob.conclusion === 'success' && ipaArtifact) {
+                iosLink = `[Download IPA](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${ipaArtifact.id})`;
+              } else if (iosJob.conclusion === 'skipped') {
+                iosLink = 'N/A (build skipped for fork PR)';
+              }
+            }
             core.setOutput('android-status', statusFor(androidJob));
             core.setOutput('ios-status', statusFor(iosJob));
             core.setOutput('android-link', androidLink);
+            core.setOutput('ios-link', iosLink);
 
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
@@ -245,11 +264,11 @@ jobs:
             ### Install
             | Platform | Link |
             |----------|------|
-            | 🍎 **iOS** | Available after a PR preview deploy |
+            | 🍎 **iOS (Ad Hoc IPA)** | ${{ steps.preview-status.outputs.ios-link }} |
             | 🤖 **Android (APK)** | ${{ steps.preview-status.outputs.android-link }} |
 
             ### Promote
-            Comment `/deploy` on this PR to deploy the current PR head to TestFlight and the Play Store internal track. The deploy workflow reuses these unsigned preview intermediates when their build number is still deployable; otherwise it rebuilds with a newer build number before uploading.
+            Comment `/deploy` on this PR to deploy the current PR head to TestFlight and the Play Store internal track. The deploy workflow reuses the preview Android intermediates and re-signs the preview ad hoc iOS IPA when their build number is still deployable; otherwise it rebuilds with a newer build number before uploading.
 
             ${{ needs.compute-version.outputs.commits-list }}
 
@@ -313,6 +332,9 @@ jobs:
             const apkArtifact = artifacts.find((artifact) =>
               artifact.name.startsWith('android-apk-private-'),
             );
+            const ipaArtifact = artifacts.find((artifact) =>
+              artifact.name.startsWith('ios-adhoc-private-'),
+            );
             let androidLink = `[View workflow run](${runUrl})`;
             if (androidJob && androidJob.status === 'completed') {
               if (androidJob.conclusion === 'success' && apkArtifact) {
@@ -321,9 +343,18 @@ jobs:
                 androidLink = 'N/A (build skipped for fork PR)';
               }
             }
+            let iosLink = `[View workflow run](${runUrl})`;
+            if (iosJob && iosJob.status === 'completed') {
+              if (iosJob.conclusion === 'success' && ipaArtifact) {
+                iosLink = `[Download IPA](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${ipaArtifact.id})`;
+              } else if (iosJob.conclusion === 'skipped') {
+                iosLink = 'N/A (build skipped for fork PR)';
+              }
+            }
             core.setOutput('android-status', statusFor(androidJob));
             core.setOutput('ios-status', statusFor(iosJob));
             core.setOutput('android-link', androidLink);
+            core.setOutput('ios-link', iosLink);
 
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
@@ -343,11 +374,11 @@ jobs:
             ### Install
             | Platform | Link |
             |----------|------|
-            | 🍎 **iOS** | Available after a PR preview deploy |
+            | 🍎 **iOS (Ad Hoc IPA)** | ${{ steps.preview-status.outputs.ios-link }} |
             | 🤖 **Android (APK)** | ${{ steps.preview-status.outputs.android-link }} |
 
             ### Promote
-            Comment `/deploy` on this PR to deploy the current PR head to TestFlight and the Play Store internal track. The deploy workflow reuses these unsigned preview intermediates when their build number is still deployable; otherwise it rebuilds with a newer build number before uploading.
+            Comment `/deploy` on this PR to deploy the current PR head to TestFlight and the Play Store internal track. The deploy workflow reuses the preview Android intermediates and re-signs the preview ad hoc iOS IPA when their build number is still deployable; otherwise it rebuilds with a newer build number before uploading.
 
             ${{ needs.compute-version.outputs.commits-list }}
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -230,9 +230,13 @@ jobs:
               run_id: runId,
               per_page: 100,
             });
-            const apkArtifact = artifacts.find((artifact) =>
-              artifact.name.startsWith('android-apk-private-'),
-            );
+            const apkArtifact =
+              artifacts.find((artifact) =>
+                artifact.name.startsWith('android-apk-private-') && artifact.name.endsWith('.apk'),
+              ) ||
+              artifacts.find((artifact) =>
+                artifact.name.startsWith('android-apk-private-'),
+              );
             const ipaArtifact = artifacts.find((artifact) =>
               artifact.name.startsWith('ios-adhoc-private-'),
             );
@@ -340,9 +344,13 @@ jobs:
               run_id: runId,
               per_page: 100,
             });
-            const apkArtifact = artifacts.find((artifact) =>
-              artifact.name.startsWith('android-apk-private-'),
-            );
+            const apkArtifact =
+              artifacts.find((artifact) =>
+                artifact.name.startsWith('android-apk-private-') && artifact.name.endsWith('.apk'),
+              ) ||
+              artifacts.find((artifact) =>
+                artifact.name.startsWith('android-apk-private-'),
+              );
             const ipaArtifact = artifacts.find((artifact) =>
               artifact.name.startsWith('ios-adhoc-private-'),
             );

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Download iOS artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: ios-production-${{ needs.compute-version.outputs.build-name }}-${{ needs.compute-version.outputs.build-number }}
+          name: ios-production-${{ needs.compute-version.outputs.build-name }}-${{ needs.compute-version.outputs.build-number }}.ipa
           path: artifacts/ios
 
       - name: Generate release checksums

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -98,8 +98,8 @@ Configure these secrets in your repository settings (Settings → Secrets and va
 ### PR Preview (`preview.yml`)
 
 Triggered automatically on PRs to `main` or `develop`. Builds the **private** flavor and:
-- **iOS**: Builds an **ad hoc signed** IPA artifact for direct download from the workflow/PR comment
-- **Android**: Builds a **debug** APK for direct download (linked in PR comment). Signed release artifacts remain limited to release/deploy workflows with configured secrets.
+- **iOS**: Builds an **ad hoc signed** IPA and uploads the raw `.ipa` file for direct download from the workflow/PR comment
+- **Android**: Builds a **debug** APK and uploads the raw `.apk` file for direct download (linked in PR comment). Signed release artifacts remain limited to release/deploy workflows with configured secrets.
 
 When `/deploy` promotes a PR preview, it reuses the existing preview Android artifacts and re-signs the preview ad hoc IPA for TestFlight when their build number is still ahead of the latest private deploy. If a newer private build has already been deployed, the workflow automatically rebuilds with a fresh build number before uploading to TestFlight and Play internal.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -101,6 +101,8 @@ Triggered automatically on PRs to `main` or `develop`. Builds the **private** fl
 - **iOS**: Builds an **ad hoc signed** IPA and uploads the raw `.ipa` file for direct download from the workflow/PR comment
 - **Android**: Builds a **debug** APK and uploads the raw `.apk` file for direct download (linked in PR comment). Signed release artifacts remain limited to release/deploy workflows with configured secrets.
 
+Preview artifact uploads use GitHub's single-file artifact mode so the linked download is the raw `.ipa` / `.apk` file instead of an extra artifact ZIP wrapper.
+
 When `/deploy` promotes a PR preview, it reuses the existing preview Android artifacts and re-signs the preview ad hoc IPA for TestFlight when their build number is still ahead of the latest private deploy. If a newer private build has already been deployed, the workflow automatically rebuilds with a fresh build number before uploading to TestFlight and Play internal.
 
 ### Deploy Private (`develop.yml`)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -98,10 +98,10 @@ Configure these secrets in your repository settings (Settings → Secrets and va
 ### PR Preview (`preview.yml`)
 
 Triggered automatically on PRs to `main` or `develop`. Builds the **private** flavor and:
-- **iOS**: Run the **Deploy PR Preview** workflow manually from the Actions tab
+- **iOS**: Builds an **ad hoc signed** IPA artifact for direct download from the workflow/PR comment
 - **Android**: Builds a **debug** APK for direct download (linked in PR comment). Signed release artifacts remain limited to release/deploy workflows with configured secrets.
 
-When `/deploy` promotes a PR preview, it reuses the existing unsigned preview artifacts when their build number is still ahead of the latest private deploy. If a newer private build has already been deployed, the workflow automatically rebuilds with a fresh build number before uploading to TestFlight and Play internal.
+When `/deploy` promotes a PR preview, it reuses the existing preview Android artifacts and re-signs the preview ad hoc IPA for TestFlight when their build number is still ahead of the latest private deploy. If a newer private build has already been deployed, the workflow automatically rebuilds with a fresh build number before uploading to TestFlight and Play internal.
 
 ### Deploy Private (`develop.yml`)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -99,9 +99,9 @@ Configure these secrets in your repository settings (Settings → Secrets and va
 
 Triggered automatically on PRs to `main` or `develop`. Builds the **private** flavor and:
 - **iOS**: Builds an **ad hoc signed** IPA and uploads the raw `.ipa` file for direct download from the workflow/PR comment
-- **Android**: Builds a **debug** APK and uploads the raw `.apk` file for direct download (linked in PR comment). Signed release artifacts remain limited to release/deploy workflows with configured secrets.
+- **Android**: Builds a **debug** APK, uploads the raw `.apk` file for direct download (linked in PR comment), and also keeps the legacy ZIP-wrapped APK artifact. Signed release artifacts remain limited to release/deploy workflows with configured secrets.
 
-Preview artifact uploads use GitHub's single-file artifact mode so the linked download is the raw `.ipa` / `.apk` file instead of an extra artifact ZIP wrapper.
+Preview artifact uploads use GitHub's single-file artifact mode so the linked download is the raw `.ipa` / `.apk` file instead of an extra artifact ZIP wrapper, while Android also publishes the older ZIP-wrapped artifact for compatibility.
 
 When `/deploy` promotes a PR preview, it reuses the existing preview Android artifacts and re-signs the preview ad hoc IPA for TestFlight when their build number is still ahead of the latest private deploy. If a newer private build has already been deployed, the workflow automatically rebuilds with a fresh build number before uploading to TestFlight and Play internal.
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -26,6 +26,18 @@ platform :ios do
   }.freeze
 
   TEAM_ID = '43AWMS3YJX'.freeze
+  SIGNING_TYPES = {
+    'appstore' => {
+      match_type: 'appstore',
+      export_method: 'app-store',
+      profile_label: 'AppStore',
+    },
+    'adhoc' => {
+      match_type: 'adhoc',
+      export_method: 'ad-hoc',
+      profile_label: 'AdHoc',
+    },
+  }.freeze
 
   private_lane :get_api_key do
     app_store_connect_api_key(
@@ -52,24 +64,36 @@ platform :ios do
     )
   end
 
+  private_lane :signing_config do |options|
+    distribution_type = (options[:distribution_type] || 'appstore').to_s
+    config = SIGNING_TYPES[distribution_type]
+    UI.user_error!(
+      "Unknown distribution_type '#{distribution_type}'. Supported types: #{SIGNING_TYPES.keys.join(', ')}",
+    ) if config.nil?
+
+    config
+  end
+
   private_lane :build_and_sign do |options|
     scheme = options[:scheme]
+    distribution_type = (options[:distribution_type] || 'appstore').to_s
+    signing = signing_config(distribution_type: distribution_type)
     app_id = APP_IDS[scheme]
     live_activity_app_id = LIVE_ACTIVITY_APP_IDS[scheme]
 
     sync_certs(
       app_identifier: [app_id, live_activity_app_id],
-      type: 'appstore',
+      type: signing[:match_type],
       readonly: false,
     )
 
-    profile_name = ENV["sigh_#{app_id}_appstore_profile-name"] ||
-                   ENV["sigh_#{app_id}_appstore_profile_name"] ||
-                   "match AppStore #{app_id}"
+    profile_name = ENV["sigh_#{app_id}_#{distribution_type}_profile-name"] ||
+                   ENV["sigh_#{app_id}_#{distribution_type}_profile_name"] ||
+                   "match #{signing[:profile_label]} #{app_id}"
     live_activity_profile_name =
-      ENV["sigh_#{live_activity_app_id}_appstore_profile-name"] ||
-      ENV["sigh_#{live_activity_app_id}_appstore_profile_name"] ||
-      "match AppStore #{live_activity_app_id}"
+      ENV["sigh_#{live_activity_app_id}_#{distribution_type}_profile-name"] ||
+      ENV["sigh_#{live_activity_app_id}_#{distribution_type}_profile_name"] ||
+      "match #{signing[:profile_label]} #{live_activity_app_id}"
 
     update_code_signing_settings(
       use_automatic_signing: false,
@@ -97,7 +121,7 @@ platform :ios do
       workspace: 'Runner.xcworkspace',
       scheme: scheme,
       configuration: "Release-#{scheme}",
-      export_method: 'app-store',
+      export_method: signing[:export_method],
       output_directory: '../build/ios/ipa',
       archive_path: '../build/ios/archive/Runner.xcarchive',
       xcargs: "DEVELOPMENT_TEAM=#{TEAM_ID}",
@@ -125,8 +149,9 @@ platform :ios do
 
   private_lane :resolved_profile_path do |options|
     app_id = options[:app_identifier]
-    profile_path = ENV["sigh_#{app_id}_appstore_profile-path"] ||
-                   ENV["sigh_#{app_id}_appstore_profile_path"]
+    distribution_type = (options[:distribution_type] || 'appstore').to_s
+    profile_path = ENV["sigh_#{app_id}_#{distribution_type}_profile-path"] ||
+                   ENV["sigh_#{app_id}_#{distribution_type}_profile_path"]
 
     UI.user_error!("Missing installed provisioning profile path for #{app_id}") if profile_path.to_s.empty?
     UI.user_error!("Provisioning profile not found at #{profile_path} for #{app_id}") unless File.exist?(profile_path)
@@ -136,8 +161,9 @@ platform :ios do
 
   private_lane :resolved_certificate_name do |options|
     app_id = options[:app_identifier]
-    certificate_name = ENV["sigh_#{app_id}_appstore_certificate-name"] ||
-                       ENV["sigh_#{app_id}_appstore_certificate_name"]
+    distribution_type = (options[:distribution_type] || 'appstore').to_s
+    certificate_name = ENV["sigh_#{app_id}_#{distribution_type}_certificate-name"] ||
+                       ENV["sigh_#{app_id}_#{distribution_type}_certificate_name"]
 
     UI.user_error!("Missing installed certificate name for #{app_id}") if certificate_name.to_s.empty?
 
@@ -240,20 +266,30 @@ platform :ios do
 
   desc 'Setup code signing for CI builds'
   lane :setup_signing do |options|
-    app_id = options[:app_identifier] || 'xyz.depollsoft.monkeyssh.private'
-    sync_certs(app_identifier: app_id, type: 'appstore')
+    scheme = options[:scheme] || 'Private'
+    distribution_type = (options[:distribution_type] || 'appstore').to_s
+    signing = signing_config(distribution_type: distribution_type)
+    app_id = APP_IDS[scheme]
+    live_activity_app_id = LIVE_ACTIVITY_APP_IDS[scheme]
+
+    sync_certs(
+      app_identifier: [app_id, live_activity_app_id],
+      type: signing[:match_type],
+    )
   end
 
   desc 'Build and sign an IPA without uploading it'
   lane :build_ipa do |options|
     scheme = options[:scheme] || 'Private'
-    build_and_sign(scheme: scheme)
+    distribution_type = (options[:distribution_type] || 'appstore').to_s
+    build_and_sign(scheme: scheme, distribution_type: distribution_type)
   end
 
-  desc 'Re-sign an existing IPA for App Store Connect upload'
+  desc 'Re-sign an existing IPA for App Store Connect or ad hoc distribution'
   lane :resign_ipa do |options|
     scheme = options[:scheme] || 'Private'
-    unsigned_ipa_path = options[:unsigned_ipa_path].to_s
+    distribution_type = (options[:distribution_type] || 'appstore').to_s
+    source_ipa_path = options[:source_ipa_path].to_s
     output_ipa_path = options[:output_ipa_path].to_s
     supported_schemes = APP_IDS.keys & LIVE_ACTIVITY_APP_IDS.keys
     unless APP_IDS.key?(scheme) && LIVE_ACTIVITY_APP_IDS.key?(scheme)
@@ -262,27 +298,36 @@ platform :ios do
     app_id = APP_IDS[scheme]
     live_activity_app_id = LIVE_ACTIVITY_APP_IDS[scheme]
 
-    UI.user_error!('unsigned_ipa_path is required') if unsigned_ipa_path.empty?
-    unsigned_ipa_path = File.expand_path(unsigned_ipa_path)
+    UI.user_error!('source_ipa_path is required') if source_ipa_path.empty?
+    source_ipa_path = File.expand_path(source_ipa_path)
     output_ipa_path = File.expand_path(output_ipa_path) unless output_ipa_path.empty?
-    UI.user_error!("IPA not found at #{unsigned_ipa_path}") unless File.exist?(unsigned_ipa_path)
+    UI.user_error!("IPA not found at #{source_ipa_path}") unless File.exist?(source_ipa_path)
 
     sync_certs(
       app_identifier: [app_id, live_activity_app_id],
-      type: 'appstore',
+      type: signing_config(distribution_type: distribution_type)[:match_type],
       readonly: false,
     )
 
-    resigned_ipa_path = unsigned_ipa_path
+    resigned_ipa_path = source_ipa_path
     unless output_ipa_path.empty?
       FileUtils.mkdir_p(File.dirname(output_ipa_path))
-      FileUtils.cp(unsigned_ipa_path, output_ipa_path)
+      FileUtils.cp(source_ipa_path, output_ipa_path)
       resigned_ipa_path = output_ipa_path
     end
 
-    signing_identity = resolved_certificate_name(app_identifier: app_id)
-    app_profile_path = resolved_profile_path(app_identifier: app_id)
-    live_activity_profile_path = resolved_profile_path(app_identifier: live_activity_app_id)
+    signing_identity = resolved_certificate_name(
+      app_identifier: app_id,
+      distribution_type: distribution_type,
+    )
+    app_profile_path = resolved_profile_path(
+      app_identifier: app_id,
+      distribution_type: distribution_type,
+    )
+    live_activity_profile_path = resolved_profile_path(
+      app_identifier: live_activity_app_id,
+      distribution_type: distribution_type,
+    )
 
     Dir.mktmpdir('flutty-resign-ipa') do |tmpdir|
       sh("unzip -q #{resigned_ipa_path.shellescape} -d #{tmpdir.shellescape}")

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -275,6 +275,7 @@ platform :ios do
     sync_certs(
       app_identifier: [app_id, live_activity_app_id],
       type: signing[:match_type],
+      readonly: false,
     )
   end
 

--- a/scripts/package_unsigned_ipa.sh
+++ b/scripts/package_unsigned_ipa.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Packages a Flutter iOS device build into an unsigned IPA.
+
+set -euo pipefail
+
+BUILD_DIR=${1:-build/ios/iphoneos}
+OUTPUT_PATH=${2:-build/ios/ipa/Runner-unsigned.ipa}
+OUTPUT_DIR=$(dirname "$OUTPUT_PATH")
+STAGING_DIR="$(dirname "$OUTPUT_DIR")/unsigned"
+
+APP_PATH=$(find "$BUILD_DIR" -maxdepth 1 -name '*.app' -type d -print -quit)
+if [ -z "$APP_PATH" ]; then
+    echo "Expected a built .app bundle under $BUILD_DIR, but none was found."
+    ls -la "$BUILD_DIR" || true
+    exit 1
+fi
+APP_BUNDLE_NAME=$(basename "$APP_PATH")
+
+bundle_executable_path() {
+    local bundle_path="$1"
+    local info_plist="$bundle_path/Info.plist"
+    if [ ! -f "$info_plist" ]; then
+        echo "Expected Info.plist at $info_plist" >&2
+        return 1
+    fi
+
+    /usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$info_plist"
+}
+
+add_swift_scan_args() {
+    local bundle_path="$1"
+    local executable_name
+    executable_name=$(bundle_executable_path "$bundle_path")
+    SWIFT_SCAN_ARGS+=("--scan-executable" "$bundle_path/$executable_name")
+
+    if [ -d "$bundle_path/Frameworks" ]; then
+        SWIFT_SCAN_ARGS+=("--scan-folder" "$bundle_path/Frameworks")
+    fi
+}
+
+rm -rf "$STAGING_DIR"
+mkdir -p "$STAGING_DIR/Payload" "$OUTPUT_DIR"
+OUTPUT_PATH="$(cd "$OUTPUT_DIR" && pwd)/$(basename "$OUTPUT_PATH")"
+ditto "$APP_PATH" "$STAGING_DIR/Payload/$APP_BUNDLE_NAME"
+
+SWIFT_SUPPORT_DIR="$STAGING_DIR/SwiftSupport/iphoneos"
+mkdir -p "$SWIFT_SUPPORT_DIR"
+declare -a SWIFT_SCAN_ARGS=()
+add_swift_scan_args "$STAGING_DIR/Payload/$APP_BUNDLE_NAME"
+if [ -d "$STAGING_DIR/Payload/$APP_BUNDLE_NAME/PlugIns" ]; then
+    while IFS= read -r -d '' appex_path; do
+        add_swift_scan_args "$appex_path"
+    done < <(find "$STAGING_DIR/Payload/$APP_BUNDLE_NAME/PlugIns" -mindepth 1 -maxdepth 1 -name '*.appex' -type d -print0)
+fi
+xcrun swift-stdlib-tool --copy --platform iphoneos --destination "$SWIFT_SUPPORT_DIR" "${SWIFT_SCAN_ARGS[@]}"
+if ! find "$SWIFT_SUPPORT_DIR" -type f | grep -q .; then
+    rm -rf "$STAGING_DIR/SwiftSupport"
+fi
+
+(
+    cd "$STAGING_DIR"
+    zip_inputs=(Payload)
+    if [ -d SwiftSupport ]; then
+        zip_inputs+=(SwiftSupport)
+    fi
+    zip -qry "$OUTPUT_PATH" "${zip_inputs[@]}"
+)


### PR DESCRIPTION
## Summary

- publish APK artifacts from the shared mobile build workflow for both preview and deploy paths
- package unsigned CI iOS builds as IPAs instead of uploading the raw `.app` bundle
- keep preview deploy artifact reuse working while preserving direct IPA/APK artifacts and uncompressed uploads
