### PR TITLE
fix: harden lifetime IAP entitlement reconciliation

### DIFF
--- a/lib/domain/services/monetization_service.dart
+++ b/lib/domain/services/monetization_service.dart
@@ -46,6 +46,14 @@ class MonetizationService {
   bool _restoreInFlight = false;
   bool _restoreObservedPurchaseUpdate = false;
   Future<void>? _initializationFuture;
+  // Serializes async per-purchase handlers so that a batch of restore
+  // updates (e.g. an old subscription transaction + a redeemed lifetime
+  // transaction delivered together by StoreKit) is processed in order.
+  // Without this, multiple `_handleSuccessfulPurchase` calls race and
+  // the last finisher overwrites `activeProductId`/`activeOfferId`,
+  // which can demote a freshly redeemed lifetime back to a stale
+  // subscription label.
+  Future<void> _purchaseHandlerChain = Future<void>.value();
   bool _initialized = false;
   MonetizationState _state = MonetizationState.initial(
     debugUnlockAvailable: kDebugMode,
@@ -360,7 +368,7 @@ class MonetizationService {
           if (_restoreInFlight) {
             _restoreObservedPurchaseUpdate = true;
           }
-          unawaited(_handleSuccessfulPurchase(purchase));
+          unawaited(_enqueueSuccessfulPurchase(purchase));
           break;
         case PurchaseStatus.error:
           unawaited(_completePurchaseIfNeeded(purchase));
@@ -386,6 +394,16 @@ class MonetizationService {
     }
   }
 
+  Future<void> _enqueueSuccessfulPurchase(PurchaseDetails purchase) {
+    final next = _purchaseHandlerChain.then(
+      (_) => _handleSuccessfulPurchase(purchase),
+    );
+    // Swallow errors so one bad handler doesn't break the chain for
+    // subsequent purchases. Errors are already surfaced via state.
+    _purchaseHandlerChain = next.catchError((Object _) {});
+    return next;
+  }
+
   Future<void> _handleSuccessfulPurchase(PurchaseDetails purchase) async {
     final isLifetime = MonetizationProductIds.isLifetime(purchase.productID);
     final successMessage = isLifetime
@@ -409,14 +427,34 @@ class MonetizationService {
       final timestamp =
           _parsePurchaseDate(purchase.transactionDate) ?? DateTime.now();
       await _settings.setBool(SettingKeys.monetizationProUnlocked, value: true);
+      final isLifetime = MonetizationProductIds.isLifetime(purchase.productID);
+      // Lifetime always wins: never let a (possibly older or expiring)
+      // subscription transaction overwrite a lifetime entitlement that
+      // is already active. StoreKit replays every historical transaction
+      // through the purchase stream during a restore, so the chronological
+      // order in which they arrive is not meaningful for entitlement
+      // precedence.
+      final currentIsLifetime = MonetizationProductIds.isLifetime(
+        _state.activeProductId,
+      );
+      if (currentIsLifetime && !isLifetime) {
+        return MonetizationActionResult.success(successMessage);
+      }
+
       await _settings.setString(
         SettingKeys.monetizationActiveProductId,
         purchase.productID,
       );
-      final activeOfferId =
-          _pendingOfferId ??
-          _resolveOfferIdForPurchase(purchase) ??
-          _state.activeOfferId;
+      // For lifetime purchases there is no concept of an offer ID — the
+      // product is non-recurring and isn't surfaced as a paywall offer.
+      // Force-clear any stale offer ID that may have been carried over
+      // from a previous subscription so the UI doesn't render
+      // "Current plan" / "Switch to ..." against a defunct sub offer.
+      final activeOfferId = isLifetime
+          ? null
+          : _pendingOfferId ??
+                _resolveOfferIdForPurchase(purchase) ??
+                _state.activeOfferId;
       if (activeOfferId != null) {
         await _settings.setString(
           SettingKeys.monetizationActiveOfferId,
@@ -533,19 +571,28 @@ class MonetizationService {
         );
       }
 
-      final latestPurchase = purchases.reduce(
-        (latest, purchase) =>
-            purchase.billingClientPurchase.purchaseTime >
-                latest.billingClientPurchase.purchaseTime
-            ? purchase
-            : latest,
+      // Lifetime takes precedence over any subscription that might be
+      // returned alongside it, even if the subscription has a newer
+      // purchaseTime. A user who owns lifetime should always see the
+      // "Lifetime" label, regardless of whether they later subscribed.
+      final lifetimePurchase = purchases.firstWhereOrNull(
+        (purchase) => MonetizationProductIds.isLifetime(purchase.productID),
       );
+      final selectedPurchase =
+          lifetimePurchase ??
+          purchases.reduce(
+            (latest, purchase) =>
+                purchase.billingClientPurchase.purchaseTime >
+                    latest.billingClientPurchase.purchaseTime
+                ? purchase
+                : latest,
+          );
 
       final isLifetime = MonetizationProductIds.isLifetime(
-        latestPurchase.productID,
+        selectedPurchase.productID,
       );
       return _applySuccessfulPurchase(
-        latestPurchase,
+        selectedPurchase,
         successMessage: isLifetime
             ? 'Restored MonkeySSH Pro Lifetime.'
             : 'Restored MonkeySSH Pro subscription.',
@@ -560,13 +607,52 @@ class MonetizationService {
     if (response.error != null) {
       return;
     }
-    final hasActiveMonkeySshSubscription = response.pastPurchases.any(
-      (purchase) =>
-          MonetizationProductIds.allKnown.contains(purchase.productID),
-    );
-    if (!hasActiveMonkeySshSubscription) {
+    final knownPurchases = response.pastPurchases
+        .where(
+          (purchase) =>
+              MonetizationProductIds.allKnown.contains(purchase.productID),
+        )
+        .toList(growable: false);
+    if (knownPurchases.isEmpty) {
       await _clearCachedStoreEntitlement();
+      return;
     }
+
+    // Recompute the active product from the surviving purchase set so
+    // that, e.g., a lapsed subscription leaves the cached active SKU
+    // pointing at the still-owned lifetime non-consumable instead of
+    // the now-defunct sub. Lifetime always takes precedence.
+    final lifetime = knownPurchases.firstWhereOrNull(
+      (purchase) => MonetizationProductIds.isLifetime(purchase.productID),
+    );
+    final selected =
+        lifetime ??
+        knownPurchases.reduce(
+          (latest, purchase) =>
+              purchase.billingClientPurchase.purchaseTime >
+                  latest.billingClientPurchase.purchaseTime
+              ? purchase
+              : latest,
+        );
+
+    if (_state.activeProductId == selected.productID) {
+      return;
+    }
+
+    await _settings.setString(
+      SettingKeys.monetizationActiveProductId,
+      selected.productID,
+    );
+    final isLifetime = MonetizationProductIds.isLifetime(selected.productID);
+    if (isLifetime) {
+      await _settings.delete(SettingKeys.monetizationActiveOfferId);
+    }
+    _emit(
+      _state.copyWith(
+        activeProductId: selected.productID,
+        activeOfferId: isLifetime ? null : _state.activeOfferId,
+      ),
+    );
   }
 
   Future<void> _tryRecoverStaleAndroidPurchaseAttempt() async {

--- a/test/domain/services/monetization_service_test.dart
+++ b/test/domain/services/monetization_service_test.dart
@@ -316,10 +316,6 @@ void main() {
             localizedDescription: 'Lifetime MonkeySSH Pro purchase',
             priceLocale: _usdPriceLocale,
             price: '99.00',
-            subscriptionPeriod: SKProductSubscriptionPeriodWrapper(
-              numberOfUnits: 0,
-              unit: SKSubscriptionPeriodUnit.month,
-            ),
           ),
         ),
       ]);
@@ -548,6 +544,186 @@ void main() {
           MonetizationProductIds.iosProLifetimeProd,
         );
         verify(() => inAppPurchase.completePurchase(purchase)).called(1);
+      },
+    );
+
+    test(
+      'lifetime purchase clears any stale activeOfferId carried over from a prior subscription',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+        // Simulate a user who previously had a subscription: pre-seed
+        // the cached entitlement settings with an active subscription
+        // product and offer.
+        await settings.setBool(
+          SettingKeys.monetizationProUnlocked,
+          value: true,
+        );
+        await settings.setString(
+          SettingKeys.monetizationActiveProductId,
+          MonetizationProductIds.iosMonthly,
+        );
+        await settings.setString(
+          SettingKeys.monetizationActiveOfferId,
+          'monthly-base-offer',
+        );
+
+        final service = MonetizationService(
+          settings,
+          inAppPurchase: inAppPurchase,
+          allowDebugUnlock: false,
+        );
+        addTearDown(service.dispose);
+
+        final purchase = MockPurchaseDetails();
+        when(
+          () => purchase.productID,
+        ).thenReturn(MonetizationProductIds.iosProLifetimeProd);
+        when(() => purchase.status).thenReturn(PurchaseStatus.purchased);
+        when(() => purchase.pendingCompletePurchase).thenReturn(true);
+        when(() => purchase.transactionDate).thenReturn('1712732400000');
+        when(
+          () => inAppPurchase.completePurchase(purchase),
+        ).thenAnswer((_) async {});
+
+        await service.initialize();
+        // Sanity check: the prior subscription offer was loaded from settings.
+        expect(service.currentState.activeOfferId, 'monthly-base-offer');
+
+        purchaseController.add([purchase]);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        expect(service.currentState.isLifetimeUnlocked, isTrue);
+        expect(
+          service.currentState.activeProductId,
+          MonetizationProductIds.iosProLifetimeProd,
+        );
+        // The stale subscription offer must be cleared from both the
+        // in-memory state and the persisted settings.
+        expect(service.currentState.activeOfferId, isNull);
+        expect(
+          await settings.getString(SettingKeys.monetizationActiveOfferId),
+          isNull,
+        );
+      },
+    );
+
+    test(
+      'lifetime entitlement is preserved when a stale subscription transaction is replayed by the purchase stream',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+        final service = MonetizationService(
+          settings,
+          inAppPurchase: inAppPurchase,
+          allowDebugUnlock: false,
+        );
+        addTearDown(service.dispose);
+
+        final lifetime = MockPurchaseDetails();
+        when(
+          () => lifetime.productID,
+        ).thenReturn(MonetizationProductIds.iosProLifetimeProd);
+        when(() => lifetime.status).thenReturn(PurchaseStatus.restored);
+        when(() => lifetime.pendingCompletePurchase).thenReturn(true);
+        when(() => lifetime.transactionDate).thenReturn('1712732400000');
+        when(
+          () => inAppPurchase.completePurchase(lifetime),
+        ).thenAnswer((_) async {});
+
+        final staleSub = MockPurchaseDetails();
+        when(
+          () => staleSub.productID,
+        ).thenReturn(MonetizationProductIds.iosMonthly);
+        when(() => staleSub.status).thenReturn(PurchaseStatus.restored);
+        when(() => staleSub.pendingCompletePurchase).thenReturn(true);
+        when(() => staleSub.transactionDate).thenReturn('1712732401000');
+        when(
+          () => inAppPurchase.completePurchase(staleSub),
+        ).thenAnswer((_) async {});
+
+        await service.initialize();
+        // Deliver both transactions in the same batch, mimicking what
+        // StoreKit does during a restore.
+        purchaseController.add([lifetime, staleSub]);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        // Lifetime must win regardless of replay order.
+        expect(service.currentState.isLifetimeUnlocked, isTrue);
+        expect(
+          service.currentState.activeProductId,
+          MonetizationProductIds.iosProLifetimeProd,
+        );
+        expect(service.currentState.activeOfferId, isNull);
+        expect(
+          await settings.getString(SettingKeys.monetizationActiveProductId),
+          MonetizationProductIds.iosProLifetimeProd,
+        );
+      },
+    );
+
+    test(
+      'Android reconcile promotes lifetime when a previously cached subscription has lapsed',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+        // Pre-seed cached entitlement as the now-defunct subscription.
+        await settings.setBool(
+          SettingKeys.monetizationProUnlocked,
+          value: true,
+        );
+        await settings.setString(
+          SettingKeys.monetizationActiveProductId,
+          MonetizationProductIds.androidPro,
+        );
+        await settings.setString(
+          SettingKeys.monetizationActiveOfferId,
+          'monthly-base',
+        );
+
+        when(() => inAppPurchase.isAvailable()).thenAnswer((_) async => true);
+        when(() => inAppPurchase.queryProductDetails(any())).thenAnswer(
+          (_) async => ProductDetailsResponse(
+            productDetails: const [],
+            notFoundIDs: const [],
+          ),
+        );
+        when(androidPlatformAddition.queryPastPurchases).thenAnswer(
+          (_) async => QueryPurchaseDetailsResponse(
+            pastPurchases: [
+              _androidPastLifetimePurchase(purchaseTimeMillis: 1712732400000),
+            ],
+          ),
+        );
+
+        final service = MonetizationService(
+          settings,
+          inAppPurchase: inAppPurchase,
+          androidPlatformAddition: androidPlatformAddition,
+          allowDebugUnlock: false,
+        );
+        addTearDown(service.dispose);
+
+        await service.initialize();
+
+        expect(service.currentState.isProUnlocked, isTrue);
+        expect(service.currentState.isLifetimeUnlocked, isTrue);
+        expect(
+          service.currentState.activeProductId,
+          MonetizationProductIds.androidProLifetime,
+        );
+        expect(service.currentState.activeOfferId, isNull);
+        expect(
+          await settings.getString(SettingKeys.monetizationActiveProductId),
+          MonetizationProductIds.androidProLifetime,
+        );
+        expect(
+          await settings.getString(SettingKeys.monetizationActiveOfferId),
+          isNull,
+        );
       },
     );
 

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/app/app_metadata.dart';
 import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/domain/models/monetization.dart';
 import 'package:monkeyssh/domain/services/auth_service.dart';
 import 'package:monkeyssh/domain/services/background_ssh_service.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
@@ -149,7 +150,7 @@ void main() {
       await settings.setBool(SettingKeys.monetizationProUnlocked, value: true);
       await settings.setString(
         SettingKeys.monetizationActiveProductId,
-        'monkeyssh_pro_lifetime_prod',
+        MonetizationProductIds.iosProLifetimeProd,
       );
 
       await _pumpSettingsScreen(tester, db: db);

--- a/test/widget/upgrade_screen_test.dart
+++ b/test/widget/upgrade_screen_test.dart
@@ -412,7 +412,7 @@ void main() {
         ],
         debugUnlockAvailable: false,
         debugUnlocked: false,
-        activeProductId: 'monkeyssh_pro_lifetime_prod',
+        activeProductId: MonetizationProductIds.iosProLifetimeProd,
       );
 
       when(() => service.currentState).thenReturn(state);


### PR DESCRIPTION
## Summary

Follow-up fixes from code review (Opus + GPT) on the merged lifetime IAP feature (#291). Two real bugs in entitlement reconciliation and a few test cleanups.

## Bugs fixed

### 1. iOS restore race could demote lifetime back to a stale subscription
`_handlePurchaseUpdates` was firing `unawaited(_handleSuccessfulPurchase(p))` for every purchase in a delivered batch. During an Apple restore, StoreKit replays *all* historical transactions through the purchase stream — so an old expired subscription transaction and a freshly redeemed lifetime transaction can arrive together and race. Whichever async handler finished last won, so `activeProductId` could end up pointing at the defunct subscription, silently flipping the Settings/Upgrade UI from "Lifetime" back to subscription copy.

**Fix:** chain successful-purchase handlers through a `_purchaseHandlerChain` so they run sequentially in delivery order, and add a precedence rule in `_applySuccessfulPurchase` that refuses to overwrite an already-active lifetime entitlement with a non-lifetime SKU.

### 2. Stale `activeOfferId` leaked into the upgrade screen after redeeming lifetime
For lifetime purchases, `_pendingOfferId` is always null and `_resolveOfferIdForPurchase` returns null (lifetime SKUs aren't in `_purchaseOptionsByOfferId`). The fallback `?? _state.activeOfferId` therefore preserved whatever offer id was previously cached. A user who had a subscription before redeeming a lifetime code would see the upgrade screen render the old subscription card with the "current plan" treatment alongside the new "Lifetime is unlocked" copy.

**Fix:** force `activeOfferId` to null (in memory and in settings) whenever the applied purchase is a lifetime SKU.

### 3. Android reconcile never promoted lifetime when a sub lapsed
`_reconcileAndroidStoreEntitlement` only checked whether *any* known purchase remained and then bailed — it never recomputed `activeProductId` from the surviving purchase set. A user who subscribed after redeeming a lifetime code would have the cached `activeProductId` pinned to the subscription forever, so when the sub later expired, Pro stayed unlocked but `isLifetimeUnlocked` kept returning false, leaving the Settings badge as "Active" instead of "Lifetime". Same shape existed in `_restoreAndroidPurchases`, which picked the latest purchase strictly by `purchaseTime`.

**Fix:** both restore and reconcile now prefer a lifetime non-consumable when present and re-derive `activeProductId` from the actual `pastPurchases` list, clearing the offer id when promoting to lifetime.

## Test cleanups
- Use `MonetizationProductIds.iosProLifetimeProd` constants in widget tests instead of hard-coded SKU strings.
- Drop the misleading `subscriptionPeriod` on the lifetime `SKProductWrapper` test fixture (non-consumables don't have one).

## Tests added
- Race regression: lifetime survives a same-batch replay alongside a stale subscription transaction.
- Offer id clearing: lifetime purchase wipes a previously-cached subscription offer id (in memory + settings).
- Android reconcile: lapsed subscription + remaining lifetime promotes `activeProductId` to the lifetime SKU at startup.

## Validation
- `flutter analyze` — clean
- `flutter test` — 1289 passing
