### PR TITLE
fix: anchor tmux bar to the keyboard toolbar instead of floating above it

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -4158,26 +4158,42 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           ),
         ],
       ),
-      body: Column(
-        children: [
-          Expanded(
-            child: _buildTerminalWithTmuxBar(
-              terminalTheme,
-              isMobile,
-              theme,
-              connectionState,
-            ),
-          ),
-          if (_showKeyboardToolbar &&
+      body: Builder(
+        builder: (bodyContext) {
+          final showsKeyboardToolbar =
+              _showKeyboardToolbar &&
               !showsDisconnectedOverlay &&
-              (!_isNativeSelectionMode || _isMobilePlatform))
-            KeyboardToolbar(
-              controller: _toolbarController,
-              terminal: _terminal,
-              onKeyPressed: _handleKeyboardToolbarKeyPressed,
-              terminalFocusNode: _terminalFocusNode,
-            ),
-        ],
+              (!_isNativeSelectionMode || _isMobilePlatform);
+          final terminalArea = _buildTerminalWithTmuxBar(
+            terminalTheme,
+            isMobile,
+            theme,
+            connectionState,
+          );
+          return Column(
+            children: [
+              Expanded(
+                // The KeyboardToolbar below already absorbs the bottom
+                // safe-area inset via its own SafeArea, so strip it here to
+                // prevent the tmux bar from floating above the toolbar.
+                child: showsKeyboardToolbar
+                    ? MediaQuery.removePadding(
+                        context: bodyContext,
+                        removeBottom: true,
+                        child: terminalArea,
+                      )
+                    : terminalArea,
+              ),
+              if (showsKeyboardToolbar)
+                KeyboardToolbar(
+                  controller: _toolbarController,
+                  terminal: _terminal,
+                  onKeyPressed: _handleKeyboardToolbarKeyPressed,
+                  terminalFocusNode: _terminalFocusNode,
+                ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -113,4 +113,59 @@ void main() {
       expect(resolvePreferredTmuxSessionName(), isNull);
     });
   });
+
+  group('tmux bar safe insets vs. keyboard toolbar', () {
+    testWidgets(
+      'collapses to zero when the chrome below already absorbs the safe area',
+      (tester) async {
+        late MediaQueryData strippedMediaQuery;
+        await tester.pumpWidget(
+          MediaQuery(
+            data: const MediaQueryData(
+              padding: EdgeInsets.only(bottom: 34),
+              viewPadding: EdgeInsets.only(bottom: 34),
+            ),
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: Builder(
+                builder: (outerContext) => Column(
+                  children: [
+                    Expanded(
+                      child: MediaQuery.removePadding(
+                        context: outerContext,
+                        removeBottom: true,
+                        child: Builder(
+                          builder: (innerContext) {
+                            strippedMediaQuery = MediaQuery.of(innerContext);
+                            return const SizedBox.expand();
+                          },
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 84),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+
+        // The tmux bar is positioned via resolveTmuxBarSafeInsets, which uses
+        // the surrounding MediaQuery's bottom padding. When a chrome below the
+        // terminal absorbs the home-indicator inset, the upper area must see
+        // padding.bottom == 0 so the bar sits flush against that chrome
+        // instead of floating above it.
+        expect(resolveTmuxBarSafeInsets(strippedMediaQuery).bottom, 0);
+        expect(
+          resolveTmuxBarRevealBottomOffset(
+            _tmuxExpandableBarHandleHeight +
+                resolveTmuxBarSafeInsets(strippedMediaQuery).bottom,
+          ),
+          0,
+        );
+      },
+    );
+  });
 }
+
+const double _tmuxExpandableBarHandleHeight = 22;


### PR DESCRIPTION
## Summary

The tmux bar was floating ~34px above the keyboard toolbar (the extra-keys row) when the system keyboard was dismissed, leaving an obvious gap above the toolbar.

## Root cause

The terminal `Scaffold.body` is:

```
Column(
  Expanded(_buildTerminalWithTmuxBar(...)),  // tmux bar lives in here
  KeyboardToolbar(...),                       // SafeArea(bottom: true)
)
```

`KeyboardToolbar` already absorbs the bottom home-indicator inset via its own `SafeArea(bottom: true)` whenever the system keyboard is dismissed. But the upper `Expanded` still saw the original `MediaQuery.padding.bottom`, and the tmux bar uses `resolveTmuxBarSafeInsets(...).bottom` (= `padding.bottom`) to lift itself off the bottom — so the bar floated `padding.bottom` pixels above the bottom of its area, which was the top of the toolbar. Net effect: a visible gap above the toolbar.

## Fix

Wrap the terminal area in `MediaQuery.removePadding(removeBottom: true)` whenever the keyboard toolbar is rendered below it. The toolbar consumes the safe area itself, so the tmux bar should treat the bottom of its area as the actual usable edge.

## Tests

- Added a layout regression test in `test/widget/terminal_screen_layout_test.dart` that verifies the upper area's bottom safe-area inset is zeroed when wrapped this way, and that the tmux bar's reveal offset collapses to `0`.
- Full suite (`flutter test --no-pub`): all 1281 tests pass.
- `flutter analyze`: clean.

## Manual verification

Reproduce per the original screenshot:
1. Connect to a host, attach a tmux session.
2. Dismiss the system keyboard.
3. Confirm the green tmux status row sits flush against the top of the extra-keys toolbar (no floating gap).
