### PR TITLE
fix: keep wrapped worktree paths clickable

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -6693,7 +6693,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         if (!mounted || verifiedPath == null) {
           return;
         }
-        setState(() {});
+        setState(() {
+          _shouldScheduleVisibleTerminalPathUnderlineRefreshFromBuild = true;
+        });
       } finally {
         _verifyingTerminalPathCacheKeys.remove(cacheKey);
       }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1038,7 +1038,7 @@ final _terminalFilePathPattern = RegExp(
   r'''(?:~(?:/[^\s<>"'$#&|;]+)?|/(?:[^\s<>"'$#&|;]+)|\.\.?/(?:[^\s<>"'$#&|;]+)|[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+)''',
 );
 final _terminalFilePathLineSuffixPattern = RegExp(
-  r'''(?:~(?:/[^\s<>"'$#&|;]+)?|/(?:[^\s<>"'$#&|;]+)|\.\.?/(?:[^\s<>"'$#&|;]+)|[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+)$''',
+  r'''(?:~(?:/[^\s<>"'$#&|;]+)?|/(?:[^\s<>"'$#&|;]+)|\.\.?/(?:[^\s<>"'$#&|;]+)|[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+/?)$''',
 );
 final _terminalFilePathStackTraceSuffixPattern = RegExp(
   r'(?:L\d+(?::\d+)?|:\d+(?::\d+)?)$',
@@ -1685,6 +1685,7 @@ String _trimTerminalPathContinuationPrefix(String text) {
 bool _startsFreshTerminalFilePathLine(String text) =>
     text == '~' ||
     text.startsWith('~/') ||
+    text.startsWith('/') ||
     text.startsWith('./') ||
     text.startsWith('../');
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1037,6 +1037,9 @@ final _terminalLinkPattern = RegExp(
 final _terminalFilePathPattern = RegExp(
   r'''(?:~(?:/[^\s<>"'$#&|;]+)?|/(?:[^\s<>"'$#&|;]+)|\.\.?/(?:[^\s<>"'$#&|;]+)|[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+)''',
 );
+final _terminalFilePathLineSuffixPattern = RegExp(
+  r'''(?:~(?:/[^\s<>"'$#&|;]+)?|/(?:[^\s<>"'$#&|;]+)|\.\.?/(?:[^\s<>"'$#&|;]+)|[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+)$''',
+);
 final _terminalFilePathStackTraceSuffixPattern = RegExp(
   r'(?:L\d+(?::\d+)?|:\d+(?::\d+)?)$',
 );
@@ -1044,6 +1047,9 @@ final _terminalFilePathShellOperatorSuffixPattern = RegExp(
   r'(?:&&|\|\||[&;|])+$',
 );
 final _terminalWrappedCountSuffixPattern = RegExp(r'\d+$');
+final _terminalStandalonePathMetadataPattern = RegExp(
+  r'^(?:L\d+(?::\d+)?|:\d+(?::\d+)?)(?:\s|\(|$)',
+);
 const _terminalSftpPathPrefix = 'monkeyssh-sftp-path:';
 const _terminalPathVerificationTimeout = Duration(seconds: 5);
 const _terminalInputIndicatorDuration = Duration(milliseconds: 700);
@@ -1676,36 +1682,42 @@ String _trimTerminalPathContinuationPrefix(String text) {
   return text.substring(index);
 }
 
+bool _startsFreshTerminalFilePathLine(String text) =>
+    text == '~' ||
+    text.startsWith('~/') ||
+    text.startsWith('./') ||
+    text.startsWith('../');
+
+bool _hasLeadingTerminalPathFragment(String text) =>
+    text.isNotEmpty && _isTerminalFilePathBodyCharacter(text[0]);
+
+bool _looksLikeTerminalPathContinuationAcrossRenderedLines({
+  required String previousText,
+  required String nextText,
+}) {
+  final trimmedPreviousText = trimTerminalLinePadding(previousText);
+  final trimmedNextText = trimTerminalLinePadding(nextText);
+  if (trimmedPreviousText.isEmpty || trimmedNextText.isEmpty) {
+    return false;
+  }
+  if (_terminalStandalonePathMetadataPattern.hasMatch(trimmedNextText) ||
+      _startsFreshTerminalFilePathLine(trimmedNextText)) {
+    return false;
+  }
+  return _terminalFilePathLineSuffixPattern.hasMatch(trimmedPreviousText) &&
+      (_terminalFilePathPattern.matchAsPrefix(trimmedNextText) != null ||
+          _hasLeadingTerminalPathFragment(trimmedNextText));
+}
+
 /// Whether adjacent rendered lines should be treated as one file-path span.
 @visibleForTesting
 bool isTerminalPathContinuationAcrossLines({
   required String previousLineText,
   required String nextLineText,
-}) {
-  final previousText = trimTerminalLinePadding(previousLineText);
-  final nextText = trimTerminalLinePadding(nextLineText);
-  if (previousText.isEmpty || nextText.isEmpty) {
-    return false;
-  }
-
-  final nextWithoutIndentation = _trimTerminalPathContinuationPrefix(nextText);
-  if (nextWithoutIndentation.isNotEmpty &&
-      nextWithoutIndentation.length != nextText.length &&
-      _isTerminalFilePathBodyCharacter(previousText[previousText.length - 1]) &&
-      _isTerminalFilePathBodyCharacter(nextWithoutIndentation[0])) {
-    return true;
-  }
-
-  final combinedText = '$previousText\n$nextText';
-  final splitOffset = previousText.length;
-  for (final detectedPath in _detectTerminalFilePathMatches(combinedText)) {
-    if (detectedPath.start < splitOffset &&
-        detectedPath.end > splitOffset + 1) {
-      return true;
-    }
-  }
-  return false;
-}
+}) => _looksLikeTerminalPathContinuationAcrossRenderedLines(
+  previousText: previousLineText,
+  nextText: _trimTerminalPathContinuationPrefix(nextLineText),
+);
 
 _NormalizedTerminalPathSnapshot _normalizeTerminalFilePathDetectionText(
   String text,
@@ -1715,6 +1727,7 @@ _NormalizedTerminalPathSnapshot _normalizeTerminalFilePathDetectionText(
   final normalizedToOriginalStarts = <int>[];
   final normalizedToOriginalEnds = <int>[];
   var index = 0;
+  var lineStart = 0;
 
   while (index < text.length) {
     final character = text[index];
@@ -1734,17 +1747,19 @@ _NormalizedTerminalPathSnapshot _normalizeTerminalFilePathDetectionText(
         continuationEnd++;
       }
 
-      final previousCharacter = normalizedCharacters.isEmpty
-          ? null
-          : normalizedCharacters.last;
-      final nextCharacter = continuationEnd < text.length
-          ? text[continuationEnd]
-          : null;
+      var nextLineEnd = continuationEnd;
+      while (nextLineEnd < text.length &&
+          text[nextLineEnd] != '\r' &&
+          text[nextLineEnd] != '\n') {
+        nextLineEnd++;
+      }
+
       final isPathContinuation =
-          previousCharacter != null &&
-          nextCharacter != null &&
-          _isTerminalFilePathBodyCharacter(previousCharacter) &&
-          _isTerminalFilePathBodyCharacter(nextCharacter);
+          continuationEnd < text.length &&
+          _looksLikeTerminalPathContinuationAcrossRenderedLines(
+            previousText: text.substring(lineStart, index),
+            nextText: text.substring(continuationEnd, nextLineEnd),
+          );
       if (isPathContinuation) {
         for (
           var skippedIndex = index;
@@ -1754,6 +1769,7 @@ _NormalizedTerminalPathSnapshot _normalizeTerminalFilePathDetectionText(
           originalToNormalizedOffsets[skippedIndex] =
               normalizedCharacters.length;
         }
+        lineStart = lineBreakEnd;
         index = continuationEnd;
         continue;
       }
@@ -1765,6 +1781,7 @@ _NormalizedTerminalPathSnapshot _normalizeTerminalFilePathDetectionText(
       normalizedCharacters.add('\n');
       normalizedToOriginalStarts.add(index);
       normalizedToOriginalEnds.add(lineBreakEnd);
+      lineStart = lineBreakEnd;
       index = lineBreakEnd;
       continue;
     }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1038,7 +1038,7 @@ final _terminalFilePathPattern = RegExp(
   r'''(?:~(?:/[^\s<>"'$#&|;]+)?|/(?:[^\s<>"'$#&|;]+)|\.\.?/(?:[^\s<>"'$#&|;]+)|[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+)''',
 );
 final _terminalFilePathLineSuffixPattern = RegExp(
-  r'''(?:~(?:/[^\s<>"'$#&|;]+)?|/(?:[^\s<>"'$#&|;]+)|\.\.?/(?:[^\s<>"'$#&|;]+)|[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+/?)$''',
+  r'''(?:~(?:/[^\s<>"'$#&|;]+)?/?|/(?:[^\s<>"'$#&|;]+)?|\.\.?/(?:[^\s<>"'$#&|;]+)?|[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+/?)$''',
 );
 final _terminalFilePathStackTraceSuffixPattern = RegExp(
   r'(?:L\d+(?::\d+)?|:\d+(?::\d+)?)$',
@@ -1689,6 +1689,26 @@ bool _startsFreshTerminalFilePathLine(String text) =>
     text.startsWith('./') ||
     text.startsWith('../');
 
+String? _leadingTerminalFilePathCandidate(String text) {
+  final match = _terminalFilePathPattern.matchAsPrefix(text);
+  if (match == null) {
+    return null;
+  }
+
+  final candidate = trimTerminalFilePathCandidate(match.group(0)!);
+  return isSupportedTerminalFilePath(candidate) ? candidate : null;
+}
+
+bool _hasMeaningfulTextBeforeTrailingTerminalPath(
+  String text,
+  Match trailingPathMatch,
+) => _trimTerminalPathContinuationPrefix(
+  text.substring(0, trailingPathMatch.start),
+).trim().isNotEmpty;
+
+bool _endsWithTerminalPathContinuationBoundary(String path) =>
+    path == '~' || path.endsWith('/');
+
 bool _hasLeadingTerminalPathFragment(String text) =>
     text.isNotEmpty && _isTerminalFilePathBodyCharacter(text[0]);
 
@@ -1701,13 +1721,44 @@ bool _looksLikeTerminalPathContinuationAcrossRenderedLines({
   if (trimmedPreviousText.isEmpty || trimmedNextText.isEmpty) {
     return false;
   }
-  if (_terminalStandalonePathMetadataPattern.hasMatch(trimmedNextText) ||
-      _startsFreshTerminalFilePathLine(trimmedNextText)) {
+  if (_terminalStandalonePathMetadataPattern.hasMatch(trimmedNextText)) {
     return false;
   }
-  return _terminalFilePathLineSuffixPattern.hasMatch(trimmedPreviousText) &&
-      (_terminalFilePathPattern.matchAsPrefix(trimmedNextText) != null ||
-          _hasLeadingTerminalPathFragment(trimmedNextText));
+
+  final previousPathMatch = _terminalFilePathLineSuffixPattern.firstMatch(
+    trimmedPreviousText,
+  );
+  if (previousPathMatch == null) {
+    return false;
+  }
+
+  final previousPath = trimTerminalFilePathCandidate(
+    previousPathMatch.group(0)!,
+  );
+  final previousHasLeadingContext =
+      _hasMeaningfulTextBeforeTrailingTerminalPath(
+        trimmedPreviousText,
+        previousPathMatch,
+      );
+  final previousEndsWithBoundary = _endsWithTerminalPathContinuationBoundary(
+    previousPath,
+  );
+  final nextLeadingPath = _leadingTerminalFilePathCandidate(trimmedNextText);
+
+  if (_startsFreshTerminalFilePathLine(trimmedNextText)) {
+    return previousHasLeadingContext || previousEndsWithBoundary;
+  }
+
+  if (nextLeadingPath != null && !isExplicitTerminalFilePath(nextLeadingPath)) {
+    if (!previousHasLeadingContext &&
+        !previousEndsWithBoundary &&
+        !isExplicitTerminalFilePath(previousPath)) {
+      return false;
+    }
+    return true;
+  }
+
+  return _hasLeadingTerminalPathFragment(trimmedNextText);
 }
 
 /// Whether adjacent rendered lines should be treated as one file-path span.
@@ -5910,7 +5961,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       );
       builder.write(lineSnapshot.text);
       columnOffsets.add(lineSnapshot.columnOffsets);
-      if (lineIndex < endRow) {
+      if (lineIndex < endRow && !buffer.lines[lineIndex + 1].isWrapped) {
         builder.write('\n');
       }
     }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2711,7 +2711,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           : 0,
     );
     _syncNativeScrollFromTerminal();
-    _queueVisibleTerminalPathUnderlineRefresh();
+    _refreshVisibleTerminalPathUnderlines();
   }
 
   void _followLiveOutput() {
@@ -4763,10 +4763,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           fit: StackFit.expand,
           children: [
             terminalView,
-            for (final underline in _visibleTerminalPathUnderlines)
+            for (final entry in _visibleTerminalPathUnderlines.asMap().entries)
               Positioned(
-                left: underline.underlineRect.left,
-                top: underline.underlineRect.top,
+                left: entry.value.underlineRect.left,
+                top: entry.value.underlineRect.top,
                 child: IgnorePointer(
                   child: DecoratedBox(
                     decoration: BoxDecoration(
@@ -4774,8 +4774,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                       borderRadius: BorderRadius.circular(999),
                     ),
                     child: SizedBox(
-                      width: underline.underlineRect.width,
-                      height: underline.underlineRect.height,
+                      key: ValueKey<String>(
+                        'terminal-path-underline:${entry.key}:${entry.value.path}',
+                      ),
+                      width: entry.value.underlineRect.width,
+                      height: entry.value.underlineRect.height,
                     ),
                   ),
                 ),

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -28,6 +28,8 @@ class _MockSshClient extends Mock implements SSHClient {}
 
 class _MockShellChannel extends Mock implements SSHSession {}
 
+class _MockSftpClient extends Mock implements SftpClient {}
+
 class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
   _TestActiveSessionsNotifier(this.session);
 
@@ -619,6 +621,51 @@ void main() {
 
         expect(underlineFinder, findsOneWidget);
         expect(tester.getTopLeft(underlineFinder).dy, isNot(initialTop));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'verified relative paths gain an underline after verification completes',
+      (tester) async {
+        const relativePath = 'lib/presentation/screens/terminal_screen.dart';
+        const workingDirectory = '/Users/tester/project';
+        final sftp = _MockSftpClient();
+        final statCompleter = Completer<SftpFileAttrs>();
+
+        when(() => sshClient.sftp()).thenAnswer((_) async => sftp);
+        when(
+          () => sftp.stat('$workingDirectory/$relativePath'),
+        ).thenAnswer((_) => statCompleter.future);
+
+        await pumpScreen(tester);
+        shellStdoutController.add(
+          Uint8List.fromList(
+            utf8.encode(
+              '\u001b]7;file://remote.example.com$workingDirectory\u0007',
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        session.terminal!.write('git add $relativePath');
+        await tester.pump();
+
+        final underlineFinder = find.byWidgetPredicate((widget) {
+          final key = widget.key;
+          return key is ValueKey<String> &&
+              key.value.contains('terminal-path-underline:') &&
+              key.value.contains(relativePath);
+        });
+
+        expect(underlineFinder, findsNothing);
+
+        statCompleter.complete(
+          SftpFileAttrs(mode: const SftpFileMode.value(1 << 14)),
+        );
+        await tester.pumpAndSettle();
+
+        expect(underlineFinder, findsOneWidget);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -579,6 +579,51 @@ void main() {
     );
 
     testWidgets(
+      'prompt path underline tracks scroll without dropping a frame',
+      (tester) async {
+        await pumpScreen(tester);
+
+        final output = <String>[
+          for (var index = 0; index < 80; index++) 'line $index',
+          'metadata rows no longer get folded into the path',
+          '~/Code/flutty [⇢main]',
+        ].join('\r\n');
+        session.terminal!.write(output);
+        await tester.pumpAndSettle();
+
+        final underlineFinder = find.byWidgetPredicate((widget) {
+          final key = widget.key;
+          return key is ValueKey<String> &&
+              key.value.startsWith('terminal-path-underline:');
+        });
+
+        expect(underlineFinder, findsOneWidget);
+        final initialTop = tester.getTopLeft(underlineFinder).dy;
+        final terminalView = tester.widget<MonkeyTerminalView>(
+          find.byType(MonkeyTerminalView),
+        );
+        final scrollController = terminalView.scrollController;
+        final lineHeight = tester
+            .state<MonkeyTerminalViewState>(find.byType(MonkeyTerminalView))
+            .renderTerminal
+            .lineHeight;
+        expect(scrollController, isNotNull);
+        expect(scrollController!.position.maxScrollExtent, greaterThan(0));
+        scrollController.jumpTo(
+          (scrollController.offset - (lineHeight / 2)).clamp(
+            0.0,
+            scrollController.position.maxScrollExtent,
+          ),
+        );
+        await tester.pump();
+
+        expect(underlineFinder, findsOneWidget);
+        expect(tester.getTopLeft(underlineFinder).dy, isNot(initialTop));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
       'extra keys toggle uses distinct copy',
       (tester) async {
         await pumpScreen(tester);

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -394,6 +394,25 @@ void main() {
       );
     });
 
+    test(
+      'detects relative paths split immediately after a directory slash',
+      () {
+        const text =
+            'Open lib/presentation/\n'
+            '    screens/terminal_screen.dart next.';
+        final detectedPath = detectTerminalFilePathAtTextOffset(
+          text,
+          text.indexOf('screens'),
+        );
+
+        expect(detectedPath, isNotNull);
+        expect(
+          detectedPath!.path,
+          'lib/presentation/screens/terminal_screen.dart',
+        );
+      },
+    );
+
     test('ignores colored guide prefixes in continuation indentation', () {
       const text =
           'Open /srv/app/lib/presentation/\n'
@@ -624,6 +643,17 @@ void main() {
 
       expect(detectedPath, isNotNull);
       expect(detectedPath!.path, '~/Code/flutty');
+    });
+
+    test('does not merge separate absolute paths on adjacent lines', () {
+      const text = '/tmp/foo\n/var/log/app.log';
+      final detectedPath = detectTerminalFilePathAtTextOffset(
+        text,
+        text.indexOf('/var/log'),
+      );
+
+      expect(detectedPath, isNotNull);
+      expect(detectedPath!.path, '/var/log/app.log');
     });
 
     test('ignores branch-like slash paths without a file-like basename', () {
@@ -1063,6 +1093,26 @@ void main() {
           nextLineText: '└ L330:390 (61 lines read)',
         ),
         isFalse,
+      );
+    });
+
+    test('does not join separate absolute path starts across lines', () {
+      expect(
+        isTerminalPathContinuationAcrossLines(
+          previousLineText: '/tmp/foo',
+          nextLineText: '/var/log/app.log',
+        ),
+        isFalse,
+      );
+    });
+
+    test('joins relative paths split after a directory separator', () {
+      expect(
+        isTerminalPathContinuationAcrossLines(
+          previousLineText: 'Open lib/presentation/',
+          nextLineText: 'screens/terminal_screen.dart',
+        ),
+        isTrue,
       );
     });
 

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -413,6 +413,42 @@ void main() {
       },
     );
 
+    test('detects tilde-root paths split before the next segment', () {
+      const text = 'Open ~/\nCode/flutty next.';
+      final detectedPath = detectTerminalFilePathAtTextOffset(
+        text,
+        text.indexOf('Code'),
+      );
+
+      expect(detectedPath, isNotNull);
+      expect(detectedPath!.path, '~/Code/flutty');
+    });
+
+    test('detects slash-root paths split before the next segment', () {
+      const text = 'Open /\nvar/log/app.log next.';
+      final detectedPath = detectTerminalFilePathAtTextOffset(
+        text,
+        text.indexOf('var/log'),
+      );
+
+      expect(detectedPath, isNotNull);
+      expect(detectedPath!.path, '/var/log/app.log');
+    });
+
+    test(
+      'detects absolute paths that resume with a slash after leading context',
+      () {
+        const text = 'Open /Users/tester\n/project/lib/main.dart next.';
+        final detectedPath = detectTerminalFilePathAtTextOffset(
+          text,
+          text.indexOf('project/lib'),
+        );
+
+        expect(detectedPath, isNotNull);
+        expect(detectedPath!.path, '/Users/tester/project/lib/main.dart');
+      },
+    );
+
     test('ignores colored guide prefixes in continuation indentation', () {
       const text =
           'Open /srv/app/lib/presentation/\n'
@@ -654,6 +690,22 @@ void main() {
 
       expect(detectedPath, isNotNull);
       expect(detectedPath!.path, '/var/log/app.log');
+    });
+
+    test('does not merge separate relative paths on adjacent lines', () {
+      const text =
+          'lib/presentation/screens/terminal_screen.dart\n'
+          'test/widget/terminal_screen_selection_test.dart';
+      final detectedPath = detectTerminalFilePathAtTextOffset(
+        text,
+        text.indexOf('test/widget'),
+      );
+
+      expect(detectedPath, isNotNull);
+      expect(
+        detectedPath!.path,
+        'test/widget/terminal_screen_selection_test.dart',
+      );
     });
 
     test('ignores branch-like slash paths without a file-like basename', () {
@@ -1113,6 +1165,46 @@ void main() {
           nextLineText: 'screens/terminal_screen.dart',
         ),
         isTrue,
+      );
+    });
+
+    test('joins tilde-root prefixes split before the next segment', () {
+      expect(
+        isTerminalPathContinuationAcrossLines(
+          previousLineText: 'Open ~/',
+          nextLineText: 'Code/flutty',
+        ),
+        isTrue,
+      );
+    });
+
+    test('joins slash-root prefixes split before the next segment', () {
+      expect(
+        isTerminalPathContinuationAcrossLines(
+          previousLineText: 'Open /',
+          nextLineText: 'var/log/app.log',
+        ),
+        isTrue,
+      );
+    });
+
+    test('joins absolute path continuations that resume with a slash', () {
+      expect(
+        isTerminalPathContinuationAcrossLines(
+          previousLineText: 'Open /Users/tester',
+          nextLineText: '/project/lib/main.dart',
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not join separate relative path starts across lines', () {
+      expect(
+        isTerminalPathContinuationAcrossLines(
+          previousLineText: 'lib/presentation/screens/terminal_screen.dart',
+          nextLineText: 'test/widget/terminal_screen_selection_test.dart',
+        ),
+        isFalse,
       );
     });
 

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -613,6 +613,19 @@ void main() {
       );
     });
 
+    test('detects prompt-style explicit paths after ordinary prose rows', () {
+      const text =
+          'metadata rows no longer get folded into the path\n'
+          '~/Code/flutty [⇢main]';
+      final detectedPath = detectTerminalFilePathAtTextOffset(
+        text,
+        text.indexOf('Code'),
+      );
+
+      expect(detectedPath, isNotNull);
+      expect(detectedPath!.path, '~/Code/flutty');
+    });
+
     test('ignores branch-like slash paths without a file-like basename', () {
       expect(
         detectTerminalFilePathAtTextOffset(
@@ -1048,6 +1061,16 @@ void main() {
           previousLineText:
               '~/Code/flutty.worktrees/session-resumption-all-provide',
           nextLineText: '└ L330:390 (61 lines read)',
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not join ordinary prose rows to a following prompt path', () {
+      expect(
+        isTerminalPathContinuationAcrossLines(
+          previousLineText: 'metadata rows no longer get folded into the path',
+          nextLineText: '~/Code/flutty [⇢main]',
         ),
         isFalse,
       );

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -591,6 +591,28 @@ void main() {
       );
     });
 
+    test('ignores separate view metadata rows after wrapped worktree paths', () {
+      const text =
+          'Read terminal_screen.dart\n'
+          '~/Code/flutty.worktrees/session-resumption-all-provide\n'
+          'rs/lib/presentation/screens/terminal_screen.dart\n'
+          '└ L330:390 (61 lines read)';
+      final detectedPath = detectTerminalFilePathAtTextOffset(
+        text,
+        text.indexOf('session-resumption'),
+      );
+
+      expect(detectedPath, isNotNull);
+      expect(
+        detectedPath!.path,
+        '~/Code/flutty.worktrees/session-resumption-all-providers/lib/presentation/screens/terminal_screen.dart',
+      );
+      expect(
+        detectTerminalFilePathAtTextOffset(text, text.indexOf('L330')),
+        isNull,
+      );
+    });
+
     test('ignores branch-like slash paths without a file-like basename', () {
       expect(
         detectTerminalFilePathAtTextOffset(
@@ -1004,6 +1026,28 @@ void main() {
         isTerminalPathContinuationAcrossLines(
           previousLineText: 'Read terminal_screen.dart',
           nextLineText: 'Read sftp_screen.dart',
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not join file labels to a following explicit path row', () {
+      expect(
+        isTerminalPathContinuationAcrossLines(
+          previousLineText: 'Read terminal_screen.dart',
+          nextLineText:
+              '~/Code/flutty.worktrees/session-resumption-all-provide',
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not join standalone view metadata rows after a path', () {
+      expect(
+        isTerminalPathContinuationAcrossLines(
+          previousLineText:
+              '~/Code/flutty.worktrees/session-resumption-all-provide',
+          nextLineText: '└ L330:390 (61 lines read)',
         ),
         isFalse,
       );


### PR DESCRIPTION
## Summary

- stop treating `Read ...` label rows as part of the following explicit worktree path
- ignore standalone `L330:390 (...)` metadata rows when resolving wrapped terminal file paths
- add regression tests for wrapped worktree path detection and continuation rules
