### PR TITLE
fix: add disconnect action to connected host context menu

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -658,10 +658,25 @@ class HostsPanel extends ConsumerWidget {
 enum _HostContextAction {
   connect,
   newConnection,
+  disconnect,
   edit,
   duplicate,
   export,
   delete,
+}
+
+Future<void> _disconnectConnection(WidgetRef ref, int connectionId) async {
+  ref.read(tmuxServiceProvider).clearCache(connectionId);
+  await ref.read(activeSessionsProvider.notifier).disconnect(connectionId);
+}
+
+Future<void> _disconnectHostConnections(
+  WidgetRef ref,
+  Iterable<int> connectionIds,
+) async {
+  for (final connectionId in connectionIds.toList(growable: false)) {
+    await _disconnectConnection(ref, connectionId);
+  }
 }
 
 class _HostRow extends ConsumerWidget {
@@ -1037,6 +1052,11 @@ class _HostRow extends ConsumerWidget {
     Offset globalPosition,
   ) async {
     final colorScheme = Theme.of(context).colorScheme;
+    final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
+    final connectionIds = sessionsNotifier.getConnectionsForHost(host.id);
+    final disconnectLabel = connectionIds.length > 1
+        ? 'Disconnect all'
+        : 'Disconnect';
 
     final overlay = Overlay.maybeOf(context);
     final overlayBox = overlay?.context.findRenderObject() as RenderBox?;
@@ -1066,6 +1086,15 @@ class _HostRow extends ConsumerWidget {
             title: Text('New connection'),
           ),
         ),
+        if (connectionIds.isNotEmpty)
+          PopupMenuItem<_HostContextAction>(
+            value: _HostContextAction.disconnect,
+            child: ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: const Icon(Icons.link_off_rounded),
+              title: Text(disconnectLabel),
+            ),
+          ),
         const PopupMenuDivider(),
         const PopupMenuItem<_HostContextAction>(
           value: _HostContextAction.edit,
@@ -1116,6 +1145,9 @@ class _HostRow extends ConsumerWidget {
         return;
       case _HostContextAction.newConnection:
         await _openNewConnection(context, ref);
+        return;
+      case _HostContextAction.disconnect:
+        await _disconnectHostConnections(ref, connectionIds);
         return;
       case _HostContextAction.edit:
         unawaited(context.push('/hosts/edit/${host.id}'));
@@ -1406,14 +1438,12 @@ class _ConnectionsPanel extends ConsumerWidget {
                           trailing: IconButton(
                             icon: const Icon(Icons.close),
                             tooltip: 'Disconnect',
-                            onPressed: () async {
-                              ref
-                                  .read(tmuxServiceProvider)
-                                  .clearCache(connection.connectionId);
-                              await ref
-                                  .read(activeSessionsProvider.notifier)
-                                  .disconnect(connection.connectionId);
-                            },
+                            onPressed: () => unawaited(
+                              _disconnectConnection(
+                                ref,
+                                connection.connectionId,
+                              ),
+                            ),
                           ),
                           onTap: () => unawaited(
                             context.push(

--- a/test/widget/hosts_screen_test.dart
+++ b/test/widget/hosts_screen_test.dart
@@ -17,17 +17,47 @@ import 'package:monkeyssh/presentation/screens/hosts_screen.dart';
 class _MockHostRepository extends Mock implements HostRepository {}
 
 class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
+  _TestActiveSessionsNotifier({
+    List<ActiveConnection> initialConnections = const <ActiveConnection>[],
+  }) {
+    _connections.addEntries(
+      initialConnections.map(
+        (connection) => MapEntry(connection.connectionId, connection),
+      ),
+    );
+  }
+
+  final Map<int, ActiveConnection> _connections = <int, ActiveConnection>{};
+  final List<int> disconnectedConnectionIds = <int>[];
+
   @override
-  Map<int, SshConnectionState> build() => <int, SshConnectionState>{};
+  Map<int, SshConnectionState> build() => {
+    for (final connection in _connections.values)
+      connection.connectionId: connection.state,
+  };
 
   @override
   ConnectionAttemptStatus? getConnectionAttempt(int hostId) => null;
 
   @override
-  List<int> getConnectionsForHost(int hostId) => const [];
+  List<int> getConnectionsForHost(int hostId) => _connections.values
+      .where((connection) => connection.hostId == hostId)
+      .map((connection) => connection.connectionId)
+      .toList(growable: false);
 
   @override
-  ActiveConnection? getActiveConnection(int connectionId) => null;
+  ActiveConnection? getActiveConnection(int connectionId) =>
+      _connections[connectionId];
+
+  @override
+  Future<void> disconnect(int connectionId) async {
+    disconnectedConnectionIds.add(connectionId);
+    _connections.remove(connectionId);
+    state = {
+      for (final connection in _connections.values)
+        connection.connectionId: connection.state,
+    };
+  }
 }
 
 Host _buildHost({
@@ -58,6 +88,22 @@ Host _buildHost({
   autoConnectSnippetId: null,
   autoConnectRequiresConfirmation: false,
   sortOrder: sortOrder,
+);
+
+ActiveConnection _buildActiveConnection({
+  required int connectionId,
+  required int hostId,
+  SshConnectionState state = SshConnectionState.connected,
+}) => ActiveConnection(
+  connectionId: connectionId,
+  hostId: hostId,
+  state: state,
+  createdAt: DateTime(2026),
+  config: const SshConnectionConfig(
+    hostname: 'alpha.example.com',
+    port: 22,
+    username: 'root',
+  ),
 );
 
 void main() {
@@ -188,9 +234,50 @@ void main() {
 
     expect(find.text('Connect'), findsOneWidget);
     expect(find.text('New connection'), findsOneWidget);
+    expect(find.text('Disconnect'), findsNothing);
+    expect(find.text('Disconnect all'), findsNothing);
     expect(find.text('Edit'), findsOneWidget);
     expect(find.text('Duplicate'), findsOneWidget);
     expect(find.text('Export Encrypted File (Pro)'), findsOneWidget);
     expect(find.text('Delete'), findsOneWidget);
   });
+
+  testWidgets(
+    'connected host long press can disconnect from the context menu',
+    (tester) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final sessionsNotifier = _TestActiveSessionsNotifier(
+        initialConnections: [
+          _buildActiveConnection(connectionId: 7, hostId: 1),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            activeSessionsProvider.overrideWith(() => sessionsNotifier),
+            allHostsProvider.overrideWith(
+              (ref) => Stream.value([
+                _buildHost(id: 1, label: 'Alpha', sortOrder: 0),
+              ]),
+            ),
+          ],
+          child: const MaterialApp(home: HostsScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.longPress(find.text('Alpha'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Disconnect'), findsOneWidget);
+
+      await tester.tap(find.text('Disconnect'));
+      await tester.pumpAndSettle();
+
+      expect(sessionsNotifier.disconnectedConnectionIds, orderedEquals([7]));
+    },
+  );
 }


### PR DESCRIPTION
## Summary

- add a disconnect action to the host long-press context menu when that host has active connections
- reuse a shared disconnect helper so host-level and connection-level disconnects both clear tmux cache first
- extend the hosts screen widget coverage for connected and disconnected menu states

## Testing

- flutter analyze
- flutter test
