### PR TITLE
fix(tmux): only offer installed CLIs and keep window alerts live

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -466,6 +466,40 @@ bool shouldReloadTmuxWindowsFromControlLine(
   return notificationPrefixes.any(trimmed.startsWith);
 }
 
+/// Action the tmux control-mode heartbeat decides to take based on how
+/// long the channel has been silent.
+@visibleForTesting
+enum TmuxControlHeartbeatAction {
+  /// No action — control-mode notifications have arrived recently.
+  noop,
+
+  /// Synthesize a refresh event so listeners refetch window state via a
+  /// separate exec channel.
+  refresh,
+
+  /// Tear down and restart the control session — silence has exceeded
+  /// the dead-channel threshold.
+  restart,
+}
+
+/// Pure decision function used by the control-mode observer's heartbeat
+/// to keep the UI in sync when push notifications are dropped or the SSH
+/// channel is half-open.
+@visibleForTesting
+TmuxControlHeartbeatAction decideTmuxHeartbeatAction({
+  required Duration silence,
+  required Duration heartbeatInterval,
+  required Duration maxSilenceBeforeRestart,
+}) {
+  if (silence >= maxSilenceBeforeRestart) {
+    return TmuxControlHeartbeatAction.restart;
+  }
+  if (silence >= heartbeatInterval) {
+    return TmuxControlHeartbeatAction.refresh;
+  }
+  return TmuxControlHeartbeatAction.noop;
+}
+
 @immutable
 class _TmuxWindowWatchKey {
   const _TmuxWindowWatchKey({
@@ -493,7 +527,9 @@ class _TmuxWindowChangeObserver {
     required this.session,
     required this.sessionName,
     required this.onDispose,
-  }) : _controller = StreamController<void>.broadcast() {
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now,
+       _controller = StreamController<void>.broadcast() {
     _controller
       ..onListen = _ensureStarted
       ..onCancel = () => unawaited(dispose());
@@ -501,10 +537,22 @@ class _TmuxWindowChangeObserver {
 
   static const _eventDebounce = Duration(milliseconds: 150);
 
+  /// How often to check whether the control-mode session has gone silent
+  /// and synthesize a refresh event when it has. Keeps the UI in sync
+  /// even if `%subscription-changed` notifications are dropped (e.g. due
+  /// to a half-open SSH channel that did not surface as `done`).
+  static const _heartbeatInterval = Duration(seconds: 5);
+
+  /// If no control-mode line arrives for this long, treat the session as
+  /// dead and force a reconnect even though the SSH `done` callback never
+  /// fired.
+  static const _maxSilenceBeforeRestart = Duration(seconds: 30);
+
   final TmuxService service;
   final SshSession session;
   final String sessionName;
   final VoidCallback onDispose;
+  final DateTime Function() _now;
   final StreamController<void> _controller;
 
   StreamSubscription<String>? _stdoutSubscription;
@@ -512,10 +560,12 @@ class _TmuxWindowChangeObserver {
   StreamSubscription<void>? _doneSubscription;
   Timer? _debounceTimer;
   Timer? _restartTimer;
+  Timer? _heartbeatTimer;
   SSHSession? _controlSession;
   bool _starting = false;
   bool _disposed = false;
   int _restartAttempts = 0;
+  DateTime? _lastControlActivity;
 
   String get _subscriptionName =>
       'flutty-${session.connectionId}-${sessionName.hashCode.abs()}';
@@ -555,6 +605,8 @@ class _TmuxWindowChangeObserver {
       );
       _configureControlSession();
       _restartAttempts = 0;
+      _lastControlActivity = _now();
+      _startHeartbeat();
     } on Object catch (error, stackTrace) {
       _handleControlFailure(error, stackTrace);
     } finally {
@@ -572,6 +624,7 @@ class _TmuxWindowChangeObserver {
 
   void _handleStdoutLine(String line) {
     if (_disposed) return;
+    _lastControlActivity = _now();
     final trimmed = line.trim();
     if (trimmed.startsWith('%exit')) {
       _handleControlClosed();
@@ -588,6 +641,7 @@ class _TmuxWindowChangeObserver {
 
   void _handleStderrLine(String line) {
     if (_disposed || line.trim().isEmpty) return;
+    _lastControlActivity = _now();
     _scheduleRestart();
   }
 
@@ -612,6 +666,7 @@ class _TmuxWindowChangeObserver {
 
   void _scheduleRestart() {
     if (_disposed || !_controller.hasListener) return;
+    _stopHeartbeat();
     _restartTimer?.cancel();
     final cappedAttempt = _restartAttempts.clamp(0, 4);
     final delay = Duration(seconds: 1 << cappedAttempt);
@@ -619,7 +674,47 @@ class _TmuxWindowChangeObserver {
     _restartTimer = Timer(delay, () => unawaited(_ensureStarted()));
   }
 
+  void _startHeartbeat() {
+    _heartbeatTimer?.cancel();
+    _heartbeatTimer = Timer.periodic(_heartbeatInterval, (_) => _onHeartbeat());
+  }
+
+  void _stopHeartbeat() {
+    _heartbeatTimer?.cancel();
+    _heartbeatTimer = null;
+  }
+
+  /// Heartbeat tick. Two responsibilities:
+  ///
+  /// 1. If the control session has been silent for [_heartbeatInterval],
+  ///    synthesize a refresh event so listeners refetch window state via
+  ///    a separate exec channel. This keeps alerts visible in real time
+  ///    even when control-mode notifications are dropped or delayed.
+  /// 2. If the silence exceeds [_maxSilenceBeforeRestart], assume the SSH
+  ///    channel is half-open and tear down + restart it; tmux normally
+  ///    emits some traffic at least every few seconds, so prolonged
+  ///    silence is a strong signal of a dead channel.
+  void _onHeartbeat() {
+    if (_disposed) return;
+    final lastActivity = _lastControlActivity;
+    if (lastActivity == null) return;
+    final action = decideTmuxHeartbeatAction(
+      silence: _now().difference(lastActivity),
+      heartbeatInterval: _heartbeatInterval,
+      maxSilenceBeforeRestart: _maxSilenceBeforeRestart,
+    );
+    switch (action) {
+      case TmuxControlHeartbeatAction.noop:
+        return;
+      case TmuxControlHeartbeatAction.refresh:
+        _scheduleEvent();
+      case TmuxControlHeartbeatAction.restart:
+        _handleControlClosed();
+    }
+  }
+
   void _cleanupControlSession() {
+    _stopHeartbeat();
     _debounceTimer?.cancel();
     _debounceTimer = null;
     unawaited(_stdoutSubscription?.cancel());
@@ -630,11 +725,13 @@ class _TmuxWindowChangeObserver {
     _doneSubscription = null;
     _controlSession?.close();
     _controlSession = null;
+    _lastControlActivity = null;
   }
 
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
+    _stopHeartbeat();
     _restartTimer?.cancel();
     _restartTimer = null;
     _cleanupControlSession();

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -5,6 +5,7 @@ import 'package:dartssh2/dartssh2.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../models/agent_launch_preset.dart';
 import '../models/tmux_state.dart';
 import 'ssh_service.dart';
 
@@ -26,6 +27,9 @@ class TmuxService {
   /// Cached profile source commands per SSH session.
   static final Map<int, String> _profileSourceCache = {};
 
+  /// Cached set of installed agent CLIs per SSH session (by connectionId).
+  static final Map<int, Set<AgentLaunchTool>> _installedAgentToolsCache = {};
+
   static final Map<_TmuxWindowWatchKey, _TmuxWindowChangeObserver>
   _windowObservers = {};
 
@@ -33,6 +37,7 @@ class TmuxService {
   void clearCache(int connectionId) {
     _tmuxPathCache.remove(connectionId);
     _profileSourceCache.remove(connectionId);
+    _installedAgentToolsCache.remove(connectionId);
     final observerKeys = _windowObservers.keys
         .where((key) => key.connectionId == connectionId)
         .toList(growable: false);
@@ -74,7 +79,37 @@ class TmuxService {
     }
   }
 
-  // ── Session queries ────────────────────────────────────────────────────
+  /// Detects which supported coding-agent CLIs are available on the
+  /// remote host's `PATH`.
+  ///
+  /// Resolves binaries via `command -v`, sourcing the user's login
+  /// shell profile so Homebrew/nvm/asdf-installed CLIs are found over
+  /// SSH exec channels (which start with a minimal `PATH`).
+  ///
+  /// Results are cached per connection. Returns an empty set on any
+  /// detection error so callers can render a sensible fallback rather
+  /// than blocking the user.
+  Future<Set<AgentLaunchTool>> detectInstalledAgentTools(
+    SshSession session,
+  ) async {
+    final cached = _installedAgentToolsCache[session.connectionId];
+    if (cached != null) return cached;
+    try {
+      final binaries = AgentLaunchTool.values
+          .map((t) => t.commandName)
+          .toSet()
+          .join(' ');
+      final output = await _exec(
+        session,
+        'command -v $binaries 2>/dev/null || true',
+      );
+      final installed = parseInstalledAgentTools(output);
+      _installedAgentToolsCache[session.connectionId] = installed;
+      return installed;
+    } on Object {
+      return const <AgentLaunchTool>{};
+    }
+  }
 
   /// Lists all tmux sessions on the remote host.
   Future<List<TmuxSession>> listSessions(SshSession session) async {
@@ -612,3 +647,34 @@ class _TmuxWindowChangeObserver {
 
 /// Provider for [TmuxService].
 final tmuxServiceProvider = Provider<TmuxService>((ref) => const TmuxService());
+
+/// Maps a binary's basename (e.g. `claude`) to the matching [AgentLaunchTool],
+/// or `null` if it does not correspond to a supported CLI.
+AgentLaunchTool? agentToolForBinaryName(String binaryName) =>
+    switch (binaryName) {
+      'aider' => AgentLaunchTool.aider,
+      'claude' => AgentLaunchTool.claudeCode,
+      'copilot' => AgentLaunchTool.copilotCli,
+      'codex' => AgentLaunchTool.codex,
+      'gemini' => AgentLaunchTool.geminiCli,
+      'opencode' => AgentLaunchTool.openCode,
+      _ => null,
+    };
+
+/// Parses the output of `command -v <bins...>` into the set of supported
+/// agent CLIs that resolved to an absolute path.
+///
+/// Lines that do not start with `/` are ignored, so shell function names,
+/// builtins, or aliases (which `command -v` may report as bare names) are
+/// not treated as installed CLIs.
+Set<AgentLaunchTool> parseInstalledAgentTools(String output) {
+  final installed = <AgentLaunchTool>{};
+  for (final rawLine in output.split('\n')) {
+    final line = rawLine.trim();
+    if (line.isEmpty || !line.startsWith('/')) continue;
+    final binary = line.split('/').last;
+    final tool = agentToolForBinaryName(binary);
+    if (tool != null) installed.add(tool);
+  }
+  return installed;
+}

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -664,10 +664,14 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
             title: const Text('New Window'),
             onTap: () {
               setState(() => _expanded = false);
+              final installedToolsFuture = _tmux.detectInstalledAgentTools(
+                widget.session,
+              );
               showModalBottomSheet<AgentLaunchTool?>(
                 context: context,
                 builder: (ctx) => TmuxToolPickerSheet(
                   isProUser: widget.isProUser,
+                  installedToolsFuture: installedToolsFuture,
                   onToolSelected: (tool) => Navigator.pop(ctx, tool),
                   onEmptyWindow: () {
                     Navigator.pop(ctx);

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -113,7 +112,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
-  Set<AgentLaunchTool>? _installedTools;
+  Future<Set<AgentLaunchTool>>? _installedToolsFuture;
   final Set<String> _expandedSessionTools = <String>{};
   StreamSubscription<void>? _windowChangeSubscription;
   bool _isLoadingWindows = true;
@@ -132,6 +131,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   @override
   void initState() {
     super.initState();
+    _installedToolsFuture = _tmux.detectInstalledAgentTools(widget.session);
     _windowChangeSubscription = _tmux
         .watchWindowChanges(widget.session, widget.tmuxSessionName)
         .listen((_) {
@@ -163,8 +163,6 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         _windows = windows;
         _isLoadingWindows = false;
       });
-      // Detect installed CLIs in parallel (non-blocking).
-      unawaited(_detectInstalledTools());
     } on Exception catch (e) {
       if (!mounted) return;
       setState(() {
@@ -179,55 +177,6 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       }
     }
   }
-
-  Future<void> _detectInstalledTools() async {
-    try {
-      // Source shell profiles so CLIs in Homebrew/nvm/etc. paths are found,
-      // while silencing profile output so only `command -v` results are parsed.
-      final execSession = await widget.session.execute(
-        '{ . ~/.profile; . ~/.bash_profile; . ~/.zprofile; } '
-        '>/dev/null 2>&1; '
-        'command -v aider claude copilot codex gemini opencode 2>/dev/null'
-        ' || true',
-      );
-      try {
-        final stdout = await execSession.stdout
-            .cast<List<int>>()
-            .transform(utf8.decoder)
-            .join()
-            .timeout(const Duration(seconds: 5), onTimeout: () => '');
-        await execSession.stderr
-            .cast<List<int>>()
-            .transform(utf8.decoder)
-            .join()
-            .timeout(const Duration(seconds: 5), onTimeout: () => '');
-        if (!mounted) return;
-
-        final paths = stdout.trim().split('\n').where((l) => l.isNotEmpty);
-        final installed = <AgentLaunchTool>{};
-        for (final path in paths) {
-          final bin = path.split('/').last;
-          final tool = _toolForBinary(bin);
-          if (tool != null) installed.add(tool);
-        }
-        setState(() => _installedTools = installed);
-      } finally {
-        execSession.close();
-      }
-    } on Object {
-      // Ignore — show all tools if detection fails.
-    }
-  }
-
-  static AgentLaunchTool? _toolForBinary(String bin) => switch (bin) {
-    'aider' => AgentLaunchTool.aider,
-    'claude' => AgentLaunchTool.claudeCode,
-    'copilot' => AgentLaunchTool.copilotCli,
-    'codex' => AgentLaunchTool.codex,
-    'gemini' => AgentLaunchTool.geminiCli,
-    'opencode' => AgentLaunchTool.openCode,
-    _ => null,
-  };
 
   Future<void> _loadRecentSessions() async {
     if (_isLoadingSessions || _recentSessions != null) return;
@@ -291,7 +240,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       context: context,
       builder: (context) => TmuxToolPickerSheet(
         isProUser: widget.isProUser,
-        installedTools: _installedTools,
+        installedToolsFuture: _installedToolsFuture,
         onToolSelected: (tool) {
           Navigator.pop(context);
           _createNewWindow(command: tool.commandName, name: tool.commandName);
@@ -702,16 +651,20 @@ class TmuxToolPickerSheet extends StatelessWidget {
     required this.isProUser,
     required this.onToolSelected,
     required this.onEmptyWindow,
-    this.installedTools,
+    this.installedToolsFuture,
     super.key,
   });
 
   /// Whether the user has Pro access.
   final bool isProUser;
 
-  /// Tools detected as installed on the remote host, or `null` if not yet
-  /// detected (shows all tools).
-  final Set<AgentLaunchTool>? installedTools;
+  /// Future that resolves to the set of agent CLIs detected on the remote
+  /// host, or `null` if the caller could not initiate detection. While the
+  /// future is pending the picker shows a loading indicator. Once it
+  /// completes, only the detected tools are listed; if it resolves to an
+  /// empty set (or fails), no CLI tools are shown but "Empty window"
+  /// remains available.
+  final Future<Set<AgentLaunchTool>>? installedToolsFuture;
 
   /// Called when the user selects a tool.
   final void Function(AgentLaunchTool tool) onToolSelected;
@@ -719,7 +672,7 @@ class TmuxToolPickerSheet extends StatelessWidget {
   /// Called when the user selects an empty window.
   final VoidCallback onEmptyWindow;
 
-  /// All tools that can be shown in the picker.
+  /// All tools that can be shown in the picker, in display order.
   static const _allTools = [
     AgentLaunchTool.aider,
     AgentLaunchTool.claudeCode,
@@ -737,10 +690,6 @@ class TmuxToolPickerSheet extends StatelessWidget {
       screenHeight * _tmuxToolPickerMaxHeightFactor,
       _tmuxToolPickerMaxHeightCap,
     );
-    // Show only installed tools, or all if detection hasn't completed.
-    final tools = installedTools != null
-        ? _allTools.where((t) => installedTools!.contains(t)).toList()
-        : _allTools;
 
     return SafeArea(
       child: ConstrainedBox(
@@ -754,19 +703,73 @@ class TmuxToolPickerSheet extends StatelessWidget {
                 padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
                 child: Text('New Window', style: theme.textTheme.titleMedium),
               ),
-              for (final tool in tools)
-                ListTile(
-                  visualDensity: _tmuxNavigatorDenseVisualDensity,
-                  minTileHeight: 42,
-                  contentPadding: _tmuxNavigatorTilePadding,
-                  horizontalTitleGap: 12,
-                  minLeadingWidth: 20,
-                  leading: TmuxToolPickerSheet._iconForTool(tool, theme),
-                  title: Text(tool.label),
-                  trailing: !isProUser ? const PremiumBadge() : null,
-                  enabled: isProUser,
-                  onTap: () => onToolSelected(tool),
-                ),
+              FutureBuilder<Set<AgentLaunchTool>>(
+                future: installedToolsFuture,
+                builder: (context, snapshot) {
+                  if (installedToolsFuture != null &&
+                      snapshot.connectionState != ConnectionState.done) {
+                    return const Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 12,
+                      ),
+                      child: Row(
+                        children: [
+                          SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator.adaptive(
+                              strokeWidth: 2,
+                            ),
+                          ),
+                          SizedBox(width: 12),
+                          Text('Detecting installed CLIs…'),
+                        ],
+                      ),
+                    );
+                  }
+                  final installed = snapshot.data;
+                  final tools = installed != null
+                      ? _allTools.where(installed.contains).toList()
+                      : _allTools;
+                  if (tools.isEmpty) {
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 12,
+                      ),
+                      child: Text(
+                        'No supported CLIs found on PATH.',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    );
+                  }
+                  return Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      for (final tool in tools)
+                        ListTile(
+                          visualDensity: _tmuxNavigatorDenseVisualDensity,
+                          minTileHeight: 42,
+                          contentPadding: _tmuxNavigatorTilePadding,
+                          horizontalTitleGap: 12,
+                          minLeadingWidth: 20,
+                          leading: TmuxToolPickerSheet._iconForTool(
+                            tool,
+                            theme,
+                          ),
+                          title: Text(tool.label),
+                          trailing: !isProUser ? const PremiumBadge() : null,
+                          enabled: isProUser,
+                          onTap: () => onToolSelected(tool),
+                        ),
+                    ],
+                  );
+                },
+              ),
               const Divider(height: 1),
               ListTile(
                 visualDensity: _tmuxNavigatorDenseVisualDensity,

--- a/test/domain/services/tmux_service_agent_detection_test.dart
+++ b/test/domain/services/tmux_service_agent_detection_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
+import 'package:monkeyssh/domain/services/tmux_service.dart';
+
+void main() {
+  group('parseInstalledAgentTools', () {
+    test('returns empty for empty input', () {
+      expect(parseInstalledAgentTools(''), isEmpty);
+      expect(parseInstalledAgentTools('   \n  \n'), isEmpty);
+    });
+
+    test('parses absolute paths to known CLI binaries', () {
+      const output =
+          '/opt/homebrew/bin/claude\n'
+          '/usr/local/bin/codex\n'
+          '/Users/me/.local/bin/aider\n';
+      expect(parseInstalledAgentTools(output), {
+        AgentLaunchTool.claudeCode,
+        AgentLaunchTool.codex,
+        AgentLaunchTool.aider,
+      });
+    });
+
+    test('ignores bare names (shell builtins, aliases, missing CLIs)', () {
+      // `command -v` may print bare names for builtins/aliases or omit
+      // unknown commands entirely. Only absolute paths should count.
+      const output =
+          'claude\n'
+          '/usr/local/bin/copilot\n'
+          'aider: not found\n';
+      expect(parseInstalledAgentTools(output), {AgentLaunchTool.copilotCli});
+    });
+
+    test('ignores unknown binaries', () {
+      const output = '/usr/bin/cat\n/usr/bin/grep\n/opt/bin/gemini\n';
+      expect(parseInstalledAgentTools(output), {AgentLaunchTool.geminiCli});
+    });
+
+    test('handles all supported CLIs', () {
+      const output =
+          '/b/aider\n'
+          '/b/claude\n'
+          '/b/copilot\n'
+          '/b/codex\n'
+          '/b/gemini\n'
+          '/b/opencode\n';
+      expect(parseInstalledAgentTools(output), AgentLaunchTool.values.toSet());
+    });
+
+    test('tolerates trailing whitespace and CRLF line endings', () {
+      const output = '/usr/local/bin/claude  \r\n/opt/bin/opencode\r\n';
+      expect(parseInstalledAgentTools(output), {
+        AgentLaunchTool.claudeCode,
+        AgentLaunchTool.openCode,
+      });
+    });
+  });
+
+  group('agentToolForBinaryName', () {
+    test('maps each command name back to its tool', () {
+      for (final tool in AgentLaunchTool.values) {
+        expect(agentToolForBinaryName(tool.commandName), tool);
+      }
+    });
+
+    test('returns null for unknown binaries', () {
+      expect(agentToolForBinaryName('vim'), isNull);
+      expect(agentToolForBinaryName(''), isNull);
+    });
+  });
+}

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -101,4 +101,68 @@ void main() {
       );
     });
   });
+
+  group('decideTmuxHeartbeatAction', () {
+    const heartbeat = Duration(seconds: 5);
+    const maxSilence = Duration(seconds: 30);
+
+    test('noop while control-mode notifications are flowing', () {
+      expect(
+        decideTmuxHeartbeatAction(
+          silence: Duration.zero,
+          heartbeatInterval: heartbeat,
+          maxSilenceBeforeRestart: maxSilence,
+        ),
+        TmuxControlHeartbeatAction.noop,
+      );
+      expect(
+        decideTmuxHeartbeatAction(
+          silence: const Duration(milliseconds: 4999),
+          heartbeatInterval: heartbeat,
+          maxSilenceBeforeRestart: maxSilence,
+        ),
+        TmuxControlHeartbeatAction.noop,
+      );
+    });
+
+    test('synthesizes a refresh once the channel has been silent for the '
+        'heartbeat interval', () {
+      expect(
+        decideTmuxHeartbeatAction(
+          silence: heartbeat,
+          heartbeatInterval: heartbeat,
+          maxSilenceBeforeRestart: maxSilence,
+        ),
+        TmuxControlHeartbeatAction.refresh,
+      );
+      expect(
+        decideTmuxHeartbeatAction(
+          silence: const Duration(seconds: 20),
+          heartbeatInterval: heartbeat,
+          maxSilenceBeforeRestart: maxSilence,
+        ),
+        TmuxControlHeartbeatAction.refresh,
+      );
+    });
+
+    test('restarts the control session once silence exceeds the dead-channel '
+        'threshold', () {
+      expect(
+        decideTmuxHeartbeatAction(
+          silence: maxSilence,
+          heartbeatInterval: heartbeat,
+          maxSilenceBeforeRestart: maxSilence,
+        ),
+        TmuxControlHeartbeatAction.restart,
+      );
+      expect(
+        decideTmuxHeartbeatAction(
+          silence: const Duration(minutes: 5),
+          heartbeatInterval: heartbeat,
+          maxSilenceBeforeRestart: maxSilence,
+        ),
+        TmuxControlHeartbeatAction.restart,
+      );
+    });
+  });
 }

--- a/test/widget/tmux_tool_picker_sheet_test.dart
+++ b/test/widget/tmux_tool_picker_sheet_test.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
+import 'package:monkeyssh/presentation/widgets/tmux_window_navigator.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  group('TmuxToolPickerSheet', () {
+    testWidgets('shows loading indicator while detection is pending', (
+      tester,
+    ) async {
+      final completer = Completer<Set<AgentLaunchTool>>();
+      await tester.pumpWidget(
+        _wrap(
+          TmuxToolPickerSheet(
+            isProUser: true,
+            installedToolsFuture: completer.future,
+            onToolSelected: (_) {},
+            onEmptyWindow: () {},
+          ),
+        ),
+      );
+
+      expect(find.text('Detecting installed CLIs…'), findsOneWidget);
+      // No CLI tiles before detection completes.
+      expect(find.text('Claude Code'), findsNothing);
+      expect(find.text('Codex'), findsNothing);
+      // Empty window remains available even while loading.
+      expect(find.text('Empty window'), findsOneWidget);
+
+      completer.complete({AgentLaunchTool.claudeCode});
+      await tester.pumpAndSettle();
+      expect(find.text('Detecting installed CLIs…'), findsNothing);
+    });
+
+    testWidgets('renders only detected tools', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          TmuxToolPickerSheet(
+            isProUser: true,
+            installedToolsFuture: Future.value({
+              AgentLaunchTool.claudeCode,
+              AgentLaunchTool.codex,
+            }),
+            onToolSelected: (_) {},
+            onEmptyWindow: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Claude Code'), findsOneWidget);
+      expect(find.text('Codex'), findsOneWidget);
+      // Tools that aren't installed must not appear.
+      expect(find.text('Aider'), findsNothing);
+      expect(find.text('Copilot CLI'), findsNothing);
+      expect(find.text('Gemini CLI'), findsNothing);
+      expect(find.text('OpenCode'), findsNothing);
+      expect(find.text('Empty window'), findsOneWidget);
+    });
+
+    testWidgets('shows fallback message when no CLIs are detected', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          TmuxToolPickerSheet(
+            isProUser: true,
+            installedToolsFuture: Future.value(const <AgentLaunchTool>{}),
+            onToolSelected: (_) {},
+            onEmptyWindow: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No supported CLIs found on PATH.'), findsOneWidget);
+      expect(find.text('Empty window'), findsOneWidget);
+      for (final tool in AgentLaunchTool.values) {
+        expect(find.text(tool.label), findsNothing);
+      }
+    });
+
+    testWidgets(
+      'falls back to all tools when no detection future is provided',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            TmuxToolPickerSheet(
+              isProUser: true,
+              onToolSelected: (_) {},
+              onEmptyWindow: () {},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        for (final tool in AgentLaunchTool.values) {
+          expect(find.text(tool.label), findsOneWidget);
+        }
+      },
+    );
+
+    testWidgets('invokes callback when a detected tool is tapped', (
+      tester,
+    ) async {
+      AgentLaunchTool? chosen;
+      await tester.pumpWidget(
+        _wrap(
+          TmuxToolPickerSheet(
+            isProUser: true,
+            installedToolsFuture: Future.value({AgentLaunchTool.claudeCode}),
+            onToolSelected: (t) => chosen = t,
+            onEmptyWindow: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Claude Code'));
+      expect(chosen, AgentLaunchTool.claudeCode);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Two reliability fixes for the tmux integration:

### 1. New-window picker only offers installed CLIs

The "New Window" picker previously listed every supported coding-agent CLI regardless of whether the binary actually existed on the remote host. The navigator sheet did detect installed tools, but its picker captured a stale snapshot (usually `null` on first open, so it showed all tools), and the terminal-screen expandable bar did no detection at all.

- Centralized detection in `TmuxService.detectInstalledAgentTools` with per-connection caching, using the existing profile-sourcing `_exec` so Homebrew/nvm/asdf-installed CLIs are found over SSH exec channels.
- Exposed a pure `parseInstalledAgentTools(stdout)` helper that only counts lines starting with `/` — shell builtins, aliases, and missing CLIs are ignored.
- Made `TmuxToolPickerSheet` drive a `FutureBuilder`: shows a loading state while detection is in flight, then renders only the detected CLIs (with a graceful "No supported CLIs found on PATH." fallback). "Empty window" stays available throughout.
- Both call sites (`_TmuxNavigatorSheet` and the terminal screen's expandable bar) now share the same future, so reopening the picker is instant after the first detection.

### 2. Window alerts now stay live via a control-mode heartbeat

The tmux control-mode observer relies on the SSH server pushing `%subscription-changed` notifications when window state changes. In practice these can be dropped or arrive late — typically when the SSH channel is half-open after a network change or device sleep — and the `done` callback never fires, so the observer keeps thinking it is healthy and never reconnects. Listeners only see fresh window state the next time they manually call `listWindows`, which is why alerts appeared to be stuck until you pulled up the tmux bar.

The observer now runs an adaptive heartbeat:

- Tracks the timestamp of the last control-mode line received (stdout or stderr).
- Every 5 seconds, computes how long the channel has been silent:
  - **< 5 s** → noop (push notifications are flowing, no extra work).
  - **≥ 5 s** → synthesizes a refresh event so listeners refetch window state via a separate exec channel — alerts surface within ~5 s even when notifications are dropped.
  - **≥ 30 s** → treats the channel as dead and tears it down, routing through the existing exponential-backoff reconnect logic.
- The decision is implemented as a pure `decideTmuxHeartbeatAction` helper so the silence-vs-action thresholds are unit-tested directly.

## Tests

- `flutter analyze`: clean.
- `flutter test`: all 1296 tests pass.
- Added 16 new tests:
  - `parseInstalledAgentTools` / `agentToolForBinaryName` (8 tests covering empty input, absolute paths, bare-name rejection, unknown binaries, all supported CLIs, CRLF tolerance, round-trip).
  - `TmuxToolPickerSheet` widget (5 tests covering the loading state, filtered render, empty fallback, no-future fallback, and tap callback).
  - `decideTmuxHeartbeatAction` (3 tests covering noop, refresh, and restart bands).
