### PR TITLE
feat: add tmux status bar toggle

### DIFF
--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -1,3 +1,5 @@
+import 'tmux_state.dart';
+
 /// Supported coding-agent CLIs for host-scoped launch presets.
 enum AgentLaunchTool {
   /// Anthropic Claude Code.
@@ -59,6 +61,7 @@ class AgentLaunchPreset {
     required this.tool,
     this.workingDirectory,
     this.tmuxSessionName,
+    this.tmuxDisableStatusBar = false,
     this.additionalArguments,
   });
 
@@ -76,6 +79,7 @@ class AgentLaunchPreset {
       tool: tool,
       workingDirectory: _readTrimmedString(json['workingDirectory']),
       tmuxSessionName: _readTrimmedString(json['tmuxSessionName']),
+      tmuxDisableStatusBar: json['tmuxDisableStatusBar'] == true,
       additionalArguments: _readTrimmedString(json['additionalArguments']),
     );
   }
@@ -88,6 +92,9 @@ class AgentLaunchPreset {
 
   /// Optional tmux session to create or attach before launching the agent.
   final String? tmuxSessionName;
+
+  /// Whether tmux's built-in status bar should be disabled for this session.
+  final bool tmuxDisableStatusBar;
 
   /// Optional extra arguments passed to the CLI.
   final String? additionalArguments;
@@ -107,6 +114,7 @@ class AgentLaunchPreset {
       'workingDirectory': value.trim(),
     if (tmuxSessionName case final value? when value.trim().isNotEmpty)
       'tmuxSessionName': value.trim(),
+    if (tmuxDisableStatusBar) 'tmuxDisableStatusBar': true,
     if (additionalArguments case final value? when value.trim().isNotEmpty)
       'additionalArguments': value.trim(),
   };
@@ -116,11 +124,13 @@ class AgentLaunchPreset {
     AgentLaunchTool? tool,
     String? workingDirectory,
     String? tmuxSessionName,
+    bool? tmuxDisableStatusBar,
     String? additionalArguments,
   }) => AgentLaunchPreset(
     tool: tool ?? this.tool,
     workingDirectory: workingDirectory ?? this.workingDirectory,
     tmuxSessionName: tmuxSessionName ?? this.tmuxSessionName,
+    tmuxDisableStatusBar: tmuxDisableStatusBar ?? this.tmuxDisableStatusBar,
     additionalArguments: additionalArguments ?? this.additionalArguments,
   );
 }
@@ -142,6 +152,7 @@ String buildAgentLaunchCommand(AgentLaunchPreset preset) {
       if (workingDirectory != null && workingDirectory.isNotEmpty)
         '-c ${_quoteShellPath(workingDirectory)}',
       _quoteShellArgument(baseCommand),
+      if (preset.tmuxDisableStatusBar) tmuxDisableStatusBarCommand,
     ];
     return commandParts.join(' ');
   }

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -361,6 +361,9 @@ bool _isAsciiLetterOrDigit(int rune) =>
 
 // ── tmux command helpers ──────────────────────────────────────────────────
 
+/// tmux command fragment that disables tmux's built-in status bar.
+const tmuxDisableStatusBarCommand = r'\; set status off';
+
 /// Builds a `tmux new-session` command from structured configuration.
 ///
 /// Always uses `-A` (attach-or-create) so reconnecting reuses the session.

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -39,6 +39,47 @@ extension _HostStartupModePresentation on _HostStartupMode {
   };
 }
 
+const _tmuxDisableStatusBarCommand = r'\; set status off';
+final _tmuxDisableStatusBarPattern = RegExp(
+  r'(^|\s)\\;\s*set\s+status\s+off(?=\s|$)',
+);
+
+bool _hasTmuxDisableStatusBarCommand(String? extraFlags) {
+  final normalized = extraFlags?.trim();
+  if (normalized == null || normalized.isEmpty) {
+    return false;
+  }
+  return _tmuxDisableStatusBarPattern.hasMatch(normalized);
+}
+
+String _stripTmuxDisableStatusBarCommand(String? extraFlags) {
+  final normalized = extraFlags?.trim();
+  if (normalized == null || normalized.isEmpty) {
+    return '';
+  }
+  return normalized
+      .replaceAll(_tmuxDisableStatusBarPattern, ' ')
+      .replaceAll(RegExp(r'\s{2,}'), ' ')
+      .trim();
+}
+
+String? _resolveTmuxExtraFlags({
+  required String extraFlags,
+  required bool disableStatusBar,
+}) {
+  final normalized = extraFlags.trim();
+  if (!disableStatusBar) {
+    return normalized.isEmpty ? null : normalized;
+  }
+  if (normalized.isEmpty) {
+    return _tmuxDisableStatusBarCommand;
+  }
+  if (_hasTmuxDisableStatusBarCommand(normalized)) {
+    return normalized;
+  }
+  return '$normalized $_tmuxDisableStatusBarCommand';
+}
+
 /// Screen for adding or editing a host.
 class HostEditScreen extends ConsumerStatefulWidget {
   /// Creates a new [HostEditScreen].
@@ -81,6 +122,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   bool _isFavorite = false;
   bool _isLoading = false;
   bool _showPassword = false;
+  bool _disableTmuxStatusBar = false;
 
   Host? _existingHost;
   List<PortForward> _portForwards = [];
@@ -121,6 +163,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     final preset = await ref
         .read(agentLaunchPresetServiceProvider)
         .getPresetForHost(host.id);
+    final tmuxExtraFlags = host.tmuxExtraFlags ?? '';
     if (!mounted) return;
     setState(() {
       _existingHost = host;
@@ -139,8 +182,11 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       _selectedFontFamily = host.terminalFontFamily;
       _tmuxSessionController.text = host.tmuxSessionName ?? '';
       _tmuxWorkingDirectoryController.text = host.tmuxWorkingDirectory ?? '';
-      _tmuxExtraFlagsController.text = host.tmuxExtraFlags ?? '';
+      _tmuxExtraFlagsController.text = _stripTmuxDisableStatusBarCommand(
+        tmuxExtraFlags,
+      );
       _autoConnectCommandController.text = host.autoConnectCommand ?? '';
+      _disableTmuxStatusBar = _hasTmuxDisableStatusBarCommand(tmuxExtraFlags);
       _selectedAutoConnectMode = resolveAutoConnectCommandMode(
         command: host.autoConnectCommand,
         snippetId: host.autoConnectSnippetId,
@@ -644,12 +690,16 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   }
 
   Widget _buildTmuxStartupFields(BuildContext context) {
+    final effectiveTmuxExtraFlags = _resolveTmuxExtraFlags(
+      extraFlags: _tmuxExtraFlagsController.text,
+      disableStatusBar: _disableTmuxStatusBar,
+    );
     final preview = _tmuxSessionController.text.trim().isEmpty
         ? null
         : buildTmuxCommand(
             sessionName: _tmuxSessionController.text.trim(),
             workingDirectory: _tmuxWorkingDirectoryController.text.trim(),
-            extraFlags: _tmuxExtraFlagsController.text.trim(),
+            extraFlags: effectiveTmuxExtraFlags,
           );
 
     return Column(
@@ -701,6 +751,20 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
           ),
           autocorrect: false,
           onChanged: (_) => setState(() {}),
+        ),
+        const SizedBox(height: 4),
+        CheckboxListTile(
+          key: const Key('host-tmux-disable-status-bar-checkbox'),
+          value: _disableTmuxStatusBar,
+          contentPadding: EdgeInsets.zero,
+          controlAffinity: ListTileControlAffinity.leading,
+          title: const Text('Hide tmux status bar'),
+          subtitle: const Text(
+            'Append `\\; set status off` so Flutty\'s tmux bar is the only one shown.',
+          ),
+          onChanged: (value) {
+            setState(() => _disableTmuxStatusBar = value ?? false);
+          },
         ),
         if (preview != null) ...[
           const SizedBox(height: 12),
@@ -989,7 +1053,10 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         _ => hasAutomationAccess ? null : _existingHost?.tmuxWorkingDirectory,
       };
       final normalizedTmuxExtraFlags = switch (_selectedStartupMode) {
-        _HostStartupMode.tmux => tmuxExtraFlags.isEmpty ? null : tmuxExtraFlags,
+        _HostStartupMode.tmux => _resolveTmuxExtraFlags(
+          extraFlags: tmuxExtraFlags,
+          disableStatusBar: _disableTmuxStatusBar,
+        ),
         _HostStartupMode.none => null,
         _ => hasAutomationAccess ? null : _existingHost?.tmuxExtraFlags,
       };

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -39,7 +39,6 @@ extension _HostStartupModePresentation on _HostStartupMode {
   };
 }
 
-const _tmuxDisableStatusBarCommand = r'\; set status off';
 final _tmuxDisableStatusBarPattern = RegExp(
   r'(^|\s)\\;\s*set\s+status\s+off(?=\s|$)',
 );
@@ -72,12 +71,12 @@ String? _resolveTmuxExtraFlags({
     return normalized.isEmpty ? null : normalized;
   }
   if (normalized.isEmpty) {
-    return _tmuxDisableStatusBarCommand;
+    return tmuxDisableStatusBarCommand;
   }
   if (_hasTmuxDisableStatusBarCommand(normalized)) {
     return normalized;
   }
-  return '$normalized $_tmuxDisableStatusBarCommand';
+  return '$normalized $tmuxDisableStatusBarCommand';
 }
 
 /// Screen for adding or editing a host.
@@ -123,6 +122,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   bool _isLoading = false;
   bool _showPassword = false;
   bool _disableTmuxStatusBar = false;
+  bool _disableAgentTmuxStatusBar = false;
 
   Host? _existingHost;
   List<PortForward> _portForwards = [];
@@ -187,6 +187,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       );
       _autoConnectCommandController.text = host.autoConnectCommand ?? '';
       _disableTmuxStatusBar = _hasTmuxDisableStatusBarCommand(tmuxExtraFlags);
+      _disableAgentTmuxStatusBar = preset?.tmuxDisableStatusBar ?? false;
       _selectedAutoConnectMode = resolveAutoConnectCommandMode(
         command: host.autoConnectCommand,
         snippetId: host.autoConnectSnippetId,
@@ -854,7 +855,24 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
           ),
           autocorrect: false,
           onChanged: hasAgentPresetAccess
-              ? (_) => _syncAutoConnectCommandFromPreset()
+              ? (_) => _handleAgentPresetFieldChanged()
+              : null,
+        ),
+        const SizedBox(height: 12),
+        CheckboxListTile(
+          key: const Key('host-agent-disable-status-bar-checkbox'),
+          value: _disableAgentTmuxStatusBar,
+          contentPadding: EdgeInsets.zero,
+          controlAffinity: ListTileControlAffinity.leading,
+          title: const Text('Hide tmux status bar'),
+          subtitle: const Text(
+            'When a tmux session is set, append `\\; set status off` so Flutty\'s tmux bar is the only one shown.',
+          ),
+          onChanged: hasAgentPresetAccess
+              ? (value) {
+                  setState(() => _disableAgentTmuxStatusBar = value ?? false);
+                  _syncAutoConnectCommandFromPreset();
+                }
               : null,
         ),
         const SizedBox(height: 12),
@@ -869,7 +887,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
           ),
           autocorrect: false,
           onChanged: hasAgentPresetAccess
-              ? (_) => _syncAutoConnectCommandFromPreset()
+              ? (_) => _handleAgentPresetFieldChanged()
               : null,
         ),
         const SizedBox(height: 12),
@@ -1433,8 +1451,14 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       tool: _selectedAgentLaunchTool,
       workingDirectory: _agentWorkingDirectoryController.text.trim(),
       tmuxSessionName: _agentTmuxSessionController.text.trim(),
+      tmuxDisableStatusBar: _disableAgentTmuxStatusBar,
       additionalArguments: _agentArgumentsController.text.trim(),
     );
+  }
+
+  void _handleAgentPresetFieldChanged() {
+    setState(() {});
+    _syncAutoConnectCommandFromPreset();
   }
 
   void _syncAutoConnectCommandFromPreset() {

--- a/test/domain/models/agent_launch_preset_test.dart
+++ b/test/domain/models/agent_launch_preset_test.dart
@@ -33,6 +33,19 @@ void main() {
       );
     });
 
+    test('can disable the tmux status bar for agent sessions', () {
+      const preset = AgentLaunchPreset(
+        tool: AgentLaunchTool.copilotCli,
+        tmuxSessionName: 'copilot',
+        tmuxDisableStatusBar: true,
+      );
+
+      expect(
+        buildAgentLaunchCommand(preset),
+        r"tmux new-session -A -s 'copilot' 'copilot' \; set status off",
+      );
+    });
+
     test('builds command for codex tool', () {
       const preset = AgentLaunchPreset(
         tool: AgentLaunchTool.codex,
@@ -68,6 +81,7 @@ void main() {
       tool: AgentLaunchTool.copilotCli,
       workingDirectory: '~/src/flutty',
       tmuxSessionName: 'copilot',
+      tmuxDisableStatusBar: true,
       additionalArguments: '--resume',
     );
 
@@ -76,6 +90,7 @@ void main() {
     expect(decoded.tool, preset.tool);
     expect(decoded.workingDirectory, preset.workingDirectory);
     expect(decoded.tmuxSessionName, preset.tmuxSessionName);
+    expect(decoded.tmuxDisableStatusBar, isTrue);
     expect(decoded.additionalArguments, preset.additionalArguments);
   });
 

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -363,6 +363,13 @@ void main() {
       );
     });
 
+    test('supports tmux commands in extra flags', () {
+      expect(
+        buildTmuxCommand(sessionName: 'dev', extraFlags: r'\; set status off'),
+        r"tmux new-session -A -s 'dev' \; set status off",
+      );
+    });
+
     test('includes all options', () {
       expect(
         buildTmuxCommand(

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -358,6 +358,189 @@ void main() {
     });
 
     testWidgets(
+      'adds the tmux status bar command when the checkbox is enabled',
+      (tester) async {
+        final database = AppDatabase.forTesting(NativeDatabase.memory());
+        final encryptionService = SecretEncryptionService.forTesting();
+        addTearDown(database.close);
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await tester.binding.setSurfaceSize(const Size(420, 900));
+
+        final hostRepository = _FakeHostRepository(
+          host: _testHost(
+            id: 1,
+            label: 'Imported Host',
+            autoConnectRequiresConfirmation: false,
+            tmuxSessionName: 'old-workspace',
+          ),
+          database: database,
+          encryptionService: encryptionService,
+        );
+        final router = GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) =>
+                  const Scaffold(body: SizedBox.shrink()),
+            ),
+            GoRoute(
+              path: '/edit',
+              builder: (context, state) => const HostEditScreen(hostId: 1),
+            ),
+          ],
+        );
+        addTearDown(router.dispose);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(database),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              keyRepositoryProvider.overrideWithValue(
+                _FakeKeyRepository(
+                  database: database,
+                  encryptionService: encryptionService,
+                ),
+              ),
+              snippetRepositoryProvider.overrideWithValue(
+                _FakeSnippetRepository(snippets: const [], database: database),
+              ),
+              portForwardRepositoryProvider.overrideWithValue(
+                _FakePortForwardRepository(database: database),
+              ),
+            ],
+            child: MaterialApp.router(routerConfig: router),
+          ),
+        );
+
+        unawaited(router.push('/edit'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        await tester.enterText(
+          find.byKey(const Key('host-tmux-session-field')),
+          'workspace',
+        );
+        await tester.enterText(
+          find.byKey(const Key('host-tmux-extra-flags-field')),
+          '-f ~/.tmux.conf',
+        );
+        final statusBarCheckbox = tester.widget<CheckboxListTile>(
+          find.byKey(const Key('host-tmux-disable-status-bar-checkbox')),
+        );
+        statusBarCheckbox.onChanged!(true);
+        await tester.pump();
+
+        final saveButton = find.byKey(
+          const Key('host-save-button'),
+          skipOffstage: false,
+        );
+        await tester.scrollUntilVisible(
+          saveButton,
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.ensureVisible(saveButton);
+        tester.widget<FilledButton>(saveButton).onPressed!();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(hostRepository.updatedHost, isNotNull);
+        expect(
+          hostRepository.updatedHost!.tmuxExtraFlags,
+          r'-f ~/.tmux.conf \; set status off',
+        );
+      },
+    );
+
+    testWidgets('loads an existing tmux status bar command into the checkbox', (
+      tester,
+    ) async {
+      final database = AppDatabase.forTesting(NativeDatabase.memory());
+      final encryptionService = SecretEncryptionService.forTesting();
+      addTearDown(database.close);
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.binding.setSurfaceSize(const Size(420, 900));
+
+      final hostRepository = _FakeHostRepository(
+        host: _testHost(
+          id: 1,
+          label: 'Imported Host',
+          autoConnectRequiresConfirmation: false,
+          tmuxSessionName: 'workspace',
+          tmuxExtraFlags: r'-f ~/.tmux.conf \; set status off',
+        ),
+        database: database,
+        encryptionService: encryptionService,
+      );
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) =>
+                const Scaffold(body: SizedBox.shrink()),
+          ),
+          GoRoute(
+            path: '/edit',
+            builder: (context, state) => const HostEditScreen(hostId: 1),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(database),
+            hostRepositoryProvider.overrideWithValue(hostRepository),
+            keyRepositoryProvider.overrideWithValue(
+              _FakeKeyRepository(
+                database: database,
+                encryptionService: encryptionService,
+              ),
+            ),
+            snippetRepositoryProvider.overrideWithValue(
+              _FakeSnippetRepository(snippets: const [], database: database),
+            ),
+            portForwardRepositoryProvider.overrideWithValue(
+              _FakePortForwardRepository(database: database),
+            ),
+          ],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+
+      unawaited(router.push('/edit'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      final extraFlagsField = tester.widget<TextFormField>(
+        find.byKey(const Key('host-tmux-extra-flags-field')),
+      );
+      final statusBarCheckbox = tester.widget<CheckboxListTile>(
+        find.byKey(const Key('host-tmux-disable-status-bar-checkbox')),
+      );
+
+      expect(extraFlagsField.controller!.text, '-f ~/.tmux.conf');
+      expect(statusBarCheckbox.value, isTrue);
+
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('host-save-button')),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.tap(find.byKey(const Key('host-save-button')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(hostRepository.updatedHost, isNotNull);
+      expect(
+        hostRepository.updatedHost!.tmuxExtraFlags,
+        r'-f ~/.tmux.conf \; set status off',
+      );
+    });
+
+    testWidgets(
       'prefers an existing agent preset over legacy tmux startup fields',
       (tester) async {
         final database = AppDatabase.forTesting(NativeDatabase.memory());
@@ -439,12 +622,17 @@ void main() {
         expect(find.byKey(const Key('host-agent-tool-field')), findsOneWidget);
         expect(find.byKey(const Key('host-tmux-session-field')), findsNothing);
 
+        final saveButton = find.byKey(
+          const Key('host-save-button'),
+          skipOffstage: false,
+        );
         await tester.scrollUntilVisible(
-          find.byKey(const Key('host-save-button')),
+          saveButton,
           200,
           scrollable: find.byType(Scrollable).first,
         );
-        await tester.tap(find.byKey(const Key('host-save-button')));
+        await tester.ensureVisible(saveButton);
+        tester.widget<FilledButton>(saveButton).onPressed!();
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -541,7 +541,7 @@ void main() {
     });
 
     testWidgets(
-      'prefers an existing agent preset over legacy tmux startup fields',
+      'shows and saves the tmux status bar checkbox for agent startup',
       (tester) async {
         final database = AppDatabase.forTesting(NativeDatabase.memory());
         final encryptionService = SecretEncryptionService.forTesting();
@@ -552,9 +552,8 @@ void main() {
         final hostRepository = _FakeHostRepository(
           host: _testHost(
             id: 1,
-            label: 'Legacy Mixed Host',
+            label: 'Agent Host',
             autoConnectRequiresConfirmation: false,
-            tmuxSessionName: 'workspace',
           ),
           database: database,
           encryptionService: encryptionService,
@@ -619,7 +618,131 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 
+        final checkboxFinder = find.byKey(
+          const Key('host-agent-disable-status-bar-checkbox'),
+        );
+        expect(checkboxFinder, findsOneWidget);
+        final checkbox = tester.widget<CheckboxListTile>(checkboxFinder);
+        expect(checkbox.value, isFalse);
+
+        checkbox.onChanged!(true);
+        await tester.pump();
+
+        final saveButton = find.byKey(
+          const Key('host-save-button'),
+          skipOffstage: false,
+        );
+        await tester.scrollUntilVisible(
+          saveButton,
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.ensureVisible(saveButton);
+        tester.widget<FilledButton>(saveButton).onPressed!();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(hostRepository.updatedHost, isNotNull);
+        expect(
+          hostRepository.updatedHost!.autoConnectCommand,
+          contains(r'\; set status off'),
+        );
+
+        final savedPreset =
+            verify(
+                  () => presetService.setPresetForHost(1, captureAny()),
+                ).captured.single
+                as AgentLaunchPreset;
+        expect(savedPreset.tmuxDisableStatusBar, isTrue);
+      },
+    );
+
+    testWidgets(
+      'prefers an existing agent preset over legacy tmux startup fields',
+      (tester) async {
+        final database = AppDatabase.forTesting(NativeDatabase.memory());
+        final encryptionService = SecretEncryptionService.forTesting();
+        addTearDown(database.close);
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await tester.binding.setSurfaceSize(const Size(420, 900));
+
+        final hostRepository = _FakeHostRepository(
+          host: _testHost(
+            id: 1,
+            label: 'Legacy Mixed Host',
+            autoConnectRequiresConfirmation: false,
+            tmuxSessionName: 'workspace',
+          ),
+          database: database,
+          encryptionService: encryptionService,
+        );
+        final presetService = _MockAgentLaunchPresetService();
+        const preset = AgentLaunchPreset(
+          tool: AgentLaunchTool.codex,
+          tmuxSessionName: 'agent-session',
+          tmuxDisableStatusBar: true,
+        );
+        when(
+          () => presetService.getPresetForHost(1),
+        ).thenAnswer((_) async => preset);
+        when(
+          () => presetService.setPresetForHost(1, any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => presetService.deletePresetForHost(1),
+        ).thenAnswer((_) async {});
+
+        final router = GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) =>
+                  const Scaffold(body: SizedBox.shrink()),
+            ),
+            GoRoute(
+              path: '/edit',
+              builder: (context, state) => const HostEditScreen(hostId: 1),
+            ),
+          ],
+        );
+        addTearDown(router.dispose);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              databaseProvider.overrideWithValue(database),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              agentLaunchPresetServiceProvider.overrideWithValue(presetService),
+              keyRepositoryProvider.overrideWithValue(
+                _FakeKeyRepository(
+                  database: database,
+                  encryptionService: encryptionService,
+                ),
+              ),
+              snippetRepositoryProvider.overrideWithValue(
+                _FakeSnippetRepository(snippets: const [], database: database),
+              ),
+              portForwardRepositoryProvider.overrideWithValue(
+                _FakePortForwardRepository(database: database),
+              ),
+            ],
+            child: MaterialApp.router(routerConfig: router),
+          ),
+        );
+
+        unawaited(router.push('/edit'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
         expect(find.byKey(const Key('host-agent-tool-field')), findsOneWidget);
+        final checkboxFinder = find.byKey(
+          const Key('host-agent-disable-status-bar-checkbox'),
+        );
+        expect(checkboxFinder, findsOneWidget);
+        expect(tester.widget<CheckboxListTile>(checkboxFinder).value, isTrue);
         expect(find.byKey(const Key('host-tmux-session-field')), findsNothing);
 
         final saveButton = find.byKey(
@@ -636,7 +759,17 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 
-        verify(() => presetService.setPresetForHost(1, any())).called(1);
+        expect(hostRepository.updatedHost, isNotNull);
+        expect(
+          hostRepository.updatedHost!.autoConnectCommand,
+          contains(r'\; set status off'),
+        );
+        final savedPreset =
+            verify(
+                  () => presetService.setPresetForHost(1, captureAny()),
+                ).captured.single
+                as AgentLaunchPreset;
+        expect(savedPreset.tmuxDisableStatusBar, isTrue);
         verifyNever(() => presetService.deletePresetForHost(1));
       },
     );


### PR DESCRIPTION
## Summary

- add a Hide tmux status bar checkbox to tmux host startup settings
- persist the option by appending `\; set status off` to generated tmux flags
- cover the new toggle and existing-host loading behavior with tests
