### PR TITLE
fix: guard paywall for lifetime owners

### DIFF
--- a/lib/domain/services/monetization_service.dart
+++ b/lib/domain/services/monetization_service.dart
@@ -198,6 +198,11 @@ class MonetizationService {
         'Subscriptions are only available through the App Store and Google Play.',
       );
     }
+    if (_state.isLifetimeUnlocked) {
+      return const MonetizationActionResult.failure(
+        'MonkeySSH Pro Lifetime is already active. Manage your subscription in the store if you need to cancel a monthly or annual renewal.',
+      );
+    }
     await _tryRecoverStaleAndroidPurchaseAttempt();
     if (_pendingPurchaseResult != null || _restoreInFlight) {
       return const MonetizationActionResult.failure(

--- a/lib/presentation/screens/upgrade_screen.dart
+++ b/lib/presentation/screens/upgrade_screen.dart
@@ -100,6 +100,16 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
     _ => 'your local storefront',
   };
 
+  String _lifetimeDetailLabel(BuildContext context, MonetizationState state) {
+    if (state.entitlementUpdatedAt case final unlockedAt?) {
+      final formattedDate = MaterialLocalizations.of(
+        context,
+      ).formatMediumDate(unlockedAt);
+      return 'Unlocked with a one-time purchase on $formattedDate.';
+    }
+    return 'Unlocked with a one-time purchase.';
+  }
+
   Future<void> _purchasePro(String offerId) async {
     final messenger = ScaffoldMessenger.of(context);
     final result = await ref
@@ -174,6 +184,7 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
     final state =
         ref.watch(monetizationStateProvider).asData?.value ??
         ref.read(monetizationServiceProvider).currentState;
+    final isLifetimeUnlocked = state.isLifetimeUnlocked;
     final isCatalogLoading = state.isLoading && state.offers.isEmpty;
     final isBusy = state.isLoading || _restoreInProgress;
     final progressMessage = switch ((state.isLoading, _restoreInProgress)) {
@@ -184,21 +195,26 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
       _ => null,
     };
     final feature = widget.feature;
-    final highlightedOffer = state.activeOffer ?? state.defaultOffer;
-    final priceLabel =
-        highlightedOffer?.displayPriceLabel ??
-        (isCatalogLoading ? 'Loading pricing...' : _pricingSourceLabel());
-    final priceDetailLabel =
-        highlightedOffer?.detailLabel ??
-        (highlightedOffer == null
-            ? 'The exact price comes from your local storefront and currency.'
-            : null);
+    final highlightedOffer = isLifetimeUnlocked
+        ? null
+        : state.activeOffer ?? state.defaultOffer;
+    final priceLabel = isLifetimeUnlocked
+        ? 'MonkeySSH Pro Lifetime'
+        : highlightedOffer?.displayPriceLabel ??
+              (isCatalogLoading ? 'Loading pricing...' : _pricingSourceLabel());
+    final priceDetailLabel = isLifetimeUnlocked
+        ? _lifetimeDetailLabel(context, state)
+        : highlightedOffer?.detailLabel ??
+              (highlightedOffer == null
+                  ? 'The exact price comes from your local storefront and currency.'
+                  : null);
     final sharedIntroductoryOfferLabel = _sharedIntroductoryOfferLabel(
       state.offers,
     );
-    final introductoryOfferLabel =
-        sharedIntroductoryOfferLabel ??
-        highlightedOffer?.introductoryOfferLabel;
+    final introductoryOfferLabel = isLifetimeUnlocked
+        ? null
+        : sharedIntroductoryOfferLabel ??
+              highlightedOffer?.introductoryOfferLabel;
     final annualSavingsPercent = _annualSavingsPercent(state.offers);
     final priceCardTextStyle = theme.textTheme.bodyMedium?.copyWith(
       color: colorScheme.onSurfaceVariant,
@@ -233,6 +249,16 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
             const SizedBox(height: 20),
             _UpgradeProgressBanner(message: message),
           ],
+          if (isLifetimeUnlocked) ...[
+            const SizedBox(height: 20),
+            _UpgradeBanner(
+              key: const ValueKey('lifetime-status-banner'),
+              message:
+                  'MonkeySSH Pro Lifetime is already active. If an older monthly or annual subscription is still renewing, manage it in ${_storefrontLabel()} to cancel future renewals.',
+              backgroundColor: colorScheme.tertiaryContainer,
+              foregroundColor: colorScheme.onTertiaryContainer,
+            ),
+          ],
           const SizedBox(height: 24),
           Text('Included with Pro', style: theme.textTheme.titleMedium),
           const SizedBox(height: 12),
@@ -254,7 +280,7 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
             subtitle:
                 'Share hosts, keys, and migration bundles through encrypted files.',
           ),
-          if (state.offers.isNotEmpty) ...[
+          if (state.offers.isNotEmpty && !isLifetimeUnlocked) ...[
             const SizedBox(height: 24),
             Text('Choose a plan', style: theme.textTheme.titleMedium),
             if (annualSavingsPercent case final savings?) ...[
@@ -334,8 +360,8 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
                   ],
                   Text(
                     state.isProUnlocked
-                        ? state.isLifetimeUnlocked
-                              ? 'MonkeySSH Pro Lifetime is unlocked on this device.'
+                        ? isLifetimeUnlocked
+                              ? 'You already own MonkeySSH Pro Lifetime. If an older monthly or annual subscription is still active, manage it in ${_storefrontLabel()} to cancel future renewals.'
                               : switch (state.activeOffer) {
                                   final activeOffer? =>
                                     '${activeOffer.planLabel} is active on this device.',
@@ -371,7 +397,11 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
                 ? null
                 : _openManageSubscriptions,
             style: TextButton.styleFrom(foregroundColor: colorScheme.onSurface),
-            child: const Text('Manage subscription'),
+            child: Text(
+              isLifetimeUnlocked
+                  ? 'Manage existing subscription'
+                  : 'Manage subscription',
+            ),
           ),
           if (state.debugUnlockAvailable) ...[
             const SizedBox(height: 24),

--- a/test/domain/services/monetization_service_test.dart
+++ b/test/domain/services/monetization_service_test.dart
@@ -870,6 +870,59 @@ void main() {
     });
 
     test(
+      'purchaseOffer refuses recurring plans when lifetime is already active',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+        await settings.setBool(
+          SettingKeys.monetizationProUnlocked,
+          value: true,
+        );
+        await settings.setString(
+          SettingKeys.monetizationActiveProductId,
+          MonetizationProductIds.androidProLifetime,
+        );
+
+        when(() => inAppPurchase.isAvailable()).thenAnswer((_) async => true);
+        when(() => inAppPurchase.queryProductDetails(any())).thenAnswer(
+          (_) async => ProductDetailsResponse(
+            productDetails: _androidCatalogDetails(),
+            notFoundIDs: const [],
+          ),
+        );
+        when(androidPlatformAddition.queryPastPurchases).thenAnswer(
+          (_) async => QueryPurchaseDetailsResponse(
+            pastPurchases: [
+              _androidPastLifetimePurchase(purchaseTimeMillis: 1712732400000),
+            ],
+          ),
+        );
+
+        final service = MonetizationService(
+          settings,
+          inAppPurchase: inAppPurchase,
+          androidPlatformAddition: androidPlatformAddition,
+          allowDebugUnlock: false,
+        );
+        addTearDown(service.dispose);
+
+        await service.initialize();
+        final offerId = service.currentState.offers.first.id;
+
+        final result = await service.purchaseOffer(offerId);
+
+        expect(result.success, isFalse);
+        expect(result.cancelled, isFalse);
+        expect(result.message, contains('Lifetime is already active'));
+        verifyNever(
+          () => inAppPurchase.buyNonConsumable(
+            purchaseParam: any(named: 'purchaseParam'),
+          ),
+        );
+      },
+    );
+
+    test(
       'purchaseOffer lets Android users retry with another plan after dismissing Play checkout',
       () async {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;

--- a/test/widget/upgrade_screen_test.dart
+++ b/test/widget/upgrade_screen_test.dart
@@ -391,13 +391,13 @@ void main() {
   });
 
   testWidgets(
-    'shows lifetime active copy and never offers a lifetime plan card',
+    'shows lifetime ownership info and hides recurring plan actions',
     (tester) async {
       final service = _MockMonetizationService();
-      const state = MonetizationState(
+      final state = MonetizationState(
         billingAvailability: MonetizationBillingAvailability.available,
-        entitlements: MonetizationEntitlements.pro(),
-        offers: [
+        entitlements: const MonetizationEntitlements.pro(),
+        offers: const [
           MonetizationOffer(
             id: 'monthly',
             productId: 'monkeyssh_pro_monthly',
@@ -413,6 +413,7 @@ void main() {
         debugUnlockAvailable: false,
         debugUnlocked: false,
         activeProductId: MonetizationProductIds.iosProLifetimeProd,
+        entitlementUpdatedAt: DateTime(2026, 4, 10),
       );
 
       when(() => service.currentState).thenReturn(state);
@@ -434,20 +435,26 @@ void main() {
       );
       await tester.pumpAndSettle();
       await tester.dragUntilVisible(
-        find.text('MonkeySSH Pro Lifetime is unlocked on this device.'),
+        find.byKey(const ValueKey('lifetime-status-banner')),
         find.byType(ListView),
         const Offset(0, -200),
       );
       await tester.pumpAndSettle();
 
       expect(
-        find.text('MonkeySSH Pro Lifetime is unlocked on this device.'),
+        find.byKey(const ValueKey('lifetime-status-banner')),
         findsOneWidget,
       );
-      // Lifetime is never offered as a buyable plan card in the paywall;
-      // the only "Lifetime" text on screen comes from the active-state
-      // copy verified above.
-      expect(find.text('Lifetime'), findsNothing);
+      expect(find.text('MonkeySSH Pro Lifetime'), findsOneWidget);
+      expect(
+        find.textContaining('Unlocked with a one-time purchase on'),
+        findsOneWidget,
+      );
+      expect(find.text('Choose a plan'), findsNothing);
+      expect(find.text('Monthly'), findsNothing);
+      expect(find.textContaining('cancel future renewals'), findsWidgets);
+      expect(find.text('Subscribe monthly'), findsNothing);
+      expect(find.text('Switch to Monthly'), findsNothing);
       expect(find.text('Subscribe lifetime'), findsNothing);
       expect(find.text('Switch to Lifetime'), findsNothing);
     },


### PR DESCRIPTION
## Summary

- block recurring purchase attempts when MonkeySSH Pro Lifetime is already active
- show lifetime ownership details on the paywall instead of recurring subscription choices
- keep the subscription-management path available so older renewals can still be cancelled

## Testing

- flutter analyze
- flutter test test/widget/upgrade_screen_test.dart test/domain/services/monetization_service_test.dart
- flutter test
