### PR TITLE
fix: align build workflow permissions

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -174,7 +174,6 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: write
 
 jobs:
   build-android:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -45,6 +45,10 @@ jobs:
   deploy:
     name: Build & Deploy Private
     needs: compute-version
+    permissions:
+      actions: read
+      contents: read
+      issues: write
     uses: ./.github/workflows/build-deploy.yml
     with:
       build-name: ${{ needs.compute-version.outputs.build-name }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -128,6 +128,10 @@ jobs:
     name: Build Android Preview
     needs: compute-version
     if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      actions: read
+      contents: read
+      issues: write
     uses: ./.github/workflows/build-deploy.yml
     with:
       build-name: ${{ needs.compute-version.outputs.build-name }}
@@ -147,6 +151,10 @@ jobs:
     name: Build iOS Preview
     needs: compute-version
     if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      actions: read
+      contents: read
+      issues: write
     uses: ./.github/workflows/build-deploy.yml
     with:
       build-name: ${{ needs.compute-version.outputs.build-name }}

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -55,6 +55,10 @@ jobs:
   deploy:
     name: Build & Deploy Internal Release
     needs: compute-version
+    permissions:
+      actions: read
+      contents: read
+      issues: write
     uses: ./.github/workflows/build-deploy.yml
     with:
       build-name: ${{ needs.compute-version.outputs.build-name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,10 @@ jobs:
   deploy:
     name: Build & Deploy Release
     needs: compute-version
+    permissions:
+      actions: read
+      contents: read
+      issues: write
     uses: ./.github/workflows/build-deploy.yml
     with:
       build-name: ${{ needs.compute-version.outputs.build-name }}


### PR DESCRIPTION
## Summary

- fix the reusable workflow permission mismatch that caused `release-internal` to fail with `startup_failure` before jobs started
- remove the unused `pull-requests: write` scope from `build-deploy.yml`
- grant the matching `issues: write` scope from each caller that invokes `build-deploy.yml`

## Validation

- ran `actionlint` on the updated workflow set (ignoring the existing custom runner label warning for `ubicloud-standard-4`)
