### PR TITLE
fix: respect Android terminal safe insets

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -105,6 +105,17 @@ String? resolvePreferredTmuxSessionName({
   String? autoConnectCommand,
 }) => structuredSessionName ?? parseTmuxSessionName(autoConnectCommand);
 
+/// Resolves the safe-area insets the tmux bar should stay within.
+@visibleForTesting
+EdgeInsets resolveTmuxBarSafeInsets(MediaQueryData mediaQuery) {
+  final horizontalInsets = resolveTerminalRenderPadding(mediaQuery);
+  return EdgeInsets.only(
+    left: horizontalInsets.left,
+    right: horizontalInsets.right,
+    bottom: mediaQuery.padding.bottom,
+  );
+}
+
 /// Resolves the tmux bar's vertical offset from the animated bottom padding.
 @visibleForTesting
 double resolveTmuxBarRevealBottomOffset(
@@ -3392,55 +3403,67 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _isTmuxActive &&
         _showTmuxBar &&
         connectionState == SshConnectionState.connected;
-    final targetBottomPadding = showTmux
-        ? _TmuxExpandableBar.handleHeight
-        : 0.0;
 
     return LayoutBuilder(
-      builder: (context, constraints) => TweenAnimationBuilder<double>(
-        tween: Tween<double>(end: targetBottomPadding),
-        duration: _tmuxBarRevealDuration,
-        curve: Curves.easeOutCubic,
-        child: _buildTmuxExpandableBar(theme, constraints.maxHeight),
-        builder: (context, animatedBottomPadding, child) {
-          final barOpacity = resolveTmuxBarRevealOpacity(animatedBottomPadding);
+      builder: (context, constraints) {
+        final tmuxBarSafeInsets = resolveTmuxBarSafeInsets(
+          MediaQuery.of(context),
+        );
+        final targetBottomPadding = showTmux
+            ? _TmuxExpandableBar.handleHeight + tmuxBarSafeInsets.bottom
+            : 0.0;
+        final availableHeight = max(
+          0,
+          constraints.maxHeight - tmuxBarSafeInsets.bottom,
+        ).toDouble();
 
-          return Stack(
-            children: [
-              // Reserve actual layout space for the collapsed handle so the
-              // terminal viewport ends exactly at the handle boundary.
-              Positioned.fill(
-                child: ColoredBox(
-                  color: terminalTheme.background,
-                  child: Column(
-                    children: [
-                      Expanded(
-                        child: _buildTerminalView(terminalTheme, isMobile),
-                      ),
-                      SizedBox(height: animatedBottomPadding),
-                    ],
-                  ),
-                ),
-              ),
-              if (showTmux || animatedBottomPadding > 0)
-                Positioned(
-                  left: 0,
-                  right: 0,
-                  bottom: resolveTmuxBarRevealBottomOffset(
-                    animatedBottomPadding,
-                  ),
-                  child: IgnorePointer(
-                    ignoring: barOpacity == 0,
-                    child: Opacity(
-                      opacity: barOpacity,
-                      child: child ?? const SizedBox.shrink(),
+        return TweenAnimationBuilder<double>(
+          tween: Tween<double>(end: targetBottomPadding),
+          duration: _tmuxBarRevealDuration,
+          curve: Curves.easeOutCubic,
+          child: _buildTmuxExpandableBar(theme, availableHeight),
+          builder: (context, animatedBottomPadding, child) {
+            final barOpacity = resolveTmuxBarRevealOpacity(
+              animatedBottomPadding,
+            );
+
+            return Stack(
+              children: [
+                // Reserve actual layout space for the collapsed handle so the
+                // terminal viewport ends exactly at the handle boundary.
+                Positioned.fill(
+                  child: ColoredBox(
+                    color: terminalTheme.background,
+                    child: Column(
+                      children: [
+                        Expanded(
+                          child: _buildTerminalView(terminalTheme, isMobile),
+                        ),
+                        SizedBox(height: animatedBottomPadding),
+                      ],
                     ),
                   ),
                 ),
-            ],
-          );
-        },
-      ),
+                if (showTmux || animatedBottomPadding > 0)
+                  Positioned(
+                    left: tmuxBarSafeInsets.left,
+                    right: tmuxBarSafeInsets.right,
+                    bottom: resolveTmuxBarRevealBottomOffset(
+                      animatedBottomPadding,
+                    ),
+                    child: IgnorePointer(
+                      ignoring: barOpacity == 0,
+                      child: Opacity(
+                        opacity: barOpacity,
+                        child: child ?? const SizedBox.shrink(),
+                      ),
+                    ),
+                  ),
+              ],
+            );
+          },
+        );
+      },
     );
   }
 

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -4,6 +4,7 @@
 // ignore_for_file: implementation_imports, public_member_api_docs, directives_ordering, always_put_required_named_parameters_first, cast_nullable_to_non_nullable, prefer_expression_function_bodies, sort_child_properties_last, use_if_null_to_convert_nulls_to_bools, avoid_bool_literals_in_conditional_expressions
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -39,10 +40,50 @@ EdgeInsets resolveTerminalRenderPadding(MediaQueryData mediaQuery) {
   if (!isLandscape) {
     return EdgeInsets.zero;
   }
-  return EdgeInsets.only(
-    left: mediaQuery.padding.left,
-    right: mediaQuery.padding.right,
+  final leftInset = math.max(
+    mediaQuery.padding.left,
+    mediaQuery.viewPadding.left,
   );
+  final rightInset = math.max(
+    mediaQuery.padding.right,
+    mediaQuery.viewPadding.right,
+  );
+  return EdgeInsets.only(left: leftInset, right: rightInset);
+}
+
+/// Terminal viewport padding applied outside the render object.
+///
+/// Horizontal safe-area insets are applied by the outer viewport container so
+/// the terminal stays clear of cutouts while still filling the safe width.
+EdgeInsets resolveTerminalViewportPadding(
+  MediaQueryData mediaQuery, {
+  EdgeInsets basePadding = EdgeInsets.zero,
+}) {
+  final renderPadding = resolveTerminalRenderPadding(mediaQuery);
+  return EdgeInsets.fromLTRB(
+    basePadding.left + renderPadding.left,
+    basePadding.top + renderPadding.top,
+    basePadding.right + renderPadding.right,
+    basePadding.bottom + renderPadding.bottom,
+  );
+}
+
+/// Slightly stretches the terminal horizontally to absorb the final remainder
+/// when the viewport width does not divide evenly into whole cells.
+@visibleForTesting
+double resolveTerminalHorizontalFillScale({
+  required double viewportWidth,
+  required double cellWidth,
+  required int columns,
+}) {
+  if (viewportWidth <= 0 || cellWidth <= 0 || columns <= 0) {
+    return 1;
+  }
+  final contentWidth = cellWidth * columns;
+  if (contentWidth <= 0) {
+    return 1;
+  }
+  return (viewportWidth / contentWidth).clamp(1.0, 1.03);
 }
 
 /// Adapted xterm terminal view with a trackpad scroll fix for alt-buffer apps.
@@ -214,6 +255,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
   String? _composingText;
   Offset _lastTouchScrollPosition = Offset.zero;
   double _touchScrollRemainder = 0;
+  int _lastTerminalViewWidth = 0;
 
   late TerminalController _controller;
 
@@ -227,6 +269,8 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
     _focusNode = widget.focusNode ?? FocusNode();
     _controller = widget.controller ?? TerminalController();
     _scrollController = widget.scrollController ?? ScrollController();
+    _lastTerminalViewWidth = widget.terminal.viewWidth;
+    widget.terminal.addListener(_handleTerminalMetricsChanged);
     _shortcutManager = ShortcutManager(
       shortcuts: widget.shortcuts ?? defaultTerminalShortcuts,
     );
@@ -235,6 +279,11 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
 
   @override
   void didUpdateWidget(covariant MonkeyTerminalView oldWidget) {
+    if (oldWidget.terminal != widget.terminal) {
+      oldWidget.terminal.removeListener(_handleTerminalMetricsChanged);
+      _lastTerminalViewWidth = widget.terminal.viewWidth;
+      widget.terminal.addListener(_handleTerminalMetricsChanged);
+    }
     if (oldWidget.focusNode != widget.focusNode) {
       if (oldWidget.focusNode == null) {
         _focusNode.dispose();
@@ -259,6 +308,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
 
   @override
   void dispose() {
+    widget.terminal.removeListener(_handleTerminalMetricsChanged);
     if (widget.focusNode == null) {
       _focusNode.dispose();
     }
@@ -272,8 +322,27 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
     super.dispose();
   }
 
+  void _handleTerminalMetricsChanged() {
+    final currentViewWidth = widget.terminal.viewWidth;
+    if (currentViewWidth == _lastTerminalViewWidth) {
+      return;
+    }
+    _lastTerminalViewWidth = currentViewWidth;
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final terminalViewportPadding = resolveTerminalViewportPadding(
+      mediaQuery,
+      basePadding: widget.padding ?? EdgeInsets.zero,
+    );
+    final shouldFillHorizontalRemainder =
+        terminalViewportPadding.left == 0 && terminalViewportPadding.right == 0;
+
     Widget child = Scrollable(
       key: _scrollableKey,
       controller: _scrollController,
@@ -286,7 +355,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
           terminal: widget.terminal,
           controller: _controller,
           offset: offset,
-          padding: resolveTerminalRenderPadding(MediaQuery.of(context)),
+          padding: EdgeInsets.zero,
           autoResize: widget.autoResize,
           textStyle: widget.textStyle,
           textScaler: widget.textScaler ?? MediaQuery.textScalerOf(context),
@@ -431,11 +500,28 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
 
     child = MouseRegion(cursor: widget.mouseCursor, child: child);
 
+    if (shouldFillHorizontalRemainder && _viewportKey.currentContext != null) {
+      final horizontalFillScale = resolveTerminalHorizontalFillScale(
+        viewportWidth: renderTerminal.size.width,
+        cellWidth: renderTerminal.cellSize.width,
+        columns: widget.terminal.viewWidth,
+      );
+      if (horizontalFillScale > 1) {
+        child = Transform.scale(
+          alignment: Alignment.centerLeft,
+          scaleX: horizontalFillScale,
+          child: child,
+        );
+      }
+    }
+
+    child = ClipRect(child: child);
+
     child = Container(
       color: widget.theme.background.withValues(
         alpha: widget.backgroundOpacity,
       ),
-      padding: widget.padding,
+      padding: terminalViewportPadding,
       child: child,
     );
 

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -37,5 +37,89 @@ void main() {
         const EdgeInsets.only(left: 44, right: 34),
       );
     });
+
+    test('uses landscape viewPadding when padding is already consumed', () {
+      const mediaQuery = MediaQueryData(
+        size: Size(844, 390),
+        viewPadding: EdgeInsets.fromLTRB(44, 0, 34, 21),
+      );
+
+      expect(
+        resolveTerminalRenderPadding(mediaQuery),
+        const EdgeInsets.only(left: 44, right: 34),
+      );
+    });
+  });
+
+  group('resolveTerminalViewportPadding', () {
+    test('keeps portrait viewport padding edge-to-edge', () {
+      const mediaQuery = MediaQueryData(
+        size: Size(390, 844),
+        padding: EdgeInsets.fromLTRB(12, 18, 16, 34),
+      );
+
+      expect(
+        resolveTerminalViewportPadding(
+          mediaQuery,
+          basePadding: const EdgeInsets.fromLTRB(0, 8, 0, 0),
+        ),
+        const EdgeInsets.fromLTRB(0, 8, 0, 0),
+      );
+    });
+
+    test('keeps landscape viewport inside the horizontal safe area', () {
+      const mediaQuery = MediaQueryData(
+        size: Size(844, 390),
+        padding: EdgeInsets.fromLTRB(44, 0, 34, 21),
+      );
+
+      expect(
+        resolveTerminalViewportPadding(
+          mediaQuery,
+          basePadding: const EdgeInsets.fromLTRB(0, 8, 0, 0),
+        ),
+        const EdgeInsets.fromLTRB(44, 8, 34, 0),
+      );
+    });
+  });
+
+  group('resolveTerminalHorizontalFillScale', () {
+    test('fills the final horizontal remainder without shrinking', () {
+      expect(
+        resolveTerminalHorizontalFillScale(
+          viewportWidth: 390,
+          cellWidth: 9.5,
+          columns: 40,
+        ),
+        closeTo(1.0263, 0.0001),
+      );
+    });
+
+    test('returns 1 for invalid dimensions', () {
+      expect(
+        resolveTerminalHorizontalFillScale(
+          viewportWidth: 0,
+          cellWidth: 9.5,
+          columns: 40,
+        ),
+        1,
+      );
+      expect(
+        resolveTerminalHorizontalFillScale(
+          viewportWidth: 390,
+          cellWidth: 0,
+          columns: 40,
+        ),
+        1,
+      );
+      expect(
+        resolveTerminalHorizontalFillScale(
+          viewportWidth: 390,
+          cellWidth: 9.5,
+          columns: 0,
+        ),
+        1,
+      );
+    });
   });
 }

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -41,12 +41,42 @@ void main() {
       expect(resolveTmuxBarRevealBottomOffset(0), -22);
       expect(resolveTmuxBarRevealBottomOffset(11), -11);
       expect(resolveTmuxBarRevealBottomOffset(22), 0);
+      expect(resolveTmuxBarRevealBottomOffset(56), 34);
 
       expect(resolveTmuxBarRevealOpacity(-10), 0);
       expect(resolveTmuxBarRevealOpacity(0), 0);
       expect(resolveTmuxBarRevealOpacity(11), 0.5);
       expect(resolveTmuxBarRevealOpacity(22), 1);
       expect(resolveTmuxBarRevealOpacity(40), 1);
+    });
+
+    test('tmux bar stays inside visible safe insets', () {
+      const portraitMediaQuery = MediaQueryData(
+        size: Size(390, 844),
+        padding: EdgeInsets.only(bottom: 34),
+      );
+      const portraitKeyboardMediaQuery = MediaQueryData(
+        size: Size(390, 844),
+        viewPadding: EdgeInsets.only(bottom: 34),
+        viewInsets: EdgeInsets.only(bottom: 320),
+      );
+      const landscapeMediaQuery = MediaQueryData(
+        size: Size(844, 390),
+        padding: EdgeInsets.fromLTRB(44, 0, 34, 21),
+      );
+
+      expect(
+        resolveTmuxBarSafeInsets(portraitMediaQuery),
+        const EdgeInsets.only(bottom: 34),
+      );
+      expect(
+        resolveTmuxBarSafeInsets(portraitKeyboardMediaQuery),
+        EdgeInsets.zero,
+      );
+      expect(
+        resolveTmuxBarSafeInsets(landscapeMediaQuery),
+        const EdgeInsets.fromLTRB(44, 0, 34, 21),
+      );
     });
 
     test(


### PR DESCRIPTION
## Summary

- remove the remaining portrait right-edge gutter from the terminal viewport
- keep the terminal viewport inside horizontal safe insets in landscape, including cutout-driven `viewPadding`
- keep the tmux bar inside visible safe insets and reserve bottom inset space when it is shown

## Testing

- `flutter analyze`
- `flutter test test/widget/monkey_terminal_view_layout_test.dart test/widget/terminal_screen_layout_test.dart`
- repo pre-commit hook (`flutter analyze` and `flutter test`)
