### PR TITLE
fix: ignore quoted shell tokens in terminal review

### DIFF
--- a/lib/domain/models/auto_connect_command.dart
+++ b/lib/domain/models/auto_connect_command.dart
@@ -17,8 +17,6 @@ final _disallowedCommandControlCharacters = RegExp(
   r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]',
 );
 final _multilinePattern = RegExp(r'[\r\n]');
-final _shellChainingPattern = RegExp(r'&&|\|\||[;&|]');
-final _shellRedirectionPattern = RegExp('>>?|<');
 
 /// Reasons a terminal command should be reviewed before it is inserted or run.
 enum TerminalCommandReviewReason {
@@ -183,22 +181,108 @@ List<TerminalCommandReviewReason> _collectSuspiciousCommandReasons(
   String command,
 ) {
   final reasons = <TerminalCommandReviewReason>[];
+  final shellTokens = _collectSuspiciousShellTokens(command);
   if (_multilinePattern.hasMatch(command)) {
     reasons.add(TerminalCommandReviewReason.multiline);
   }
   if (_disallowedCommandControlCharacters.hasMatch(command)) {
     reasons.add(TerminalCommandReviewReason.controlCharacters);
   }
-  if (_shellChainingPattern.hasMatch(command)) {
+  if (shellTokens.shellChaining) {
     reasons.add(TerminalCommandReviewReason.shellChaining);
   }
-  if (_shellRedirectionPattern.hasMatch(command)) {
+  if (shellTokens.redirection) {
     reasons.add(TerminalCommandReviewReason.redirection);
   }
-  if (command.contains('`') || command.contains(r'$(')) {
+  if (shellTokens.commandSubstitution) {
     reasons.add(TerminalCommandReviewReason.commandSubstitution);
   }
   return reasons;
+}
+
+({bool shellChaining, bool redirection, bool commandSubstitution})
+_collectSuspiciousShellTokens(String command) {
+  var shellChaining = false;
+  var redirection = false;
+  var commandSubstitution = false;
+  var escapeNext = false;
+  var inSingleQuote = false;
+  var inDoubleQuote = false;
+
+  for (var index = 0; index < command.length; index++) {
+    final character = command[index];
+
+    if (escapeNext) {
+      escapeNext = false;
+      continue;
+    }
+
+    if (inSingleQuote) {
+      if (character == '\'') {
+        inSingleQuote = false;
+      }
+      continue;
+    }
+
+    if (inDoubleQuote) {
+      if (character == r'\') {
+        escapeNext = true;
+        continue;
+      }
+      if (character == '"') {
+        inDoubleQuote = false;
+        continue;
+      }
+      if (character == '`') {
+        commandSubstitution = true;
+        continue;
+      }
+      if (character == r'$' &&
+          index + 1 < command.length &&
+          command[index + 1] == '(') {
+        commandSubstitution = true;
+      }
+      continue;
+    }
+
+    if (character == r'\') {
+      escapeNext = true;
+      continue;
+    }
+    if (character == '\'') {
+      inSingleQuote = true;
+      continue;
+    }
+    if (character == '"') {
+      inDoubleQuote = true;
+      continue;
+    }
+    if (character == '`') {
+      commandSubstitution = true;
+      continue;
+    }
+    if (character == r'$' &&
+        index + 1 < command.length &&
+        command[index + 1] == '(') {
+      commandSubstitution = true;
+      continue;
+    }
+    if (character == ';' || character == '&' || character == '|') {
+      shellChaining = true;
+    } else if (character == '<' || character == '>') {
+      redirection = true;
+    }
+
+    if (shellChaining && redirection && commandSubstitution) {
+      break;
+    }
+  }
+
+  return (
+    shellChaining: shellChaining,
+    redirection: redirection,
+    commandSubstitution: commandSubstitution,
+  );
 }
 
 String _describeReviewReason(TerminalCommandReviewReason reason) =>

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -141,6 +141,24 @@ bool shouldReattachTmuxAfterWindowAction({
   return shellStatus != TerminalShellStatus.runningCommand;
 }
 
+/// Returns whether shell-command review warnings should be shown for text
+/// inserted into the active terminal context.
+///
+/// These warnings are most useful when input is likely targeting a shell
+/// prompt. When a full-screen app owns the alternate buffer, or shell
+/// integration reports that a command is still running, the input is more
+/// likely to be consumed by that program than by the shell itself.
+@visibleForTesting
+bool shouldReviewTerminalCommandInsertion({
+  required TerminalShellStatus? shellStatus,
+  required bool isUsingAltBuffer,
+}) {
+  if (isUsingAltBuffer) {
+    return false;
+  }
+  return shellStatus != TerminalShellStatus.runningCommand;
+}
+
 /// Resolves the safe-area insets the tmux bar should stay within.
 @visibleForTesting
 EdgeInsets resolveTmuxBarSafeInsets(MediaQueryData mediaQuery) {
@@ -2393,6 +2411,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   TerminalShellStatus? get _shellStatus => _observedSession?.shellStatus;
 
   int? get _lastExitCode => _observedSession?.lastExitCode;
+
+  bool get _shouldReviewTerminalCommandInsertion =>
+      shouldReviewTerminalCommandInsertion(
+        shellStatus: _shellStatus,
+        isUsingAltBuffer: _isUsingAltBuffer,
+      );
 
   String _terminalCommandAfterInsertion(String insertedText) {
     final snapshot = _buildWrappedTerminalCommandSnapshot();
@@ -6913,18 +6937,20 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         return;
       }
 
-      final shouldPaste = await _confirmTerminalInsertionIfNeeded(
-        insertedText: text,
-        buildReview: (commandText) => assessClipboardPasteCommand(
-          commandText,
-          bracketedPasteModeEnabled: _terminal.bracketedPasteMode,
-        ),
-        title: 'Review clipboard paste',
-        messageBuilder: (review) => review.bracketedPasteModeEnabled
-            ? 'This clipboard content looks risky even with bracketed paste enabled.'
-            : 'This clipboard content could execute multiple or reshaped commands.',
-        confirmLabel: 'Paste anyway',
-      );
+      final shouldPaste =
+          !_shouldReviewTerminalCommandInsertion ||
+          await _confirmTerminalInsertionIfNeeded(
+            insertedText: text,
+            buildReview: (commandText) => assessClipboardPasteCommand(
+              commandText,
+              bracketedPasteModeEnabled: _terminal.bracketedPasteMode,
+            ),
+            title: 'Review clipboard paste',
+            messageBuilder: (review) => review.bracketedPasteModeEnabled
+                ? 'This clipboard content looks risky even with bracketed paste enabled.'
+                : 'This clipboard content could execute multiple or reshaped commands.',
+            confirmLabel: 'Paste anyway',
+          );
       if (!shouldPaste) {
         _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
         return;
@@ -7318,6 +7344,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   Future<bool> _confirmKeyboardInsertion(TerminalCommandReview review) async {
+    if (!_shouldReviewTerminalCommandInsertion) {
+      return true;
+    }
     final shouldInsert = await _confirmCommandInsertion(
       title: 'Review keyboard paste',
       message:
@@ -7331,6 +7360,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   Future<bool> _confirmDesktopInsertedText(String text) async {
     if (text.length <= 1) {
+      return true;
+    }
+    if (!_shouldReviewTerminalCommandInsertion) {
       return true;
     }
 

--- a/test/domain/models/auto_connect_command_test.dart
+++ b/test/domain/models/auto_connect_command_test.dart
@@ -237,6 +237,29 @@ void main() {
       );
     });
 
+    test('ignores quoted shell-like text during clipboard review', () {
+      final review = assessClipboardPasteCommand(
+        'printf "%s" "fish & chips | <html>"',
+        bracketedPasteModeEnabled: false,
+      );
+
+      expect(review.requiresReview, isFalse);
+      expect(review.reasons, isEmpty);
+    });
+
+    test('still flags command substitution inside double quotes', () {
+      final review = assessClipboardPasteCommand(
+        r'echo "$(id)"',
+        bracketedPasteModeEnabled: false,
+      );
+
+      expect(review.requiresReview, isTrue);
+      expect(
+        review.reasons,
+        contains(TerminalCommandReviewReason.commandSubstitution),
+      );
+    });
+
     test(
       'safe single-line commands without special tokens do not require review',
       () {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -93,6 +93,7 @@ void main() {
     late Host host;
     late Completer<void> shellDoneCompleter;
     late StreamController<Uint8List> shellStdoutController;
+    late List<List<int>> shellWrites;
 
     setUp(() {
       db = AppDatabase.forTesting(NativeDatabase.memory());
@@ -102,6 +103,7 @@ void main() {
       host = _buildHost(id: 1);
       shellDoneCompleter = Completer<void>();
       shellStdoutController = StreamController<Uint8List>.broadcast();
+      shellWrites = <List<int>>[];
 
       when(() => hostRepository.getById(host.id)).thenAnswer((_) async => host);
       when(
@@ -116,7 +118,12 @@ void main() {
       when(
         () => shellChannel.done,
       ).thenAnswer((_) => shellDoneCompleter.future);
-      when(() => shellChannel.write(any())).thenReturn(null);
+      when(() => shellChannel.write(any())).thenAnswer((invocation) {
+        final value = invocation.positionalArguments.single;
+        if (value is List<int>) {
+          shellWrites.add(List<int>.from(value));
+        }
+      });
 
       session = SshSession(
         connectionId: 7,
@@ -297,6 +304,30 @@ void main() {
           hasLength(greaterThanOrEqualTo(1)),
         );
         await tester.pump(const Duration(milliseconds: 200));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
+      'running shell commands bypass keyboard paste review',
+      (tester) async {
+        await pumpScreen(tester);
+
+        session.terminal!.write('\u001b]133;C\u0007');
+        await tester.pump();
+
+        expect(session.shellStatus, TerminalShellStatus.runningCommand);
+
+        shellWrites.clear();
+        const suspiciousText = 'echo ready; rm -rf /';
+        tester.testTextInput.updateEditingValue(
+          _editingValue(suspiciousText, selectionOffset: suspiciousText.length),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Review keyboard paste'), findsNothing);
+        expect(shellWrites.map(utf8.decode).join(), suspiciousText);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),
     );

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -196,6 +196,47 @@ void main() {
         isTrue,
       );
     });
+
+    test('reviews terminal command insertion at shell prompts', () {
+      expect(
+        shouldReviewTerminalCommandInsertion(
+          shellStatus: TerminalShellStatus.prompt,
+          isUsingAltBuffer: false,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldReviewTerminalCommandInsertion(
+          shellStatus: TerminalShellStatus.editingCommand,
+          isUsingAltBuffer: false,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldReviewTerminalCommandInsertion(
+          shellStatus: null,
+          isUsingAltBuffer: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('suppresses terminal command insertion review in CLI contexts', () {
+      expect(
+        shouldReviewTerminalCommandInsertion(
+          shellStatus: TerminalShellStatus.runningCommand,
+          isUsingAltBuffer: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldReviewTerminalCommandInsertion(
+          shellStatus: TerminalShellStatus.prompt,
+          isUsingAltBuffer: true,
+        ),
+        isFalse,
+      );
+    });
   });
 
   group('tmux bar safe insets vs. keyboard toolbar', () {

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -5242,6 +5242,53 @@ void main() {
     });
 
     testWidgets(
+      'does not review quoted shell-like IME text as suspicious paste',
+      (tester) async {
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add);
+        final focusNode = FocusNode();
+        final reviews = <TerminalCommandReview>[];
+        const benignCommand = 'printf "%s" "fish & chips | <html>"';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TerminalTextInputHandler(
+                terminal: terminal,
+                focusNode: focusNode,
+                deleteDetection: true,
+                onReviewInsertedText: (review) async {
+                  reviews.add(review);
+                  return true;
+                },
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        tester.testTextInput.updateEditingValue(
+          const TextEditingValue(
+            text: '$_deleteDetectionMarker$benignCommand',
+            selection: TextSelection.collapsed(
+              offset: _deleteDetectionMarker.length + benignCommand.length,
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(reviews, isEmpty);
+        expect(terminalOutput.join(), benignCommand);
+
+        focusNode.dispose();
+      },
+    );
+
+    testWidgets(
       'reviews a suspicious committed IME payload after composition ends',
       (tester) async {
         final terminalOutput = <String>[];


### PR DESCRIPTION
## Summary

- replace broad regex review checks with a shell-aware scanner that ignores quoted and escaped literals
- keep command substitution warnings active while reducing false-positive paste and IME warnings for quoted text
- add regression coverage for clipboard review and IME insertion flows

## Testing

- flutter analyze
- flutter test test/domain/models/auto_connect_command_test.dart test/widget/terminal_text_input_handler_test.dart
- flutter test
