### PR TITLE
fix: smooth alt-buffer scrolling

### DIFF
--- a/lib/presentation/widgets/monkey_terminal_gesture_detector.dart
+++ b/lib/presentation/widgets/monkey_terminal_gesture_detector.dart
@@ -27,6 +27,7 @@ class MonkeyTerminalGestureDetector extends StatefulWidget {
     this.onDragUpdate,
     this.onTouchScrollStart,
     this.onTouchScrollUpdate,
+    this.onTouchScrollEnd,
     this.onDoubleTapDown,
     this.shouldBypassDoubleTap,
   });
@@ -68,6 +69,8 @@ class MonkeyTerminalGestureDetector extends StatefulWidget {
   final GestureDragStartCallback? onTouchScrollStart;
 
   final GestureDragUpdateCallback? onTouchScrollUpdate;
+
+  final GestureDragEndCallback? onTouchScrollEnd;
 
   @override
   State<MonkeyTerminalGestureDetector> createState() =>
@@ -194,7 +197,8 @@ class _MonkeyTerminalGestureDetectorState
         );
 
     if (widget.onTouchScrollStart != null ||
-        widget.onTouchScrollUpdate != null) {
+        widget.onTouchScrollUpdate != null ||
+        widget.onTouchScrollEnd != null) {
       gestures[VerticalDragGestureRecognizer] =
           GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
             () => VerticalDragGestureRecognizer(
@@ -205,7 +209,8 @@ class _MonkeyTerminalGestureDetectorState
               instance
                 ..dragStartBehavior = DragStartBehavior.down
                 ..onStart = widget.onTouchScrollStart
-                ..onUpdate = widget.onTouchScrollUpdate;
+                ..onUpdate = widget.onTouchScrollUpdate
+                ..onEnd = widget.onTouchScrollEnd;
             },
           );
     }

--- a/lib/presentation/widgets/monkey_terminal_gesture_handler.dart
+++ b/lib/presentation/widgets/monkey_terminal_gesture_handler.dart
@@ -31,6 +31,7 @@ class MonkeyTerminalGestureHandler extends StatefulWidget {
     this.onLongPressMoveUpdate,
     this.onTouchScrollStart,
     this.onTouchScrollUpdate,
+    this.onTouchScrollEnd,
     this.resolveLinkTap,
     this.onLinkTapDown,
     this.onLinkTap,
@@ -63,6 +64,8 @@ class MonkeyTerminalGestureHandler extends StatefulWidget {
   final GestureDragStartCallback? onTouchScrollStart;
 
   final GestureDragUpdateCallback? onTouchScrollUpdate;
+
+  final GestureDragEndCallback? onTouchScrollEnd;
 
   /// Optional override for touch long-press start. When provided, the default
   /// behavior of selecting a word in the terminal is suppressed.
@@ -121,6 +124,7 @@ class _TerminalGestureHandlerState extends State<MonkeyTerminalGestureHandler> {
       onTertiaryTapUp: onTertiaryTapUp,
       onTouchScrollStart: onTouchScrollStart,
       onTouchScrollUpdate: onTouchScrollUpdate,
+      onTouchScrollEnd: onTouchScrollEnd,
       onLongPressStart: onLongPressStart,
       onLongPressMoveUpdate: onLongPressMoveUpdate,
       // onLongPressUp: onLongPressUp,
@@ -218,6 +222,11 @@ class _TerminalGestureHandlerState extends State<MonkeyTerminalGestureHandler> {
   void onTouchScrollUpdate(DragUpdateDetails details) {
     _clearPendingLinkTap();
     widget.onTouchScrollUpdate?.call(details);
+  }
+
+  void onTouchScrollEnd(DragEndDetails details) {
+    _clearPendingLinkTap();
+    widget.onTouchScrollEnd?.call(details);
   }
 
   void onSecondaryTapUp(TapUpDetails details) {

--- a/lib/presentation/widgets/monkey_terminal_scroll_gesture_handler.dart
+++ b/lib/presentation/widgets/monkey_terminal_scroll_gesture_handler.dart
@@ -41,9 +41,12 @@ class _MonkeyTerminalScrollGestureHandlerState
   /// widget does nothing.
   var isAltBuffer = false;
 
-  /// The variable that tracks the line offset in last scroll event. Used to
-  /// determine how many the scroll events should be sent to the terminal.
-  var lastLineOffset = 0;
+  /// Tracks the last scroll offset reported by [InfiniteScrollView].
+  var lastScrollOffset = 0.0;
+
+  /// Accumulates partial scroll deltas so reversing direction still requires a
+  /// full line-height of movement before another terminal wheel event is sent.
+  var scrollRemainder = 0.0;
 
   /// This variable tracks the last offset where the scroll gesture started.
   /// Used to calculate the cell offset of the terminal mouse event.
@@ -68,6 +71,7 @@ class _MonkeyTerminalScrollGestureHandlerState
       oldWidget.terminal.removeListener(_onTerminalUpdated);
       widget.terminal.addListener(_onTerminalUpdated);
       isAltBuffer = widget.terminal.isUsingAltBuffer;
+      _resetScrollTracking();
     }
     super.didUpdateWidget(oldWidget);
   }
@@ -75,6 +79,7 @@ class _MonkeyTerminalScrollGestureHandlerState
   void _onTerminalUpdated() {
     if (isAltBuffer != widget.terminal.isUsingAltBuffer) {
       isAltBuffer = widget.terminal.isUsingAltBuffer;
+      _resetScrollTracking();
       setState(() {});
     }
   }
@@ -98,16 +103,25 @@ class _MonkeyTerminalScrollGestureHandlerState
     }
   }
 
+  void _resetScrollTracking() {
+    lastScrollOffset = 0;
+    scrollRemainder = 0;
+  }
+
   void _onScroll(double offset) {
-    final currentLineOffset = offset ~/ widget.getLineHeight();
-
-    final delta = currentLineOffset - lastLineOffset;
-
-    for (var i = 0; i < delta.abs(); i++) {
-      _sendScrollEvent(delta < 0);
+    final lineHeight = widget.getLineHeight();
+    if (lineHeight <= 0) {
+      return;
     }
 
-    lastLineOffset = currentLineOffset;
+    scrollRemainder += offset - lastScrollOffset;
+    lastScrollOffset = offset;
+
+    while (scrollRemainder.abs() >= lineHeight) {
+      final scrollUp = scrollRemainder < 0;
+      _sendScrollEvent(scrollUp);
+      scrollRemainder += scrollUp ? lineHeight : -lineHeight;
+    }
   }
 
   void _rememberPointerPosition(Offset position) {

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -297,6 +297,8 @@ class MonkeyTerminalView extends StatefulWidget {
 
 class MonkeyTerminalViewState extends State<MonkeyTerminalView>
     with SingleTickerProviderStateMixin {
+  static const _touchScrollReportedWheelLinesPerEvent = 3.0;
+
   late FocusNode _focusNode;
 
   late final ShortcutManager _shortcutManager;
@@ -362,6 +364,10 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
         _scrollController.dispose();
       }
       _scrollController = widget.scrollController ?? ScrollController();
+    }
+    if (oldWidget.simulateScroll != widget.simulateScroll) {
+      _stopTouchScrollInertia();
+      _touchScrollRemainder = 0;
     }
     if (oldWidget.touchScrollToTerminal && !widget.touchScrollToTerminal) {
       _stopTouchScrollInertia();
@@ -693,15 +699,26 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
     );
   }
 
+  double get _touchScrollStepHeight {
+    final lineHeight = renderTerminal.lineHeight;
+    if (lineHeight <= 0) {
+      return 0;
+    }
+    if (widget.terminal.mouseMode.reportScroll) {
+      return lineHeight * _touchScrollReportedWheelLinesPerEvent;
+    }
+    return lineHeight;
+  }
+
   void _applyTouchScrollDelta(double delta) {
     _touchScrollRemainder += delta;
 
-    final lineHeight = renderTerminal.lineHeight;
-    if (lineHeight <= 0) {
+    final stepHeight = _touchScrollStepHeight;
+    if (stepHeight <= 0) {
       return;
     }
 
-    while (_touchScrollRemainder.abs() >= lineHeight) {
+    while (_touchScrollRemainder.abs() >= stepHeight) {
       final scrollUp = _touchScrollRemainder > 0;
       final handled = _sendTouchScrollMouseInput(
         scrollUp ? TerminalMouseButton.wheelUp : TerminalMouseButton.wheelDown,
@@ -714,7 +731,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
         );
       }
 
-      _touchScrollRemainder += scrollUp ? -lineHeight : lineHeight;
+      _touchScrollRemainder += scrollUp ? -stepHeight : stepHeight;
     }
   }
 

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -7,9 +7,11 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:ui';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:xterm/src/core/buffer/cell_offset.dart';
 import 'package:xterm/src/core/buffer/range.dart';
@@ -293,7 +295,8 @@ class MonkeyTerminalView extends StatefulWidget {
   State<MonkeyTerminalView> createState() => MonkeyTerminalViewState();
 }
 
-class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
+class MonkeyTerminalViewState extends State<MonkeyTerminalView>
+    with SingleTickerProviderStateMixin {
   late FocusNode _focusNode;
 
   late final ShortcutManager _shortcutManager;
@@ -307,6 +310,9 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
   String? _composingText;
   Offset _lastTouchScrollPosition = Offset.zero;
   double _touchScrollRemainder = 0;
+  late final Ticker _touchScrollInertiaTicker;
+  Simulation? _touchScrollInertiaSimulation;
+  double _lastTouchScrollInertiaOffset = 0;
   int _lastTerminalViewWidth = 0;
 
   late TerminalController _controller;
@@ -327,6 +333,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
       shortcuts: widget.shortcuts ?? defaultTerminalShortcuts,
     );
     super.initState();
+    _touchScrollInertiaTicker = createTicker(_onTouchScrollInertiaTick);
   }
 
   @override
@@ -335,6 +342,8 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
       oldWidget.terminal.removeListener(_handleTerminalMetricsChanged);
       _lastTerminalViewWidth = widget.terminal.viewWidth;
       widget.terminal.addListener(_handleTerminalMetricsChanged);
+      _stopTouchScrollInertia();
+      _touchScrollRemainder = 0;
     }
     if (oldWidget.focusNode != widget.focusNode) {
       if (oldWidget.focusNode == null) {
@@ -354,6 +363,10 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
       }
       _scrollController = widget.scrollController ?? ScrollController();
     }
+    if (oldWidget.touchScrollToTerminal && !widget.touchScrollToTerminal) {
+      _stopTouchScrollInertia();
+      _touchScrollRemainder = 0;
+    }
     _shortcutManager.shortcuts = widget.shortcuts ?? defaultTerminalShortcuts;
     super.didUpdateWidget(oldWidget);
   }
@@ -361,6 +374,8 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
   @override
   void dispose() {
     widget.terminal.removeListener(_handleTerminalMetricsChanged);
+    _stopTouchScrollInertia();
+    _touchScrollInertiaTicker.dispose();
     if (widget.focusNode == null) {
       _focusNode.dispose();
     }
@@ -552,6 +567,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
       onTouchScrollUpdate: widget.touchScrollToTerminal
           ? _onTouchScrollUpdate
           : null,
+      onTouchScrollEnd: widget.touchScrollToTerminal ? _onTouchScrollEnd : null,
       readOnly: widget.readOnly,
       child: child,
     );
@@ -609,6 +625,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
   }
 
   void _onTapDown(TapDownDetails details) {
+    _stopTouchScrollInertia();
     if (_controller.selection != null) {
       _controller.clearSelection();
     } else {
@@ -629,6 +646,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
   }
 
   void _onLinkTapDown(TapDownDetails details) {
+    _stopTouchScrollInertia();
     final offset = renderTerminal.getCellOffset(details.localPosition);
     widget.onLinkTapDown?.call(details, offset);
   }
@@ -649,13 +667,34 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
   }
 
   void _onTouchScrollStart(DragStartDetails details) {
+    _stopTouchScrollInertia();
     _lastTouchScrollPosition = details.localPosition;
     _touchScrollRemainder = 0;
   }
 
   void _onTouchScrollUpdate(DragUpdateDetails details) {
     _lastTouchScrollPosition = details.localPosition;
-    _touchScrollRemainder += details.delta.dy;
+    _applyTouchScrollDelta(details.delta.dy);
+  }
+
+  void _onTouchScrollEnd(DragEndDetails details) {
+    final primaryVelocity = details.primaryVelocity;
+    if (primaryVelocity == null) {
+      return;
+    }
+    _startTouchScrollInertia(primaryVelocity);
+  }
+
+  Tolerance get _touchScrollTolerance {
+    final devicePixelRatio = View.of(context).devicePixelRatio;
+    return Tolerance(
+      velocity: 1.0 / (0.050 * devicePixelRatio),
+      distance: 1.0 / devicePixelRatio,
+    );
+  }
+
+  void _applyTouchScrollDelta(double delta) {
+    _touchScrollRemainder += delta;
 
     final lineHeight = renderTerminal.lineHeight;
     if (lineHeight <= 0) {
@@ -676,6 +715,48 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView> {
       }
 
       _touchScrollRemainder += scrollUp ? -lineHeight : lineHeight;
+    }
+  }
+
+  void _startTouchScrollInertia(double velocity) {
+    final clampedVelocity = velocity.clamp(
+      -kMaxFlingVelocity,
+      kMaxFlingVelocity,
+    );
+    if (clampedVelocity.abs() < kMinFlingVelocity) {
+      return;
+    }
+
+    _stopTouchScrollInertia();
+    _touchScrollInertiaSimulation = ClampingScrollSimulation(
+      position: 0,
+      velocity: clampedVelocity,
+      tolerance: _touchScrollTolerance,
+    );
+    _touchScrollInertiaTicker.start();
+  }
+
+  void _stopTouchScrollInertia() {
+    _touchScrollInertiaTicker.stop();
+    _touchScrollInertiaSimulation = null;
+    _lastTouchScrollInertiaOffset = 0;
+  }
+
+  void _onTouchScrollInertiaTick(Duration elapsed) {
+    final simulation = _touchScrollInertiaSimulation;
+    if (simulation == null) {
+      _touchScrollInertiaTicker.stop();
+      return;
+    }
+
+    final elapsedSeconds =
+        elapsed.inMicroseconds / Duration.microsecondsPerSecond;
+    final scrollOffset = simulation.x(elapsedSeconds);
+    _applyTouchScrollDelta(scrollOffset - _lastTouchScrollInertiaOffset);
+    _lastTouchScrollInertiaOffset = scrollOffset;
+
+    if (simulation.isDone(elapsedSeconds)) {
+      _stopTouchScrollInertia();
     }
   }
 

--- a/test/widget/monkey_terminal_scroll_gesture_handler_test.dart
+++ b/test/widget/monkey_terminal_scroll_gesture_handler_test.dart
@@ -73,4 +73,68 @@ void main() {
       }
     },
   );
+
+  testWidgets(
+    'trackpad reversal waits for a full line before sending a reverse step',
+    (tester) async {
+      final terminal = Terminal()
+        ..useAltBuffer()
+        ..setMouseMode(MouseMode.upDownScroll)
+        ..setMouseReportMode(MouseReportMode.sgr);
+      final output = <String>[];
+      terminal.onOutput = output.add;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: SizedBox(
+                width: 200,
+                height: 200,
+                child: MonkeyTerminalScrollGestureHandler(
+                  terminal: terminal,
+                  simulateScroll: false,
+                  getCellOffset: (_) => const CellOffset(1, 1),
+                  getLineHeight: () => 10,
+                  child: const ColoredBox(
+                    key: ValueKey('reverse-threshold-target'),
+                    color: Colors.black,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final center = tester.getCenter(
+        find.byKey(const ValueKey('reverse-threshold-target')),
+      );
+      final gesture = await tester.createGesture(
+        kind: PointerDeviceKind.trackpad,
+      );
+
+      await gesture.panZoomStart(center);
+      await tester.pump();
+      await gesture.panZoomUpdate(
+        center + const Offset(0, -10),
+        pan: const Offset(0, -10),
+      );
+      await tester.pump();
+
+      expect(output, hasLength(1));
+
+      await gesture.panZoomUpdate(
+        center + const Offset(0, -4),
+        pan: const Offset(0, -4),
+      );
+      await tester.pump();
+
+      expect(output, hasLength(1));
+
+      await gesture.panZoomEnd();
+      await tester.pump();
+    },
+  );
 }

--- a/test/widget/monkey_terminal_view_touch_scroll_test.dart
+++ b/test/widget/monkey_terminal_view_touch_scroll_test.dart
@@ -1,7 +1,9 @@
 // ignore_for_file: implementation_imports, public_member_api_docs
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/presentation/widgets/monkey_terminal_gesture_detector.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
 import 'package:xterm/xterm.dart';
 
@@ -67,6 +69,70 @@ void main() {
 
     expect(output.join(), contains('\u001b[<65;'));
     expect(output.join(), isNot(contains('\u001b[B')));
+  });
+
+  testWidgets('touch scroll keeps moving with inertia after lift-off', (
+    tester,
+  ) async {
+    final terminal = Terminal()..useAltBuffer();
+    final output = <String>[];
+    terminal.onOutput = output.add;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 300,
+          height: 200,
+          child: MonkeyTerminalView(
+            terminal,
+            hardwareKeyboardOnly: true,
+            touchScrollToTerminal: true,
+          ),
+        ),
+      ),
+    );
+
+    final detector = tester.widget<MonkeyTerminalGestureDetector>(
+      find.byType(MonkeyTerminalGestureDetector),
+    );
+    detector.onTouchScrollStart!(
+      DragStartDetails(
+        kind: PointerDeviceKind.touch,
+        localPosition: const Offset(150, 100),
+      ),
+    );
+    detector.onTouchScrollUpdate!(
+      DragUpdateDetails(
+        kind: PointerDeviceKind.touch,
+        globalPosition: const Offset(150, 40),
+        localPosition: const Offset(150, 40),
+        delta: const Offset(0, -60),
+      ),
+    );
+    detector.onTouchScrollUpdate!(
+      DragUpdateDetails(
+        kind: PointerDeviceKind.touch,
+        globalPosition: const Offset(150, 10),
+        localPosition: const Offset(150, 10),
+        delta: const Offset(0, -60),
+      ),
+    );
+
+    final beforeLiftOutputCount = output.length;
+    expect(beforeLiftOutputCount, greaterThan(0));
+
+    detector.onTouchScrollEnd!(
+      DragEndDetails(
+        primaryVelocity: -2000,
+        velocity: const Velocity(pixelsPerSecond: Offset(0, -2000)),
+      ),
+    );
+    await tester.pump();
+
+    final afterLiftOutputCount = output.length;
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(output.length, greaterThan(afterLiftOutputCount));
   });
 
   testWidgets('double taps invoke the terminal view callback', (tester) async {

--- a/test/widget/monkey_terminal_view_touch_scroll_test.dart
+++ b/test/widget/monkey_terminal_view_touch_scroll_test.dart
@@ -7,6 +7,20 @@ import 'package:monkeyssh/presentation/widgets/monkey_terminal_gesture_detector.
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
 import 'package:xterm/xterm.dart';
 
+int _countOccurrences(String text, String pattern) {
+  var count = 0;
+  var start = 0;
+
+  while (true) {
+    final index = text.indexOf(pattern, start);
+    if (index == -1) {
+      return count;
+    }
+    count += 1;
+    start = index + pattern.length;
+  }
+}
+
 void main() {
   testWidgets('touch scroll falls back to arrow keys in alt buffer', (
     tester,
@@ -70,6 +84,104 @@ void main() {
     expect(output.join(), contains('\u001b[<65;'));
     expect(output.join(), isNot(contains('\u001b[B')));
   });
+
+  testWidgets(
+    'mouse-reporting apps require more drag distance per touch scroll step',
+    (tester) async {
+      final expectedOutput = <String>[];
+      Terminal()
+        ..onOutput = expectedOutput.add
+        ..keyInput(TerminalKey.arrowDown);
+      final expectedArrowDown = expectedOutput.join();
+
+      final arrowTerminal = Terminal()..useAltBuffer();
+      final arrowOutput = <String>[];
+      arrowTerminal.onOutput = arrowOutput.add;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SizedBox(
+            width: 300,
+            height: 200,
+            child: MonkeyTerminalView(
+              arrowTerminal,
+              hardwareKeyboardOnly: true,
+              touchScrollToTerminal: true,
+            ),
+          ),
+        ),
+      );
+
+      var detector = tester.widget<MonkeyTerminalGestureDetector>(
+        find.byType(MonkeyTerminalGestureDetector),
+      );
+      detector.onTouchScrollStart!(
+        DragStartDetails(
+          kind: PointerDeviceKind.touch,
+          localPosition: const Offset(150, 100),
+        ),
+      );
+      detector.onTouchScrollUpdate!(
+        DragUpdateDetails(
+          kind: PointerDeviceKind.touch,
+          globalPosition: const Offset(150, 10),
+          localPosition: const Offset(150, 10),
+          delta: const Offset(0, -240),
+        ),
+      );
+      await tester.pump();
+
+      final arrowCount = _countOccurrences(
+        arrowOutput.join(),
+        expectedArrowDown,
+      );
+      expect(arrowCount, greaterThan(0));
+
+      final wheelTerminal = Terminal()
+        ..useAltBuffer()
+        ..setMouseMode(MouseMode.upDownScroll)
+        ..setMouseReportMode(MouseReportMode.sgr);
+      final wheelOutput = <String>[];
+      wheelTerminal.onOutput = wheelOutput.add;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SizedBox(
+            width: 300,
+            height: 200,
+            child: MonkeyTerminalView(
+              wheelTerminal,
+              hardwareKeyboardOnly: true,
+              touchScrollToTerminal: true,
+            ),
+          ),
+        ),
+      );
+
+      detector = tester.widget<MonkeyTerminalGestureDetector>(
+        find.byType(MonkeyTerminalGestureDetector),
+      );
+      detector.onTouchScrollStart!(
+        DragStartDetails(
+          kind: PointerDeviceKind.touch,
+          localPosition: const Offset(150, 100),
+        ),
+      );
+      detector.onTouchScrollUpdate!(
+        DragUpdateDetails(
+          kind: PointerDeviceKind.touch,
+          globalPosition: const Offset(150, 10),
+          localPosition: const Offset(150, 10),
+          delta: const Offset(0, -240),
+        ),
+      );
+      await tester.pump();
+
+      final wheelCount = _countOccurrences(wheelOutput.join(), '\u001b[<65;');
+      expect(wheelCount, greaterThan(0));
+      expect(wheelCount, lessThan(arrowCount));
+    },
+  );
 
   testWidgets('touch scroll keeps moving with inertia after lift-off', (
     tester,


### PR DESCRIPTION
## Summary

- smooth alt-buffer trackpad scrolling by consuming incremental `InfiniteScrollView` deltas so reverse drags do not emit extra terminal wheel steps
- make live touch drags in mouse-reporting TUIs require more finger travel per terminal scroll step so content stays closer to the finger while it is still down
- add touch drag end handling plus a decelerating inertial continuation so alt-mode terminal scrolling does not stop dead when a fling lifts off
- add widget regressions for reverse-drag threshold handling, gentler touch drag scaling, and inertial touch scrolling

## Validation

- dart format lib/presentation/widgets/monkey_terminal_gesture_detector.dart lib/presentation/widgets/monkey_terminal_gesture_handler.dart lib/presentation/widgets/monkey_terminal_scroll_gesture_handler.dart lib/presentation/widgets/monkey_terminal_view.dart test/widget/monkey_terminal_scroll_gesture_handler_test.dart test/widget/monkey_terminal_view_touch_scroll_test.dart
- flutter test test/widget/monkey_terminal_scroll_gesture_handler_test.dart test/widget/monkey_terminal_view_touch_scroll_test.dart test/widget/terminal_screen_scroll_policy_test.dart test/widget/monkey_terminal_gesture_handler_test.dart
- flutter analyze
- flutter test
