### PR TITLE
fix(tmux): detect agent CLIs added from interactive rc files (Claude regression)

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -82,29 +82,30 @@ class TmuxService {
   /// Detects which supported coding-agent CLIs are available on the
   /// remote host's `PATH`.
   ///
-  /// Resolves binaries via `command -v`, sourcing the user's login
-  /// shell profile so Homebrew/nvm/asdf-installed CLIs are found over
-  /// SSH exec channels (which start with a minimal `PATH`).
+  /// Resolves binaries via `command -v` inside an interactive instance of
+  /// the user's `$SHELL` (`zsh -ic` / `bash -ic` / …). This is necessary
+  /// because many users add agent CLIs (Claude, npm-global bins, etc.)
+  /// to `PATH` from their interactive rc file (`~/.zshrc`, `~/.bashrc`)
+  /// rather than from a login profile, and SSH exec channels otherwise
+  /// only see the minimal system `PATH` plus what we source from
+  /// `~/.profile` / `~/.bash_profile` / `~/.zprofile`. The detection
+  /// command is built per-binary so it also works on POSIX-strict
+  /// `/bin/sh` (dash), where `command -v` rejects multiple operands.
   ///
-  /// Results are cached per connection. Returns an empty set on any
-  /// detection error so callers can render a sensible fallback rather
-  /// than blocking the user.
+  /// Successful detections are cached per connection. Empty results
+  /// (typically a transient detection failure) are intentionally not
+  /// cached, so a later call can recover.
   Future<Set<AgentLaunchTool>> detectInstalledAgentTools(
     SshSession session,
   ) async {
     final cached = _installedAgentToolsCache[session.connectionId];
     if (cached != null) return cached;
     try {
-      final binaries = AgentLaunchTool.values
-          .map((t) => t.commandName)
-          .toSet()
-          .join(' ');
-      final output = await _exec(
-        session,
-        'command -v $binaries 2>/dev/null || true',
-      );
+      final output = await _exec(session, buildAgentToolDetectionCommand());
       final installed = parseInstalledAgentTools(output);
-      _installedAgentToolsCache[session.connectionId] = installed;
+      if (installed.isNotEmpty) {
+        _installedAgentToolsCache[session.connectionId] = installed;
+      }
       return installed;
     } on Object {
       return const <AgentLaunchTool>{};
@@ -758,7 +759,38 @@ AgentLaunchTool? agentToolForBinaryName(String binaryName) =>
       _ => null,
     };
 
-/// Parses the output of `command -v <bins...>` into the set of supported
+/// Builds the shell command used by [TmuxService.detectInstalledAgentTools]
+/// to resolve agent CLI binaries on a remote host.
+///
+/// The command:
+///
+/// - Loops one binary at a time so it works on POSIX-strict shells like
+///   `dash`, where `command -v a b c` rejects the extra operands and
+///   prints nothing.
+/// - Re-invokes the user's interactive `$SHELL` (`zsh -ic`, `bash -ic`,
+///   …) so PATH additions made from `~/.zshrc` / `~/.bashrc` (where
+///   tools like `claude` and other npm-global / asdf / mise / pyenv
+///   installs are commonly added) are picked up. Login-only profile
+///   sourcing — what SSH exec channels otherwise see — misses these.
+/// - Falls back to `/bin/sh` if `$SHELL` is unset, and tolerates the
+///   inner `command -v` exiting non-zero when a binary is missing.
+@visibleForTesting
+String buildAgentToolDetectionCommand() {
+  final binaries =
+      AgentLaunchTool.values.map((t) => t.commandName).toSet().toList()..sort();
+  final inner =
+      'for c in ${binaries.join(' ')}; do '
+      r'command -v "$c" 2>/dev/null; '
+      'done';
+  // Single-quote the inner snippet for the outer shell, then escape any
+  // single quotes inside it. There are none today, but this keeps the
+  // builder safe if someone adds a binary name containing a quote.
+  final quotedInner = "'${inner.replaceAll("'", "'\"'\"'")}'";
+  return r'SH="${SHELL:-/bin/sh}"; "$SH" -ic '
+      '$quotedInner '
+      '2>/dev/null || true';
+}
+
 /// agent CLIs that resolved to an absolute path.
 ///
 /// Lines that do not start with `/` are ignored, so shell function names,

--- a/test/domain/services/tmux_service_agent_detection_test.dart
+++ b/test/domain/services/tmux_service_agent_detection_test.dart
@@ -3,6 +3,47 @@ import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
 import 'package:monkeyssh/domain/services/tmux_service.dart';
 
 void main() {
+  group('buildAgentToolDetectionCommand', () {
+    test('runs an interactive instance of the user\'s shell', () {
+      // The whole point of the rewrite: invoke `\$SHELL -ic`, falling
+      // back to /bin/sh, so PATH additions from ~/.zshrc / ~/.bashrc
+      // are picked up. SSH exec channels otherwise only see login
+      // profiles and miss tools like `claude` that npm-global users
+      // expose from rc files.
+      final command = buildAgentToolDetectionCommand();
+      expect(command, contains(r'SH="${SHELL:-/bin/sh}"'));
+      expect(command, contains(r'"$SH" -ic '));
+    });
+
+    test('loops per-binary so it works on POSIX-strict shells (dash)', () {
+      // dash and other strict POSIX shells reject `command -v a b c`
+      // and print nothing; a per-binary loop avoids that pitfall.
+      final command = buildAgentToolDetectionCommand();
+      expect(command, contains('for c in '));
+      expect(command, contains(r'command -v "$c"'));
+    });
+
+    test('queries every supported agent CLI', () {
+      final command = buildAgentToolDetectionCommand();
+      for (final tool in AgentLaunchTool.values) {
+        expect(
+          command,
+          contains(tool.commandName),
+          reason: 'detection command must look up ${tool.commandName}',
+        );
+      }
+    });
+
+    test('tolerates missing binaries without failing the outer shell', () {
+      final command = buildAgentToolDetectionCommand();
+      // 2>/dev/null suppresses noisy "not found" messages from rc files
+      // and the inner shell; `|| true` keeps the exit status clean so
+      // the SSH exec channel does not surface a misleading error.
+      expect(command, contains('2>/dev/null'));
+      expect(command, endsWith('|| true'));
+    });
+  });
+
   group('parseInstalledAgentTools', () {
     test('returns empty for empty input', () {
       expect(parseInstalledAgentTools(''), isEmpty);
@@ -19,6 +60,15 @@ void main() {
         AgentLaunchTool.codex,
         AgentLaunchTool.aider,
       });
+    });
+
+    test('detects claude installed in ~/.local/bin (the regression case)', () {
+      // Reproduces the user-reported regression: claude lives in
+      // ~/.local/bin, which is added to PATH from ~/.zshrc rather
+      // than ~/.zprofile. The interactive-shell command builder
+      // resolves it; the parser must accept the path.
+      const output = '/Users/depoll/.local/bin/claude\n';
+      expect(parseInstalledAgentTools(output), {AgentLaunchTool.claudeCode});
     });
 
     test('ignores bare names (shell builtins, aliases, missing CLIs)', () {


### PR DESCRIPTION
## Summary

Follow-up to #294. The new-window picker was missing CLIs (notably Claude) for users who add their PATH from `~/.zshrc` / `~/.bashrc` rather than from a login profile. SSH exec channels run with a minimal PATH and we only source login profiles (`~/.zprofile`, `~/.bash_profile`, `~/.profile`), so `command -v claude` produced no output and the picker filtered Claude out. To make matters worse, the empty result was cached for the rest of the connection, so the picker stayed broken until reconnect.

## Root cause

Many users — and especially anyone with an npm-global `claude` install — add `~/.local/bin` (or `~/.npm-global/bin`, or `mise`/`asdf` shims) to PATH from `~/.zshrc`, often above the standard `[[ $- != *i* ]] && return` guard or with no guard at all. Login profiles like `~/.zprofile` are intentionally minimal in many setups and never touch PATH. Since the SSH exec channel only invokes the user's shell non-interactively, the rc files don't run, so the binary is invisible to `command -v`.

A second, latent issue: the previous lookup used `command -v a b c d …`, which is undefined behavior in POSIX. On strict shells like `dash` (the default `/bin/sh` on Debian/Ubuntu), `command -v` accepts only one operand, exits 127 on the first miss, and prints nothing.

## Fix

Run the lookup inside an interactive instance of the user's shell, one binary at a time:

```sh
SH="${SHELL:-/bin/sh}"; "$SH" -ic 'for c in aider claude codex copilot gemini opencode; do command -v "$c" 2>/dev/null; done' 2>/dev/null || true
```

- `$SHELL -ic` (with `/bin/sh` fallback) sources rc files, picking up PATH additions made there.
- Per-binary loop avoids the dash multi-operand pitfall and works identically on bash, zsh, and sh.
- `2>/dev/null` and `|| true` keep noisy rc files / missing binaries from surfacing as channel errors.

Empty detection results are also no longer cached, so a transient failure (e.g. a slow rc file getting cut off by the existing 10 s exec timeout) doesn't stick — the next picker open re-detects.

The shell command itself is produced by a new `buildAgentToolDetectionCommand` helper so the interactive-shell, per-binary, and error-tolerance properties are unit-tested directly.

## Tests

- `flutter analyze`: clean.
- `flutter test`: 1327 tests pass.
- New tests in `test/domain/services/tmux_service_agent_detection_test.dart`:
  - `buildAgentToolDetectionCommand` runs `$SHELL -ic`, loops per-binary, queries every supported CLI, and tolerates missing binaries.
  - `parseInstalledAgentTools` regression case for `/Users/.../.local/bin/claude` (the user-reported scenario).
