### PR TITLE
feat: lifetime IAP redeemable via store promo codes

### DIFF
--- a/lib/domain/models/monetization.dart
+++ b/lib/domain/models/monetization.dart
@@ -18,26 +18,61 @@ abstract final class MonetizationProductIds {
   /// Apple App Store annual subscription product for the production app.
   static const iosAnnualProd = 'monkeyssh_pro_annual_prod';
 
+  /// Google Play one-time lifetime product.
+  ///
+  /// This product is intentionally never displayed in the in-app paywall.
+  /// It is distributed exclusively via Google Play promo codes redeemed
+  /// outside of the app and surfaces in the app through the store
+  /// purchase/restore flow.
+  static const androidProLifetime = 'monkeyssh_pro_lifetime';
+
+  /// Apple App Store non-consumable lifetime product for the preview app.
+  ///
+  /// Distributed exclusively via App Store offer/promo codes and surfaces
+  /// in the app via the store purchase/restore flow.
+  static const iosProLifetime = 'monkeyssh_pro_lifetime';
+
+  /// Apple App Store non-consumable lifetime product for the production app.
+  ///
+  /// Distributed exclusively via App Store offer/promo codes and surfaces
+  /// in the app via the store purchase/restore flow.
+  static const iosProLifetimeProd = 'monkeyssh_pro_lifetime_prod';
+
   /// All recognized paid products across platforms.
+  // The Android lifetime SKU and the iOS preview lifetime SKU share the
+  // same product identifier on purpose; we only list each unique string
+  // once to keep this a valid `const` set literal.
   static const allKnown = <String>{
     androidPro,
     iosMonthly,
     iosAnnual,
     iosMonthlyProd,
     iosAnnualProd,
+    androidProLifetime,
+    iosProLifetimeProd,
   };
+
+  /// All recognized lifetime (one-time) product identifiers.
+  // Same identifier sharing applies as in [allKnown].
+  static const allLifetime = <String>{androidProLifetime, iosProLifetimeProd};
 
   /// Product identifiers to query on the current platform.
   static Set<String> forPlatform(TargetPlatform platform) => switch (platform) {
-    TargetPlatform.android => const {androidPro},
+    TargetPlatform.android => const {androidPro, androidProLifetime},
     TargetPlatform.iOS || TargetPlatform.macOS => const {
       iosMonthly,
       iosAnnual,
       iosMonthlyProd,
       iosAnnualProd,
+      iosProLifetime,
+      iosProLifetimeProd,
     },
     _ => const {},
   };
+
+  /// Whether [productId] identifies a lifetime (one-time) product.
+  static bool isLifetime(String? productId) =>
+      productId != null && allLifetime.contains(productId);
 }
 
 /// Premium features controlled by MonkeySSH Pro.
@@ -107,6 +142,9 @@ enum MonetizationBillingPeriod {
   /// Annual billing cadence.
   annual,
 
+  /// One-time, lifetime purchase (no recurring billing).
+  lifetime,
+
   /// A billing cadence that could not be identified.
   unknown,
 }
@@ -117,6 +155,7 @@ extension MonetizationBillingPeriodPresentation on MonetizationBillingPeriod {
   String get label => switch (this) {
     MonetizationBillingPeriod.monthly => 'Monthly',
     MonetizationBillingPeriod.annual => 'Annual',
+    MonetizationBillingPeriod.lifetime => 'Lifetime',
     MonetizationBillingPeriod.unknown => 'MonkeySSH Pro',
   };
 
@@ -124,6 +163,7 @@ extension MonetizationBillingPeriodPresentation on MonetizationBillingPeriod {
   String get billingSuffix => switch (this) {
     MonetizationBillingPeriod.monthly => 'month',
     MonetizationBillingPeriod.annual => 'year',
+    MonetizationBillingPeriod.lifetime => 'lifetime',
     MonetizationBillingPeriod.unknown => 'billing period',
   };
 }
@@ -258,6 +298,15 @@ class MonetizationState {
 
   /// Whether MonkeySSH Pro is currently unlocked.
   bool get isProUnlocked => entitlements.proUnlocked;
+
+  /// Whether the active product is the lifetime (one-time) purchase.
+  ///
+  /// `true` only when [isProUnlocked] is `true` and [activeProductId]
+  /// matches a known lifetime SKU. The lifetime product is intentionally
+  /// not exposed in the in-app paywall, so this is the canonical signal
+  /// for UI surfaces that need to render lifetime-specific copy.
+  bool get isLifetimeUnlocked =>
+      isProUnlocked && MonetizationProductIds.isLifetime(activeProductId);
 
   /// Default offer to preselect on the paywall, if any.
   MonetizationOffer? get defaultOffer =>

--- a/lib/domain/services/monetization_service.dart
+++ b/lib/domain/services/monetization_service.dart
@@ -387,9 +387,15 @@ class MonetizationService {
   }
 
   Future<void> _handleSuccessfulPurchase(PurchaseDetails purchase) async {
+    final isLifetime = MonetizationProductIds.isLifetime(purchase.productID);
+    final successMessage = isLifetime
+        ? (purchase.status == PurchaseStatus.restored
+              ? 'Restored MonkeySSH Pro Lifetime.'
+              : 'MonkeySSH Pro Lifetime activated.')
+        : 'MonkeySSH Pro unlocked.';
     final result = await _applySuccessfulPurchase(
       purchase,
-      successMessage: 'MonkeySSH Pro unlocked.',
+      successMessage: successMessage,
     );
     _resolvePendingPurchase(result);
   }
@@ -535,9 +541,14 @@ class MonetizationService {
             : latest,
       );
 
+      final isLifetime = MonetizationProductIds.isLifetime(
+        latestPurchase.productID,
+      );
       return _applySuccessfulPurchase(
         latestPurchase,
-        successMessage: 'Restored MonkeySSH Pro subscription.',
+        successMessage: isLifetime
+            ? 'Restored MonkeySSH Pro Lifetime.'
+            : 'Restored MonkeySSH Pro subscription.',
       );
     } finally {
       _restoreInFlight = false;
@@ -666,16 +677,25 @@ _MonetizationCatalog _buildMonetizationCatalog(
   );
 }
 
-_CatalogOfferCandidate? _buildCatalogOfferCandidate(ProductDetails details) =>
-    switch (details) {
-      final GooglePlayProductDetails googlePlayDetails =>
-        _buildGooglePlayOfferCandidate(googlePlayDetails),
-      final AppStoreProductDetails appStoreDetails =>
-        _buildAppStoreOfferCandidate(appStoreDetails),
-      final AppStoreProduct2Details appStore2Details =>
-        _buildAppStore2OfferCandidate(appStore2Details),
-      _ => _buildFallbackOfferCandidate(details),
-    };
+_CatalogOfferCandidate? _buildCatalogOfferCandidate(ProductDetails details) {
+  // Lifetime products are intentionally never displayed in the paywall.
+  // They are distributed exclusively via store promo/offer codes redeemed
+  // outside the app and surface in the app via the purchase / restore
+  // flow, where they update the entitlement directly without going
+  // through `MonetizationState.offers`.
+  if (MonetizationProductIds.isLifetime(details.id)) {
+    return null;
+  }
+  return switch (details) {
+    final GooglePlayProductDetails googlePlayDetails =>
+      _buildGooglePlayOfferCandidate(googlePlayDetails),
+    final AppStoreProductDetails appStoreDetails =>
+      _buildAppStoreOfferCandidate(appStoreDetails),
+    final AppStoreProduct2Details appStore2Details =>
+      _buildAppStore2OfferCandidate(appStore2Details),
+    _ => _buildFallbackOfferCandidate(details),
+  };
+}
 
 _CatalogOfferCandidate? _buildGooglePlayOfferCandidate(
   GooglePlayProductDetails details,
@@ -830,7 +850,8 @@ int _billingPeriodSortOrder(MonetizationBillingPeriod billingPeriod) =>
     switch (billingPeriod) {
       MonetizationBillingPeriod.monthly => 0,
       MonetizationBillingPeriod.annual => 1,
-      MonetizationBillingPeriod.unknown => 2,
+      MonetizationBillingPeriod.lifetime => 2,
+      MonetizationBillingPeriod.unknown => 3,
     };
 
 PricingPhaseWrapper _findRecurringPricingPhase(
@@ -920,6 +941,7 @@ String _buildDisplayPriceLabel(
 ) => switch (billingPeriod) {
   MonetizationBillingPeriod.monthly => '$priceLabel / month',
   MonetizationBillingPeriod.annual => '$priceLabel / year',
+  MonetizationBillingPeriod.lifetime => '$priceLabel — one-time',
   MonetizationBillingPeriod.unknown => priceLabel,
 };
 
@@ -927,6 +949,7 @@ String? _defaultOfferDetailLabel(MonetizationBillingPeriod billingPeriod) =>
     switch (billingPeriod) {
       MonetizationBillingPeriod.monthly => 'Billed monthly',
       MonetizationBillingPeriod.annual => 'Billed yearly',
+      MonetizationBillingPeriod.lifetime => 'One-time purchase',
       MonetizationBillingPeriod.unknown => null,
     };
 

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -90,11 +90,15 @@ class _SubscriptionSection extends ConsumerWidget {
           title: const Text('Subscription'),
           subtitle: Text(
             state.isProUnlocked
-                ? 'Unlocked on this device'
+                ? state.isLifetimeUnlocked
+                      ? 'Lifetime — unlocked on this device'
+                      : 'Unlocked on this device'
                 : 'Unlock transfers, automation, and agent launch presets',
           ),
           trailing: state.isProUnlocked
-              ? const PremiumBadge(label: 'Active')
+              ? PremiumBadge(
+                  label: state.isLifetimeUnlocked ? 'Lifetime' : 'Active',
+                )
               : const PremiumBadge(),
           onTap: () => context.pushNamed(Routes.upgrade),
         ),

--- a/lib/presentation/screens/upgrade_screen.dart
+++ b/lib/presentation/screens/upgrade_screen.dart
@@ -334,12 +334,14 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
                   ],
                   Text(
                     state.isProUnlocked
-                        ? switch (state.activeOffer) {
-                            final activeOffer? =>
-                              '${activeOffer.planLabel} is active on this device.',
-                            null =>
-                              'MonkeySSH Pro is already unlocked on this device.',
-                          }
+                        ? state.isLifetimeUnlocked
+                              ? 'MonkeySSH Pro Lifetime is unlocked on this device.'
+                              : switch (state.activeOffer) {
+                                  final activeOffer? =>
+                                    '${activeOffer.planLabel} is active on this device.',
+                                  null =>
+                                    'MonkeySSH Pro is already unlocked on this device.',
+                                }
                         : 'No trial traps, fake urgency, or hidden close buttons. You can restore or manage your subscription from Settings at any time.',
                     style: priceCardEmphasisStyle,
                   ),

--- a/test/domain/services/monetization_service_test.dart
+++ b/test/domain/services/monetization_service_test.dart
@@ -43,6 +43,8 @@ void main() {
           MonetizationProductIds.iosAnnual,
           MonetizationProductIds.iosMonthlyProd,
           MonetizationProductIds.iosAnnualProd,
+          MonetizationProductIds.iosProLifetime,
+          MonetizationProductIds.iosProLifetimeProd,
         ]),
       );
       expect(
@@ -52,6 +54,15 @@ void main() {
           MonetizationProductIds.iosAnnual,
           MonetizationProductIds.iosMonthlyProd,
           MonetizationProductIds.iosAnnualProd,
+          MonetizationProductIds.iosProLifetime,
+          MonetizationProductIds.iosProLifetimeProd,
+        ]),
+      );
+      expect(
+        MonetizationProductIds.forPlatform(TargetPlatform.android),
+        unorderedEquals([
+          MonetizationProductIds.androidPro,
+          MonetizationProductIds.androidProLifetime,
         ]),
       );
       expect(
@@ -59,8 +70,27 @@ void main() {
         containsAll({
           MonetizationProductIds.iosMonthlyProd,
           MonetizationProductIds.iosAnnualProd,
+          MonetizationProductIds.iosProLifetimeProd,
+          MonetizationProductIds.androidProLifetime,
         }),
       );
+      expect(
+        MonetizationProductIds.isLifetime(
+          MonetizationProductIds.androidProLifetime,
+        ),
+        isTrue,
+      );
+      expect(
+        MonetizationProductIds.isLifetime(
+          MonetizationProductIds.iosProLifetimeProd,
+        ),
+        isTrue,
+      );
+      expect(
+        MonetizationProductIds.isLifetime(MonetizationProductIds.androidPro),
+        isFalse,
+      );
+      expect(MonetizationProductIds.isLifetime(null), isFalse);
     },
   );
 
@@ -261,6 +291,66 @@ void main() {
 
       expect(offers.single.currencySymbol, 'USD');
     });
+
+    test('excludes lifetime products from the paywall offers list', () {
+      final offers = buildMonetizationOffers([
+        AppStoreProductDetails.fromSKProduct(
+          SKProductWrapper(
+            productIdentifier: MonetizationProductIds.iosMonthly,
+            localizedTitle: 'MonkeySSH Pro Monthly',
+            localizedDescription: 'Monthly MonkeySSH Pro subscription',
+            priceLocale: _usdPriceLocale,
+            price: '5.00',
+            subscriptionPeriod: SKProductSubscriptionPeriodWrapper(
+              numberOfUnits: 1,
+              unit: SKSubscriptionPeriodUnit.month,
+            ),
+          ),
+        ),
+        // A non-consumable lifetime App Store product has no
+        // subscriptionPeriod. It must never appear in the paywall.
+        AppStoreProductDetails.fromSKProduct(
+          SKProductWrapper(
+            productIdentifier: MonetizationProductIds.iosProLifetimeProd,
+            localizedTitle: 'MonkeySSH Pro Lifetime',
+            localizedDescription: 'Lifetime MonkeySSH Pro purchase',
+            priceLocale: _usdPriceLocale,
+            price: '99.00',
+            subscriptionPeriod: SKProductSubscriptionPeriodWrapper(
+              numberOfUnits: 0,
+              unit: SKSubscriptionPeriodUnit.month,
+            ),
+          ),
+        ),
+      ]);
+
+      expect(offers, hasLength(1));
+      expect(offers.single.productId, MonetizationProductIds.iosMonthly);
+    });
+
+    test(
+      'excludes lifetime Google Play one-time products from the paywall',
+      () {
+        final offers = buildMonetizationOffers(
+          GooglePlayProductDetails.fromProductDetails(
+            const ProductDetailsWrapper(
+              description: 'MonkeySSH Pro Lifetime',
+              name: 'MonkeySSH Pro Lifetime',
+              productId: MonetizationProductIds.androidProLifetime,
+              productType: ProductType.inapp,
+              title: 'MonkeySSH Pro Lifetime',
+              oneTimePurchaseOfferDetails: OneTimePurchaseOfferDetailsWrapper(
+                priceAmountMicros: 99000000,
+                priceCurrencyCode: 'USD',
+                formattedPrice: r'$99.00',
+              ),
+            ),
+          ),
+        );
+
+        expect(offers, isEmpty);
+      },
+    );
   });
 
   group('MonetizationService', () {
@@ -420,6 +510,89 @@ void main() {
         verify(() => inAppPurchase.isAvailable()).called(1);
       },
     );
+
+    test(
+      'purchase stream activates lifetime entitlement when a redeemed lifetime product arrives',
+      () async {
+        final service = MonetizationService(
+          settings,
+          inAppPurchase: inAppPurchase,
+          allowDebugUnlock: false,
+        );
+        addTearDown(service.dispose);
+
+        final purchase = MockPurchaseDetails();
+        when(
+          () => purchase.productID,
+        ).thenReturn(MonetizationProductIds.iosProLifetimeProd);
+        when(() => purchase.status).thenReturn(PurchaseStatus.purchased);
+        when(() => purchase.pendingCompletePurchase).thenReturn(true);
+        when(() => purchase.transactionDate).thenReturn('1712732400000');
+        when(
+          () => inAppPurchase.completePurchase(purchase),
+        ).thenAnswer((_) async {});
+
+        await service.initialize();
+        purchaseController.add([purchase]);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        expect(service.currentState.isProUnlocked, isTrue);
+        expect(service.currentState.isLifetimeUnlocked, isTrue);
+        expect(
+          service.currentState.activeProductId,
+          MonetizationProductIds.iosProLifetimeProd,
+        );
+        expect(service.currentState.activeOfferId, isNull);
+        expect(
+          await settings.getString(SettingKeys.monetizationActiveProductId),
+          MonetizationProductIds.iosProLifetimeProd,
+        );
+        verify(() => inAppPurchase.completePurchase(purchase)).called(1);
+      },
+    );
+
+    test('restored lifetime purchase from Google Play unlocks pro', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      when(() => inAppPurchase.isAvailable()).thenAnswer((_) async => true);
+      when(() => inAppPurchase.queryProductDetails(any())).thenAnswer(
+        (_) async => ProductDetailsResponse(
+          productDetails: const [],
+          notFoundIDs: const [],
+        ),
+      );
+      when(androidPlatformAddition.queryPastPurchases).thenAnswer(
+        (_) async => QueryPurchaseDetailsResponse(
+          pastPurchases: [
+            _androidPastLifetimePurchase(purchaseTimeMillis: 1712732400000),
+          ],
+        ),
+      );
+
+      final service = MonetizationService(
+        settings,
+        inAppPurchase: inAppPurchase,
+        androidPlatformAddition: androidPlatformAddition,
+        allowDebugUnlock: false,
+      );
+      addTearDown(service.dispose);
+
+      final result = await service.restorePurchases();
+
+      expect(result.success, isTrue);
+      expect(result.message, contains('Lifetime'));
+      expect(service.currentState.isProUnlocked, isTrue);
+      expect(service.currentState.isLifetimeUnlocked, isTrue);
+      expect(
+        service.currentState.activeProductId,
+        MonetizationProductIds.androidProLifetime,
+      );
+      expect(
+        await settings.getBool(SettingKeys.monetizationProUnlocked),
+        isTrue,
+      );
+    });
 
     test(
       'purchase stream updates cached entitlements after a purchase',
@@ -951,6 +1124,32 @@ GooglePlayPurchaseDetails _androidPastPurchase({
     signature: 'signature',
     products: const [MonetizationProductIds.androidPro],
     isAutoRenewing: true,
+    originalJson: '{}',
+    isAcknowledged: true,
+    purchaseState: PurchaseStateWrapper.purchased,
+  ),
+  status: PurchaseStatus.restored,
+);
+
+GooglePlayPurchaseDetails _androidPastLifetimePurchase({
+  required int purchaseTimeMillis,
+}) => GooglePlayPurchaseDetails(
+  purchaseID: 'lifetime-$purchaseTimeMillis',
+  productID: MonetizationProductIds.androidProLifetime,
+  verificationData: PurchaseVerificationData(
+    localVerificationData: 'local-verification-data',
+    serverVerificationData: 'server-verification-data',
+    source: 'google_play',
+  ),
+  transactionDate: purchaseTimeMillis.toString(),
+  billingClientPurchase: PurchaseWrapper(
+    orderId: 'lifetime-$purchaseTimeMillis',
+    packageName: 'xyz.depollsoft.monkeyssh',
+    purchaseTime: purchaseTimeMillis,
+    purchaseToken: 'token-$purchaseTimeMillis',
+    signature: 'signature',
+    products: const [MonetizationProductIds.androidProLifetime],
+    isAutoRenewing: false,
     originalJson: '{}',
     isAcknowledged: true,
     purchaseState: PurchaseStateWrapper.purchased,

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -140,6 +140,24 @@ void main() {
       expect(find.text('Active'), findsOneWidget);
     });
 
+    testWidgets('shows lifetime state when Pro is unlocked via lifetime SKU', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final settings = SettingsService(db);
+      await settings.setBool(SettingKeys.monetizationProUnlocked, value: true);
+      await settings.setString(
+        SettingKeys.monetizationActiveProductId,
+        'monkeyssh_pro_lifetime_prod',
+      );
+
+      await _pumpSettingsScreen(tester, db: db);
+
+      expect(find.text('Lifetime — unlocked on this device'), findsOneWidget);
+      expect(find.text('Lifetime'), findsOneWidget);
+    });
+
     testWidgets('displays theme option', (tester) async {
       final db = AppDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);

--- a/test/widget/upgrade_screen_test.dart
+++ b/test/widget/upgrade_screen_test.dart
@@ -389,4 +389,67 @@ void main() {
     expect(find.textContaining('Processing your request with'), findsOneWidget);
     expect(find.byType(LinearProgressIndicator), findsOneWidget);
   });
+
+  testWidgets(
+    'shows lifetime active copy and never offers a lifetime plan card',
+    (tester) async {
+      final service = _MockMonetizationService();
+      const state = MonetizationState(
+        billingAvailability: MonetizationBillingAvailability.available,
+        entitlements: MonetizationEntitlements.pro(),
+        offers: [
+          MonetizationOffer(
+            id: 'monthly',
+            productId: 'monkeyssh_pro_monthly',
+            billingPeriod: MonetizationBillingPeriod.monthly,
+            planLabel: 'Monthly',
+            priceLabel: r'$5.00',
+            displayPriceLabel: r'$5.00 / month',
+            rawPrice: 5,
+            currencyCode: 'USD',
+            currencySymbol: r'$',
+          ),
+        ],
+        debugUnlockAvailable: false,
+        debugUnlocked: false,
+        activeProductId: 'monkeyssh_pro_lifetime_prod',
+      );
+
+      when(() => service.currentState).thenReturn(state);
+      when(
+        () => service.purchaseOffer(any()),
+      ).thenAnswer(_cancelledPurchaseResult);
+      _stubRestorePurchases(service);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            monetizationServiceProvider.overrideWithValue(service),
+            monetizationStateProvider.overrideWith(
+              (ref) => Stream.value(state),
+            ),
+          ],
+          child: const MaterialApp(home: UpgradeScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.dragUntilVisible(
+        find.text('MonkeySSH Pro Lifetime is unlocked on this device.'),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('MonkeySSH Pro Lifetime is unlocked on this device.'),
+        findsOneWidget,
+      );
+      // Lifetime is never offered as a buyable plan card in the paywall;
+      // the only "Lifetime" text on screen comes from the active-state
+      // copy verified above.
+      expect(find.text('Lifetime'), findsNothing);
+      expect(find.text('Subscribe lifetime'), findsNothing);
+      expect(find.text('Switch to Lifetime'), findsNothing);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Adds a **lifetime "Pro" purchase** that exists in the App Store and Google Play but is **never displayed in the in-app paywall**. Users acquire it exclusively by redeeming an App Store offer code or Google Play promo code (URLs you share). The app picks up the entitlement via the existing purchase stream / Restore Purchases flow.

## Why this design

You asked for a way to sell a one-time lifetime upgrade that isn't browsable in the app — only obtainable via a link you share. Apple's Offer Codes and Google Play's promo codes are designed for exactly this:

- `https://apps.apple.com/redeem?ctx=offercodes&id=<APP_ID>&code=<CODE>`
- `https://play.google.com/redeem?code=<CODE>`

No in-app purchase UI needed. The product is registered with both stores so receipts are valid, but the app never builds a "Lifetime" plan card.

## What changed

- **`MonetizationProductIds`**: new `androidProLifetime`, `iosProLifetime`, `iosProLifetimeProd`, `allLifetime`, `isLifetime()` helper. Lifetime IDs included in `forPlatform` so `queryProductDetails` knows about them.
- **`MonetizationBillingPeriod.lifetime`**: new enum value with sort order, label, billing suffix, display-price suffix ("— one-time"), and detail label ("One-time purchase"). All exhaustive switches updated.
- **Catalog builder**: `_buildCatalogOfferCandidate` returns `null` for any lifetime SKU, so they're filtered out of `MonetizationState.offers` (the paywall list).
- **`MonetizationState.isLifetimeUnlocked`**: derived getter (proUnlocked && active product is a lifetime SKU).
- **Purchase flow**: `_handleSuccessfulPurchase` and `_restoreAndroidPurchases` use lifetime-specific success messages.
- **Settings screen**: shows "Lifetime — unlocked on this device" and a "Lifetime" badge when active.
- **Upgrade screen**: shows "MonkeySSH Pro Lifetime is unlocked on this device." in the active-state copy when applicable. Lifetime never appears as a buyable card.
- **Tests**: ID surface (`forPlatform`/`allKnown`/`isLifetime`), paywall exclusion for both iOS non-consumable and Android one-time products, lifetime entitlement activation via the purchase stream, Android restore picking up a past lifetime purchase, and widget tests for the new settings + upgrade screen copy.

## Manual store setup (required before this ships)

This PR is the app-side wiring only. You still need to:

### App Store Connect

1. Create non-consumable IAPs with product IDs:
   - `monkeyssh_pro_lifetime` (preview app)
   - `monkeyssh_pro_lifetime_prod` (production app)
2. Submit for review (can be reviewed in the same submission as a build update).
3. Generate **Offer Codes** for the production product. Distribute the generated URL.

### Google Play Console

1. Create a one-time in-app product (not a subscription) with product ID `monkeyssh_pro_lifetime`.
2. Generate **promo codes** under Monetization → Promo codes. Distribute the generated URL.

## App review notes

Apple may ask where the IAP is sold since it isn't visible in the app. The standard answer is that it's redemption-only via App Store Offer Codes — that's an accepted distribution model and doesn't require external-purchase entitlements.

## Validation

- `flutter analyze` — no issues.
- `dart format .` — clean.
- `flutter test` — all 1281 tests pass (including new coverage).

## Out of scope

- Family Sharing toggling.
- Refund / revocation handling beyond what the existing service does.
- An in-app deep link to trigger the purchase directly (intentionally not added — the goal is no in-app surface).
