### PR TITLE
feat: add per-host CLI yolo mode

### DIFF
--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -162,6 +162,12 @@ enum _ShellQuoteMode { none, single, double }
 const _backslashCodeUnit = 0x5C;
 
 final _unquotedTmuxFlagTokenPattern = RegExp(r'^[A-Za-z0-9_./~:=,+-]+$');
+final _codexApprovalModeEqualsPattern = RegExp(
+  r'''(?<!\S)--approval-mode=(?:"[^"]*"|'[^']*'|\S+)''',
+);
+final _codexApprovalModeSeparatedPattern = RegExp(
+  r'''(?<!\S)--approval-mode\s+(?:"[^"]*"|'[^']*'|\S+)''',
+);
 
 /// Builds the shell command for a saved agent launch preset.
 String buildAgentLaunchCommand(
@@ -202,20 +208,61 @@ String buildAgentToolCommand(
   String? additionalArguments,
   bool startInYoloMode = false,
 }) {
-  final trimmedAdditionalArguments = additionalArguments?.trim();
   final commandParts = <String>[tool.commandName];
-  final yoloArgument = tool.yoloArgument;
-  if (startInYoloMode &&
-      yoloArgument != null &&
-      (trimmedAdditionalArguments == null ||
-          !trimmedAdditionalArguments.contains(yoloArgument))) {
-    commandParts.add(yoloArgument);
-  }
-  if (trimmedAdditionalArguments != null &&
-      trimmedAdditionalArguments.isNotEmpty) {
-    commandParts.add(trimmedAdditionalArguments);
+  final normalizedArguments = _normalizeAgentToolArguments(
+    tool: tool,
+    additionalArguments: additionalArguments,
+    startInYoloMode: startInYoloMode,
+  );
+  if (normalizedArguments != null && normalizedArguments.isNotEmpty) {
+    commandParts.add(normalizedArguments);
   }
   return commandParts.join(' ');
+}
+
+String? _normalizeAgentToolArguments({
+  required AgentLaunchTool tool,
+  required String? additionalArguments,
+  required bool startInYoloMode,
+}) {
+  final yoloArgument = tool.yoloArgument;
+  final trimmedAdditionalArguments = additionalArguments?.trim();
+  if (!startInYoloMode || yoloArgument == null) {
+    return trimmedAdditionalArguments;
+  }
+
+  final sanitizedAdditionalArguments = switch (tool) {
+    AgentLaunchTool.codex => _stripCodexApprovalModeArguments(
+      trimmedAdditionalArguments,
+    ),
+    _ => trimmedAdditionalArguments,
+  };
+
+  if (sanitizedAdditionalArguments == null ||
+      sanitizedAdditionalArguments.isEmpty) {
+    return yoloArgument;
+  }
+
+  if (sanitizedAdditionalArguments.contains(yoloArgument)) {
+    return sanitizedAdditionalArguments;
+  }
+
+  return '$yoloArgument $sanitizedAdditionalArguments';
+}
+
+String? _stripCodexApprovalModeArguments(String? additionalArguments) {
+  final trimmedAdditionalArguments = additionalArguments?.trim();
+  if (trimmedAdditionalArguments == null ||
+      trimmedAdditionalArguments.isEmpty) {
+    return null;
+  }
+
+  final normalizedArguments = trimmedAdditionalArguments
+      .replaceAll(_codexApprovalModeEqualsPattern, ' ')
+      .replaceAll(_codexApprovalModeSeparatedPattern, ' ')
+      .replaceAll(RegExp(r'\s+'), ' ')
+      .trim();
+  return normalizedArguments.isEmpty ? null : normalizedArguments;
 }
 
 List<String> _tokenizeTmuxNewSessionFlags(String? value) {

--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -52,6 +52,19 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
     AgentLaunchTool.openCode => true,
     AgentLaunchTool.geminiCli => true,
   };
+
+  /// Whether this tool supports launching directly into YOLO mode.
+  bool get supportsYoloMode => yoloArgument != null;
+
+  /// Command-line argument that enables YOLO mode for this tool, if available.
+  String? get yoloArgument => switch (this) {
+    AgentLaunchTool.claudeCode => '--dangerously-skip-permissions',
+    AgentLaunchTool.copilotCli => null,
+    AgentLaunchTool.aider => '--yes-always',
+    AgentLaunchTool.codex => '--approval-mode never',
+    AgentLaunchTool.openCode => null,
+    AgentLaunchTool.geminiCli => '--yolo',
+  };
 }
 
 /// Host-scoped preset for launching a coding agent after connect.
@@ -151,13 +164,15 @@ const _backslashCodeUnit = 0x5C;
 final _unquotedTmuxFlagTokenPattern = RegExp(r'^[A-Za-z0-9_./~:=,+-]+$');
 
 /// Builds the shell command for a saved agent launch preset.
-String buildAgentLaunchCommand(AgentLaunchPreset preset) {
-  final baseCommand = [
-    preset.tool.commandName,
-    if (preset.additionalArguments case final value?
-        when value.trim().isNotEmpty)
-      value.trim(),
-  ].join(' ');
+String buildAgentLaunchCommand(
+  AgentLaunchPreset preset, {
+  bool startInYoloMode = false,
+}) {
+  final baseCommand = buildAgentToolCommand(
+    preset.tool,
+    additionalArguments: preset.additionalArguments,
+    startInYoloMode: startInYoloMode,
+  );
 
   final tmuxSessionName = preset.tmuxSessionName?.trim();
   final workingDirectory = preset.workingDirectory?.trim();
@@ -179,6 +194,28 @@ String buildAgentLaunchCommand(AgentLaunchPreset preset) {
   }
 
   return baseCommand;
+}
+
+/// Builds the base shell command for launching [tool].
+String buildAgentToolCommand(
+  AgentLaunchTool tool, {
+  String? additionalArguments,
+  bool startInYoloMode = false,
+}) {
+  final trimmedAdditionalArguments = additionalArguments?.trim();
+  final commandParts = <String>[tool.commandName];
+  final yoloArgument = tool.yoloArgument;
+  if (startInYoloMode &&
+      yoloArgument != null &&
+      (trimmedAdditionalArguments == null ||
+          !trimmedAdditionalArguments.contains(yoloArgument))) {
+    commandParts.add(yoloArgument);
+  }
+  if (trimmedAdditionalArguments != null &&
+      trimmedAdditionalArguments.isNotEmpty) {
+    commandParts.add(trimmedAdditionalArguments);
+  }
+  return commandParts.join(' ');
 }
 
 List<String> _tokenizeTmuxNewSessionFlags(String? value) {

--- a/lib/domain/models/host_cli_launch_preferences.dart
+++ b/lib/domain/models/host_cli_launch_preferences.dart
@@ -1,0 +1,28 @@
+/// Host-scoped defaults for coding CLI launches.
+class HostCliLaunchPreferences {
+  /// Creates a new [HostCliLaunchPreferences].
+  const HostCliLaunchPreferences({this.startInYoloMode = false});
+
+  /// Decodes [HostCliLaunchPreferences] from JSON.
+  factory HostCliLaunchPreferences.fromJson(Map<String, dynamic> json) =>
+      HostCliLaunchPreferences(
+        startInYoloMode: json['startInYoloMode'] == true,
+      );
+
+  /// Whether supported coding CLIs should launch in YOLO mode for this host.
+  final bool startInYoloMode;
+
+  /// Whether this preferences record has no saved overrides.
+  bool get isEmpty => !startInYoloMode;
+
+  /// Encodes this preferences record as JSON.
+  Map<String, dynamic> toJson() => {
+    if (startInYoloMode) 'startInYoloMode': true,
+  };
+
+  /// Returns a copy of this record with selected fields replaced.
+  HostCliLaunchPreferences copyWith({bool? startInYoloMode}) =>
+      HostCliLaunchPreferences(
+        startInYoloMode: startInYoloMode ?? this.startInYoloMode,
+      );
+}

--- a/lib/domain/services/host_cli_launch_preferences_service.dart
+++ b/lib/domain/services/host_cli_launch_preferences_service.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/host_cli_launch_preferences.dart';
+import 'settings_service.dart';
+
+/// Persists host-scoped coding CLI launch preferences in app settings.
+class HostCliLaunchPreferencesService {
+  /// Creates a new [HostCliLaunchPreferencesService].
+  HostCliLaunchPreferencesService(this._settings);
+
+  final SettingsService _settings;
+
+  /// Loads the saved launch preferences for [hostId].
+  Future<HostCliLaunchPreferences> getPreferencesForHost(int hostId) async {
+    final preferences = await _readPreferenceMap();
+    final value = preferences[hostId.toString()];
+    if (value is! Map<String, dynamic>) {
+      return const HostCliLaunchPreferences();
+    }
+    return HostCliLaunchPreferences.fromJson(value);
+  }
+
+  /// Saves [preferences] for [hostId].
+  Future<void> setPreferencesForHost(
+    int hostId,
+    HostCliLaunchPreferences preferences,
+  ) async {
+    if (preferences.isEmpty) {
+      await deletePreferencesForHost(hostId);
+      return;
+    }
+
+    final savedPreferences = await _readPreferenceMap();
+    savedPreferences[hostId.toString()] = preferences.toJson();
+    await _settings.setJson(
+      SettingKeys.hostCliLaunchPreferences,
+      savedPreferences,
+    );
+  }
+
+  /// Removes any saved launch preferences for [hostId].
+  Future<void> deletePreferencesForHost(int hostId) async {
+    final savedPreferences = await _readPreferenceMap();
+    savedPreferences.remove(hostId.toString());
+    if (savedPreferences.isEmpty) {
+      await _settings.delete(SettingKeys.hostCliLaunchPreferences);
+      return;
+    }
+    await _settings.setJson(
+      SettingKeys.hostCliLaunchPreferences,
+      savedPreferences,
+    );
+  }
+
+  Future<Map<String, dynamic>> _readPreferenceMap() async =>
+      await _settings.getJson(SettingKeys.hostCliLaunchPreferences) ?? {};
+}
+
+/// Provider for [HostCliLaunchPreferencesService].
+final hostCliLaunchPreferencesServiceProvider =
+    Provider<HostCliLaunchPreferencesService>(
+      (ref) =>
+          HostCliLaunchPreferencesService(ref.watch(settingsServiceProvider)),
+    );

--- a/lib/domain/services/secure_transfer_service.dart
+++ b/lib/domain/services/secure_transfer_service.dart
@@ -9,7 +9,10 @@ import '../../data/database/database.dart';
 import '../../data/repositories/host_repository.dart';
 import '../../data/repositories/key_repository.dart';
 import '../models/auto_connect_command.dart';
+import '../models/host_cli_launch_preferences.dart';
+import 'host_cli_launch_preferences_service.dart';
 import 'host_key_verification.dart';
+import 'settings_service.dart';
 
 /// Supported transfer payload types.
 enum TransferPayloadType {
@@ -155,6 +158,10 @@ class SecureTransferService {
   static const _nonceBytes = 12;
   static const _pbkdf2Iterations = 120000;
   static const _maxPbkdf2Iterations = 1000000;
+  static const _hostScopedSettingsKeys = {
+    SettingKeys.agentLaunchPresets,
+    SettingKeys.hostCliLaunchPreferences,
+  };
 
   /// Creates an encrypted host transfer payload.
   Future<String> createHostPayload({
@@ -166,6 +173,8 @@ class SecureTransferService {
     if (includeReferencedKey && host.keyId != null) {
       referencedKey = await _keyRepository.getById(host.keyId!);
     }
+    final cliLaunchPreferences = await _hostCliLaunchPreferencesService
+        .getPreferencesForHost(host.id);
 
     final hostData = Map<String, dynamic>.from(host.toJson())
       ..['keyId'] = referencedKey == null ? null : host.keyId
@@ -177,7 +186,12 @@ class SecureTransferService {
       type: TransferPayloadType.host,
       schemaVersion: _schemaVersion,
       createdAt: DateTime.now().toUtc(),
-      data: {'host': hostData, 'referencedKey': referencedKey?.toJson()},
+      data: {
+        'host': hostData,
+        'referencedKey': referencedKey?.toJson(),
+        if (!cliLaunchPreferences.isEmpty)
+          'hostCliLaunchPreferences': cliLaunchPreferences.toJson(),
+      },
     );
     return _encryptPayload(payload, transferPassphrase);
   }
@@ -404,6 +418,18 @@ class SecureTransferService {
           autoConnectRequiresConfirmation: Value(requiresAutoConnectReview),
         ),
       );
+      final rawCliLaunchPreferences = payload.data['hostCliLaunchPreferences'];
+      if (rawCliLaunchPreferences is Map) {
+        final cliLaunchPreferences = HostCliLaunchPreferences.fromJson(
+          Map<String, dynamic>.from(rawCliLaunchPreferences),
+        );
+        if (!cliLaunchPreferences.isEmpty) {
+          await _hostCliLaunchPreferencesService.setPreferencesForHost(
+            hostId,
+            cliLaunchPreferences,
+          );
+        }
+      }
 
       final createdHost = await _hostRepository.getById(hostId);
       if (createdHost == null) {
@@ -519,6 +545,7 @@ class SecureTransferService {
           _settingsFromData(data),
           clearExisting: mode == MigrationImportMode.replace,
           allowedSettingsKeys: allowedSettingsKeys,
+          hostMapping: hostMapping,
         );
       } finally {
         if (deferForeignKeysEnabled) {
@@ -1025,9 +1052,13 @@ class SecureTransferService {
   Future<void> _importSettings(
     Map<String, String> settings, {
     required bool clearExisting,
+    required Map<int, int> hostMapping,
     Set<String>? allowedSettingsKeys,
   }) async {
-    final filteredSettings = _filterSettings(settings, allowedSettingsKeys);
+    final filteredSettings = _prepareImportedSettings(
+      _filterSettings(settings, allowedSettingsKeys),
+      hostMapping: hostMapping,
+    );
     if (clearExisting) {
       if (allowedSettingsKeys == null) {
         await _db.customStatement('DELETE FROM settings');
@@ -1040,10 +1071,14 @@ class SecureTransferService {
       }
     }
     for (final entry in filteredSettings.entries) {
+      final value =
+          !clearExisting && _hostScopedSettingsKeys.contains(entry.key)
+          ? await _mergeHostScopedSettingValue(entry.key, entry.value)
+          : entry.value;
       await _db
           .into(_db.settings)
           .insertOnConflictUpdate(
-            SettingsCompanion.insert(key: entry.key, value: entry.value),
+            SettingsCompanion.insert(key: entry.key, value: value),
           );
     }
   }
@@ -1096,11 +1131,92 @@ class SecureTransferService {
     );
   }
 
+  Map<String, String> _prepareImportedSettings(
+    Map<String, String> settings, {
+    required Map<int, int> hostMapping,
+  }) {
+    final preparedSettings = <String, String>{};
+    for (final entry in settings.entries) {
+      if (!_hostScopedSettingsKeys.contains(entry.key)) {
+        preparedSettings[entry.key] = entry.value;
+        continue;
+      }
+
+      final remappedValue = _remapHostScopedSettingValue(
+        entry.value,
+        hostMapping,
+      );
+      if (remappedValue != null) {
+        preparedSettings[entry.key] = remappedValue;
+      }
+    }
+    return _sortedStringMap(preparedSettings);
+  }
+
+  String? _remapHostScopedSettingValue(
+    String rawValue,
+    Map<int, int> hostMapping,
+  ) {
+    final decodedSetting = _decodeHostScopedSettingValue(rawValue);
+    final remappedSetting = <String, dynamic>{};
+    for (final entry in decodedSetting.entries) {
+      final oldHostId = int.tryParse(entry.key);
+      if (oldHostId == null) {
+        remappedSetting[entry.key] = entry.value;
+        continue;
+      }
+
+      final mappedHostId = hostMapping[oldHostId];
+      if (mappedHostId != null) {
+        remappedSetting[mappedHostId.toString()] = entry.value;
+      }
+    }
+
+    if (remappedSetting.isEmpty) {
+      return null;
+    }
+    return jsonEncode(_canonicalizeJsonValue(remappedSetting));
+  }
+
+  Future<String> _mergeHostScopedSettingValue(
+    String key,
+    String importedValue,
+  ) async {
+    final existingSetting = await (_db.select(
+      _db.settings,
+    )..where((s) => s.key.equals(key))).getSingleOrNull();
+    if (existingSetting == null) {
+      return importedValue;
+    }
+
+    final mergedSetting = <String, dynamic>{
+      ..._decodeHostScopedSettingValue(existingSetting.value),
+      ..._decodeHostScopedSettingValue(importedValue),
+    };
+    return jsonEncode(_canonicalizeJsonValue(mergedSetting));
+  }
+
+  Map<String, dynamic> _decodeHostScopedSettingValue(String rawValue) {
+    final decodedValue = jsonDecode(rawValue);
+    if (decodedValue is! Map) {
+      throw const FormatException('Invalid host-scoped setting payload');
+    }
+    return {
+      for (final entry in decodedValue.entries)
+        '${entry.key}': _canonicalizeJsonValue(entry.value),
+    };
+  }
+
   Map<String, String> _sortedStringMap(Map<String, String> settings) =>
       Map<String, String>.fromEntries(
         settings.entries.toList(growable: false)
           ..sort((first, second) => first.key.compareTo(second.key)),
       );
+
+  SettingsService get _settingsService => SettingsService(_db);
+
+  HostCliLaunchPreferencesService get _hostCliLaunchPreferencesService =>
+      HostCliLaunchPreferencesService(_settingsService);
 
   List<Map<String, dynamic>> _sortedJsonRecords(
     Iterable<Map<String, dynamic>> records,

--- a/lib/domain/services/settings_service.dart
+++ b/lib/domain/services/settings_service.dart
@@ -80,6 +80,9 @@ abstract final class SettingKeys {
   /// Saved host-scoped coding-agent launch presets.
   static const agentLaunchPresets = 'agent_launch_presets';
 
+  /// Saved host-scoped coding CLI launch preferences.
+  static const hostCliLaunchPreferences = 'host_cli_launch_preferences';
+
   /// Enable shared clipboard between device and remote session.
   ///
   /// The terminal can sync through OSC 52 and remote clipboard utilities when

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -13,10 +13,12 @@ import '../../data/repositories/port_forward_repository.dart';
 import '../../data/repositories/snippet_repository.dart';
 import '../../domain/models/agent_launch_preset.dart';
 import '../../domain/models/auto_connect_command.dart';
+import '../../domain/models/host_cli_launch_preferences.dart';
 import '../../domain/models/monetization.dart';
 import '../../domain/models/terminal_themes.dart';
 import '../../domain/models/tmux_state.dart';
 import '../../domain/services/agent_launch_preset_service.dart';
+import '../../domain/services/host_cli_launch_preferences_service.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/secure_transfer_service.dart';
 import '../../domain/services/ssh_service.dart';
@@ -124,6 +126,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   bool _showPassword = false;
   bool _disableTmuxStatusBar = false;
   bool _disableAgentTmuxStatusBar = false;
+  bool _startClisInYoloMode = false;
 
   Host? _existingHost;
   List<PortForward> _portForwards = [];
@@ -165,6 +168,9 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     final preset = await ref
         .read(agentLaunchPresetServiceProvider)
         .getPresetForHost(host.id);
+    final cliLaunchPreferences = await ref
+        .read(hostCliLaunchPreferencesServiceProvider)
+        .getPreferencesForHost(host.id);
     final tmuxExtraFlags = host.tmuxExtraFlags ?? '';
     if (!mounted) return;
     setState(() {
@@ -190,6 +196,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       _autoConnectCommandController.text = host.autoConnectCommand ?? '';
       _disableTmuxStatusBar = _hasTmuxDisableStatusBarCommand(tmuxExtraFlags);
       _disableAgentTmuxStatusBar = preset?.tmuxDisableStatusBar ?? false;
+      _startClisInYoloMode = cliLaunchPreferences.startInYoloMode;
       _selectedAutoConnectMode = resolveAutoConnectCommandMode(
         command: host.autoConnectCommand,
         snippetId: host.autoConnectSnippetId,
@@ -200,7 +207,10 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         autoConnectMode: _selectedAutoConnectMode,
       );
       if (preset != null) {
-        final presetCommand = _tryBuildAgentLaunchCommand(preset);
+        final presetCommand = _tryBuildAgentLaunchCommand(
+          preset,
+          startInYoloMode: cliLaunchPreferences.startInYoloMode,
+        );
         _selectedAgentLaunchTool = preset.tool;
         _agentWorkingDirectoryController.text = preset.workingDirectory ?? '';
         _agentTmuxSessionController.text = preset.tmuxSessionName ?? '';
@@ -650,6 +660,25 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
           ),
         ],
         const SizedBox(height: 12),
+        CheckboxListTile(
+          key: const Key('host-cli-yolo-mode-checkbox'),
+          value: _startClisInYoloMode,
+          contentPadding: EdgeInsets.zero,
+          controlAffinity: ListTileControlAffinity.leading,
+          title: const Text('Start supported coding CLIs in YOLO mode'),
+          subtitle: Text(
+            hasAgentPresetAccess
+                ? 'Applies to coding CLI launches on this host. Claude Code, Codex, Gemini CLI, and Aider support startup YOLO mode.'
+                : 'MonkeySSH Pro unlocks host-specific coding CLI defaults like YOLO mode.',
+          ),
+          onChanged: hasAgentPresetAccess
+              ? (value) {
+                  setState(() => _startClisInYoloMode = value ?? false);
+                  _syncAutoConnectCommandFromPreset();
+                }
+              : null,
+        ),
+        const SizedBox(height: 12),
         DropdownButtonFormField<_HostStartupMode>(
           key: const Key('host-startup-mode-field'),
           // ignore: deprecated_member_use
@@ -799,7 +828,10 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     String? generatedCommand;
     String? generatedCommandError;
     try {
-      generatedCommand = buildAgentLaunchCommand(currentPreset);
+      generatedCommand = buildAgentLaunchCommand(
+        currentPreset,
+        startInYoloMode: _startClisInYoloMode,
+      );
     } on FormatException catch (error) {
       generatedCommandError = _formatFormatExceptionMessage(error);
     }
@@ -919,6 +951,16 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
               ? (_) => _handleAgentPresetFieldChanged()
               : null,
         ),
+        if (_startClisInYoloMode &&
+            !_selectedAgentLaunchTool.supportsYoloMode) ...[
+          const SizedBox(height: 12),
+          Text(
+            '${_selectedAgentLaunchTool.label} does not expose a startup YOLO flag, so this host setting only affects other supported CLIs.',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
         const SizedBox(height: 12),
         Text(
           'Generated command',
@@ -1072,6 +1114,9 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       );
       final repo = ref.read(hostRepositoryProvider);
       final presetService = ref.read(agentLaunchPresetServiceProvider);
+      final cliLaunchPreferencesService = ref.read(
+        hostCliLaunchPreferencesServiceProvider,
+      );
       final port = int.parse(_portController.text);
       final password = _passwordController.text.isEmpty
           ? null
@@ -1090,7 +1135,10 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       final currentPreset = _buildCurrentAgentLaunchPreset();
       final presetCommand = currentPreset == null
           ? null
-          : buildAgentLaunchCommand(currentPreset);
+          : buildAgentLaunchCommand(
+              currentPreset,
+              startInYoloMode: _startClisInYoloMode,
+            );
       final tmuxSessionName = _tmuxSessionController.text.trim();
       final tmuxWorkingDirectory = _tmuxWorkingDirectoryController.text.trim();
       final tmuxExtraFlags = _tmuxExtraFlagsController.text.trim();
@@ -1241,6 +1289,13 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       }
 
       if (savedHostId != null) {
+        if (hasAgentPresetAccess) {
+          await cliLaunchPreferencesService.setPreferencesForHost(
+            savedHostId,
+            HostCliLaunchPreferences(startInYoloMode: _startClisInYoloMode),
+          );
+        }
+
         final preset = _buildCurrentAgentLaunchPreset();
         if (_selectedStartupMode == _HostStartupMode.agent &&
             hasAutomationAccess &&
@@ -1517,12 +1572,18 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     }
   }
 
-  String? _tryBuildAgentLaunchCommand(AgentLaunchPreset? preset) {
+  String? _tryBuildAgentLaunchCommand(
+    AgentLaunchPreset? preset, {
+    bool? startInYoloMode,
+  }) {
     if (preset == null) {
       return null;
     }
     try {
-      return buildAgentLaunchCommand(preset);
+      return buildAgentLaunchCommand(
+        preset,
+        startInYoloMode: startInYoloMode ?? _startClisInYoloMode,
+      );
     } on FormatException {
       return null;
     }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -30,6 +30,7 @@ import '../../domain/models/terminal_theme.dart';
 import '../../domain/models/terminal_themes.dart';
 import '../../domain/models/tmux_state.dart';
 import '../../domain/services/agent_session_discovery_service.dart';
+import '../../domain/services/host_cli_launch_preferences_service.dart';
 import '../../domain/services/local_notification_service.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/remote_clipboard_sync_service.dart';
@@ -255,6 +256,7 @@ class _TmuxExpandableBar extends StatefulWidget {
     required this.tmuxSessionName,
     required this.availableHeight,
     required this.isProUser,
+    required this.startClisInYoloMode,
     required this.ref,
     required this.onAction,
   });
@@ -270,6 +272,9 @@ class _TmuxExpandableBar extends StatefulWidget {
 
   /// Whether the user has Pro access.
   final bool isProUser;
+
+  /// Whether supported coding CLIs should launch in YOLO mode for this host.
+  final bool startClisInYoloMode;
 
   /// Riverpod ref.
   final WidgetRef ref;
@@ -720,7 +725,10 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
                 }
                 widget.onAction(
                   TmuxNewWindowAction(
-                    command: tool.commandName,
+                    command: buildAgentToolCommand(
+                      tool,
+                      startInYoloMode: widget.startClisInYoloMode,
+                    ),
                     windowName: tool.commandName,
                   ),
                 );
@@ -2342,6 +2350,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   // Theme state
   Host? _host;
+  bool _startClisInYoloMode = false;
   TerminalThemeData? _currentTheme;
   TerminalThemeData? _sessionThemeOverride;
 
@@ -2916,6 +2925,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     // Load host data first for theme
     final hostRepo = ref.read(hostRepositoryProvider);
     _host = await hostRepo.getById(widget.hostId);
+    final cliLaunchPreferences = await ref
+        .read(hostCliLaunchPreferencesServiceProvider)
+        .getPreferencesForHost(widget.hostId);
+    _startClisInYoloMode = cliLaunchPreferences.startInYoloMode;
     await _loadTheme();
     await _connect(preferredConnectionId: widget.connectionId);
   }
@@ -3647,6 +3660,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       tmuxSessionName: _tmuxSessionName!,
       availableHeight: availableHeight,
       isProUser: isProUser,
+      startClisInYoloMode: _startClisInYoloMode,
       ref: ref,
       onAction: _handleTmuxAction,
     );
@@ -3700,6 +3714,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       session: session,
       tmuxSessionName: _tmuxSessionName!,
       isProUser: isProUser,
+      startClisInYoloMode: _startClisInYoloMode,
     );
 
     if (!mounted || action == null) return;

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -30,6 +30,7 @@ Future<TmuxNavigatorAction?> showTmuxNavigator({
   required SshSession session,
   required String tmuxSessionName,
   required bool isProUser,
+  required bool startClisInYoloMode,
 }) => showModalBottomSheet<TmuxNavigatorAction>(
   context: context,
   isScrollControlled: true,
@@ -37,6 +38,7 @@ Future<TmuxNavigatorAction?> showTmuxNavigator({
     session: session,
     tmuxSessionName: tmuxSessionName,
     isProUser: isProUser,
+    startClisInYoloMode: startClisInYoloMode,
     ref: ref,
   ),
 );
@@ -94,12 +96,14 @@ class _TmuxNavigatorSheet extends StatefulWidget {
     required this.session,
     required this.tmuxSessionName,
     required this.isProUser,
+    required this.startClisInYoloMode,
     required this.ref,
   });
 
   final SshSession session;
   final String tmuxSessionName;
   final bool isProUser;
+  final bool startClisInYoloMode;
   final WidgetRef ref;
 
   @override
@@ -243,7 +247,13 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         installedToolsFuture: _installedToolsFuture,
         onToolSelected: (tool) {
           Navigator.pop(context);
-          _createNewWindow(command: tool.commandName, name: tool.commandName);
+          _createNewWindow(
+            command: buildAgentToolCommand(
+              tool,
+              startInYoloMode: widget.startClisInYoloMode,
+            ),
+            name: tool.commandName,
+          );
         },
         onEmptyWindow: () {
           Navigator.pop(context);

--- a/test/domain/models/agent_launch_preset_test.dart
+++ b/test/domain/models/agent_launch_preset_test.dart
@@ -196,6 +196,18 @@ void main() {
         'codex --approval-mode never --model gpt-5.4',
       );
     });
+
+    test('replaces conflicting codex approval-mode arguments in yolo mode', () {
+      const preset = AgentLaunchPreset(
+        tool: AgentLaunchTool.codex,
+        additionalArguments: '--approval-mode auto --model gpt-5.4',
+      );
+
+      expect(
+        buildAgentLaunchCommand(preset, startInYoloMode: true),
+        'codex --approval-mode never --model gpt-5.4',
+      );
+    });
   });
 
   test('round-trips preset json', () {

--- a/test/domain/models/agent_launch_preset_test.dart
+++ b/test/domain/models/agent_launch_preset_test.dart
@@ -4,6 +4,44 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
 
 void main() {
+  group('buildAgentToolCommand', () {
+    test('adds yolo flags for supported tools', () {
+      expect(
+        buildAgentToolCommand(
+          AgentLaunchTool.claudeCode,
+          startInYoloMode: true,
+        ),
+        'claude --dangerously-skip-permissions',
+      );
+      expect(
+        buildAgentToolCommand(AgentLaunchTool.codex, startInYoloMode: true),
+        'codex --approval-mode never',
+      );
+      expect(
+        buildAgentToolCommand(AgentLaunchTool.geminiCli, startInYoloMode: true),
+        'gemini --yolo',
+      );
+      expect(
+        buildAgentToolCommand(AgentLaunchTool.aider, startInYoloMode: true),
+        'aider --yes-always',
+      );
+    });
+
+    test('leaves unsupported tools unchanged in yolo mode', () {
+      expect(
+        buildAgentToolCommand(
+          AgentLaunchTool.copilotCli,
+          startInYoloMode: true,
+        ),
+        'copilot',
+      );
+      expect(
+        buildAgentToolCommand(AgentLaunchTool.openCode, startInYoloMode: true),
+        'opencode',
+      );
+    });
+  });
+
   group('buildAgentLaunchCommand', () {
     test('builds a working-directory command without tmux', () {
       const preset = AgentLaunchPreset(
@@ -134,6 +172,30 @@ void main() {
 
       expect(buildAgentLaunchCommand(preset), 'gemini');
     });
+
+    test('adds yolo mode to supported presets', () {
+      const preset = AgentLaunchPreset(
+        tool: AgentLaunchTool.codex,
+        workingDirectory: '~/project',
+      );
+
+      expect(
+        buildAgentLaunchCommand(preset, startInYoloMode: true),
+        r'cd "$HOME/project" && codex --approval-mode never',
+      );
+    });
+
+    test('does not duplicate a yolo flag already in extra arguments', () {
+      const preset = AgentLaunchPreset(
+        tool: AgentLaunchTool.codex,
+        additionalArguments: '--approval-mode never --model gpt-5.4',
+      );
+
+      expect(
+        buildAgentLaunchCommand(preset, startInYoloMode: true),
+        'codex --approval-mode never --model gpt-5.4',
+      );
+    });
   });
 
   test('round-trips preset json', () {
@@ -205,6 +267,15 @@ void main() {
           reason: '${tool.name} should support resume',
         );
       }
+    });
+
+    test('supportsYoloMode is only true for supported tools', () {
+      expect(AgentLaunchTool.claudeCode.supportsYoloMode, isTrue);
+      expect(AgentLaunchTool.aider.supportsYoloMode, isTrue);
+      expect(AgentLaunchTool.codex.supportsYoloMode, isTrue);
+      expect(AgentLaunchTool.geminiCli.supportsYoloMode, isTrue);
+      expect(AgentLaunchTool.copilotCli.supportsYoloMode, isFalse);
+      expect(AgentLaunchTool.openCode.supportsYoloMode, isFalse);
     });
   });
 

--- a/test/domain/services/host_cli_launch_preferences_service_test.dart
+++ b/test/domain/services/host_cli_launch_preferences_service_test.dart
@@ -1,0 +1,53 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/domain/models/host_cli_launch_preferences.dart';
+import 'package:monkeyssh/domain/services/host_cli_launch_preferences_service.dart';
+import 'package:monkeyssh/domain/services/settings_service.dart';
+
+void main() {
+  late AppDatabase database;
+  late HostCliLaunchPreferencesService service;
+
+  setUp(() {
+    database = AppDatabase.forTesting(NativeDatabase.memory());
+    service = HostCliLaunchPreferencesService(SettingsService(database));
+  });
+
+  tearDown(() async {
+    await database.close();
+  });
+
+  test('stores and loads host CLI launch preferences', () async {
+    const preferences = HostCliLaunchPreferences(startInYoloMode: true);
+
+    await service.setPreferencesForHost(42, preferences);
+    final loaded = await service.getPreferencesForHost(42);
+
+    expect(loaded.startInYoloMode, isTrue);
+  });
+
+  test(
+    'returns default preferences when a host has no saved overrides',
+    () async {
+      final loaded = await service.getPreferencesForHost(7);
+
+      expect(loaded.startInYoloMode, isFalse);
+      expect(loaded.isEmpty, isTrue);
+    },
+  );
+
+  test('deletes stored preferences when saved settings are empty', () async {
+    await service.setPreferencesForHost(
+      7,
+      const HostCliLaunchPreferences(startInYoloMode: true),
+    );
+    await service.setPreferencesForHost(7, const HostCliLaunchPreferences());
+
+    final loaded = await service.getPreferencesForHost(7);
+    expect(loaded.startInYoloMode, isFalse);
+    expect(loaded.isEmpty, isTrue);
+  });
+}

--- a/test/domain/services/secure_transfer_service_test.dart
+++ b/test/domain/services/secure_transfer_service_test.dart
@@ -11,8 +11,13 @@ import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/key_repository.dart';
 import 'package:monkeyssh/data/security/secret_encryption_service.dart';
+import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
+import 'package:monkeyssh/domain/models/host_cli_launch_preferences.dart';
+import 'package:monkeyssh/domain/services/agent_launch_preset_service.dart';
+import 'package:monkeyssh/domain/services/host_cli_launch_preferences_service.dart';
 import 'package:monkeyssh/domain/services/host_key_verification.dart';
 import 'package:monkeyssh/domain/services/secure_transfer_service.dart';
+import 'package:monkeyssh/domain/services/settings_service.dart';
 
 void main() {
   late AppDatabase db;
@@ -176,6 +181,58 @@ void main() {
         db.hosts,
       )..where((h) => h.id.equals(imported.id))).getSingle();
       expect(stored.password, startsWith('ENCv1:'));
+    });
+
+    test('importHostPayload preserves host CLI launch preferences', () async {
+      final settingsService = SettingsService(db);
+      final cliLaunchPreferencesService = HostCliLaunchPreferencesService(
+        settingsService,
+      );
+      final hostId = await db
+          .into(db.hosts)
+          .insert(
+            HostsCompanion.insert(
+              label: 'Imported Host',
+              hostname: 'imported.example.com',
+              username: 'root',
+            ),
+          );
+      await cliLaunchPreferencesService.setPreferencesForHost(
+        hostId,
+        const HostCliLaunchPreferences(startInYoloMode: true),
+      );
+      final host = await (db.select(
+        db.hosts,
+      )..where((h) => h.id.equals(hostId))).getSingle();
+
+      final encodedPayload = await transferService.createHostPayload(
+        host: host,
+        transferPassphrase: '1234',
+      );
+      final decryptedPayload = await transferService.decryptPayload(
+        encodedPayload: encodedPayload,
+        transferPassphrase: '1234',
+      );
+
+      final importedDb = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(importedDb.close);
+      final importedEncryptionService = SecretEncryptionService.forTesting();
+      final importedTransferService = SecureTransferService(
+        importedDb,
+        KeyRepository(importedDb, importedEncryptionService),
+        HostRepository(importedDb, importedEncryptionService),
+      );
+      final importedSettingsService = SettingsService(importedDb);
+      final importedCliLaunchPreferencesService =
+          HostCliLaunchPreferencesService(importedSettingsService);
+
+      final importedHost = await importedTransferService.importHostPayload(
+        decryptedPayload,
+      );
+      final importedPreferences = await importedCliLaunchPreferencesService
+          .getPreferencesForHost(importedHost.id);
+
+      expect(importedPreferences.startInYoloMode, isTrue);
     });
 
     test(
@@ -711,6 +768,105 @@ void main() {
             .getSingle();
         expect(importedHost.createdAt.toUtc(), createdAt);
         expect(importedHost.updatedAt.toUtc(), updatedAt);
+      },
+    );
+
+    test(
+      'merge import remaps and preserves host-scoped launch settings',
+      () async {
+        final sourceSettingsService = SettingsService(db);
+        final sourcePresetService = AgentLaunchPresetService(
+          sourceSettingsService,
+        );
+        final sourceCliLaunchPreferencesService =
+            HostCliLaunchPreferencesService(sourceSettingsService);
+        final sourceHostId = await hostRepository.insert(
+          HostsCompanion.insert(
+            label: 'Imported Host',
+            hostname: 'imported.example.com',
+            username: 'root',
+          ),
+        );
+        await sourcePresetService.setPresetForHost(
+          sourceHostId,
+          const AgentLaunchPreset(
+            tool: AgentLaunchTool.codex,
+            additionalArguments: '--model gpt-5.4',
+          ),
+        );
+        await sourceCliLaunchPreferencesService.setPreferencesForHost(
+          sourceHostId,
+          const HostCliLaunchPreferences(startInYoloMode: true),
+        );
+        final migrationData = await transferService.createMigrationData(
+          includeKnownHosts: false,
+        );
+
+        final importedDb = AppDatabase.forTesting(NativeDatabase.memory());
+        addTearDown(importedDb.close);
+        final importedEncryptionService = SecretEncryptionService.forTesting();
+        final importedHostRepository = HostRepository(
+          importedDb,
+          importedEncryptionService,
+        );
+        final importedTransferService = SecureTransferService(
+          importedDb,
+          KeyRepository(importedDb, importedEncryptionService),
+          importedHostRepository,
+        );
+        final importedSettingsService = SettingsService(importedDb);
+        final importedPresetService = AgentLaunchPresetService(
+          importedSettingsService,
+        );
+        final importedCliLaunchPreferencesService =
+            HostCliLaunchPreferencesService(importedSettingsService);
+
+        final localHostId = await importedHostRepository.insert(
+          HostsCompanion.insert(
+            label: 'Local Host',
+            hostname: 'local.example.com',
+            username: 'root',
+          ),
+        );
+        await importedPresetService.setPresetForHost(
+          localHostId,
+          const AgentLaunchPreset(
+            tool: AgentLaunchTool.claudeCode,
+            additionalArguments: '--resume',
+          ),
+        );
+        await importedCliLaunchPreferencesService.setPreferencesForHost(
+          localHostId,
+          const HostCliLaunchPreferences(startInYoloMode: true),
+        );
+
+        await importedTransferService.importMigrationData(
+          data: migrationData,
+          mode: MigrationImportMode.merge,
+          includeKnownHosts: false,
+        );
+
+        final importedHost = await (importedDb.select(
+          importedDb.hosts,
+        )..where((host) => host.label.equals('Imported Host'))).getSingle();
+        final localPreset = await importedPresetService.getPresetForHost(
+          localHostId,
+        );
+        final importedPreset = await importedPresetService.getPresetForHost(
+          importedHost.id,
+        );
+        final localPreferences = await importedCliLaunchPreferencesService
+            .getPreferencesForHost(localHostId);
+        final importedPreferences = await importedCliLaunchPreferencesService
+            .getPreferencesForHost(importedHost.id);
+
+        expect(importedHost.id, isNot(localHostId));
+        expect(localPreset?.tool, AgentLaunchTool.claudeCode);
+        expect(localPreset?.additionalArguments, '--resume');
+        expect(importedPreset?.tool, AgentLaunchTool.codex);
+        expect(importedPreset?.additionalArguments, '--model gpt-5.4');
+        expect(localPreferences.startInYoloMode, isTrue);
+        expect(importedPreferences.startInYoloMode, isTrue);
       },
     );
 

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -341,7 +341,12 @@ void main() {
         200,
         scrollable: find.byType(Scrollable).first,
       );
-      await tester.tap(find.byKey(const Key('host-save-button')));
+      final saveButton = find.byKey(
+        const Key('host-save-button'),
+        skipOffstage: false,
+      );
+      await tester.ensureVisible(saveButton);
+      tester.widget<FilledButton>(saveButton).onPressed!();
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
@@ -529,7 +534,12 @@ void main() {
         200,
         scrollable: find.byType(Scrollable).first,
       );
-      await tester.tap(find.byKey(const Key('host-save-button')));
+      final saveButton = find.byKey(
+        const Key('host-save-button'),
+        skipOffstage: false,
+      );
+      await tester.ensureVisible(saveButton);
+      tester.widget<FilledButton>(saveButton).onPressed!();
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
@@ -684,6 +694,118 @@ void main() {
         expect(savedPreset.tmuxDisableStatusBar, isTrue);
         expect(savedPreset.tmuxSessionName, 'agent-session');
         expect(savedPreset.tmuxExtraFlags, '-x 200 -y 60');
+      },
+    );
+
+    testWidgets(
+      'uses the host CLI yolo mode setting in generated agent commands',
+      (tester) async {
+        final database = AppDatabase.forTesting(NativeDatabase.memory());
+        final encryptionService = SecretEncryptionService.forTesting();
+        addTearDown(database.close);
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await tester.binding.setSurfaceSize(const Size(420, 900));
+
+        final hostRepository = _FakeHostRepository(
+          host: _testHost(
+            id: 1,
+            label: 'Agent Host',
+            autoConnectRequiresConfirmation: false,
+          ),
+          database: database,
+          encryptionService: encryptionService,
+        );
+        final presetService = _MockAgentLaunchPresetService();
+        const preset = AgentLaunchPreset(tool: AgentLaunchTool.codex);
+        when(
+          () => presetService.getPresetForHost(1),
+        ).thenAnswer((_) async => preset);
+        when(
+          () => presetService.setPresetForHost(1, any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => presetService.deletePresetForHost(1),
+        ).thenAnswer((_) async {});
+
+        final router = GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) =>
+                  const Scaffold(body: SizedBox.shrink()),
+            ),
+            GoRoute(
+              path: '/edit',
+              builder: (context, state) => const HostEditScreen(hostId: 1),
+            ),
+          ],
+        );
+        addTearDown(router.dispose);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              databaseProvider.overrideWithValue(database),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              agentLaunchPresetServiceProvider.overrideWithValue(presetService),
+              keyRepositoryProvider.overrideWithValue(
+                _FakeKeyRepository(
+                  database: database,
+                  encryptionService: encryptionService,
+                ),
+              ),
+              snippetRepositoryProvider.overrideWithValue(
+                _FakeSnippetRepository(snippets: const [], database: database),
+              ),
+              portForwardRepositoryProvider.overrideWithValue(
+                _FakePortForwardRepository(database: database),
+              ),
+            ],
+            child: MaterialApp.router(routerConfig: router),
+          ),
+        );
+
+        unawaited(router.push('/edit'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final yoloFinder = find.byKey(const Key('host-cli-yolo-mode-checkbox'));
+        expect(yoloFinder, findsOneWidget);
+        expect(tester.widget<CheckboxListTile>(yoloFinder).value, isFalse);
+
+        await tester.tap(yoloFinder);
+        await tester.pump();
+
+        expect(
+          find.textContaining(
+            'codex --approval-mode never',
+            findRichText: true,
+          ),
+          findsOneWidget,
+        );
+
+        final saveButton = find.byKey(
+          const Key('host-save-button'),
+          skipOffstage: false,
+        );
+        await tester.scrollUntilVisible(
+          saveButton,
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.ensureVisible(saveButton);
+        tester.widget<FilledButton>(saveButton).onPressed!();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(hostRepository.updatedHost, isNotNull);
+        expect(
+          hostRepository.updatedHost!.autoConnectCommand,
+          contains('--approval-mode never'),
+        );
       },
     );
 


### PR DESCRIPTION
## Summary

- add a host-scoped CLI launch preference backed by settings storage for whether supported coding CLIs should start in YOLO mode
- apply tool-specific YOLO flags in shared command building so saved agent startup commands and tmux new-window launches stay consistent
- expose the toggle in the host editor and add coverage for command building, persistence, and host editing behavior

## Testing

- flutter analyze --no-pub
- flutter test --no-pub
