### PR TITLE
fix: recover session resumption across git worktrees

### DIFF
--- a/integration_test/tmux_ai_sessions_validation_test.dart
+++ b/integration_test/tmux_ai_sessions_validation_test.dart
@@ -1,0 +1,261 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:monkeyssh/app/app.dart';
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/data/repositories/key_repository.dart';
+import 'package:monkeyssh/domain/models/monetization.dart';
+import 'package:monkeyssh/domain/services/host_key_prompt_handler_provider.dart';
+import 'package:monkeyssh/domain/services/host_key_verification.dart';
+import 'package:monkeyssh/domain/services/monetization_service.dart';
+import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
+
+const _hostLabel = 'Local tmux AI sessions';
+const _sshPort = String.fromEnvironment('FLUTTY_TMUX_BAR_SSH_PORT');
+const _sshUser = String.fromEnvironment('FLUTTY_TMUX_BAR_SSH_USER');
+const _sshPrivateKeyBase64 = String.fromEnvironment(
+  'FLUTTY_TMUX_BAR_SSH_KEY_B64',
+);
+const _sshPublicKeyBase64 = String.fromEnvironment(
+  'FLUTTY_TMUX_BAR_SSH_PUB_B64',
+);
+const _tmuxSessionName = String.fromEnvironment(
+  'FLUTTY_TMUX_BAR_SESSION',
+  defaultValue: 'MonkeySSH',
+);
+const _tmuxWorkingDirectory = String.fromEnvironment('FLUTTY_TMUX_BAR_WORKDIR');
+const _tmuxHandleBarKey = ValueKey<String>('tmux-handle-bar');
+const _expectedProviders = <String>[
+  'Claude Code',
+  'Codex',
+  'Copilot CLI',
+  'Gemini CLI',
+  'OpenCode',
+];
+
+String get _deviceReachableHost =>
+    Platform.isAndroid ? '10.0.2.2' : '127.0.0.1';
+
+MonetizationState _proMonetizationState() => const MonetizationState(
+  billingAvailability: MonetizationBillingAvailability.available,
+  entitlements: MonetizationEntitlements.pro(),
+  offers: [],
+  debugUnlockAvailable: false,
+  debugUnlocked: false,
+);
+
+Future<void> _pumpUntilFound(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 30),
+  Duration step = const Duration(milliseconds: 200),
+}) async {
+  await _pumpUntil(
+    tester,
+    () => finder.evaluate().isNotEmpty,
+    description: 'finder: $finder',
+    timeout: timeout,
+    step: step,
+  );
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() predicate, {
+  required String description,
+  String Function()? debugState,
+  Duration timeout = const Duration(seconds: 30),
+  Duration step = const Duration(milliseconds: 200),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(step);
+    if (predicate()) {
+      return;
+    }
+  }
+
+  final details = debugState?.call();
+  fail(
+    details == null || details.isEmpty
+        ? 'Timed out waiting for $description'
+        : 'Timed out waiting for $description\n$details',
+  );
+}
+
+String _describeVisibleAiSessionState(WidgetTester tester) {
+  final providerTiles = _expectedProviders
+      .map((provider) {
+        final titleFinder = find.text(provider);
+        if (titleFinder.evaluate().isEmpty) {
+          return '$provider=<missing>';
+        }
+        final tileFinder = find.ancestor(
+          of: titleFinder.first,
+          matching: find.byType(ListTile),
+        );
+        if (tileFinder.evaluate().isEmpty) {
+          return '$provider=<no tile>';
+        }
+        final tileTexts = find
+            .descendant(of: tileFinder.first, matching: find.byType(Text))
+            .evaluate()
+            .map((element) => (element.widget as Text).data?.trim())
+            .whereType<String>()
+            .where((text) => text.isNotEmpty)
+            .toList(growable: false);
+        return '$provider=${tileTexts.join(' / ')}';
+      })
+      .join(' || ');
+  final visibleTexts =
+      tester.allWidgets
+          .whereType<Text>()
+          .map((widget) => widget.data?.trim())
+          .whereType<String>()
+          .where((text) => text.isNotEmpty)
+          .toSet()
+          .toList()
+        ..sort();
+  return 'Provider tiles: $providerTiles\n'
+      'Visible text widgets: ${visibleTexts.join(' | ')}';
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final binding = IntegrationTestWidgetsFlutterBinding.instance;
+
+  testWidgets(
+    'shows recent AI sessions for every expected provider on device',
+    (tester) async {
+      expect(_sshPort, isNotEmpty);
+      expect(_sshUser, isNotEmpty);
+      expect(_sshPrivateKeyBase64, isNotEmpty);
+      expect(_sshPublicKeyBase64, isNotEmpty);
+      expect(_tmuxWorkingDirectory, isNotEmpty);
+
+      await tester.binding.setSurfaceSize(const Size(430, 932));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final container = ProviderContainer(
+        overrides: [
+          hostKeyPromptHandlerProvider.overrideWithValue(
+            (_) async => HostKeyTrustDecision.trust,
+          ),
+          monetizationStateProvider.overrideWith(
+            (ref) => Stream<MonetizationState>.value(_proMonetizationState()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final db = container.read(databaseProvider);
+      await db.customStatement('DELETE FROM known_hosts;');
+      await db.customStatement('DELETE FROM hosts;');
+      await db.customStatement('DELETE FROM ssh_keys;');
+
+      final keyId = await container
+          .read(keyRepositoryProvider)
+          .insert(
+            SshKeysCompanion.insert(
+              name: 'Temporary tmux AI session validation key',
+              keyType: 'ed25519',
+              publicKey: utf8.decode(base64Decode(_sshPublicKeyBase64)),
+              privateKey: utf8.decode(base64Decode(_sshPrivateKeyBase64)),
+            ),
+          );
+
+      final hostId = await container
+          .read(hostRepositoryProvider)
+          .insert(
+            HostsCompanion.insert(
+              label: _hostLabel,
+              hostname: _deviceReachableHost,
+              port: Value(int.parse(_sshPort)),
+              username: _sshUser,
+              keyId: Value(keyId),
+              autoConnectRequiresConfirmation: const Value(false),
+              tmuxSessionName: const Value(_tmuxSessionName),
+              tmuxWorkingDirectory: const Value(_tmuxWorkingDirectory),
+            ),
+          );
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const FluttyApp(),
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      final hostRow = find.byKey(ValueKey('home-host-$hostId'));
+      await _pumpUntilFound(tester, hostRow);
+
+      await tester.tap(hostRow);
+      await tester.pump();
+
+      await _pumpUntilFound(
+        tester,
+        find.byType(TerminalScreen),
+        timeout: const Duration(seconds: 20),
+      );
+      final handleBar = find.byKey(_tmuxHandleBarKey);
+      await _pumpUntilFound(tester, handleBar);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      await tester.tap(handleBar);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      await _pumpUntilFound(
+        tester,
+        find.text('AI Sessions'),
+        timeout: const Duration(seconds: 15),
+      );
+      await tester.tap(find.text('AI Sessions'));
+      await tester.pump();
+
+      try {
+        await _pumpUntil(
+          tester,
+          () =>
+              _expectedProviders.every(
+                (provider) => find.text(provider).evaluate().isNotEmpty,
+              ) &&
+              find
+                  .text('No recent sessions for this project')
+                  .evaluate()
+                  .isEmpty &&
+              find.text('No recent sessions found').evaluate().isEmpty &&
+              find
+                  .text('Could not load recent AI sessions.')
+                  .evaluate()
+                  .isEmpty,
+          description:
+              'all expected AI session providers with non-empty results',
+          debugState: () => _describeVisibleAiSessionState(tester),
+          timeout: const Duration(seconds: 90),
+        );
+      } on TestFailure {
+        await binding.takeScreenshot('tmux-ai-sessions-timeout');
+        rethrow;
+      }
+
+      for (final provider in _expectedProviders) {
+        expect(find.text(provider), findsWidgets);
+      }
+      expect(find.text('No recent sessions for this project'), findsNothing);
+      expect(find.text('No recent sessions found'), findsNothing);
+      expect(find.text('Could not load recent AI sessions.'), findsNothing);
+
+      await binding.takeScreenshot('tmux-ai-sessions-populated');
+    },
+  );
+}

--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -52,6 +52,17 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
     AgentLaunchTool.openCode => true,
     AgentLaunchTool.geminiCli => true,
   };
+
+  /// Matching discovered-session provider name, if this tool supports recent
+  /// session discovery.
+  String? get discoveredSessionToolName => switch (this) {
+    AgentLaunchTool.claudeCode => 'Claude Code',
+    AgentLaunchTool.copilotCli => 'Copilot CLI',
+    AgentLaunchTool.aider => null,
+    AgentLaunchTool.codex => 'Codex',
+    AgentLaunchTool.openCode => 'OpenCode',
+    AgentLaunchTool.geminiCli => 'Gemini CLI',
+  };
 }
 
 /// Host-scoped preset for launching a coding agent after connect.

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -945,6 +945,34 @@ class AgentSessionDiscoveryService {
     return latestResult ?? DiscoveredSessionsResult(sessions: const []);
   }
 
+  /// Warms the discovery cache for the given scope without changing UI state.
+  ///
+  /// This is useful for preloading likely session views ahead of user
+  /// interaction so later visible loads can return from cache or join the
+  /// in-flight discovery work.
+  Future<void> prefetchSessions(
+    SshSession session, {
+    String? workingDirectory,
+    int maxPerTool = 12,
+  }) async {
+    try {
+      await discoverSessionsStream(
+        session,
+        workingDirectory: workingDirectory,
+        maxPerTool: maxPerTool,
+      ).drain<void>();
+    } on Object catch (error, stackTrace) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          library: 'agent_session_discovery_service',
+          context: ErrorDescription('while prefetching recent AI sessions'),
+        ),
+      );
+    }
+  }
+
   /// Discovers recent sessions and emits incremental updates as each tool
   /// finishes loading.
   ///

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -581,7 +581,48 @@ String? resolveGeminiProjectWorkingDirectory(
   return null;
 }
 
+/// Resolves the best Gemini CLI project root for the active working directory.
+///
+/// Prefers the shortest related directory that still contains the active path,
+/// which typically corresponds to the current worktree root.
+@visibleForTesting
+String? resolveGeminiCliProjectRoot(
+  String? workingDirectory,
+  Iterable<String> relatedWorkingDirectories,
+) {
+  final trimmedWorkingDirectory = _trimWorkingDirectory(workingDirectory);
+  if (trimmedWorkingDirectory == null) return null;
+
+  String? projectRoot;
+  for (final candidate in <String>[
+    trimmedWorkingDirectory,
+    ...relatedWorkingDirectories,
+  ]) {
+    final trimmedCandidate = _trimWorkingDirectory(candidate);
+    if (trimmedCandidate == null ||
+        !_workingDirectoriesOverlap(
+          trimmedWorkingDirectory,
+          trimmedCandidate,
+        ) ||
+        !(trimmedWorkingDirectory == trimmedCandidate ||
+            trimmedWorkingDirectory.startsWith('$trimmedCandidate/'))) {
+      continue;
+    }
+
+    if (projectRoot == null || trimmedCandidate.length < projectRoot.length) {
+      projectRoot = trimmedCandidate;
+    }
+  }
+
+  return projectRoot ?? trimmedWorkingDirectory;
+}
+
 /// Builds the CLI working-directory scopes Gemini should be queried from.
+///
+/// Gemini CLI calls are relatively expensive, so keep them bounded to the
+/// active project root plus its canonical non-worktree equivalent. Broader
+/// sibling-worktree coverage comes from the file-based fallback, which is much
+/// cheaper to scan.
 ///
 /// When no directory context is available, returns a single `null` scope so the
 /// CLI still runs once in the default shell cwd instead of being skipped.
@@ -590,22 +631,22 @@ List<String?> buildGeminiCliSessionListScopes(
   String? workingDirectory,
   Iterable<String> relatedWorkingDirectories,
 ) {
-  final scopes = <String?>{};
-  final trimmedWorkingDirectory = _trimWorkingDirectory(workingDirectory);
-  if (trimmedWorkingDirectory != null) {
-    scopes.add(trimmedWorkingDirectory);
-  }
-
-  for (final directory in relatedWorkingDirectories) {
-    final trimmedDirectory = _trimWorkingDirectory(directory);
-    if (trimmedDirectory != null) {
-      scopes.add(trimmedDirectory);
-    }
-  }
-
-  if (scopes.isEmpty) {
+  final projectRoot = resolveGeminiCliProjectRoot(
+    workingDirectory,
+    relatedWorkingDirectories,
+  );
+  if (projectRoot == null) {
     return const <String?>[null];
   }
+
+  final scopes = <String?>{projectRoot};
+  final normalizedProjectRoot = normalizeWorkingDirectoryForComparison(
+    projectRoot,
+  );
+  if (normalizedProjectRoot != projectRoot) {
+    scopes.add(normalizedProjectRoot);
+  }
+
   return scopes.toList(growable: false);
 }
 

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -963,12 +963,14 @@ class AgentSessionDiscoveryService {
     SshSession session, {
     String? workingDirectory,
     int maxPerTool = 12,
+    String? toolName,
   }) async {
     DiscoveredSessionsResult? latestResult;
     await for (final result in discoverSessionsStream(
       session,
       workingDirectory: workingDirectory,
       maxPerTool: maxPerTool,
+      toolName: toolName,
     )) {
       latestResult = result;
     }
@@ -984,12 +986,14 @@ class AgentSessionDiscoveryService {
     SshSession session, {
     String? workingDirectory,
     int maxPerTool = 12,
+    String? toolName,
   }) async {
     try {
       await discoverSessionsStream(
         session,
         workingDirectory: workingDirectory,
         maxPerTool: maxPerTool,
+        toolName: toolName,
       ).drain<void>();
     } on Object catch (error, stackTrace) {
       FlutterError.reportError(
@@ -1014,12 +1018,14 @@ class AgentSessionDiscoveryService {
     SshSession session, {
     String? workingDirectory,
     int maxPerTool = 12,
+    String? toolName,
   }) async* {
     _pruneExpiredCacheEntries();
     final key = _AgentSessionDiscoveryKey.fromSession(
       session,
       workingDirectory: workingDirectory,
       maxPerTool: maxPerTool,
+      toolName: toolName,
     );
 
     final freshCachedResult = _lookupCachedDiscoveryResult(key);
@@ -1071,6 +1077,7 @@ class AgentSessionDiscoveryService {
       session,
       workingDirectory: workingDirectory,
       maxPerTool: maxPerTool,
+      toolName: toolName,
     );
   }
 
@@ -1079,6 +1086,7 @@ class AgentSessionDiscoveryService {
     SshSession session, {
     required String? workingDirectory,
     required int maxPerTool,
+    required String? toolName,
   }) {
     final controller = StreamController<DiscoveredSessionsResult>.broadcast();
     _inFlightDiscoveries[key] = controller.stream;
@@ -1096,6 +1104,7 @@ class AgentSessionDiscoveryService {
           workingDirectory: workingDirectory,
           relatedWorkingDirectories: relatedWorkingDirectories,
           maxPerTool: maxPerTool,
+          toolName: toolName,
         );
         final pendingResults = <int, Future<_IndexedToolDiscoveryResult>>{
           for (var index = 0; index < discoveries.length; index++)
@@ -1213,33 +1222,89 @@ class AgentSessionDiscoveryService {
     required String? workingDirectory,
     required List<String> relatedWorkingDirectories,
     required int maxPerTool,
-  }) => [
-    _discoverOpenCodeSessions(
+    required String? toolName,
+  }) => toolName == null
+      ? [
+          _discoverOpenCodeSessions(
+            session,
+            workingDirectory,
+            relatedWorkingDirectories,
+            maxPerTool,
+          ),
+          _discoverCodexSessions(
+            session,
+            workingDirectory,
+            relatedWorkingDirectories,
+            maxPerTool,
+          ),
+          _discoverCopilotSessions(
+            session,
+            relatedWorkingDirectories,
+            maxPerTool,
+          ),
+          _discoverGeminiSessions(
+            session,
+            workingDirectory,
+            relatedWorkingDirectories,
+            maxPerTool,
+          ),
+          _discoverClaudeSessions(
+            session,
+            workingDirectory,
+            relatedWorkingDirectories,
+            maxPerTool,
+          ),
+        ]
+      : [
+          _discoverSessionsForTool(
+            toolName,
+            session,
+            workingDirectory: workingDirectory,
+            relatedWorkingDirectories: relatedWorkingDirectories,
+            maxPerTool: maxPerTool,
+          ),
+        ];
+
+  Future<_ToolDiscoveryResult> _discoverSessionsForTool(
+    String toolName,
+    SshSession session, {
+    required String? workingDirectory,
+    required List<String> relatedWorkingDirectories,
+    required int maxPerTool,
+  }) => switch (toolName) {
+    'OpenCode' => _discoverOpenCodeSessions(
       session,
       workingDirectory,
       relatedWorkingDirectories,
       maxPerTool,
     ),
-    _discoverCodexSessions(
+    'Codex' => _discoverCodexSessions(
       session,
       workingDirectory,
       relatedWorkingDirectories,
       maxPerTool,
     ),
-    _discoverCopilotSessions(session, relatedWorkingDirectories, maxPerTool),
-    _discoverGeminiSessions(
+    'Copilot CLI' => _discoverCopilotSessions(
+      session,
+      relatedWorkingDirectories,
+      maxPerTool,
+    ),
+    'Gemini CLI' => _discoverGeminiSessions(
       session,
       workingDirectory,
       relatedWorkingDirectories,
       maxPerTool,
     ),
-    _discoverClaudeSessions(
+    'Claude Code' => _discoverClaudeSessions(
       session,
       workingDirectory,
       relatedWorkingDirectories,
       maxPerTool,
     ),
-  ];
+    _ => Future<_ToolDiscoveryResult>.value(
+      _ToolDiscoveryResult.success(toolName, const <ToolSessionInfo>[]),
+    ),
+  };
 
   DiscoveredSessionsResult _buildDiscoveredSessionsResult(
     Iterable<_ToolDiscoveryResult> results, {
@@ -2410,10 +2475,12 @@ class _AgentSessionDiscoveryKey {
     SshSession session, {
     required String? workingDirectory,
     required int maxPerTool,
+    String? toolName,
   }) => _AgentSessionDiscoveryKey(
     scopeKey: _AgentSessionDiscoveryScopeKey.fromSession(
       session,
       workingDirectory: workingDirectory,
+      toolName: toolName,
     ),
     maxPerTool: maxPerTool,
   );
@@ -2440,17 +2507,20 @@ class _AgentSessionDiscoveryScopeKey {
     required this.port,
     required this.username,
     required this.workingDirectory,
+    required this.toolName,
   });
 
   factory _AgentSessionDiscoveryScopeKey.fromSession(
     SshSession session, {
     required String? workingDirectory,
+    String? toolName,
   }) => _AgentSessionDiscoveryScopeKey(
     hostId: session.hostId,
     hostname: session.config.hostname,
     port: session.config.port,
     username: session.config.username,
     workingDirectory: _trimWorkingDirectory(workingDirectory),
+    toolName: toolName,
   );
 
   final int hostId;
@@ -2458,6 +2528,7 @@ class _AgentSessionDiscoveryScopeKey {
   final int port;
   final String username;
   final String? workingDirectory;
+  final String? toolName;
 
   @override
   bool operator ==(Object other) =>
@@ -2467,11 +2538,12 @@ class _AgentSessionDiscoveryScopeKey {
           hostname == other.hostname &&
           port == other.port &&
           username == other.username &&
-          workingDirectory == other.workingDirectory;
+          workingDirectory == other.workingDirectory &&
+          toolName == other.toolName;
 
   @override
   int get hashCode =>
-      Object.hash(hostId, hostname, port, username, workingDirectory);
+      Object.hash(hostId, hostname, port, username, workingDirectory, toolName);
 }
 
 class _CachedDiscoveryResult {

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -697,34 +698,105 @@ class AgentSessionDiscoveryService {
       session,
       workingDirectory,
     );
-    final results = await Future.wait([
-      _discoverClaudeSessions(
+    final results = await Future.wait(
+      _startToolDiscoveries(
         session,
-        workingDirectory,
-        relatedWorkingDirectories,
-        maxPerTool,
+        workingDirectory: workingDirectory,
+        relatedWorkingDirectories: relatedWorkingDirectories,
+        maxPerTool: maxPerTool,
       ),
-      _discoverCodexSessions(
-        session,
-        workingDirectory,
-        relatedWorkingDirectories,
-        maxPerTool,
-      ),
-      _discoverCopilotSessions(session, relatedWorkingDirectories, maxPerTool),
-      _discoverGeminiSessions(
-        session,
-        workingDirectory,
-        relatedWorkingDirectories,
-        maxPerTool,
-      ),
-      _discoverOpenCodeSessions(
-        session,
-        workingDirectory,
-        relatedWorkingDirectories,
-        maxPerTool,
-      ),
-    ]);
+    );
+    return _buildDiscoveredSessionsResult(
+      results,
+      workingDirectory: workingDirectory,
+      relatedWorkingDirectories: relatedWorkingDirectories,
+      maxPerTool: maxPerTool,
+    );
+  }
 
+  /// Discovers recent sessions and emits incremental updates as each tool
+  /// finishes loading.
+  ///
+  /// This lets the UI render providers as they complete instead of waiting for
+  /// the slowest tool before showing anything.
+  Stream<DiscoveredSessionsResult> discoverSessionsStream(
+    SshSession session, {
+    String? workingDirectory,
+    int maxPerTool = 12,
+  }) async* {
+    final relatedWorkingDirectories = await _resolveRelatedWorkingDirectories(
+      session,
+      workingDirectory,
+    );
+    final discoveries = _startToolDiscoveries(
+      session,
+      workingDirectory: workingDirectory,
+      relatedWorkingDirectories: relatedWorkingDirectories,
+      maxPerTool: maxPerTool,
+    );
+    final pendingResults = <int, Future<_IndexedToolDiscoveryResult>>{
+      for (var index = 0; index < discoveries.length; index++)
+        index: discoveries[index].then(
+          (result) => _IndexedToolDiscoveryResult(index, result),
+        ),
+    };
+    final completedResults = List<_ToolDiscoveryResult?>.filled(
+      discoveries.length,
+      null,
+    );
+
+    while (pendingResults.isNotEmpty) {
+      final completed = await Future.any(pendingResults.values);
+      unawaited(pendingResults.remove(completed.index));
+      completedResults[completed.index] = completed.result;
+      yield _buildDiscoveredSessionsResult(
+        completedResults.whereType<_ToolDiscoveryResult>(),
+        workingDirectory: workingDirectory,
+        relatedWorkingDirectories: relatedWorkingDirectories,
+        maxPerTool: maxPerTool,
+      );
+    }
+  }
+
+  List<Future<_ToolDiscoveryResult>> _startToolDiscoveries(
+    SshSession session, {
+    required String? workingDirectory,
+    required List<String> relatedWorkingDirectories,
+    required int maxPerTool,
+  }) => [
+    _discoverClaudeSessions(
+      session,
+      workingDirectory,
+      relatedWorkingDirectories,
+      maxPerTool,
+    ),
+    _discoverCodexSessions(
+      session,
+      workingDirectory,
+      relatedWorkingDirectories,
+      maxPerTool,
+    ),
+    _discoverCopilotSessions(session, relatedWorkingDirectories, maxPerTool),
+    _discoverGeminiSessions(
+      session,
+      workingDirectory,
+      relatedWorkingDirectories,
+      maxPerTool,
+    ),
+    _discoverOpenCodeSessions(
+      session,
+      workingDirectory,
+      relatedWorkingDirectories,
+      maxPerTool,
+    ),
+  ];
+
+  DiscoveredSessionsResult _buildDiscoveredSessionsResult(
+    Iterable<_ToolDiscoveryResult> results, {
+    required String? workingDirectory,
+    required List<String> relatedWorkingDirectories,
+    required int maxPerTool,
+  }) {
     final all = results
         .expand((result) => result.sessions)
         .map(
@@ -734,41 +806,33 @@ class AgentSessionDiscoveryService {
           ),
         )
         .whereType<ToolSessionInfo>()
-        .toList();
+        .toList(growable: false);
+    final failedTools = results
+        .where(
+          (result) => shouldSurfaceDiscoveryFailure(
+            hadError: result.hadError,
+            loadedSessionCount: result.sessions.length,
+          ),
+        )
+        .map((result) => result.toolName);
 
-    // Filter to sessions matching the working directory if provided.
     if (workingDirectory != null && workingDirectory.isNotEmpty) {
-      final filtered = _limitDiscoveredSessionsPerTool(
-        scopeDiscoveredSessionsToWorkingDirectory(
-          all,
-          workingDirectory,
-          relatedWorkingDirectories: relatedWorkingDirectories,
-        ),
-        maxPerTool,
-      );
       return DiscoveredSessionsResult(
-        sessions: filtered,
-        failedTools: results
-            .where(
-              (r) => shouldSurfaceDiscoveryFailure(
-                hadError: r.hadError,
-                loadedSessionCount: r.sessions.length,
-              ),
-            )
-            .map((r) => r.toolName),
+        sessions: _limitDiscoveredSessionsPerTool(
+          scopeDiscoveredSessionsToWorkingDirectory(
+            all,
+            workingDirectory,
+            relatedWorkingDirectories: relatedWorkingDirectories,
+          ),
+          maxPerTool,
+        ),
+        failedTools: failedTools,
       );
     }
 
     return DiscoveredSessionsResult(
       sessions: _limitDiscoveredSessionsPerTool(all, maxPerTool),
-      failedTools: results
-          .where(
-            (r) => shouldSurfaceDiscoveryFailure(
-              hadError: r.hadError,
-              loadedSessionCount: r.sessions.length,
-            ),
-          )
-          .map((r) => r.toolName),
+      failedTools: failedTools,
     );
   }
 
@@ -1778,6 +1842,13 @@ class _ToolDiscoveryResult {
   final String toolName;
   final List<ToolSessionInfo> sessions;
   final bool hadError;
+}
+
+class _IndexedToolDiscoveryResult {
+  const _IndexedToolDiscoveryResult(this.index, this.result);
+
+  final int index;
+  final _ToolDiscoveryResult result;
 }
 
 class _CodexSessionIndexResult {

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -773,6 +773,17 @@ int calculateClaudeMetadataSnapshotLimit(int maxPerTool) =>
       maximum: 80,
     );
 
+/// Limits how many recent session files should be metadata-read after the
+/// provider has already listed candidates in descending update order.
+@visibleForTesting
+int calculateRecentSessionMetadataReadLimit(int maxPerTool) =>
+    _calculateDiscoveryScanLimit(
+      maxPerTool,
+      multiplier: 3,
+      minimum: 24,
+      maximum: 48,
+    );
+
 /// Builds the Gemini chat project directory names associated with the active
 /// worktree family.
 @visibleForTesting
@@ -998,16 +1009,22 @@ class AgentSessionDiscoveryService {
       return;
     }
 
+    final scopedFreshCachedResult = _lookupScopedCachedDiscoveryResult(
+      key.scopeKey,
+    );
+    if (scopedFreshCachedResult != null) {
+      yield scopedFreshCachedResult;
+    }
+
     final inFlightStream = _inFlightDiscoveries[key];
     if (inFlightStream != null) {
       final inFlightSnapshot = _inFlightDiscoverySnapshots[key];
       if (inFlightSnapshot != null) {
         yield inFlightSnapshot;
       } else {
-        final staleCachedResult = _lookupCachedDiscoveryResult(
-          key,
-          allowStale: true,
-        );
+        final staleCachedResult =
+            _lookupCachedDiscoveryResult(key, allowStale: true) ??
+            _lookupScopedCachedDiscoveryResult(key.scopeKey, allowStale: true);
         if (staleCachedResult != null) {
           yield staleCachedResult;
         }
@@ -1016,10 +1033,16 @@ class AgentSessionDiscoveryService {
       return;
     }
 
-    final staleCachedResult = _lookupCachedDiscoveryResult(
-      key,
-      allowStale: true,
+    final scopedInFlightSnapshot = _lookupScopedInFlightDiscoverySnapshot(
+      key.scopeKey,
     );
+    if (scopedInFlightSnapshot != null) {
+      yield scopedInFlightSnapshot;
+    }
+
+    final staleCachedResult =
+        _lookupCachedDiscoveryResult(key, allowStale: true) ??
+        _lookupScopedCachedDiscoveryResult(key.scopeKey, allowStale: true);
     if (staleCachedResult != null) {
       yield staleCachedResult;
     }
@@ -1114,6 +1137,46 @@ class AgentSessionDiscoveryService {
     return null;
   }
 
+  DiscoveredSessionsResult? _lookupScopedCachedDiscoveryResult(
+    _AgentSessionDiscoveryScopeKey scopeKey, {
+    bool allowStale = false,
+  }) {
+    final now = _now();
+    _AgentSessionDiscoveryKey? bestKey;
+    _CachedDiscoveryResult? bestResult;
+    for (final entry in _discoveryCache.entries) {
+      if (entry.key.scopeKey != scopeKey) continue;
+      final age = now.difference(entry.value.cachedAt);
+      if (age >= _sessionDiscoveryCacheFreshTtl &&
+          (!allowStale || age >= _sessionDiscoveryCacheRetentionTtl)) {
+        continue;
+      }
+      if (bestKey == null ||
+          entry.key.maxPerTool > bestKey.maxPerTool ||
+          (entry.key.maxPerTool == bestKey.maxPerTool &&
+              entry.value.cachedAt.isAfter(bestResult!.cachedAt))) {
+        bestKey = entry.key;
+        bestResult = entry.value;
+      }
+    }
+    return bestResult?.result;
+  }
+
+  DiscoveredSessionsResult? _lookupScopedInFlightDiscoverySnapshot(
+    _AgentSessionDiscoveryScopeKey scopeKey,
+  ) {
+    _AgentSessionDiscoveryKey? bestKey;
+    DiscoveredSessionsResult? bestSnapshot;
+    for (final entry in _inFlightDiscoverySnapshots.entries) {
+      if (entry.key.scopeKey != scopeKey) continue;
+      if (bestKey == null || entry.key.maxPerTool > bestKey.maxPerTool) {
+        bestKey = entry.key;
+        bestSnapshot = entry.value;
+      }
+    }
+    return bestSnapshot;
+  }
+
   void _pruneExpiredCacheEntries() {
     final now = _now();
     _discoveryCache.removeWhere(
@@ -1132,7 +1195,7 @@ class AgentSessionDiscoveryService {
     required List<String> relatedWorkingDirectories,
     required int maxPerTool,
   }) => [
-    _discoverClaudeSessions(
+    _discoverOpenCodeSessions(
       session,
       workingDirectory,
       relatedWorkingDirectories,
@@ -1151,7 +1214,7 @@ class AgentSessionDiscoveryService {
       relatedWorkingDirectories,
       maxPerTool,
     ),
-    _discoverOpenCodeSessions(
+    _discoverClaudeSessions(
       session,
       workingDirectory,
       relatedWorkingDirectories,
@@ -1399,6 +1462,7 @@ class AgentSessionDiscoveryService {
         multiplier: 10,
         maximum: 120,
       );
+      final metadataReadLimit = calculateRecentSessionMetadataReadLimit(max);
       final output = await _exec(
         session,
         'find ~/.codex/sessions -name "rollout-*.jsonl" -type f '
@@ -1408,22 +1472,28 @@ class AgentSessionDiscoveryService {
         return const _ToolDiscoveryResult.success('Codex', []);
       }
 
-      final sessionIndex = await _readCodexSessionIndex(session, scanLimit);
       final rolloutPaths = output
           .trim()
           .split('\n')
           .map((line) => line.trim())
           .where((line) => line.isNotEmpty)
           .toList(growable: false);
+      final recentRolloutPaths = rolloutPaths
+          .take(metadataReadLimit)
+          .toList(growable: false);
+      final sessionIndex = await _readCodexSessionIndex(
+        session,
+        metadataReadLimit,
+      );
       final rolloutSnapshots = await _readRemoteFileSnapshots(
         session,
-        rolloutPaths,
+        recentRolloutPaths,
         maxLines: 80,
       );
       final sessions = <ToolSessionInfo>[];
       var hadError = sessionIndex.hadError;
 
-      for (final filePath in rolloutPaths) {
+      for (final filePath in recentRolloutPaths) {
         final fileName = filePath.split('/').last.replaceAll('.jsonl', '');
         final threadId = _extractCodexThreadId(fileName);
         final threadInfo = threadId != null
@@ -1537,6 +1607,7 @@ class AgentSessionDiscoveryService {
         minimum: 120,
         maximum: 240,
       );
+      final metadataReadLimit = calculateRecentSessionMetadataReadLimit(max);
       final workspacePaths = await _listCopilotWorkspacePaths(
         session,
         scanLimit,
@@ -1545,10 +1616,13 @@ class AgentSessionDiscoveryService {
       if (workspacePaths.isEmpty) {
         return const _ToolDiscoveryResult.success('Copilot CLI', []);
       }
+      final recentWorkspacePaths = workspacePaths
+          .take(metadataReadLimit)
+          .toList(growable: false);
 
       final workspaceSnapshots = await _readRemoteFileSnapshots(
         session,
-        workspacePaths,
+        recentWorkspacePaths,
       );
       final planPathsNeedingFallback = <String>[];
       final metadataByWorkspacePath =
@@ -1558,7 +1632,7 @@ class AgentSessionDiscoveryService {
           >{};
       var hadError = false;
 
-      for (final workspacePath in workspacePaths) {
+      for (final workspacePath in recentWorkspacePaths) {
         final dirPath = workspacePath.replaceFirst(
           RegExp(r'/workspace\.yaml$'),
           '/',
@@ -1599,7 +1673,7 @@ class AgentSessionDiscoveryService {
       );
       final sessions = <ToolSessionInfo>[];
 
-      for (final workspacePath in workspacePaths) {
+      for (final workspacePath in recentWorkspacePaths) {
         final metadata = metadataByWorkspacePath[workspacePath];
         final snapshot = workspaceSnapshots[workspacePath];
         if (metadata == null) {
@@ -1673,6 +1747,7 @@ class AgentSessionDiscoveryService {
       multiplier: 10,
       maximum: 120,
     );
+    final metadataReadLimit = calculateRecentSessionMetadataReadLimit(max);
     final globalCommand =
         r'find ~/.gemini/tmp \( -name "session-*.json" -o -name "session-*.jsonl" \) '
         '-path "*/chats/*" -type f '
@@ -1713,14 +1788,17 @@ class AgentSessionDiscoveryService {
         .map((line) => line.trim())
         .where((line) => line.isNotEmpty)
         .toList(growable: false);
+    final recentSessionPaths = sessionPaths
+        .take(metadataReadLimit)
+        .toList(growable: false);
     final sessionSnapshots = await _readRemoteFileSnapshots(
       session,
-      sessionPaths,
+      recentSessionPaths,
     );
 
     var hadError = false;
     final sessions = <ToolSessionInfo>[];
-    for (final filePath in sessionPaths) {
+    for (final filePath in recentSessionPaths) {
       final fileName = filePath
           .split('/')
           .last

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -181,6 +181,38 @@ String _truncateSessionIdValue(String id) {
   return '${id.substring(0, 8)}…';
 }
 
+bool _isLikelyToolStateWorkingDirectory(String directory) =>
+    directory.contains('/.copilot/session-state/') ||
+    directory.contains('/.claude/projects/') ||
+    directory.contains('/.codex/') ||
+    directory.contains('/.gemini/tmp/') ||
+    directory.contains('/.local/share/opencode/') ||
+    directory.startsWith('/tmp/') ||
+    directory.startsWith('/var/folders/');
+
+/// Chooses the best working directory to scope AI session discovery.
+///
+/// Tmux panes can temporarily report tool-state or temp directories while the
+/// user is still effectively working in a project. In those cases, prefer the
+/// terminal session's working directory when available, or skip scoping
+/// entirely instead of hiding project sessions behind a transient tool path.
+String? resolveAgentSessionScopeWorkingDirectory({
+  String? activeWorkingDirectory,
+  Uri? sessionWorkingDirectory,
+}) {
+  final trimmedActive = _trimWorkingDirectory(activeWorkingDirectory);
+  final fallbackWorkingDirectory = _trimWorkingDirectory(
+    resolveTerminalWorkingDirectoryPath(sessionWorkingDirectory),
+  );
+  if (trimmedActive == null) {
+    return fallbackWorkingDirectory;
+  }
+  if (_isLikelyToolStateWorkingDirectory(trimmedActive)) {
+    return fallbackWorkingDirectory;
+  }
+  return trimmedActive;
+}
+
 String _summarizeSessionText(String value, {int maxLength = 80}) {
   final firstMeaningfulLine = value
       .split('\n')

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -68,14 +68,24 @@ class DiscoveredSessionsResult {
   DiscoveredSessionsResult({
     required Iterable<ToolSessionInfo> sessions,
     Iterable<String> failedTools = const <String>[],
+    Iterable<String> attemptedTools = const <String>[],
   }) : sessions = List<ToolSessionInfo>.unmodifiable(sessions),
-       failedTools = Set<String>.unmodifiable(failedTools);
+       failedTools = Set<String>.unmodifiable(failedTools),
+       attemptedTools = Set<String>.unmodifiable(attemptedTools);
 
   /// The sessions that were discovered successfully.
   final List<ToolSessionInfo> sessions;
 
   /// Tool names whose session history could not be loaded.
   final Set<String> failedTools;
+
+  /// Tool names that the discovery service attempted to query during this
+  /// stream tick, regardless of whether any sessions were ultimately returned.
+  ///
+  /// The UI uses this to render a placeholder row for tools that completed
+  /// without errors but produced no matching sessions, so users can see at a
+  /// glance which providers were checked.
+  final Set<String> attemptedTools;
 
   /// Whether any tool histories failed to load.
   bool get hasFailures => failedTools.isNotEmpty;
@@ -868,6 +878,7 @@ class AgentSessionDiscoveryService {
           ),
         )
         .map((result) => result.toolName);
+    final attemptedTools = results.map((result) => result.toolName);
 
     if (workingDirectory != null && workingDirectory.isNotEmpty) {
       return DiscoveredSessionsResult(
@@ -880,12 +891,14 @@ class AgentSessionDiscoveryService {
           maxPerTool,
         ),
         failedTools: failedTools,
+        attemptedTools: attemptedTools,
       );
     }
 
     return DiscoveredSessionsResult(
       sessions: _limitDiscoveredSessionsPerTool(all, maxPerTool),
       failedTools: failedTools,
+      attemptedTools: attemptedTools,
     );
   }
 

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -21,6 +21,9 @@ const _profileSourcingPrefix =
     '{ . ~/.profile; . ~/.bash_profile; . ~/.zprofile; } >/dev/null 2>&1; '
     r'export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin${PATH:+:$PATH}"; ';
 const _remoteFileSnapshotBatchSize = 40;
+const _sessionDiscoveryCacheFreshTtl = Duration(seconds: 15);
+const _sessionDiscoveryCacheRetentionTtl = Duration(minutes: 2);
+const _relatedWorkingDirectoriesCacheTtl = Duration(minutes: 1);
 
 /// Filters noisy discovered sessions and fills in a better display summary
 /// when the tool only exposes a working directory.
@@ -894,7 +897,24 @@ List<ToolSessionInfo> scopeDiscoveredSessionsToWorkingDirectory(
 /// [ToolSessionInfo] entries.
 class AgentSessionDiscoveryService {
   /// Creates a new [AgentSessionDiscoveryService].
-  const AgentSessionDiscoveryService();
+  AgentSessionDiscoveryService({DateTime Function()? now})
+    : _now = now ?? DateTime.now;
+
+  final DateTime Function() _now;
+  final Map<_AgentSessionDiscoveryKey, _CachedDiscoveryResult> _discoveryCache =
+      <_AgentSessionDiscoveryKey, _CachedDiscoveryResult>{};
+  final Map<_AgentSessionDiscoveryKey, Stream<DiscoveredSessionsResult>>
+  _inFlightDiscoveries =
+      <_AgentSessionDiscoveryKey, Stream<DiscoveredSessionsResult>>{};
+  final Map<_AgentSessionDiscoveryKey, DiscoveredSessionsResult>
+  _inFlightDiscoverySnapshots =
+      <_AgentSessionDiscoveryKey, DiscoveredSessionsResult>{};
+  final Map<_AgentSessionDiscoveryScopeKey, _CachedRelatedWorkingDirectories>
+  _relatedWorkingDirectoriesCache =
+      <_AgentSessionDiscoveryScopeKey, _CachedRelatedWorkingDirectories>{};
+  final Map<_AgentSessionDiscoveryScopeKey, Future<List<String>>>
+  _inFlightRelatedWorkingDirectories =
+      <_AgentSessionDiscoveryScopeKey, Future<List<String>>>{};
 
   /// Discovers recent sessions across all supported tools for the given
   /// [workingDirectory] on the remote host.
@@ -914,68 +934,168 @@ class AgentSessionDiscoveryService {
     String? workingDirectory,
     int maxPerTool = 12,
   }) async {
-    final relatedWorkingDirectories = await _resolveRelatedWorkingDirectories(
+    DiscoveredSessionsResult? latestResult;
+    await for (final result in discoverSessionsStream(
       session,
-      workingDirectory,
-    );
-    final results = await Future.wait(
-      _startToolDiscoveries(
-        session,
-        workingDirectory: workingDirectory,
-        relatedWorkingDirectories: relatedWorkingDirectories,
-        maxPerTool: maxPerTool,
-      ),
-    );
-    return _buildDiscoveredSessionsResult(
-      results,
       workingDirectory: workingDirectory,
-      relatedWorkingDirectories: relatedWorkingDirectories,
       maxPerTool: maxPerTool,
-    );
+    )) {
+      latestResult = result;
+    }
+    return latestResult ?? DiscoveredSessionsResult(sessions: const []);
   }
 
   /// Discovers recent sessions and emits incremental updates as each tool
   /// finishes loading.
   ///
   /// This lets the UI render providers as they complete instead of waiting for
-  /// the slowest tool before showing anything.
+  /// the slowest tool before showing anything. Repeated loads for the same
+  /// connection and scope reuse a short-lived cached result, while concurrent
+  /// loads share the same in-flight discovery work.
   Stream<DiscoveredSessionsResult> discoverSessionsStream(
     SshSession session, {
     String? workingDirectory,
     int maxPerTool = 12,
   }) async* {
-    final relatedWorkingDirectories = await _resolveRelatedWorkingDirectories(
-      session,
-      workingDirectory,
-    );
-    final discoveries = _startToolDiscoveries(
+    _pruneExpiredCacheEntries();
+    final key = _AgentSessionDiscoveryKey.fromSession(
       session,
       workingDirectory: workingDirectory,
-      relatedWorkingDirectories: relatedWorkingDirectories,
       maxPerTool: maxPerTool,
     );
-    final pendingResults = <int, Future<_IndexedToolDiscoveryResult>>{
-      for (var index = 0; index < discoveries.length; index++)
-        index: discoveries[index].then(
-          (result) => _IndexedToolDiscoveryResult(index, result),
-        ),
-    };
-    final completedResults = List<_ToolDiscoveryResult?>.filled(
-      discoveries.length,
-      null,
-    );
 
-    while (pendingResults.isNotEmpty) {
-      final completed = await Future.any(pendingResults.values);
-      pendingResults.remove(completed.index)?.ignore();
-      completedResults[completed.index] = completed.result;
-      yield _buildDiscoveredSessionsResult(
-        completedResults.whereType<_ToolDiscoveryResult>(),
-        workingDirectory: workingDirectory,
-        relatedWorkingDirectories: relatedWorkingDirectories,
-        maxPerTool: maxPerTool,
-      );
+    final freshCachedResult = _lookupCachedDiscoveryResult(key);
+    if (freshCachedResult != null) {
+      yield freshCachedResult;
+      return;
     }
+
+    final inFlightStream = _inFlightDiscoveries[key];
+    if (inFlightStream != null) {
+      final inFlightSnapshot = _inFlightDiscoverySnapshots[key];
+      if (inFlightSnapshot != null) {
+        yield inFlightSnapshot;
+      } else {
+        final staleCachedResult = _lookupCachedDiscoveryResult(
+          key,
+          allowStale: true,
+        );
+        if (staleCachedResult != null) {
+          yield staleCachedResult;
+        }
+      }
+      yield* inFlightStream;
+      return;
+    }
+
+    final staleCachedResult = _lookupCachedDiscoveryResult(
+      key,
+      allowStale: true,
+    );
+    if (staleCachedResult != null) {
+      yield staleCachedResult;
+    }
+
+    yield* _startSharedDiscovery(
+      key,
+      session,
+      workingDirectory: workingDirectory,
+      maxPerTool: maxPerTool,
+    );
+  }
+
+  Stream<DiscoveredSessionsResult> _startSharedDiscovery(
+    _AgentSessionDiscoveryKey key,
+    SshSession session, {
+    required String? workingDirectory,
+    required int maxPerTool,
+  }) {
+    final controller = StreamController<DiscoveredSessionsResult>.broadcast();
+    _inFlightDiscoveries[key] = controller.stream;
+
+    unawaited(() async {
+      DiscoveredSessionsResult? latestResult;
+      try {
+        final relatedWorkingDirectories =
+            await _resolveRelatedWorkingDirectoriesCached(
+              session,
+              workingDirectory,
+            );
+        final discoveries = _startToolDiscoveries(
+          session,
+          workingDirectory: workingDirectory,
+          relatedWorkingDirectories: relatedWorkingDirectories,
+          maxPerTool: maxPerTool,
+        );
+        final pendingResults = <int, Future<_IndexedToolDiscoveryResult>>{
+          for (var index = 0; index < discoveries.length; index++)
+            index: discoveries[index].then(
+              (result) => _IndexedToolDiscoveryResult(index, result),
+            ),
+        };
+        final completedResults = List<_ToolDiscoveryResult?>.filled(
+          discoveries.length,
+          null,
+        );
+
+        while (pendingResults.isNotEmpty) {
+          final completed = await Future.any(pendingResults.values);
+          pendingResults.remove(completed.index)?.ignore();
+          completedResults[completed.index] = completed.result;
+          latestResult = _buildDiscoveredSessionsResult(
+            completedResults.whereType<_ToolDiscoveryResult>(),
+            workingDirectory: workingDirectory,
+            relatedWorkingDirectories: relatedWorkingDirectories,
+            maxPerTool: maxPerTool,
+          );
+          _inFlightDiscoverySnapshots[key] = latestResult;
+          controller.add(latestResult);
+        }
+
+        if (latestResult != null) {
+          _discoveryCache[key] = _CachedDiscoveryResult(
+            result: latestResult,
+            cachedAt: _now(),
+          );
+        }
+      } on Object catch (error, stackTrace) {
+        controller.addError(error, stackTrace);
+      } finally {
+        _inFlightDiscoveries.remove(key);
+        _inFlightDiscoverySnapshots.remove(key);
+        await controller.close();
+      }
+    }());
+
+    return controller.stream;
+  }
+
+  DiscoveredSessionsResult? _lookupCachedDiscoveryResult(
+    _AgentSessionDiscoveryKey key, {
+    bool allowStale = false,
+  }) {
+    final cached = _discoveryCache[key];
+    if (cached == null) return null;
+    final age = _now().difference(cached.cachedAt);
+    if (age < _sessionDiscoveryCacheFreshTtl) {
+      return cached.result;
+    }
+    if (allowStale && age < _sessionDiscoveryCacheRetentionTtl) {
+      return cached.result;
+    }
+    return null;
+  }
+
+  void _pruneExpiredCacheEntries() {
+    final now = _now();
+    _discoveryCache.removeWhere(
+      (_, entry) =>
+          now.difference(entry.cachedAt) >= _sessionDiscoveryCacheRetentionTtl,
+    );
+    _relatedWorkingDirectoriesCache.removeWhere(
+      (_, entry) =>
+          now.difference(entry.cachedAt) >= _relatedWorkingDirectoriesCacheTtl,
+    );
   }
 
   List<Future<_ToolDiscoveryResult>> _startToolDiscoveries(
@@ -2029,6 +2149,46 @@ class AgentSessionDiscoveryService {
     epoch > 9999999999 ? epoch : epoch * 1000,
   );
 
+  Future<List<String>> _resolveRelatedWorkingDirectoriesCached(
+    SshSession session,
+    String? workingDirectory,
+  ) {
+    final key = _AgentSessionDiscoveryScopeKey.fromSession(
+      session,
+      workingDirectory: workingDirectory,
+    );
+    if (key.workingDirectory == null) {
+      return Future<List<String>>.value(const <String>[]);
+    }
+
+    _pruneExpiredCacheEntries();
+    final cached = _relatedWorkingDirectoriesCache[key];
+    if (cached != null) {
+      return Future<List<String>>.value(cached.directories);
+    }
+
+    final inFlight = _inFlightRelatedWorkingDirectories[key];
+    if (inFlight != null) {
+      return inFlight;
+    }
+
+    final future =
+        _resolveRelatedWorkingDirectories(session, key.workingDirectory).then((
+          directories,
+        ) {
+          _relatedWorkingDirectoriesCache[key] =
+              _CachedRelatedWorkingDirectories(
+                directories: directories,
+                cachedAt: _now(),
+              );
+          return directories;
+        });
+    _inFlightRelatedWorkingDirectories[key] = future;
+    return future.whenComplete(
+      () => _inFlightRelatedWorkingDirectories.remove(key),
+    );
+  }
+
   Future<List<String>> _resolveRelatedWorkingDirectories(
     SshSession session,
     String? workingDirectory,
@@ -2112,6 +2272,98 @@ class AgentSessionDiscoveryService {
   }
 
   static String _truncateId(String id) => _truncateSessionIdValue(id);
+}
+
+@immutable
+class _AgentSessionDiscoveryKey {
+  const _AgentSessionDiscoveryKey({
+    required this.scopeKey,
+    required this.maxPerTool,
+  });
+
+  factory _AgentSessionDiscoveryKey.fromSession(
+    SshSession session, {
+    required String? workingDirectory,
+    required int maxPerTool,
+  }) => _AgentSessionDiscoveryKey(
+    scopeKey: _AgentSessionDiscoveryScopeKey.fromSession(
+      session,
+      workingDirectory: workingDirectory,
+    ),
+    maxPerTool: maxPerTool,
+  );
+
+  final _AgentSessionDiscoveryScopeKey scopeKey;
+  final int maxPerTool;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _AgentSessionDiscoveryKey &&
+          scopeKey == other.scopeKey &&
+          maxPerTool == other.maxPerTool;
+
+  @override
+  int get hashCode => Object.hash(scopeKey, maxPerTool);
+}
+
+@immutable
+class _AgentSessionDiscoveryScopeKey {
+  const _AgentSessionDiscoveryScopeKey({
+    required this.hostId,
+    required this.hostname,
+    required this.port,
+    required this.username,
+    required this.workingDirectory,
+  });
+
+  factory _AgentSessionDiscoveryScopeKey.fromSession(
+    SshSession session, {
+    required String? workingDirectory,
+  }) => _AgentSessionDiscoveryScopeKey(
+    hostId: session.hostId,
+    hostname: session.config.hostname,
+    port: session.config.port,
+    username: session.config.username,
+    workingDirectory: _trimWorkingDirectory(workingDirectory),
+  );
+
+  final int hostId;
+  final String hostname;
+  final int port;
+  final String username;
+  final String? workingDirectory;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _AgentSessionDiscoveryScopeKey &&
+          hostId == other.hostId &&
+          hostname == other.hostname &&
+          port == other.port &&
+          username == other.username &&
+          workingDirectory == other.workingDirectory;
+
+  @override
+  int get hashCode =>
+      Object.hash(hostId, hostname, port, username, workingDirectory);
+}
+
+class _CachedDiscoveryResult {
+  const _CachedDiscoveryResult({required this.result, required this.cachedAt});
+
+  final DiscoveredSessionsResult result;
+  final DateTime cachedAt;
+}
+
+class _CachedRelatedWorkingDirectories {
+  const _CachedRelatedWorkingDirectories({
+    required this.directories,
+    required this.cachedAt,
+  });
+
+  final List<String> directories;
+  final DateTime cachedAt;
 }
 
 class _ToolDiscoveryResult {
@@ -2293,5 +2545,5 @@ String? _resolveGeminiWorkingDirectory(
 /// Provider for [AgentSessionDiscoveryService].
 final agentSessionDiscoveryServiceProvider =
     Provider<AgentSessionDiscoveryService>(
-      (ref) => const AgentSessionDiscoveryService(),
+      (ref) => AgentSessionDiscoveryService(),
     );

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -17,8 +17,9 @@ const _genericSessionSummaries = <String>{
 };
 
 const _profileSourcingPrefix =
-    '{ . ~/.profile; . ~/.bash_profile; . ~/.zprofile; } '
-    '>/dev/null 2>&1; ';
+    r'export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin${PATH:+:$PATH}"; '
+    '{ . ~/.profile; . ~/.bash_profile; . ~/.zprofile; } >/dev/null 2>&1; '
+    r'export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin${PATH:+:$PATH}"; ';
 const _remoteFileSnapshotBatchSize = 40;
 
 /// Filters noisy discovered sessions and fills in a better display summary
@@ -60,6 +61,23 @@ int compareDiscoveredSessionsByRecency(ToolSessionInfo a, ToolSessionInfo b) {
   final toolCompare = a.toolName.compareTo(b.toolName);
   if (toolCompare != 0) return toolCompare;
   return (a.summary ?? '').compareTo(b.summary ?? '');
+}
+
+/// Orders tool groups for UI rendering: providers with sessions first, then
+/// attempted providers that yielded no sessions, alphabetized.
+List<String> orderedDiscoveredSessionTools(
+  Map<String, List<ToolSessionInfo>> grouped,
+  Iterable<String> attemptedTools,
+) {
+  final ordered = <String>[...grouped.keys];
+  final emptyAttempts =
+      attemptedTools
+          .where((tool) => !grouped.containsKey(tool))
+          .toSet()
+          .toList()
+        ..sort();
+  ordered.addAll(emptyAttempts);
+  return ordered;
 }
 
 /// Discovered session results plus any tool histories that could not be read.
@@ -112,6 +130,31 @@ bool shouldSurfaceDiscoveryFailure({
   required bool hadError,
   required int loadedSessionCount,
 }) => hadError && loadedSessionCount == 0;
+
+/// Builds the SQL predicate used to scope session directories to the active
+/// project root or its descendants without relying on `LIKE` wildcards.
+String? buildSqlWorkingDirectoryScopeClause(
+  Iterable<String> directories, {
+  required String columnName,
+}) {
+  final scopedDirectories = directories
+      .map(_trimWorkingDirectory)
+      .whereType<String>()
+      .toSet()
+      .toList(growable: false);
+  if (scopedDirectories.isEmpty) {
+    return null;
+  }
+
+  return scopedDirectories
+      .map(
+        (directory) => _buildSqlWorkingDirectoryPrefixPredicate(
+          directory,
+          columnName: columnName,
+        ),
+      )
+      .join(' OR ');
+}
 
 String? _normalizeDiscoveredSessionSummary(
   ToolSessionInfo info, {
@@ -201,6 +244,7 @@ bool _isLikelyToolStateWorkingDirectory(String directory) =>
     directory.contains('/.codex/') ||
     directory.endsWith('/.gemini') ||
     directory.contains('/.gemini/') ||
+    directory.endsWith('/.local/share/opencode') ||
     directory.contains('/.local/share/opencode/') ||
     directory.startsWith('/tmp/') ||
     directory.startsWith('/private/tmp/') ||
@@ -209,9 +253,12 @@ bool _isLikelyToolStateWorkingDirectory(String directory) =>
 /// Chooses the best working directory to scope AI session discovery.
 ///
 /// Tmux panes can temporarily report tool-state or temp directories while the
-/// user is still effectively working in a project. In those cases, prefer the
-/// terminal session's working directory when available, or skip scoping
-/// entirely instead of hiding project sessions behind a transient tool path.
+/// user is still effectively working in a project. Tmux window metadata can
+/// also lag behind the active pane's live OSC 7 working directory, especially
+/// after changing directories inside an existing tmux window. In those cases,
+/// prefer the terminal session's working directory when it is more specific or
+/// conflicts with the pane snapshot, or skip scoping entirely instead of
+/// hiding project sessions behind a stale or transient tool path.
 String? resolveAgentSessionScopeWorkingDirectory({
   String? activeWorkingDirectory,
   Uri? sessionWorkingDirectory,
@@ -223,10 +270,54 @@ String? resolveAgentSessionScopeWorkingDirectory({
   if (trimmedActive == null) {
     return fallbackWorkingDirectory;
   }
+  if (fallbackWorkingDirectory == null) {
+    return _isLikelyToolStateWorkingDirectory(trimmedActive)
+        ? null
+        : trimmedActive;
+  }
   if (_isLikelyToolStateWorkingDirectory(trimmedActive)) {
     return fallbackWorkingDirectory;
   }
+  if (_isLikelyToolStateWorkingDirectory(fallbackWorkingDirectory)) {
+    return trimmedActive;
+  }
+
+  final comparableActive = normalizeWorkingDirectoryForComparison(
+    trimmedActive,
+  );
+  final comparableFallback = normalizeWorkingDirectoryForComparison(
+    fallbackWorkingDirectory,
+  );
+  if (!_workingDirectoriesOverlap(comparableActive, comparableFallback)) {
+    return fallbackWorkingDirectory;
+  }
+  if (comparableFallback.startsWith('$comparableActive/')) {
+    return fallbackWorkingDirectory;
+  }
   return trimmedActive;
+}
+
+/// Chooses the best tmux AI-session scope, preferring the live terminal cwd and
+/// using tmux metadata only as a last resort when no live cwd is available.
+String? resolveTmuxAiSessionScopeWorkingDirectory({
+  String? liveTerminalWorkingDirectory,
+  String? tmuxWorkingDirectory,
+  Uri? sessionWorkingDirectory,
+}) {
+  final liveScope = resolveAgentSessionScopeWorkingDirectory(
+    activeWorkingDirectory: liveTerminalWorkingDirectory,
+    sessionWorkingDirectory: sessionWorkingDirectory,
+  );
+  if (liveScope != null) return liveScope;
+
+  final trimmedTmuxWorkingDirectory = _trimWorkingDirectory(
+    tmuxWorkingDirectory,
+  );
+  if (trimmedTmuxWorkingDirectory == null) return null;
+  return resolveAgentSessionScopeWorkingDirectory(
+    activeWorkingDirectory: trimmedTmuxWorkingDirectory,
+    sessionWorkingDirectory: sessionWorkingDirectory,
+  );
 }
 
 String _summarizeSessionText(String value, {int maxLength = 80}) {
@@ -269,6 +360,8 @@ parseCopilotWorkspaceYamlMetadata(String raw) {
   String? summary;
   String? workingDirectory;
   DateTime? updatedAt;
+  String? repository;
+  String? branch;
 
   for (var index = 0; index < lines.length; index++) {
     final line = lines[index];
@@ -286,6 +379,22 @@ parseCopilotWorkspaceYamlMetadata(String raw) {
       ).firstMatch(line);
       if (updatedAtMatch != null) {
         updatedAt = DateTime.tryParse(updatedAtMatch.group(1)!.trim());
+      }
+    }
+
+    if (repository == null) {
+      final repositoryMatch = RegExp(
+        r'^repository:\s*(.+)\s*$',
+      ).firstMatch(line);
+      if (repositoryMatch != null) {
+        repository = repositoryMatch.group(1)!.trim();
+      }
+    }
+
+    if (branch == null) {
+      final branchMatch = RegExp(r'^branch:\s*(.+)\s*$').firstMatch(line);
+      if (branchMatch != null) {
+        branch = branchMatch.group(1)!.trim();
       }
     }
 
@@ -316,6 +425,21 @@ parseCopilotWorkspaceYamlMetadata(String raw) {
     final normalizedInlineValue = inlineValue.trim();
     if (normalizedInlineValue.isNotEmpty) {
       summary = _summarizeSessionText(normalizedInlineValue);
+    }
+  }
+
+  if (summary == null) {
+    final repositorySummary = repository?.trim();
+    final branchSummary = branch?.trim();
+    if (repositorySummary != null &&
+        repositorySummary.isNotEmpty &&
+        branchSummary != null &&
+        branchSummary.isNotEmpty) {
+      summary = _summarizeSessionText('$repositorySummary ($branchSummary)');
+    } else if (repositorySummary != null && repositorySummary.isNotEmpty) {
+      summary = _summarizeSessionText(repositorySummary);
+    } else if (branchSummary != null && branchSummary.isNotEmpty) {
+      summary = _summarizeSessionText(branchSummary);
     }
   }
 
@@ -672,6 +796,39 @@ List<String> buildGeminiProjectDirectoryNames(
       .toList(growable: false);
 }
 
+/// Builds the narrow Gemini project directory names that should be preferred
+/// for the active scope before falling back to the broader worktree family.
+@visibleForTesting
+List<String> buildScopedGeminiProjectDirectoryNames(
+  String activeWorkingDirectory,
+  Iterable<String> relatedWorkingDirectories,
+) {
+  final trimmedActive = _trimWorkingDirectory(activeWorkingDirectory);
+  if (trimmedActive == null) {
+    return const <String>[];
+  }
+
+  final activeRootCandidates =
+      relatedWorkingDirectories
+          .map(_trimWorkingDirectory)
+          .whereType<String>()
+          .where(
+            (directory) =>
+                directory == trimmedActive ||
+                trimmedActive.startsWith('$directory/'),
+          )
+          .toList(growable: false)
+        ..sort((a, b) => a.length.compareTo(b.length));
+  final activeRoot = activeRootCandidates.firstOrNull ?? trimmedActive;
+
+  return <String>{
+        _pathLastSegment(activeRoot),
+        _pathLastSegment(normalizeWorkingDirectoryForComparison(activeRoot)),
+      }
+      .where((name) => name.isNotEmpty && name != '.' && name != '~')
+      .toList(growable: false);
+}
+
 /// Sorts merged discovery sessions by recency before applying a scan cap.
 @visibleForTesting
 List<ToolSessionInfo> sortAndLimitDiscoveredSessions(
@@ -810,7 +967,7 @@ class AgentSessionDiscoveryService {
 
     while (pendingResults.isNotEmpty) {
       final completed = await Future.any(pendingResults.values);
-      unawaited(pendingResults.remove(completed.index));
+      pendingResults.remove(completed.index)?.ignore();
       completedResults[completed.index] = completed.result;
       yield _buildDiscoveredSessionsResult(
         completedResults.whereType<_ToolDiscoveryResult>(),
@@ -1374,9 +1531,13 @@ class AgentSessionDiscoveryService {
         '-exec ls -1t {} + 2>/dev/null | head -n $scanLimit';
     var output = '';
 
-    final projectDirectoryNames = buildGeminiProjectDirectoryNames(
-      relatedWorkingDirectories,
-    );
+    final projectDirectoryNames =
+        workingDirectory != null && workingDirectory.isNotEmpty
+        ? buildScopedGeminiProjectDirectoryNames(
+            workingDirectory,
+            relatedWorkingDirectories,
+          )
+        : buildGeminiProjectDirectoryNames(relatedWorkingDirectories);
     if (workingDirectory != null &&
         workingDirectory.isNotEmpty &&
         projectDirectoryNames.isNotEmpty) {
@@ -1485,6 +1646,24 @@ class AgentSessionDiscoveryService {
         maximum: 120,
       );
       var hadError = false;
+
+      if (workingDirectory != null && workingDirectory.isNotEmpty) {
+        final scopedDbOutput = await _queryOpenCodeDb(
+          session,
+          scanLimit,
+          scopedDirectories: relatedWorkingDirectories,
+        );
+        if (scopedDbOutput.trim().isNotEmpty) {
+          return _ToolDiscoveryResult.success(
+            'OpenCode',
+            sortAndLimitDiscoveredSessions(
+              _parseOpenCodeDbOutput(scopedDbOutput),
+              scanLimit,
+            ),
+          );
+        }
+      }
+
       // Preferred: use the CLI's own JSON output.
       final cliOutput = await _exec(
         session,
@@ -1521,17 +1700,7 @@ class AgentSessionDiscoveryService {
       // Fallback: query the SQLite database directly.
       // Use ASCII Unit Separator (\x1f) to avoid collision with pipes
       // in session titles or directory paths.
-      final dbOutput = await _exec(
-        session,
-        r'SEP=$(printf "\037"); sqlite3 -separator "$SEP" '
-        '~/.local/share/opencode/opencode.db '
-        "'SELECT id, title, directory, time_updated "
-        'FROM session '
-        'WHERE parent_id IS NULL '
-        'AND time_archived IS NULL '
-        'ORDER BY time_updated DESC '
-        "LIMIT $scanLimit;' 2>/dev/null",
-      );
+      final dbOutput = await _queryOpenCodeDb(session, scanLimit);
       if (dbOutput.trim().isNotEmpty) {
         final sessions = _parseOpenCodeDbOutput(dbOutput);
         final scopedSessions =
@@ -1618,6 +1787,35 @@ class AgentSessionDiscoveryService {
       );
     }
     return sessions;
+  }
+
+  Future<String> _queryOpenCodeDb(
+    SshSession session,
+    int scanLimit, {
+    Iterable<String> scopedDirectories = const <String>[],
+  }) {
+    final directoryScopeClause = buildSqlWorkingDirectoryScopeClause(
+      scopedDirectories,
+      columnName: 'directory',
+    );
+    final sql = StringBuffer()
+      ..write('SELECT id, title, directory, time_updated ')
+      ..write('FROM session ')
+      ..write('WHERE parent_id IS NULL ')
+      ..write('AND time_archived IS NULL ');
+    if (directoryScopeClause != null) {
+      sql.write('AND ($directoryScopeClause) ');
+    }
+    sql
+      ..write('ORDER BY time_updated DESC ')
+      ..write('LIMIT $scanLimit;');
+
+    return _exec(
+      session,
+      r'SEP=$(printf "\037"); sqlite3 -separator "$SEP" '
+      '~/.local/share/opencode/opencode.db '
+      '${_shellQuote(sql.toString())} 2>/dev/null',
+    );
   }
 
   // ── Helpers ────────────────────────────────────────────────────────────
@@ -1721,24 +1919,43 @@ class AgentSessionDiscoveryService {
           .toList(growable: false);
       final command = StringBuffer()
         ..write(r'SEP=$(printf "\037"); ')
+        ..write(
+          r'STAT_BIN=/usr/bin/stat; [ -x "$STAT_BIN" ] || STAT_BIN=stat; ',
+        )
+        ..write(
+          r'HEAD_BIN=/usr/bin/head; [ -x "$HEAD_BIN" ] || HEAD_BIN=head; ',
+        )
+        ..write(
+          r'BASE64_BIN=/usr/bin/base64; [ -x "$BASE64_BIN" ] || BASE64_BIN=base64; ',
+        )
+        ..write(r'TR_BIN=/usr/bin/tr; [ -x "$TR_BIN" ] || TR_BIN=tr; ')
+        ..write(r'CAT_BIN=/bin/cat; [ -x "$CAT_BIN" ] || CAT_BIN=cat; ')
+        ..write(r'SED_BIN=/usr/bin/sed; [ -x "$SED_BIN" ] || SED_BIN=sed; ')
+        ..write(
+          r'TAIL_BIN=/usr/bin/tail; [ -x "$TAIL_BIN" ] || TAIL_BIN=tail; ',
+        )
         ..write('for path in ')
         ..write(batchPaths.map(_shellQuote).join(' '))
         ..write(r'; do [ -f "$path" ] || continue; ')
         ..write(
-          r'mtime=$( (stat -c %Y "$path" 2>/dev/null || '
-          r'stat -f %m "$path" 2>/dev/null) | head -1); ',
+          r'mtime=$( ($STAT_BIN -c %Y "$path" 2>/dev/null || '
+          r'$STAT_BIN -f %m "$path" 2>/dev/null) | $HEAD_BIN -n 1); ',
         )
         ..write(r'printf "%s%s%s%s" "$path" "$SEP" "${mtime:-}" "$SEP"; ');
 
       if (maxLines == null) {
-        command.write(r'cat "$path" 2>/dev/null | base64 | tr -d "\n"; ');
+        command.write(
+          r'$CAT_BIN "$path" 2>/dev/null | $BASE64_BIN | $TR_BIN -d "\n"; ',
+        );
       } else {
         command.write(
           tail
-              ? 'tail -n $maxLines '
-                    r'"$path" 2>/dev/null | base64 | tr -d "\n"; '
-              : "sed -n '1,${maxLines}p' "
-                    r'"$path" 2>/dev/null | base64 | tr -d "\n"; ',
+              ? r'$TAIL_BIN -n '
+                    '$maxLines'
+                    r' "$path" 2>/dev/null | $BASE64_BIN | $TR_BIN -d "\n"; '
+              : r'''$SED_BIN -n '1,'''
+                    '$maxLines'
+                    r'''p' "$path" 2>/dev/null | $BASE64_BIN | $TR_BIN -d "\n"; ''',
         );
       }
 
@@ -1969,6 +2186,19 @@ Map<String, dynamic>? _decodeJsonOrJsonlObject(String raw) {
   }
   return lastObject;
 }
+
+String _buildSqlWorkingDirectoryPrefixPredicate(
+  String directory, {
+  required String columnName,
+}) {
+  final quotedDirectory = _sqliteQuote(directory);
+  final quotedDirectoryPrefix = _sqliteQuote('$directory/');
+  return '($columnName = $quotedDirectory OR '
+      'substr($columnName, 1, length($quotedDirectory) + 1) = '
+      '$quotedDirectoryPrefix)';
+}
+
+String _sqliteQuote(String value) => "'${value.replaceAll("'", "''")}'";
 
 Map<String, dynamic>? _readMapField(Map<String, dynamic>? map, String key) {
   final value = map?[key];

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -70,8 +70,9 @@ int compareDiscoveredSessionsByRecency(ToolSessionInfo a, ToolSessionInfo b) {
 /// attempted providers that yielded no sessions, alphabetized.
 List<String> orderedDiscoveredSessionTools(
   Map<String, List<ToolSessionInfo>> grouped,
-  Iterable<String> attemptedTools,
-) {
+  Iterable<String> attemptedTools, {
+  String? preferredToolName,
+}) {
   final ordered = <String>[...grouped.keys];
   final emptyAttempts =
       attemptedTools
@@ -79,6 +80,13 @@ List<String> orderedDiscoveredSessionTools(
           .toSet()
           .toList()
         ..sort();
+  if (preferredToolName case final preferred? when preferred.isNotEmpty) {
+    if (ordered.remove(preferred)) {
+      ordered.insert(0, preferred);
+    } else if (emptyAttempts.remove(preferred)) {
+      ordered.insert(0, preferred);
+    }
+  }
   ordered.addAll(emptyAttempts);
   return ordered;
 }

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -349,6 +349,170 @@ parseGeminiSessionMetadata(
   );
 }
 
+String? _trimWorkingDirectory(String? value) {
+  final trimmed = value?.trim();
+  if (trimmed == null || trimmed.isEmpty) return null;
+  final withoutTrailingSlash = trimmed.length > 1 && trimmed.endsWith('/')
+      ? trimmed.replaceFirst(RegExp(r'/+$'), '')
+      : trimmed;
+  return withoutTrailingSlash.replaceAll(RegExp('/+'), '/');
+}
+
+/// Normalizes a working directory for cross-worktree comparisons.
+///
+/// Paths under `repo.worktrees/<branch>/...` are normalized to `repo/...` so
+/// sessions from sibling checkouts can still match the active project scope.
+@visibleForTesting
+String normalizeWorkingDirectoryForComparison(String value) {
+  final trimmed = _trimWorkingDirectory(value);
+  if (trimmed == null) return value.trim();
+
+  final segments = trimmed.split('/');
+  final normalizedSegments = <String>[];
+  for (var index = 0; index < segments.length; index++) {
+    final segment = segments[index];
+    if (segment.endsWith('.worktrees') && index + 1 < segments.length) {
+      normalizedSegments.add(
+        segment.substring(0, segment.length - '.worktrees'.length),
+      );
+      index += 1;
+      continue;
+    }
+    normalizedSegments.add(segment);
+  }
+
+  final normalized = normalizedSegments.join('/');
+  return trimmed.startsWith('/') && !normalized.startsWith('/')
+      ? '/$normalized'
+      : normalized;
+}
+
+String? _relativeWorkingDirectoryPath(String child, String root) {
+  if (child == root) return '';
+  final prefix = '$root/';
+  if (!child.startsWith(prefix)) return null;
+  return child.substring(prefix.length);
+}
+
+String _joinWorkingDirectoryPath(String root, String relativePath) =>
+    relativePath.isEmpty ? root : '$root/$relativePath';
+
+bool _workingDirectoriesOverlap(String a, String b) =>
+    a == b || a.startsWith('$b/') || b.startsWith('$a/');
+
+/// Parses `git worktree list --porcelain` output into root paths.
+@visibleForTesting
+List<String> parseGitWorktreeRoots(String raw) {
+  final roots = <String>[];
+  for (final line in const LineSplitter().convert(raw)) {
+    if (!line.startsWith('worktree ')) continue;
+    final root = _trimWorkingDirectory(line.substring('worktree '.length));
+    if (root != null) roots.add(root);
+  }
+  return roots;
+}
+
+/// Builds all directories that should be treated as the active project scope.
+///
+/// This includes the active directory itself, the normalized `.worktrees`
+/// equivalent, the git worktree roots when available, and corresponding
+/// subdirectories across sibling worktrees.
+@visibleForTesting
+List<String> buildRelatedWorkingDirectories(
+  String activeWorkingDirectory, {
+  String? gitRoot,
+  Iterable<String> gitWorktreeRoots = const <String>[],
+}) {
+  final trimmedActive = _trimWorkingDirectory(activeWorkingDirectory);
+  if (trimmedActive == null) return const <String>[];
+
+  final directories = <String>{};
+
+  void addDirectory(String? directory) {
+    final trimmed = _trimWorkingDirectory(directory);
+    if (trimmed == null) return;
+    directories
+      ..add(trimmed)
+      ..add(normalizeWorkingDirectoryForComparison(trimmed));
+  }
+
+  addDirectory(trimmedActive);
+
+  final trimmedGitRoot = _trimWorkingDirectory(gitRoot);
+  final relativePath = trimmedGitRoot == null
+      ? null
+      : _relativeWorkingDirectoryPath(trimmedActive, trimmedGitRoot);
+
+  addDirectory(trimmedGitRoot);
+
+  if (relativePath != null && relativePath.isNotEmpty) {
+    for (final root in gitWorktreeRoots) {
+      final trimmedRoot = _trimWorkingDirectory(root);
+      if (trimmedRoot == null) continue;
+      addDirectory(_joinWorkingDirectoryPath(trimmedRoot, relativePath));
+    }
+  }
+
+  for (final root in gitWorktreeRoots) {
+    addDirectory(root);
+  }
+
+  return directories.toList(growable: false);
+}
+
+/// Whether a discovered session directory belongs to the active project scope.
+@visibleForTesting
+bool matchesDiscoveredSessionWorkingDirectory(
+  String expectedWorkingDirectory,
+  String? sessionDirectory, {
+  Iterable<String> relatedWorkingDirectories = const <String>[],
+}) {
+  final trimmedSessionDirectory = _trimWorkingDirectory(sessionDirectory);
+  if (trimmedSessionDirectory == null) return false;
+  final comparableSessionDirectory = normalizeWorkingDirectoryForComparison(
+    trimmedSessionDirectory,
+  );
+  final candidates = relatedWorkingDirectories.isNotEmpty
+      ? relatedWorkingDirectories
+      : <String>[expectedWorkingDirectory];
+  for (final candidate in candidates) {
+    final trimmedCandidate = _trimWorkingDirectory(candidate);
+    if (trimmedCandidate == null) continue;
+    final comparableCandidate = normalizeWorkingDirectoryForComparison(
+      trimmedCandidate,
+    );
+    if (_workingDirectoriesOverlap(
+      comparableCandidate,
+      comparableSessionDirectory,
+    )) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Resolves a Gemini project directory label to a concrete worktree path.
+@visibleForTesting
+String? resolveGeminiProjectWorkingDirectory(
+  String? projectDirectoryName,
+  Iterable<String> relatedWorkingDirectories,
+) {
+  final trimmedProjectDirectoryName = projectDirectoryName?.trim();
+  if (trimmedProjectDirectoryName == null ||
+      trimmedProjectDirectoryName.isEmpty) {
+    return null;
+  }
+
+  for (final directory in relatedWorkingDirectories) {
+    final trimmedDirectory = _trimWorkingDirectory(directory);
+    if (trimmedDirectory == null) continue;
+    if (_pathLastSegment(trimmedDirectory) == trimmedProjectDirectoryName) {
+      return trimmedDirectory;
+    }
+  }
+  return null;
+}
+
 /// Discovers recent AI coding tool sessions on remote hosts by scanning
 /// known session storage locations.
 ///
@@ -377,11 +541,20 @@ class AgentSessionDiscoveryService {
     String? workingDirectory,
     int maxPerTool = 12,
   }) async {
+    final relatedWorkingDirectories = await _resolveRelatedWorkingDirectories(
+      session,
+      workingDirectory,
+    );
     final results = await Future.wait([
       _discoverClaudeSessions(session, workingDirectory, maxPerTool),
       _discoverCodexSessions(session, maxPerTool),
       _discoverCopilotSessions(session, maxPerTool),
-      _discoverGeminiSessions(session, workingDirectory, maxPerTool),
+      _discoverGeminiSessions(
+        session,
+        workingDirectory,
+        relatedWorkingDirectories,
+        maxPerTool,
+      ),
       _discoverOpenCodeSessions(session, maxPerTool),
     ]);
 
@@ -401,9 +574,10 @@ class AgentSessionDiscoveryService {
       final filtered = _limitDiscoveredSessionsPerTool(
         all
             .where(
-              (s) => _matchesWorkingDirectory(
+              (s) => matchesDiscoveredSessionWorkingDirectory(
                 workingDirectory,
                 s.workingDirectory,
+                relatedWorkingDirectories: relatedWorkingDirectories,
               ),
             )
             .toList(),
@@ -777,29 +951,58 @@ class AgentSessionDiscoveryService {
   Future<_ToolDiscoveryResult> _discoverGeminiSessions(
     SshSession session,
     String? workingDirectory,
+    List<String> relatedWorkingDirectories,
     int max,
   ) async {
     try {
-      // Preferred: use the CLI's own session list.
-      final cdPrefix = workingDirectory != null && workingDirectory.isNotEmpty
-          ? 'cd ${_shellQuote(workingDirectory)} && '
-          : '';
-      final cliOutput = await _exec(
-        session,
-        '${cdPrefix}gemini --list-sessions 2>/dev/null',
-      );
-      if (cliOutput.contains('[') && cliOutput.contains(']')) {
-        final parsed = _parseGeminiCliOutput(cliOutput, workingDirectory);
-        if (parsed.isNotEmpty) {
-          return _ToolDiscoveryResult.success(
-            'Gemini CLI',
-            parsed.take(max * 5).toList(),
+      final searchDirectories = <String>{};
+      final trimmedWorkingDirectory = _trimWorkingDirectory(workingDirectory);
+      if (trimmedWorkingDirectory != null) {
+        searchDirectories.add(trimmedWorkingDirectory);
+      }
+      searchDirectories
+        ..addAll(
+          relatedWorkingDirectories.map(normalizeWorkingDirectoryForComparison),
+        )
+        ..addAll(relatedWorkingDirectories);
+
+      var hadError = false;
+      final sessionsById = <String, ToolSessionInfo>{};
+
+      for (final searchDirectory in searchDirectories) {
+        try {
+          final cliOutput = await _exec(
+            session,
+            '[ -d ${_shellQuote(searchDirectory)} ] && '
+            'cd ${_shellQuote(searchDirectory)} && '
+            'gemini --list-sessions 2>/dev/null',
           );
+          if (!cliOutput.contains('[') || !cliOutput.contains(']')) continue;
+          final parsed = _parseGeminiCliOutput(cliOutput, searchDirectory);
+          for (final info in parsed) {
+            _mergeToolSessionInfo(sessionsById, info);
+          }
+        } on Object {
+          hadError = true;
         }
       }
 
-      // Fallback: scan chat JSON files directly.
-      return _discoverGeminiSessionsFromFiles(session, workingDirectory, max);
+      final fallback = await _discoverGeminiSessionsFromFiles(
+        session,
+        workingDirectory,
+        relatedWorkingDirectories,
+        max,
+      );
+      hadError = hadError || fallback.hadError;
+      for (final info in fallback.sessions) {
+        _mergeToolSessionInfo(sessionsById, info);
+      }
+
+      return _ToolDiscoveryResult.success(
+        'Gemini CLI',
+        sessionsById.values.take(max * 5).toList(growable: false),
+        hadError: hadError,
+      );
     } on Object {
       return const _ToolDiscoveryResult.failure('Gemini CLI');
     }
@@ -840,6 +1043,7 @@ class AgentSessionDiscoveryService {
   Future<_ToolDiscoveryResult> _discoverGeminiSessionsFromFiles(
     SshSession session,
     String? workingDirectory,
+    List<String> relatedWorkingDirectories,
     int max,
   ) async {
     final scanLimit = max * 5;
@@ -872,12 +1076,10 @@ class AgentSessionDiscoveryService {
         final pathParts = filePath.split('/');
         final chatsIdx = pathParts.indexOf('chats');
         final projectDir = chatsIdx > 0 ? pathParts[chatsIdx - 1] : null;
-        final fallbackWorkingDirectory =
-            projectDir != null &&
-                workingDirectory != null &&
-                _pathLastSegment(workingDirectory) == projectDir
-            ? workingDirectory
-            : null;
+        final fallbackWorkingDirectory = resolveGeminiProjectWorkingDirectory(
+          projectDir,
+          relatedWorkingDirectories,
+        );
 
         String? summary;
         var sessionWorkingDirectory = fallbackWorkingDirectory;
@@ -1158,8 +1360,69 @@ END {
     epoch > 9999999999 ? epoch : epoch * 1000,
   );
 
+  Future<List<String>> _resolveRelatedWorkingDirectories(
+    SshSession session,
+    String? workingDirectory,
+  ) async {
+    final trimmedWorkingDirectory = _trimWorkingDirectory(workingDirectory);
+    if (trimmedWorkingDirectory == null) return const <String>[];
+
+    try {
+      final gitOutput = await _exec(
+        session,
+        r'ROOT=$(git -C '
+        '${_shellQuote(trimmedWorkingDirectory)}'
+        ' rev-parse --show-toplevel 2>/dev/null) && '
+        r'[ -n "$ROOT" ] && printf "root=%s\n" "$ROOT" && '
+        'git -C '
+        '${_shellQuote(trimmedWorkingDirectory)}'
+        ' worktree list --porcelain 2>/dev/null',
+      );
+      if (gitOutput.trim().isEmpty) {
+        return buildRelatedWorkingDirectories(trimmedWorkingDirectory);
+      }
+
+      String? gitRoot;
+      final worktreeLines = StringBuffer();
+      for (final line in const LineSplitter().convert(gitOutput)) {
+        if (gitRoot == null && line.startsWith('root=')) {
+          gitRoot = _trimWorkingDirectory(line.substring('root='.length));
+          continue;
+        }
+        worktreeLines.writeln(line);
+      }
+
+      return buildRelatedWorkingDirectories(
+        trimmedWorkingDirectory,
+        gitRoot: gitRoot,
+        gitWorktreeRoots: parseGitWorktreeRoots(worktreeLines.toString()),
+      );
+    } on Object {
+      return buildRelatedWorkingDirectories(trimmedWorkingDirectory);
+    }
+  }
+
   static String _shellQuote(String value) =>
       "'${value.replaceAll("'", "'\"'\"'")}'";
+
+  void _mergeToolSessionInfo(
+    Map<String, ToolSessionInfo> sessionsById,
+    ToolSessionInfo info,
+  ) {
+    final existing = sessionsById[info.sessionId];
+    if (existing == null) {
+      sessionsById[info.sessionId] = info;
+      return;
+    }
+
+    sessionsById[info.sessionId] = ToolSessionInfo(
+      toolName: existing.toolName,
+      sessionId: existing.sessionId,
+      workingDirectory: existing.workingDirectory ?? info.workingDirectory,
+      lastActive: existing.lastActive ?? info.lastActive,
+      summary: existing.summary ?? info.summary,
+    );
+  }
 
   List<ToolSessionInfo> _limitDiscoveredSessionsPerTool(
     List<ToolSessionInfo> sessions,

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -189,6 +189,28 @@ String _summarizeSessionText(String value, {int maxLength = 80}) {
   return '${collapsed.substring(0, maxLength - 3)}...';
 }
 
+String? _extractPlanSummary(String raw) {
+  for (final line in const LineSplitter().convert(raw)) {
+    final cleaned = line.replaceAll(RegExp(r'^#+\s*'), '').trim();
+    if (cleaned.isNotEmpty && cleaned.length > 3) {
+      return _summarizeSessionText(cleaned);
+    }
+  }
+  return null;
+}
+
+int _calculateDiscoveryScanLimit(
+  int maxPerTool, {
+  int multiplier = 5,
+  int minimum = 60,
+  int maximum = 180,
+}) {
+  final scaledLimit = maxPerTool * multiplier;
+  if (scaledLimit < minimum) return minimum;
+  if (scaledLimit > maximum) return maximum;
+  return scaledLimit;
+}
+
 /// Parses Copilot CLI workspace metadata from `workspace.yaml`.
 @visibleForTesting
 ({String? summary, String? workingDirectory, DateTime? updatedAt})
@@ -294,6 +316,52 @@ parseCodexRolloutMetadata(String raw) {
     summary: summary,
     workingDirectory: workingDirectory,
     updatedAt: updatedAt,
+    parsedAny: parsedAny,
+  );
+}
+
+/// Parses Claude session metadata from a saved JSONL transcript.
+@visibleForTesting
+({
+  String? customTitle,
+  String? agentName,
+  String? lastPrompt,
+  String? userSummary,
+  bool parsedAny,
+})
+parseClaudeSessionMetadata(String raw) {
+  String? customTitle;
+  String? agentName;
+  String? lastPrompt;
+  String? userSummary;
+  var parsedAny = false;
+
+  for (final line in const LineSplitter().convert(raw)) {
+    final decoded = _tryDecodeJsonObject(line);
+    if (decoded == null) continue;
+    parsedAny = true;
+
+    customTitle = _readStringField(decoded, 'customTitle') ?? customTitle;
+    agentName = _readStringField(decoded, 'agentName') ?? agentName;
+    lastPrompt = _readStringField(decoded, 'lastPrompt') ?? lastPrompt;
+
+    if (userSummary != null ||
+        _readStringField(decoded, 'type') != 'user' ||
+        decoded['isMeta'] == true) {
+      continue;
+    }
+
+    final message = _readMapField(decoded, 'message');
+    userSummary = _extractClaudeUserSummary(
+      _readStringField(message, 'content'),
+    );
+  }
+
+  return (
+    customTitle: customTitle,
+    agentName: agentName,
+    lastPrompt: lastPrompt,
+    userSummary: userSummary,
     parsedAny: parsedAny,
   );
 }
@@ -585,16 +653,31 @@ class AgentSessionDiscoveryService {
       workingDirectory,
     );
     final results = await Future.wait([
-      _discoverClaudeSessions(session, workingDirectory, maxPerTool),
-      _discoverCodexSessions(session, maxPerTool),
-      _discoverCopilotSessions(session, maxPerTool),
+      _discoverClaudeSessions(
+        session,
+        workingDirectory,
+        relatedWorkingDirectories,
+        maxPerTool,
+      ),
+      _discoverCodexSessions(
+        session,
+        workingDirectory,
+        relatedWorkingDirectories,
+        maxPerTool,
+      ),
+      _discoverCopilotSessions(session, relatedWorkingDirectories, maxPerTool),
       _discoverGeminiSessions(
         session,
         workingDirectory,
         relatedWorkingDirectories,
         maxPerTool,
       ),
-      _discoverOpenCodeSessions(session, maxPerTool),
+      _discoverOpenCodeSessions(
+        session,
+        workingDirectory,
+        relatedWorkingDirectories,
+        maxPerTool,
+      ),
     ]);
 
     final all = results
@@ -684,12 +767,18 @@ class AgentSessionDiscoveryService {
   Future<_ToolDiscoveryResult> _discoverClaudeSessions(
     SshSession session,
     String? workingDirectory,
+    List<String> relatedWorkingDirectories,
     int max,
   ) async {
     try {
       // Read more lines than needed to account for duplicate sessionIds
       // (e.g. multiple history entries for the same active session).
-      final tailCount = max * 5;
+      final tailCount = _calculateDiscoveryScanLimit(
+        max,
+        multiplier: 20,
+        minimum: 120,
+        maximum: 400,
+      );
       final output = await _exec(
         session,
         'tail -n $tailCount ~/.claude/history.jsonl 2>/dev/null',
@@ -714,9 +803,42 @@ class AgentSessionDiscoveryService {
         }
       }
 
-      final sessionFilesById = await _findClaudeSessionFiles(session, seenIds);
+      final scopedHistoryEntries =
+          workingDirectory != null && workingDirectory.isNotEmpty
+          ? historyEntries
+                .where(
+                  (entry) => matchesDiscoveredSessionWorkingDirectory(
+                    workingDirectory,
+                    entry['directory'] as String? ??
+                        entry['project'] as String?,
+                    relatedWorkingDirectories: relatedWorkingDirectories,
+                  ),
+                )
+                .toList(growable: false)
+          : historyEntries;
+      final relevantHistoryEntries = scopedHistoryEntries.isNotEmpty
+          ? scopedHistoryEntries
+          : historyEntries;
+      final sessionFilesById = await _findClaudeSessionFiles(
+        session,
+        relevantHistoryEntries.map(
+          (entry) => entry['sessionId'] as String? ?? '',
+        ),
+      );
+      final sessionFileHeadSnapshots = await _readRemoteFileSnapshots(
+        session,
+        sessionFilesById.values,
+        maxLines: 120,
+      );
+      final sessionFileTailSnapshots = await _readRemoteFileSnapshots(
+        session,
+        sessionFilesById.values,
+        maxLines: 120,
+        tail: true,
+      );
       final sessions = <ToolSessionInfo>[];
-      for (final decoded in historyEntries) {
+      var hadError = false;
+      for (final decoded in relevantHistoryEntries) {
         try {
           final sessionId = decoded['sessionId'] as String? ?? '';
           if (sessionId.isEmpty) continue;
@@ -733,18 +855,28 @@ class AgentSessionDiscoveryService {
           String? summary;
           final sessionFilePath = sessionFilesById[sessionId] ?? '';
           if (sessionFilePath.isNotEmpty) {
-            lastActive ??= await _readModificationTime(
-              session,
-              sessionFilePath,
-            );
-            final metadata = await _readClaudeSessionMetadata(
-              session,
-              sessionFilePath,
-            );
+            final headSnapshot = sessionFileHeadSnapshots[sessionFilePath];
+            final tailSnapshot = sessionFileTailSnapshots[sessionFilePath];
+            final snapshot = tailSnapshot ?? headSnapshot;
+            lastActive ??= snapshot?.modifiedAt;
+            final combinedContent = switch ((headSnapshot, tailSnapshot)) {
+              (null, null) => '',
+              (final head?, null) => head.content,
+              (null, final tail?) => tail.content,
+              (final head?, final tail?) =>
+                head.content == tail.content
+                    ? head.content
+                    : '${head.content}\n${tail.content}',
+            };
+            final metadata = parseClaudeSessionMetadata(combinedContent);
+            if (combinedContent.trim().isNotEmpty && !metadata.parsedAny) {
+              hadError = true;
+            }
             summary = _firstNonEmpty([
               metadata.customTitle,
               metadata.agentName,
               metadata.lastPrompt,
+              metadata.userSummary,
             ]);
           }
 
@@ -766,12 +898,16 @@ class AgentSessionDiscoveryService {
               summary: summary,
             ),
           );
-          if (sessions.length >= max) break;
         } on Object {
+          hadError = true;
           continue;
         }
       }
-      return _ToolDiscoveryResult.success('Claude Code', sessions);
+      return _ToolDiscoveryResult.success(
+        'Claude Code',
+        sortAndLimitDiscoveredSessions(sessions, tailCount),
+        hadError: hadError,
+      );
     } on Object {
       return const _ToolDiscoveryResult.failure('Claude Code');
     }
@@ -782,10 +918,16 @@ class AgentSessionDiscoveryService {
 
   Future<_ToolDiscoveryResult> _discoverCodexSessions(
     SshSession session,
+    String? workingDirectory,
+    List<String> relatedWorkingDirectories,
     int max,
   ) async {
     try {
-      final scanLimit = max * 5;
+      final scanLimit = _calculateDiscoveryScanLimit(
+        max,
+        multiplier: 10,
+        maximum: 120,
+      );
       final output = await _exec(
         session,
         'find ~/.codex/sessions -name "rollout-*.jsonl" -type f '
@@ -796,12 +938,21 @@ class AgentSessionDiscoveryService {
       }
 
       final sessionIndex = await _readCodexSessionIndex(session, scanLimit);
+      final rolloutPaths = output
+          .trim()
+          .split('\n')
+          .map((line) => line.trim())
+          .where((line) => line.isNotEmpty)
+          .toList(growable: false);
+      final rolloutSnapshots = await _readRemoteFileSnapshots(
+        session,
+        rolloutPaths,
+        maxLines: 80,
+      );
       final sessions = <ToolSessionInfo>[];
       var hadError = sessionIndex.hadError;
 
-      for (final line in output.trim().split('\n')) {
-        if (line.trim().isEmpty) continue;
-        final filePath = line.trim();
+      for (final filePath in rolloutPaths) {
         final fileName = filePath.split('/').last.replaceAll('.jsonl', '');
         final threadId = _extractCodexThreadId(fileName);
         final threadInfo = threadId != null
@@ -809,40 +960,55 @@ class AgentSessionDiscoveryService {
             : null;
 
         var summary = threadInfo?.threadName;
-        String? workingDirectory;
+        String? sessionWorkingDirectory;
         var lastActive = threadInfo?.updatedAt;
 
-        try {
-          final rolloutHead = await _exec(
-            session,
-            'sed -n \'1,80p\' ${_shellQuote(filePath)} 2>/dev/null',
-          );
-          final metadata = parseCodexRolloutMetadata(rolloutHead);
-          if (rolloutHead.trim().isNotEmpty && !metadata.parsedAny) {
+        final snapshot = rolloutSnapshots[filePath];
+        if (snapshot == null) {
+          hadError = true;
+        } else {
+          try {
+            final metadata = parseCodexRolloutMetadata(snapshot.content);
+            if (snapshot.content.trim().isNotEmpty && !metadata.parsedAny) {
+              hadError = true;
+            }
+            summary ??= metadata.summary;
+            sessionWorkingDirectory = metadata.workingDirectory;
+            lastActive ??= metadata.updatedAt;
+          } on Object {
             hadError = true;
           }
-          summary ??= metadata.summary;
-          workingDirectory = metadata.workingDirectory;
-          lastActive ??= metadata.updatedAt;
-        } on Object {
-          hadError = true;
+          lastActive ??= snapshot.modifiedAt;
         }
-
-        lastActive ??= await _readModificationTime(session, filePath);
 
         sessions.add(
           ToolSessionInfo(
             toolName: 'Codex',
             sessionId: fileName,
-            workingDirectory: workingDirectory,
+            workingDirectory: sessionWorkingDirectory,
             lastActive: lastActive,
             summary: summary ?? _truncateId(fileName),
           ),
         );
       }
+      final scopedSessions =
+          workingDirectory != null && workingDirectory.isNotEmpty
+          ? sessions
+                .where(
+                  (info) => matchesDiscoveredSessionWorkingDirectory(
+                    workingDirectory,
+                    info.workingDirectory,
+                    relatedWorkingDirectories: relatedWorkingDirectories,
+                  ),
+                )
+                .toList(growable: false)
+          : sessions;
       return _ToolDiscoveryResult.success(
         'Codex',
-        sessions,
+        sortAndLimitDiscoveredSessions(
+          scopedSessions.isNotEmpty ? scopedSessions : sessions,
+          scanLimit,
+        ),
         hadError: hadError,
       );
     } on Object {
@@ -890,90 +1056,111 @@ class AgentSessionDiscoveryService {
 
   Future<_ToolDiscoveryResult> _discoverCopilotSessions(
     SshSession session,
+    List<String> relatedWorkingDirectories,
     int max,
   ) async {
     try {
-      final scanLimit = max * 5;
-      final output = await _exec(
-        session,
-        'find ~/.copilot/session-state -mindepth 2 -maxdepth 2 '
-        '-name workspace.yaml -type f '
-        '-exec ls -1t {} + 2>/dev/null | head -n $scanLimit',
+      final scanLimit = _calculateDiscoveryScanLimit(
+        max,
+        multiplier: 20,
+        minimum: 120,
+        maximum: 240,
       );
-      if (output.trim().isEmpty) {
+      final workspacePaths = await _listCopilotWorkspacePaths(
+        session,
+        scanLimit,
+        relatedWorkingDirectories,
+      );
+      if (workspacePaths.isEmpty) {
         return const _ToolDiscoveryResult.success('Copilot CLI', []);
       }
 
-      final workspacePaths = output
-          .trim()
-          .split('\n')
-          .map((line) => line.trim())
-          .where((line) => line.isNotEmpty)
-          .toList(growable: false);
-
+      final workspaceSnapshots = await _readRemoteFileSnapshots(
+        session,
+        workspacePaths,
+      );
+      final planPathsNeedingFallback = <String>[];
+      final metadataByWorkspacePath =
+          <
+            String,
+            ({String? summary, String? workingDirectory, DateTime? updatedAt})
+          >{};
       var hadError = false;
-      final sessions = await Future.wait(
-        workspacePaths.map((workspacePath) async {
-          final dirPath = workspacePath.replaceFirst(
-            RegExp(r'/workspace\.yaml$'),
-            '/',
+
+      for (final workspacePath in workspacePaths) {
+        final dirPath = workspacePath.replaceFirst(
+          RegExp(r'/workspace\.yaml$'),
+          '/',
+        );
+        final snapshot = workspaceSnapshots[workspacePath];
+        if (snapshot == null) {
+          hadError = true;
+          metadataByWorkspacePath[workspacePath] = (
+            summary: null,
+            workingDirectory: null,
+            updatedAt: null,
           );
-          final dirName = dirPath.split('/').where((s) => s.isNotEmpty).last;
-          DateTime? lastActive;
+          planPathsNeedingFallback.add('${dirPath}plan.md');
+          continue;
+        }
 
-          String? summary;
-          String? workingDirectory;
-          try {
-            final yaml = await _exec(
-              session,
-              'cat ${_shellQuote(workspacePath)} 2>/dev/null',
-            );
-            if (yaml.trim().isNotEmpty) {
-              final metadata = parseCopilotWorkspaceYamlMetadata(yaml);
-              summary = metadata.summary;
-              workingDirectory = metadata.workingDirectory;
-              lastActive = metadata.updatedAt;
-            }
-          } on Object {
-            hadError = true;
+        try {
+          final metadata = parseCopilotWorkspaceYamlMetadata(snapshot.content);
+          metadataByWorkspacePath[workspacePath] = metadata;
+          if (metadata.summary?.isEmpty ?? true) {
+            planPathsNeedingFallback.add('${dirPath}plan.md');
           }
+        } on Object {
+          hadError = true;
+          metadataByWorkspacePath[workspacePath] = (
+            summary: null,
+            workingDirectory: null,
+            updatedAt: snapshot.modifiedAt,
+          );
+          planPathsNeedingFallback.add('${dirPath}plan.md');
+        }
+      }
 
-          lastActive ??= await _readModificationTime(session, workspacePath);
+      final planSnapshots = await _readRemoteFileSnapshots(
+        session,
+        planPathsNeedingFallback,
+        maxLines: 3,
+      );
+      final sessions = <ToolSessionInfo>[];
 
-          if (summary == null || summary.isEmpty) {
-            try {
-              final planHead = await _exec(
-                session,
-                'head -3 ${_shellQuote('${dirPath}plan.md')} 2>/dev/null',
-              );
-              if (planHead.trim().isNotEmpty) {
-                for (final planLine in planHead.trim().split('\n')) {
-                  final cleaned = planLine
-                      .replaceAll(RegExp(r'^#+\s*'), '')
-                      .trim();
-                  if (cleaned.isNotEmpty && cleaned.length > 3) {
-                    summary = _summarizeSessionText(cleaned);
-                    break;
-                  }
-                }
-              }
-            } on Object {
-              hadError = true;
-            }
-          }
+      for (final workspacePath in workspacePaths) {
+        final metadata = metadataByWorkspacePath[workspacePath];
+        final snapshot = workspaceSnapshots[workspacePath];
+        if (metadata == null) {
+          hadError = true;
+          continue;
+        }
 
-          return ToolSessionInfo(
+        final dirPath = workspacePath.replaceFirst(
+          RegExp(r'/workspace\.yaml$'),
+          '/',
+        );
+        final dirName = dirPath.split('/').where((s) => s.isNotEmpty).last;
+        final planSnapshot = planSnapshots['${dirPath}plan.md'];
+        final fallbackSummary = planSnapshot == null
+            ? null
+            : _extractPlanSummary(planSnapshot.content);
+
+        sessions.add(
+          ToolSessionInfo(
             toolName: 'Copilot CLI',
             sessionId: dirName,
-            workingDirectory: workingDirectory,
-            lastActive: lastActive,
-            summary: summary ?? _truncateId(dirName),
-          );
-        }),
-      );
+            workingDirectory: metadata.workingDirectory,
+            lastActive: metadata.updatedAt ?? snapshot?.modifiedAt,
+            summary:
+                metadata.summary ?? fallbackSummary ?? _truncateId(dirName),
+          ),
+        );
+      }
+
       return _ToolDiscoveryResult.success(
         'Copilot CLI',
-        sessions,
+        sortAndLimitDiscoveredSessions(sessions, scanLimit),
         hadError: hadError,
       );
     } on Object {
@@ -1079,7 +1266,11 @@ class AgentSessionDiscoveryService {
     List<String> relatedWorkingDirectories,
     int max,
   ) async {
-    final scanLimit = max * 5;
+    final scanLimit = _calculateDiscoveryScanLimit(
+      max,
+      multiplier: 10,
+      maximum: 120,
+    );
     final output = await _exec(
       session,
       r'find ~/.gemini/tmp \( -name "session-*.json" -o -name "session-*.jsonl" \) '
@@ -1096,69 +1287,65 @@ class AgentSessionDiscoveryService {
         .map((line) => line.trim())
         .where((line) => line.isNotEmpty)
         .toList(growable: false);
+    final sessionSnapshots = await _readRemoteFileSnapshots(
+      session,
+      sessionPaths,
+    );
 
     var hadError = false;
-    final sessions = await Future.wait(
-      sessionPaths.map((filePath) async {
-        final fileName = filePath
-            .split('/')
-            .last
-            .replaceAll('.jsonl', '')
-            .replaceAll('.json', '');
+    final sessions = <ToolSessionInfo>[];
+    for (final filePath in sessionPaths) {
+      final fileName = filePath
+          .split('/')
+          .last
+          .replaceAll('.jsonl', '')
+          .replaceAll('.json', '');
 
-        final pathParts = filePath.split('/');
-        final chatsIdx = pathParts.indexOf('chats');
-        final projectDir = chatsIdx > 0 ? pathParts[chatsIdx - 1] : null;
-        final fallbackWorkingDirectory = resolveGeminiProjectWorkingDirectory(
-          projectDir,
-          relatedWorkingDirectories,
+      final pathParts = filePath.split('/');
+      final chatsIdx = pathParts.indexOf('chats');
+      final projectDir = chatsIdx > 0 ? pathParts[chatsIdx - 1] : null;
+      final fallbackWorkingDirectory = resolveGeminiProjectWorkingDirectory(
+        projectDir,
+        relatedWorkingDirectories,
+      );
+
+      final snapshot = sessionSnapshots[filePath];
+      if (snapshot == null) {
+        hadError = true;
+        continue;
+      }
+
+      try {
+        final metadata = parseGeminiSessionMetadata(
+          snapshot.content,
+          activeWorkingDirectory: workingDirectory,
+          fallbackWorkingDirectory: fallbackWorkingDirectory,
         );
-
-        String? summary;
-        var sessionWorkingDirectory = fallbackWorkingDirectory;
-        DateTime? lastActive;
-        String? sessionId = fileName;
-        try {
-          final sessionRecord = await _exec(
-            session,
-            'cat ${_shellQuote(filePath)} 2>/dev/null',
-          );
-          final metadata = parseGeminiSessionMetadata(
-            sessionRecord,
-            activeWorkingDirectory: workingDirectory,
-            fallbackWorkingDirectory: fallbackWorkingDirectory,
-          );
-          if (sessionRecord.trim().isNotEmpty && !metadata.parsedAny) {
-            hadError = true;
-            return null;
-          }
-          if (metadata.isSubagent) return null;
-          summary = metadata.summary;
-          sessionWorkingDirectory = metadata.workingDirectory;
-          lastActive = metadata.updatedAt;
-          final discoveredSessionId = metadata.sessionId;
-          if (discoveredSessionId != null && discoveredSessionId.isNotEmpty) {
-            sessionId = discoveredSessionId;
-          }
-        } on Object {
+        if (snapshot.content.trim().isNotEmpty && !metadata.parsedAny) {
           hadError = true;
-          return null;
+          continue;
         }
+        if (metadata.isSubagent) continue;
 
-        lastActive ??= await _readModificationTime(session, filePath);
-
-        return ToolSessionInfo(
-          toolName: 'Gemini CLI',
-          sessionId: sessionId,
-          workingDirectory: sessionWorkingDirectory,
-          lastActive: lastActive,
-          summary: summary ?? projectDir ?? _truncateId(fileName),
+        sessions.add(
+          ToolSessionInfo(
+            toolName: 'Gemini CLI',
+            sessionId:
+                metadata.sessionId != null && metadata.sessionId!.isNotEmpty
+                ? metadata.sessionId!
+                : fileName,
+            workingDirectory: metadata.workingDirectory,
+            lastActive: metadata.updatedAt ?? snapshot.modifiedAt,
+            summary: metadata.summary ?? projectDir ?? _truncateId(fileName),
+          ),
         );
-      }),
-    );
+      } on Object {
+        hadError = true;
+      }
+    }
     return _ToolDiscoveryResult.success(
       'Gemini CLI',
-      sessions.whereType<ToolSessionInfo>().toList(growable: false),
+      sortAndLimitDiscoveredSessions(sessions, scanLimit),
       hadError: hadError,
     );
   }
@@ -1170,10 +1357,16 @@ class AgentSessionDiscoveryService {
 
   Future<_ToolDiscoveryResult> _discoverOpenCodeSessions(
     SshSession session,
+    String? workingDirectory,
+    List<String> relatedWorkingDirectories,
     int max,
   ) async {
     try {
-      final scanLimit = max * 5;
+      final scanLimit = _calculateDiscoveryScanLimit(
+        max,
+        multiplier: 10,
+        maximum: 120,
+      );
       var hadError = false;
       // Preferred: use the CLI's own JSON output.
       final cliOutput = await _exec(
@@ -1182,9 +1375,25 @@ class AgentSessionDiscoveryService {
       );
       if (cliOutput.trim().startsWith('[')) {
         try {
+          final sessions = _parseOpenCodeCliJson(cliOutput);
+          final scopedSessions =
+              workingDirectory != null && workingDirectory.isNotEmpty
+              ? sessions
+                    .where(
+                      (info) => matchesDiscoveredSessionWorkingDirectory(
+                        workingDirectory,
+                        info.workingDirectory,
+                        relatedWorkingDirectories: relatedWorkingDirectories,
+                      ),
+                    )
+                    .toList(growable: false)
+              : sessions;
           return _ToolDiscoveryResult.success(
             'OpenCode',
-            _parseOpenCodeCliJson(cliOutput),
+            sortAndLimitDiscoveredSessions(
+              scopedSessions.isNotEmpty ? scopedSessions : sessions,
+              scanLimit,
+            ),
           );
         } on Object {
           hadError = true;
@@ -1207,9 +1416,25 @@ class AgentSessionDiscoveryService {
         "LIMIT $scanLimit;' 2>/dev/null",
       );
       if (dbOutput.trim().isNotEmpty) {
+        final sessions = _parseOpenCodeDbOutput(dbOutput);
+        final scopedSessions =
+            workingDirectory != null && workingDirectory.isNotEmpty
+            ? sessions
+                  .where(
+                    (info) => matchesDiscoveredSessionWorkingDirectory(
+                      workingDirectory,
+                      info.workingDirectory,
+                      relatedWorkingDirectories: relatedWorkingDirectories,
+                    ),
+                  )
+                  .toList(growable: false)
+            : sessions;
         return _ToolDiscoveryResult.success(
           'OpenCode',
-          _parseOpenCodeDbOutput(dbOutput),
+          sortAndLimitDiscoveredSessions(
+            scopedSessions.isNotEmpty ? scopedSessions : sessions,
+            scanLimit,
+          ),
           hadError: hadError,
         );
       }
@@ -1295,6 +1520,130 @@ class AgentSessionDiscoveryService {
     }
   }
 
+  Future<List<String>> _listCopilotWorkspacePaths(
+    SshSession session,
+    int scanLimit,
+    Iterable<String> relatedWorkingDirectories,
+  ) async {
+    final scopedDirectories = relatedWorkingDirectories
+        .map(_trimWorkingDirectory)
+        .whereType<String>()
+        .toSet()
+        .toList(growable: false);
+
+    final globalCommand =
+        'find ~/.copilot/session-state -mindepth 2 -maxdepth 2 '
+        '-name workspace.yaml -type f '
+        '-exec ls -1t {} + 2>/dev/null | head -n $scanLimit';
+    if (scopedDirectories.isEmpty) {
+      final output = await _exec(session, globalCommand);
+      return output
+          .trim()
+          .split('\n')
+          .map((line) => line.trim())
+          .where((line) => line.isNotEmpty)
+          .toList(growable: false);
+    }
+
+    final scopedCommand = StringBuffer()
+      ..write(r'pattern_file=$(mktemp); ')
+      ..writeAll(
+        scopedDirectories.map(
+          (directory) =>
+              'printf "%s\\n" ${_shellQuote('cwd: $directory')} '
+              r'>> "$pattern_file"; ',
+        ),
+      )
+      ..write(
+        r'matching_paths=$(grep -l -x -F -f "$pattern_file" '
+        '~/.copilot/session-state/*/workspace.yaml 2>/dev/null); '
+        r'rm -f "$pattern_file"; '
+        r'if [ -n "$matching_paths" ]; then '
+        r'printf "%s\n" "$matching_paths" | xargs ls -1t 2>/dev/null '
+        '| head -n $scanLimit; '
+        'fi',
+      );
+
+    final scopedOutput = await _exec(session, scopedCommand.toString());
+    final output = scopedOutput.trim().isNotEmpty
+        ? scopedOutput
+        : await _exec(session, globalCommand);
+    return output
+        .trim()
+        .split('\n')
+        .map((line) => line.trim())
+        .where((line) => line.isNotEmpty)
+        .toList(growable: false);
+  }
+
+  Future<Map<String, _RemoteFileSnapshot>> _readRemoteFileSnapshots(
+    SshSession session,
+    Iterable<String> paths, {
+    int? maxLines,
+    bool tail = false,
+  }) async {
+    final uniquePaths = paths
+        .where((path) => path.isNotEmpty)
+        .toSet()
+        .toList(growable: false);
+    if (uniquePaths.isEmpty) {
+      return const <String, _RemoteFileSnapshot>{};
+    }
+
+    final command = StringBuffer()
+      ..write(r'SEP=$(printf "\037"); ')
+      ..write('for path in ')
+      ..write(uniquePaths.map(_shellQuote).join(' '))
+      ..write(r'; do [ -f "$path" ] || continue; ')
+      ..write(
+        r'mtime=$( (stat -c %Y "$path" 2>/dev/null || '
+        r'stat -f %m "$path" 2>/dev/null) | head -1); ',
+      )
+      ..write(r'printf "%s%s%s%s" "$path" "$SEP" "${mtime:-}" "$SEP"; ');
+
+    if (maxLines == null) {
+      command.write(r'cat "$path" 2>/dev/null | base64 | tr -d "\n"; ');
+    } else {
+      command.write(
+        tail
+            ? 'tail -n $maxLines '
+                  r'"$path" 2>/dev/null | base64 | tr -d "\n"; '
+            : "sed -n '1,${maxLines}p' "
+                  r'"$path" 2>/dev/null | base64 | tr -d "\n"; ',
+      );
+    }
+
+    command.write(r'''printf "\n"; done''');
+
+    final output = await _exec(session, command.toString());
+    final snapshots = <String, _RemoteFileSnapshot>{};
+    for (final line in output.split('\n')) {
+      if (line.trim().isEmpty) continue;
+      final parts = line.split('\x1f');
+      if (parts.length < 3) continue;
+
+      final path = parts[0].trim();
+      if (path.isEmpty) continue;
+
+      DateTime? modifiedAt;
+      final epoch = int.tryParse(parts[1].trim());
+      if (epoch != null && epoch > 0) {
+        modifiedAt = _dateTimeFromEpoch(epoch);
+      }
+
+      try {
+        final content = utf8.decode(base64Decode(parts[2].trim()));
+        snapshots[path] = _RemoteFileSnapshot(
+          content: content,
+          modifiedAt: modifiedAt,
+        );
+      } on FormatException {
+        continue;
+      }
+    }
+    return snapshots;
+  }
+
   Future<Map<String, String>> _findClaudeSessionFiles(
     SshSession session,
     Iterable<String> sessionIds,
@@ -1328,65 +1677,6 @@ class AgentSessionDiscoveryService {
       filesById.putIfAbsent(sessionId, () => path);
     }
     return filesById;
-  }
-
-  Future<DateTime?> _readModificationTime(
-    SshSession session,
-    String path,
-  ) async {
-    try {
-      final output = await _exec(
-        session,
-        '(stat -c %Y ${_shellQuote(path)} 2>/dev/null || '
-        'stat -f %m ${_shellQuote(path)} 2>/dev/null) | head -1',
-      );
-      final epoch = int.tryParse(output.trim());
-      if (epoch == null || epoch <= 0) return null;
-      return _dateTimeFromEpoch(epoch);
-    } on Object {
-      return null;
-    }
-  }
-
-  Future<({String customTitle, String agentName, String lastPrompt})>
-  _readClaudeSessionMetadata(SshSession session, String path) async {
-    final output = await _exec(
-      session,
-      'awk '
-      '${_shellQuote(r'''
-match($0, /"customTitle":"([^"]*)"/, value) { customTitle = value[1] }
-match($0, /"agentName":"([^"]*)"/, value) { agentName = value[1] }
-match($0, /"lastPrompt":"([^"]*)"/, value) { lastPrompt = value[1] }
-END {
-  printf "customTitle=%s\nagentName=%s\nlastPrompt=%s\n", customTitle, agentName, lastPrompt
-}
-''')} '
-      '${_shellQuote(path)} 2>/dev/null',
-    );
-    var customTitle = '';
-    var agentName = '';
-    var lastPrompt = '';
-    for (final line in output.split('\n')) {
-      final separator = line.indexOf('=');
-      if (separator <= 0) {
-        continue;
-      }
-      final key = line.substring(0, separator);
-      final value = line.substring(separator + 1).trim();
-      switch (key) {
-        case 'customTitle':
-          customTitle = value;
-        case 'agentName':
-          agentName = value;
-        case 'lastPrompt':
-          lastPrompt = value;
-      }
-    }
-    return (
-      customTitle: customTitle,
-      agentName: agentName,
-      lastPrompt: lastPrompt,
-    );
   }
 
   DateTime _dateTimeFromEpoch(int epoch) => DateTime.fromMillisecondsSinceEpoch(
@@ -1530,6 +1820,13 @@ class _CodexSessionIndexEntry {
   final DateTime? updatedAt;
 }
 
+class _RemoteFileSnapshot {
+  const _RemoteFileSnapshot({required this.content, this.modifiedAt});
+
+  final String content;
+  final DateTime? modifiedAt;
+}
+
 Map<String, dynamic>? _tryDecodeJsonObject(String raw) {
   try {
     final decoded = jsonDecode(raw);
@@ -1613,6 +1910,13 @@ String? _extractGeminiUserSummary(List<dynamic>? messages) {
     }
   }
   return null;
+}
+
+String? _extractClaudeUserSummary(String? value) {
+  final trimmed = value?.trim();
+  if (trimmed == null || trimmed.isEmpty) return null;
+  if (trimmed.startsWith('/') || trimmed.startsWith('<')) return null;
+  return _summarizeSessionText(trimmed);
 }
 
 String? _resolveGeminiWorkingDirectory(

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -18,6 +18,7 @@ const _genericSessionSummaries = <String>{
 const _profileSourcingPrefix =
     '{ . ~/.profile; . ~/.bash_profile; . ~/.zprofile; } '
     '>/dev/null 2>&1; ';
+const _remoteFileSnapshotBatchSize = 40;
 
 /// Filters noisy discovered sessions and fills in a better display summary
 /// when the tool only exposes a working directory.
@@ -581,73 +582,30 @@ String? resolveGeminiProjectWorkingDirectory(
   return null;
 }
 
-/// Resolves the best Gemini CLI project root for the active working directory.
-///
-/// Prefers the shortest related directory that still contains the active path,
-/// which typically corresponds to the current worktree root.
+/// Builds the Gemini chat project directory names associated with the active
+/// worktree family.
 @visibleForTesting
-String? resolveGeminiCliProjectRoot(
-  String? workingDirectory,
+List<String> buildGeminiProjectDirectoryNames(
   Iterable<String> relatedWorkingDirectories,
 ) {
-  final trimmedWorkingDirectory = _trimWorkingDirectory(workingDirectory);
-  if (trimmedWorkingDirectory == null) return null;
+  final directories = relatedWorkingDirectories
+      .map(_trimWorkingDirectory)
+      .whereType<String>()
+      .toSet()
+      .toList(growable: false);
+  final rootDirectories = directories
+      .where(
+        (directory) => !directories.any(
+          (other) => other != directory && directory.startsWith('$other/'),
+        ),
+      )
+      .toList(growable: false);
 
-  String? projectRoot;
-  for (final candidate in <String>[
-    trimmedWorkingDirectory,
-    ...relatedWorkingDirectories,
-  ]) {
-    final trimmedCandidate = _trimWorkingDirectory(candidate);
-    if (trimmedCandidate == null ||
-        !_workingDirectoriesOverlap(
-          trimmedWorkingDirectory,
-          trimmedCandidate,
-        ) ||
-        !(trimmedWorkingDirectory == trimmedCandidate ||
-            trimmedWorkingDirectory.startsWith('$trimmedCandidate/'))) {
-      continue;
-    }
-
-    if (projectRoot == null || trimmedCandidate.length < projectRoot.length) {
-      projectRoot = trimmedCandidate;
-    }
-  }
-
-  return projectRoot ?? trimmedWorkingDirectory;
-}
-
-/// Builds the CLI working-directory scopes Gemini should be queried from.
-///
-/// Gemini CLI calls are relatively expensive, so keep them bounded to the
-/// active project root plus its canonical non-worktree equivalent. Broader
-/// sibling-worktree coverage comes from the file-based fallback, which is much
-/// cheaper to scan.
-///
-/// When no directory context is available, returns a single `null` scope so the
-/// CLI still runs once in the default shell cwd instead of being skipped.
-@visibleForTesting
-List<String?> buildGeminiCliSessionListScopes(
-  String? workingDirectory,
-  Iterable<String> relatedWorkingDirectories,
-) {
-  final projectRoot = resolveGeminiCliProjectRoot(
-    workingDirectory,
-    relatedWorkingDirectories,
-  );
-  if (projectRoot == null) {
-    return const <String?>[null];
-  }
-
-  final scopes = <String?>{projectRoot};
-  final normalizedProjectRoot = normalizeWorkingDirectoryForComparison(
-    projectRoot,
-  );
-  if (normalizedProjectRoot != projectRoot) {
-    scopes.add(normalizedProjectRoot);
-  }
-
-  return scopes.toList(growable: false);
+  return rootDirectories
+      .map(_pathLastSegment)
+      .where((name) => name.isNotEmpty && name != '.' && name != '~')
+      .toSet()
+      .toList(growable: false);
 }
 
 /// Sorts merged discovery sessions by recency before applying a scan cap.
@@ -659,6 +617,52 @@ List<ToolSessionInfo> sortAndLimitDiscoveredSessions(
   final sortedSessions = sessions.toList(growable: false)
     ..sort(compareDiscoveredSessionsByRecency);
   return sortedSessions.take(limit).toList(growable: false);
+}
+
+/// Scopes discovered sessions to the active working directory on a per-tool
+/// basis, preserving a tool's unscoped results when it lacks matching cwd
+/// metadata instead of dropping that provider entirely.
+@visibleForTesting
+List<ToolSessionInfo> scopeDiscoveredSessionsToWorkingDirectory(
+  Iterable<ToolSessionInfo> sessions,
+  String workingDirectory, {
+  Iterable<String> relatedWorkingDirectories = const <String>[],
+}) {
+  final sessionsByTool = <String, List<ToolSessionInfo>>{};
+  for (final session in sessions) {
+    sessionsByTool
+        .putIfAbsent(session.toolName, () => <ToolSessionInfo>[])
+        .add(session);
+  }
+
+  final scopedSessions = <ToolSessionInfo>[];
+  for (final toolSessions in sessionsByTool.values) {
+    final matchingSessions = toolSessions
+        .where(
+          (session) => matchesDiscoveredSessionWorkingDirectory(
+            workingDirectory,
+            session.workingDirectory,
+            relatedWorkingDirectories: relatedWorkingDirectories,
+          ),
+        )
+        .toList(growable: false);
+    if (matchingSessions.isNotEmpty) {
+      scopedSessions.addAll(matchingSessions);
+      continue;
+    }
+
+    final sessionsWithoutWorkingDirectory = toolSessions
+        .where(
+          (session) =>
+              session.workingDirectory == null ||
+              session.workingDirectory!.isEmpty,
+        )
+        .toList(growable: false);
+    scopedSessions.addAll(sessionsWithoutWorkingDirectory);
+  }
+
+  scopedSessions.sort(compareDiscoveredSessionsByRecency);
+  return scopedSessions;
 }
 
 /// Discovers recent AI coding tool sessions on remote hosts by scanning
@@ -735,33 +739,24 @@ class AgentSessionDiscoveryService {
     // Filter to sessions matching the working directory if provided.
     if (workingDirectory != null && workingDirectory.isNotEmpty) {
       final filtered = _limitDiscoveredSessionsPerTool(
-        all
-            .where(
-              (s) => matchesDiscoveredSessionWorkingDirectory(
-                workingDirectory,
-                s.workingDirectory,
-                relatedWorkingDirectories: relatedWorkingDirectories,
-              ),
-            )
-            .toList(),
+        scopeDiscoveredSessionsToWorkingDirectory(
+          all,
+          workingDirectory,
+          relatedWorkingDirectories: relatedWorkingDirectories,
+        ),
         maxPerTool,
       );
-      // Return filtered results if any match; otherwise return all so the UI
-      // still has a fallback when the remote tool doesn't persist directory
-      // metadata for its sessions.
-      if (filtered.isNotEmpty) {
-        return DiscoveredSessionsResult(
-          sessions: filtered,
-          failedTools: results
-              .where(
-                (r) => shouldSurfaceDiscoveryFailure(
-                  hadError: r.hadError,
-                  loadedSessionCount: r.sessions.length,
-                ),
-              )
-              .map((r) => r.toolName),
-        );
-      }
+      return DiscoveredSessionsResult(
+        sessions: filtered,
+        failedTools: results
+            .where(
+              (r) => shouldSurfaceDiscoveryFailure(
+                hadError: r.hadError,
+                loadedSessionCount: r.sessions.length,
+              ),
+            )
+            .map((r) => r.toolName),
+      );
     }
 
     return DiscoveredSessionsResult(
@@ -1210,10 +1205,9 @@ class AgentSessionDiscoveryService {
   }
 
   // ── Gemini CLI ─────────────────────────────────────────────────────────
-  // `gemini --list-sessions` outputs a human-readable list scoped to
-  // the current project. Each line looks like:
-  //   1. Title text (time ago) [session-uuid]
-  // Falls back to scanning chat JSON files if the CLI is unavailable.
+  // Sessions: ~/.gemini/tmp/**/chats/session-*.json*
+  // File-based discovery is substantially faster than `gemini --list-sessions`
+  // on large worktree families, so prefer the stored chat files directly.
 
   Future<_ToolDiscoveryResult> _discoverGeminiSessions(
     SshSession session,
@@ -1222,83 +1216,15 @@ class AgentSessionDiscoveryService {
     int max,
   ) async {
     try {
-      final searchDirectories = buildGeminiCliSessionListScopes(
-        workingDirectory,
-        relatedWorkingDirectories,
-      );
-
-      var hadError = false;
-      final sessionsById = <String, ToolSessionInfo>{};
-
-      for (final searchDirectory in searchDirectories) {
-        try {
-          final cliCommand = searchDirectory == null
-              ? 'gemini --list-sessions 2>/dev/null'
-              : '[ -d ${_shellQuote(searchDirectory)} ] && '
-                    'cd ${_shellQuote(searchDirectory)} && '
-                    'gemini --list-sessions 2>/dev/null';
-          final cliOutput = await _exec(session, cliCommand);
-          if (!cliOutput.contains('[') || !cliOutput.contains(']')) continue;
-          final parsed = _parseGeminiCliOutput(cliOutput, searchDirectory);
-          for (final info in parsed) {
-            _mergeToolSessionInfo(sessionsById, info);
-          }
-        } on Object {
-          hadError = true;
-        }
-      }
-
-      final fallback = await _discoverGeminiSessionsFromFiles(
+      return await _discoverGeminiSessionsFromFiles(
         session,
         workingDirectory,
         relatedWorkingDirectories,
         max,
       );
-      hadError = hadError || fallback.hadError;
-      for (final info in fallback.sessions) {
-        _mergeToolSessionInfo(sessionsById, info);
-      }
-
-      return _ToolDiscoveryResult.success(
-        'Gemini CLI',
-        sortAndLimitDiscoveredSessions(sessionsById.values, max * 5),
-        hadError: hadError,
-      );
     } on Object {
       return const _ToolDiscoveryResult.failure('Gemini CLI');
     }
-  }
-
-  /// Parses Gemini CLI `--list-sessions` text output.
-  ///
-  /// Each session line matches:
-  ///   `N. Title text (time ago) [session-uuid]`
-  static final _geminiSessionLinePattern = RegExp(
-    r'^\s*\d+\.\s+(.+?)\s+\([^)]+\)\s+\[([0-9a-f-]+)\]\s*$',
-  );
-
-  List<ToolSessionInfo> _parseGeminiCliOutput(
-    String output,
-    String? workingDirectory,
-  ) {
-    final sessions = <ToolSessionInfo>[];
-    for (final line in output.split('\n')) {
-      final match = _geminiSessionLinePattern.firstMatch(line);
-      if (match == null) continue;
-
-      final title = match.group(1)!.trim();
-      final id = match.group(2)!.trim();
-
-      sessions.add(
-        ToolSessionInfo(
-          toolName: 'Gemini CLI',
-          sessionId: id,
-          workingDirectory: workingDirectory,
-          summary: title.length > 80 ? '${title.substring(0, 77)}...' : title,
-        ),
-      );
-    }
-    return sessions;
   }
 
   Future<_ToolDiscoveryResult> _discoverGeminiSessionsFromFiles(
@@ -1312,12 +1238,32 @@ class AgentSessionDiscoveryService {
       multiplier: 10,
       maximum: 120,
     );
-    final output = await _exec(
-      session,
-      r'find ~/.gemini/tmp \( -name "session-*.json" -o -name "session-*.jsonl" \) '
-      '-path "*/chats/*" -type f '
-      '-exec ls -1t {} + 2>/dev/null | head -n $scanLimit',
+    final globalCommand =
+        r'find ~/.gemini/tmp \( -name "session-*.json" -o -name "session-*.jsonl" \) '
+        '-path "*/chats/*" -type f '
+        '-exec ls -1t {} + 2>/dev/null | head -n $scanLimit';
+    var output = '';
+
+    final projectDirectoryNames = buildGeminiProjectDirectoryNames(
+      relatedWorkingDirectories,
     );
+    if (workingDirectory != null &&
+        workingDirectory.isNotEmpty &&
+        projectDirectoryNames.isNotEmpty) {
+      final scopedPathFilters = projectDirectoryNames
+          .map((name) => '-path ${_shellQuote('*/$name/chats/*')}')
+          .join(' -o ');
+      output = await _exec(
+        session,
+        r'find ~/.gemini/tmp \( -name "session-*.json" -o -name "session-*.jsonl" \) '
+        '-type f '
+        '\\( $scopedPathFilters \\) '
+        '-exec ls -1t {} + 2>/dev/null | head -n $scanLimit',
+      );
+    }
+    if (output.trim().isEmpty) {
+      output = await _exec(session, globalCommand);
+    }
     if (output.trim().isEmpty) {
       return const _ToolDiscoveryResult.success('Gemini CLI', []);
     }
@@ -1630,56 +1576,65 @@ class AgentSessionDiscoveryService {
     if (uniquePaths.isEmpty) {
       return const <String, _RemoteFileSnapshot>{};
     }
-
-    final command = StringBuffer()
-      ..write(r'SEP=$(printf "\037"); ')
-      ..write('for path in ')
-      ..write(uniquePaths.map(_shellQuote).join(' '))
-      ..write(r'; do [ -f "$path" ] || continue; ')
-      ..write(
-        r'mtime=$( (stat -c %Y "$path" 2>/dev/null || '
-        r'stat -f %m "$path" 2>/dev/null) | head -1); ',
-      )
-      ..write(r'printf "%s%s%s%s" "$path" "$SEP" "${mtime:-}" "$SEP"; ');
-
-    if (maxLines == null) {
-      command.write(r'cat "$path" 2>/dev/null | base64 | tr -d "\n"; ');
-    } else {
-      command.write(
-        tail
-            ? 'tail -n $maxLines '
-                  r'"$path" 2>/dev/null | base64 | tr -d "\n"; '
-            : "sed -n '1,${maxLines}p' "
-                  r'"$path" 2>/dev/null | base64 | tr -d "\n"; ',
-      );
-    }
-
-    command.write(r'''printf "\n"; done''');
-
-    final output = await _exec(session, command.toString());
     final snapshots = <String, _RemoteFileSnapshot>{};
-    for (final line in output.split('\n')) {
-      if (line.trim().isEmpty) continue;
-      final parts = line.split('\x1f');
-      if (parts.length < 3) continue;
+    for (
+      var start = 0;
+      start < uniquePaths.length;
+      start += _remoteFileSnapshotBatchSize
+    ) {
+      final batchPaths = uniquePaths
+          .skip(start)
+          .take(_remoteFileSnapshotBatchSize)
+          .toList(growable: false);
+      final command = StringBuffer()
+        ..write(r'SEP=$(printf "\037"); ')
+        ..write('for path in ')
+        ..write(batchPaths.map(_shellQuote).join(' '))
+        ..write(r'; do [ -f "$path" ] || continue; ')
+        ..write(
+          r'mtime=$( (stat -c %Y "$path" 2>/dev/null || '
+          r'stat -f %m "$path" 2>/dev/null) | head -1); ',
+        )
+        ..write(r'printf "%s%s%s%s" "$path" "$SEP" "${mtime:-}" "$SEP"; ');
 
-      final path = parts[0].trim();
-      if (path.isEmpty) continue;
-
-      DateTime? modifiedAt;
-      final epoch = int.tryParse(parts[1].trim());
-      if (epoch != null && epoch > 0) {
-        modifiedAt = _dateTimeFromEpoch(epoch);
+      if (maxLines == null) {
+        command.write(r'cat "$path" 2>/dev/null | base64 | tr -d "\n"; ');
+      } else {
+        command.write(
+          tail
+              ? 'tail -n $maxLines '
+                    r'"$path" 2>/dev/null | base64 | tr -d "\n"; '
+              : "sed -n '1,${maxLines}p' "
+                    r'"$path" 2>/dev/null | base64 | tr -d "\n"; ',
+        );
       }
 
-      try {
-        final content = utf8.decode(base64Decode(parts[2].trim()));
-        snapshots[path] = _RemoteFileSnapshot(
-          content: content,
-          modifiedAt: modifiedAt,
-        );
-      } on FormatException {
-        continue;
+      command.write(r'''printf "\n"; done''');
+
+      final output = await _exec(session, command.toString());
+      for (final line in output.split('\n')) {
+        if (line.trim().isEmpty) continue;
+        final parts = line.split('\x1f');
+        if (parts.length < 3) continue;
+
+        final path = parts[0].trim();
+        if (path.isEmpty) continue;
+
+        DateTime? modifiedAt;
+        final epoch = int.tryParse(parts[1].trim());
+        if (epoch != null && epoch > 0) {
+          modifiedAt = _dateTimeFromEpoch(epoch);
+        }
+
+        try {
+          final content = utf8.decode(base64Decode(parts[2].trim()));
+          snapshots[path] = _RemoteFileSnapshot(
+            content: content,
+            modifiedAt: modifiedAt,
+          );
+        } on FormatException {
+          continue;
+        }
       }
     }
     return snapshots;
@@ -1768,25 +1723,6 @@ class AgentSessionDiscoveryService {
 
   static String _shellQuote(String value) =>
       "'${value.replaceAll("'", "'\"'\"'")}'";
-
-  void _mergeToolSessionInfo(
-    Map<String, ToolSessionInfo> sessionsById,
-    ToolSessionInfo info,
-  ) {
-    final existing = sessionsById[info.sessionId];
-    if (existing == null) {
-      sessionsById[info.sessionId] = info;
-      return;
-    }
-
-    sessionsById[info.sessionId] = ToolSessionInfo(
-      toolName: existing.toolName,
-      sessionId: existing.sessionId,
-      workingDirectory: existing.workingDirectory ?? info.workingDirectory,
-      lastActive: existing.lastActive ?? info.lastActive,
-      summary: existing.summary ?? info.summary,
-    );
-  }
 
   List<ToolSessionInfo> _limitDiscoveredSessionsPerTool(
     List<ToolSessionInfo> sessions,

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -583,6 +583,21 @@ String? resolveGeminiProjectWorkingDirectory(
   return null;
 }
 
+/// Reads the Claude history working directory using only string-typed fields.
+@visibleForTesting
+String? readClaudeHistoryWorkingDirectory(Map<String, dynamic> entry) =>
+    _readStringField(entry, 'directory') ?? _readStringField(entry, 'project');
+
+/// Limits how many Claude session files should be snapshot-read for metadata.
+@visibleForTesting
+int calculateClaudeMetadataSnapshotLimit(int maxPerTool) =>
+    _calculateDiscoveryScanLimit(
+      maxPerTool,
+      multiplier: 4,
+      minimum: 40,
+      maximum: 80,
+    );
+
 /// Builds the Gemini chat project directory names associated with the active
 /// worktree family.
 @visibleForTesting
@@ -909,8 +924,7 @@ class AgentSessionDiscoveryService {
                 .where(
                   (entry) => matchesDiscoveredSessionWorkingDirectory(
                     workingDirectory,
-                    entry['directory'] as String? ??
-                        entry['project'] as String?,
+                    readClaudeHistoryWorkingDirectory(entry),
                     relatedWorkingDirectories: relatedWorkingDirectories,
                   ),
                 )
@@ -919,10 +933,13 @@ class AgentSessionDiscoveryService {
       final relevantHistoryEntries = scopedHistoryEntries.isNotEmpty
           ? scopedHistoryEntries
           : historyEntries;
+      final snapshotHistoryEntries = relevantHistoryEntries
+          .take(calculateClaudeMetadataSnapshotLimit(max))
+          .toList(growable: false);
       final sessionFilesById = await _findClaudeSessionFiles(
         session,
-        relevantHistoryEntries.map(
-          (entry) => entry['sessionId'] as String? ?? '',
+        snapshotHistoryEntries.map(
+          (entry) => _readStringField(entry, 'sessionId') ?? '',
         ),
       );
       final sessionFileHeadSnapshots = await _readRemoteFileSnapshots(
@@ -940,7 +957,7 @@ class AgentSessionDiscoveryService {
       var hadError = false;
       for (final decoded in relevantHistoryEntries) {
         try {
-          final sessionId = decoded['sessionId'] as String? ?? '';
+          final sessionId = _readStringField(decoded, 'sessionId') ?? '';
           if (sessionId.isEmpty) continue;
 
           // timestamp may be int (epoch ms) or String (ISO 8601).
@@ -981,19 +998,17 @@ class AgentSessionDiscoveryService {
           }
 
           // Fall back to history index fields.
-          final display = decoded['display'] as String?;
+          final display = _readStringField(decoded, 'display');
           summary ??=
-              decoded['title'] as String? ??
-              decoded['query'] as String? ??
+              _readStringField(decoded, 'title') ??
+              _readStringField(decoded, 'query') ??
               (display != null && !display.startsWith('/') ? display : null);
 
           sessions.add(
             ToolSessionInfo(
               toolName: 'Claude Code',
               sessionId: sessionId,
-              workingDirectory:
-                  decoded['directory'] as String? ??
-                  decoded['project'] as String?,
+              workingDirectory: readClaudeHistoryWorkingDirectory(decoded),
               lastActive: lastActive,
               summary: summary,
             ),
@@ -1610,7 +1625,10 @@ class AgentSessionDiscoveryService {
         '~/.copilot/session-state/*/workspace.yaml 2>/dev/null); '
         r'rm -f "$pattern_file"; '
         r'if [ -n "$matching_paths" ]; then '
-        r'printf "%s\n" "$matching_paths" | xargs ls -1t 2>/dev/null '
+        r'printf "%s\n" "$matching_paths" '
+        '| while IFS= read -r path; do '
+        r'[ -n "$path" ] && printf "%s\0" "$path"; '
+        'done | xargs -0 ls -1t 2>/dev/null '
         '| head -n $scanLimit; '
         'fi',
       );

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -66,28 +66,39 @@ int compareDiscoveredSessionsByRecency(ToolSessionInfo a, ToolSessionInfo b) {
   return (a.summary ?? '').compareTo(b.summary ?? '');
 }
 
-/// Orders tool groups for UI rendering: providers with sessions first, then
-/// attempted providers that yielded no sessions, alphabetized.
+const _knownDiscoveredSessionTools = <String>[
+  'Claude Code',
+  'Copilot CLI',
+  'Codex',
+  'Gemini CLI',
+  'OpenCode',
+];
+
+/// Orders discovered-session providers for UI rendering in a stable list.
+///
+/// The known provider rows stay visible in a fixed order so incremental
+/// streaming updates do not insert or remove rows while the menu is open. Any
+/// unexpected provider names are appended alphabetically after the known set.
 List<String> orderedDiscoveredSessionTools(
   Map<String, List<ToolSessionInfo>> grouped,
   Iterable<String> attemptedTools, {
   String? preferredToolName,
 }) {
-  final ordered = <String>[...grouped.keys];
-  final emptyAttempts =
-      attemptedTools
-          .where((tool) => !grouped.containsKey(tool))
-          .toSet()
-          .toList()
+  final ordered = List<String>.of(_knownDiscoveredSessionTools);
+  final extraTools =
+      <String>{
+          ...grouped.keys,
+          ...attemptedTools,
+        }.where((tool) => !_knownDiscoveredSessionTools.contains(tool)).toList()
         ..sort();
   if (preferredToolName case final preferred? when preferred.isNotEmpty) {
     if (ordered.remove(preferred)) {
       ordered.insert(0, preferred);
-    } else if (emptyAttempts.remove(preferred)) {
+    } else if (extraTools.remove(preferred)) {
       ordered.insert(0, preferred);
     }
   }
-  ordered.addAll(emptyAttempts);
+  ordered.addAll(extraTools);
   return ordered;
 }
 

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -513,6 +513,45 @@ String? resolveGeminiProjectWorkingDirectory(
   return null;
 }
 
+/// Builds the CLI working-directory scopes Gemini should be queried from.
+///
+/// When no directory context is available, returns a single `null` scope so the
+/// CLI still runs once in the default shell cwd instead of being skipped.
+@visibleForTesting
+List<String?> buildGeminiCliSessionListScopes(
+  String? workingDirectory,
+  Iterable<String> relatedWorkingDirectories,
+) {
+  final scopes = <String?>{};
+  final trimmedWorkingDirectory = _trimWorkingDirectory(workingDirectory);
+  if (trimmedWorkingDirectory != null) {
+    scopes.add(trimmedWorkingDirectory);
+  }
+
+  for (final directory in relatedWorkingDirectories) {
+    final trimmedDirectory = _trimWorkingDirectory(directory);
+    if (trimmedDirectory != null) {
+      scopes.add(trimmedDirectory);
+    }
+  }
+
+  if (scopes.isEmpty) {
+    return const <String?>[null];
+  }
+  return scopes.toList(growable: false);
+}
+
+/// Sorts merged discovery sessions by recency before applying a scan cap.
+@visibleForTesting
+List<ToolSessionInfo> sortAndLimitDiscoveredSessions(
+  Iterable<ToolSessionInfo> sessions,
+  int limit,
+) {
+  final sortedSessions = sessions.toList(growable: false)
+    ..sort(compareDiscoveredSessionsByRecency);
+  return sortedSessions.take(limit).toList(growable: false);
+}
+
 /// Discovers recent AI coding tool sessions on remote hosts by scanning
 /// known session storage locations.
 ///
@@ -955,28 +994,22 @@ class AgentSessionDiscoveryService {
     int max,
   ) async {
     try {
-      final searchDirectories = <String>{};
-      final trimmedWorkingDirectory = _trimWorkingDirectory(workingDirectory);
-      if (trimmedWorkingDirectory != null) {
-        searchDirectories.add(trimmedWorkingDirectory);
-      }
-      searchDirectories
-        ..addAll(
-          relatedWorkingDirectories.map(normalizeWorkingDirectoryForComparison),
-        )
-        ..addAll(relatedWorkingDirectories);
+      final searchDirectories = buildGeminiCliSessionListScopes(
+        workingDirectory,
+        relatedWorkingDirectories,
+      );
 
       var hadError = false;
       final sessionsById = <String, ToolSessionInfo>{};
 
       for (final searchDirectory in searchDirectories) {
         try {
-          final cliOutput = await _exec(
-            session,
-            '[ -d ${_shellQuote(searchDirectory)} ] && '
-            'cd ${_shellQuote(searchDirectory)} && '
-            'gemini --list-sessions 2>/dev/null',
-          );
+          final cliCommand = searchDirectory == null
+              ? 'gemini --list-sessions 2>/dev/null'
+              : '[ -d ${_shellQuote(searchDirectory)} ] && '
+                    'cd ${_shellQuote(searchDirectory)} && '
+                    'gemini --list-sessions 2>/dev/null';
+          final cliOutput = await _exec(session, cliCommand);
           if (!cliOutput.contains('[') || !cliOutput.contains(']')) continue;
           final parsed = _parseGeminiCliOutput(cliOutput, searchDirectory);
           for (final info in parsed) {
@@ -1000,7 +1033,7 @@ class AgentSessionDiscoveryService {
 
       return _ToolDiscoveryResult.success(
         'Gemini CLI',
-        sessionsById.values.take(max * 5).toList(growable: false),
+        sortAndLimitDiscoveredSessions(sessionsById.values, max * 5),
         hadError: hadError,
       );
     } on Object {

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -182,12 +182,18 @@ String _truncateSessionIdValue(String id) {
 }
 
 bool _isLikelyToolStateWorkingDirectory(String directory) =>
-    directory.contains('/.copilot/session-state/') ||
-    directory.contains('/.claude/projects/') ||
+    directory == '/tmp' ||
+    directory.endsWith('/.copilot') ||
+    directory.contains('/.copilot/') ||
+    directory.endsWith('/.claude') ||
+    directory.contains('/.claude/') ||
+    directory.endsWith('/.codex') ||
     directory.contains('/.codex/') ||
-    directory.contains('/.gemini/tmp/') ||
+    directory.endsWith('/.gemini') ||
+    directory.contains('/.gemini/') ||
     directory.contains('/.local/share/opencode/') ||
     directory.startsWith('/tmp/') ||
+    directory.startsWith('/private/tmp/') ||
     directory.startsWith('/var/folders/');
 
 /// Chooses the best working directory to scope AI session discovery.

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -29,6 +29,7 @@ import '../../domain/services/terminal_theme_service.dart';
 import '../../domain/services/tmux_service.dart';
 import '../../domain/services/transfer_intent_service.dart';
 import '../providers/entity_list_providers.dart';
+import '../widgets/ai_session_picker.dart';
 import '../widgets/connection_attempt_dialog.dart';
 import '../widgets/connection_preview_snippet.dart';
 import '../widgets/file_picker_helpers.dart';
@@ -2349,8 +2350,8 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
   Set<String> _attemptedSessionTools = const <String>{};
+  Set<String> _failedSessionTools = const <String>{};
   String? _preferredSessionToolName;
-  final Set<String> _expandedSessionTools = <String>{};
   StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
   String? _sessionLoadError;
   String? _sessionName;
@@ -2423,17 +2424,6 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     _sessionFetchLimit =
         storedState['sessionFetchLimit'] as int? ?? _sessionFetchLimit;
 
-    final expandedSessionTools = storedState['expandedSessionTools'];
-    if (expandedSessionTools is List<Object?>) {
-      _expandedSessionTools
-        ..clear()
-        ..addAll(
-          expandedSessionTools.whereType<String>().where(
-            (toolName) => toolName.isNotEmpty,
-          ),
-        );
-    }
-
     if (!_hasAgentSessionAccess) {
       _showSessions = false;
     }
@@ -2453,7 +2443,6 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       'expanded': _expanded,
       'showSessions': _showSessions,
       'sessionFetchLimit': _sessionFetchLimit,
-      'expandedSessionTools': _expandedSessionTools.toList(growable: false),
     }, identifier: _pageStorageIdentifier);
   }
 
@@ -2664,45 +2653,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                 ),
               ),
               if (_showSessions) ...[
-                if (_isLoadingSessions &&
-                    (_recentSessions == null || _recentSessions!.isEmpty))
-                  const Padding(
-                    padding: EdgeInsets.symmetric(vertical: 8),
-                    child: Center(
-                      child: SizedBox(
-                        width: 14,
-                        height: 14,
-                        child: CircularProgressIndicator.adaptive(
-                          strokeWidth: 2,
-                        ),
-                      ),
-                    ),
-                  )
-                else if (_sessionLoadError != null &&
-                    _recentSessions != null &&
-                    _recentSessions!.isEmpty)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 4),
-                    child: Text(
-                      _sessionLoadError!,
-                      style: theme.textTheme.labelSmall?.copyWith(
-                        color: theme.colorScheme.error,
-                      ),
-                    ),
-                  )
-                else if (_recentSessions != null &&
-                    _recentSessions!.isEmpty &&
-                    _attemptedSessionTools.isEmpty)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 4),
-                    child: Text(
-                      'No recent sessions found',
-                      style: theme.textTheme.labelSmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                  )
-                else if (_recentSessions != null) ...[
+                if (_hasVisibleSessionProviders) ...[
                   if (_sessionLoadError != null)
                     Padding(
                       padding: const EdgeInsets.only(bottom: 4),
@@ -2713,33 +2664,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                         ),
                       ),
                     ),
-                  ...() {
-                    final grouped = _groupSessions(_recentSessions!);
-                    return orderedDiscoveredSessionTools(
-                      grouped,
-                      _attemptedSessionTools,
-                      preferredToolName: _preferredSessionToolName,
-                    ).map(
-                      (toolName) => _buildSessionGroup(
-                        theme,
-                        toolName,
-                        grouped[toolName] ?? const <ToolSessionInfo>[],
-                      ),
-                    );
-                  }(),
-                  if (_isLoadingSessions)
-                    const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 8),
-                      child: Center(
-                        child: SizedBox(
-                          width: 14,
-                          height: 14,
-                          child: CircularProgressIndicator.adaptive(
-                            strokeWidth: 2,
-                          ),
-                        ),
-                      ),
-                    ),
+                  ..._buildSessionProviderEntries().map(
+                    (provider) => _buildSessionProviderRow(theme, provider),
+                  ),
                   if (_canLoadMoreSessions)
                     Padding(
                       padding: const EdgeInsets.only(top: 2),
@@ -2748,7 +2675,26 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                         child: const Text('Load more'),
                       ),
                     ),
-                ],
+                ] else if (_sessionLoadError != null && _recentSessions != null)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Text(
+                      _sessionLoadError!,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.error,
+                      ),
+                    ),
+                  )
+                else if (_recentSessions != null)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Text(
+                      'No recent sessions found',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
               ],
             ] else
               InkWell(
@@ -2839,6 +2785,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       _isLoadingSessions = true;
       _sessionLoadError = null;
       _canLoadMoreSessions = false;
+      _failedSessionTools = const <String>{};
     });
 
     final session = ref
@@ -2877,6 +2824,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
               setState(() {
                 _recentSessions = result.sessions;
                 _attemptedSessionTools = result.attemptedTools;
+                _failedSessionTools = result.failedTools;
                 _sessionLoadError = result.failureMessage;
               });
             },
@@ -2884,6 +2832,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
               if (!mounted || loadGeneration != _sessionLoadGeneration) return;
               setState(() {
                 _recentSessions ??= const [];
+                _failedSessionTools = const <String>{};
                 _sessionLoadError = 'Could not load recent AI sessions.';
                 _canLoadMoreSessions = false;
                 _isLoadingSessions = false;
@@ -2909,6 +2858,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       if (!mounted || loadGeneration != _sessionLoadGeneration) return;
       setState(() {
         _recentSessions ??= const [];
+        _failedSessionTools = const <String>{};
         _sessionLoadError = 'Could not load recent AI sessions.';
         _canLoadMoreSessions = false;
         _isLoadingSessions = false;
@@ -2962,6 +2912,19 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         .ignore();
   }
 
+  Future<void> _showSessionPickerForTool(
+    AiSessionProviderEntry provider,
+  ) async {
+    if (!provider.isSelectable) return;
+    final selected = await showAiSessionPickerDialog(
+      context: context,
+      toolName: provider.toolName,
+      sessions: provider.sessions,
+    );
+    if (!mounted || selected == null) return;
+    _resumeSession(selected);
+  }
+
   Map<String, List<ToolSessionInfo>> _groupSessions(
     List<ToolSessionInfo> sessions,
   ) {
@@ -2974,141 +2937,94 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     return grouped;
   }
 
-  Widget _buildSessionGroup(
-    ThemeData theme,
-    String toolName,
-    List<ToolSessionInfo> sessions,
-  ) {
-    final isEmpty = sessions.isEmpty;
-    final isExpanded = !isEmpty && _expandedSessionTools.contains(toolName);
+  bool get _hasVisibleSessionProviders =>
+      _isLoadingSessions ||
+      _attemptedSessionTools.isNotEmpty ||
+      _failedSessionTools.isNotEmpty ||
+      (_recentSessions?.isNotEmpty ?? false);
 
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        InkWell(
-          onTap: isEmpty
-              ? null
-              : () {
-                  setState(() {
-                    if (isExpanded) {
-                      _expandedSessionTools.remove(toolName);
-                    } else {
-                      _expandedSessionTools.add(toolName);
-                    }
-                  });
-                  _persistUiState();
-                },
-          borderRadius: BorderRadius.circular(6),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 6),
-            child: Row(
-              children: [
-                Icon(
-                  _toolIconData(toolName),
-                  size: 14,
-                  color: isEmpty
-                      ? theme.colorScheme.onSurfaceVariant
-                      : theme.colorScheme.primary,
-                ),
-                const SizedBox(width: 6),
-                Expanded(
-                  child: Text(
-                    toolName,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: isEmpty
-                          ? theme.colorScheme.onSurfaceVariant
-                          : theme.colorScheme.onSurface,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
-                Text(
-                  isEmpty ? 'no recent' : '${sessions.length}',
-                  style: theme.textTheme.labelSmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                ),
-                if (!isEmpty) ...[
-                  const SizedBox(width: 4),
-                  Icon(
-                    isExpanded ? Icons.expand_less : Icons.expand_more,
-                    size: 14,
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                ],
-              ],
-            ),
-          ),
-        ),
-        if (isExpanded)
-          for (final session in sessions)
-            _buildSessionRow(theme, session, indent: 20),
-      ],
+  List<AiSessionProviderEntry> _buildSessionProviderEntries() {
+    final grouped = _groupSessions(
+      _recentSessions ?? const <ToolSessionInfo>[],
+    );
+    final orderedTools = orderedDiscoveredSessionTools(grouped, <String>{
+      ..._attemptedSessionTools,
+      ..._failedSessionTools,
+    }, preferredToolName: _preferredSessionToolName);
+    return buildAiSessionProviderEntries(
+      orderedTools: orderedTools,
+      groupedSessions: grouped,
+      attemptedTools: _attemptedSessionTools,
+      failedTools: _failedSessionTools,
+      isLoading: _isLoadingSessions,
     );
   }
 
-  Widget _buildSessionRow(
+  Widget _buildSessionProviderRow(
     ThemeData theme,
-    ToolSessionInfo info, {
-    double indent = 0,
-  }) {
-    final iconData = _toolIconData(info.toolName);
-
-    return InkWell(
-      onTap: () => _resumeSession(info),
-      borderRadius: BorderRadius.circular(6),
-      child: Padding(
-        padding: EdgeInsets.fromLTRB(6 + indent, 6, 6, 6),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Icon(iconData, size: 14, color: theme.colorScheme.primary),
-            const SizedBox(width: 6),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    info.summary ?? info.sessionId,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: theme.colorScheme.onSurface,
-                    ),
-                  ),
-                  if (info.lastUpdatedLabel.isNotEmpty)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 2),
-                      child: Text(
-                        info.lastUpdatedLabel,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.labelSmall?.copyWith(
-                          fontSize: 10,
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                    ),
-                ],
+    AiSessionProviderEntry provider,
+  ) => InkWell(
+    onTap: provider.isSelectable
+        ? () => unawaited(_showSessionPickerForTool(provider))
+        : null,
+    borderRadius: BorderRadius.circular(6),
+    child: Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 6),
+      child: Row(
+        children: [
+          Icon(
+            aiSessionToolIconData(provider.toolName),
+            size: 14,
+            color: provider.hasFailure
+                ? theme.colorScheme.error
+                : provider.isSelectable
+                ? theme.colorScheme.primary
+                : theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              provider.toolName,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: provider.hasFailure
+                    ? theme.colorScheme.error
+                    : provider.isSelectable
+                    ? theme.colorScheme.onSurface
+                    : theme.colorScheme.onSurfaceVariant,
+                fontWeight: FontWeight.w600,
               ),
             ),
+          ),
+          if (provider.isLoading)
+            const SizedBox(
+              width: 12,
+              height: 12,
+              child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+            )
+          else ...[
+            Text(
+              provider.compactStatusLabel,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: provider.hasFailure
+                    ? theme.colorScheme.error
+                    : theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            if (provider.isSelectable) ...[
+              const SizedBox(width: 4),
+              Icon(
+                Icons.chevron_right,
+                size: 14,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ],
           ],
-        ),
+        ],
       ),
-    );
-  }
-
-  IconData _toolIconData(String toolName) => switch (toolName) {
-    'Claude Code' => Icons.auto_awesome,
-    'Codex' => Icons.code,
-    'Copilot CLI' => Icons.flight,
-    'Gemini CLI' => Icons.diamond_outlined,
-    'OpenCode' => Icons.terminal,
-    _ => Icons.smart_toy_outlined,
-  };
+    ),
+  );
 
   Widget _buildWindowRow(ThemeData theme, TmuxWindow window) {
     final title = window.displayTitle;

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2344,28 +2344,21 @@ class _TmuxConnectionBadge extends ConsumerStatefulWidget {
 
 class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   static const _initialSessionFetchLimit = 24;
-  static const _sessionFetchStep = 12;
+  static const _prefetchSessionFetchLimit = 6;
   static const _tmuxQueryRetryDelay = Duration(seconds: 2);
 
   List<TmuxWindow>? _windows;
-  List<ToolSessionInfo>? _recentSessions;
-  Set<String> _attemptedSessionTools = const <String>{};
-  Set<String> _failedSessionTools = const <String>{};
   String? _preferredSessionToolName;
-  StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
-  String? _sessionLoadError;
   String? _sessionName;
   bool _queried = false;
   bool _expanded = false;
   bool _showSessions = false;
-  bool _isLoadingSessions = false;
-  bool _canLoadMoreSessions = false;
-  int _sessionFetchLimit = _initialSessionFetchLimit;
-  int _sessionLoadGeneration = 0;
   bool _restoredUiState = false;
   StreamSubscription<void>? _windowChangeSubscription;
+  Timer? _tmuxRetryTimer;
   bool _loadingWindows = false;
   bool _pendingWindowReload = false;
+  bool _tmuxQueryScheduled = false;
 
   @override
   void initState() {
@@ -2384,7 +2377,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
 
   @override
   void dispose() {
-    unawaited(_sessionDiscoverySubscription?.cancel());
+    _tmuxRetryTimer?.cancel();
     unawaited(_windowChangeSubscription?.cancel());
     super.dispose();
   }
@@ -2406,6 +2399,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     final preferredToolName = preset?.tool.discoveredSessionToolName;
     if (_preferredSessionToolName == preferredToolName) return;
     setState(() => _preferredSessionToolName = preferredToolName);
+    if (_showSessions) {
+      unawaited(_prefetchPreferredSessionProvider());
+    }
   }
 
   @override
@@ -2421,17 +2417,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
 
     _expanded = storedState['expanded'] as bool? ?? _expanded;
     _showSessions = storedState['showSessions'] as bool? ?? _showSessions;
-    _sessionFetchLimit =
-        storedState['sessionFetchLimit'] as int? ?? _sessionFetchLimit;
 
     if (!_hasAgentSessionAccess) {
       _showSessions = false;
-    }
-
-    if (_showSessions && _hasAgentSessionAccess) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) _loadRecentSessions();
-      });
     }
   }
 
@@ -2442,7 +2430,6 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     PageStorage.maybeOf(context)?.writeState(context, <String, Object>{
       'expanded': _expanded,
       'showSessions': _showSessions,
-      'sessionFetchLimit': _sessionFetchLimit,
     }, identifier: _pageStorageIdentifier);
   }
 
@@ -2459,6 +2446,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     if (retries <= 0 || !mounted) {
       if (mounted) {
         setState(() => _queried = true);
+        _scheduleTmuxRetry();
       }
       return;
     }
@@ -2473,6 +2461,43 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     ref: ref,
     feature: MonetizationFeature.agentLaunchPresets,
   );
+
+  String? _resolveRecentSessionScopeWorkingDirectory(SshSession session) {
+    final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
+    return resolveAgentSessionScopeWorkingDirectory(
+      activeWorkingDirectory: activeWindow?.currentPath,
+      sessionWorkingDirectory: session.workingDirectory,
+    );
+  }
+
+  Future<void> _prefetchPreferredSessionProvider() async {
+    if (!_hasAgentSessionAccess) return;
+    final toolName = _preferredSessionToolName;
+    if (toolName == null || toolName.isEmpty) return;
+    final session = ref
+        .read(activeSessionsProvider.notifier)
+        .getSession(widget.connectionId);
+    if (session == null) return;
+
+    await ref
+        .read(agentSessionDiscoveryServiceProvider)
+        .prefetchSessions(
+          session,
+          workingDirectory: _resolveRecentSessionScopeWorkingDirectory(session),
+          maxPerTool: _prefetchSessionFetchLimit,
+          toolName: toolName,
+        );
+  }
+
+  void _scheduleTmuxRetry() {
+    if (_tmuxRetryTimer?.isActive ?? false) return;
+    _tmuxRetryTimer = Timer(const Duration(seconds: 10), () {
+      _tmuxRetryTimer = null;
+      if (mounted) {
+        unawaited(_queryTmux());
+      }
+    });
+  }
 
   Future<void> _queryTmux({int retries = 3}) async {
     final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
@@ -2521,6 +2546,12 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
           .read(tmuxServiceProvider)
           .listWindows(session, sessionName);
       if (!mounted) return;
+      if (windows.isEmpty) {
+        _scheduleTmuxRetry();
+      } else {
+        _tmuxRetryTimer?.cancel();
+        _tmuxRetryTimer = null;
+      }
       setState(() {
         _windows = windows;
         _sessionName = sessionName;
@@ -2528,6 +2559,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       });
     } on Object {
       if (!mounted) return;
+      _scheduleTmuxRetry();
       setState(() {
         _queried = true;
       });
@@ -2542,6 +2574,22 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
 
   @override
   Widget build(BuildContext context) {
+    final connectionState = ref.watch(
+      activeSessionsProvider.select((state) => state[widget.connectionId]),
+    );
+    if (connectionState == SshConnectionState.connected &&
+        !_tmuxQueryScheduled &&
+        !_loadingWindows &&
+        (_sessionName == null || !_queried)) {
+      _tmuxQueryScheduled = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _tmuxQueryScheduled = false;
+        if (mounted) {
+          unawaited(_queryTmux());
+        }
+      });
+    }
+
     if (!_queried || _windows == null || _windows!.isEmpty) {
       return const SizedBox.shrink();
     }
@@ -2621,7 +2669,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                 onTap: () {
                   setState(() => _showSessions = !_showSessions);
                   _persistUiState();
-                  if (_showSessions) _loadRecentSessions();
+                  if (_showSessions) {
+                    unawaited(_prefetchPreferredSessionProvider());
+                  }
                 },
                 child: Padding(
                   padding: const EdgeInsets.symmetric(
@@ -2653,48 +2703,44 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                 ),
               ),
               if (_showSessions) ...[
-                if (_hasVisibleSessionProviders) ...[
-                  if (_sessionLoadError != null)
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 4),
-                      child: Text(
-                        _sessionLoadError!,
-                        style: theme.textTheme.labelSmall?.copyWith(
-                          color: theme.colorScheme.error,
-                        ),
+                Builder(
+                  builder: (context) {
+                    final session = ref
+                        .read(activeSessionsProvider.notifier)
+                        .getSession(widget.connectionId);
+                    if (session == null) {
+                      return const SizedBox.shrink();
+                    }
+
+                    final scopeWorkingDirectory =
+                        _resolveRecentSessionScopeWorkingDirectory(session);
+                    return AiSessionProviderList(
+                      key: ValueKey<Object>(
+                        Object.hashAll(<Object?>[
+                          widget.connectionId,
+                          _sessionName,
+                          scopeWorkingDirectory,
+                          _preferredSessionToolName,
+                        ]),
                       ),
-                    ),
-                  ..._buildSessionProviderEntries().map(
-                    (provider) => _buildSessionProviderRow(theme, provider),
-                  ),
-                  if (_canLoadMoreSessions)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 2),
-                      child: TextButton(
-                        onPressed: _loadMoreSessions,
-                        child: const Text('Load more'),
+                      orderedTools: orderedDiscoveredSessionTools(
+                        const <String, List<ToolSessionInfo>>{},
+                        const <String>{},
+                        preferredToolName: _preferredSessionToolName,
                       ),
-                    ),
-                ] else if (_sessionLoadError != null && _recentSessions != null)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 4),
-                    child: Text(
-                      _sessionLoadError!,
-                      style: theme.textTheme.labelSmall?.copyWith(
-                        color: theme.colorScheme.error,
-                      ),
-                    ),
-                  )
-                else if (_recentSessions != null)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 4),
-                    child: Text(
-                      'No recent sessions found',
-                      style: theme.textTheme.labelSmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                  ),
+                      loadSessionsForTool: (toolName, maxSessions) => ref
+                          .read(agentSessionDiscoveryServiceProvider)
+                          .discoverSessionsStream(
+                            session,
+                            workingDirectory: scopeWorkingDirectory,
+                            maxPerTool: maxSessions,
+                            toolName: toolName,
+                          ),
+                      itemBuilder: (context, provider) =>
+                          _buildSessionProviderRow(theme, provider),
+                    );
+                  },
+                ),
               ],
             ] else
               InkWell(
@@ -2772,121 +2818,6 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     widget.onTap();
   }
 
-  Future<void> _loadRecentSessions({bool forceReload = false}) async {
-    if (!_hasAgentSessionAccess) {
-      return;
-    }
-    if (_isLoadingSessions || (_recentSessions != null && !forceReload)) return;
-    final previousCount = _recentSessions?.length ?? 0;
-    final loadGeneration = ++_sessionLoadGeneration;
-    await _sessionDiscoverySubscription?.cancel();
-    _sessionDiscoverySubscription = null;
-    setState(() {
-      _isLoadingSessions = true;
-      _sessionLoadError = null;
-      _canLoadMoreSessions = false;
-      _failedSessionTools = const <String>{};
-    });
-
-    final session = ref
-        .read(activeSessionsProvider.notifier)
-        .getSession(widget.connectionId);
-    if (session == null) {
-      if (mounted && loadGeneration == _sessionLoadGeneration) {
-        setState(() {
-          _recentSessions = const [];
-          _canLoadMoreSessions = false;
-          _isLoadingSessions = false;
-        });
-      }
-      return;
-    }
-    unawaited(_loadPreferredSessionToolName(session.hostId));
-
-    try {
-      final discovery = ref.read(agentSessionDiscoveryServiceProvider);
-      // Scope sessions to the active tmux window's working directory
-      // so results match the current project context.
-      final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
-      final scopeWorkingDirectory = resolveAgentSessionScopeWorkingDirectory(
-        activeWorkingDirectory: activeWindow?.currentPath,
-        sessionWorkingDirectory: session.workingDirectory,
-      );
-      _sessionDiscoverySubscription = discovery
-          .discoverSessionsStream(
-            session,
-            workingDirectory: scopeWorkingDirectory,
-            maxPerTool: _sessionFetchLimit,
-          )
-          .listen(
-            (result) {
-              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
-              setState(() {
-                _recentSessions = result.sessions;
-                _attemptedSessionTools = result.attemptedTools;
-                _failedSessionTools = result.failedTools;
-                _sessionLoadError = result.failureMessage;
-              });
-            },
-            onError: (Object _) {
-              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
-              setState(() {
-                _recentSessions ??= const [];
-                _failedSessionTools = const <String>{};
-                _sessionLoadError = 'Could not load recent AI sessions.';
-                _canLoadMoreSessions = false;
-                _isLoadingSessions = false;
-              });
-              _sessionDiscoverySubscription = null;
-              _persistUiState();
-            },
-            onDone: () {
-              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
-              final sessions = _recentSessions ?? const <ToolSessionInfo>[];
-              setState(() {
-                _canLoadMoreSessions =
-                    sessions.length > previousCount &&
-                    _hasSessionGroupAtLimit(sessions);
-                _isLoadingSessions = false;
-              });
-              _sessionDiscoverySubscription = null;
-              _persistUiState();
-            },
-            cancelOnError: true,
-          );
-    } on Exception {
-      if (!mounted || loadGeneration != _sessionLoadGeneration) return;
-      setState(() {
-        _recentSessions ??= const [];
-        _failedSessionTools = const <String>{};
-        _sessionLoadError = 'Could not load recent AI sessions.';
-        _canLoadMoreSessions = false;
-        _isLoadingSessions = false;
-      });
-      _sessionDiscoverySubscription = null;
-      _persistUiState();
-    }
-  }
-
-  void _loadMoreSessions() {
-    if (_isLoadingSessions) return;
-    setState(() => _sessionFetchLimit += _sessionFetchStep);
-    _persistUiState();
-    _loadRecentSessions(forceReload: true);
-  }
-
-  bool _hasSessionGroupAtLimit(List<ToolSessionInfo> sessions) {
-    final countsByTool = <String, int>{};
-    for (final session in sessions) {
-      countsByTool.update(
-        session.toolName,
-        (count) => count + 1,
-        ifAbsent: () => 1,
-      );
-    }
-    return countsByTool.values.any((count) => count >= _sessionFetchLimit);
-  }
-
   void _resumeSession(ToolSessionInfo info) {
     if (!_hasAgentSessionAccess) {
       unawaited(_handleLockedAiSessionsTap());
@@ -2915,49 +2846,28 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   Future<void> _showSessionPickerForTool(
     AiSessionProviderEntry provider,
   ) async {
-    if (!provider.isSelectable) return;
+    final session = ref
+        .read(activeSessionsProvider.notifier)
+        .getSession(widget.connectionId);
+    if (session == null) return;
+
     final selected = await showAiSessionPickerDialog(
       context: context,
       toolName: provider.toolName,
-      sessions: provider.sessions,
+      initialMaxSessions: _initialSessionFetchLimit,
+      loadSessions: (maxSessions) => ref
+          .read(agentSessionDiscoveryServiceProvider)
+          .discoverSessionsStream(
+            session,
+            workingDirectory: _resolveRecentSessionScopeWorkingDirectory(
+              session,
+            ),
+            maxPerTool: maxSessions,
+            toolName: provider.toolName,
+          ),
     );
     if (!mounted || selected == null) return;
     _resumeSession(selected);
-  }
-
-  Map<String, List<ToolSessionInfo>> _groupSessions(
-    List<ToolSessionInfo> sessions,
-  ) {
-    final grouped = <String, List<ToolSessionInfo>>{};
-    for (final session in sessions) {
-      grouped
-          .putIfAbsent(session.toolName, () => <ToolSessionInfo>[])
-          .add(session);
-    }
-    return grouped;
-  }
-
-  bool get _hasVisibleSessionProviders =>
-      _isLoadingSessions ||
-      _attemptedSessionTools.isNotEmpty ||
-      _failedSessionTools.isNotEmpty ||
-      (_recentSessions?.isNotEmpty ?? false);
-
-  List<AiSessionProviderEntry> _buildSessionProviderEntries() {
-    final grouped = _groupSessions(
-      _recentSessions ?? const <ToolSessionInfo>[],
-    );
-    final orderedTools = orderedDiscoveredSessionTools(grouped, <String>{
-      ..._attemptedSessionTools,
-      ..._failedSessionTools,
-    }, preferredToolName: _preferredSessionToolName);
-    return buildAiSessionProviderEntries(
-      orderedTools: orderedTools,
-      groupedSessions: grouped,
-      attemptedTools: _attemptedSessionTools,
-      failedTools: _failedSessionTools,
-      isLoading: _isLoadingSessions,
-    );
   }
 
   Widget _buildSessionProviderRow(
@@ -2997,13 +2907,21 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
               ),
             ),
           ),
-          if (provider.isLoading)
+          if (provider.isLoading && !provider.hasSessions)
             const SizedBox(
               width: 12,
               height: 12,
               child: CircularProgressIndicator.adaptive(strokeWidth: 2),
             )
           else ...[
+            if (provider.isLoading) ...[
+              const SizedBox(
+                width: 12,
+                height: 12,
+                child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+              ),
+              const SizedBox(width: 4),
+            ],
             Text(
               provider.compactStatusLabel,
               style: theme.textTheme.labelSmall?.copyWith(

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2340,7 +2340,7 @@ class _TmuxConnectionBadge extends ConsumerStatefulWidget {
 }
 
 class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
-  static const _initialSessionFetchLimit = 12;
+  static const _initialSessionFetchLimit = 24;
   static const _sessionFetchStep = 12;
   static const _tmuxQueryRetryDelay = Duration(seconds: 2);
 

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2346,6 +2346,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
 
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
+  Set<String> _attemptedSessionTools = const <String>{};
   final Set<String> _expandedSessionTools = <String>{};
   StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
   String? _sessionLoadError;
@@ -2658,7 +2659,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                       ),
                     ),
                   )
-                else if (_recentSessions != null && _recentSessions!.isEmpty)
+                else if (_recentSessions != null &&
+                    _recentSessions!.isEmpty &&
+                    _attemptedSessionTools.isEmpty)
                   Padding(
                     padding: const EdgeInsets.symmetric(vertical: 4),
                     child: Text(
@@ -2679,10 +2682,16 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                         ),
                       ),
                     ),
-                  ..._groupSessions(_recentSessions!).entries.map(
-                    (entry) =>
-                        _buildSessionGroup(theme, entry.key, entry.value),
-                  ),
+                  ...() {
+                    final grouped = _groupSessions(_recentSessions!);
+                    return _orderedSessionTools(grouped).map(
+                      (toolName) => _buildSessionGroup(
+                        theme,
+                        toolName,
+                        grouped[toolName] ?? const <ToolSessionInfo>[],
+                      ),
+                    );
+                  }(),
                   if (_isLoadingSessions)
                     const Padding(
                       padding: EdgeInsets.symmetric(vertical: 8),
@@ -2831,6 +2840,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
               if (!mounted || loadGeneration != _sessionLoadGeneration) return;
               setState(() {
                 _recentSessions = result.sessions;
+                _attemptedSessionTools = result.attemptedTools;
                 _sessionLoadError = result.failureMessage;
               });
             },
@@ -2928,27 +2938,46 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     return grouped;
   }
 
+  /// Returns the ordered set of tool names to render: tools with sessions
+  /// first (in their natural grouping order), followed by attempted tools
+  /// that returned no sessions, sorted alphabetically.
+  List<String> _orderedSessionTools(
+    Map<String, List<ToolSessionInfo>> grouped,
+  ) {
+    final ordered = <String>[...grouped.keys];
+    final emptyAttempts =
+        _attemptedSessionTools
+            .where((tool) => !grouped.containsKey(tool))
+            .toList()
+          ..sort();
+    ordered.addAll(emptyAttempts);
+    return ordered;
+  }
+
   Widget _buildSessionGroup(
     ThemeData theme,
     String toolName,
     List<ToolSessionInfo> sessions,
   ) {
-    final isExpanded = _expandedSessionTools.contains(toolName);
+    final isEmpty = sessions.isEmpty;
+    final isExpanded = !isEmpty && _expandedSessionTools.contains(toolName);
 
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
         InkWell(
-          onTap: () {
-            setState(() {
-              if (isExpanded) {
-                _expandedSessionTools.remove(toolName);
-              } else {
-                _expandedSessionTools.add(toolName);
-              }
-            });
-            _persistUiState();
-          },
+          onTap: isEmpty
+              ? null
+              : () {
+                  setState(() {
+                    if (isExpanded) {
+                      _expandedSessionTools.remove(toolName);
+                    } else {
+                      _expandedSessionTools.add(toolName);
+                    }
+                  });
+                  _persistUiState();
+                },
           borderRadius: BorderRadius.circular(6),
           child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 6),
@@ -2957,7 +2986,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                 Icon(
                   _toolIconData(toolName),
                   size: 14,
-                  color: theme.colorScheme.primary,
+                  color: isEmpty
+                      ? theme.colorScheme.onSurfaceVariant
+                      : theme.colorScheme.primary,
                 ),
                 const SizedBox(width: 6),
                 Expanded(
@@ -2966,23 +2997,27 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: theme.textTheme.labelSmall?.copyWith(
-                      color: theme.colorScheme.onSurface,
+                      color: isEmpty
+                          ? theme.colorScheme.onSurfaceVariant
+                          : theme.colorScheme.onSurface,
                       fontWeight: FontWeight.w600,
                     ),
                   ),
                 ),
                 Text(
-                  '${sessions.length}',
+                  isEmpty ? 'no recent' : '${sessions.length}',
                   style: theme.textTheme.labelSmall?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
                 ),
-                const SizedBox(width: 4),
-                Icon(
-                  isExpanded ? Icons.expand_less : Icons.expand_more,
-                  size: 14,
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
+                if (!isEmpty) ...[
+                  const SizedBox(width: 4),
+                  Icon(
+                    isExpanded ? Icons.expand_less : Icons.expand_more,
+                    size: 14,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ],
               ],
             ),
           ),

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -13,10 +13,12 @@ import '../../data/database/database.dart';
 import '../../data/repositories/host_repository.dart';
 import '../../data/repositories/key_repository.dart';
 import '../../data/repositories/snippet_repository.dart';
+import '../../domain/models/agent_launch_preset.dart';
 import '../../domain/models/monetization.dart';
 import '../../domain/models/terminal_theme.dart';
 import '../../domain/models/terminal_themes.dart';
 import '../../domain/models/tmux_state.dart';
+import '../../domain/services/agent_launch_preset_service.dart';
 import '../../domain/services/agent_session_discovery_service.dart';
 import '../../domain/services/auth_service.dart';
 import '../../domain/services/monetization_service.dart';
@@ -2347,6 +2349,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
   Set<String> _attemptedSessionTools = const <String>{};
+  String? _preferredSessionToolName;
   final Set<String> _expandedSessionTools = <String>{};
   StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
   String? _sessionLoadError;
@@ -2366,7 +2369,16 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   @override
   void initState() {
     super.initState();
+    unawaited(_loadPreferredSessionToolName());
     _queryTmux();
+  }
+
+  @override
+  void didUpdateWidget(covariant _TmuxConnectionBadge oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.connectionId != widget.connectionId) {
+      unawaited(_loadPreferredSessionToolName());
+    }
   }
 
   @override
@@ -2374,6 +2386,25 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     unawaited(_sessionDiscoverySubscription?.cancel());
     unawaited(_windowChangeSubscription?.cancel());
     super.dispose();
+  }
+
+  Future<void> _loadPreferredSessionToolName([int? hostId]) async {
+    final resolvedHostId =
+        hostId ??
+        ref
+            .read(activeSessionsProvider.notifier)
+            .getSession(widget.connectionId)
+            ?.hostId;
+    if (resolvedHostId == null) return;
+
+    final preset = await ref
+        .read(agentLaunchPresetServiceProvider)
+        .getPresetForHost(resolvedHostId);
+    if (!mounted) return;
+
+    final preferredToolName = preset?.tool.discoveredSessionToolName;
+    if (_preferredSessionToolName == preferredToolName) return;
+    setState(() => _preferredSessionToolName = preferredToolName);
   }
 
   @override
@@ -2687,6 +2718,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                     return orderedDiscoveredSessionTools(
                       grouped,
                       _attemptedSessionTools,
+                      preferredToolName: _preferredSessionToolName,
                     ).map(
                       (toolName) => _buildSessionGroup(
                         theme,
@@ -2822,6 +2854,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       }
       return;
     }
+    unawaited(_loadPreferredSessionToolName(session.hostId));
 
     try {
       final discovery = ref.read(agentSessionDiscoveryServiceProvider);

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2684,7 +2684,10 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                     ),
                   ...() {
                     final grouped = _groupSessions(_recentSessions!);
-                    return _orderedSessionTools(grouped).map(
+                    return orderedDiscoveredSessionTools(
+                      grouped,
+                      _attemptedSessionTools,
+                    ).map(
                       (toolName) => _buildSessionGroup(
                         theme,
                         toolName,
@@ -2936,22 +2939,6 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
           .add(session);
     }
     return grouped;
-  }
-
-  /// Returns the ordered set of tool names to render: tools with sessions
-  /// first (in their natural grouping order), followed by attempted tools
-  /// that returned no sessions, sorted alphabetically.
-  List<String> _orderedSessionTools(
-    Map<String, List<ToolSessionInfo>> grouped,
-  ) {
-    final ordered = <String>[...grouped.keys];
-    final emptyAttempts =
-        _attemptedSessionTools
-            .where((tool) => !grouped.containsKey(tool))
-            .toList()
-          ..sort();
-    ordered.addAll(emptyAttempts);
-    return ordered;
   }
 
   Widget _buildSessionGroup(

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2816,10 +2816,14 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       // Scope sessions to the active tmux window's working directory
       // so results match the current project context.
       final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
+      final scopeWorkingDirectory = resolveAgentSessionScopeWorkingDirectory(
+        activeWorkingDirectory: activeWindow?.currentPath,
+        sessionWorkingDirectory: session.workingDirectory,
+      );
       _sessionDiscoverySubscription = discovery
           .discoverSessionsStream(
             session,
-            workingDirectory: activeWindow?.currentPath,
+            workingDirectory: scopeWorkingDirectory,
             maxPerTool: _sessionFetchLimit,
           )
           .listen(

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2353,6 +2353,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   bool _queried = false;
   bool _expanded = false;
   bool _showSessions = false;
+  bool _hasInitializedSessionProviders = false;
   bool _restoredUiState = false;
   StreamSubscription<void>? _windowChangeSubscription;
   Timer? _tmuxRetryTimer;
@@ -2420,6 +2421,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
 
     if (!_hasAgentSessionAccess) {
       _showSessions = false;
+    }
+    if (_showSessions) {
+      _hasInitializedSessionProviders = true;
     }
   }
 
@@ -2667,9 +2671,15 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
               GestureDetector(
                 behavior: HitTestBehavior.opaque,
                 onTap: () {
-                  setState(() => _showSessions = !_showSessions);
+                  final showSessions = !_showSessions;
+                  setState(() {
+                    _showSessions = showSessions;
+                    if (showSessions) {
+                      _hasInitializedSessionProviders = true;
+                    }
+                  });
                   _persistUiState();
-                  if (_showSessions) {
+                  if (showSessions) {
                     unawaited(_prefetchPreferredSessionProvider());
                   }
                 },
@@ -2702,46 +2712,47 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                   ),
                 ),
               ),
-              if (_showSessions) ...[
-                Builder(
-                  builder: (context) {
-                    final session = ref
-                        .read(activeSessionsProvider.notifier)
-                        .getSession(widget.connectionId);
-                    if (session == null) {
-                      return const SizedBox.shrink();
-                    }
+              if (_hasInitializedSessionProviders)
+                Offstage(
+                  offstage: !_showSessions,
+                  child: Builder(
+                    builder: (context) {
+                      final session = ref
+                          .read(activeSessionsProvider.notifier)
+                          .getSession(widget.connectionId);
+                      if (session == null) {
+                        return const SizedBox.shrink();
+                      }
 
-                    final scopeWorkingDirectory =
-                        _resolveRecentSessionScopeWorkingDirectory(session);
-                    return AiSessionProviderList(
-                      key: ValueKey<Object>(
-                        Object.hashAll(<Object?>[
-                          widget.connectionId,
-                          _sessionName,
-                          scopeWorkingDirectory,
-                          _preferredSessionToolName,
-                        ]),
-                      ),
-                      orderedTools: orderedDiscoveredSessionTools(
-                        const <String, List<ToolSessionInfo>>{},
-                        const <String>{},
-                        preferredToolName: _preferredSessionToolName,
-                      ),
-                      loadSessionsForTool: (toolName, maxSessions) => ref
-                          .read(agentSessionDiscoveryServiceProvider)
-                          .discoverSessionsStream(
-                            session,
-                            workingDirectory: scopeWorkingDirectory,
-                            maxPerTool: maxSessions,
-                            toolName: toolName,
-                          ),
-                      itemBuilder: (context, provider) =>
-                          _buildSessionProviderRow(theme, provider),
-                    );
-                  },
+                      final scopeWorkingDirectory =
+                          _resolveRecentSessionScopeWorkingDirectory(session);
+                      return AiSessionProviderList(
+                        key: ValueKey<Object>(
+                          Object.hashAll(<Object?>[
+                            widget.connectionId,
+                            _sessionName,
+                            scopeWorkingDirectory,
+                          ]),
+                        ),
+                        orderedTools: orderedDiscoveredSessionTools(
+                          const <String, List<ToolSessionInfo>>{},
+                          const <String>{},
+                          preferredToolName: _preferredSessionToolName,
+                        ),
+                        loadSessionsForTool: (toolName, maxSessions) => ref
+                            .read(agentSessionDiscoveryServiceProvider)
+                            .discoverSessionsStream(
+                              session,
+                              workingDirectory: scopeWorkingDirectory,
+                              maxPerTool: maxSessions,
+                              toolName: toolName,
+                            ),
+                        itemBuilder: (context, provider) =>
+                            _buildSessionProviderRow(theme, provider),
+                      );
+                    },
+                  ),
                 ),
-              ],
             ] else
               InkWell(
                 onTap: () => unawaited(_handleLockedAiSessionsTap()),

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2825,19 +2825,10 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
           .listen(
             (result) {
               if (!mounted || loadGeneration != _sessionLoadGeneration) return;
-              final shouldPersistUiState =
-                  _expandedSessionTools.isEmpty && result.sessions.isNotEmpty;
               setState(() {
                 _recentSessions = result.sessions;
                 _sessionLoadError = result.failureMessage;
-                if (_expandedSessionTools.isEmpty &&
-                    result.sessions.isNotEmpty) {
-                  _expandedSessionTools.add(result.sessions.first.toolName);
-                }
               });
-              if (shouldPersistUiState) {
-                _persistUiState();
-              }
             },
             onError: (Object _) {
               if (!mounted || loadGeneration != _sessionLoadGeneration) return;

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2347,6 +2347,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
   final Set<String> _expandedSessionTools = <String>{};
+  StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
   String? _sessionLoadError;
   String? _sessionName;
   bool _queried = false;
@@ -2355,6 +2356,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   bool _isLoadingSessions = false;
   bool _canLoadMoreSessions = false;
   int _sessionFetchLimit = _initialSessionFetchLimit;
+  int _sessionLoadGeneration = 0;
   bool _restoredUiState = false;
   StreamSubscription<void>? _windowChangeSubscription;
   bool _loadingWindows = false;
@@ -2368,6 +2370,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
 
   @override
   void dispose() {
+    unawaited(_sessionDiscoverySubscription?.cancel());
     unawaited(_windowChangeSubscription?.cancel());
     super.dispose();
   }
@@ -2785,16 +2788,20 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     }
     if (_isLoadingSessions || (_recentSessions != null && !forceReload)) return;
     final previousCount = _recentSessions?.length ?? 0;
+    final loadGeneration = ++_sessionLoadGeneration;
+    await _sessionDiscoverySubscription?.cancel();
+    _sessionDiscoverySubscription = null;
     setState(() {
       _isLoadingSessions = true;
       _sessionLoadError = null;
+      _canLoadMoreSessions = false;
     });
 
     final session = ref
         .read(activeSessionsProvider.notifier)
         .getSession(widget.connectionId);
     if (session == null) {
-      if (mounted) {
+      if (mounted && loadGeneration == _sessionLoadGeneration) {
         setState(() {
           _recentSessions = const [];
           _canLoadMoreSessions = false;
@@ -2809,32 +2816,63 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       // Scope sessions to the active tmux window's working directory
       // so results match the current project context.
       final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
-      final result = await discovery.discoverSessions(
-        session,
-        workingDirectory: activeWindow?.currentPath,
-        maxPerTool: _sessionFetchLimit,
-      );
-      if (!mounted) return;
-      setState(() {
-        _recentSessions = result.sessions;
-        _sessionLoadError = result.failureMessage;
-        if (_expandedSessionTools.isEmpty && result.sessions.isNotEmpty) {
-          _expandedSessionTools.add(result.sessions.first.toolName);
-        }
-        _canLoadMoreSessions =
-            result.sessions.length > previousCount &&
-            _hasSessionGroupAtLimit(result.sessions);
-        _isLoadingSessions = false;
-      });
-      _persistUiState();
+      _sessionDiscoverySubscription = discovery
+          .discoverSessionsStream(
+            session,
+            workingDirectory: activeWindow?.currentPath,
+            maxPerTool: _sessionFetchLimit,
+          )
+          .listen(
+            (result) {
+              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
+              final shouldPersistUiState =
+                  _expandedSessionTools.isEmpty && result.sessions.isNotEmpty;
+              setState(() {
+                _recentSessions = result.sessions;
+                _sessionLoadError = result.failureMessage;
+                if (_expandedSessionTools.isEmpty &&
+                    result.sessions.isNotEmpty) {
+                  _expandedSessionTools.add(result.sessions.first.toolName);
+                }
+              });
+              if (shouldPersistUiState) {
+                _persistUiState();
+              }
+            },
+            onError: (Object _) {
+              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
+              setState(() {
+                _recentSessions ??= const [];
+                _sessionLoadError = 'Could not load recent AI sessions.';
+                _canLoadMoreSessions = false;
+                _isLoadingSessions = false;
+              });
+              _sessionDiscoverySubscription = null;
+              _persistUiState();
+            },
+            onDone: () {
+              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
+              final sessions = _recentSessions ?? const <ToolSessionInfo>[];
+              setState(() {
+                _canLoadMoreSessions =
+                    sessions.length > previousCount &&
+                    _hasSessionGroupAtLimit(sessions);
+                _isLoadingSessions = false;
+              });
+              _sessionDiscoverySubscription = null;
+              _persistUiState();
+            },
+            cancelOnError: true,
+          );
     } on Exception {
-      if (!mounted) return;
+      if (!mounted || loadGeneration != _sessionLoadGeneration) return;
       setState(() {
-        _recentSessions = const [];
+        _recentSessions ??= const [];
         _sessionLoadError = 'Could not load recent AI sessions.';
         _canLoadMoreSessions = false;
         _isLoadingSessions = false;
       });
+      _sessionDiscoverySubscription = null;
       _persistUiState();
     }
   }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -407,10 +407,14 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     try {
       final discovery = widget.ref.read(agentSessionDiscoveryServiceProvider);
       final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
+      final scopeWorkingDirectory = resolveAgentSessionScopeWorkingDirectory(
+        activeWorkingDirectory: activeWindow?.currentPath,
+        sessionWorkingDirectory: widget.session.workingDirectory,
+      );
       _sessionDiscoverySubscription = discovery
           .discoverSessionsStream(
             widget.session,
-            workingDirectory: activeWindow?.currentPath,
+            workingDirectory: scopeWorkingDirectory,
             maxPerTool: _sessionFetchLimit,
           )
           .listen(

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -304,6 +304,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   bool _expanded = false;
   bool _isLoading = true;
   bool _showSessions = false;
+  bool _hasInitializedSessionProviders = false;
   double _dragOffset = 0;
   StreamSubscription<void>? _windowChangeSubscription;
   late AnimationController _bounceController;
@@ -773,38 +774,47 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           color: theme.colorScheme.onSurfaceVariant,
         ),
         onTap: () {
-          setState(() => _showSessions = !_showSessions);
-          if (_showSessions) {
+          final showSessions = !_showSessions;
+          setState(() {
+            _showSessions = showSessions;
+            if (showSessions) {
+              _hasInitializedSessionProviders = true;
+            }
+          });
+          if (showSessions) {
             unawaited(_prefetchPreferredSessionProvider());
           }
         },
       ),
-      if (_showSessions) ...[
-        AiSessionProviderList(
-          key: ValueKey<Object>(
-            Object.hashAll(<Object?>[
-              widget.session.connectionId,
-              widget.tmuxSessionName,
-              _resolveRecentSessionScopeWorkingDirectory(),
-              _preferredLaunchTool?.discoveredSessionToolName,
-            ]),
+      if (_hasInitializedSessionProviders)
+        Offstage(
+          offstage: !_showSessions,
+          child: AiSessionProviderList(
+            key: ValueKey<Object>(
+              Object.hashAll(<Object?>[
+                widget.session.connectionId,
+                widget.tmuxSessionName,
+                _resolveRecentSessionScopeWorkingDirectory(),
+              ]),
+            ),
+            orderedTools: orderedDiscoveredSessionTools(
+              const <String, List<ToolSessionInfo>>{},
+              const <String>{},
+              preferredToolName:
+                  _preferredLaunchTool?.discoveredSessionToolName,
+            ),
+            loadSessionsForTool: (toolName, maxSessions) =>
+                _discovery.discoverSessionsStream(
+                  widget.session,
+                  workingDirectory:
+                      _resolveRecentSessionScopeWorkingDirectory(),
+                  maxPerTool: maxSessions,
+                  toolName: toolName,
+                ),
+            itemBuilder: (context, provider) =>
+                _buildSessionProviderTile(theme, provider),
           ),
-          orderedTools: orderedDiscoveredSessionTools(
-            const <String, List<ToolSessionInfo>>{},
-            const <String>{},
-            preferredToolName: _preferredLaunchTool?.discoveredSessionToolName,
-          ),
-          loadSessionsForTool: (toolName, maxSessions) =>
-              _discovery.discoverSessionsStream(
-                widget.session,
-                workingDirectory: _resolveRecentSessionScopeWorkingDirectory(),
-                maxPerTool: maxSessions,
-                toolName: toolName,
-              ),
-          itemBuilder: (context, provider) =>
-              _buildSessionProviderTile(theme, provider),
         ),
-      ],
     ],
   );
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -296,6 +296,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   static const _groupTilePadding = EdgeInsets.only(left: 52, right: 12);
   static const _sessionTilePadding = EdgeInsets.only(left: 68, right: 12);
   static const _initialSessionFetchLimit = 12;
+  static const _prefetchSessionFetchLimit = 6;
   static const _sessionFetchStep = 12;
 
   List<TmuxWindow>? _windows;
@@ -340,6 +341,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         ]).animate(
           CurvedAnimation(parent: _bounceController, curve: Curves.easeInOut),
         );
+    if (widget.isProUser) {
+      unawaited(_prefetchRecentSessions());
+    }
     _loadWindows();
     _subscribeToWindowChanges();
   }
@@ -353,6 +357,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     }
     unawaited(_windowChangeSubscription?.cancel());
     _subscribeToWindowChanges();
+    if (widget.isProUser) {
+      unawaited(_prefetchRecentSessions());
+    }
     _loadWindows();
   }
 
@@ -389,12 +396,14 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         );
   }
 
-  Future<void> _prefetchRecentSessions([List<TmuxWindow>? windows]) =>
-      _discovery.prefetchSessions(
-        widget.session,
-        workingDirectory: _resolveRecentSessionScopeWorkingDirectory(windows),
-        maxPerTool: _sessionFetchLimit,
-      );
+  Future<void> _prefetchRecentSessions({
+    List<TmuxWindow>? windows,
+    int maxPerTool = _prefetchSessionFetchLimit,
+  }) => _discovery.prefetchSessions(
+    widget.session,
+    workingDirectory: _resolveRecentSessionScopeWorkingDirectory(windows),
+    maxPerTool: maxPerTool,
+  );
 
   Future<void> _loadWindows() async {
     if (_loadingWindows) {
@@ -445,7 +454,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         _isLoading = false;
       });
       if (widget.isProUser) {
-        unawaited(_prefetchRecentSessions(windows));
+        unawaited(_prefetchRecentSessions(windows: windows));
       }
     } on Object {
       if (!mounted) return;

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -260,6 +260,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
 
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
+  Set<String> _attemptedSessionTools = const <String>{};
   final Set<String> _expandedSessionTools = <String>{};
   final Set<int> _seenAlertWindows = <int>{};
   StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
@@ -422,6 +423,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
               if (!mounted || loadGeneration != _sessionLoadGeneration) return;
               setState(() {
                 _recentSessions = result.sessions;
+                _attemptedSessionTools = result.attemptedTools;
                 _sessionLoadError = result.failureMessage;
               });
             },
@@ -783,7 +785,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
               ),
             ),
           )
-        else if (_recentSessions != null && _recentSessions!.isEmpty)
+        else if (_recentSessions != null &&
+            _recentSessions!.isEmpty &&
+            _attemptedSessionTools.isEmpty)
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             child: Text(
@@ -804,9 +808,16 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
                 ),
               ),
             ),
-          ..._groupSessions(_recentSessions!).entries.map(
-            (entry) => _buildSessionGroup(theme, entry.key, entry.value),
-          ),
+          ...() {
+            final grouped = _groupSessions(_recentSessions!);
+            return _orderedSessionTools(grouped).map(
+              (toolName) => _buildSessionGroup(
+                theme,
+                toolName,
+                grouped[toolName] ?? const <ToolSessionInfo>[],
+              ),
+            );
+          }(),
           if (_isLoadingSessions)
             const Padding(
               padding: EdgeInsets.symmetric(vertical: 8),
@@ -843,12 +854,29 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     return grouped;
   }
 
+  /// Returns the ordered set of tool names to render: tools with sessions
+  /// first, then attempted tools that returned no sessions, sorted
+  /// alphabetically.
+  List<String> _orderedSessionTools(
+    Map<String, List<ToolSessionInfo>> grouped,
+  ) {
+    final ordered = <String>[...grouped.keys];
+    final emptyAttempts =
+        _attemptedSessionTools
+            .where((tool) => !grouped.containsKey(tool))
+            .toList()
+          ..sort();
+    ordered.addAll(emptyAttempts);
+    return ordered;
+  }
+
   Widget _buildSessionGroup(
     ThemeData theme,
     String toolName,
     List<ToolSessionInfo> sessions,
   ) {
-    final isExpanded = _expandedSessionTools.contains(toolName);
+    final isEmpty = sessions.isEmpty;
+    final isExpanded = !isEmpty && _expandedSessionTools.contains(toolName);
     final iconData = switch (toolName) {
       'Claude Code' => Icons.auto_awesome,
       'Codex' => Icons.code,
@@ -868,27 +896,46 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           contentPadding: _groupTilePadding,
           horizontalTitleGap: 12,
           minLeadingWidth: 18,
-          leading: Icon(iconData, size: 16, color: theme.colorScheme.primary),
-          title: Text(toolName),
+          leading: Icon(
+            iconData,
+            size: 16,
+            color: isEmpty
+                ? theme.colorScheme.onSurfaceVariant
+                : theme.colorScheme.primary,
+          ),
+          title: Text(
+            toolName,
+            style: isEmpty
+                ? theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  )
+                : null,
+          ),
           subtitle: Text(
-            '${sessions.length} session${sessions.length == 1 ? '' : 's'}',
+            isEmpty
+                ? 'No recent sessions for this project'
+                : '${sessions.length} session${sessions.length == 1 ? '' : 's'}',
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
           ),
-          trailing: Icon(
-            isExpanded ? Icons.expand_less : Icons.expand_more,
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-          onTap: () {
-            setState(() {
-              if (isExpanded) {
-                _expandedSessionTools.remove(toolName);
-              } else {
-                _expandedSessionTools.add(toolName);
-              }
-            });
-          },
+          trailing: isEmpty
+              ? null
+              : Icon(
+                  isExpanded ? Icons.expand_less : Icons.expand_more,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+          onTap: isEmpty
+              ? null
+              : () {
+                  setState(() {
+                    if (isExpanded) {
+                      _expandedSessionTools.remove(toolName);
+                    } else {
+                      _expandedSessionTools.add(toolName);
+                    }
+                  });
+                },
         ),
         if (isExpanded)
           for (final session in sessions)

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -419,10 +419,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
               setState(() {
                 _recentSessions = result.sessions;
                 _sessionLoadError = result.failureMessage;
-                if (_expandedSessionTools.isEmpty &&
-                    result.sessions.isNotEmpty) {
-                  _expandedSessionTools.add(result.sessions.first.toolName);
-                }
               });
             },
             onError: (Object _) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -40,6 +40,7 @@ import '../../domain/services/ssh_service.dart';
 import '../../domain/services/terminal_hyperlink_tracker.dart';
 import '../../domain/services/terminal_theme_service.dart';
 import '../../domain/services/tmux_service.dart';
+import '../widgets/ai_session_picker.dart';
 import '../widgets/keyboard_toolbar.dart';
 import '../widgets/monkey_terminal_view.dart';
 import '../widgets/premium_access.dart';
@@ -295,7 +296,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   static const _denseTileVisualDensity = VisualDensity(vertical: -2);
   static const _denseTilePadding = EdgeInsets.symmetric(horizontal: 12);
   static const _groupTilePadding = EdgeInsets.only(left: 52, right: 12);
-  static const _sessionTilePadding = EdgeInsets.only(left: 68, right: 12);
   static const _initialSessionFetchLimit = 12;
   static const _prefetchSessionFetchLimit = 6;
   static const _sessionFetchStep = 12;
@@ -303,8 +303,8 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
   Set<String> _attemptedSessionTools = const <String>{};
+  Set<String> _failedSessionTools = const <String>{};
   AgentLaunchTool? _preferredLaunchTool;
-  final Set<String> _expandedSessionTools = <String>{};
   final Set<int> _seenAlertWindows = <int>{};
   StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
   String? _sessionLoadError;
@@ -494,6 +494,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       _isLoadingSessions = true;
       _sessionLoadError = null;
       _canLoadMoreSessions = false;
+      _failedSessionTools = const <String>{};
     });
 
     try {
@@ -506,17 +507,10 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           .listen(
             (result) {
               if (!mounted || loadGeneration != _sessionLoadGeneration) return;
-              final counts = <String, int>{};
-              for (final session in result.sessions) {
-                counts.update(
-                  session.toolName,
-                  (count) => count + 1,
-                  ifAbsent: () => 1,
-                );
-              }
               setState(() {
                 _recentSessions = result.sessions;
                 _attemptedSessionTools = result.attemptedTools;
+                _failedSessionTools = result.failedTools;
                 _sessionLoadError = result.failureMessage;
               });
             },
@@ -524,6 +518,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
               if (!mounted || loadGeneration != _sessionLoadGeneration) return;
               setState(() {
                 _recentSessions ??= const [];
+                _failedSessionTools = const <String>{};
                 _sessionLoadError = 'Could not load recent AI sessions.';
                 _canLoadMoreSessions = false;
                 _isLoadingSessions = false;
@@ -547,6 +542,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       if (!mounted || loadGeneration != _sessionLoadGeneration) return;
       setState(() {
         _recentSessions ??= const [];
+        _failedSessionTools = const <String>{};
         _sessionLoadError = 'Could not load recent AI sessions.';
         _canLoadMoreSessions = false;
         _isLoadingSessions = false;
@@ -580,6 +576,19 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     widget.onAction(
       TmuxResumeSessionAction(command, workingDirectory: info.workingDirectory),
     );
+  }
+
+  Future<void> _showSessionPickerForTool(
+    AiSessionProviderEntry provider,
+  ) async {
+    if (!provider.isSelectable) return;
+    final selected = await showAiSessionPickerDialog(
+      context: context,
+      toolName: provider.toolName,
+      sessions: provider.sessions,
+    );
+    if (!mounted || selected == null) return;
+    _resumeSession(selected);
   }
 
   int _tmuxAlertNotificationId(int windowIndex) =>
@@ -860,43 +869,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         },
       ),
       if (_showSessions) ...[
-        if (_isLoadingSessions &&
-            (_recentSessions == null || _recentSessions!.isEmpty))
-          const Padding(
-            padding: EdgeInsets.symmetric(vertical: 8),
-            child: Center(
-              child: SizedBox(
-                width: 16,
-                height: 16,
-                child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-              ),
-            ),
-          )
-        else if (_sessionLoadError != null &&
-            _recentSessions != null &&
-            _recentSessions!.isEmpty)
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Text(
-              _sessionLoadError!,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.error,
-              ),
-            ),
-          )
-        else if (_recentSessions != null &&
-            _recentSessions!.isEmpty &&
-            _attemptedSessionTools.isEmpty)
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Text(
-              'No recent sessions found',
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
-          )
-        else if (_recentSessions != null) ...[
+        if (_hasVisibleSessionProviders) ...[
           if (_sessionLoadError != null)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -907,32 +880,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
                 ),
               ),
             ),
-          ...() {
-            final grouped = _groupSessions(_recentSessions!);
-            return orderedDiscoveredSessionTools(
-              grouped,
-              _attemptedSessionTools,
-              preferredToolName:
-                  _preferredLaunchTool?.discoveredSessionToolName,
-            ).map(
-              (toolName) => _buildSessionGroup(
-                theme,
-                toolName,
-                grouped[toolName] ?? const <ToolSessionInfo>[],
-              ),
-            );
-          }(),
-          if (_isLoadingSessions)
-            const Padding(
-              padding: EdgeInsets.symmetric(vertical: 8),
-              child: Center(
-                child: SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-                ),
-              ),
-            ),
+          ..._buildSessionProviderEntries().map(
+            (provider) => _buildSessionProviderTile(theme, provider),
+          ),
           if (_canLoadMoreSessions)
             Padding(
               padding: const EdgeInsets.only(bottom: 8),
@@ -941,10 +891,52 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
                 child: const Text('Load more'),
               ),
             ),
-        ],
+        ] else if (_sessionLoadError != null && _recentSessions != null)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text(
+              _sessionLoadError!,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.error,
+              ),
+            ),
+          )
+        else if (_recentSessions != null)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text(
+              'No recent sessions found',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
       ],
     ],
   );
+
+  bool get _hasVisibleSessionProviders =>
+      _isLoadingSessions ||
+      _attemptedSessionTools.isNotEmpty ||
+      _failedSessionTools.isNotEmpty ||
+      (_recentSessions?.isNotEmpty ?? false);
+
+  List<AiSessionProviderEntry> _buildSessionProviderEntries() {
+    final grouped = _groupSessions(
+      _recentSessions ?? const <ToolSessionInfo>[],
+    );
+    final orderedTools = orderedDiscoveredSessionTools(grouped, <String>{
+      ..._attemptedSessionTools,
+      ..._failedSessionTools,
+    }, preferredToolName: _preferredLaunchTool?.discoveredSessionToolName);
+    return buildAiSessionProviderEntries(
+      orderedTools: orderedTools,
+      groupedSessions: grouped,
+      attemptedTools: _attemptedSessionTools,
+      failedTools: _failedSessionTools,
+      isLoading: _isLoadingSessions,
+    );
+  }
 
   Map<String, List<ToolSessionInfo>> _groupSessions(
     List<ToolSessionInfo> sessions,
@@ -958,106 +950,57 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     return grouped;
   }
 
-  Widget _buildSessionGroup(
+  Widget _buildSessionProviderTile(
     ThemeData theme,
-    String toolName,
-    List<ToolSessionInfo> sessions,
+    AiSessionProviderEntry provider,
   ) {
-    final isEmpty = sessions.isEmpty;
-    final isExpanded = !isEmpty && _expandedSessionTools.contains(toolName);
-    final iconData = switch (toolName) {
-      'Claude Code' => Icons.auto_awesome,
-      'Codex' => Icons.code,
-      'Copilot CLI' => Icons.flight,
-      'Gemini CLI' => Icons.diamond_outlined,
-      'OpenCode' => Icons.terminal,
-      _ => Icons.smart_toy_outlined,
-    };
+    final titleColor = provider.hasFailure
+        ? theme.colorScheme.error
+        : provider.isSelectable
+        ? theme.colorScheme.onSurface
+        : theme.colorScheme.onSurfaceVariant;
+    final iconColor = provider.hasFailure
+        ? theme.colorScheme.error
+        : provider.isSelectable
+        ? theme.colorScheme.primary
+        : theme.colorScheme.onSurfaceVariant;
 
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        ListTile(
-          dense: true,
-          visualDensity: _denseTileVisualDensity,
-          minVerticalPadding: 2,
-          contentPadding: _groupTilePadding,
-          horizontalTitleGap: 12,
-          minLeadingWidth: 18,
-          leading: Icon(
-            iconData,
-            size: 16,
-            color: isEmpty
-                ? theme.colorScheme.onSurfaceVariant
-                : theme.colorScheme.primary,
-          ),
-          title: Text(
-            toolName,
-            style: isEmpty
-                ? theme.textTheme.bodyMedium?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                  )
-                : null,
-          ),
-          subtitle: Text(
-            isEmpty
-                ? 'No recent sessions for this project'
-                : '${sessions.length} session${sessions.length == 1 ? '' : 's'}',
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          ),
-          trailing: isEmpty
-              ? null
-              : Icon(
-                  isExpanded ? Icons.expand_less : Icons.expand_more,
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-          onTap: isEmpty
-              ? null
-              : () {
-                  setState(() {
-                    if (isExpanded) {
-                      _expandedSessionTools.remove(toolName);
-                    } else {
-                      _expandedSessionTools.add(toolName);
-                    }
-                  });
-                },
+    return ListTile(
+      dense: true,
+      visualDensity: _denseTileVisualDensity,
+      minVerticalPadding: 2,
+      contentPadding: _groupTilePadding,
+      horizontalTitleGap: 12,
+      minLeadingWidth: 18,
+      leading: Icon(
+        aiSessionToolIconData(provider.toolName),
+        size: 16,
+        color: iconColor,
+      ),
+      title: Text(
+        provider.toolName,
+        style: theme.textTheme.bodyMedium?.copyWith(color: titleColor),
+      ),
+      subtitle: Text(
+        provider.statusLabel,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: provider.hasFailure
+              ? theme.colorScheme.error
+              : theme.colorScheme.onSurfaceVariant,
         ),
-        if (isExpanded)
-          for (final session in sessions)
-            ListTile(
-              dense: true,
-              visualDensity: _denseTileVisualDensity,
-              minVerticalPadding: 2,
-              contentPadding: _sessionTilePadding,
-              horizontalTitleGap: 12,
-              minLeadingWidth: 18,
-              title: Text(
-                session.summary ?? session.sessionId,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              subtitle: session.lastUpdatedLabel.isNotEmpty
-                  ? Text(
-                      session.lastUpdatedLabel,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                    )
-                  : null,
-              trailing: TextButton(
-                onPressed: () => _resumeSession(session),
-                style: TextButton.styleFrom(
-                  visualDensity: VisualDensity.compact,
-                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  padding: const EdgeInsets.symmetric(horizontal: 8),
-                ),
-                child: const Text('Resume'),
-              ),
-            ),
-      ],
+      ),
+      trailing: provider.isLoading
+          ? const SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+            )
+          : provider.isSelectable
+          ? Icon(Icons.chevron_right, color: theme.colorScheme.onSurfaceVariant)
+          : null,
+      onTap: provider.isSelectable
+          ? () => unawaited(_showSessionPickerForTool(provider))
+          : null,
     );
   }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -321,6 +321,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
 
   TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
 
+  AgentSessionDiscoveryService get _discovery =>
+      widget.ref.read(agentSessionDiscoveryServiceProvider);
+
   @override
   void initState() {
     super.initState();
@@ -373,6 +376,26 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         });
   }
 
+  String? _resolveRecentSessionScopeWorkingDirectory([
+    List<TmuxWindow>? windows,
+  ]) {
+    final activeWindow = (windows ?? _windows)
+        ?.where((window) => window.isActive)
+        .firstOrNull;
+    return widget.scopeWorkingDirectory ??
+        resolveAgentSessionScopeWorkingDirectory(
+          activeWorkingDirectory: activeWindow?.currentPath,
+          sessionWorkingDirectory: widget.session.workingDirectory,
+        );
+  }
+
+  Future<void> _prefetchRecentSessions([List<TmuxWindow>? windows]) =>
+      _discovery.prefetchSessions(
+        widget.session,
+        workingDirectory: _resolveRecentSessionScopeWorkingDirectory(windows),
+        maxPerTool: _sessionFetchLimit,
+      );
+
   Future<void> _loadWindows() async {
     if (_loadingWindows) {
       _pendingWindowReload = true;
@@ -421,6 +444,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         _windows = windows;
         _isLoading = false;
       });
+      if (widget.isProUser) {
+        unawaited(_prefetchRecentSessions(windows));
+      }
     } on Object {
       if (!mounted) return;
       if (_isLoading) setState(() => _isLoading = false);
@@ -446,18 +472,10 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     });
 
     try {
-      final discovery = widget.ref.read(agentSessionDiscoveryServiceProvider);
-      final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
-      final scopeWorkingDirectory =
-          widget.scopeWorkingDirectory ??
-          resolveAgentSessionScopeWorkingDirectory(
-            activeWorkingDirectory: activeWindow?.currentPath,
-            sessionWorkingDirectory: widget.session.workingDirectory,
-          );
-      _sessionDiscoverySubscription = discovery
+      _sessionDiscoverySubscription = _discovery
           .discoverSessionsStream(
             widget.session,
-            workingDirectory: scopeWorkingDirectory,
+            workingDirectory: _resolveRecentSessionScopeWorkingDirectory(),
             maxPerTool: _sessionFetchLimit,
           )
           .listen(
@@ -656,7 +674,12 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       final wasExpanded = _expanded;
       setState(() => _expanded = !_expanded);
       // Refresh window list when expanding to get current active state.
-      if (!wasExpanded) _loadWindows();
+      if (!wasExpanded) {
+        _loadWindows();
+        if (widget.isProUser) {
+          unawaited(_prefetchRecentSessions());
+        }
+      }
     },
     child: SizedBox(
       height: _TmuxExpandableBar.handleHeight,

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -307,15 +307,15 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         oldWidget.tmuxSessionName == widget.tmuxSessionName) {
       return;
     }
-    _windowChangeSubscription?.cancel();
+    unawaited(_windowChangeSubscription?.cancel());
     _subscribeToWindowChanges();
     _loadWindows();
   }
 
   @override
   void dispose() {
-    _sessionDiscoverySubscription?.cancel();
-    _windowChangeSubscription?.cancel();
+    unawaited(_sessionDiscoverySubscription?.cancel());
+    unawaited(_windowChangeSubscription?.cancel());
     for (final windowIndex in _seenAlertWindows) {
       _clearAlertNotification(windowIndex);
     }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -262,6 +262,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   List<ToolSessionInfo>? _recentSessions;
   final Set<String> _expandedSessionTools = <String>{};
   final Set<int> _seenAlertWindows = <int>{};
+  StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
   String? _sessionLoadError;
   bool _expanded = false;
   bool _isLoading = true;
@@ -270,6 +271,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   bool _showSessions = false;
   double _dragOffset = 0;
   int _sessionFetchLimit = _initialSessionFetchLimit;
+  int _sessionLoadGeneration = 0;
   StreamSubscription<void>? _windowChangeSubscription;
   late AnimationController _bounceController;
   late Animation<double> _bounceAnimation;
@@ -312,6 +314,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
 
   @override
   void dispose() {
+    _sessionDiscoverySubscription?.cancel();
     _windowChangeSubscription?.cancel();
     for (final windowIndex in _seenAlertWindows) {
       _clearAlertNotification(windowIndex);
@@ -392,39 +395,68 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   Future<void> _loadRecentSessions({bool forceReload = false}) async {
     if (_isLoadingSessions || (_recentSessions != null && !forceReload)) return;
     final previousCount = _recentSessions?.length ?? 0;
+    final loadGeneration = ++_sessionLoadGeneration;
+    await _sessionDiscoverySubscription?.cancel();
+    _sessionDiscoverySubscription = null;
     setState(() {
       _isLoadingSessions = true;
       _sessionLoadError = null;
+      _canLoadMoreSessions = false;
     });
 
     try {
       final discovery = widget.ref.read(agentSessionDiscoveryServiceProvider);
       final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
-      final result = await discovery.discoverSessions(
-        widget.session,
-        workingDirectory: activeWindow?.currentPath,
-        maxPerTool: _sessionFetchLimit,
-      );
-      if (!mounted) return;
-      setState(() {
-        _recentSessions = result.sessions;
-        _sessionLoadError = result.failureMessage;
-        if (_expandedSessionTools.isEmpty && result.sessions.isNotEmpty) {
-          _expandedSessionTools.add(result.sessions.first.toolName);
-        }
-        _canLoadMoreSessions =
-            result.sessions.length > previousCount &&
-            _hasSessionGroupAtLimit(result.sessions);
-        _isLoadingSessions = false;
-      });
+      _sessionDiscoverySubscription = discovery
+          .discoverSessionsStream(
+            widget.session,
+            workingDirectory: activeWindow?.currentPath,
+            maxPerTool: _sessionFetchLimit,
+          )
+          .listen(
+            (result) {
+              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
+              setState(() {
+                _recentSessions = result.sessions;
+                _sessionLoadError = result.failureMessage;
+                if (_expandedSessionTools.isEmpty &&
+                    result.sessions.isNotEmpty) {
+                  _expandedSessionTools.add(result.sessions.first.toolName);
+                }
+              });
+            },
+            onError: (Object _) {
+              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
+              setState(() {
+                _recentSessions ??= const [];
+                _sessionLoadError = 'Could not load recent AI sessions.';
+                _canLoadMoreSessions = false;
+                _isLoadingSessions = false;
+              });
+              _sessionDiscoverySubscription = null;
+            },
+            onDone: () {
+              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
+              final sessions = _recentSessions ?? const <ToolSessionInfo>[];
+              setState(() {
+                _canLoadMoreSessions =
+                    sessions.length > previousCount &&
+                    _hasSessionGroupAtLimit(sessions);
+                _isLoadingSessions = false;
+              });
+              _sessionDiscoverySubscription = null;
+            },
+            cancelOnError: true,
+          );
     } on Exception {
-      if (!mounted) return;
+      if (!mounted || loadGeneration != _sessionLoadGeneration) return;
       setState(() {
-        _recentSessions = const [];
+        _recentSessions ??= const [];
         _sessionLoadError = 'Could not load recent AI sessions.';
         _canLoadMoreSessions = false;
         _isLoadingSessions = false;
       });
+      _sessionDiscoverySubscription = null;
     }
   }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -174,6 +174,34 @@ double resolveTmuxBarRevealOpacity(
   return (terminalBottomPadding / handleHeight).clamp(0.0, 1.0);
 }
 
+/// Resolves the active tmux window title to show in the collapsed bar handle.
+@visibleForTesting
+String? resolveTmuxBarActiveWindowTitle(Iterable<TmuxWindow>? windows) {
+  final activeWindow = windows?.where((window) => window.isActive).firstOrNull;
+  final title = activeWindow?.displayTitle.trim();
+  if (title == null || title.isEmpty) {
+    return null;
+  }
+  return title;
+}
+
+/// Resolves the compact label shown in the tmux bar handle.
+@visibleForTesting
+String resolveTmuxBarHandleLabel(
+  String tmuxSessionName, {
+  String? activeWindowTitle,
+}) {
+  final sessionName = tmuxSessionName.trim();
+  final title = activeWindowTitle?.trim();
+  if (title == null || title.isEmpty || title == sessionName) {
+    return sessionName;
+  }
+  if (sessionName.isEmpty) {
+    return title;
+  }
+  return '$sessionName · $title';
+}
+
 final _oscEscapeSequencePattern = RegExp(
   '\x1B\\][^\x07\x1B]*(?:\x07|\x1B\\\\)',
   dotAll: true,
@@ -612,68 +640,84 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     );
   }
 
-  Widget _buildHandleBar(ThemeData theme) => GestureDetector(
-    key: const ValueKey('tmux-handle-bar'),
-    onTap: () {
-      final wasExpanded = _expanded;
-      setState(() => _expanded = !_expanded);
-      // Refresh window list when expanding to get current active state.
-      if (!wasExpanded) {
-        _loadWindows();
-        if (widget.isProUser) {
-          unawaited(_prefetchPreferredSessionProvider());
+  Widget _buildHandleBar(ThemeData theme) {
+    final handleLabel = resolveTmuxBarHandleLabel(
+      widget.tmuxSessionName,
+      activeWindowTitle: resolveTmuxBarActiveWindowTitle(_windows),
+    );
+    return GestureDetector(
+      key: const ValueKey('tmux-handle-bar'),
+      onTap: () {
+        final wasExpanded = _expanded;
+        setState(() => _expanded = !_expanded);
+        // Refresh window list when expanding to get current active state.
+        if (!wasExpanded) {
+          _loadWindows();
+          if (widget.isProUser) {
+            unawaited(_prefetchPreferredSessionProvider());
+          }
         }
-      }
-    },
-    child: SizedBox(
-      height: _TmuxExpandableBar.handleHeight,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12),
-        child: Stack(
-          alignment: Alignment.center,
-          children: [
-            // Centered drag handle pill.
-            Container(
-              width: 28,
-              height: 3,
-              decoration: BoxDecoration(
-                color: theme.colorScheme.onSurfaceVariant.withAlpha(80),
-                borderRadius: BorderRadius.circular(2),
+      },
+      child: SizedBox(
+        height: _TmuxExpandableBar.handleHeight,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Stack(
+            children: [
+              Align(
+                alignment: Alignment.topCenter,
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Container(
+                    width: 28,
+                    height: 3,
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.onSurfaceVariant.withAlpha(80),
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
               ),
-            ),
-            // Left-aligned session name, right-aligned chevron.
-            Row(
-              children: [
-                Icon(
-                  Icons.window_outlined,
-                  size: 12,
-                  color: theme.colorScheme.primary,
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.window_outlined,
+                      size: 12,
+                      color: theme.colorScheme.primary,
+                    ),
+                    const SizedBox(width: 4),
+                    Expanded(
+                      child: Text(
+                        handleLabel,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          fontSize: 10,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    AnimatedRotation(
+                      duration: const Duration(milliseconds: 300),
+                      turns: _expanded ? 0.5 : 0,
+                      child: Icon(
+                        Icons.keyboard_arrow_up,
+                        size: 14,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
                 ),
-                const SizedBox(width: 4),
-                Text(
-                  widget.tmuxSessionName,
-                  style: theme.textTheme.labelSmall?.copyWith(
-                    fontSize: 10,
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                ),
-                const Spacer(),
-                AnimatedRotation(
-                  duration: const Duration(milliseconds: 300),
-                  turns: _expanded ? 0.5 : 0,
-                  child: Icon(
-                    Icons.keyboard_arrow_up,
-                    size: 14,
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                ),
-              ],
-            ),
-          ],
+              ),
+            ],
+          ),
         ),
       ),
-    ),
-  );
+    );
+  }
 
   Widget _buildWindowList(ThemeData theme) {
     if (_isLoading) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -29,6 +29,7 @@ import '../../domain/models/monetization.dart';
 import '../../domain/models/terminal_theme.dart';
 import '../../domain/models/terminal_themes.dart';
 import '../../domain/models/tmux_state.dart';
+import '../../domain/services/agent_launch_preset_service.dart';
 import '../../domain/services/agent_session_discovery_service.dart';
 import '../../domain/services/local_notification_service.dart';
 import '../../domain/services/monetization_service.dart';
@@ -302,6 +303,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
   Set<String> _attemptedSessionTools = const <String>{};
+  AgentLaunchTool? _preferredLaunchTool;
   final Set<String> _expandedSessionTools = <String>{};
   final Set<int> _seenAlertWindows = <int>{};
   StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
@@ -341,6 +343,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         ]).animate(
           CurvedAnimation(parent: _bounceController, curve: Curves.easeInOut),
         );
+    unawaited(_loadPreferredLaunchTool());
     if (widget.isProUser) {
       unawaited(_prefetchRecentSessions());
     }
@@ -357,6 +360,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     }
     unawaited(_windowChangeSubscription?.cancel());
     _subscribeToWindowChanges();
+    unawaited(_loadPreferredLaunchTool());
     if (widget.isProUser) {
       unawaited(_prefetchRecentSessions());
     }
@@ -372,6 +376,18 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     }
     _bounceController.dispose();
     super.dispose();
+  }
+
+  Future<void> _loadPreferredLaunchTool() async {
+    final hostId = widget.session.hostId;
+    final preset = await widget.ref
+        .read(agentLaunchPresetServiceProvider)
+        .getPresetForHost(hostId);
+    if (!mounted || widget.session.hostId != hostId) return;
+
+    final preferredLaunchTool = preset?.tool;
+    if (_preferredLaunchTool == preferredLaunchTool) return;
+    setState(() => _preferredLaunchTool = preferredLaunchTool);
   }
 
   void _subscribeToWindowChanges() {
@@ -788,6 +804,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
                 builder: (ctx) => TmuxToolPickerSheet(
                   isProUser: widget.isProUser,
                   installedToolsFuture: installedToolsFuture,
+                  preferredTool: _preferredLaunchTool,
                   onToolSelected: (tool) => Navigator.pop(ctx, tool),
                   onEmptyWindow: () {
                     Navigator.pop(ctx);
@@ -895,6 +912,8 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
             return orderedDiscoveredSessionTools(
               grouped,
               _attemptedSessionTools,
+              preferredToolName:
+                  _preferredLaunchTool?.discoveredSessionToolName,
             ).map(
               (toolName) => _buildSessionGroup(
                 theme,

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -221,6 +221,7 @@ class _TmuxExpandableBar extends StatefulWidget {
     required this.isProUser,
     required this.ref,
     required this.onAction,
+    this.scopeWorkingDirectory,
   });
 
   /// The active SSH session.
@@ -240,6 +241,9 @@ class _TmuxExpandableBar extends StatefulWidget {
 
   /// Callback for navigator actions.
   final Future<void> Function(TmuxNavigatorAction) onAction;
+
+  /// Best-known project working directory for AI session scoping.
+  final String? scopeWorkingDirectory;
 
   /// Height of the collapsed handle bar. The terminal adds this as
   /// bottom padding so the handle sits over empty space.
@@ -408,10 +412,12 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     try {
       final discovery = widget.ref.read(agentSessionDiscoveryServiceProvider);
       final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
-      final scopeWorkingDirectory = resolveAgentSessionScopeWorkingDirectory(
-        activeWorkingDirectory: activeWindow?.currentPath,
-        sessionWorkingDirectory: widget.session.workingDirectory,
-      );
+      final scopeWorkingDirectory =
+          widget.scopeWorkingDirectory ??
+          resolveAgentSessionScopeWorkingDirectory(
+            activeWorkingDirectory: activeWindow?.currentPath,
+            sessionWorkingDirectory: widget.session.workingDirectory,
+          );
       _sessionDiscoverySubscription = discovery
           .discoverSessionsStream(
             widget.session,
@@ -421,6 +427,14 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           .listen(
             (result) {
               if (!mounted || loadGeneration != _sessionLoadGeneration) return;
+              final counts = <String, int>{};
+              for (final session in result.sessions) {
+                counts.update(
+                  session.toolName,
+                  (count) => count + 1,
+                  ifAbsent: () => 1,
+                );
+              }
               setState(() {
                 _recentSessions = result.sessions;
                 _attemptedSessionTools = result.attemptedTools;
@@ -810,7 +824,10 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
             ),
           ...() {
             final grouped = _groupSessions(_recentSessions!);
-            return _orderedSessionTools(grouped).map(
+            return orderedDiscoveredSessionTools(
+              grouped,
+              _attemptedSessionTools,
+            ).map(
               (toolName) => _buildSessionGroup(
                 theme,
                 toolName,
@@ -852,22 +869,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           .add(session);
     }
     return grouped;
-  }
-
-  /// Returns the ordered set of tool names to render: tools with sessions
-  /// first, then attempted tools that returned no sessions, sorted
-  /// alphabetically.
-  List<String> _orderedSessionTools(
-    Map<String, List<ToolSessionInfo>> grouped,
-  ) {
-    final ordered = <String>[...grouped.keys];
-    final emptyAttempts =
-        _attemptedSessionTools
-            .where((tool) => !grouped.containsKey(tool))
-            .toList()
-          ..sort();
-    ordered.addAll(emptyAttempts);
-    return ordered;
   }
 
   Widget _buildSessionGroup(
@@ -2426,12 +2427,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   Uri? get _workingDirectory => _observedSession?.workingDirectory;
 
+  String? get _liveWorkingDirectoryPath =>
+      resolveTerminalWorkingDirectoryPath(_workingDirectory);
+
   String? get _workingDirectoryLabel =>
       formatTerminalWorkingDirectoryLabel(_workingDirectory);
 
   String? get _workingDirectoryPath =>
-      resolveTerminalWorkingDirectoryPath(_workingDirectory) ??
-      _tmuxWorkingDirectory;
+      _liveWorkingDirectoryPath ?? _tmuxWorkingDirectory;
 
   TerminalShellStatus? get _shellStatus => _observedSession?.shellStatus;
 
@@ -3692,6 +3695,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       isProUser: isProUser,
       ref: ref,
       onAction: _handleTmuxAction,
+      scopeWorkingDirectory: resolveTmuxAiSessionScopeWorkingDirectory(
+        liveTerminalWorkingDirectory: _liveWorkingDirectoryPath,
+        tmuxWorkingDirectory: _tmuxWorkingDirectory,
+        sessionWorkingDirectory: session.workingDirectory,
+      ),
     );
   }
 
@@ -3743,6 +3751,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       session: session,
       tmuxSessionName: _tmuxSessionName!,
       isProUser: isProUser,
+      scopeWorkingDirectory: resolveTmuxAiSessionScopeWorkingDirectory(
+        liveTerminalWorkingDirectory: _liveWorkingDirectoryPath,
+        tmuxWorkingDirectory: _tmuxWorkingDirectory,
+        sessionWorkingDirectory: session.workingDirectory,
+      ),
     );
 
     if (!mounted || action == null) return;

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -296,26 +296,15 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   static const _denseTileVisualDensity = VisualDensity(vertical: -2);
   static const _denseTilePadding = EdgeInsets.symmetric(horizontal: 12);
   static const _groupTilePadding = EdgeInsets.only(left: 52, right: 12);
-  static const _initialSessionFetchLimit = 12;
   static const _prefetchSessionFetchLimit = 6;
-  static const _sessionFetchStep = 12;
 
   List<TmuxWindow>? _windows;
-  List<ToolSessionInfo>? _recentSessions;
-  Set<String> _attemptedSessionTools = const <String>{};
-  Set<String> _failedSessionTools = const <String>{};
   AgentLaunchTool? _preferredLaunchTool;
   final Set<int> _seenAlertWindows = <int>{};
-  StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
-  String? _sessionLoadError;
   bool _expanded = false;
   bool _isLoading = true;
-  bool _isLoadingSessions = false;
-  bool _canLoadMoreSessions = false;
   bool _showSessions = false;
   double _dragOffset = 0;
-  int _sessionFetchLimit = _initialSessionFetchLimit;
-  int _sessionLoadGeneration = 0;
   StreamSubscription<void>? _windowChangeSubscription;
   late AnimationController _bounceController;
   late Animation<double> _bounceAnimation;
@@ -344,9 +333,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           CurvedAnimation(parent: _bounceController, curve: Curves.easeInOut),
         );
     unawaited(_loadPreferredLaunchTool());
-    if (widget.isProUser) {
-      unawaited(_prefetchRecentSessions());
-    }
     _loadWindows();
     _subscribeToWindowChanges();
   }
@@ -361,15 +347,11 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     unawaited(_windowChangeSubscription?.cancel());
     _subscribeToWindowChanges();
     unawaited(_loadPreferredLaunchTool());
-    if (widget.isProUser) {
-      unawaited(_prefetchRecentSessions());
-    }
     _loadWindows();
   }
 
   @override
   void dispose() {
-    unawaited(_sessionDiscoverySubscription?.cancel());
     unawaited(_windowChangeSubscription?.cancel());
     for (final windowIndex in _seenAlertWindows) {
       _clearAlertNotification(windowIndex);
@@ -388,6 +370,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     final preferredLaunchTool = preset?.tool;
     if (_preferredLaunchTool == preferredLaunchTool) return;
     setState(() => _preferredLaunchTool = preferredLaunchTool);
+    if (widget.isProUser) {
+      unawaited(_prefetchPreferredSessionProvider());
+    }
   }
 
   void _subscribeToWindowChanges() {
@@ -412,14 +397,19 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         );
   }
 
-  Future<void> _prefetchRecentSessions({
+  Future<void> _prefetchPreferredSessionProvider({
     List<TmuxWindow>? windows,
     int maxPerTool = _prefetchSessionFetchLimit,
-  }) => _discovery.prefetchSessions(
-    widget.session,
-    workingDirectory: _resolveRecentSessionScopeWorkingDirectory(windows),
-    maxPerTool: maxPerTool,
-  );
+  }) async {
+    final toolName = _preferredLaunchTool?.discoveredSessionToolName;
+    if (toolName == null || toolName.isEmpty) return;
+    await _discovery.prefetchSessions(
+      widget.session,
+      workingDirectory: _resolveRecentSessionScopeWorkingDirectory(windows),
+      maxPerTool: maxPerTool,
+      toolName: toolName,
+    );
+  }
 
   Future<void> _loadWindows() async {
     if (_loadingWindows) {
@@ -470,7 +460,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         _isLoading = false;
       });
       if (widget.isProUser) {
-        unawaited(_prefetchRecentSessions(windows: windows));
+        unawaited(_prefetchPreferredSessionProvider(windows: windows));
       }
     } on Object {
       if (!mounted) return;
@@ -482,91 +472,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         unawaited(_loadWindows());
       }
     }
-  }
-
-  Future<void> _loadRecentSessions({bool forceReload = false}) async {
-    if (_isLoadingSessions || (_recentSessions != null && !forceReload)) return;
-    final previousCount = _recentSessions?.length ?? 0;
-    final loadGeneration = ++_sessionLoadGeneration;
-    await _sessionDiscoverySubscription?.cancel();
-    _sessionDiscoverySubscription = null;
-    setState(() {
-      _isLoadingSessions = true;
-      _sessionLoadError = null;
-      _canLoadMoreSessions = false;
-      _failedSessionTools = const <String>{};
-    });
-
-    try {
-      _sessionDiscoverySubscription = _discovery
-          .discoverSessionsStream(
-            widget.session,
-            workingDirectory: _resolveRecentSessionScopeWorkingDirectory(),
-            maxPerTool: _sessionFetchLimit,
-          )
-          .listen(
-            (result) {
-              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
-              setState(() {
-                _recentSessions = result.sessions;
-                _attemptedSessionTools = result.attemptedTools;
-                _failedSessionTools = result.failedTools;
-                _sessionLoadError = result.failureMessage;
-              });
-            },
-            onError: (Object _) {
-              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
-              setState(() {
-                _recentSessions ??= const [];
-                _failedSessionTools = const <String>{};
-                _sessionLoadError = 'Could not load recent AI sessions.';
-                _canLoadMoreSessions = false;
-                _isLoadingSessions = false;
-              });
-              _sessionDiscoverySubscription = null;
-            },
-            onDone: () {
-              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
-              final sessions = _recentSessions ?? const <ToolSessionInfo>[];
-              setState(() {
-                _canLoadMoreSessions =
-                    sessions.length > previousCount &&
-                    _hasSessionGroupAtLimit(sessions);
-                _isLoadingSessions = false;
-              });
-              _sessionDiscoverySubscription = null;
-            },
-            cancelOnError: true,
-          );
-    } on Exception {
-      if (!mounted || loadGeneration != _sessionLoadGeneration) return;
-      setState(() {
-        _recentSessions ??= const [];
-        _failedSessionTools = const <String>{};
-        _sessionLoadError = 'Could not load recent AI sessions.';
-        _canLoadMoreSessions = false;
-        _isLoadingSessions = false;
-      });
-      _sessionDiscoverySubscription = null;
-    }
-  }
-
-  void _loadMoreSessions() {
-    if (_isLoadingSessions) return;
-    setState(() => _sessionFetchLimit += _sessionFetchStep);
-    _loadRecentSessions(forceReload: true);
-  }
-
-  bool _hasSessionGroupAtLimit(List<ToolSessionInfo> sessions) {
-    final countsByTool = <String, int>{};
-    for (final session in sessions) {
-      countsByTool.update(
-        session.toolName,
-        (count) => count + 1,
-        ifAbsent: () => 1,
-      );
-    }
-    return countsByTool.values.any((count) => count >= _sessionFetchLimit);
   }
 
   void _resumeSession(ToolSessionInfo info) {
@@ -581,11 +486,15 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   Future<void> _showSessionPickerForTool(
     AiSessionProviderEntry provider,
   ) async {
-    if (!provider.isSelectable) return;
     final selected = await showAiSessionPickerDialog(
       context: context,
       toolName: provider.toolName,
-      sessions: provider.sessions,
+      loadSessions: (maxSessions) => _discovery.discoverSessionsStream(
+        widget.session,
+        workingDirectory: _resolveRecentSessionScopeWorkingDirectory(),
+        maxPerTool: maxSessions,
+        toolName: provider.toolName,
+      ),
     );
     if (!mounted || selected == null) return;
     _resumeSession(selected);
@@ -711,7 +620,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       if (!wasExpanded) {
         _loadWindows();
         if (widget.isProUser) {
-          unawaited(_prefetchRecentSessions());
+          unawaited(_prefetchPreferredSessionProvider());
         }
       }
     },
@@ -865,90 +774,39 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         ),
         onTap: () {
           setState(() => _showSessions = !_showSessions);
-          if (_showSessions) _loadRecentSessions();
+          if (_showSessions) {
+            unawaited(_prefetchPreferredSessionProvider());
+          }
         },
       ),
       if (_showSessions) ...[
-        if (_hasVisibleSessionProviders) ...[
-          if (_sessionLoadError != null)
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Text(
-                _sessionLoadError!,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.error,
-                ),
-              ),
-            ),
-          ..._buildSessionProviderEntries().map(
-            (provider) => _buildSessionProviderTile(theme, provider),
+        AiSessionProviderList(
+          key: ValueKey<Object>(
+            Object.hashAll(<Object?>[
+              widget.session.connectionId,
+              widget.tmuxSessionName,
+              _resolveRecentSessionScopeWorkingDirectory(),
+              _preferredLaunchTool?.discoveredSessionToolName,
+            ]),
           ),
-          if (_canLoadMoreSessions)
-            Padding(
-              padding: const EdgeInsets.only(bottom: 8),
-              child: TextButton(
-                onPressed: _loadMoreSessions,
-                child: const Text('Load more'),
-              ),
-            ),
-        ] else if (_sessionLoadError != null && _recentSessions != null)
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Text(
-              _sessionLoadError!,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.error,
-              ),
-            ),
-          )
-        else if (_recentSessions != null)
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Text(
-              'No recent sessions found',
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
+          orderedTools: orderedDiscoveredSessionTools(
+            const <String, List<ToolSessionInfo>>{},
+            const <String>{},
+            preferredToolName: _preferredLaunchTool?.discoveredSessionToolName,
           ),
+          loadSessionsForTool: (toolName, maxSessions) =>
+              _discovery.discoverSessionsStream(
+                widget.session,
+                workingDirectory: _resolveRecentSessionScopeWorkingDirectory(),
+                maxPerTool: maxSessions,
+                toolName: toolName,
+              ),
+          itemBuilder: (context, provider) =>
+              _buildSessionProviderTile(theme, provider),
+        ),
       ],
     ],
   );
-
-  bool get _hasVisibleSessionProviders =>
-      _isLoadingSessions ||
-      _attemptedSessionTools.isNotEmpty ||
-      _failedSessionTools.isNotEmpty ||
-      (_recentSessions?.isNotEmpty ?? false);
-
-  List<AiSessionProviderEntry> _buildSessionProviderEntries() {
-    final grouped = _groupSessions(
-      _recentSessions ?? const <ToolSessionInfo>[],
-    );
-    final orderedTools = orderedDiscoveredSessionTools(grouped, <String>{
-      ..._attemptedSessionTools,
-      ..._failedSessionTools,
-    }, preferredToolName: _preferredLaunchTool?.discoveredSessionToolName);
-    return buildAiSessionProviderEntries(
-      orderedTools: orderedTools,
-      groupedSessions: grouped,
-      attemptedTools: _attemptedSessionTools,
-      failedTools: _failedSessionTools,
-      isLoading: _isLoadingSessions,
-    );
-  }
-
-  Map<String, List<ToolSessionInfo>> _groupSessions(
-    List<ToolSessionInfo> sessions,
-  ) {
-    final grouped = <String, List<ToolSessionInfo>>{};
-    for (final session in sessions) {
-      grouped
-          .putIfAbsent(session.toolName, () => <ToolSessionInfo>[])
-          .add(session);
-    }
-    return grouped;
-  }
 
   Widget _buildSessionProviderTile(
     ThemeData theme,
@@ -989,15 +847,30 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
               : theme.colorScheme.onSurfaceVariant,
         ),
       ),
-      trailing: provider.isLoading
+      trailing: provider.isLoading && !provider.hasSessions
           ? const SizedBox(
               width: 16,
               height: 16,
               child: CircularProgressIndicator.adaptive(strokeWidth: 2),
             )
-          : provider.isSelectable
-          ? Icon(Icons.chevron_right, color: theme.colorScheme.onSurfaceVariant)
-          : null,
+          : Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (provider.isLoading) ...[
+                  const SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                  ),
+                  const SizedBox(width: 4),
+                ],
+                if (provider.isSelectable)
+                  Icon(
+                    Icons.chevron_right,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+              ],
+            ),
       onTap: provider.isSelectable
           ? () => unawaited(_showSessionPickerForTool(provider))
           : null,

--- a/lib/presentation/widgets/ai_session_picker.dart
+++ b/lib/presentation/widgets/ai_session_picker.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../domain/models/tmux_state.dart';
@@ -15,6 +14,7 @@ class AiSessionProviderEntry {
     required this.wasAttempted,
     required this.hasFailure,
     required this.isLoading,
+    this.hasSessionsOverride,
   });
 
   /// Provider display name.
@@ -32,8 +32,11 @@ class AiSessionProviderEntry {
   /// Whether this provider is still pending during the current load.
   final bool isLoading;
 
+  /// Optional explicit session-availability flag for lightweight row updates.
+  final bool? hasSessionsOverride;
+
   /// Whether the provider currently has at least one discovered session.
-  bool get hasSessions => sessions.isNotEmpty;
+  bool get hasSessions => hasSessionsOverride ?? sessions.isNotEmpty;
 
   /// Provider rows stay tappable so users can load or retry on demand.
   bool get isSelectable => true;
@@ -139,11 +142,9 @@ class AiSessionProviderList extends StatefulWidget {
 class _AiSessionProviderListState extends State<AiSessionProviderList> {
   final Map<String, StreamSubscription<DiscoveredSessionsResult>>
   _subscriptions = <String, StreamSubscription<DiscoveredSessionsResult>>{};
-  final Map<String, List<ToolSessionInfo>> _sessionsByTool =
-      <String, List<ToolSessionInfo>>{};
-  final Set<String> _attemptedTools = <String>{};
-  final Set<String> _failedTools = <String>{};
-  final Set<String> _loadingTools = <String>{};
+  final Map<String, ValueNotifier<AiSessionProviderEntry>> _entryNotifiers =
+      <String, ValueNotifier<AiSessionProviderEntry>>{};
+  final Map<String, bool> _currentLoadHasSessions = <String, bool>{};
   late List<String> _orderedTools;
   int _loadGeneration = 0;
 
@@ -151,6 +152,7 @@ class _AiSessionProviderListState extends State<AiSessionProviderList> {
   void initState() {
     super.initState();
     _orderedTools = widget.orderedTools.toList(growable: false);
+    _disposeObsoleteNotifiers();
     _startLoadingProviders();
   }
 
@@ -176,6 +178,9 @@ class _AiSessionProviderListState extends State<AiSessionProviderList> {
   @override
   void dispose() {
     unawaited(_cancelSubscriptions());
+    for (final notifier in _entryNotifiers.values) {
+      notifier.dispose();
+    }
     super.dispose();
   }
 
@@ -196,19 +201,17 @@ class _AiSessionProviderListState extends State<AiSessionProviderList> {
   Future<void> _restartLoadingProviders() async {
     await _cancelSubscriptions();
     if (!mounted) return;
-    setState(() {
-      final orderedToolSet = _orderedTools.toSet();
-      _sessionsByTool.removeWhere(
-        (toolName, _) => !orderedToolSet.contains(toolName),
+    _disposeObsoleteNotifiers();
+    for (final toolName in _orderedTools) {
+      final current = _entryForTool(toolName);
+      _setEntry(
+        toolName,
+        hasSessions: current.hasSessions,
+        wasAttempted: current.wasAttempted,
+        hasFailure: current.hasFailure,
+        isLoading: false,
       );
-      _attemptedTools.removeWhere(
-        (toolName) => !orderedToolSet.contains(toolName),
-      );
-      _failedTools.removeWhere(
-        (toolName) => !orderedToolSet.contains(toolName),
-      );
-      _loadingTools.clear();
-    });
+    }
     _startLoadingProviders();
   }
 
@@ -221,95 +224,136 @@ class _AiSessionProviderListState extends State<AiSessionProviderList> {
     }
   }
 
+  void _disposeObsoleteNotifiers() {
+    final orderedToolSet = _orderedTools.toSet();
+    final obsoleteToolNames = _entryNotifiers.keys
+        .where((toolName) => !orderedToolSet.contains(toolName))
+        .toList(growable: false);
+    for (final toolName in obsoleteToolNames) {
+      _currentLoadHasSessions.remove(toolName);
+      _entryNotifiers.remove(toolName)?.dispose();
+    }
+  }
+
+  AiSessionProviderEntry _createInitialEntry(String toolName) =>
+      AiSessionProviderEntry(
+        toolName: toolName,
+        sessions: const <ToolSessionInfo>[],
+        wasAttempted: false,
+        hasFailure: false,
+        isLoading: false,
+        hasSessionsOverride: false,
+      );
+
+  ValueNotifier<AiSessionProviderEntry> _entryNotifier(String toolName) =>
+      _entryNotifiers.putIfAbsent(
+        toolName,
+        () => ValueNotifier<AiSessionProviderEntry>(
+          _createInitialEntry(toolName),
+        ),
+      );
+
+  AiSessionProviderEntry _entryForTool(String toolName) =>
+      _entryNotifier(toolName).value;
+
+  bool _sameEntry(AiSessionProviderEntry a, AiSessionProviderEntry b) =>
+      a.toolName == b.toolName &&
+      a.hasSessions == b.hasSessions &&
+      a.wasAttempted == b.wasAttempted &&
+      a.hasFailure == b.hasFailure &&
+      a.isLoading == b.isLoading;
+
+  void _setEntry(
+    String toolName, {
+    required bool hasSessions,
+    required bool wasAttempted,
+    required bool hasFailure,
+    required bool isLoading,
+  }) {
+    final notifier = _entryNotifier(toolName);
+    final next = AiSessionProviderEntry(
+      toolName: toolName,
+      sessions: const <ToolSessionInfo>[],
+      wasAttempted: wasAttempted,
+      hasFailure: hasFailure,
+      isLoading: isLoading,
+      hasSessionsOverride: hasSessions,
+    );
+    if (_sameEntry(notifier.value, next)) {
+      return;
+    }
+    notifier.value = next;
+  }
+
   void _startLoadingProviders() {
     final generation = _loadGeneration;
     for (final toolName in _orderedTools) {
-      final existingSessions = _sessionsByTool[toolName];
+      _currentLoadHasSessions[toolName] = false;
+      final current = _entryForTool(toolName);
       final hasVisibleState =
-          (existingSessions?.isNotEmpty ?? false) ||
-          _attemptedTools.contains(toolName) ||
-          _failedTools.contains(toolName);
+          current.hasSessions || current.wasAttempted || current.hasFailure;
       if (!hasVisibleState) {
-        _loadingTools.add(toolName);
+        _setEntry(
+          toolName,
+          hasSessions: false,
+          wasAttempted: false,
+          hasFailure: false,
+          isLoading: true,
+        );
       }
       _subscriptions[toolName] = widget
           .loadSessionsForTool(toolName, widget.initialMaxSessions)
           .listen(
             (result) {
               if (!mounted || generation != _loadGeneration) return;
-              final sessions = result.sessions
-                  .where((session) => session.toolName == toolName)
-                  .toList(growable: false);
+              final current = _entryForTool(toolName);
+              final sawSessions = result.sessions.any(
+                (session) => session.toolName == toolName,
+              );
+              if (sawSessions) {
+                _currentLoadHasSessions[toolName] = true;
+              }
               final wasAttempted =
                   result.attemptedTools.contains(toolName) ||
                   result.failedTools.contains(toolName) ||
-                  sessions.isNotEmpty;
+                  sawSessions;
               final hadFailure = result.failedTools.contains(toolName);
-              const isLoading = false;
-              final sessionsChanged = !listEquals(
-                _sessionsByTool[toolName],
-                sessions,
+              _setEntry(
+                toolName,
+                hasSessions:
+                    current.hasSessions ||
+                    (_currentLoadHasSessions[toolName] ?? false),
+                wasAttempted: wasAttempted,
+                hasFailure: hadFailure,
+                isLoading: false,
               );
-              final attemptedChanged =
-                  _attemptedTools.contains(toolName) != wasAttempted;
-              final failureChanged =
-                  _failedTools.contains(toolName) != hadFailure;
-              final loadingChanged =
-                  _loadingTools.contains(toolName) != isLoading;
-              if (!sessionsChanged &&
-                  !attemptedChanged &&
-                  !failureChanged &&
-                  !loadingChanged) {
-                return;
-              }
-              setState(() {
-                _sessionsByTool[toolName] = sessions;
-                if (wasAttempted) {
-                  _attemptedTools.add(toolName);
-                } else {
-                  _attemptedTools.remove(toolName);
-                }
-                if (hadFailure) {
-                  _failedTools.add(toolName);
-                } else {
-                  _failedTools.remove(toolName);
-                }
-                _loadingTools.remove(toolName);
-              });
             },
             onError: (Object _) {
               if (!mounted || generation != _loadGeneration) return;
-              final needsUpdate =
-                  !_attemptedTools.contains(toolName) ||
-                  !_failedTools.contains(toolName) ||
-                  _loadingTools.contains(toolName) ||
-                  !_sessionsByTool.containsKey(toolName);
-              if (!needsUpdate) {
-                _subscriptions.remove(toolName);
-                return;
-              }
-              setState(() {
-                _attemptedTools.add(toolName);
-                _failedTools.add(toolName);
-                _loadingTools.remove(toolName);
-                _sessionsByTool.putIfAbsent(
-                  toolName,
-                  () => const <ToolSessionInfo>[],
-                );
-              });
+              final current = _entryForTool(toolName);
+              _setEntry(
+                toolName,
+                hasSessions:
+                    current.hasSessions ||
+                    (_currentLoadHasSessions[toolName] ?? false),
+                wasAttempted: true,
+                hasFailure: true,
+                isLoading: false,
+              );
+              _currentLoadHasSessions.remove(toolName);
               _subscriptions.remove(toolName);
             },
             onDone: () {
               if (!mounted || generation != _loadGeneration) return;
-              final needsUpdate =
-                  !_attemptedTools.contains(toolName) ||
-                  _loadingTools.contains(toolName);
-              if (needsUpdate) {
-                setState(() {
-                  _attemptedTools.add(toolName);
-                  _loadingTools.remove(toolName);
-                });
-              }
+              final current = _entryForTool(toolName);
+              _setEntry(
+                toolName,
+                hasSessions: _currentLoadHasSessions[toolName] ?? false,
+                wasAttempted: true,
+                hasFailure: current.hasFailure,
+                isLoading: false,
+              );
+              _currentLoadHasSessions.remove(toolName);
               _subscriptions.remove(toolName);
             },
             cancelOnError: true,
@@ -317,21 +361,19 @@ class _AiSessionProviderListState extends State<AiSessionProviderList> {
     }
   }
 
-  AiSessionProviderEntry _entryForTool(String toolName) =>
-      AiSessionProviderEntry(
-        toolName: toolName,
-        sessions: _sessionsByTool[toolName] ?? const <ToolSessionInfo>[],
-        wasAttempted: _attemptedTools.contains(toolName),
-        hasFailure: _failedTools.contains(toolName),
-        isLoading: _loadingTools.contains(toolName),
-      );
-
   @override
   Widget build(BuildContext context) => Column(
     mainAxisSize: MainAxisSize.min,
     children: [
       for (final toolName in _orderedTools)
-        widget.itemBuilder(context, _entryForTool(toolName)),
+        RepaintBoundary(
+          child: ValueListenableBuilder<AiSessionProviderEntry>(
+            key: ValueKey<String>('ai-session-provider-$toolName'),
+            valueListenable: _entryNotifier(toolName),
+            builder: (context, provider, _) =>
+                widget.itemBuilder(context, provider),
+          ),
+        ),
     ],
   );
 }

--- a/lib/presentation/widgets/ai_session_picker.dart
+++ b/lib/presentation/widgets/ai_session_picker.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../../domain/models/tmux_state.dart';
+import '../../domain/services/agent_session_discovery_service.dart';
 
 /// Derived UI state for a discovered-session provider row.
 class AiSessionProviderEntry {
@@ -31,25 +34,25 @@ class AiSessionProviderEntry {
   /// Whether the provider currently has at least one discovered session.
   bool get hasSessions => sessions.isNotEmpty;
 
-  /// Whether the provider tile should open a session picker.
-  bool get isSelectable => hasSessions;
+  /// Provider rows stay tappable so users can load or retry on demand.
+  bool get isSelectable => true;
 
   /// Full status text for roomy list tiles.
   String get statusLabel {
     if (hasFailure) return 'Could not load recent sessions';
-    if (isLoading) return 'Loading recent sessions…';
     if (hasSessions) {
       return '${sessions.length} session${sessions.length == 1 ? '' : 's'}';
     }
+    if (isLoading) return 'Loading recent sessions…';
     if (wasAttempted) return 'No recent sessions for this project';
-    return 'Not loaded yet';
+    return 'Tap to view recent sessions';
   }
 
   /// Compact status text for tighter provider rows.
   String get compactStatusLabel {
     if (hasFailure) return 'error';
-    if (isLoading) return 'loading';
     if (hasSessions) return '${sessions.length}';
+    if (isLoading) return 'loading';
     if (wasAttempted) return 'no recent';
     return '';
   }
@@ -95,86 +98,412 @@ IconData aiSessionToolIconData(String toolName) => switch (toolName) {
   _ => Icons.smart_toy_outlined,
 };
 
+/// Loader callback used by [AiSessionPickerDialog].
+typedef AiSessionLoader =
+    Stream<DiscoveredSessionsResult> Function(int maxSessions);
+
+/// Loader callback used by [AiSessionProviderList].
+typedef AiSessionProviderLoader =
+    Stream<DiscoveredSessionsResult> Function(String toolName, int maxSessions);
+
+/// Builder callback used by [AiSessionProviderList].
+typedef AiSessionProviderEntryBuilder =
+    Widget Function(BuildContext context, AiSessionProviderEntry provider);
+
+/// Stable provider rows that live-update as each provider finishes loading.
+class AiSessionProviderList extends StatefulWidget {
+  /// Creates a new [AiSessionProviderList].
+  const AiSessionProviderList({
+    required this.orderedTools,
+    required this.loadSessionsForTool,
+    required this.itemBuilder,
+    this.initialMaxSessions = 6,
+    super.key,
+  });
+
+  /// Ordered provider names to render.
+  final Iterable<String> orderedTools;
+
+  /// Loads recent sessions for a single provider.
+  final AiSessionProviderLoader loadSessionsForTool;
+
+  /// Builds each provider row.
+  final AiSessionProviderEntryBuilder itemBuilder;
+
+  /// Initial number of sessions to request per provider row.
+  final int initialMaxSessions;
+
+  @override
+  State<AiSessionProviderList> createState() => _AiSessionProviderListState();
+}
+
+class _AiSessionProviderListState extends State<AiSessionProviderList> {
+  final Map<String, StreamSubscription<DiscoveredSessionsResult>>
+  _subscriptions = <String, StreamSubscription<DiscoveredSessionsResult>>{};
+  final Map<String, List<ToolSessionInfo>> _sessionsByTool =
+      <String, List<ToolSessionInfo>>{};
+  final Set<String> _attemptedTools = <String>{};
+  final Set<String> _failedTools = <String>{};
+  final Set<String> _loadingTools = <String>{};
+  late List<String> _orderedTools;
+  int _loadGeneration = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _orderedTools = widget.orderedTools.toList(growable: false);
+    _startLoadingProviders();
+  }
+
+  @override
+  void didUpdateWidget(covariant AiSessionProviderList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final orderedTools = widget.orderedTools.toList(growable: false);
+    if (_sameOrderedTools(_orderedTools, orderedTools) &&
+        oldWidget.initialMaxSessions == widget.initialMaxSessions) {
+      _orderedTools = orderedTools;
+      return;
+    }
+
+    _orderedTools = orderedTools;
+    unawaited(_restartLoadingProviders());
+  }
+
+  @override
+  void dispose() {
+    unawaited(_cancelSubscriptions());
+    super.dispose();
+  }
+
+  bool _sameOrderedTools(List<String> a, List<String> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (var index = 0; index < a.length; index++) {
+      if (a[index] != b[index]) return false;
+    }
+    return true;
+  }
+
+  Future<void> _restartLoadingProviders() async {
+    await _cancelSubscriptions();
+    if (!mounted) return;
+    setState(() {
+      _sessionsByTool.clear();
+      _attemptedTools.clear();
+      _failedTools.clear();
+      _loadingTools.clear();
+    });
+    _startLoadingProviders();
+  }
+
+  Future<void> _cancelSubscriptions() async {
+    _loadGeneration++;
+    final subscriptions = _subscriptions.values.toList(growable: false);
+    _subscriptions.clear();
+    for (final subscription in subscriptions) {
+      await subscription.cancel();
+    }
+  }
+
+  void _startLoadingProviders() {
+    final generation = _loadGeneration;
+    for (final toolName in _orderedTools) {
+      _loadingTools.add(toolName);
+      _subscriptions[toolName] = widget
+          .loadSessionsForTool(toolName, widget.initialMaxSessions)
+          .listen(
+            (result) {
+              if (!mounted || generation != _loadGeneration) return;
+              final sessions = result.sessions
+                  .where((session) => session.toolName == toolName)
+                  .toList(growable: false);
+              final wasAttempted =
+                  result.attemptedTools.contains(toolName) ||
+                  result.failedTools.contains(toolName) ||
+                  sessions.isNotEmpty;
+              setState(() {
+                _sessionsByTool[toolName] = sessions;
+                if (wasAttempted) {
+                  _attemptedTools.add(toolName);
+                }
+                if (result.failedTools.contains(toolName)) {
+                  _failedTools.add(toolName);
+                } else {
+                  _failedTools.remove(toolName);
+                }
+              });
+            },
+            onError: (Object _) {
+              if (!mounted || generation != _loadGeneration) return;
+              setState(() {
+                _attemptedTools.add(toolName);
+                _failedTools.add(toolName);
+                _loadingTools.remove(toolName);
+                _sessionsByTool.putIfAbsent(
+                  toolName,
+                  () => const <ToolSessionInfo>[],
+                );
+              });
+              _subscriptions.remove(toolName);
+            },
+            onDone: () {
+              if (!mounted || generation != _loadGeneration) return;
+              setState(() {
+                _attemptedTools.add(toolName);
+                _loadingTools.remove(toolName);
+              });
+              _subscriptions.remove(toolName);
+            },
+            cancelOnError: true,
+          );
+    }
+  }
+
+  AiSessionProviderEntry _entryForTool(String toolName) =>
+      AiSessionProviderEntry(
+        toolName: toolName,
+        sessions: _sessionsByTool[toolName] ?? const <ToolSessionInfo>[],
+        wasAttempted: _attemptedTools.contains(toolName),
+        hasFailure: _failedTools.contains(toolName),
+        isLoading: _loadingTools.contains(toolName),
+      );
+
+  @override
+  Widget build(BuildContext context) => Column(
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      for (final toolName in _orderedTools)
+        widget.itemBuilder(context, _entryForTool(toolName)),
+    ],
+  );
+}
+
 /// Shows a dialog for picking one of a provider's recent sessions.
 Future<ToolSessionInfo?> showAiSessionPickerDialog({
   required BuildContext context,
   required String toolName,
-  required List<ToolSessionInfo> sessions,
+  required AiSessionLoader loadSessions,
+  int initialMaxSessions = 12,
+  int sessionFetchStep = 12,
 }) => showDialog<ToolSessionInfo>(
   context: context,
-  builder: (context) =>
-      AiSessionPickerDialog(toolName: toolName, sessions: sessions),
+  builder: (context) => AiSessionPickerDialog(
+    toolName: toolName,
+    loadSessions: loadSessions,
+    initialMaxSessions: initialMaxSessions,
+    sessionFetchStep: sessionFetchStep,
+  ),
 );
 
 /// Dialog for picking one of a provider's recent sessions.
-class AiSessionPickerDialog extends StatelessWidget {
+class AiSessionPickerDialog extends StatefulWidget {
   /// Creates a new [AiSessionPickerDialog].
   const AiSessionPickerDialog({
     required this.toolName,
-    required this.sessions,
+    required this.loadSessions,
+    this.initialMaxSessions = 12,
+    this.sessionFetchStep = 12,
     super.key,
   });
 
   /// Provider display name.
   final String toolName;
 
-  /// Candidate sessions to choose from.
-  final List<ToolSessionInfo> sessions;
+  /// Loads recent sessions for the selected provider.
+  final AiSessionLoader loadSessions;
+
+  /// Initial number of sessions to request.
+  final int initialMaxSessions;
+
+  /// Step to use when the user asks for more sessions.
+  final int sessionFetchStep;
+
+  @override
+  State<AiSessionPickerDialog> createState() => _AiSessionPickerDialogState();
+}
+
+class _AiSessionPickerDialogState extends State<AiSessionPickerDialog> {
+  StreamSubscription<DiscoveredSessionsResult>? _subscription;
+  List<ToolSessionInfo>? _sessions;
+  String? _error;
+  late int _maxSessions;
+  int _loadGeneration = 0;
+  bool _isLoading = false;
+  bool _hasFailure = false;
+  bool _canLoadMore = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _maxSessions = widget.initialMaxSessions;
+    unawaited(_loadSessions());
+  }
+
+  @override
+  void dispose() {
+    unawaited(_subscription?.cancel());
+    super.dispose();
+  }
+
+  Future<void> _loadSessions() async {
+    final loadGeneration = ++_loadGeneration;
+    await _subscription?.cancel();
+    _subscription = null;
+    if (!mounted) return;
+
+    setState(() {
+      _isLoading = true;
+      _error = null;
+      _hasFailure = false;
+      _canLoadMore = false;
+    });
+
+    _subscription = widget
+        .loadSessions(_maxSessions)
+        .listen(
+          (result) {
+            if (!mounted || loadGeneration != _loadGeneration) return;
+            setState(() {
+              _sessions = result.sessions;
+              _hasFailure = result.hasFailures;
+              _error = result.failureMessage;
+            });
+          },
+          onError: (Object _) {
+            if (!mounted || loadGeneration != _loadGeneration) return;
+            setState(() {
+              _sessions ??= const <ToolSessionInfo>[];
+              _hasFailure = true;
+              _error = 'Could not load recent AI sessions.';
+              _isLoading = false;
+              _canLoadMore = false;
+            });
+            _subscription = null;
+          },
+          onDone: () {
+            if (!mounted || loadGeneration != _loadGeneration) return;
+            final sessions = _sessions ?? const <ToolSessionInfo>[];
+            setState(() {
+              _isLoading = false;
+              _canLoadMore = !_hasFailure && sessions.length >= _maxSessions;
+            });
+            _subscription = null;
+          },
+          cancelOnError: true,
+        );
+  }
+
+  void _loadMore() {
+    if (_isLoading) return;
+    setState(() => _maxSessions += widget.sessionFetchStep);
+    unawaited(_loadSessions());
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final sessions = _sessions ?? const <ToolSessionInfo>[];
+    final hasSessions = sessions.isNotEmpty;
     final maxDialogHeight = MediaQuery.sizeOf(context).height * 0.6;
 
     return AlertDialog(
-      title: Text(toolName),
+      title: Text(widget.toolName),
       contentPadding: const EdgeInsets.fromLTRB(0, 12, 0, 0),
-      content: ConstrainedBox(
-        constraints: BoxConstraints(maxWidth: 420, maxHeight: maxDialogHeight),
-        child: SizedBox(
-          width: double.maxFinite,
-          child: sessions.isEmpty
-              ? Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 24,
-                    vertical: 12,
-                  ),
-                  child: Text(
-                    'No recent sessions found.',
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
+      content: hasSessions
+          ? SizedBox(
+              width: double.maxFinite,
+              height: maxDialogHeight,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (_error != null)
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                      child: Text(
+                        _error!,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.error,
+                        ),
+                      ),
+                    ),
+                  Expanded(
+                    child: Scrollbar(
+                      child: ListView.separated(
+                        itemCount: sessions.length,
+                        separatorBuilder: (_, _) => const Divider(height: 1),
+                        itemBuilder: (context, index) => _AiSessionPickerTile(
+                          session: sessions[index],
+                          onTap: () =>
+                              Navigator.of(context).pop(sessions[index]),
+                        ),
+                      ),
                     ),
                   ),
-                )
-              : Scrollbar(
-                  child: SingleChildScrollView(
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        for (
-                          var index = 0;
-                          index < sessions.length;
-                          index++
-                        ) ...[
-                          if (index > 0) const Divider(height: 1),
-                          _AiSessionPickerTile(
-                            session: sessions[index],
-                            onTap: () =>
-                                Navigator.of(context).pop(sessions[index]),
-                          ),
-                        ],
-                      ],
+                  if (_isLoading)
+                    const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 12),
+                      child: SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator.adaptive(
+                          strokeWidth: 2,
+                        ),
+                      ),
                     ),
-                  ),
+                ],
+              ),
+            )
+          : SizedBox(
+              width: 420,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24,
+                  vertical: 12,
                 ),
-        ),
-      ),
+                child: _buildEmptyContent(theme),
+              ),
+            ),
       actions: [
+        if (_canLoadMore)
+          TextButton(onPressed: _loadMore, child: const Text('Load more')),
+        if (!_isLoading && !hasSessions)
+          TextButton(
+            onPressed: () => unawaited(_loadSessions()),
+            child: const Text('Retry'),
+          ),
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
           child: const Text('Cancel'),
         ),
       ],
+    );
+  }
+
+  Widget _buildEmptyContent(ThemeData theme) {
+    if (_isLoading) {
+      return const Center(
+        child: SizedBox(
+          width: 20,
+          height: 20,
+          child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+        ),
+      );
+    }
+
+    if (_error != null) {
+      return Text(
+        _error!,
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      );
+    }
+
+    return Text(
+      'No recent sessions found.',
+      style: theme.textTheme.bodyMedium?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
     );
   }
 }

--- a/lib/presentation/widgets/ai_session_picker.dart
+++ b/lib/presentation/widgets/ai_session_picker.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../domain/models/tmux_state.dart';
@@ -165,6 +166,11 @@ class _AiSessionProviderListState extends State<AiSessionProviderList> {
       return;
     }
 
+    if (_sameToolSet(_orderedTools, orderedTools) &&
+        oldWidget.initialMaxSessions == widget.initialMaxSessions) {
+      return;
+    }
+
     _orderedTools = orderedTools;
     unawaited(_restartLoadingProviders());
   }
@@ -184,13 +190,25 @@ class _AiSessionProviderListState extends State<AiSessionProviderList> {
     return true;
   }
 
+  bool _sameToolSet(List<String> a, List<String> b) {
+    if (a.length != b.length) return false;
+    return a.toSet().containsAll(b);
+  }
+
   Future<void> _restartLoadingProviders() async {
     await _cancelSubscriptions();
     if (!mounted) return;
     setState(() {
-      _sessionsByTool.clear();
-      _attemptedTools.clear();
-      _failedTools.clear();
+      final orderedToolSet = _orderedTools.toSet();
+      _sessionsByTool.removeWhere(
+        (toolName, _) => !orderedToolSet.contains(toolName),
+      );
+      _attemptedTools.removeWhere(
+        (toolName) => !orderedToolSet.contains(toolName),
+      );
+      _failedTools.removeWhere(
+        (toolName) => !orderedToolSet.contains(toolName),
+      );
       _loadingTools.clear();
     });
     _startLoadingProviders();
@@ -208,7 +226,14 @@ class _AiSessionProviderListState extends State<AiSessionProviderList> {
   void _startLoadingProviders() {
     final generation = _loadGeneration;
     for (final toolName in _orderedTools) {
-      _loadingTools.add(toolName);
+      final existingSessions = _sessionsByTool[toolName];
+      final hasVisibleState =
+          (existingSessions?.isNotEmpty ?? false) ||
+          _attemptedTools.contains(toolName) ||
+          _failedTools.contains(toolName);
+      if (!hasVisibleState) {
+        _loadingTools.add(toolName);
+      }
       _subscriptions[toolName] = widget
           .loadSessionsForTool(toolName, widget.initialMaxSessions)
           .listen(
@@ -221,20 +246,50 @@ class _AiSessionProviderListState extends State<AiSessionProviderList> {
                   result.attemptedTools.contains(toolName) ||
                   result.failedTools.contains(toolName) ||
                   sessions.isNotEmpty;
+              final hadFailure = result.failedTools.contains(toolName);
+              const isLoading = false;
+              final sessionsChanged = !listEquals(
+                _sessionsByTool[toolName],
+                sessions,
+              );
+              final attemptedChanged =
+                  _attemptedTools.contains(toolName) != wasAttempted;
+              final failureChanged =
+                  _failedTools.contains(toolName) != hadFailure;
+              final loadingChanged =
+                  _loadingTools.contains(toolName) != isLoading;
+              if (!sessionsChanged &&
+                  !attemptedChanged &&
+                  !failureChanged &&
+                  !loadingChanged) {
+                return;
+              }
               setState(() {
                 _sessionsByTool[toolName] = sessions;
                 if (wasAttempted) {
                   _attemptedTools.add(toolName);
+                } else {
+                  _attemptedTools.remove(toolName);
                 }
-                if (result.failedTools.contains(toolName)) {
+                if (hadFailure) {
                   _failedTools.add(toolName);
                 } else {
                   _failedTools.remove(toolName);
                 }
+                _loadingTools.remove(toolName);
               });
             },
             onError: (Object _) {
               if (!mounted || generation != _loadGeneration) return;
+              final needsUpdate =
+                  !_attemptedTools.contains(toolName) ||
+                  !_failedTools.contains(toolName) ||
+                  _loadingTools.contains(toolName) ||
+                  !_sessionsByTool.containsKey(toolName);
+              if (!needsUpdate) {
+                _subscriptions.remove(toolName);
+                return;
+              }
               setState(() {
                 _attemptedTools.add(toolName);
                 _failedTools.add(toolName);
@@ -248,10 +303,15 @@ class _AiSessionProviderListState extends State<AiSessionProviderList> {
             },
             onDone: () {
               if (!mounted || generation != _loadGeneration) return;
-              setState(() {
-                _attemptedTools.add(toolName);
-                _loadingTools.remove(toolName);
-              });
+              final needsUpdate =
+                  !_attemptedTools.contains(toolName) ||
+                  _loadingTools.contains(toolName);
+              if (needsUpdate) {
+                setState(() {
+                  _attemptedTools.add(toolName);
+                  _loadingTools.remove(toolName);
+                });
+              }
               _subscriptions.remove(toolName);
             },
             cancelOnError: true,

--- a/lib/presentation/widgets/ai_session_picker.dart
+++ b/lib/presentation/widgets/ai_session_picker.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/models/tmux_state.dart';
+
+/// Derived UI state for a discovered-session provider row.
+class AiSessionProviderEntry {
+  /// Creates a new [AiSessionProviderEntry].
+  const AiSessionProviderEntry({
+    required this.toolName,
+    required this.sessions,
+    required this.wasAttempted,
+    required this.hasFailure,
+    required this.isLoading,
+  });
+
+  /// Provider display name.
+  final String toolName;
+
+  /// Sessions discovered for this provider.
+  final List<ToolSessionInfo> sessions;
+
+  /// Whether discovery finished for this provider in the current pass.
+  final bool wasAttempted;
+
+  /// Whether discovery failed for this provider.
+  final bool hasFailure;
+
+  /// Whether this provider is still pending during the current load.
+  final bool isLoading;
+
+  /// Whether the provider currently has at least one discovered session.
+  bool get hasSessions => sessions.isNotEmpty;
+
+  /// Whether the provider tile should open a session picker.
+  bool get isSelectable => hasSessions;
+
+  /// Full status text for roomy list tiles.
+  String get statusLabel {
+    if (hasFailure) return 'Could not load recent sessions';
+    if (isLoading) return 'Loading recent sessions…';
+    if (hasSessions) {
+      return '${sessions.length} session${sessions.length == 1 ? '' : 's'}';
+    }
+    if (wasAttempted) return 'No recent sessions for this project';
+    return 'Not loaded yet';
+  }
+
+  /// Compact status text for tighter provider rows.
+  String get compactStatusLabel {
+    if (hasFailure) return 'error';
+    if (isLoading) return 'loading';
+    if (hasSessions) return '${sessions.length}';
+    if (wasAttempted) return 'no recent';
+    return '';
+  }
+}
+
+/// Builds stable provider rows from the current discovery snapshot.
+List<AiSessionProviderEntry> buildAiSessionProviderEntries({
+  required Iterable<String> orderedTools,
+  required Map<String, List<ToolSessionInfo>> groupedSessions,
+  required bool isLoading,
+  Iterable<String> attemptedTools = const <String>[],
+  Iterable<String> failedTools = const <String>[],
+}) {
+  final attemptedToolSet = attemptedTools.toSet();
+  final failedToolSet = failedTools.toSet();
+
+  return orderedTools
+      .map(
+        (toolName) => AiSessionProviderEntry(
+          toolName: toolName,
+          sessions: groupedSessions[toolName] ?? const <ToolSessionInfo>[],
+          wasAttempted:
+              attemptedToolSet.contains(toolName) ||
+              failedToolSet.contains(toolName),
+          hasFailure: failedToolSet.contains(toolName),
+          isLoading:
+              isLoading &&
+              !attemptedToolSet.contains(toolName) &&
+              !failedToolSet.contains(toolName) &&
+              !(groupedSessions[toolName]?.isNotEmpty ?? false),
+        ),
+      )
+      .toList(growable: false);
+}
+
+/// Returns the icon used for a discovered-session provider.
+IconData aiSessionToolIconData(String toolName) => switch (toolName) {
+  'Claude Code' => Icons.auto_awesome,
+  'Codex' => Icons.code,
+  'Copilot CLI' => Icons.flight,
+  'Gemini CLI' => Icons.diamond_outlined,
+  'OpenCode' => Icons.terminal,
+  _ => Icons.smart_toy_outlined,
+};
+
+/// Shows a dialog for picking one of a provider's recent sessions.
+Future<ToolSessionInfo?> showAiSessionPickerDialog({
+  required BuildContext context,
+  required String toolName,
+  required List<ToolSessionInfo> sessions,
+}) => showDialog<ToolSessionInfo>(
+  context: context,
+  builder: (context) =>
+      AiSessionPickerDialog(toolName: toolName, sessions: sessions),
+);
+
+/// Dialog for picking one of a provider's recent sessions.
+class AiSessionPickerDialog extends StatelessWidget {
+  /// Creates a new [AiSessionPickerDialog].
+  const AiSessionPickerDialog({
+    required this.toolName,
+    required this.sessions,
+    super.key,
+  });
+
+  /// Provider display name.
+  final String toolName;
+
+  /// Candidate sessions to choose from.
+  final List<ToolSessionInfo> sessions;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final maxDialogHeight = MediaQuery.sizeOf(context).height * 0.6;
+
+    return AlertDialog(
+      title: Text(toolName),
+      contentPadding: const EdgeInsets.fromLTRB(0, 12, 0, 0),
+      content: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: 420, maxHeight: maxDialogHeight),
+        child: SizedBox(
+          width: double.maxFinite,
+          child: sessions.isEmpty
+              ? Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 24,
+                    vertical: 12,
+                  ),
+                  child: Text(
+                    'No recent sessions found.',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                )
+              : Scrollbar(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        for (
+                          var index = 0;
+                          index < sessions.length;
+                          index++
+                        ) ...[
+                          if (index > 0) const Divider(height: 1),
+                          _AiSessionPickerTile(
+                            session: sessions[index],
+                            onTap: () =>
+                                Navigator.of(context).pop(sessions[index]),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+}
+
+class _AiSessionPickerTile extends StatelessWidget {
+  const _AiSessionPickerTile({required this.session, required this.onTap});
+
+  final ToolSessionInfo session;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return ListTile(
+      dense: true,
+      visualDensity: VisualDensity.compact,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+      horizontalTitleGap: 12,
+      minLeadingWidth: 20,
+      leading: Icon(
+        aiSessionToolIconData(session.toolName),
+        size: 20,
+        color: theme.colorScheme.primary,
+      ),
+      title: Text(
+        session.summary ?? session.sessionId,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        session.lastUpdatedLabel.isNotEmpty
+            ? session.lastUpdatedLabel
+            : session.toolName,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/presentation/widgets/ai_session_picker.dart
+++ b/lib/presentation/widgets/ai_session_picker.dart
@@ -41,9 +41,7 @@ class AiSessionProviderEntry {
   /// Full status text for roomy list tiles.
   String get statusLabel {
     if (hasFailure) return 'Could not load recent sessions';
-    if (hasSessions) {
-      return '${sessions.length} session${sessions.length == 1 ? '' : 's'}';
-    }
+    if (hasSessions) return 'Recent sessions available';
     if (isLoading) return 'Loading recent sessions…';
     if (wasAttempted) return 'No recent sessions for this project';
     return 'Tap to view recent sessions';
@@ -52,7 +50,7 @@ class AiSessionProviderEntry {
   /// Compact status text for tighter provider rows.
   String get compactStatusLabel {
     if (hasFailure) return 'error';
-    if (hasSessions) return '${sessions.length}';
+    if (hasSessions) return 'ready';
     if (isLoading) return 'loading';
     if (wasAttempted) return 'no recent';
     return '';
@@ -383,6 +381,9 @@ class AiSessionPickerDialog extends StatefulWidget {
 }
 
 class _AiSessionPickerDialogState extends State<AiSessionPickerDialog> {
+  static const _loadMoreScrollThreshold = 240.0;
+
+  final ScrollController _scrollController = ScrollController();
   StreamSubscription<DiscoveredSessionsResult>? _subscription;
   List<ToolSessionInfo>? _sessions;
   String? _error;
@@ -396,11 +397,13 @@ class _AiSessionPickerDialogState extends State<AiSessionPickerDialog> {
   void initState() {
     super.initState();
     _maxSessions = widget.initialMaxSessions;
+    _scrollController.addListener(_maybeLoadMoreForScrollPosition);
     unawaited(_loadSessions());
   }
 
   @override
   void dispose() {
+    _scrollController.dispose();
     unawaited(_subscription?.cancel());
     super.dispose();
   }
@@ -459,6 +462,13 @@ class _AiSessionPickerDialogState extends State<AiSessionPickerDialog> {
     unawaited(_loadSessions());
   }
 
+  void _maybeLoadMoreForScrollPosition() {
+    if (_isLoading || !_canLoadMore || !_scrollController.hasClients) return;
+    if (_scrollController.position.extentAfter <= _loadMoreScrollThreshold) {
+      _loadMore();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -489,6 +499,7 @@ class _AiSessionPickerDialogState extends State<AiSessionPickerDialog> {
                   Expanded(
                     child: Scrollbar(
                       child: ListView.separated(
+                        controller: _scrollController,
                         itemCount: sessions.length,
                         separatorBuilder: (_, _) => const Divider(height: 1),
                         itemBuilder: (context, index) => _AiSessionPickerTile(
@@ -524,8 +535,6 @@ class _AiSessionPickerDialogState extends State<AiSessionPickerDialog> {
               ),
             ),
       actions: [
-        if (_canLoadMore)
-          TextButton(onPressed: _loadMore, child: const Text('Load more')),
         if (!_isLoading && !hasSessions)
           TextButton(
             onPressed: () => unawaited(_loadSessions()),

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -194,10 +194,14 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     try {
       // Get working directory from the active window if available.
       final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
+      final scopeWorkingDirectory = resolveAgentSessionScopeWorkingDirectory(
+        activeWorkingDirectory: activeWindow?.currentPath,
+        sessionWorkingDirectory: widget.session.workingDirectory,
+      );
       _sessionDiscoverySubscription = _discovery
           .discoverSessionsStream(
             widget.session,
-            workingDirectory: activeWindow?.currentPath,
+            workingDirectory: scopeWorkingDirectory,
             maxPerTool: _maxSessionsPerTool,
           )
           .listen(
@@ -497,7 +501,8 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
           },
         ),
         if (_showRecentSessions) ...[
-          if (_isLoadingSessions)
+          if (_isLoadingSessions &&
+              (_recentSessions == null || _recentSessions!.isEmpty))
             const Padding(
               padding: EdgeInsets.all(16),
               child: Center(
@@ -547,6 +552,17 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
             ...groupedSessions.entries.map(
               (entry) => _buildSessionGroup(theme, entry.key, entry.value),
             ),
+            if (_isLoadingSessions)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: Center(
+                  child: SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                  ),
+                ),
+              ),
           ],
         ],
       ],

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -30,6 +30,7 @@ Future<TmuxNavigatorAction?> showTmuxNavigator({
   required SshSession session,
   required String tmuxSessionName,
   required bool isProUser,
+  String? scopeWorkingDirectory,
 }) => showModalBottomSheet<TmuxNavigatorAction>(
   context: context,
   isScrollControlled: true,
@@ -38,6 +39,7 @@ Future<TmuxNavigatorAction?> showTmuxNavigator({
     tmuxSessionName: tmuxSessionName,
     isProUser: isProUser,
     ref: ref,
+    scopeWorkingDirectory: scopeWorkingDirectory,
   ),
 );
 
@@ -95,12 +97,14 @@ class _TmuxNavigatorSheet extends StatefulWidget {
     required this.tmuxSessionName,
     required this.isProUser,
     required this.ref,
+    this.scopeWorkingDirectory,
   });
 
   final SshSession session;
   final String tmuxSessionName;
   final bool isProUser;
   final WidgetRef ref;
+  final String? scopeWorkingDirectory;
 
   @override
   State<_TmuxNavigatorSheet> createState() => _TmuxNavigatorSheetState();
@@ -195,10 +199,12 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     try {
       // Get working directory from the active window if available.
       final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
-      final scopeWorkingDirectory = resolveAgentSessionScopeWorkingDirectory(
-        activeWorkingDirectory: activeWindow?.currentPath,
-        sessionWorkingDirectory: widget.session.workingDirectory,
-      );
+      final scopeWorkingDirectory =
+          widget.scopeWorkingDirectory ??
+          resolveAgentSessionScopeWorkingDirectory(
+            activeWorkingDirectory: activeWindow?.currentPath,
+            sessionWorkingDirectory: widget.session.workingDirectory,
+          );
       _sessionDiscoverySubscription = _discovery
           .discoverSessionsStream(
             widget.session,
@@ -553,7 +559,10 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
                   ),
                 ),
               ),
-            ..._orderedSessionTools(groupedSessions).map(
+            ...orderedDiscoveredSessionTools(
+              groupedSessions,
+              _attemptedSessionTools,
+            ).map(
               (toolName) => _buildSessionGroup(
                 theme,
                 toolName,
@@ -575,23 +584,6 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         ],
       ],
     );
-  }
-
-  /// Returns the ordered set of tool names to render: tools with sessions
-  /// first (in their natural grouping order), followed by attempted tools
-  /// that returned no sessions, sorted alphabetically. This makes it visible
-  /// when a provider was queried but produced no matches.
-  List<String> _orderedSessionTools(
-    Map<String, List<ToolSessionInfo>> grouped,
-  ) {
-    final ordered = <String>[...grouped.keys];
-    final emptyAttempts =
-        _attemptedSessionTools
-            .where((tool) => !grouped.containsKey(tool))
-            .toList()
-          ..sort();
-    ordered.addAll(emptyAttempts);
-    return ordered;
   }
 
   Map<String, List<ToolSessionInfo>> _groupSessions(

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -112,6 +112,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
+  Set<String> _attemptedSessionTools = const <String>{};
   Future<Set<AgentLaunchTool>>? _installedToolsFuture;
   final Set<String> _expandedSessionTools = <String>{};
   StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
@@ -209,6 +210,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
               if (!mounted || loadGeneration != _sessionLoadGeneration) return;
               setState(() {
                 _recentSessions = result.sessions;
+                _attemptedSessionTools = result.attemptedTools;
                 _sessionLoadError = result.failureMessage;
               });
             },
@@ -525,7 +527,9 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
                 ),
               ),
             )
-          else if (_recentSessions != null && _recentSessions!.isEmpty)
+          else if (_recentSessions != null &&
+              _recentSessions!.isEmpty &&
+              _attemptedSessionTools.isEmpty)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
               child: Text(
@@ -549,8 +553,12 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
                   ),
                 ),
               ),
-            ...groupedSessions.entries.map(
-              (entry) => _buildSessionGroup(theme, entry.key, entry.value),
+            ..._orderedSessionTools(groupedSessions).map(
+              (toolName) => _buildSessionGroup(
+                theme,
+                toolName,
+                groupedSessions[toolName] ?? const <ToolSessionInfo>[],
+              ),
             ),
             if (_isLoadingSessions)
               const Padding(
@@ -567,6 +575,23 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         ],
       ],
     );
+  }
+
+  /// Returns the ordered set of tool names to render: tools with sessions
+  /// first (in their natural grouping order), followed by attempted tools
+  /// that returned no sessions, sorted alphabetically. This makes it visible
+  /// when a provider was queried but produced no matches.
+  List<String> _orderedSessionTools(
+    Map<String, List<ToolSessionInfo>> grouped,
+  ) {
+    final ordered = <String>[...grouped.keys];
+    final emptyAttempts =
+        _attemptedSessionTools
+            .where((tool) => !grouped.containsKey(tool))
+            .toList()
+          ..sort();
+    ordered.addAll(emptyAttempts);
+    return ordered;
   }
 
   Map<String, List<ToolSessionInfo>> _groupSessions(
@@ -587,6 +612,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     String toolName,
     List<ToolSessionInfo> sessions,
   ) {
+    final isEmpty = sessions.isEmpty;
     final isExpanded = _expandedSessionTools.contains(toolName);
 
     return Column(
@@ -600,28 +626,41 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
           horizontalTitleGap: 12,
           minLeadingWidth: 20,
           leading: _toolIcon(toolName, theme),
-          title: Text(toolName),
+          title: Text(
+            toolName,
+            style: isEmpty
+                ? theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  )
+                : null,
+          ),
           subtitle: Text(
-            '${sessions.length} session${sessions.length == 1 ? '' : 's'}',
+            isEmpty
+                ? 'No recent sessions for this project'
+                : '${sessions.length} session${sessions.length == 1 ? '' : 's'}',
             style: theme.textTheme.bodySmall?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
           ),
-          trailing: Icon(
-            isExpanded ? Icons.expand_less : Icons.expand_more,
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-          onTap: () {
-            setState(() {
-              if (isExpanded) {
-                _expandedSessionTools.remove(toolName);
-              } else {
-                _expandedSessionTools.add(toolName);
-              }
-            });
-          },
+          trailing: isEmpty
+              ? null
+              : Icon(
+                  isExpanded ? Icons.expand_less : Icons.expand_more,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+          onTap: isEmpty
+              ? null
+              : () {
+                  setState(() {
+                    if (isExpanded) {
+                      _expandedSessionTools.remove(toolName);
+                    } else {
+                      _expandedSessionTools.add(toolName);
+                    }
+                  });
+                },
         ),
-        if (isExpanded)
+        if (isExpanded && !isEmpty)
           ...sessions.map(
             (session) => _buildSessionTile(
               session,

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -145,8 +145,8 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
   @override
   void dispose() {
-    _sessionDiscoverySubscription?.cancel();
-    _windowChangeSubscription?.cancel();
+    unawaited(_sessionDiscoverySubscription?.cancel());
+    unawaited(_windowChangeSubscription?.cancel());
     super.dispose();
   }
 

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -114,12 +114,14 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   List<ToolSessionInfo>? _recentSessions;
   Future<Set<AgentLaunchTool>>? _installedToolsFuture;
   final Set<String> _expandedSessionTools = <String>{};
+  StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
   StreamSubscription<void>? _windowChangeSubscription;
   bool _isLoadingWindows = true;
   bool _isLoadingSessions = false;
   bool _showRecentSessions = false;
   String? _sessionLoadError;
   String? _error;
+  int _sessionLoadGeneration = 0;
   bool _loadingWindows = false;
   bool _pendingWindowReload = false;
 
@@ -143,6 +145,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
   @override
   void dispose() {
+    _sessionDiscoverySubscription?.cancel();
     _windowChangeSubscription?.cancel();
     super.dispose();
   }
@@ -180,6 +183,9 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
   Future<void> _loadRecentSessions() async {
     if (_isLoadingSessions || _recentSessions != null) return;
+    final loadGeneration = ++_sessionLoadGeneration;
+    await _sessionDiscoverySubscription?.cancel();
+    _sessionDiscoverySubscription = null;
     setState(() {
       _isLoadingSessions = true;
       _sessionLoadError = null;
@@ -188,27 +194,50 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     try {
       // Get working directory from the active window if available.
       final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
-      final result = await _discovery.discoverSessions(
-        widget.session,
-        workingDirectory: activeWindow?.currentPath,
-        maxPerTool: _maxSessionsPerTool,
-      );
-      if (!mounted) return;
-      setState(() {
-        _recentSessions = result.sessions;
-        _sessionLoadError = result.failureMessage;
-        if (_expandedSessionTools.isEmpty && result.sessions.isNotEmpty) {
-          _expandedSessionTools.add(result.sessions.first.toolName);
-        }
-        _isLoadingSessions = false;
-      });
+      _sessionDiscoverySubscription = _discovery
+          .discoverSessionsStream(
+            widget.session,
+            workingDirectory: activeWindow?.currentPath,
+            maxPerTool: _maxSessionsPerTool,
+          )
+          .listen(
+            (result) {
+              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
+              setState(() {
+                _recentSessions = result.sessions;
+                _sessionLoadError = result.failureMessage;
+                if (_expandedSessionTools.isEmpty &&
+                    result.sessions.isNotEmpty) {
+                  _expandedSessionTools.add(result.sessions.first.toolName);
+                }
+              });
+            },
+            onError: (Object _) {
+              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
+              setState(() {
+                _recentSessions ??= const [];
+                _sessionLoadError = 'Could not load recent AI sessions.';
+                _isLoadingSessions = false;
+              });
+              _sessionDiscoverySubscription = null;
+            },
+            onDone: () {
+              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
+              setState(() {
+                _isLoadingSessions = false;
+              });
+              _sessionDiscoverySubscription = null;
+            },
+            cancelOnError: true,
+          );
     } on Exception {
-      if (!mounted) return;
+      if (!mounted || loadGeneration != _sessionLoadGeneration) return;
       setState(() {
-        _recentSessions = const [];
+        _recentSessions ??= const [];
         _sessionLoadError = 'Could not load recent AI sessions.';
         _isLoadingSessions = false;
       });
+      _sessionDiscoverySubscription = null;
     }
   }
 

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -11,12 +11,12 @@ import '../../domain/services/agent_session_discovery_service.dart';
 import '../../domain/services/ssh_service.dart';
 import '../../domain/services/tmux_service.dart';
 import '../widgets/premium_badge.dart';
+import 'ai_session_picker.dart';
 import 'tmux_window_status_badge.dart';
 
 const _tmuxNavigatorDenseVisualDensity = VisualDensity(vertical: -2);
 const _tmuxNavigatorTilePadding = EdgeInsets.symmetric(horizontal: 16);
 const _tmuxNavigatorGroupTilePadding = EdgeInsets.only(left: 16, right: 16);
-const _tmuxNavigatorSessionTilePadding = EdgeInsets.only(left: 56, right: 12);
 const _tmuxNavigatorMaxHeightFactor = 0.48;
 const _tmuxNavigatorMaxHeightCap = 440.0;
 const _tmuxToolPickerMaxHeightFactor = 0.36;
@@ -139,9 +139,9 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
   Set<String> _attemptedSessionTools = const <String>{};
+  Set<String> _failedSessionTools = const <String>{};
   AgentLaunchTool? _preferredLaunchTool;
   Future<Set<AgentLaunchTool>>? _installedToolsFuture;
-  final Set<String> _expandedSessionTools = <String>{};
   StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
   StreamSubscription<void>? _windowChangeSubscription;
   bool _isLoadingWindows = true;
@@ -238,6 +238,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     setState(() {
       _isLoadingSessions = true;
       _sessionLoadError = null;
+      _failedSessionTools = const <String>{};
     });
 
     try {
@@ -261,6 +262,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
               setState(() {
                 _recentSessions = result.sessions;
                 _attemptedSessionTools = result.attemptedTools;
+                _failedSessionTools = result.failedTools;
                 _sessionLoadError = result.failureMessage;
               });
             },
@@ -268,6 +270,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
               if (!mounted || loadGeneration != _sessionLoadGeneration) return;
               setState(() {
                 _recentSessions ??= const [];
+                _failedSessionTools = const <String>{};
                 _sessionLoadError = 'Could not load recent AI sessions.';
                 _isLoadingSessions = false;
               });
@@ -286,6 +289,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       if (!mounted || loadGeneration != _sessionLoadGeneration) return;
       setState(() {
         _recentSessions ??= const [];
+        _failedSessionTools = const <String>{};
         _sessionLoadError = 'Could not load recent AI sessions.';
         _isLoadingSessions = false;
       });
@@ -314,6 +318,19 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       context,
       TmuxResumeSessionAction(command, workingDirectory: info.workingDirectory),
     );
+  }
+
+  Future<void> _showSessionPickerForTool(
+    AiSessionProviderEntry provider,
+  ) async {
+    if (!provider.isSelectable) return;
+    final selected = await showAiSessionPickerDialog(
+      context: context,
+      toolName: provider.toolName,
+      sessions: provider.sessions,
+    );
+    if (!mounted || selected == null) return;
+    _resumeSession(selected);
   }
 
   void _showNewWindowPicker() {
@@ -513,7 +530,6 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
   Widget _buildRecentSessionsSection(ThemeData theme) {
     final visibleCount = _recentSessions?.length ?? 0;
-    final groupedSessions = _groupSessions(_recentSessions);
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -554,43 +570,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
           },
         ),
         if (_showRecentSessions) ...[
-          if (_isLoadingSessions &&
-              (_recentSessions == null || _recentSessions!.isEmpty))
-            const Padding(
-              padding: EdgeInsets.all(16),
-              child: Center(
-                child: SizedBox(
-                  width: 20,
-                  height: 20,
-                  child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-                ),
-              ),
-            )
-          else if (_sessionLoadError != null &&
-              _recentSessions != null &&
-              _recentSessions!.isEmpty)
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Text(
-                _sessionLoadError!,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.error,
-                ),
-              ),
-            )
-          else if (_recentSessions != null &&
-              _recentSessions!.isEmpty &&
-              _attemptedSessionTools.isEmpty)
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Text(
-                'No recent AI sessions found on this host.',
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-              ),
-            )
-          else if (_recentSessions != null) ...[
+          if (_hasVisibleSessionProviders) ...[
             if (_sessionLoadError != null)
               Padding(
                 padding: const EdgeInsets.symmetric(
@@ -604,32 +584,53 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
                   ),
                 ),
               ),
-            ...orderedDiscoveredSessionTools(
-              groupedSessions,
-              _attemptedSessionTools,
-              preferredToolName:
-                  _preferredLaunchTool?.discoveredSessionToolName,
-            ).map(
-              (toolName) => _buildSessionGroup(
-                theme,
-                toolName,
-                groupedSessions[toolName] ?? const <ToolSessionInfo>[],
-              ),
+            ..._buildSessionProviderEntries().map(
+              (provider) => _buildSessionProviderTile(theme, provider),
             ),
-            if (_isLoadingSessions)
-              const Padding(
-                padding: EdgeInsets.symmetric(vertical: 8),
-                child: Center(
-                  child: SizedBox(
-                    width: 16,
-                    height: 16,
-                    child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-                  ),
+          ] else if (_sessionLoadError != null && _recentSessions != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Text(
+                _sessionLoadError!,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
                 ),
               ),
-          ],
+            )
+          else if (_recentSessions != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Text(
+                'No recent AI sessions found on this host.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
         ],
       ],
+    );
+  }
+
+  bool get _hasVisibleSessionProviders =>
+      _isLoadingSessions ||
+      _attemptedSessionTools.isNotEmpty ||
+      _failedSessionTools.isNotEmpty ||
+      (_recentSessions?.isNotEmpty ?? false);
+
+  List<AiSessionProviderEntry> _buildSessionProviderEntries() {
+    final groupedSessions = _groupSessions(_recentSessions);
+    final orderedTools = orderedDiscoveredSessionTools(
+      groupedSessions,
+      <String>{..._attemptedSessionTools, ..._failedSessionTools},
+      preferredToolName: _preferredLaunchTool?.discoveredSessionToolName,
+    );
+    return buildAiSessionProviderEntries(
+      orderedTools: orderedTools,
+      groupedSessions: groupedSessions,
+      attemptedTools: _attemptedSessionTools,
+      failedTools: _failedSessionTools,
+      isLoading: _isLoadingSessions,
     );
   }
 
@@ -646,121 +647,54 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     return grouped;
   }
 
-  Widget _buildSessionGroup(
+  Widget _buildSessionProviderTile(
     ThemeData theme,
-    String toolName,
-    List<ToolSessionInfo> sessions,
-  ) {
-    final isEmpty = sessions.isEmpty;
-    final isExpanded = _expandedSessionTools.contains(toolName);
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        ListTile(
-          dense: true,
-          visualDensity: _tmuxNavigatorDenseVisualDensity,
-          minVerticalPadding: 2,
-          contentPadding: _tmuxNavigatorGroupTilePadding,
-          horizontalTitleGap: 12,
-          minLeadingWidth: 20,
-          leading: _toolIcon(toolName, theme),
-          title: Text(
-            toolName,
-            style: isEmpty
-                ? theme.textTheme.bodyMedium?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                  )
-                : null,
-          ),
-          subtitle: Text(
-            isEmpty
-                ? 'No recent sessions for this project'
-                : '${sessions.length} session${sessions.length == 1 ? '' : 's'}',
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          ),
-          trailing: isEmpty
-              ? null
-              : Icon(
-                  isExpanded ? Icons.expand_less : Icons.expand_more,
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-          onTap: isEmpty
-              ? null
-              : () {
-                  setState(() {
-                    if (isExpanded) {
-                      _expandedSessionTools.remove(toolName);
-                    } else {
-                      _expandedSessionTools.add(toolName);
-                    }
-                  });
-                },
-        ),
-        if (isExpanded && !isEmpty)
-          ...sessions.map(
-            (session) => _buildSessionTile(
-              session,
-              contentPadding: _tmuxNavigatorSessionTilePadding,
-            ),
-          ),
-      ],
-    );
-  }
-
-  Widget _buildSessionTile(
-    ToolSessionInfo info, {
-    EdgeInsetsGeometry? contentPadding,
-  }) {
-    final theme = Theme.of(context);
-
-    return ListTile(
-      dense: true,
-      visualDensity: _tmuxNavigatorDenseVisualDensity,
-      minVerticalPadding: 2,
-      contentPadding: contentPadding,
-      leading: _toolIcon(info.toolName, theme),
-      horizontalTitleGap: 12,
-      minLeadingWidth: 20,
-      title: Text(
-        info.summary ?? info.sessionId,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
+    AiSessionProviderEntry provider,
+  ) => ListTile(
+    dense: true,
+    visualDensity: _tmuxNavigatorDenseVisualDensity,
+    minVerticalPadding: 2,
+    contentPadding: _tmuxNavigatorGroupTilePadding,
+    horizontalTitleGap: 12,
+    minLeadingWidth: 20,
+    leading: _toolIcon(provider.toolName, theme),
+    title: Text(
+      provider.toolName,
+      style: theme.textTheme.bodyMedium?.copyWith(
+        color: provider.hasFailure
+            ? theme.colorScheme.error
+            : provider.isSelectable
+            ? theme.colorScheme.onSurface
+            : theme.colorScheme.onSurfaceVariant,
       ),
-      subtitle: Text(
-        info.lastUpdatedLabel.isNotEmpty
-            ? info.lastUpdatedLabel
-            : info.toolName,
-        style: theme.textTheme.bodySmall?.copyWith(
-          color: theme.colorScheme.onSurfaceVariant,
-        ),
+    ),
+    subtitle: Text(
+      provider.statusLabel,
+      style: theme.textTheme.bodySmall?.copyWith(
+        color: provider.hasFailure
+            ? theme.colorScheme.error
+            : theme.colorScheme.onSurfaceVariant,
       ),
-      trailing: TextButton(
-        onPressed: () => _resumeSession(info),
-        style: TextButton.styleFrom(
-          visualDensity: VisualDensity.compact,
-          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-          padding: const EdgeInsets.symmetric(horizontal: 8),
-        ),
-        child: const Text('Resume'),
-      ),
-    );
-  }
+    ),
+    trailing: provider.isLoading
+        ? const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+          )
+        : provider.isSelectable
+        ? Icon(Icons.chevron_right, color: theme.colorScheme.onSurfaceVariant)
+        : null,
+    onTap: provider.isSelectable
+        ? () => unawaited(_showSessionPickerForTool(provider))
+        : null,
+  );
 
-  Widget _toolIcon(String toolName, ThemeData theme) {
-    final iconData = switch (toolName) {
-      'Claude Code' => Icons.auto_awesome,
-      'Codex' => Icons.code,
-      'Copilot CLI' => Icons.flight,
-      'Gemini CLI' => Icons.diamond_outlined,
-      'OpenCode' => Icons.terminal,
-      _ => Icons.smart_toy_outlined,
-    };
-
-    return Icon(iconData, size: 20, color: theme.colorScheme.primary);
-  }
+  Widget _toolIcon(String toolName, ThemeData theme) => Icon(
+    aiSessionToolIconData(toolName),
+    size: 20,
+    color: theme.colorScheme.primary,
+  );
 }
 
 /// Bottom sheet for picking an AI coding tool to launch in a new tmux window.

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -206,10 +206,6 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
               setState(() {
                 _recentSessions = result.sessions;
                 _sessionLoadError = result.failureMessage;
-                if (_expandedSessionTools.isEmpty &&
-                    result.sessions.isNotEmpty) {
-                  _expandedSessionTools.add(result.sessions.first.toolName);
-                }
               });
             },
             onError: (Object _) {

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -135,21 +135,15 @@ class _TmuxNavigatorSheet extends StatefulWidget {
 class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   /// Maximum number of recent sessions to show per tool.
   static const _maxSessionsPerTool = 16;
+  static const _prefetchSessionFetchLimit = 6;
 
   List<TmuxWindow>? _windows;
-  List<ToolSessionInfo>? _recentSessions;
-  Set<String> _attemptedSessionTools = const <String>{};
-  Set<String> _failedSessionTools = const <String>{};
   AgentLaunchTool? _preferredLaunchTool;
   Future<Set<AgentLaunchTool>>? _installedToolsFuture;
-  StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
   StreamSubscription<void>? _windowChangeSubscription;
   bool _isLoadingWindows = true;
-  bool _isLoadingSessions = false;
   bool _showRecentSessions = false;
-  String? _sessionLoadError;
   String? _error;
-  int _sessionLoadGeneration = 0;
   bool _loadingWindows = false;
   bool _pendingWindowReload = false;
 
@@ -182,7 +176,6 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
   @override
   void dispose() {
-    unawaited(_sessionDiscoverySubscription?.cancel());
     unawaited(_windowChangeSubscription?.cancel());
     super.dispose();
   }
@@ -197,6 +190,30 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     final preferredLaunchTool = preset?.tool;
     if (_preferredLaunchTool == preferredLaunchTool) return;
     setState(() => _preferredLaunchTool = preferredLaunchTool);
+    unawaited(_prefetchPreferredSessionProvider());
+  }
+
+  Future<void> _prefetchPreferredSessionProvider({
+    List<TmuxWindow>? windows,
+    int maxPerTool = _prefetchSessionFetchLimit,
+  }) async {
+    final toolName = _preferredLaunchTool?.discoveredSessionToolName;
+    if (toolName == null || toolName.isEmpty) return;
+    final activeWindow = (windows ?? _windows)
+        ?.where((window) => window.isActive)
+        .firstOrNull;
+    final scopeWorkingDirectory =
+        widget.scopeWorkingDirectory ??
+        resolveAgentSessionScopeWorkingDirectory(
+          activeWorkingDirectory: activeWindow?.currentPath,
+          sessionWorkingDirectory: widget.session.workingDirectory,
+        );
+    await _discovery.prefetchSessions(
+      widget.session,
+      workingDirectory: scopeWorkingDirectory,
+      maxPerTool: maxPerTool,
+      toolName: toolName,
+    );
   }
 
   Future<void> _loadWindows() async {
@@ -215,6 +232,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         _windows = windows;
         _isLoadingWindows = false;
       });
+      unawaited(_prefetchPreferredSessionProvider(windows: windows));
     } on Exception catch (e) {
       if (!mounted) return;
       setState(() {
@@ -227,73 +245,6 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         _pendingWindowReload = false;
         unawaited(_loadWindows());
       }
-    }
-  }
-
-  Future<void> _loadRecentSessions() async {
-    if (_isLoadingSessions || _recentSessions != null) return;
-    final loadGeneration = ++_sessionLoadGeneration;
-    await _sessionDiscoverySubscription?.cancel();
-    _sessionDiscoverySubscription = null;
-    setState(() {
-      _isLoadingSessions = true;
-      _sessionLoadError = null;
-      _failedSessionTools = const <String>{};
-    });
-
-    try {
-      // Get working directory from the active window if available.
-      final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
-      final scopeWorkingDirectory =
-          widget.scopeWorkingDirectory ??
-          resolveAgentSessionScopeWorkingDirectory(
-            activeWorkingDirectory: activeWindow?.currentPath,
-            sessionWorkingDirectory: widget.session.workingDirectory,
-          );
-      _sessionDiscoverySubscription = _discovery
-          .discoverSessionsStream(
-            widget.session,
-            workingDirectory: scopeWorkingDirectory,
-            maxPerTool: _maxSessionsPerTool,
-          )
-          .listen(
-            (result) {
-              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
-              setState(() {
-                _recentSessions = result.sessions;
-                _attemptedSessionTools = result.attemptedTools;
-                _failedSessionTools = result.failedTools;
-                _sessionLoadError = result.failureMessage;
-              });
-            },
-            onError: (Object _) {
-              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
-              setState(() {
-                _recentSessions ??= const [];
-                _failedSessionTools = const <String>{};
-                _sessionLoadError = 'Could not load recent AI sessions.';
-                _isLoadingSessions = false;
-              });
-              _sessionDiscoverySubscription = null;
-            },
-            onDone: () {
-              if (!mounted || loadGeneration != _sessionLoadGeneration) return;
-              setState(() {
-                _isLoadingSessions = false;
-              });
-              _sessionDiscoverySubscription = null;
-            },
-            cancelOnError: true,
-          );
-    } on Exception {
-      if (!mounted || loadGeneration != _sessionLoadGeneration) return;
-      setState(() {
-        _recentSessions ??= const [];
-        _failedSessionTools = const <String>{};
-        _sessionLoadError = 'Could not load recent AI sessions.';
-        _isLoadingSessions = false;
-      });
-      _sessionDiscoverySubscription = null;
     }
   }
 
@@ -323,11 +274,26 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   Future<void> _showSessionPickerForTool(
     AiSessionProviderEntry provider,
   ) async {
-    if (!provider.isSelectable) return;
     final selected = await showAiSessionPickerDialog(
       context: context,
       toolName: provider.toolName,
-      sessions: provider.sessions,
+      initialMaxSessions: _maxSessionsPerTool,
+      sessionFetchStep: _maxSessionsPerTool,
+      loadSessions: (maxSessions) {
+        final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
+        final scopeWorkingDirectory =
+            widget.scopeWorkingDirectory ??
+            resolveAgentSessionScopeWorkingDirectory(
+              activeWorkingDirectory: activeWindow?.currentPath,
+              sessionWorkingDirectory: widget.session.workingDirectory,
+            );
+        return _discovery.discoverSessionsStream(
+          widget.session,
+          workingDirectory: scopeWorkingDirectory,
+          maxPerTool: maxSessions,
+          toolName: provider.toolName,
+        );
+      },
     );
     if (!mounted || selected == null) return;
     _resumeSession(selected);
@@ -528,124 +494,71 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     );
   }
 
-  Widget _buildRecentSessionsSection(ThemeData theme) {
-    final visibleCount = _recentSessions?.length ?? 0;
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        ListTile(
-          dense: true,
-          visualDensity: _tmuxNavigatorDenseVisualDensity,
-          minTileHeight: 42,
-          contentPadding: _tmuxNavigatorTilePadding,
-          horizontalTitleGap: 12,
-          minLeadingWidth: 18,
-          leading: Icon(
-            _showRecentSessions ? Icons.expand_less : Icons.expand_more,
-            size: 18,
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-          title: Row(
-            children: [
-              const Text('Recent AI Sessions'),
-              if (visibleCount > 0) ...[
-                const SizedBox(width: 6),
-                Text(
-                  '($visibleCount)',
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                ),
-              ],
-              const Spacer(),
-              const PremiumBadge(),
-            ],
-          ),
-          onTap: () {
-            setState(() => _showRecentSessions = !_showRecentSessions);
-            if (_showRecentSessions) {
-              _loadRecentSessions();
-            }
-          },
+  Widget _buildRecentSessionsSection(ThemeData theme) => Column(
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      ListTile(
+        dense: true,
+        visualDensity: _tmuxNavigatorDenseVisualDensity,
+        minTileHeight: 42,
+        contentPadding: _tmuxNavigatorTilePadding,
+        horizontalTitleGap: 12,
+        minLeadingWidth: 18,
+        leading: Icon(
+          _showRecentSessions ? Icons.expand_less : Icons.expand_more,
+          size: 18,
+          color: theme.colorScheme.onSurfaceVariant,
         ),
-        if (_showRecentSessions) ...[
-          if (_hasVisibleSessionProviders) ...[
-            if (_sessionLoadError != null)
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 8,
-                ),
-                child: Text(
-                  _sessionLoadError!,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.error,
-                  ),
-                ),
-              ),
-            ..._buildSessionProviderEntries().map(
-              (provider) => _buildSessionProviderTile(theme, provider),
-            ),
-          ] else if (_sessionLoadError != null && _recentSessions != null)
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Text(
-                _sessionLoadError!,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.error,
-                ),
-              ),
-            )
-          else if (_recentSessions != null)
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Text(
-                'No recent AI sessions found on this host.',
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-              ),
-            ),
-        ],
+        title: const Row(
+          children: [Text('Recent AI Sessions'), Spacer(), PremiumBadge()],
+        ),
+        onTap: () {
+          setState(() => _showRecentSessions = !_showRecentSessions);
+          if (_showRecentSessions) {
+            unawaited(_prefetchPreferredSessionProvider());
+          }
+        },
+      ),
+      if (_showRecentSessions) ...[
+        AiSessionProviderList(
+          key: ValueKey<Object>(
+            Object.hashAll(<Object?>[
+              widget.session.connectionId,
+              widget.tmuxSessionName,
+              widget.scopeWorkingDirectory,
+              _windows
+                  ?.where((window) => window.isActive)
+                  .firstOrNull
+                  ?.currentPath,
+              _preferredLaunchTool?.discoveredSessionToolName,
+            ]),
+          ),
+          orderedTools: orderedDiscoveredSessionTools(
+            const <String, List<ToolSessionInfo>>{},
+            const <String>{},
+            preferredToolName: _preferredLaunchTool?.discoveredSessionToolName,
+          ),
+          loadSessionsForTool: (toolName, maxSessions) {
+            final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
+            final scopeWorkingDirectory =
+                widget.scopeWorkingDirectory ??
+                resolveAgentSessionScopeWorkingDirectory(
+                  activeWorkingDirectory: activeWindow?.currentPath,
+                  sessionWorkingDirectory: widget.session.workingDirectory,
+                );
+            return _discovery.discoverSessionsStream(
+              widget.session,
+              workingDirectory: scopeWorkingDirectory,
+              maxPerTool: maxSessions,
+              toolName: toolName,
+            );
+          },
+          itemBuilder: (context, provider) =>
+              _buildSessionProviderTile(theme, provider),
+        ),
       ],
-    );
-  }
-
-  bool get _hasVisibleSessionProviders =>
-      _isLoadingSessions ||
-      _attemptedSessionTools.isNotEmpty ||
-      _failedSessionTools.isNotEmpty ||
-      (_recentSessions?.isNotEmpty ?? false);
-
-  List<AiSessionProviderEntry> _buildSessionProviderEntries() {
-    final groupedSessions = _groupSessions(_recentSessions);
-    final orderedTools = orderedDiscoveredSessionTools(
-      groupedSessions,
-      <String>{..._attemptedSessionTools, ..._failedSessionTools},
-      preferredToolName: _preferredLaunchTool?.discoveredSessionToolName,
-    );
-    return buildAiSessionProviderEntries(
-      orderedTools: orderedTools,
-      groupedSessions: groupedSessions,
-      attemptedTools: _attemptedSessionTools,
-      failedTools: _failedSessionTools,
-      isLoading: _isLoadingSessions,
-    );
-  }
-
-  Map<String, List<ToolSessionInfo>> _groupSessions(
-    List<ToolSessionInfo>? sessions,
-  ) {
-    final grouped = <String, List<ToolSessionInfo>>{};
-    if (sessions == null) return grouped;
-    for (final session in sessions) {
-      grouped
-          .putIfAbsent(session.toolName, () => <ToolSessionInfo>[])
-          .add(session);
-    }
-    return grouped;
-  }
+    ],
+  );
 
   Widget _buildSessionProviderTile(
     ThemeData theme,
@@ -676,15 +589,30 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
             : theme.colorScheme.onSurfaceVariant,
       ),
     ),
-    trailing: provider.isLoading
+    trailing: provider.isLoading && !provider.hasSessions
         ? const SizedBox(
             width: 16,
             height: 16,
             child: CircularProgressIndicator.adaptive(strokeWidth: 2),
           )
-        : provider.isSelectable
-        ? Icon(Icons.chevron_right, color: theme.colorScheme.onSurfaceVariant)
-        : null,
+        : Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (provider.isLoading) ...[
+                const SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                ),
+                const SizedBox(width: 4),
+              ],
+              if (provider.isSelectable)
+                Icon(
+                  Icons.chevron_right,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+            ],
+          ),
     onTap: provider.isSelectable
         ? () => unawaited(_showSessionPickerForTool(provider))
         : null,

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -142,8 +142,6 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   Future<Set<AgentLaunchTool>>? _installedToolsFuture;
   StreamSubscription<void>? _windowChangeSubscription;
   bool _isLoadingWindows = true;
-  bool _showRecentSessions = false;
-  bool _hasInitializedRecentSessions = false;
   String? _error;
   bool _loadingWindows = false;
   bool _pendingWindowReload = false;
@@ -359,7 +357,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
             const SizedBox(height: 4),
 
-            // Scrollable window list
+            // Scrollable popup content
             Flexible(
               child: ListView(
                 shrinkWrap: true,
@@ -381,36 +379,32 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
                     )
                   else if (_windows != null && _windows!.isNotEmpty)
                     ..._windows!.map(_buildWindowTile),
+                  const Divider(height: 1),
+                  // New Window button
+                  ListTile(
+                    visualDensity: _tmuxNavigatorDenseVisualDensity,
+                    minTileHeight: 42,
+                    contentPadding: _tmuxNavigatorTilePadding,
+                    horizontalTitleGap: 12,
+                    minLeadingWidth: 20,
+                    leading: Icon(
+                      Icons.add_circle_outline,
+                      color: theme.colorScheme.primary,
+                      size: 18,
+                    ),
+                    title: const Text('New Window'),
+                    dense: true,
+                    onTap: _showNewWindowPicker,
+                  ),
+                  // Recent AI Sessions
+                  if (widget.isProUser) ...[
+                    const Divider(height: 1),
+                    _buildRecentSessionsSection(theme),
+                  ],
+                  const SizedBox(height: 8),
                 ],
               ),
             ),
-
-            const Divider(height: 1),
-
-            // New Window button
-            ListTile(
-              visualDensity: _tmuxNavigatorDenseVisualDensity,
-              minTileHeight: 42,
-              contentPadding: _tmuxNavigatorTilePadding,
-              horizontalTitleGap: 12,
-              minLeadingWidth: 20,
-              leading: Icon(
-                Icons.add_circle_outline,
-                color: theme.colorScheme.primary,
-                size: 18,
-              ),
-              title: const Text('New Window'),
-              dense: true,
-              onTap: _showNewWindowPicker,
-            ),
-
-            // Recent AI Sessions (collapsed by default)
-            if (widget.isProUser) ...[
-              const Divider(height: 1),
-              _buildRecentSessionsSection(theme),
-            ],
-
-            const SizedBox(height: 8),
           ],
         ),
       ),
@@ -506,68 +500,49 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         horizontalTitleGap: 12,
         minLeadingWidth: 18,
         leading: Icon(
-          _showRecentSessions ? Icons.expand_less : Icons.expand_more,
+          Icons.smart_toy_outlined,
           size: 18,
           color: theme.colorScheme.onSurfaceVariant,
         ),
         title: const Row(
           children: [Text('Recent AI Sessions'), Spacer(), PremiumBadge()],
         ),
-        onTap: () {
-          final showRecentSessions = !_showRecentSessions;
-          setState(() {
-            _showRecentSessions = showRecentSessions;
-            if (showRecentSessions) {
-              _hasInitializedRecentSessions = true;
-            }
-          });
-          if (showRecentSessions) {
-            unawaited(_prefetchPreferredSessionProvider());
-          }
-        },
       ),
-      if (_hasInitializedRecentSessions)
-        Offstage(
-          offstage: !_showRecentSessions,
-          child: AiSessionProviderList(
-            key: ValueKey<Object>(
-              Object.hashAll(<Object?>[
-                widget.session.connectionId,
-                widget.tmuxSessionName,
-                widget.scopeWorkingDirectory,
-                _windows
-                    ?.where((window) => window.isActive)
-                    .firstOrNull
-                    ?.currentPath,
-              ]),
-            ),
-            orderedTools: orderedDiscoveredSessionTools(
-              const <String, List<ToolSessionInfo>>{},
-              const <String>{},
-              preferredToolName:
-                  _preferredLaunchTool?.discoveredSessionToolName,
-            ),
-            loadSessionsForTool: (toolName, maxSessions) {
-              final activeWindow = _windows
-                  ?.where((w) => w.isActive)
-                  .firstOrNull;
-              final scopeWorkingDirectory =
-                  widget.scopeWorkingDirectory ??
-                  resolveAgentSessionScopeWorkingDirectory(
-                    activeWorkingDirectory: activeWindow?.currentPath,
-                    sessionWorkingDirectory: widget.session.workingDirectory,
-                  );
-              return _discovery.discoverSessionsStream(
-                widget.session,
-                workingDirectory: scopeWorkingDirectory,
-                maxPerTool: maxSessions,
-                toolName: toolName,
-              );
-            },
-            itemBuilder: (context, provider) =>
-                _buildSessionProviderTile(theme, provider),
-          ),
+      AiSessionProviderList(
+        key: ValueKey<Object>(
+          Object.hashAll(<Object?>[
+            widget.session.connectionId,
+            widget.tmuxSessionName,
+            widget.scopeWorkingDirectory,
+            _windows
+                ?.where((window) => window.isActive)
+                .firstOrNull
+                ?.currentPath,
+          ]),
         ),
+        orderedTools: orderedDiscoveredSessionTools(
+          const <String, List<ToolSessionInfo>>{},
+          const <String>{},
+          preferredToolName: _preferredLaunchTool?.discoveredSessionToolName,
+        ),
+        loadSessionsForTool: (toolName, maxSessions) {
+          final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
+          final scopeWorkingDirectory =
+              widget.scopeWorkingDirectory ??
+              resolveAgentSessionScopeWorkingDirectory(
+                activeWorkingDirectory: activeWindow?.currentPath,
+                sessionWorkingDirectory: widget.session.workingDirectory,
+              );
+          return _discovery.discoverSessionsStream(
+            widget.session,
+            workingDirectory: scopeWorkingDirectory,
+            maxPerTool: maxSessions,
+            toolName: toolName,
+          );
+        },
+        itemBuilder: (context, provider) =>
+            _buildSessionProviderTile(theme, provider),
+      ),
     ],
   );
 

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -143,6 +143,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   StreamSubscription<void>? _windowChangeSubscription;
   bool _isLoadingWindows = true;
   bool _showRecentSessions = false;
+  bool _hasInitializedRecentSessions = false;
   String? _error;
   bool _loadingWindows = false;
   bool _pendingWindowReload = false;
@@ -513,50 +514,60 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
           children: [Text('Recent AI Sessions'), Spacer(), PremiumBadge()],
         ),
         onTap: () {
-          setState(() => _showRecentSessions = !_showRecentSessions);
-          if (_showRecentSessions) {
+          final showRecentSessions = !_showRecentSessions;
+          setState(() {
+            _showRecentSessions = showRecentSessions;
+            if (showRecentSessions) {
+              _hasInitializedRecentSessions = true;
+            }
+          });
+          if (showRecentSessions) {
             unawaited(_prefetchPreferredSessionProvider());
           }
         },
       ),
-      if (_showRecentSessions) ...[
-        AiSessionProviderList(
-          key: ValueKey<Object>(
-            Object.hashAll(<Object?>[
-              widget.session.connectionId,
-              widget.tmuxSessionName,
-              widget.scopeWorkingDirectory,
-              _windows
-                  ?.where((window) => window.isActive)
-                  .firstOrNull
-                  ?.currentPath,
-              _preferredLaunchTool?.discoveredSessionToolName,
-            ]),
+      if (_hasInitializedRecentSessions)
+        Offstage(
+          offstage: !_showRecentSessions,
+          child: AiSessionProviderList(
+            key: ValueKey<Object>(
+              Object.hashAll(<Object?>[
+                widget.session.connectionId,
+                widget.tmuxSessionName,
+                widget.scopeWorkingDirectory,
+                _windows
+                    ?.where((window) => window.isActive)
+                    .firstOrNull
+                    ?.currentPath,
+              ]),
+            ),
+            orderedTools: orderedDiscoveredSessionTools(
+              const <String, List<ToolSessionInfo>>{},
+              const <String>{},
+              preferredToolName:
+                  _preferredLaunchTool?.discoveredSessionToolName,
+            ),
+            loadSessionsForTool: (toolName, maxSessions) {
+              final activeWindow = _windows
+                  ?.where((w) => w.isActive)
+                  .firstOrNull;
+              final scopeWorkingDirectory =
+                  widget.scopeWorkingDirectory ??
+                  resolveAgentSessionScopeWorkingDirectory(
+                    activeWorkingDirectory: activeWindow?.currentPath,
+                    sessionWorkingDirectory: widget.session.workingDirectory,
+                  );
+              return _discovery.discoverSessionsStream(
+                widget.session,
+                workingDirectory: scopeWorkingDirectory,
+                maxPerTool: maxSessions,
+                toolName: toolName,
+              );
+            },
+            itemBuilder: (context, provider) =>
+                _buildSessionProviderTile(theme, provider),
           ),
-          orderedTools: orderedDiscoveredSessionTools(
-            const <String, List<ToolSessionInfo>>{},
-            const <String>{},
-            preferredToolName: _preferredLaunchTool?.discoveredSessionToolName,
-          ),
-          loadSessionsForTool: (toolName, maxSessions) {
-            final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
-            final scopeWorkingDirectory =
-                widget.scopeWorkingDirectory ??
-                resolveAgentSessionScopeWorkingDirectory(
-                  activeWorkingDirectory: activeWindow?.currentPath,
-                  sessionWorkingDirectory: widget.session.workingDirectory,
-                );
-            return _discovery.discoverSessionsStream(
-              widget.session,
-              workingDirectory: scopeWorkingDirectory,
-              maxPerTool: maxSessions,
-              toolName: toolName,
-            );
-          },
-          itemBuilder: (context, provider) =>
-              _buildSessionProviderTile(theme, provider),
         ),
-      ],
     ],
   );
 

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../domain/models/agent_launch_preset.dart';
 import '../../domain/models/tmux_state.dart';
+import '../../domain/services/agent_launch_preset_service.dart';
 import '../../domain/services/agent_session_discovery_service.dart';
 import '../../domain/services/ssh_service.dart';
 import '../../domain/services/tmux_service.dart';
@@ -20,6 +21,27 @@ const _tmuxNavigatorMaxHeightFactor = 0.48;
 const _tmuxNavigatorMaxHeightCap = 440.0;
 const _tmuxToolPickerMaxHeightFactor = 0.36;
 const _tmuxToolPickerMaxHeightCap = 320.0;
+
+List<AgentLaunchTool> _orderedAgentLaunchTools(
+  Iterable<AgentLaunchTool> tools, {
+  AgentLaunchTool? preferredTool,
+}) {
+  final ordered = tools.toList(growable: false);
+  if (preferredTool == null) {
+    return ordered;
+  }
+
+  final preferredIndex = ordered.indexOf(preferredTool);
+  if (preferredIndex <= 0) {
+    return ordered;
+  }
+
+  return <AgentLaunchTool>[
+    ordered[preferredIndex],
+    ...ordered.take(preferredIndex),
+    ...ordered.skip(preferredIndex + 1),
+  ];
+}
 
 /// Shows the tmux window navigator bottom sheet.
 ///
@@ -117,6 +139,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   List<TmuxWindow>? _windows;
   List<ToolSessionInfo>? _recentSessions;
   Set<String> _attemptedSessionTools = const <String>{};
+  AgentLaunchTool? _preferredLaunchTool;
   Future<Set<AgentLaunchTool>>? _installedToolsFuture;
   final Set<String> _expandedSessionTools = <String>{};
   StreamSubscription<DiscoveredSessionsResult>? _sessionDiscoverySubscription;
@@ -138,6 +161,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   @override
   void initState() {
     super.initState();
+    unawaited(_loadPreferredLaunchTool());
     _installedToolsFuture = _tmux.detectInstalledAgentTools(widget.session);
     _windowChangeSubscription = _tmux
         .watchWindowChanges(widget.session, widget.tmuxSessionName)
@@ -149,10 +173,30 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   }
 
   @override
+  void didUpdateWidget(covariant _TmuxNavigatorSheet oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.session.hostId != widget.session.hostId) {
+      unawaited(_loadPreferredLaunchTool());
+    }
+  }
+
+  @override
   void dispose() {
     unawaited(_sessionDiscoverySubscription?.cancel());
     unawaited(_windowChangeSubscription?.cancel());
     super.dispose();
+  }
+
+  Future<void> _loadPreferredLaunchTool() async {
+    final hostId = widget.session.hostId;
+    final preset = await widget.ref
+        .read(agentLaunchPresetServiceProvider)
+        .getPresetForHost(hostId);
+    if (!mounted || widget.session.hostId != hostId) return;
+
+    final preferredLaunchTool = preset?.tool;
+    if (_preferredLaunchTool == preferredLaunchTool) return;
+    setState(() => _preferredLaunchTool = preferredLaunchTool);
   }
 
   Future<void> _loadWindows() async {
@@ -278,6 +322,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       builder: (context) => TmuxToolPickerSheet(
         isProUser: widget.isProUser,
         installedToolsFuture: _installedToolsFuture,
+        preferredTool: _preferredLaunchTool,
         onToolSelected: (tool) {
           Navigator.pop(context);
           _createNewWindow(command: tool.commandName, name: tool.commandName);
@@ -562,6 +607,8 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
             ...orderedDiscoveredSessionTools(
               groupedSessions,
               _attemptedSessionTools,
+              preferredToolName:
+                  _preferredLaunchTool?.discoveredSessionToolName,
             ).map(
               (toolName) => _buildSessionGroup(
                 theme,
@@ -724,6 +771,7 @@ class TmuxToolPickerSheet extends StatelessWidget {
     required this.onToolSelected,
     required this.onEmptyWindow,
     this.installedToolsFuture,
+    this.preferredTool,
     super.key,
   });
 
@@ -737,6 +785,9 @@ class TmuxToolPickerSheet extends StatelessWidget {
   /// empty set (or fails), no CLI tools are shown but "Empty window"
   /// remains available.
   final Future<Set<AgentLaunchTool>>? installedToolsFuture;
+
+  /// Host-configured preferred tool, if one exists.
+  final AgentLaunchTool? preferredTool;
 
   /// Called when the user selects a tool.
   final void Function(AgentLaunchTool tool) onToolSelected;
@@ -801,9 +852,12 @@ class TmuxToolPickerSheet extends StatelessWidget {
                     );
                   }
                   final installed = snapshot.data;
-                  final tools = installed != null
-                      ? _allTools.where(installed.contains).toList()
-                      : _allTools;
+                  final tools = _orderedAgentLaunchTools(
+                    installed != null
+                        ? _allTools.where(installed.contains)
+                        : _allTools,
+                    preferredTool: preferredTool,
+                  );
                   if (tools.isEmpty) {
                     return Padding(
                       padding: const EdgeInsets.symmetric(

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -717,6 +717,47 @@ cwd: /tmp/demo
   });
 
   group('discoverSessionsStream caching', () {
+    test('toolName limits discovery to the requested provider', () async {
+      final client = _MockSshClient();
+      final commands = <String>[];
+      when(() => client.execute(any())).thenAnswer((invocation) async {
+        final command = invocation.positionalArguments.first as String;
+        commands.add(command);
+        if (command.contains('opencode session list --format json')) {
+          return _buildExecSession(
+            stdout:
+                '[{"id":"session-1","title":"OpenCode only","directory":"/Users/depoll/Code/flutty","updated":"2026-04-21T20:00:00.000Z"}]',
+          );
+        }
+        if (command.contains('find ~/.codex/sessions')) {
+          return _buildExecSession(stdout: '/tmp/rollout-should-not-run.jsonl');
+        }
+        return _buildExecSession();
+      });
+
+      final discovery = AgentSessionDiscoveryService();
+      final session = _buildDiscoverySession(client);
+      final result = await discovery.discoverSessions(
+        session,
+        toolName: 'OpenCode',
+      );
+
+      expect(result.sessions.map((session) => session.toolName), ['OpenCode']);
+      expect(result.sessions.map((session) => session.sessionId), [
+        'session-1',
+      ]);
+      expect(
+        commands.where(
+          (command) => command.contains('opencode session list --format json'),
+        ),
+        hasLength(1),
+      );
+      expect(
+        commands.where((command) => command.contains('find ~/.codex/sessions')),
+        isEmpty,
+      );
+    });
+
     test('prefetchSessions warms the cache for the next visible load', () async {
       final client = _MockSshClient();
       final commands = <String>[];

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -689,6 +689,34 @@ cwd: /tmp/demo
   });
 
   group('discoverSessionsStream caching', () {
+    test('prefetchSessions warms the cache for the next visible load', () async {
+      final client = _MockSshClient();
+      final commands = <String>[];
+      when(() => client.execute(any())).thenAnswer((invocation) async {
+        final command = invocation.positionalArguments.first as String;
+        commands.add(command);
+        if (command.contains('opencode session list --format json')) {
+          return _buildExecSession(
+            stdout:
+                '[{"id":"session-1","title":"Prefetched result","directory":"/Users/depoll/Code/flutty","updated":"2026-04-21T20:00:00.000Z"}]',
+          );
+        }
+        return _buildExecSession();
+      });
+
+      final discovery = AgentSessionDiscoveryService();
+      final session = _buildDiscoverySession(client);
+
+      await discovery.prefetchSessions(session);
+      final commandCountAfterPrefetch = commands.length;
+      final results = await discovery.discoverSessionsStream(session).toList();
+
+      expect(results.single.sessions.map((session) => session.sessionId), [
+        'session-1',
+      ]);
+      expect(commands.length, commandCountAfterPrefetch);
+    });
+
     test('reuses fresh results for repeated loads in the same scope', () async {
       final client = _MockSshClient();
       final commands = <String>[];

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -110,6 +110,47 @@ branch refs/heads/fix/session-resumption
     });
   });
 
+  group('buildGeminiCliSessionListScopes', () {
+    test('deduplicates related working directories without re-normalizing', () {
+      expect(
+        buildGeminiCliSessionListScopes('/Users/depoll/Code/flutty', const [
+          '/Users/depoll/Code/flutty',
+          '/Users/depoll/Code/flutty.worktrees/feature-other',
+          '/Users/depoll/Code/flutty',
+        ]),
+        [
+          '/Users/depoll/Code/flutty',
+          '/Users/depoll/Code/flutty.worktrees/feature-other',
+        ],
+      );
+    });
+
+    test('falls back to one default CLI scope when no directory is known', () {
+      expect(buildGeminiCliSessionListScopes(null, const []), [isNull]);
+    });
+  });
+
+  group('sortAndLimitDiscoveredSessions', () {
+    test('sorts by recency before applying the cap', () {
+      final limitedSessions = sortAndLimitDiscoveredSessions([
+        ToolSessionInfo(
+          toolName: 'Gemini CLI',
+          sessionId: 'older',
+          summary: 'older',
+          lastActive: DateTime(2026, 4, 12),
+        ),
+        ToolSessionInfo(
+          toolName: 'Gemini CLI',
+          sessionId: 'newer',
+          summary: 'newer',
+          lastActive: DateTime(2026, 4, 13),
+        ),
+      ], 1);
+
+      expect(limitedSessions.map((session) => session.sessionId), ['newer']);
+    });
+  });
+
   group('normalizeDiscoveredSessionInfo', () {
     test('drops unnamed sessions without usable fallback context', () {
       const info = ToolSessionInfo(

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -136,6 +136,27 @@ branch refs/heads/fix/session-resumption
       );
     });
 
+    test('falls back from AI tool home directories to the terminal cwd', () {
+      expect(
+        resolveAgentSessionScopeWorkingDirectory(
+          activeWorkingDirectory: '/Users/depoll/.copilot',
+          sessionWorkingDirectory: Uri.parse(
+            'file:///Users/depoll/Code/flutty',
+          ),
+        ),
+        '/Users/depoll/Code/flutty',
+      );
+      expect(
+        resolveAgentSessionScopeWorkingDirectory(
+          activeWorkingDirectory: '/Users/depoll/.gemini',
+          sessionWorkingDirectory: Uri.parse(
+            'file:///Users/depoll/Code/flutty',
+          ),
+        ),
+        '/Users/depoll/Code/flutty',
+      );
+    });
+
     test('drops temp-only paths when there is no terminal cwd fallback', () {
       expect(
         resolveAgentSessionScopeWorkingDirectory(

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -1,6 +1,42 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/domain/services/agent_session_discovery_service.dart';
+import 'package:monkeyssh/domain/services/ssh_service.dart';
+
+class _MockSshClient extends Mock implements SSHClient {}
+
+class _MockExecSession extends Mock implements SSHSession {}
+
+SshSession _buildDiscoverySession(SSHClient client) => SshSession(
+  connectionId: 1,
+  hostId: 1,
+  client: client,
+  config: const SshConnectionConfig(
+    hostname: 'example.com',
+    port: 22,
+    username: 'demo',
+  ),
+);
+
+Stream<Uint8List> _utf8Stream(String value) => value.isEmpty
+    ? const Stream<Uint8List>.empty()
+    : Stream<Uint8List>.value(Uint8List.fromList(utf8.encode(value)));
+
+void _ignoreInvocation(Invocation _) {}
+
+SSHSession _buildExecSession({String stdout = '', String stderr = ''}) {
+  final session = _MockExecSession();
+  when(() => session.stdout).thenAnswer((_) => _utf8Stream(stdout));
+  when(() => session.stderr).thenAnswer((_) => _utf8Stream(stderr));
+  when(session.close).thenAnswer(_ignoreInvocation);
+  return session;
+}
 
 void main() {
   group('normalizeWorkingDirectoryForComparison', () {
@@ -650,5 +686,112 @@ cwd: /tmp/demo
       expect(metadata.summary, 'can i rename this session?');
       expect(metadata.workingDirectory, '/Users/depoll/Code/flutty');
     });
+  });
+
+  group('discoverSessionsStream caching', () {
+    test('reuses fresh results for repeated loads in the same scope', () async {
+      final client = _MockSshClient();
+      final commands = <String>[];
+      when(() => client.execute(any())).thenAnswer((invocation) async {
+        final command = invocation.positionalArguments.first as String;
+        commands.add(command);
+        if (command.contains('opencode session list --format json')) {
+          return _buildExecSession(
+            stdout:
+                '[{"id":"session-1","title":"Cache result","directory":"/Users/depoll/Code/flutty","updated":"2026-04-21T20:00:00.000Z"}]',
+          );
+        }
+        return _buildExecSession();
+      });
+
+      final discovery = AgentSessionDiscoveryService();
+      final session = _buildDiscoverySession(client);
+
+      final firstResults = await discovery
+          .discoverSessionsStream(session)
+          .toList();
+      final firstCommandCount = commands.length;
+      final secondResults = await discovery
+          .discoverSessionsStream(session)
+          .toList();
+
+      expect(firstResults, isNotEmpty);
+      expect(firstResults.last.sessions.map((session) => session.sessionId), [
+        'session-1',
+      ]);
+      expect(secondResults, hasLength(1));
+      expect(
+        secondResults.single.sessions.map((session) => session.sessionId),
+        ['session-1'],
+      );
+      expect(commands.length, firstCommandCount);
+    });
+
+    test(
+      'reuses related worktree lookups across max-per-tool refreshes',
+      () async {
+        final client = _MockSshClient();
+        final commands = <String>[];
+        when(() => client.execute(any())).thenAnswer((invocation) async {
+          final command = invocation.positionalArguments.first as String;
+          commands.add(command);
+          if (command.contains('worktree list --porcelain')) {
+            return _buildExecSession(
+              stdout: '''
+root=/Users/depoll/Code/flutty
+worktree /Users/depoll/Code/flutty
+HEAD afdab6c
+branch refs/heads/main
+''',
+            );
+          }
+          if (command.contains('opencode session list --format json')) {
+            return _buildExecSession(
+              stdout:
+                  '[{"id":"session-1","title":"Scoped cache result","directory":"/Users/depoll/Code/flutty","updated":"2026-04-21T20:00:00.000Z"}]',
+            );
+          }
+          return _buildExecSession();
+        });
+
+        final discovery = AgentSessionDiscoveryService();
+        final session = _buildDiscoverySession(client);
+
+        final firstResults = await discovery
+            .discoverSessionsStream(
+              session,
+              workingDirectory: '/Users/depoll/Code/flutty',
+            )
+            .toList();
+        final secondResults = await discovery
+            .discoverSessionsStream(
+              session,
+              workingDirectory: '/Users/depoll/Code/flutty',
+              maxPerTool: 24,
+            )
+            .toList();
+
+        expect(firstResults.last.sessions.map((session) => session.sessionId), [
+          'session-1',
+        ]);
+        expect(
+          secondResults.last.sessions.map((session) => session.sessionId),
+          ['session-1'],
+        );
+        expect(
+          commands.where(
+            (command) => command.contains('worktree list --porcelain'),
+          ),
+          hasLength(1),
+        );
+        expect(
+          commands.where(
+            (command) =>
+                command.contains('opencode session list --format json'),
+          ),
+          hasLength(2),
+        );
+      },
+    );
   });
 }

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -111,16 +111,37 @@ branch refs/heads/fix/session-resumption
   });
 
   group('buildGeminiCliSessionListScopes', () {
-    test('deduplicates related working directories without re-normalizing', () {
+    test('limits CLI scopes to the active worktree root and main checkout', () {
       expect(
-        buildGeminiCliSessionListScopes('/Users/depoll/Code/flutty', const [
-          '/Users/depoll/Code/flutty',
+        buildGeminiCliSessionListScopes(
           '/Users/depoll/Code/flutty.worktrees/feature-other',
-          '/Users/depoll/Code/flutty',
-        ]),
+          const [
+            '/Users/depoll/Code/flutty',
+            '/Users/depoll/Code/flutty.worktrees/feature-other',
+            '/Users/depoll/Code/flutty.worktrees/fix-another-branch',
+          ],
+        ),
         [
-          '/Users/depoll/Code/flutty',
           '/Users/depoll/Code/flutty.worktrees/feature-other',
+          '/Users/depoll/Code/flutty',
+        ],
+      );
+    });
+
+    test('uses project roots instead of active subdirectories', () {
+      expect(
+        buildGeminiCliSessionListScopes(
+          '/Users/depoll/Code/flutty.worktrees/feature-other/lib',
+          const [
+            '/Users/depoll/Code/flutty.worktrees/feature-other/lib',
+            '/Users/depoll/Code/flutty/lib',
+            '/Users/depoll/Code/flutty.worktrees/feature-other',
+            '/Users/depoll/Code/flutty',
+          ],
+        ),
+        [
+          '/Users/depoll/Code/flutty.worktrees/feature-other',
+          '/Users/depoll/Code/flutty',
         ],
       );
     });

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -110,6 +110,34 @@ branch refs/heads/fix/session-resumption
     });
   });
 
+  group('readClaudeHistoryWorkingDirectory', () {
+    test('ignores malformed non-string directory metadata', () {
+      expect(
+        readClaudeHistoryWorkingDirectory({
+          'directory': {'path': '/Users/depoll/Code/flutty'},
+          'project': 42,
+        }),
+        isNull,
+      );
+
+      expect(
+        readClaudeHistoryWorkingDirectory({
+          'directory': 42,
+          'project': '/Users/depoll/Code/flutty',
+        }),
+        '/Users/depoll/Code/flutty',
+      );
+    });
+  });
+
+  group('calculateClaudeMetadataSnapshotLimit', () {
+    test('caps Claude metadata snapshots to a smaller recent window', () {
+      expect(calculateClaudeMetadataSnapshotLimit(6), 40);
+      expect(calculateClaudeMetadataSnapshotLimit(24), 80);
+      expect(calculateClaudeMetadataSnapshotLimit(48), 80);
+    });
+  });
+
   group('buildGeminiProjectDirectoryNames', () {
     test('keeps only worktree roots and ignores nested subdirectories', () {
       expect(

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -320,6 +320,43 @@ cwd: /tmp/demo
     });
   });
 
+  group('parseClaudeSessionMetadata', () {
+    test('extracts the first real user prompt and ignores slash commands', () {
+      final metadata = parseClaudeSessionMetadata('''
+{"type":"user","isMeta":false,"message":{"role":"user","content":"/exit"}}
+{"type":"user","isMeta":false,"message":{"role":"user","content":"Fix the tmux session list loading bug"}}
+''');
+
+      expect(metadata.parsedAny, isTrue);
+      expect(metadata.userSummary, 'Fix the tmux session list loading bug');
+    });
+
+    test('preserves explicit metadata fields when present', () {
+      final metadata = parseClaudeSessionMetadata('''
+{"customTitle":"Investigate slow AI session loading","agentName":"Opus","lastPrompt":"ignored"}
+''');
+
+      expect(metadata.customTitle, 'Investigate slow AI session loading');
+      expect(metadata.agentName, 'Opus');
+      expect(metadata.lastPrompt, 'ignored');
+    });
+
+    test(
+      'prefers the latest metadata fields while keeping the first prompt',
+      () {
+        final metadata = parseClaudeSessionMetadata('''
+{"type":"user","isMeta":false,"message":{"role":"user","content":"Original prompt"}}
+{"customTitle":"Initial title","lastPrompt":"older"}
+{"customTitle":"Renamed title","lastPrompt":"newer"}
+''');
+
+        expect(metadata.userSummary, 'Original prompt');
+        expect(metadata.customTitle, 'Renamed title');
+        expect(metadata.lastPrompt, 'newer');
+      },
+    );
+  });
+
   group('parseGeminiSessionMetadata', () {
     test('uses stored summary and lastUpdated for main sessions', () {
       final metadata = parseGeminiSessionMetadata('''

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -148,7 +148,40 @@ branch refs/heads/fix/session-resumption
       );
       expect(
         resolveAgentSessionScopeWorkingDirectory(
+          activeWorkingDirectory: '/Users/depoll/.local/share/opencode',
+          sessionWorkingDirectory: Uri.parse(
+            'file:///Users/depoll/Code/flutty',
+          ),
+        ),
+        '/Users/depoll/Code/flutty',
+      );
+      expect(
+        resolveAgentSessionScopeWorkingDirectory(
           activeWorkingDirectory: '/Users/depoll/.gemini',
+          sessionWorkingDirectory: Uri.parse(
+            'file:///Users/depoll/Code/flutty',
+          ),
+        ),
+        '/Users/depoll/Code/flutty',
+      );
+    });
+
+    test('prefers a more specific terminal cwd over a broader pane cwd', () {
+      expect(
+        resolveAgentSessionScopeWorkingDirectory(
+          activeWorkingDirectory: '/Users/depoll',
+          sessionWorkingDirectory: Uri.parse(
+            'file:///Users/depoll/Code/flutty',
+          ),
+        ),
+        '/Users/depoll/Code/flutty',
+      );
+    });
+
+    test('prefers the live terminal cwd when tmux metadata disagrees', () {
+      expect(
+        resolveAgentSessionScopeWorkingDirectory(
+          activeWorkingDirectory: '/Users/depoll/Code/another-project',
           sessionWorkingDirectory: Uri.parse(
             'file:///Users/depoll/Code/flutty',
           ),
@@ -163,6 +196,30 @@ branch refs/heads/fix/session-resumption
           activeWorkingDirectory: '/var/folders/demo/output',
         ),
         isNull,
+      );
+    });
+  });
+
+  group('resolveTmuxAiSessionScopeWorkingDirectory', () {
+    test('prefers the live terminal cwd over stale tmux metadata', () {
+      expect(
+        resolveTmuxAiSessionScopeWorkingDirectory(
+          liveTerminalWorkingDirectory: '/Users/depoll/Code/flutty',
+          tmuxWorkingDirectory: '/Users/depoll/Code/another-project',
+          sessionWorkingDirectory: Uri.parse(
+            'file:///Users/depoll/Code/flutty',
+          ),
+        ),
+        '/Users/depoll/Code/flutty',
+      );
+    });
+
+    test('falls back to tmux metadata only when no live cwd exists', () {
+      expect(
+        resolveTmuxAiSessionScopeWorkingDirectory(
+          tmuxWorkingDirectory: '/Users/depoll/Code/flutty',
+        ),
+        '/Users/depoll/Code/flutty',
       );
     });
   });
@@ -205,6 +262,22 @@ branch refs/heads/fix/session-resumption
           '/Users/depoll/Code/flutty',
         ]),
         ['feature-other', 'flutty'],
+      );
+    });
+  });
+
+  group('buildScopedGeminiProjectDirectoryNames', () {
+    test('keeps the active worktree name plus the canonical checkout name', () {
+      expect(
+        buildScopedGeminiProjectDirectoryNames(
+          '/Users/depoll/Code/flutty.worktrees/session-resumption-all-providers',
+          const [
+            '/Users/depoll/Code/flutty',
+            '/Users/depoll/Code/flutty.worktrees/session-resumption-all-providers',
+            '/Users/depoll/Code/flutty.worktrees/feature-other',
+          ],
+        ),
+        ['session-resumption-all-providers', 'flutty'],
       );
     });
   });
@@ -274,6 +347,23 @@ branch refs/heads/fix/session-resumption
 
       expect(limitedSessions.map((session) => session.sessionId), ['newer']);
     });
+  });
+
+  group('orderedDiscoveredSessionTools', () {
+    test(
+      'lists grouped tools first and appends empty attempts alphabetically',
+      () {
+        final ordered = orderedDiscoveredSessionTools(
+          {
+            'Claude Code': const <ToolSessionInfo>[],
+            'Codex': const <ToolSessionInfo>[],
+          },
+          const ['OpenCode', 'Gemini CLI', 'Codex'],
+        );
+
+        expect(ordered, ['Claude Code', 'Codex', 'Gemini CLI', 'OpenCode']);
+      },
+    );
   });
 
   group('normalizeDiscoveredSessionInfo', () {
@@ -388,6 +478,20 @@ updated_at: 2026-04-14T01:02:03.000Z
       expect(metadata.updatedAt, DateTime.parse('2026-04-14T01:02:03.000Z'));
     });
 
+    test('falls back to repository and branch when summary is missing', () {
+      final metadata = parseCopilotWorkspaceYamlMetadata('''
+id: example
+cwd: /Users/depoll/Code/flutty
+repository: depollsoft/MonkeySSH
+branch: main
+updated_at: 2026-04-14T01:02:03.000Z
+''');
+
+      expect(metadata.summary, 'depollsoft/MonkeySSH (main)');
+      expect(metadata.workingDirectory, '/Users/depoll/Code/flutty');
+      expect(metadata.updatedAt, DateTime.parse('2026-04-14T01:02:03.000Z'));
+    });
+
     test('normalizes inline summary text to a single display line', () {
       final metadata = parseCopilotWorkspaceYamlMetadata('''
 summary:   Add   PR preview   commit list   
@@ -397,6 +501,23 @@ cwd: /tmp/demo
       expect(metadata.summary, 'Add PR preview commit list');
       expect(metadata.workingDirectory, '/tmp/demo');
       expect(metadata.updatedAt, isNull);
+    });
+  });
+
+  group('buildSqlWorkingDirectoryScopeClause', () {
+    test('uses exact prefix predicates instead of LIKE wildcards', () {
+      final clause = buildSqlWorkingDirectoryScopeClause(const [
+        '/Users/depoll/Code/my_repo',
+      ], columnName: 'directory');
+
+      expect(clause, isNotNull);
+      expect(clause, isNot(contains('LIKE')));
+      expect(
+        clause,
+        contains(
+          "substr(directory, 1, length('/Users/depoll/Code/my_repo') + 1) = '/Users/depoll/Code/my_repo/'",
+        ),
+      );
     });
   });
 

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -288,6 +288,14 @@ branch refs/heads/fix/session-resumption
     });
   });
 
+  group('calculateRecentSessionMetadataReadLimit', () {
+    test('caps other provider metadata reads to a smaller recent window', () {
+      expect(calculateRecentSessionMetadataReadLimit(6), 24);
+      expect(calculateRecentSessionMetadataReadLimit(12), 36);
+      expect(calculateRecentSessionMetadataReadLimit(24), 48);
+    });
+  });
+
   group('buildGeminiProjectDirectoryNames', () {
     test('keeps only worktree roots and ignores nested subdirectories', () {
       expect(
@@ -707,11 +715,11 @@ cwd: /tmp/demo
       final discovery = AgentSessionDiscoveryService();
       final session = _buildDiscoverySession(client);
 
-      await discovery.prefetchSessions(session);
+      await discovery.prefetchSessions(session, maxPerTool: 6);
       final commandCountAfterPrefetch = commands.length;
-      final results = await discovery.discoverSessionsStream(session).toList();
+      final result = await discovery.discoverSessionsStream(session).first;
 
-      expect(results.single.sessions.map((session) => session.sessionId), [
+      expect(result.sessions.map((session) => session.sessionId), [
         'session-1',
       ]);
       expect(commands.length, commandCountAfterPrefetch);

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -394,32 +394,39 @@ branch refs/heads/fix/session-resumption
   });
 
   group('orderedDiscoveredSessionTools', () {
-    test(
-      'lists grouped tools first and appends empty attempts alphabetically',
-      () {
-        final ordered = orderedDiscoveredSessionTools(
-          {
-            'Claude Code': const <ToolSessionInfo>[],
-            'Codex': const <ToolSessionInfo>[],
-          },
-          const ['OpenCode', 'Gemini CLI', 'Codex'],
-        );
-
-        expect(ordered, ['Claude Code', 'Codex', 'Gemini CLI', 'OpenCode']);
-      },
-    );
-
-    test('moves the preferred tool to the front when present', () {
+    test('includes all known providers in a stable order', () {
       final ordered = orderedDiscoveredSessionTools(
         {
           'Claude Code': const <ToolSessionInfo>[],
           'Codex': const <ToolSessionInfo>[],
         },
         const ['Gemini CLI'],
+      );
+
+      expect(ordered, [
+        'Claude Code',
+        'Copilot CLI',
+        'Codex',
+        'Gemini CLI',
+        'OpenCode',
+      ]);
+    });
+
+    test('moves the preferred tool to the front and appends unknown tools', () {
+      final ordered = orderedDiscoveredSessionTools(
+        const {'Custom Tool': <ToolSessionInfo>[]},
+        const ['Custom Tool'],
         preferredToolName: 'Codex',
       );
 
-      expect(ordered, ['Codex', 'Claude Code', 'Gemini CLI']);
+      expect(ordered, [
+        'Codex',
+        'Claude Code',
+        'Copilot CLI',
+        'Gemini CLI',
+        'OpenCode',
+        'Custom Tool',
+      ]);
     });
   });
 

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -3,6 +3,113 @@ import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/domain/services/agent_session_discovery_service.dart';
 
 void main() {
+  group('normalizeWorkingDirectoryForComparison', () {
+    test('strips worktree branch segments from comparable paths', () {
+      expect(
+        normalizeWorkingDirectoryForComparison(
+          '/Users/depoll/Code/flutty.worktrees/fix-session-resumption/lib',
+        ),
+        '/Users/depoll/Code/flutty/lib',
+      );
+    });
+  });
+
+  group('parseGitWorktreeRoots', () {
+    test('extracts worktree paths from porcelain output', () {
+      expect(
+        parseGitWorktreeRoots('''
+worktree /Users/depoll/Code/flutty
+HEAD afdab6c
+branch refs/heads/main
+
+worktree /Users/depoll/Code/flutty.worktrees/fix-session-resumption
+HEAD 1234567
+branch refs/heads/fix/session-resumption
+'''),
+        [
+          '/Users/depoll/Code/flutty',
+          '/Users/depoll/Code/flutty.worktrees/fix-session-resumption',
+        ],
+      );
+    });
+  });
+
+  group('buildRelatedWorkingDirectories', () {
+    test('maps the active subdirectory across git worktrees', () {
+      expect(
+        buildRelatedWorkingDirectories(
+          '/Users/depoll/Code/flutty.worktrees/fix-session-resumption/lib',
+          gitRoot: '/Users/depoll/Code/flutty.worktrees/fix-session-resumption',
+          gitWorktreeRoots: const [
+            '/Users/depoll/Code/flutty',
+            '/Users/depoll/Code/flutty.worktrees/feature-other',
+          ],
+        ),
+        containsAll(<String>[
+          '/Users/depoll/Code/flutty.worktrees/fix-session-resumption/lib',
+          '/Users/depoll/Code/flutty/lib',
+          '/Users/depoll/Code/flutty.worktrees/feature-other/lib',
+          '/Users/depoll/Code/flutty.worktrees/feature-other',
+        ]),
+      );
+    });
+  });
+
+  group('matchesDiscoveredSessionWorkingDirectory', () {
+    test('matches the main checkout from a sibling worktree', () {
+      final relatedDirectories = buildRelatedWorkingDirectories(
+        '/Users/depoll/Code/flutty.worktrees/fix-session-resumption',
+        gitRoot: '/Users/depoll/Code/flutty.worktrees/fix-session-resumption',
+        gitWorktreeRoots: const [
+          '/Users/depoll/Code/flutty',
+          '/Users/depoll/Code/flutty.worktrees/feature-other',
+        ],
+      );
+
+      expect(
+        matchesDiscoveredSessionWorkingDirectory(
+          '/Users/depoll/Code/flutty.worktrees/fix-session-resumption',
+          '/Users/depoll/Code/flutty',
+          relatedWorkingDirectories: relatedDirectories,
+        ),
+        isTrue,
+      );
+      expect(
+        matchesDiscoveredSessionWorkingDirectory(
+          '/Users/depoll/Code/flutty.worktrees/fix-session-resumption',
+          '/tmp/another-repo/flutty',
+          relatedWorkingDirectories: relatedDirectories,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('resolveGeminiProjectWorkingDirectory', () {
+    test('maps project folder names back to the right worktree paths', () {
+      final relatedDirectories = buildRelatedWorkingDirectories(
+        '/Users/depoll/Code/flutty.worktrees/fix-session-resumption',
+        gitRoot: '/Users/depoll/Code/flutty.worktrees/fix-session-resumption',
+        gitWorktreeRoots: const [
+          '/Users/depoll/Code/flutty',
+          '/Users/depoll/Code/flutty.worktrees/feature-other',
+        ],
+      );
+
+      expect(
+        resolveGeminiProjectWorkingDirectory('flutty', relatedDirectories),
+        '/Users/depoll/Code/flutty',
+      );
+      expect(
+        resolveGeminiProjectWorkingDirectory(
+          'feature-other',
+          relatedDirectories,
+        ),
+        '/Users/depoll/Code/flutty.worktrees/feature-other',
+      );
+    });
+  });
+
   group('normalizeDiscoveredSessionInfo', () {
     test('drops unnamed sessions without usable fallback context', () {
       const info = ToolSessionInfo(

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -110,6 +110,42 @@ branch refs/heads/fix/session-resumption
     });
   });
 
+  group('resolveAgentSessionScopeWorkingDirectory', () {
+    test('keeps the active project path when it already looks valid', () {
+      expect(
+        resolveAgentSessionScopeWorkingDirectory(
+          activeWorkingDirectory: '/Users/depoll/Code/flutty',
+          sessionWorkingDirectory: Uri.parse(
+            'file:///Users/depoll/Code/flutty',
+          ),
+        ),
+        '/Users/depoll/Code/flutty',
+      );
+    });
+
+    test('falls back from Copilot state paths to the terminal cwd', () {
+      expect(
+        resolveAgentSessionScopeWorkingDirectory(
+          activeWorkingDirectory:
+              '/Users/depoll/.copilot/session-state/970e4099-a97c-456a-a6c2-408095060f72',
+          sessionWorkingDirectory: Uri.parse(
+            'file:///Users/depoll/Code/flutty',
+          ),
+        ),
+        '/Users/depoll/Code/flutty',
+      );
+    });
+
+    test('drops temp-only paths when there is no terminal cwd fallback', () {
+      expect(
+        resolveAgentSessionScopeWorkingDirectory(
+          activeWorkingDirectory: '/var/folders/demo/output',
+        ),
+        isNull,
+      );
+    });
+  });
+
   group('readClaudeHistoryWorkingDirectory', () {
     test('ignores malformed non-string directory metadata', () {
       expect(

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -110,44 +110,63 @@ branch refs/heads/fix/session-resumption
     });
   });
 
-  group('buildGeminiCliSessionListScopes', () {
-    test('limits CLI scopes to the active worktree root and main checkout', () {
+  group('buildGeminiProjectDirectoryNames', () {
+    test('keeps only worktree roots and ignores nested subdirectories', () {
       expect(
-        buildGeminiCliSessionListScopes(
-          '/Users/depoll/Code/flutty.worktrees/feature-other',
-          const [
-            '/Users/depoll/Code/flutty',
-            '/Users/depoll/Code/flutty.worktrees/feature-other',
-            '/Users/depoll/Code/flutty.worktrees/fix-another-branch',
-          ],
-        ),
-        [
-          '/Users/depoll/Code/flutty.worktrees/feature-other',
-          '/Users/depoll/Code/flutty',
-        ],
-      );
-    });
-
-    test('uses project roots instead of active subdirectories', () {
-      expect(
-        buildGeminiCliSessionListScopes(
+        buildGeminiProjectDirectoryNames(const [
           '/Users/depoll/Code/flutty.worktrees/feature-other/lib',
-          const [
-            '/Users/depoll/Code/flutty.worktrees/feature-other/lib',
-            '/Users/depoll/Code/flutty/lib',
-            '/Users/depoll/Code/flutty.worktrees/feature-other',
-            '/Users/depoll/Code/flutty',
-          ],
-        ),
+          '/Users/depoll/Code/flutty/lib',
+          '/Users/depoll/Code/flutty.worktrees/feature-other',
+          '/Users/depoll/Code/flutty',
+        ]),
+        ['feature-other', 'flutty'],
+      );
+    });
+  });
+
+  group('scopeDiscoveredSessionsToWorkingDirectory', () {
+    test('keeps providers that have no matching cwd metadata', () {
+      final scopedSessions = scopeDiscoveredSessionsToWorkingDirectory(
         [
+          ToolSessionInfo(
+            toolName: 'Claude Code',
+            sessionId: 'claude-match',
+            workingDirectory: '/Users/depoll/Code/flutty',
+            summary: 'Fix tmux filtering',
+            lastActive: DateTime(2026, 4, 20, 12),
+          ),
+          ToolSessionInfo(
+            toolName: 'Claude Code',
+            sessionId: 'claude-other',
+            workingDirectory: '/tmp/another-repo',
+            summary: 'Other project',
+            lastActive: DateTime(2026, 4, 20, 11),
+          ),
+          ToolSessionInfo(
+            toolName: 'Codex',
+            sessionId: 'codex-no-cwd',
+            summary: 'Investigate session loading',
+            lastActive: DateTime(2026, 4, 20, 10),
+          ),
+          ToolSessionInfo(
+            toolName: 'Copilot CLI',
+            sessionId: 'copilot-no-cwd',
+            summary: 'Review recent tmux fixes',
+            lastActive: DateTime(2026, 4, 20, 9),
+          ),
+        ],
+        '/Users/depoll/Code/flutty.worktrees/feature-other',
+        relatedWorkingDirectories: const [
           '/Users/depoll/Code/flutty.worktrees/feature-other',
           '/Users/depoll/Code/flutty',
         ],
       );
-    });
 
-    test('falls back to one default CLI scope when no directory is known', () {
-      expect(buildGeminiCliSessionListScopes(null, const []), [isNull]);
+      expect(scopedSessions.map((session) => session.sessionId), [
+        'claude-match',
+        'codex-no-cwd',
+        'copilot-no-cwd',
+      ]);
     });
   });
 

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -408,6 +408,19 @@ branch refs/heads/fix/session-resumption
         expect(ordered, ['Claude Code', 'Codex', 'Gemini CLI', 'OpenCode']);
       },
     );
+
+    test('moves the preferred tool to the front when present', () {
+      final ordered = orderedDiscoveredSessionTools(
+        {
+          'Claude Code': const <ToolSessionInfo>[],
+          'Codex': const <ToolSessionInfo>[],
+        },
+        const ['Gemini CLI'],
+        preferredToolName: 'Codex',
+      );
+
+      expect(ordered, ['Codex', 'Claude Code', 'Gemini CLI']);
+    });
   });
 
   group('normalizeDiscoveredSessionInfo', () {

--- a/test/widget/ai_session_picker_test.dart
+++ b/test/widget/ai_session_picker_test.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/domain/models/tmux_state.dart';
+import 'package:monkeyssh/domain/services/agent_session_discovery_service.dart';
 import 'package:monkeyssh/presentation/widgets/ai_session_picker.dart';
 
 Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
@@ -31,6 +34,92 @@ void main() {
       expect(entries[2].isLoading, isTrue);
       expect(entries[2].compactStatusLabel, 'loading');
     });
+
+    test('keeps the discovered count visible while refreshing', () {
+      const entry = AiSessionProviderEntry(
+        toolName: 'Codex',
+        sessions: <ToolSessionInfo>[
+          ToolSessionInfo(
+            toolName: 'Codex',
+            sessionId: 'session-1',
+            summary: 'Refresh in place',
+          ),
+        ],
+        wasAttempted: true,
+        hasFailure: false,
+        isLoading: true,
+      );
+
+      expect(entry.statusLabel, '1 session');
+      expect(entry.compactStatusLabel, '1');
+    });
+  });
+
+  group('AiSessionProviderList', () {
+    testWidgets('live updates provider rows in place', (tester) async {
+      final claudeController = StreamController<DiscoveredSessionsResult>();
+      final codexController = StreamController<DiscoveredSessionsResult>();
+      addTearDown(() async {
+        if (!claudeController.isClosed) {
+          await claudeController.close();
+        }
+        if (!codexController.isClosed) {
+          await codexController.close();
+        }
+      });
+
+      await tester.pumpWidget(
+        _wrap(
+          AiSessionProviderList(
+            orderedTools: const ['Claude Code', 'Codex'],
+            loadSessionsForTool: (toolName, _) => switch (toolName) {
+              'Claude Code' => claudeController.stream,
+              'Codex' => codexController.stream,
+              _ => Stream<DiscoveredSessionsResult>.value(
+                DiscoveredSessionsResult(sessions: const []),
+              ),
+            },
+            itemBuilder: (context, provider) => Text(
+              '${provider.toolName}|${provider.compactStatusLabel}|'
+              '${provider.isLoading ? 'loading' : 'idle'}|'
+              '${provider.hasFailure ? 'error' : 'ok'}',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Claude Code|loading|loading|ok'), findsOneWidget);
+      expect(find.text('Codex|loading|loading|ok'), findsOneWidget);
+
+      codexController.add(
+        DiscoveredSessionsResult(
+          sessions: const <ToolSessionInfo>[
+            ToolSessionInfo(
+              toolName: 'Codex',
+              sessionId: 'session-1',
+              summary: 'Fix the tmux menu refresh',
+            ),
+          ],
+          attemptedTools: const <String>{'Codex'},
+        ),
+      );
+      await codexController.close();
+      await tester.pump();
+
+      expect(find.text('Codex|1|idle|ok'), findsOneWidget);
+      expect(find.text('Claude Code|loading|loading|ok'), findsOneWidget);
+
+      claudeController.add(
+        DiscoveredSessionsResult(
+          sessions: const <ToolSessionInfo>[],
+          attemptedTools: const <String>{'Claude Code'},
+        ),
+      );
+      await claudeController.close();
+      await tester.pump();
+
+      expect(find.text('Claude Code|no recent|idle|ok'), findsOneWidget);
+    });
   });
 
   group('AiSessionPickerDialog', () {
@@ -50,7 +139,12 @@ void main() {
                 picked = await showAiSessionPickerDialog(
                   context: context,
                   toolName: 'Codex',
-                  sessions: const [selectedSession],
+                  loadSessions: (_) => Stream<DiscoveredSessionsResult>.value(
+                    DiscoveredSessionsResult(
+                      sessions: const <ToolSessionInfo>[selectedSession],
+                      attemptedTools: const <String>{'Codex'},
+                    ),
+                  ),
                 );
               },
               child: const Text('Open'),

--- a/test/widget/ai_session_picker_test.dart
+++ b/test/widget/ai_session_picker_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/models/tmux_state.dart';
+import 'package:monkeyssh/presentation/widgets/ai_session_picker.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  group('buildAiSessionProviderEntries', () {
+    test('derives loading, failure, and loaded provider states', () {
+      const codexSession = ToolSessionInfo(
+        toolName: 'Codex',
+        sessionId: 'session-1',
+        summary: 'Fix the tmux menu refresh',
+      );
+
+      final entries = buildAiSessionProviderEntries(
+        orderedTools: const ['Claude Code', 'Codex', 'Gemini CLI'],
+        groupedSessions: const {
+          'Codex': <ToolSessionInfo>[codexSession],
+        },
+        attemptedTools: const ['Codex'],
+        failedTools: const ['Claude Code'],
+        isLoading: true,
+      );
+
+      expect(entries[0].hasFailure, isTrue);
+      expect(entries[0].statusLabel, 'Could not load recent sessions');
+      expect(entries[1].hasSessions, isTrue);
+      expect(entries[1].statusLabel, '1 session');
+      expect(entries[2].isLoading, isTrue);
+      expect(entries[2].compactStatusLabel, 'loading');
+    });
+  });
+
+  group('AiSessionPickerDialog', () {
+    testWidgets('returns the tapped session', (tester) async {
+      const selectedSession = ToolSessionInfo(
+        toolName: 'Codex',
+        sessionId: 'session-1',
+        summary: 'Fix the tmux menu refresh',
+      );
+      ToolSessionInfo? picked;
+
+      await tester.pumpWidget(
+        _wrap(
+          Builder(
+            builder: (context) => TextButton(
+              onPressed: () async {
+                picked = await showAiSessionPickerDialog(
+                  context: context,
+                  toolName: 'Codex',
+                  sessions: const [selectedSession],
+                );
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsOneWidget);
+      expect(find.text('Fix the tmux menu refresh'), findsOneWidget);
+
+      await tester.tap(find.text('Fix the tmux menu refresh'));
+      await tester.pumpAndSettle();
+
+      expect(picked, selectedSession);
+    });
+  });
+}

--- a/test/widget/ai_session_picker_test.dart
+++ b/test/widget/ai_session_picker_test.dart
@@ -103,6 +103,11 @@ void main() {
           attemptedTools: const <String>{'Codex'},
         ),
       );
+      await tester.pump();
+
+      expect(find.text('Codex|1|idle|ok'), findsOneWidget);
+      expect(find.text('Claude Code|loading|loading|ok'), findsOneWidget);
+
       await codexController.close();
       await tester.pump();
 
@@ -119,6 +124,69 @@ void main() {
       await tester.pump();
 
       expect(find.text('Claude Code|no recent|idle|ok'), findsOneWidget);
+    });
+
+    testWidgets('keeps the visible provider order stable', (tester) async {
+      final controllers = <String, StreamController<DiscoveredSessionsResult>>{
+        'Claude Code': StreamController<DiscoveredSessionsResult>(),
+        'Codex': StreamController<DiscoveredSessionsResult>(),
+      };
+      addTearDown(() async {
+        for (final controller in controllers.values) {
+          if (!controller.isClosed) {
+            await controller.close();
+          }
+        }
+      });
+
+      var orderedTools = const ['Claude Code', 'Codex'];
+
+      await tester.pumpWidget(
+        _wrap(
+          StatefulBuilder(
+            builder: (context, setState) => Column(
+              children: [
+                TextButton(
+                  onPressed: () {
+                    setState(() {
+                      orderedTools = const ['Codex', 'Claude Code'];
+                    });
+                  },
+                  child: const Text('Reorder'),
+                ),
+                AiSessionProviderList(
+                  orderedTools: orderedTools,
+                  loadSessionsForTool: (toolName, _) =>
+                      controllers[toolName]!.stream,
+                  itemBuilder: (context, provider) => Text(
+                    provider.toolName,
+                    key: ValueKey<String>(provider.toolName),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final claudeBefore = tester.getTopLeft(
+        find.byKey(const ValueKey<String>('Claude Code')),
+      );
+      final codexBefore = tester.getTopLeft(
+        find.byKey(const ValueKey<String>('Codex')),
+      );
+      expect(claudeBefore.dy, lessThan(codexBefore.dy));
+
+      await tester.tap(find.text('Reorder'));
+      await tester.pump();
+
+      final claudeAfter = tester.getTopLeft(
+        find.byKey(const ValueKey<String>('Claude Code')),
+      );
+      final codexAfter = tester.getTopLeft(
+        find.byKey(const ValueKey<String>('Codex')),
+      );
+      expect(claudeAfter.dy, lessThan(codexAfter.dy));
     });
   });
 

--- a/test/widget/ai_session_picker_test.dart
+++ b/test/widget/ai_session_picker_test.dart
@@ -30,12 +30,12 @@ void main() {
       expect(entries[0].hasFailure, isTrue);
       expect(entries[0].statusLabel, 'Could not load recent sessions');
       expect(entries[1].hasSessions, isTrue);
-      expect(entries[1].statusLabel, '1 session');
+      expect(entries[1].statusLabel, 'Recent sessions available');
       expect(entries[2].isLoading, isTrue);
       expect(entries[2].compactStatusLabel, 'loading');
     });
 
-    test('keeps the discovered count visible while refreshing', () {
+    test('keeps provider availability visible while refreshing', () {
       const entry = AiSessionProviderEntry(
         toolName: 'Codex',
         sessions: <ToolSessionInfo>[
@@ -50,8 +50,8 @@ void main() {
         isLoading: true,
       );
 
-      expect(entry.statusLabel, '1 session');
-      expect(entry.compactStatusLabel, '1');
+      expect(entry.statusLabel, 'Recent sessions available');
+      expect(entry.compactStatusLabel, 'ready');
     });
   });
 
@@ -105,13 +105,13 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.text('Codex|1|idle|ok'), findsOneWidget);
+      expect(find.text('Codex|ready|idle|ok'), findsOneWidget);
       expect(find.text('Claude Code|loading|loading|ok'), findsOneWidget);
 
       await codexController.close();
       await tester.pump();
 
-      expect(find.text('Codex|1|idle|ok'), findsOneWidget);
+      expect(find.text('Codex|ready|idle|ok'), findsOneWidget);
       expect(find.text('Claude Code|loading|loading|ok'), findsOneWidget);
 
       claudeController.add(
@@ -191,6 +191,55 @@ void main() {
   });
 
   group('AiSessionPickerDialog', () {
+    testWidgets('loads more sessions while scrolling', (tester) async {
+      final requests = <int>[];
+      final allSessions = List.generate(
+        24,
+        (index) => ToolSessionInfo(
+          toolName: 'Codex',
+          sessionId: 'session-$index',
+          summary: 'Session $index',
+        ),
+      );
+
+      await tester.pumpWidget(
+        _wrap(
+          Builder(
+            builder: (context) => TextButton(
+              onPressed: () {
+                unawaited(
+                  showAiSessionPickerDialog(
+                    context: context,
+                    toolName: 'Codex',
+                    loadSessions: (maxSessions) {
+                      requests.add(maxSessions);
+                      return Stream<DiscoveredSessionsResult>.value(
+                        DiscoveredSessionsResult(
+                          sessions: allSessions.take(maxSessions).toList(),
+                          attemptedTools: const <String>{'Codex'},
+                        ),
+                      );
+                    },
+                  ),
+                );
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(requests, [12]);
+
+      await tester.drag(find.byType(ListView), const Offset(0, -1200));
+      await tester.pumpAndSettle();
+
+      expect(requests, [12, 24]);
+    });
+
     testWidgets('returns the tapped session', (tester) async {
       const selectedSession = ToolSessionInfo(
         toolName: 'Codex',

--- a/test/widget/ai_session_picker_test.dart
+++ b/test/widget/ai_session_picker_test.dart
@@ -188,6 +188,85 @@ void main() {
       );
       expect(claudeAfter.dy, lessThan(codexAfter.dy));
     });
+
+    testWidgets('only rebuilds the provider row that changed', (tester) async {
+      final claudeController = StreamController<DiscoveredSessionsResult>();
+      final codexController = StreamController<DiscoveredSessionsResult>();
+      final buildCounts = <String, int>{};
+      addTearDown(() async {
+        if (!claudeController.isClosed) {
+          await claudeController.close();
+        }
+        if (!codexController.isClosed) {
+          await codexController.close();
+        }
+      });
+
+      await tester.pumpWidget(
+        _wrap(
+          AiSessionProviderList(
+            orderedTools: const ['Claude Code', 'Codex'],
+            loadSessionsForTool: (toolName, _) => switch (toolName) {
+              'Claude Code' => claudeController.stream,
+              'Codex' => codexController.stream,
+              _ => Stream<DiscoveredSessionsResult>.value(
+                DiscoveredSessionsResult(sessions: const []),
+              ),
+            },
+            itemBuilder: (context, provider) {
+              buildCounts.update(
+                provider.toolName,
+                (count) => count + 1,
+                ifAbsent: () => 1,
+              );
+              return Text(
+                '${provider.toolName}|${provider.compactStatusLabel}',
+                key: ValueKey<String>(provider.toolName),
+              );
+            },
+          ),
+        ),
+      );
+
+      expect(buildCounts, {'Claude Code': 1, 'Codex': 1});
+
+      codexController.add(
+        DiscoveredSessionsResult(
+          sessions: const <ToolSessionInfo>[
+            ToolSessionInfo(
+              toolName: 'Codex',
+              sessionId: 'session-1',
+              summary: 'Only Codex should rebuild',
+            ),
+          ],
+          attemptedTools: const <String>{'Codex'},
+        ),
+      );
+      await tester.pump();
+
+      expect(buildCounts, {'Claude Code': 1, 'Codex': 2});
+
+      codexController.add(
+        DiscoveredSessionsResult(
+          sessions: const <ToolSessionInfo>[
+            ToolSessionInfo(
+              toolName: 'Codex',
+              sessionId: 'session-1',
+              summary: 'Only Codex should rebuild',
+            ),
+            ToolSessionInfo(
+              toolName: 'Codex',
+              sessionId: 'session-2',
+              summary: 'Extra streamed session should not churn the row',
+            ),
+          ],
+          attemptedTools: const <String>{'Codex'},
+        ),
+      );
+      await tester.pump();
+
+      expect(buildCounts, {'Claude Code': 1, 'Codex': 2});
+    });
   });
 
   group('AiSessionPickerDialog', () {

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 
@@ -49,6 +50,44 @@ void main() {
       expect(resolveTmuxBarRevealOpacity(11), 0.5);
       expect(resolveTmuxBarRevealOpacity(22), 1);
       expect(resolveTmuxBarRevealOpacity(40), 1);
+    });
+
+    test('uses the active tmux window title in the handle label', () {
+      const windows = <TmuxWindow>[
+        TmuxWindow(
+          index: 0,
+          name: 'shell',
+          isActive: false,
+          paneTitle: 'Ignored',
+        ),
+        TmuxWindow(
+          index: 1,
+          name: 'agent',
+          isActive: true,
+          paneTitle: '✨ Editing main.dart',
+        ),
+      ];
+
+      expect(resolveTmuxBarActiveWindowTitle(windows), '✨ Editing main.dart');
+      expect(
+        resolveTmuxBarHandleLabel(
+          'workspace',
+          activeWindowTitle: resolveTmuxBarActiveWindowTitle(windows),
+        ),
+        'workspace · ✨ Editing main.dart',
+      );
+    });
+
+    test('omits duplicate or blank tmux window titles in the handle label', () {
+      expect(resolveTmuxBarActiveWindowTitle(const <TmuxWindow>[]), isNull);
+      expect(
+        resolveTmuxBarHandleLabel('workspace', activeWindowTitle: 'workspace'),
+        'workspace',
+      );
+      expect(
+        resolveTmuxBarHandleLabel('workspace', activeWindowTitle: '  '),
+        'workspace',
+      );
     });
 
     test('tmux bar stays inside visible safe insets', () {

--- a/test/widget/tmux_tool_picker_sheet_test.dart
+++ b/test/widget/tmux_tool_picker_sheet_test.dart
@@ -123,5 +123,30 @@ void main() {
       await tester.tap(find.text('Claude Code'));
       expect(chosen, AgentLaunchTool.claudeCode);
     });
+
+    testWidgets('moves the preferred tool to the top of the list', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          TmuxToolPickerSheet(
+            isProUser: true,
+            installedToolsFuture: Future.value({
+              AgentLaunchTool.claudeCode,
+              AgentLaunchTool.codex,
+            }),
+            preferredTool: AgentLaunchTool.codex,
+            onToolSelected: (_) {},
+            onEmptyWindow: () {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getTopLeft(find.text('Codex')).dy,
+        lessThan(tester.getTopLeft(find.text('Claude Code')).dy),
+      );
+    });
   });
 }

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -1,8 +1,19 @@
 // ignore_for_file: public_member_api_docs
 
+import 'dart:async';
+
+import 'package:dartssh2/dartssh2.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
 import 'package:monkeyssh/domain/models/tmux_state.dart';
+import 'package:monkeyssh/domain/services/agent_launch_preset_service.dart';
+import 'package:monkeyssh/domain/services/agent_session_discovery_service.dart';
+import 'package:monkeyssh/domain/services/ssh_service.dart';
+import 'package:monkeyssh/domain/services/tmux_service.dart';
+import 'package:monkeyssh/presentation/widgets/tmux_window_navigator.dart';
 
 void main() {
   group('tmux navigator UI', () {
@@ -90,8 +101,102 @@ void main() {
       expect(find.text('Claude Code · 2h ago'), findsOneWidget);
       expect(find.text('Resume'), findsOneWidget);
     });
+
+    testWidgets('shows AI session providers without expanding a section', (
+      tester,
+    ) async {
+      final tmuxService = _MockTmuxService();
+      final presetService = _MockAgentLaunchPresetService();
+      final discoveryService = _MockAgentSessionDiscoveryService();
+      final session = SshSession(
+        connectionId: 1,
+        hostId: 1,
+        client: _MockSshClient(),
+        config: const SshConnectionConfig(
+          hostname: 'example.com',
+          port: 22,
+          username: 'demo',
+        ),
+      );
+      const tmuxSessionName = 'main';
+
+      when(
+        () => presetService.getPresetForHost(session.hostId),
+      ).thenAnswer((_) async => null);
+      when(
+        () => tmuxService.detectInstalledAgentTools(session),
+      ).thenAnswer((_) async => const <AgentLaunchTool>{});
+      when(
+        () => tmuxService.watchWindowChanges(session, tmuxSessionName),
+      ).thenAnswer((_) => const Stream<void>.empty());
+      when(
+        () => tmuxService.listWindows(session, tmuxSessionName),
+      ).thenAnswer((_) async => windows);
+      when(
+        () => discoveryService.discoverSessionsStream(
+          session,
+          workingDirectory: any(named: 'workingDirectory'),
+          maxPerTool: any(named: 'maxPerTool'),
+          toolName: any(named: 'toolName'),
+        ),
+      ).thenAnswer(
+        (_) => Stream<DiscoveredSessionsResult>.value(
+          DiscoveredSessionsResult(sessions: const <ToolSessionInfo>[]),
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            tmuxServiceProvider.overrideWithValue(tmuxService),
+            agentLaunchPresetServiceProvider.overrideWithValue(presetService),
+            agentSessionDiscoveryServiceProvider.overrideWithValue(
+              discoveryService,
+            ),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: Consumer(
+                builder: (context, ref, _) => TextButton(
+                  onPressed: () {
+                    unawaited(
+                      showTmuxNavigator(
+                        context: context,
+                        ref: ref,
+                        session: session,
+                        tmuxSessionName: tmuxSessionName,
+                        isProUser: true,
+                      ),
+                    );
+                  },
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Recent AI Sessions'), findsOneWidget);
+      expect(find.text('Claude Code'), findsOneWidget);
+      expect(find.byIcon(Icons.expand_more), findsNothing);
+      expect(find.byIcon(Icons.expand_less), findsNothing);
+    });
   });
 }
+
+class _MockTmuxService extends Mock implements TmuxService {}
+
+class _MockAgentLaunchPresetService extends Mock
+    implements AgentLaunchPresetService {}
+
+class _MockAgentSessionDiscoveryService extends Mock
+    implements AgentSessionDiscoveryService {}
+
+class _MockSshClient extends Mock implements SSHClient {}
 
 class _MockWindowList extends StatelessWidget {
   const _MockWindowList({required this.windows});


### PR DESCRIPTION
## Summary

- make session discovery treat sibling git worktrees as the same project scope when filtering Claude, Codex, Copilot CLI, and OpenCode sessions
- expand Gemini session discovery across the active repo's worktree family and merge CLI and file-based results
- add focused tests for worktree path normalization, scope building, path matching, and Gemini project-directory resolution

## Validation

- dart format lib/domain/services/agent_session_discovery_service.dart test/domain/services/agent_session_discovery_service_test.dart
- flutter test test/domain/services/agent_session_discovery_service_test.dart
- flutter analyze
- flutter test
