### PR TITLE
feat: add home screen host shortcuts

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -71,13 +71,15 @@ class _BackgroundLifecycleBridgeState
       syncBackgroundState: () =>
           BackgroundSshService.setForegroundState(isForeground: false),
     );
-    _listenForHomeScreenShortcutChanges();
-    _runLifecycleSync(
-      () => ref.read(homeScreenShortcutServiceProvider).initialize(),
-      errorContext:
-          'while initializing home-screen shortcuts during app startup',
-      defer: true,
-    );
+    if (supportsHomeScreenShortcutActions) {
+      _listenForHomeScreenShortcutChanges();
+      _runLifecycleSync(
+        () => ref.read(homeScreenShortcutServiceProvider).initialize(),
+        errorContext:
+            'while initializing home-screen shortcuts during app startup',
+        defer: true,
+      );
+    }
     _runLifecycleSync(
       _refreshMonetizationOnStartup,
       errorContext: 'while refreshing subscription state during app startup',

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -3,7 +3,10 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../data/database/database.dart';
+import '../data/repositories/host_repository.dart';
 import '../domain/services/background_ssh_service.dart';
+import '../domain/services/home_screen_shortcut_service.dart';
 import '../domain/services/monetization_service.dart';
 import '../domain/services/settings_service.dart';
 import '../domain/services/ssh_service.dart';
@@ -51,6 +54,12 @@ class _BackgroundLifecycleBridgeState
     extends ConsumerState<_BackgroundLifecycleBridge>
     with WidgetsBindingObserver {
   late final AppLifecycleCoordinator _lifecycleCoordinator;
+  StreamSubscription<List<Host>>? _homeScreenShortcutHostsSubscription;
+  StreamSubscription<Set<int>>? _pinnedHomeScreenShortcutHostsSubscription;
+  List<Host> _latestHomeScreenShortcutHosts = const <Host>[];
+  Set<int> _latestPinnedHomeScreenShortcutHostIds = const <int>{};
+  bool _hasLoadedHomeScreenShortcutHosts = false;
+  bool _hasLoadedPinnedHomeScreenShortcutHostIds = false;
 
   @override
   void initState() {
@@ -61,6 +70,13 @@ class _BackgroundLifecycleBridgeState
       syncForegroundBackgroundStatus: _syncForegroundBackgroundStatus,
       syncBackgroundState: () =>
           BackgroundSshService.setForegroundState(isForeground: false),
+    );
+    _listenForHomeScreenShortcutChanges();
+    _runLifecycleSync(
+      () => ref.read(homeScreenShortcutServiceProvider).initialize(),
+      errorContext:
+          'while initializing home-screen shortcuts during app startup',
+      defer: true,
     );
     _runLifecycleSync(
       _refreshMonetizationOnStartup,
@@ -77,7 +93,39 @@ class _BackgroundLifecycleBridgeState
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    unawaited(_homeScreenShortcutHostsSubscription?.cancel());
+    unawaited(_pinnedHomeScreenShortcutHostsSubscription?.cancel());
     super.dispose();
+  }
+
+  void _listenForHomeScreenShortcutChanges() {
+    final hostRepository = ref.read(hostRepositoryProvider);
+    _homeScreenShortcutHostsSubscription = hostRepository.watchAll().listen((
+      hosts,
+    ) {
+      _latestHomeScreenShortcutHosts = hosts;
+      _hasLoadedHomeScreenShortcutHosts = true;
+      _runLifecycleSync(
+        _syncHomeScreenShortcuts,
+        errorContext:
+            'while syncing home-screen shortcuts after the host list changed',
+      );
+    });
+
+    final preferencesService = ref.read(
+      homeScreenShortcutPreferencesServiceProvider,
+    );
+    _pinnedHomeScreenShortcutHostsSubscription = preferencesService
+        .watchPinnedHostIds()
+        .listen((hostIds) {
+          _latestPinnedHomeScreenShortcutHostIds = hostIds;
+          _hasLoadedPinnedHomeScreenShortcutHostIds = true;
+          _runLifecycleSync(
+            _syncHomeScreenShortcuts,
+            errorContext:
+                'while syncing home-screen shortcuts after pinned hosts changed',
+          );
+        });
   }
 
   Future<void> _syncForegroundBackgroundStatus() async {
@@ -87,6 +135,20 @@ class _BackgroundLifecycleBridgeState
 
   Future<void> _refreshMonetizationOnStartup() async {
     await ref.read(monetizationServiceProvider).initialize();
+  }
+
+  Future<void> _syncHomeScreenShortcuts() async {
+    if (!_hasLoadedHomeScreenShortcutHosts ||
+        !_hasLoadedPinnedHomeScreenShortcutHostIds) {
+      return;
+    }
+
+    await ref
+        .read(homeScreenShortcutServiceProvider)
+        .updateShortcuts(
+          hosts: _latestHomeScreenShortcutHosts,
+          pinnedHostIds: _latestPinnedHomeScreenShortcutHostIds,
+        );
   }
 
   Future<void> _syncAuthLifecycle(AppLifecycleState state) => ref

--- a/lib/domain/services/home_screen_shortcut_service.dart
+++ b/lib/domain/services/home_screen_shortcut_service.dart
@@ -1,0 +1,344 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:quick_actions/quick_actions.dart';
+
+import '../../data/database/database.dart';
+import 'settings_service.dart';
+
+/// Prefix used for host-specific home-screen shortcut payloads.
+const homeScreenShortcutHostTypePrefix = 'host:';
+
+/// Maximum number of hosts surfaced in the app icon's quick actions.
+const maxHomeScreenShortcutItems = 4;
+
+bool get _supportsHomeScreenShortcuts =>
+    !kIsWeb &&
+    (defaultTargetPlatform == TargetPlatform.android ||
+        defaultTargetPlatform == TargetPlatform.iOS);
+
+/// Builds the platform shortcut payload for a host ID.
+String buildHomeScreenShortcutHostType(int hostId) {
+  if (hostId <= 0) {
+    throw ArgumentError.value(hostId, 'hostId', 'Must be positive.');
+  }
+  return '$homeScreenShortcutHostTypePrefix$hostId';
+}
+
+/// Parses a host ID from a platform shortcut payload.
+int? parseHomeScreenShortcutHostId(Object? shortcutType) {
+  if (shortcutType is! String) {
+    return null;
+  }
+  final normalizedShortcutType = shortcutType.trim();
+  if (!normalizedShortcutType.startsWith(homeScreenShortcutHostTypePrefix)) {
+    return null;
+  }
+
+  final hostId = int.tryParse(
+    normalizedShortcutType.substring(homeScreenShortcutHostTypePrefix.length),
+  );
+  if (hostId == null || hostId <= 0) {
+    return null;
+  }
+  return hostId;
+}
+
+/// Parses the stored pinned home-screen shortcut host IDs.
+Set<int> parsePinnedHomeScreenShortcutHostIds(String? rawValue) {
+  final normalizedRawValue = rawValue?.trim();
+  if (normalizedRawValue == null || normalizedRawValue.isEmpty) {
+    return <int>{};
+  }
+
+  try {
+    final decodedValue = jsonDecode(normalizedRawValue);
+    if (decodedValue is! List<Object?>) {
+      return <int>{};
+    }
+
+    final hostIds = <int>{};
+    for (final entry in decodedValue) {
+      final hostId = switch (entry) {
+        final int value => value,
+        final String value => int.tryParse(value),
+        _ => null,
+      };
+      if (hostId != null && hostId > 0) {
+        hostIds.add(hostId);
+      }
+    }
+    return hostIds;
+  } on FormatException {
+    return <int>{};
+  }
+}
+
+int _compareNullableDateTimesDescending(DateTime? left, DateTime? right) {
+  if (identical(left, right)) {
+    return 0;
+  }
+  if (left == null) {
+    return 1;
+  }
+  if (right == null) {
+    return -1;
+  }
+  return right.compareTo(left);
+}
+
+/// Compares two hosts for home-screen shortcut priority.
+int compareHomeScreenShortcutHosts(
+  Host left,
+  Host right, {
+  required Set<int> pinnedHostIds,
+}) {
+  final leftPinned = pinnedHostIds.contains(left.id);
+  final rightPinned = pinnedHostIds.contains(right.id);
+  if (leftPinned != rightPinned) {
+    return leftPinned ? -1 : 1;
+  }
+
+  if (left.isFavorite != right.isFavorite) {
+    return left.isFavorite ? -1 : 1;
+  }
+
+  final lastConnectedComparison = _compareNullableDateTimesDescending(
+    left.lastConnectedAt,
+    right.lastConnectedAt,
+  );
+  if (lastConnectedComparison != 0) {
+    return lastConnectedComparison;
+  }
+
+  final sortOrderComparison = left.sortOrder.compareTo(right.sortOrder);
+  if (sortOrderComparison != 0) {
+    return sortOrderComparison;
+  }
+
+  return left.id.compareTo(right.id);
+}
+
+/// Selects the highest-priority hosts for home-screen shortcuts.
+List<Host> selectHomeScreenShortcutHosts(
+  Iterable<Host> hosts, {
+  required Set<int> pinnedHostIds,
+  int limit = maxHomeScreenShortcutItems,
+}) {
+  if (limit <= 0) {
+    return const <Host>[];
+  }
+
+  final rankedHosts = hosts.toList()
+    ..sort(
+      (left, right) => compareHomeScreenShortcutHosts(
+        left,
+        right,
+        pinnedHostIds: pinnedHostIds,
+      ),
+    );
+  return List<Host>.unmodifiable(rankedHosts.take(limit));
+}
+
+String _buildHomeScreenShortcutSubtitle(Host host) {
+  final endpoint = '${host.username}@${host.hostname}';
+  return host.port == 22 ? endpoint : '$endpoint:${host.port}';
+}
+
+/// Builds the platform shortcut items for the selected hosts.
+List<ShortcutItem> buildHomeScreenShortcutItems(Iterable<Host> hosts) => hosts
+    .map(
+      (host) => ShortcutItem(
+        type: buildHomeScreenShortcutHostType(host.id),
+        localizedTitle: host.label,
+        localizedSubtitle: _buildHomeScreenShortcutSubtitle(host),
+      ),
+    )
+    .toList(growable: false);
+
+/// Stores manual host pins for the limited home-screen shortcut set.
+class HomeScreenShortcutPreferencesService {
+  /// Creates a new [HomeScreenShortcutPreferencesService].
+  HomeScreenShortcutPreferencesService(this._settingsService);
+
+  final SettingsService _settingsService;
+
+  /// Returns the currently pinned host IDs.
+  Future<Set<int>> getPinnedHostIds() async {
+    final rawValue = await _settingsService.getString(
+      SettingKeys.homeScreenShortcutHostIds,
+    );
+    return parsePinnedHomeScreenShortcutHostIds(rawValue);
+  }
+
+  /// Watches the currently pinned host IDs.
+  Stream<Set<int>> watchPinnedHostIds() => _settingsService
+      .watchString(SettingKeys.homeScreenShortcutHostIds)
+      .map(parsePinnedHomeScreenShortcutHostIds)
+      .distinct(setEquals);
+
+  /// Pins or unpins a host from the home-screen shortcut set.
+  Future<void> setHostPinned(int hostId, {required bool pinned}) async {
+    if (hostId <= 0) {
+      throw ArgumentError.value(hostId, 'hostId', 'Must be positive.');
+    }
+
+    final pinnedHostIds = await getPinnedHostIds();
+    if (pinned) {
+      pinnedHostIds.add(hostId);
+    } else {
+      pinnedHostIds.remove(hostId);
+    }
+    await _writePinnedHostIds(pinnedHostIds);
+  }
+
+  Future<void> _writePinnedHostIds(Set<int> hostIds) async {
+    if (hostIds.isEmpty) {
+      await _settingsService.delete(SettingKeys.homeScreenShortcutHostIds);
+      return;
+    }
+
+    final orderedHostIds = hostIds.toList()..sort();
+    await _settingsService.setString(
+      SettingKeys.homeScreenShortcutHostIds,
+      jsonEncode(orderedHostIds),
+    );
+  }
+}
+
+/// Service that keeps platform home-screen quick actions in sync with hosts.
+class HomeScreenShortcutService {
+  /// Creates a new [HomeScreenShortcutService].
+  HomeScreenShortcutService({QuickActions? quickActions})
+    : _quickActions = quickActions ?? const QuickActions();
+
+  final QuickActions _quickActions;
+  final Queue<int> _pendingHostLaunches = Queue<int>();
+  late final StreamController<int> _hostLaunchController =
+      StreamController<int>.broadcast(
+        onListen: _handleHostLaunchListenerAttached,
+        onCancel: _handleHostLaunchListenerDetached,
+      );
+  Future<void>? _initializeFuture;
+  int _hostLaunchListenerCount = 0;
+
+  /// Stream of host IDs launched from a home-screen shortcut.
+  Stream<int> get hostLaunches {
+    unawaited(initialize());
+    return _hostLaunchController.stream;
+  }
+
+  /// Ensures the quick-action integration is initialized once.
+  Future<void> initialize() =>
+      _initializeFuture ??= _supportsHomeScreenShortcuts
+      ? _initializeInternal()
+      : Future<void>.value();
+
+  /// Updates the dynamic home-screen shortcut items.
+  Future<void> updateShortcuts({
+    required List<Host> hosts,
+    required Set<int> pinnedHostIds,
+  }) async {
+    if (!_supportsHomeScreenShortcuts) {
+      return;
+    }
+
+    await initialize();
+    final shortcutItems = buildHomeScreenShortcutItems(
+      selectHomeScreenShortcutHosts(hosts, pinnedHostIds: pinnedHostIds),
+    );
+
+    try {
+      await _quickActions.setShortcutItems(shortcutItems);
+    } on MissingPluginException {
+      return;
+    } on PlatformException {
+      return;
+    }
+  }
+
+  Future<void> _initializeInternal() async {
+    try {
+      await _quickActions.initialize((shortcutType) {
+        final hostId = parseHomeScreenShortcutHostId(shortcutType);
+        if (hostId == null) {
+          return;
+        }
+        _dispatchHostLaunch(hostId);
+      });
+    } on MissingPluginException {
+      return;
+    } on PlatformException {
+      return;
+    }
+  }
+
+  void _dispatchHostLaunch(int hostId) {
+    if (_hostLaunchListenerCount == 0) {
+      _pendingHostLaunches.add(hostId);
+      return;
+    }
+    _hostLaunchController.add(hostId);
+  }
+
+  void _handleHostLaunchListenerAttached() {
+    _hostLaunchListenerCount += 1;
+    if (_hostLaunchListenerCount == 1) {
+      Future<void>.microtask(_flushPendingHostLaunches);
+    }
+  }
+
+  void _handleHostLaunchListenerDetached() {
+    if (_hostLaunchListenerCount > 0) {
+      _hostLaunchListenerCount -= 1;
+    }
+  }
+
+  void _flushPendingHostLaunches() {
+    if (_hostLaunchController.isClosed || _hostLaunchListenerCount == 0) {
+      return;
+    }
+
+    while (_pendingHostLaunches.isNotEmpty && _hostLaunchListenerCount > 0) {
+      _hostLaunchController.add(_pendingHostLaunches.removeFirst());
+    }
+  }
+
+  /// Injects a host launch in tests without going through the platform plugin.
+  @visibleForTesting
+  void debugEmitHostLaunch(int hostId) => _dispatchHostLaunch(hostId);
+
+  /// Releases resources held by the service.
+  Future<void> dispose() async {
+    await _hostLaunchController.close();
+  }
+}
+
+/// Provider for [HomeScreenShortcutPreferencesService].
+final homeScreenShortcutPreferencesServiceProvider =
+    Provider<HomeScreenShortcutPreferencesService>(
+      (ref) => HomeScreenShortcutPreferencesService(
+        ref.watch(settingsServiceProvider),
+      ),
+    );
+
+/// Stream of host IDs pinned into the limited home-screen shortcut set.
+final pinnedHomeScreenShortcutHostIdsProvider = StreamProvider<Set<int>>((ref) {
+  final preferencesService = ref.watch(
+    homeScreenShortcutPreferencesServiceProvider,
+  );
+  return preferencesService.watchPinnedHostIds();
+});
+
+/// Provider for [HomeScreenShortcutService].
+final homeScreenShortcutServiceProvider = Provider<HomeScreenShortcutService>((
+  ref,
+) {
+  final service = HomeScreenShortcutService();
+  ref.onDispose(() => unawaited(service.dispose()));
+  return service;
+});

--- a/lib/domain/services/home_screen_shortcut_service.dart
+++ b/lib/domain/services/home_screen_shortcut_service.dart
@@ -16,7 +16,8 @@ const homeScreenShortcutHostTypePrefix = 'host:';
 /// Maximum number of hosts surfaced in the app icon's quick actions.
 const maxHomeScreenShortcutItems = 4;
 
-bool get _supportsHomeScreenShortcuts =>
+/// Whether the current platform supports app-icon home-screen shortcuts.
+bool get supportsHomeScreenShortcutActions =>
     !kIsWeb &&
     (defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS);
@@ -234,7 +235,7 @@ class HomeScreenShortcutService {
 
   /// Ensures the quick-action integration is initialized once.
   Future<void> initialize() =>
-      _initializeFuture ??= _supportsHomeScreenShortcuts
+      _initializeFuture ??= supportsHomeScreenShortcutActions
       ? _initializeInternal()
       : Future<void>.value();
 
@@ -243,7 +244,7 @@ class HomeScreenShortcutService {
     required List<Host> hosts,
     required Set<int> pinnedHostIds,
   }) async {
-    if (!_supportsHomeScreenShortcuts) {
+    if (!supportsHomeScreenShortcutActions) {
       return;
     }
 
@@ -278,6 +279,9 @@ class HomeScreenShortcutService {
   }
 
   void _dispatchHostLaunch(int hostId) {
+    if (_hostLaunchController.isClosed) {
+      return;
+    }
     if (_hostLaunchListenerCount == 0) {
       _pendingHostLaunches.add(hostId);
       return;

--- a/lib/domain/services/settings_service.dart
+++ b/lib/domain/services/settings_service.dart
@@ -80,6 +80,9 @@ abstract final class SettingKeys {
   /// Saved host-scoped coding-agent launch presets.
   static const agentLaunchPresets = 'agent_launch_presets';
 
+  /// Saved host IDs pinned into the app's home-screen shortcut set.
+  static const homeScreenShortcutHostIds = 'home_screen_shortcut_host_ids';
+
   /// Enable shared clipboard between device and remote session.
   ///
   /// The terminal can sync through OSC 52 and remote clipboard utilities when

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:drift/drift.dart' as drift;
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -36,11 +35,6 @@ import '../widgets/premium_access.dart';
 import '../widgets/reorder_helpers.dart';
 import '../widgets/tmux_window_status_badge.dart';
 import 'transfer_screen.dart';
-
-bool get _supportsHomeScreenShortcutActions =>
-    !kIsWeb &&
-    (defaultTargetPlatform == TargetPlatform.android ||
-        defaultTargetPlatform == TargetPlatform.iOS);
 
 /// The main home screen - Termius-style sidebar layout.
 class HomeScreen extends ConsumerStatefulWidget {
@@ -785,7 +779,7 @@ class _HostRow extends ConsumerWidget {
         ref.watch(pinnedHomeScreenShortcutHostIdsProvider).asData?.value ??
         const <int>{};
     final isPinnedToHomeScreen =
-        _supportsHomeScreenShortcutActions &&
+        supportsHomeScreenShortcutActions &&
         pinnedHomeScreenShortcutHostIds.contains(host.id);
     final previewEntries = connectionIds
         .map((connectionId) {
@@ -1131,7 +1125,7 @@ class _HostRow extends ConsumerWidget {
       pinnedHomeScreenShortcutHostIdsProvider,
     );
     final isPinnedToHomeScreen =
-        _supportsHomeScreenShortcutActions &&
+        supportsHomeScreenShortcutActions &&
         (pinnedHomeScreenShortcutHostIds.asData?.value.contains(host.id) ??
             false);
 
@@ -1163,7 +1157,7 @@ class _HostRow extends ConsumerWidget {
             title: Text('New connection'),
           ),
         ),
-        if (_supportsHomeScreenShortcutActions)
+        if (supportsHomeScreenShortcutActions)
           PopupMenuItem<_HostContextAction>(
             value: _HostContextAction.toggleHomeScreen,
             child: ListTile(

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:drift/drift.dart' as drift;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -19,6 +20,7 @@ import '../../domain/models/terminal_themes.dart';
 import '../../domain/models/tmux_state.dart';
 import '../../domain/services/agent_session_discovery_service.dart';
 import '../../domain/services/auth_service.dart';
+import '../../domain/services/home_screen_shortcut_service.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/secure_transfer_service.dart';
 import '../../domain/services/settings_service.dart';
@@ -34,6 +36,11 @@ import '../widgets/premium_access.dart';
 import '../widgets/reorder_helpers.dart';
 import '../widgets/tmux_window_status_badge.dart';
 import 'transfer_screen.dart';
+
+bool get _supportsHomeScreenShortcutActions =>
+    !kIsWeb &&
+    (defaultTargetPlatform == TargetPlatform.android ||
+        defaultTargetPlatform == TargetPlatform.iOS);
 
 /// The main home screen - Termius-style sidebar layout.
 class HomeScreen extends ConsumerStatefulWidget {
@@ -63,6 +70,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   final Queue<String> _incomingTransferQueue = Queue<String>();
   String? _activeIncomingTransferPayload;
   bool _isHandlingIncomingTransfer = false;
+  StreamSubscription<int>? _homeScreenShortcutSubscription;
+  final Queue<int> _pendingHomeScreenShortcutHostIds = Queue<int>();
+  int? _activeHomeScreenShortcutHostId;
+  bool _isHandlingHomeScreenShortcut = false;
 
   // Breakpoint for switching between mobile and desktop layout
   static const double _mobileBreakpoint = 600;
@@ -78,6 +89,14 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
             _enqueueIncomingTransferPayload(payload);
           }
         });
+    _homeScreenShortcutSubscription = ref
+        .read(homeScreenShortcutServiceProvider)
+        .hostLaunches
+        .listen((hostId) {
+          if (mounted) {
+            _enqueueHomeScreenShortcutHostLaunch(hostId);
+          }
+        });
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         unawaited(_checkIncomingTransferPayload());
@@ -89,6 +108,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     unawaited(_incomingTransferSubscription?.cancel());
+    unawaited(_homeScreenShortcutSubscription?.cancel());
     super.dispose();
   }
 
@@ -235,6 +255,61 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         context,
       ).showSnackBar(SnackBar(content: Text('Import failed: $error')));
     }
+  }
+
+  void _enqueueHomeScreenShortcutHostLaunch(int hostId) {
+    if (hostId <= 0 ||
+        hostId == _activeHomeScreenShortcutHostId ||
+        _pendingHomeScreenShortcutHostIds.contains(hostId)) {
+      return;
+    }
+    _pendingHomeScreenShortcutHostIds.add(hostId);
+    unawaited(_processHomeScreenShortcutQueue());
+  }
+
+  Future<void> _processHomeScreenShortcutQueue() async {
+    if (_isHandlingHomeScreenShortcut) {
+      return;
+    }
+
+    while (mounted && _pendingHomeScreenShortcutHostIds.isNotEmpty) {
+      _isHandlingHomeScreenShortcut = true;
+      final hostId = _pendingHomeScreenShortcutHostIds.removeFirst();
+      _activeHomeScreenShortcutHostId = hostId;
+      try {
+        await _openHomeScreenShortcutHost(hostId);
+      } finally {
+        _activeHomeScreenShortcutHostId = null;
+        _isHandlingHomeScreenShortcut = false;
+      }
+    }
+  }
+
+  Future<void> _openHomeScreenShortcutHost(int hostId) async {
+    final host = await ref.read(hostRepositoryProvider).getById(hostId);
+    if (!mounted) {
+      return;
+    }
+
+    if (host == null) {
+      await ref
+          .read(homeScreenShortcutPreferencesServiceProvider)
+          .setHostPinned(hostId, pinned: false);
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'That home screen host shortcut is no longer available',
+          ),
+        ),
+      );
+      return;
+    }
+
+    switchToConnectionsTab();
+    unawaited(context.push('/terminal/${host.id}'));
   }
 
   @override
@@ -658,6 +733,7 @@ class HostsPanel extends ConsumerWidget {
 enum _HostContextAction {
   connect,
   newConnection,
+  toggleHomeScreen,
   edit,
   duplicate,
   export,
@@ -705,6 +781,12 @@ class _HostRow extends ConsumerWidget {
     final hasHostThemeAccess = monetizationState.allowsFeature(
       MonetizationFeature.hostSpecificThemes,
     );
+    final pinnedHomeScreenShortcutHostIds =
+        ref.watch(pinnedHomeScreenShortcutHostIdsProvider).asData?.value ??
+        const <int>{};
+    final isPinnedToHomeScreen =
+        _supportsHomeScreenShortcutActions &&
+        pinnedHomeScreenShortcutHostIds.contains(host.id);
     final previewEntries = connectionIds
         .map((connectionId) {
           final connection = sessionsNotifier.getActiveConnection(connectionId);
@@ -821,6 +903,14 @@ class _HostRow extends ConsumerWidget {
                                 Icons.star_rounded,
                                 size: 14,
                                 color: Colors.amber.shade600,
+                              ),
+                            ],
+                            if (isPinnedToHomeScreen) ...[
+                              const SizedBox(width: 6),
+                              Icon(
+                                Icons.home_rounded,
+                                size: 14,
+                                color: colorScheme.primary,
                               ),
                             ],
                           ],
@@ -1037,6 +1127,13 @@ class _HostRow extends ConsumerWidget {
     Offset globalPosition,
   ) async {
     final colorScheme = Theme.of(context).colorScheme;
+    final pinnedHomeScreenShortcutHostIds = ref.read(
+      pinnedHomeScreenShortcutHostIdsProvider,
+    );
+    final isPinnedToHomeScreen =
+        _supportsHomeScreenShortcutActions &&
+        (pinnedHomeScreenShortcutHostIds.asData?.value.contains(host.id) ??
+            false);
 
     final overlay = Overlay.maybeOf(context);
     final overlayBox = overlay?.context.findRenderObject() as RenderBox?;
@@ -1066,6 +1163,21 @@ class _HostRow extends ConsumerWidget {
             title: Text('New connection'),
           ),
         ),
+        if (_supportsHomeScreenShortcutActions)
+          PopupMenuItem<_HostContextAction>(
+            value: _HostContextAction.toggleHomeScreen,
+            child: ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: Icon(
+                isPinnedToHomeScreen ? Icons.home_rounded : Icons.home_outlined,
+              ),
+              title: Text(
+                isPinnedToHomeScreen
+                    ? 'Remove from Home Screen'
+                    : 'Add to Home Screen',
+              ),
+            ),
+          ),
         const PopupMenuDivider(),
         const PopupMenuItem<_HostContextAction>(
           value: _HostContextAction.edit,
@@ -1117,6 +1229,13 @@ class _HostRow extends ConsumerWidget {
       case _HostContextAction.newConnection:
         await _openNewConnection(context, ref);
         return;
+      case _HostContextAction.toggleHomeScreen:
+        await _toggleHomeScreenShortcut(
+          context,
+          ref,
+          isPinnedToHomeScreen: isPinnedToHomeScreen,
+        );
+        return;
       case _HostContextAction.edit:
         unawaited(context.push('/hosts/edit/${host.id}'));
         return;
@@ -1130,6 +1249,29 @@ class _HostRow extends ConsumerWidget {
         await _confirmDelete(context, ref);
         return;
     }
+  }
+
+  Future<void> _toggleHomeScreenShortcut(
+    BuildContext context,
+    WidgetRef ref, {
+    required bool isPinnedToHomeScreen,
+  }) async {
+    await ref
+        .read(homeScreenShortcutPreferencesServiceProvider)
+        .setHostPinned(host.id, pinned: !isPinnedToHomeScreen);
+    if (!context.mounted) {
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          isPinnedToHomeScreen
+              ? 'Removed from home screen shortcuts'
+              : 'Added to home screen shortcuts',
+        ),
+      ),
+    );
   }
 
   Future<void> _exportEncryptedFile(BuildContext context, WidgetRef ref) async {
@@ -1216,7 +1358,14 @@ class _HostRow extends ConsumerWidget {
     );
 
     if ((confirmed ?? false) && context.mounted) {
-      await ref.read(hostRepositoryProvider).delete(host.id);
+      final deletedCount = await ref
+          .read(hostRepositoryProvider)
+          .delete(host.id);
+      if (deletedCount > 0) {
+        await ref
+            .read(homeScreenShortcutPreferencesServiceProvider)
+            .setHostPinned(host.id, pinned: false);
+      }
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -983,6 +983,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  quick_actions:
+    dependency: "direct main"
+    description:
+      name: quick_actions
+      sha256: "7e35dd6a21f5bbd21acf6899039eaf85001a5ac26d52cbd6a8a2814505b90798"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  quick_actions_android:
+    dependency: transitive
+    description:
+      name: quick_actions_android
+      sha256: "8e491323342fa68420ca26a9bd5a2bbcdb526bda33db45b6427c6d139fb7316d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.29"
+  quick_actions_ios:
+    dependency: transitive
+    description:
+      name: quick_actions_ios
+      sha256: be1496e7ca1debc86d9ea08e56325649fbc5abb2b6930690c97ba0dae59992b1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.4"
+  quick_actions_platform_interface:
+    dependency: transitive
+    description:
+      name: quick_actions_platform_interface
+      sha256: "1fec7068db5122cd019e9340d3d7be5d36eab099695ef3402c7059ee058329a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   quiver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   in_app_purchase: ^3.2.3
   in_app_purchase_android: ^0.4.0+10
   in_app_purchase_storekit: ^0.4.8+1
+  quick_actions: ^1.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/domain/services/home_screen_shortcut_service_test.dart
+++ b/test/domain/services/home_screen_shortcut_service_test.dart
@@ -1,0 +1,170 @@
+// ignore_for_file: public_member_api_docs, avoid_redundant_argument_values
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/domain/services/home_screen_shortcut_service.dart';
+import 'package:monkeyssh/domain/services/settings_service.dart';
+
+Host _buildHost({
+  required int id,
+  required String label,
+  required int sortOrder,
+  bool isFavorite = false,
+  DateTime? lastConnectedAt,
+  int port = 22,
+}) => Host(
+  id: id,
+  label: label,
+  hostname: '$label.example.com',
+  port: port,
+  username: 'root',
+  password: null,
+  keyId: null,
+  groupId: null,
+  jumpHostId: null,
+  isFavorite: isFavorite,
+  color: null,
+  notes: null,
+  tags: null,
+  createdAt: DateTime(2026),
+  updatedAt: DateTime(2026),
+  lastConnectedAt: lastConnectedAt,
+  terminalThemeLightId: null,
+  terminalThemeDarkId: null,
+  terminalFontFamily: null,
+  autoConnectCommand: null,
+  autoConnectSnippetId: null,
+  autoConnectRequiresConfirmation: false,
+  tmuxSessionName: null,
+  tmuxWorkingDirectory: null,
+  tmuxExtraFlags: null,
+  sortOrder: sortOrder,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('home screen shortcut payload parsing', () {
+    test('parses valid host shortcut types', () {
+      expect(parseHomeScreenShortcutHostId('host:42'), 42);
+    });
+
+    test('rejects invalid host shortcut types', () {
+      expect(parseHomeScreenShortcutHostId(null), isNull);
+      expect(parseHomeScreenShortcutHostId(''), isNull);
+      expect(parseHomeScreenShortcutHostId('help'), isNull);
+      expect(parseHomeScreenShortcutHostId('host:abc'), isNull);
+      expect(parseHomeScreenShortcutHostId('host:0'), isNull);
+    });
+  });
+
+  group('home screen shortcut ranking', () {
+    test('prefers pinned hosts, then favorites, then recents', () {
+      final selectedHosts = selectHomeScreenShortcutHosts(
+        <Host>[
+          _buildHost(
+            id: 1,
+            label: 'recent',
+            sortOrder: 10,
+            lastConnectedAt: DateTime(2026, 1, 3),
+          ),
+          _buildHost(id: 2, label: 'favorite', sortOrder: 20, isFavorite: true),
+          _buildHost(id: 3, label: 'pinned', sortOrder: 30),
+          _buildHost(id: 4, label: 'fallback', sortOrder: 0),
+        ],
+        pinnedHostIds: <int>{3},
+      );
+
+      expect(selectedHosts.map((host) => host.id).toList(), <int>[3, 2, 1, 4]);
+    });
+
+    test('limits the shortcut list to four hosts', () {
+      final selectedHosts = selectHomeScreenShortcutHosts(
+        List<Host>.generate(
+          6,
+          (index) => _buildHost(
+            id: index + 1,
+            label: 'host-${index + 1}',
+            sortOrder: index,
+          ),
+        ),
+        pinnedHostIds: const <int>{},
+      );
+
+      expect(selectedHosts, hasLength(maxHomeScreenShortcutItems));
+      expect(selectedHosts.map((host) => host.id).toList(), <int>[1, 2, 3, 4]);
+    });
+
+    test('builds shortcut items with host payloads and subtitles', () {
+      final shortcutItems = buildHomeScreenShortcutItems(<Host>[
+        _buildHost(id: 1, label: 'alpha', sortOrder: 0),
+        _buildHost(id: 2, label: 'beta', sortOrder: 1, port: 2202),
+      ]);
+
+      expect(shortcutItems, hasLength(2));
+      expect(shortcutItems.first.type, 'host:1');
+      expect(shortcutItems.first.localizedTitle, 'alpha');
+      expect(shortcutItems.first.localizedSubtitle, 'root@alpha.example.com');
+      expect(
+        shortcutItems.last.localizedSubtitle,
+        'root@beta.example.com:2202',
+      );
+    });
+  });
+
+  group('home screen shortcut preferences', () {
+    late AppDatabase db;
+    late SettingsService settingsService;
+    late HomeScreenShortcutPreferencesService preferencesService;
+
+    setUp(() {
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      settingsService = SettingsService(db);
+      preferencesService = HomeScreenShortcutPreferencesService(
+        settingsService,
+      );
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test('stores pinned host IDs in a stable sorted order', () async {
+      await preferencesService.setHostPinned(7, pinned: true);
+      await preferencesService.setHostPinned(3, pinned: true);
+
+      expect(await preferencesService.getPinnedHostIds(), <int>{3, 7});
+      expect(
+        await settingsService.getString(SettingKeys.homeScreenShortcutHostIds),
+        '[3,7]',
+      );
+    });
+
+    test(
+      'clears the persisted setting after the last pinned host is removed',
+      () async {
+        await preferencesService.setHostPinned(3, pinned: true);
+        await preferencesService.setHostPinned(3, pinned: false);
+
+        expect(await preferencesService.getPinnedHostIds(), isEmpty);
+        expect(
+          await settingsService.getString(
+            SettingKeys.homeScreenShortcutHostIds,
+          ),
+          isNull,
+        );
+      },
+    );
+  });
+
+  test('queued shortcut launches flush to the first listener', () async {
+    final service = HomeScreenShortcutService();
+    addTearDown(service.dispose);
+
+    service.debugEmitHostLaunch(9);
+
+    await expectLater(service.hostLaunches, emits(9));
+  });
+}

--- a/test/domain/services/home_screen_shortcut_service_test.dart
+++ b/test/domain/services/home_screen_shortcut_service_test.dart
@@ -167,4 +167,12 @@ void main() {
 
     await expectLater(service.hostLaunches, emits(9));
   });
+
+  test('debug-emitted launches after dispose are ignored', () async {
+    final service = HomeScreenShortcutService();
+
+    await service.dispose();
+
+    expect(() => service.debugEmitHostLaunch(9), returnsNormally);
+  });
 }

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -10,7 +10,9 @@ import 'package:mocktail/mocktail.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/snippet_repository.dart';
+import 'package:monkeyssh/domain/services/home_screen_shortcut_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
+import 'package:monkeyssh/domain/services/transfer_intent_service.dart';
 import 'package:monkeyssh/presentation/providers/entity_list_providers.dart';
 import 'package:monkeyssh/presentation/screens/home_screen.dart';
 
@@ -83,6 +85,34 @@ class _MutableActiveSessionsNotifier extends ActiveSessionsNotifier {
   }
 }
 
+class _TestTransferIntentService extends TransferIntentService {
+  @override
+  Stream<String> get incomingPayloads => const Stream<String>.empty();
+
+  @override
+  Future<String?> consumeIncomingTransferPayload() async => null;
+
+  @override
+  Future<void> dispose() async {}
+}
+
+class _TestHomeScreenShortcutService extends HomeScreenShortcutService {
+  @override
+  Stream<int> get hostLaunches => const Stream<int>.empty();
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> updateShortcuts({
+    required List<Host> hosts,
+    required Set<int> pinnedHostIds,
+  }) async {}
+
+  @override
+  Future<void> dispose() async {}
+}
+
 Host _buildHost({
   required int id,
   required String label,
@@ -153,7 +183,18 @@ void main() {
 
   Widget buildTestWidget(AppDatabase db, {Size size = const Size(800, 600)}) =>
       ProviderScope(
-        overrides: [databaseProvider.overrideWithValue(db)],
+        overrides: [
+          databaseProvider.overrideWithValue(db),
+          transferIntentServiceProvider.overrideWith(
+            (ref) => _TestTransferIntentService(),
+          ),
+          homeScreenShortcutServiceProvider.overrideWith(
+            (ref) => _TestHomeScreenShortcutService(),
+          ),
+          pinnedHomeScreenShortcutHostIdsProvider.overrideWith(
+            (ref) => Stream<Set<int>>.value(const <int>{}),
+          ),
+        ],
         child: MediaQuery(
           data: MediaQueryData(size: size),
           child: MaterialApp.router(
@@ -202,7 +243,19 @@ void main() {
     required List overrides,
     Size size = const Size(400, 800),
   }) => ProviderScope(
-    overrides: [databaseProvider.overrideWithValue(db), ...overrides],
+    overrides: [
+      databaseProvider.overrideWithValue(db),
+      transferIntentServiceProvider.overrideWith(
+        (ref) => _TestTransferIntentService(),
+      ),
+      homeScreenShortcutServiceProvider.overrideWith(
+        (ref) => _TestHomeScreenShortcutService(),
+      ),
+      pinnedHomeScreenShortcutHostIdsProvider.overrideWith(
+        (ref) => Stream<Set<int>>.value(const <int>{}),
+      ),
+      ...overrides,
+    ],
     child: MediaQuery(
       data: MediaQueryData(size: size),
       child: const MaterialApp(home: HomeScreen()),

--- a/test/widget/hosts_screen_test.dart
+++ b/test/widget/hosts_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:mocktail/mocktail.dart';
 
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/domain/services/home_screen_shortcut_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/presentation/providers/entity_list_providers.dart';
 import 'package:monkeyssh/presentation/screens/hosts_screen.dart';
@@ -106,6 +107,18 @@ ActiveConnection _buildActiveConnection({
   ),
 );
 
+Widget _buildHostsScreen({required AppDatabase db, required List overrides}) =>
+    ProviderScope(
+      overrides: [
+        databaseProvider.overrideWithValue(db),
+        pinnedHomeScreenShortcutHostIdsProvider.overrideWith(
+          (ref) => Stream<Set<int>>.value(const <int>{}),
+        ),
+        ...overrides,
+      ],
+      child: const MaterialApp(home: HostsScreen()),
+    );
+
 void main() {
   setUpAll(() {
     registerFallbackValue(<int>[]);
@@ -121,13 +134,12 @@ void main() {
     addTearDown(hostsController.close);
 
     await tester.pumpWidget(
-      ProviderScope(
+      _buildHostsScreen(
+        db: db,
         overrides: [
-          databaseProvider.overrideWithValue(db),
           activeSessionsProvider.overrideWith(_TestActiveSessionsNotifier.new),
           allHostsProvider.overrideWith((ref) => hostsController.stream),
         ],
-        child: const MaterialApp(home: HostsScreen()),
       ),
     );
 
@@ -155,13 +167,12 @@ void main() {
     addTearDown(hostsController.close);
 
     await tester.pumpWidget(
-      ProviderScope(
+      _buildHostsScreen(
+        db: db,
         overrides: [
-          databaseProvider.overrideWithValue(db),
           activeSessionsProvider.overrideWith(_TestActiveSessionsNotifier.new),
           allHostsProvider.overrideWith((ref) => hostsController.stream),
         ],
-        child: const MaterialApp(home: HostsScreen()),
       ),
     );
 
@@ -177,9 +188,9 @@ void main() {
     when(() => hostRepository.reorderByIds(any())).thenAnswer((_) async {});
 
     await tester.pumpWidget(
-      ProviderScope(
+      _buildHostsScreen(
+        db: db,
         overrides: [
-          databaseProvider.overrideWithValue(db),
           hostRepositoryProvider.overrideWithValue(hostRepository),
           activeSessionsProvider.overrideWith(_TestActiveSessionsNotifier.new),
           allHostsProvider.overrideWith(
@@ -189,7 +200,6 @@ void main() {
             ]),
           ),
         ],
-        child: const MaterialApp(home: HostsScreen()),
       ),
     );
     await tester.pumpAndSettle();
@@ -212,16 +222,15 @@ void main() {
     addTearDown(db.close);
 
     await tester.pumpWidget(
-      ProviderScope(
+      _buildHostsScreen(
+        db: db,
         overrides: [
-          databaseProvider.overrideWithValue(db),
           activeSessionsProvider.overrideWith(_TestActiveSessionsNotifier.new),
           allHostsProvider.overrideWith(
             (ref) =>
                 Stream.value([_buildHost(id: 1, label: 'Alpha', sortOrder: 0)]),
           ),
         ],
-        child: const MaterialApp(home: HostsScreen()),
       ),
     );
     await tester.pumpAndSettle();
@@ -254,9 +263,9 @@ void main() {
       );
 
       await tester.pumpWidget(
-        ProviderScope(
+        _buildHostsScreen(
+          db: db,
           overrides: [
-            databaseProvider.overrideWithValue(db),
             activeSessionsProvider.overrideWith(() => sessionsNotifier),
             allHostsProvider.overrideWith(
               (ref) => Stream.value([
@@ -264,7 +273,6 @@ void main() {
               ]),
             ),
           ],
-          child: const MaterialApp(home: HostsScreen()),
         ),
       );
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary

- add dynamic Android and iOS app-icon shortcuts for saved hosts
- let users pin any host into that shortcut set from the hosts context menu
- route shortcut launches straight into the existing terminal reuse-or-connect flow

## Testing

- `flutter analyze`
- `flutter test test/domain/services/home_screen_shortcut_service_test.dart`

## Notes

- I attempted the broader `flutter test` / pre-commit suite, but the repo still has existing Drift/Riverpod widget-test cleanup issues and long-running full-suite behavior that prevented a clean full pass unrelated to this shortcut feature.