### PR TITLE
fix(tmux): recover detached window actions

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -198,6 +198,45 @@ class TmuxService {
     }
   }
 
+  /// Returns the active pane working directory for [sessionName], if tmux
+  /// reports one.
+  Future<String?> currentPanePath(
+    SshSession session,
+    String sessionName,
+  ) async {
+    try {
+      final output = await _exec(
+        session,
+        'tmux display-message -p -t ${_shellQuote('$sessionName:')} '
+        "'#{pane_current_path}'",
+      );
+      return parseTmuxCurrentPanePath(output);
+    } on Exception {
+      return null;
+    }
+  }
+
+  /// Returns whether [sessionName] still has a non-control tmux client
+  /// attached in the foreground.
+  ///
+  /// Control-mode observers are excluded because MonkeySSH uses one for live
+  /// window updates even after the visible interactive shell has left tmux.
+  Future<bool> hasForegroundClient(
+    SshSession session,
+    String sessionName,
+  ) async {
+    try {
+      final output = await _exec(
+        session,
+        'tmux list-clients -t ${_shellQuote(sessionName)} '
+        "-F '#{client_control_mode}' 2>/dev/null",
+      );
+      return hasForegroundTmuxClient(output);
+    } on Exception {
+      return false;
+    }
+  }
+
   /// Watches tmux control-mode notifications that indicate window state
   /// has changed for [sessionName].
   Stream<void> watchWindowChanges(SshSession session, String sessionName) {
@@ -418,6 +457,30 @@ class TmuxService {
   /// Single-quotes a value for safe use in shell commands.
   static String _shellQuote(String value) =>
       "'${value.replaceAll("'", "'\"'\"'")}'";
+}
+
+/// Parses the current pane path reported by `tmux display-message`.
+@visibleForTesting
+String? parseTmuxCurrentPanePath(String output) {
+  for (final rawLine in output.split('\n')) {
+    final line = rawLine.trim();
+    if (line.isNotEmpty) {
+      return line;
+    }
+  }
+  return null;
+}
+
+/// Returns whether `tmux list-clients` output includes a non-control client.
+@visibleForTesting
+bool hasForegroundTmuxClient(String output) {
+  for (final rawLine in output.split('\n')) {
+    final line = rawLine.trim();
+    if (line == '0') {
+      return true;
+    }
+  }
+  return false;
 }
 
 const _tmuxWindowSubscriptionFormat =

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -105,6 +105,42 @@ String? resolvePreferredTmuxSessionName({
   String? autoConnectCommand,
 }) => structuredSessionName ?? parseTmuxSessionName(autoConnectCommand);
 
+/// Resolves the working directory to use when creating a new tmux window.
+@visibleForTesting
+String? resolveTmuxWindowWorkingDirectory({
+  String? explicitWorkingDirectory,
+  String? currentPaneWorkingDirectory,
+  String? observedWorkingDirectory,
+  String? launchWorkingDirectory,
+  String? hostWorkingDirectory,
+}) {
+  for (final candidate in <String?>[
+    explicitWorkingDirectory,
+    currentPaneWorkingDirectory,
+    observedWorkingDirectory,
+    launchWorkingDirectory,
+    hostWorkingDirectory,
+  ]) {
+    final trimmed = candidate?.trim();
+    if (trimmed != null && trimmed.isNotEmpty) {
+      return trimmed;
+    }
+  }
+  return null;
+}
+
+/// Returns whether a tmux window action should reattach the visible terminal.
+@visibleForTesting
+bool shouldReattachTmuxAfterWindowAction({
+  required bool hasForegroundClient,
+  required TerminalShellStatus? shellStatus,
+}) {
+  if (hasForegroundClient) {
+    return false;
+  }
+  return shellStatus != TerminalShellStatus.runningCommand;
+}
+
 /// Resolves the safe-area insets the tmux bar should stay within.
 @visibleForTesting
 EdgeInsets resolveTmuxBarSafeInsets(MediaQueryData mediaQuery) {
@@ -3625,7 +3661,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     switch (action) {
       case TmuxSwitchWindowAction(:final windowIndex):
-        _switchTmuxWindow(session, windowIndex);
+        await _switchTmuxWindow(session, windowIndex);
       case TmuxNewWindowAction(:final command, :final windowName):
         await _createTmuxWindow(session, command: command, name: windowName);
       case TmuxResumeSessionAction(
@@ -3670,7 +3706,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     switch (action) {
       case TmuxSwitchWindowAction(:final windowIndex):
-        _switchTmuxWindow(session, windowIndex);
+        await _switchTmuxWindow(session, windowIndex);
       case TmuxNewWindowAction(:final command, :final windowName):
         await _createTmuxWindow(session, command: command, name: windowName);
       case TmuxResumeSessionAction(
@@ -3693,7 +3729,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   /// `tmux select-window` is a server operation — the tmux server
   /// notifies all attached clients of the change. Writing to the PTY
   /// would inject the command as input to whatever program is running.
-  void _switchTmuxWindow(SshSession session, int windowIndex) {
+  Future<void> _switchTmuxWindow(SshSession session, int windowIndex) async {
     final sessionName = _tmuxSessionName;
     if (sessionName == null) return;
 
@@ -3704,14 +3740,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     // Clear stale working directory — it will be refreshed from
     // OSC 7 or the next tmux query.
     _tmuxWorkingDirectory = null;
+    await _reattachTmuxIfNeeded(session, sessionName);
   }
 
-  /// Creates a new tmux window via exec channel, then switches to it.
+  /// Creates a new tmux window via exec channel, then reattaches the visible
+  /// terminal if tmux is no longer in the foreground there.
   ///
-  /// Only passes `-c` when an explicit [workingDirectory] is provided
-  /// (e.g. resuming an AI session). Otherwise tmux uses its own
-  /// `default-directory` (where the session was started), matching
-  /// native `Ctrl+b, c` behavior.
+  /// Prefers the tmux session's current pane directory so "new window" starts
+  /// where the user is actually working, while still preserving explicit
+  /// working-directory overrides (e.g. resuming an AI session).
   Future<void> _createTmuxWindow(
     SshSession session, {
     String? command,
@@ -3722,11 +3759,21 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (sessionName == null) return;
 
     final tmux = ref.read(tmuxServiceProvider);
-    final resolvedWorkingDirectory =
-        workingDirectory ??
-        (command != null && command.trim().isNotEmpty
-            ? (_tmuxLaunchWorkingDirectory ?? _host?.tmuxWorkingDirectory)
-            : null);
+    String? currentPaneWorkingDirectory;
+    if (!(workingDirectory?.trim().isNotEmpty ?? false)) {
+      currentPaneWorkingDirectory = await tmux.currentPanePath(
+        session,
+        sessionName,
+      );
+    }
+    if (!mounted) return;
+    final resolvedWorkingDirectory = resolveTmuxWindowWorkingDirectory(
+      explicitWorkingDirectory: workingDirectory,
+      currentPaneWorkingDirectory: currentPaneWorkingDirectory,
+      observedWorkingDirectory: _tmuxWorkingDirectory ?? _workingDirectoryPath,
+      launchWorkingDirectory: _tmuxLaunchWorkingDirectory,
+      hostWorkingDirectory: _host?.tmuxWorkingDirectory,
+    );
     await tmux.createWindow(
       session,
       sessionName,
@@ -3734,6 +3781,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       name: name,
       workingDirectory: resolvedWorkingDirectory,
     );
+    _tmuxWorkingDirectory = resolvedWorkingDirectory;
+    await _reattachTmuxIfNeeded(session, sessionName);
   }
 
   /// Closes a tmux window via exec channel.
@@ -3742,6 +3791,48 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (sessionName == null) return;
 
     ref.read(tmuxServiceProvider).killWindow(session, sessionName, windowIndex);
+  }
+
+  Future<void> _reattachTmuxIfNeeded(
+    SshSession session,
+    String sessionName,
+  ) async {
+    final tmux = ref.read(tmuxServiceProvider);
+    final hasForegroundClient = await tmux.hasForegroundClient(
+      session,
+      sessionName,
+    );
+    if (!mounted || hasForegroundClient) {
+      return;
+    }
+
+    if (!shouldReattachTmuxAfterWindowAction(
+      hasForegroundClient: hasForegroundClient,
+      shellStatus: _shellStatus,
+    )) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'tmux updated $sessionName, but this terminal is outside tmux '
+            'while a command is still running.',
+          ),
+        ),
+      );
+      return;
+    }
+
+    final shell = _shell;
+    if (shell == null) {
+      return;
+    }
+
+    final host = _host;
+    final reattachCommand = buildTmuxCommand(
+      sessionName: sessionName,
+      workingDirectory: host?.tmuxWorkingDirectory,
+      extraFlags: host?.tmuxExtraFlags,
+    );
+    shell.write(utf8.encode(formatAutoConnectCommandForShell(reattachCommand)));
   }
 
   void _handleTrackedConnectionStateChange(

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -102,6 +102,24 @@ void main() {
     });
   });
 
+  group('tmux window action helpers', () {
+    test('parses the current pane path from display-message output', () {
+      expect(parseTmuxCurrentPanePath('/tmp/project\n'), '/tmp/project');
+      expect(
+        parseTmuxCurrentPanePath('\n  /tmp/workspace  \n'),
+        '/tmp/workspace',
+      );
+      expect(parseTmuxCurrentPanePath(' \n \n'), isNull);
+    });
+
+    test('detects only non-control tmux clients as foreground clients', () {
+      expect(hasForegroundTmuxClient('1\n1\n'), isFalse);
+      expect(hasForegroundTmuxClient('1\n0\n'), isTrue);
+      expect(hasForegroundTmuxClient('\n0\n'), isTrue);
+      expect(hasForegroundTmuxClient(' \n \n'), isFalse);
+    });
+  });
+
   group('decideTmuxHeartbeatAction', () {
     const heartbeat = Duration(seconds: 5);
     const maxSilence = Duration(seconds: 30);

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 
 void main() {
@@ -111,6 +112,89 @@ void main() {
         'parsed-session',
       );
       expect(resolvePreferredTmuxSessionName(), isNull);
+    });
+
+    test('prefers explicit and active tmux directories for new windows', () {
+      expect(
+        resolveTmuxWindowWorkingDirectory(
+          explicitWorkingDirectory: '/tmp/explicit',
+          currentPaneWorkingDirectory: '/tmp/current',
+          observedWorkingDirectory: '/tmp/observed',
+          launchWorkingDirectory: '/tmp/launch',
+          hostWorkingDirectory: '/tmp/host',
+        ),
+        '/tmp/explicit',
+      );
+      expect(
+        resolveTmuxWindowWorkingDirectory(
+          currentPaneWorkingDirectory: '/tmp/current',
+          observedWorkingDirectory: '/tmp/observed',
+          launchWorkingDirectory: '/tmp/launch',
+          hostWorkingDirectory: '/tmp/host',
+        ),
+        '/tmp/current',
+      );
+    });
+
+    test('falls back through observed, launch, and host tmux directories', () {
+      expect(
+        resolveTmuxWindowWorkingDirectory(
+          observedWorkingDirectory: '/tmp/observed',
+          launchWorkingDirectory: '/tmp/launch',
+          hostWorkingDirectory: '/tmp/host',
+        ),
+        '/tmp/observed',
+      );
+      expect(
+        resolveTmuxWindowWorkingDirectory(
+          launchWorkingDirectory: '/tmp/launch',
+          hostWorkingDirectory: '/tmp/host',
+        ),
+        '/tmp/launch',
+      );
+      expect(
+        resolveTmuxWindowWorkingDirectory(hostWorkingDirectory: '/tmp/host'),
+        '/tmp/host',
+      );
+      expect(resolveTmuxWindowWorkingDirectory(), isNull);
+    });
+
+    test('reattaches tmux window actions only when tmux lost foreground', () {
+      expect(
+        shouldReattachTmuxAfterWindowAction(
+          hasForegroundClient: true,
+          shellStatus: TerminalShellStatus.prompt,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldReattachTmuxAfterWindowAction(
+          hasForegroundClient: false,
+          shellStatus: TerminalShellStatus.prompt,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldReattachTmuxAfterWindowAction(
+          hasForegroundClient: false,
+          shellStatus: TerminalShellStatus.editingCommand,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldReattachTmuxAfterWindowAction(
+          hasForegroundClient: false,
+          shellStatus: TerminalShellStatus.runningCommand,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldReattachTmuxAfterWindowAction(
+          hasForegroundClient: false,
+          shellStatus: null,
+        ),
+        isTrue,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- reattach the visible terminal after tmux window changes when the shell has fallen out of tmux and only the control-mode observer is still attached
- start new tmux windows from the active tmux pane directory instead of the stale launch directory
- add focused tests for tmux foreground-client detection and tmux window cwd/reattach decisions
