### PR TITLE
feat: add tmux flags to agent launch presets

### DIFF
--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -91,7 +91,7 @@ class AgentLaunchPreset {
   /// Optional tmux session to create or attach before launching the agent.
   final String? tmuxSessionName;
 
-  /// Optional extra tmux flags passed before the agent command.
+  /// Optional `tmux new-session` flags passed before the agent command.
   final String? tmuxExtraFlags;
 
   /// Optional extra arguments passed to the CLI.

--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -144,6 +144,12 @@ class AgentLaunchPreset {
   );
 }
 
+enum _ShellQuoteMode { none, single, double }
+
+const _backslashCodeUnit = 0x5C;
+
+final _unquotedTmuxFlagTokenPattern = RegExp(r'^[A-Za-z0-9_./~:=,+-]+$');
+
 /// Builds the shell command for a saved agent launch preset.
 String buildAgentLaunchCommand(AgentLaunchPreset preset) {
   final baseCommand = [
@@ -154,14 +160,14 @@ String buildAgentLaunchCommand(AgentLaunchPreset preset) {
   ].join(' ');
 
   final tmuxSessionName = preset.tmuxSessionName?.trim();
-  final tmuxExtraFlags = preset.tmuxExtraFlags?.trim();
   final workingDirectory = preset.workingDirectory?.trim();
   if (tmuxSessionName != null && tmuxSessionName.isNotEmpty) {
+    final tmuxExtraFlags = _tokenizeTmuxNewSessionFlags(preset.tmuxExtraFlags);
     final commandParts = <String>[
       'tmux new-session -A -s ${_quoteShellArgument(tmuxSessionName)}',
       if (workingDirectory != null && workingDirectory.isNotEmpty)
         '-c ${_quoteShellPath(workingDirectory)}',
-      if (tmuxExtraFlags != null && tmuxExtraFlags.isNotEmpty) tmuxExtraFlags,
+      ...tmuxExtraFlags.map(_quoteTmuxFlagToken),
       _quoteShellArgument(baseCommand),
       if (preset.tmuxDisableStatusBar) tmuxDisableStatusBarCommand,
     ];
@@ -174,6 +180,123 @@ String buildAgentLaunchCommand(AgentLaunchPreset preset) {
 
   return baseCommand;
 }
+
+List<String> _tokenizeTmuxNewSessionFlags(String? value) {
+  final normalized = value?.trim();
+  if (normalized == null || normalized.isEmpty) {
+    return const [];
+  }
+  if (normalized.contains('\n') || normalized.contains('\r')) {
+    throw const FormatException(
+      'tmux new-session flags must stay on one line.',
+    );
+  }
+
+  final tokens = <String>[];
+  var currentToken = StringBuffer();
+  var tokenStarted = false;
+  var quoteMode = _ShellQuoteMode.none;
+
+  void commitToken() {
+    if (!tokenStarted) {
+      return;
+    }
+    final token = currentToken.toString();
+    if (_isTmuxCommandSeparatorToken(token)) {
+      throw const FormatException(
+        r'tmux new-session flags cannot include tmux command separators like \;.',
+      );
+    }
+    tokens.add(token);
+    currentToken = StringBuffer();
+    tokenStarted = false;
+  }
+
+  for (var index = 0; index < normalized.length; index++) {
+    final character = normalized[index];
+
+    if (quoteMode == _ShellQuoteMode.single) {
+      if (character == "'") {
+        quoteMode = _ShellQuoteMode.none;
+      } else {
+        tokenStarted = true;
+        currentToken.write(character);
+      }
+      continue;
+    }
+
+    if (quoteMode == _ShellQuoteMode.double) {
+      if (character == '"') {
+        quoteMode = _ShellQuoteMode.none;
+        continue;
+      }
+      if (character.codeUnitAt(0) == _backslashCodeUnit) {
+        if (index + 1 >= normalized.length) {
+          throw const FormatException(
+            'tmux new-session flags cannot end with an escape character.',
+          );
+        }
+        final nextCharacter = normalized[index + 1];
+        if (nextCharacter == '"' ||
+            nextCharacter.codeUnitAt(0) == _backslashCodeUnit ||
+            nextCharacter == r'$' ||
+            nextCharacter == '`') {
+          tokenStarted = true;
+          currentToken.write(nextCharacter);
+          index++;
+          continue;
+        }
+      }
+      tokenStarted = true;
+      currentToken.write(character);
+      continue;
+    }
+
+    if (character == ' ' || character == '\t') {
+      commitToken();
+      continue;
+    }
+    if (character == "'") {
+      tokenStarted = true;
+      quoteMode = _ShellQuoteMode.single;
+      continue;
+    }
+    if (character == '"') {
+      tokenStarted = true;
+      quoteMode = _ShellQuoteMode.double;
+      continue;
+    }
+    if (character.codeUnitAt(0) == _backslashCodeUnit) {
+      if (index + 1 >= normalized.length) {
+        throw const FormatException(
+          'tmux new-session flags cannot end with an escape character.',
+        );
+      }
+      tokenStarted = true;
+      currentToken.write(normalized[index + 1]);
+      index++;
+      continue;
+    }
+    tokenStarted = true;
+    currentToken.write(character);
+  }
+
+  if (quoteMode != _ShellQuoteMode.none) {
+    throw const FormatException(
+      'tmux new-session flags contain an unterminated quote.',
+    );
+  }
+
+  commitToken();
+  return tokens;
+}
+
+bool _isTmuxCommandSeparatorToken(String value) => value == ';';
+
+String _quoteTmuxFlagToken(String value) =>
+    _unquotedTmuxFlagTokenPattern.hasMatch(value)
+    ? value
+    : _quoteShellArgument(value);
 
 String _quoteShellPath(String value) {
   if (value == '~') {

--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -59,6 +59,7 @@ class AgentLaunchPreset {
     required this.tool,
     this.workingDirectory,
     this.tmuxSessionName,
+    this.tmuxExtraFlags,
     this.additionalArguments,
   });
 
@@ -76,6 +77,7 @@ class AgentLaunchPreset {
       tool: tool,
       workingDirectory: _readTrimmedString(json['workingDirectory']),
       tmuxSessionName: _readTrimmedString(json['tmuxSessionName']),
+      tmuxExtraFlags: _readTrimmedString(json['tmuxExtraFlags']),
       additionalArguments: _readTrimmedString(json['additionalArguments']),
     );
   }
@@ -88,6 +90,9 @@ class AgentLaunchPreset {
 
   /// Optional tmux session to create or attach before launching the agent.
   final String? tmuxSessionName;
+
+  /// Optional extra tmux flags passed before the agent command.
+  final String? tmuxExtraFlags;
 
   /// Optional extra arguments passed to the CLI.
   final String? additionalArguments;
@@ -107,6 +112,8 @@ class AgentLaunchPreset {
       'workingDirectory': value.trim(),
     if (tmuxSessionName case final value? when value.trim().isNotEmpty)
       'tmuxSessionName': value.trim(),
+    if (tmuxExtraFlags case final value? when value.trim().isNotEmpty)
+      'tmuxExtraFlags': value.trim(),
     if (additionalArguments case final value? when value.trim().isNotEmpty)
       'additionalArguments': value.trim(),
   };
@@ -116,11 +123,13 @@ class AgentLaunchPreset {
     AgentLaunchTool? tool,
     String? workingDirectory,
     String? tmuxSessionName,
+    String? tmuxExtraFlags,
     String? additionalArguments,
   }) => AgentLaunchPreset(
     tool: tool ?? this.tool,
     workingDirectory: workingDirectory ?? this.workingDirectory,
     tmuxSessionName: tmuxSessionName ?? this.tmuxSessionName,
+    tmuxExtraFlags: tmuxExtraFlags ?? this.tmuxExtraFlags,
     additionalArguments: additionalArguments ?? this.additionalArguments,
   );
 }
@@ -135,12 +144,14 @@ String buildAgentLaunchCommand(AgentLaunchPreset preset) {
   ].join(' ');
 
   final tmuxSessionName = preset.tmuxSessionName?.trim();
+  final tmuxExtraFlags = preset.tmuxExtraFlags?.trim();
   final workingDirectory = preset.workingDirectory?.trim();
   if (tmuxSessionName != null && tmuxSessionName.isNotEmpty) {
     final commandParts = <String>[
       'tmux new-session -A -s ${_quoteShellArgument(tmuxSessionName)}',
       if (workingDirectory != null && workingDirectory.isNotEmpty)
         '-c ${_quoteShellPath(workingDirectory)}',
+      if (tmuxExtraFlags != null && tmuxExtraFlags.isNotEmpty) tmuxExtraFlags,
       _quoteShellArgument(baseCommand),
     ];
     return commandParts.join(' ');

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -66,6 +66,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   late TextEditingController _tmuxExtraFlagsController;
   late TextEditingController _agentWorkingDirectoryController;
   late TextEditingController _agentTmuxSessionController;
+  late TextEditingController _agentTmuxExtraFlagsController;
   late TextEditingController _agentArgumentsController;
 
   int? _selectedKeyId;
@@ -100,6 +101,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     _tmuxExtraFlagsController = TextEditingController();
     _agentWorkingDirectoryController = TextEditingController();
     _agentTmuxSessionController = TextEditingController();
+    _agentTmuxExtraFlagsController = TextEditingController();
     _agentArgumentsController = TextEditingController();
 
     if (widget.hostId != null) {
@@ -155,6 +157,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         _selectedAgentLaunchTool = preset.tool;
         _agentWorkingDirectoryController.text = preset.workingDirectory ?? '';
         _agentTmuxSessionController.text = preset.tmuxSessionName ?? '';
+        _agentTmuxExtraFlagsController.text = preset.tmuxExtraFlags ?? '';
         _agentArgumentsController.text = preset.additionalArguments ?? '';
         if (_selectedAutoConnectMode == AutoConnectCommandMode.custom ||
             host.autoConnectCommand == presetCommand) {
@@ -181,6 +184,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     _tmuxExtraFlagsController.dispose();
     _agentWorkingDirectoryController.dispose();
     _agentTmuxSessionController.dispose();
+    _agentTmuxExtraFlagsController.dispose();
     _agentArgumentsController.dispose();
     super.dispose();
   }
@@ -795,6 +799,23 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         ),
         const SizedBox(height: 12),
         TextFormField(
+          key: const Key('host-agent-tmux-extra-flags-field'),
+          controller: _agentTmuxExtraFlagsController,
+          readOnly: !hasAgentPresetAccess,
+          decoration: const InputDecoration(
+            labelText: 'Extra tmux flags (optional)',
+            hintText: '-f ~/.tmux-agent.conf',
+            prefixIcon: Icon(Icons.tune_outlined),
+            helperText:
+                'Used only when a tmux session is set for the coding agent launch.',
+          ),
+          autocorrect: false,
+          onChanged: hasAgentPresetAccess
+              ? (_) => _syncAutoConnectCommandFromPreset()
+              : null,
+        ),
+        const SizedBox(height: 12),
+        TextFormField(
           key: const Key('host-agent-arguments-field'),
           controller: _agentArgumentsController,
           readOnly: !hasAgentPresetAccess,
@@ -1366,6 +1387,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       tool: _selectedAgentLaunchTool,
       workingDirectory: _agentWorkingDirectoryController.text.trim(),
       tmuxSessionName: _agentTmuxSessionController.text.trim(),
+      tmuxExtraFlags: _agentTmuxExtraFlagsController.text.trim(),
       additionalArguments: _agentArgumentsController.text.trim(),
     );
   }

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -803,11 +803,11 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
           controller: _agentTmuxExtraFlagsController,
           readOnly: !hasAgentPresetAccess,
           decoration: const InputDecoration(
-            labelText: 'Extra tmux flags (optional)',
-            hintText: '-f ~/.tmux-agent.conf',
+            labelText: 'Extra tmux new-session flags (optional)',
+            hintText: '-x 160 -y 48',
             prefixIcon: Icon(Icons.tune_outlined),
             helperText:
-                'Used only when a tmux session is set for the coding agent launch.',
+                'Passed directly to `tmux new-session`. Used only when a tmux session is set for the coding agent launch.',
           ),
           autocorrect: false,
           onChanged: hasAgentPresetAccess

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -200,14 +200,15 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         autoConnectMode: _selectedAutoConnectMode,
       );
       if (preset != null) {
-        final presetCommand = buildAgentLaunchCommand(preset);
+        final presetCommand = _tryBuildAgentLaunchCommand(preset);
         _selectedAgentLaunchTool = preset.tool;
         _agentWorkingDirectoryController.text = preset.workingDirectory ?? '';
         _agentTmuxSessionController.text = preset.tmuxSessionName ?? '';
         _agentTmuxExtraFlagsController.text = preset.tmuxExtraFlags ?? '';
         _agentArgumentsController.text = preset.additionalArguments ?? '';
-        if (_selectedAutoConnectMode == AutoConnectCommandMode.custom ||
-            host.autoConnectCommand == presetCommand) {
+        if (presetCommand != null &&
+            (_selectedAutoConnectMode == AutoConnectCommandMode.custom ||
+                host.autoConnectCommand == presetCommand)) {
           _autoConnectCommandController.text = presetCommand;
         }
       }
@@ -794,9 +795,14 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     BuildContext context, {
     required bool hasAgentPresetAccess,
   }) {
-    final generatedCommand = buildAgentLaunchCommand(
-      _buildCurrentAgentLaunchPreset()!,
-    );
+    final currentPreset = _buildCurrentAgentLaunchPreset()!;
+    String? generatedCommand;
+    String? generatedCommandError;
+    try {
+      generatedCommand = buildAgentLaunchCommand(currentPreset);
+    } on FormatException catch (error) {
+      generatedCommandError = _formatFormatExceptionMessage(error);
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -842,7 +848,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
           ),
           autocorrect: false,
           onChanged: hasAgentPresetAccess
-              ? (_) => _syncAutoConnectCommandFromPreset()
+              ? (_) => _handleAgentPresetFieldChanged()
               : null,
         ),
         const SizedBox(height: 12),
@@ -891,9 +897,11 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
             helperText:
                 'Passed directly to `tmux new-session`. Used only when a tmux session is set for the coding agent launch.',
           ),
+          autovalidateMode: AutovalidateMode.onUserInteraction,
           autocorrect: false,
+          validator: _validateAgentTmuxExtraFlags,
           onChanged: hasAgentPresetAccess
-              ? (_) => _syncAutoConnectCommandFromPreset()
+              ? (_) => _handleAgentPresetFieldChanged()
               : null,
         ),
         const SizedBox(height: 12),
@@ -917,13 +925,21 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
           style: Theme.of(context).textTheme.titleSmall,
         ),
         const SizedBox(height: 8),
-        SelectableText(
-          generatedCommand,
-          style: FluttyTheme.monoStyle.copyWith(
-            fontSize: 12,
-            color: Theme.of(context).textTheme.bodySmall?.color,
+        if (generatedCommand case final command?)
+          SelectableText(
+            command,
+            style: FluttyTheme.monoStyle.copyWith(
+              fontSize: 12,
+              color: Theme.of(context).textTheme.bodySmall?.color,
+            ),
+          )
+        else if (generatedCommandError case final error?)
+          Text(
+            error,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.error,
+            ),
           ),
-        ),
       ],
     );
   }
@@ -1483,12 +1499,48 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     _syncAutoConnectCommandFromPreset();
   }
 
+  String? _validateAgentTmuxExtraFlags(String? value) {
+    if (_agentTmuxSessionController.text.trim().isEmpty) {
+      return null;
+    }
+    try {
+      buildAgentLaunchCommand(
+        AgentLaunchPreset(
+          tool: AgentLaunchTool.claudeCode,
+          tmuxSessionName: 'preview',
+          tmuxExtraFlags: value,
+        ),
+      );
+      return null;
+    } on FormatException catch (error) {
+      return _formatFormatExceptionMessage(error);
+    }
+  }
+
+  String? _tryBuildAgentLaunchCommand(AgentLaunchPreset? preset) {
+    if (preset == null) {
+      return null;
+    }
+    try {
+      return buildAgentLaunchCommand(preset);
+    } on FormatException {
+      return null;
+    }
+  }
+
+  String _formatFormatExceptionMessage(FormatException error) => error.message;
+
   void _syncAutoConnectCommandFromPreset() {
     final preset = _buildCurrentAgentLaunchPreset();
     if (preset == null) {
       return;
     }
-    _autoConnectCommandController.text = buildAgentLaunchCommand(preset);
+    final command = _tryBuildAgentLaunchCommand(preset);
+    if (command == null) {
+      _autoConnectCommandController.clear();
+      return;
+    }
+    _autoConnectCommandController.text = command;
   }
 
   Future<void> _selectTheme({required bool isLight}) async {

--- a/test/domain/models/agent_launch_preset_test.dart
+++ b/test/domain/models/agent_launch_preset_test.dart
@@ -23,15 +23,43 @@ void main() {
         tool: AgentLaunchTool.codex,
         workingDirectory: '~/src/app',
         tmuxSessionName: 'nightly review',
+        tmuxExtraFlags: '-f ~/.tmux-agent.conf',
         additionalArguments: '--yes-always',
       );
 
       expect(
         buildAgentLaunchCommand(preset),
         'tmux new-session -A -s \'nightly review\' -c '
-        '"\$HOME/src/app" \'codex --yes-always\'',
+        '"\$HOME/src/app" -f ~/.tmux-agent.conf \'codex --yes-always\'',
       );
     });
+
+    test('ignores tmux flags when no tmux session is configured', () {
+      const preset = AgentLaunchPreset(
+        tool: AgentLaunchTool.codex,
+        tmuxExtraFlags: '-f ~/.tmux-agent.conf',
+        additionalArguments: '--yes-always',
+      );
+
+      expect(buildAgentLaunchCommand(preset), 'codex --yes-always');
+    });
+
+    test(
+      'builds command for tmux with extra flags and no working directory',
+      () {
+        const preset = AgentLaunchPreset(
+          tool: AgentLaunchTool.geminiCli,
+          tmuxSessionName: 'nightly review',
+          tmuxExtraFlags: '-f ~/.tmux-agent.conf',
+        );
+
+        expect(
+          buildAgentLaunchCommand(preset),
+          'tmux new-session -A -s \'nightly review\' '
+          '-f ~/.tmux-agent.conf \'gemini\'',
+        );
+      },
+    );
 
     test('builds command for codex tool', () {
       const preset = AgentLaunchPreset(
@@ -68,6 +96,7 @@ void main() {
       tool: AgentLaunchTool.copilotCli,
       workingDirectory: '~/src/flutty',
       tmuxSessionName: 'copilot',
+      tmuxExtraFlags: '-f ~/.tmux-agent.conf',
       additionalArguments: '--resume',
     );
 
@@ -76,6 +105,7 @@ void main() {
     expect(decoded.tool, preset.tool);
     expect(decoded.workingDirectory, preset.workingDirectory);
     expect(decoded.tmuxSessionName, preset.tmuxSessionName);
+    expect(decoded.tmuxExtraFlags, preset.tmuxExtraFlags);
     expect(decoded.additionalArguments, preset.additionalArguments);
   });
 

--- a/test/domain/models/agent_launch_preset_test.dart
+++ b/test/domain/models/agent_launch_preset_test.dart
@@ -61,6 +61,38 @@ void main() {
       },
     );
 
+    test('quotes tmux flag values with spaces safely', () {
+      const preset = AgentLaunchPreset(
+        tool: AgentLaunchTool.codex,
+        tmuxSessionName: 'nightly review',
+        tmuxExtraFlags: '-n "review window"',
+      );
+
+      expect(
+        buildAgentLaunchCommand(preset),
+        "tmux new-session -A -s 'nightly review' -n 'review window' 'codex'",
+      );
+    });
+
+    test('rejects tmux command separators in extra flags', () {
+      const preset = AgentLaunchPreset(
+        tool: AgentLaunchTool.codex,
+        tmuxSessionName: 'nightly review',
+        tmuxExtraFlags: r'-x 160 \; set status off',
+      );
+
+      expect(
+        () => buildAgentLaunchCommand(preset),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains(r'\;'),
+          ),
+        ),
+      );
+    });
+
     test('can disable the tmux status bar for agent sessions', () {
       const preset = AgentLaunchPreset(
         tool: AgentLaunchTool.copilotCli,
@@ -73,6 +105,7 @@ void main() {
         r"tmux new-session -A -s 'copilot' 'copilot' \; set status off",
       );
     });
+
     test('builds command for codex tool', () {
       const preset = AgentLaunchPreset(
         tool: AgentLaunchTool.codex,

--- a/test/domain/models/agent_launch_preset_test.dart
+++ b/test/domain/models/agent_launch_preset_test.dart
@@ -23,21 +23,21 @@ void main() {
         tool: AgentLaunchTool.codex,
         workingDirectory: '~/src/app',
         tmuxSessionName: 'nightly review',
-        tmuxExtraFlags: '-f ~/.tmux-agent.conf',
+        tmuxExtraFlags: '-x 160 -y 48',
         additionalArguments: '--yes-always',
       );
 
       expect(
         buildAgentLaunchCommand(preset),
         'tmux new-session -A -s \'nightly review\' -c '
-        '"\$HOME/src/app" -f ~/.tmux-agent.conf \'codex --yes-always\'',
+        '"\$HOME/src/app" -x 160 -y 48 \'codex --yes-always\'',
       );
     });
 
     test('ignores tmux flags when no tmux session is configured', () {
       const preset = AgentLaunchPreset(
         tool: AgentLaunchTool.codex,
-        tmuxExtraFlags: '-f ~/.tmux-agent.conf',
+        tmuxExtraFlags: '-x 160 -y 48',
         additionalArguments: '--yes-always',
       );
 
@@ -50,13 +50,13 @@ void main() {
         const preset = AgentLaunchPreset(
           tool: AgentLaunchTool.geminiCli,
           tmuxSessionName: 'nightly review',
-          tmuxExtraFlags: '-f ~/.tmux-agent.conf',
+          tmuxExtraFlags: '-x 160 -y 48',
         );
 
         expect(
           buildAgentLaunchCommand(preset),
           'tmux new-session -A -s \'nightly review\' '
-          '-f ~/.tmux-agent.conf \'gemini\'',
+          '-x 160 -y 48 \'gemini\'',
         );
       },
     );
@@ -96,7 +96,7 @@ void main() {
       tool: AgentLaunchTool.copilotCli,
       workingDirectory: '~/src/flutty',
       tmuxSessionName: 'copilot',
-      tmuxExtraFlags: '-f ~/.tmux-agent.conf',
+      tmuxExtraFlags: '-x 160 -y 48',
       additionalArguments: '--resume',
     );
 

--- a/test/domain/services/agent_launch_preset_service_test.dart
+++ b/test/domain/services/agent_launch_preset_service_test.dart
@@ -25,6 +25,7 @@ void main() {
       tool: AgentLaunchTool.claudeCode,
       workingDirectory: '~/src/flutty',
       tmuxSessionName: 'claude',
+      tmuxExtraFlags: '-f ~/.tmux-agent.conf',
       additionalArguments: '--resume',
     );
 
@@ -35,6 +36,7 @@ void main() {
     expect(loaded!.tool, preset.tool);
     expect(loaded.workingDirectory, preset.workingDirectory);
     expect(loaded.tmuxSessionName, preset.tmuxSessionName);
+    expect(loaded.tmuxExtraFlags, preset.tmuxExtraFlags);
     expect(loaded.additionalArguments, preset.additionalArguments);
   });
 

--- a/test/domain/services/agent_launch_preset_service_test.dart
+++ b/test/domain/services/agent_launch_preset_service_test.dart
@@ -25,7 +25,7 @@ void main() {
       tool: AgentLaunchTool.claudeCode,
       workingDirectory: '~/src/flutty',
       tmuxSessionName: 'claude',
-      tmuxExtraFlags: '-f ~/.tmux-agent.conf',
+      tmuxExtraFlags: '-x 160 -y 48',
       additionalArguments: '--resume',
     );
 

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -639,6 +639,14 @@ void main() {
           find.byKey(const Key('host-agent-tmux-extra-flags-field')),
           '-x 200 -y 60',
         );
+        await tester.pump();
+        expect(
+          find.textContaining(
+            "tmux new-session -A -s 'agent-session' -x 200 -y 60",
+            findRichText: true,
+          ),
+          findsOneWidget,
+        );
         final checkboxFinder = find.byKey(
           const Key('host-agent-disable-status-bar-checkbox'),
         );
@@ -678,6 +686,110 @@ void main() {
         expect(savedPreset.tmuxExtraFlags, '-x 200 -y 60');
       },
     );
+
+    testWidgets('validates agent tmux flags before saving', (tester) async {
+      final database = AppDatabase.forTesting(NativeDatabase.memory());
+      final encryptionService = SecretEncryptionService.forTesting();
+      addTearDown(database.close);
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.binding.setSurfaceSize(const Size(420, 900));
+
+      final hostRepository = _FakeHostRepository(
+        host: _testHost(
+          id: 1,
+          label: 'Agent Host',
+          autoConnectRequiresConfirmation: false,
+        ),
+        database: database,
+        encryptionService: encryptionService,
+      );
+      final presetService = _MockAgentLaunchPresetService();
+      const preset = AgentLaunchPreset(
+        tool: AgentLaunchTool.codex,
+        tmuxSessionName: 'agent-session',
+      );
+      when(
+        () => presetService.getPresetForHost(1),
+      ).thenAnswer((_) async => preset);
+      when(
+        () => presetService.setPresetForHost(1, any()),
+      ).thenAnswer((_) async {});
+      when(() => presetService.deletePresetForHost(1)).thenAnswer((_) async {});
+
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) =>
+                const Scaffold(body: SizedBox.shrink()),
+          ),
+          GoRoute(
+            path: '/edit',
+            builder: (context, state) => const HostEditScreen(hostId: 1),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            monetizationStateProvider.overrideWith(
+              (ref) => Stream.value(_proMonetizationState),
+            ),
+            databaseProvider.overrideWithValue(database),
+            hostRepositoryProvider.overrideWithValue(hostRepository),
+            agentLaunchPresetServiceProvider.overrideWithValue(presetService),
+            keyRepositoryProvider.overrideWithValue(
+              _FakeKeyRepository(
+                database: database,
+                encryptionService: encryptionService,
+              ),
+            ),
+            snippetRepositoryProvider.overrideWithValue(
+              _FakeSnippetRepository(snippets: const [], database: database),
+            ),
+            portForwardRepositoryProvider.overrideWithValue(
+              _FakePortForwardRepository(database: database),
+            ),
+          ],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+
+      unawaited(router.push('/edit'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      await tester.enterText(
+        find.byKey(const Key('host-agent-tmux-extra-flags-field')),
+        r'\; set status off',
+      );
+      await tester.pump();
+
+      expect(
+        find.text(
+          r'tmux new-session flags cannot include tmux command separators like \;.',
+        ),
+        findsWidgets,
+      );
+
+      final saveButton = find.byKey(
+        const Key('host-save-button'),
+        skipOffstage: false,
+      );
+      await tester.scrollUntilVisible(
+        saveButton,
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.ensureVisible(saveButton);
+      tester.widget<FilledButton>(saveButton).onPressed!();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      verifyNever(() => presetService.setPresetForHost(1, any()));
+    });
 
     testWidgets(
       'prefers an existing agent preset over legacy tmux startup fields',

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -380,6 +380,7 @@ void main() {
         const preset = AgentLaunchPreset(
           tool: AgentLaunchTool.codex,
           tmuxSessionName: 'agent-session',
+          tmuxExtraFlags: '-f ~/.tmux-agent.conf',
         );
         when(
           () => presetService.getPresetForHost(1),
@@ -438,6 +439,24 @@ void main() {
 
         expect(find.byKey(const Key('host-agent-tool-field')), findsOneWidget);
         expect(find.byKey(const Key('host-tmux-session-field')), findsNothing);
+        expect(
+          find.byKey(const Key('host-agent-tmux-extra-flags-field')),
+          findsOneWidget,
+        );
+        expect(
+          tester
+              .widget<TextFormField>(
+                find.byKey(const Key('host-agent-tmux-extra-flags-field')),
+              )
+              .controller!
+              .text,
+          '-f ~/.tmux-agent.conf',
+        );
+
+        await tester.enterText(
+          find.byKey(const Key('host-agent-tmux-extra-flags-field')),
+          '-f ~/.tmux-agent.custom.conf',
+        );
 
         await tester.scrollUntilVisible(
           find.byKey(const Key('host-save-button')),
@@ -448,7 +467,13 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 
-        verify(() => presetService.setPresetForHost(1, any())).called(1);
+        final capturedPreset =
+            verify(
+                  () => presetService.setPresetForHost(1, captureAny()),
+                ).captured.single
+                as AgentLaunchPreset;
+        expect(capturedPreset.tmuxSessionName, 'agent-session');
+        expect(capturedPreset.tmuxExtraFlags, '-f ~/.tmux-agent.custom.conf');
         verifyNever(() => presetService.deletePresetForHost(1));
       },
     );

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -380,7 +380,7 @@ void main() {
         const preset = AgentLaunchPreset(
           tool: AgentLaunchTool.codex,
           tmuxSessionName: 'agent-session',
-          tmuxExtraFlags: '-f ~/.tmux-agent.conf',
+          tmuxExtraFlags: '-x 160 -y 48',
         );
         when(
           () => presetService.getPresetForHost(1),
@@ -450,12 +450,12 @@ void main() {
               )
               .controller!
               .text,
-          '-f ~/.tmux-agent.conf',
+          '-x 160 -y 48',
         );
 
         await tester.enterText(
           find.byKey(const Key('host-agent-tmux-extra-flags-field')),
-          '-f ~/.tmux-agent.custom.conf',
+          '-x 200 -y 60',
         );
 
         await tester.scrollUntilVisible(
@@ -473,7 +473,7 @@ void main() {
                 ).captured.single
                 as AgentLaunchPreset;
         expect(capturedPreset.tmuxSessionName, 'agent-session');
-        expect(capturedPreset.tmuxExtraFlags, '-f ~/.tmux-agent.custom.conf');
+        expect(capturedPreset.tmuxExtraFlags, '-x 200 -y 60');
         verifyNever(() => presetService.deletePresetForHost(1));
       },
     );


### PR DESCRIPTION
## Summary

- add extra tmux flags to coding-agent launch presets
- expose the field in the host editor alongside tmux session and agent args
- cover the new field in preset model, preset service, and host editor tests
