### PR TITLE
fix(terminal): stop over-lifting Pro upsell snackbar above keyboard toolbar

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1112,16 +1112,20 @@ double selectionActionsBottomOffset(MediaQueryData mediaQuery) =>
     _selectionActionsBottomPadding + mediaQuery.padding.bottom;
 
 /// Keeps the Pro upsell snackbar tucked just above the visible bottom chrome.
+///
+/// Flutter's floating [SnackBar] already anchors itself above the keyboard
+/// inset and the bottom safe area (see `Scaffold`'s snack bar layout, which
+/// uses `min(contentBottom, size.height - viewPadding.bottom)`). The only
+/// bottom chrome the scaffold does not know about is the in-body keyboard
+/// toolbar that sits inside the body `Column`, so the margin only needs to
+/// clear that toolbar with a small visual gap.
 @visibleForTesting
 double upgradeSnackBarBottomMargin(
   MediaQueryData mediaQuery, {
   bool showKeyboardToolbar = false,
-  double keyboardToolbarHeight = 96,
+  double keyboardToolbarHeight = 84,
   double baseSpacing = 16,
-}) =>
-    mediaQuery.padding.bottom +
-    (showKeyboardToolbar ? keyboardToolbarHeight : 0) +
-    baseSpacing;
+}) => (showKeyboardToolbar ? keyboardToolbarHeight : 0) + baseSpacing;
 
 /// Resolves the transient indicator label for a terminal double-tap Tab gesture.
 @visibleForTesting

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -18,10 +18,13 @@ void main() {
     test('positions the upsell snackbar above visible bottom chrome only', () {
       const mediaQuery = MediaQueryData(padding: EdgeInsets.only(bottom: 34));
 
-      expect(upgradeSnackBarBottomMargin(mediaQuery), 50);
+      // Flutter's floating SnackBar already lifts above the home-indicator
+      // safe area, so the margin just needs a small visual gap when there is
+      // no in-body keyboard toolbar to clear.
+      expect(upgradeSnackBarBottomMargin(mediaQuery), 16);
       expect(
         upgradeSnackBarBottomMargin(mediaQuery, showKeyboardToolbar: true),
-        146,
+        100,
       );
     });
 


### PR DESCRIPTION
## Summary

The Pro upsell snackbar shown when a non-Pro user triggers `_runAutoConnectCommand` was floating noticeably high above the in-body keyboard toolbar when the soft keyboard was open.

## Root cause

`upgradeSnackBarBottomMargin` was over-lifting the floating `SnackBar` for two reasons:

1. **Double-counting the bottom safe area.** Flutter's floating `SnackBar` is already positioned by the `Scaffold` at `min(contentBottom, size.height - viewPadding.bottom)` (see `flutter/lib/src/material/scaffold.dart`), which already clears the home-indicator safe area. Adding `MediaQuery.padding.bottom` in our margin re-applied that offset.
2. **Inflated keyboard toolbar height constant.** The constant was `96`, but `KeyboardToolbar` is built from two `_KeyRow`s of `height: 42` (84px total), with its own `SafeArea` handling the bottom inset when the keyboard is hidden.

## Fix

Margin now only clears the in-body keyboard toolbar with a 16px visual gap:

```dart
(showKeyboardToolbar ? 84 : 0) + 16
```

The Scaffold continues to handle keyboard insets and the home-indicator safe area on its own.

## Tests

Updated `terminal_screen_layout_test.dart` to reflect the new expected values (16 / 100 instead of 50 / 146). Full `flutter test` pre-commit suite passes.

## Before

Toast appeared way above the keyboard toolbar with a large empty gap (see screenshot in the issue chat).

## After

Toast sits ~16px above the keyboard toolbar.
