### PR TITLE
fix: audit agent yolo launches

### DIFF
--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -65,16 +65,23 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
   };
 
   /// Whether this tool supports launching directly into YOLO mode.
-  bool get supportsYoloMode => yoloArgument != null;
+  bool get supportsYoloMode =>
+      yoloArguments.isNotEmpty || yoloEnvironment.isNotEmpty;
 
-  /// Command-line argument that enables YOLO mode for this tool, if available.
-  String? get yoloArgument => switch (this) {
-    AgentLaunchTool.claudeCode => '--dangerously-skip-permissions',
-    AgentLaunchTool.copilotCli => null,
-    AgentLaunchTool.aider => '--yes-always',
-    AgentLaunchTool.codex => '--approval-mode never',
-    AgentLaunchTool.openCode => null,
-    AgentLaunchTool.geminiCli => '--yolo',
+  /// Command-line arguments that enable YOLO mode for this tool.
+  List<String> get yoloArguments => switch (this) {
+    AgentLaunchTool.claudeCode => const ['--dangerously-skip-permissions'],
+    AgentLaunchTool.copilotCli => const ['--yolo'],
+    AgentLaunchTool.aider => const ['--yes'],
+    AgentLaunchTool.codex => const ['--yolo'],
+    AgentLaunchTool.openCode => const [],
+    AgentLaunchTool.geminiCli => const ['--yolo'],
+  };
+
+  /// Environment variables that enable YOLO mode for this tool.
+  Map<String, String> get yoloEnvironment => switch (this) {
+    AgentLaunchTool.openCode => const {'OPENCODE_PERMISSION': '{"*":"allow"}'},
+    _ => const <String, String>{},
   };
 }
 
@@ -179,6 +186,53 @@ final _codexApprovalModeEqualsPattern = RegExp(
 final _codexApprovalModeSeparatedPattern = RegExp(
   r'''(?<!\S)--approval-mode\s+(?:"[^"]*"|'[^']*'|\S+)''',
 );
+final _codexAskForApprovalEqualsPattern = RegExp(
+  r'''(?<!\S)--ask-for-approval=(?:"[^"]*"|'[^']*'|\S+)''',
+);
+final _codexAskForApprovalSeparatedPattern = RegExp(
+  r'''(?<!\S)--ask-for-approval\s+(?:"[^"]*"|'[^']*'|\S+)''',
+);
+final _codexShortApprovalPattern = RegExp(
+  r'''(?<!\S)-a\s+(?:"[^"]*"|'[^']*'|\S+)''',
+);
+final _codexSandboxEqualsPattern = RegExp(
+  r'''(?<!\S)--sandbox=(?:"[^"]*"|'[^']*'|\S+)''',
+);
+final _codexSandboxSeparatedPattern = RegExp(
+  r'''(?<!\S)--sandbox\s+(?:"[^"]*"|'[^']*'|\S+)''',
+);
+final _codexShortSandboxPattern = RegExp(
+  r'''(?<!\S)-s\s+(?:"[^"]*"|'[^']*'|\S+)''',
+);
+final _codexFullAutoPattern = RegExp(r'(?<!\S)--full-auto(?=\s|$)');
+final _codexYoloPattern = RegExp(r'(?<!\S)--yolo(?=\s|$)');
+final _codexDangerousBypassPattern = RegExp(
+  r'(?<!\S)--dangerously-bypass-approvals-and-sandbox(?=\s|$)',
+);
+final _claudeDangerouslySkipPermissionsPattern = RegExp(
+  r'(?<!\S)--dangerously-skip-permissions(?=\s|$)',
+);
+final _claudePermissionModeEqualsPattern = RegExp(
+  r'''(?<!\S)--permission-mode=(?:"[^"]*"|'[^']*'|\S+)''',
+);
+final _claudePermissionModeSeparatedPattern = RegExp(
+  r'''(?<!\S)--permission-mode\s+(?:"[^"]*"|'[^']*'|\S+)''',
+);
+final _copilotAllowAllPattern = RegExp(r'(?<!\S)--allow-all(?=\s|$)');
+final _copilotYoloPattern = RegExp(r'(?<!\S)--yolo(?=\s|$)');
+final _copilotAllowAllToolsPattern = RegExp(
+  r'(?<!\S)--allow-all-tools(?=\s|$)',
+);
+final _copilotAllowAllPathsPattern = RegExp(
+  r'(?<!\S)--allow-all-paths(?=\s|$)',
+);
+final _copilotAllowAllUrlsPattern = RegExp(r'(?<!\S)--allow-all-urls(?=\s|$)');
+final _aiderYesPattern = RegExp(r'(?<!\S)--yes(?=\s|$)');
+final _aiderYesAlwaysPattern = RegExp(r'(?<!\S)--yes-always(?=\s|$)');
+final _geminiYoloPattern = RegExp(r'(?<!\S)(?:--yolo|-y)(?=\s|$)');
+final _openCodeDangerouslySkipPermissionsPattern = RegExp(
+  r'(?<!\S)--dangerously-skip-permissions(?=\s|$)',
+);
 
 /// Builds the shell command for a saved agent launch preset.
 String buildAgentLaunchCommand(
@@ -219,7 +273,13 @@ String buildAgentToolCommand(
   String? additionalArguments,
   bool startInYoloMode = false,
 }) {
-  final commandParts = <String>[tool.commandName];
+  final commandParts = <String>[
+    ..._buildAgentToolEnvironmentAssignments(
+      tool,
+      startInYoloMode: startInYoloMode,
+    ),
+    tool.commandName,
+  ];
   final normalizedArguments = _normalizeAgentToolArguments(
     tool: tool,
     additionalArguments: additionalArguments,
@@ -236,41 +296,97 @@ String? _normalizeAgentToolArguments({
   required String? additionalArguments,
   required bool startInYoloMode,
 }) {
-  final yoloArgument = tool.yoloArgument;
   final trimmedAdditionalArguments = additionalArguments?.trim();
-  if (!startInYoloMode || yoloArgument == null) {
+  if (!startInYoloMode) {
     return trimmedAdditionalArguments;
   }
 
   final sanitizedAdditionalArguments = switch (tool) {
-    AgentLaunchTool.codex => _stripCodexApprovalModeArguments(
+    AgentLaunchTool.claudeCode =>
+      _stripArgumentPatterns(trimmedAdditionalArguments, [
+        _claudeDangerouslySkipPermissionsPattern,
+        _claudePermissionModeEqualsPattern,
+        _claudePermissionModeSeparatedPattern,
+      ]),
+    AgentLaunchTool.copilotCli =>
+      _stripArgumentPatterns(trimmedAdditionalArguments, [
+        _copilotAllowAllPattern,
+        _copilotYoloPattern,
+        _copilotAllowAllToolsPattern,
+        _copilotAllowAllPathsPattern,
+        _copilotAllowAllUrlsPattern,
+      ]),
+    AgentLaunchTool.aider => _stripArgumentPatterns(
+      trimmedAdditionalArguments,
+      [_aiderYesPattern, _aiderYesAlwaysPattern],
+    ),
+    AgentLaunchTool.codex => _stripCodexYoloConflicts(
       trimmedAdditionalArguments,
     ),
-    _ => trimmedAdditionalArguments,
+    AgentLaunchTool.openCode => _stripArgumentPatterns(
+      trimmedAdditionalArguments,
+      [_openCodeDangerouslySkipPermissionsPattern],
+    ),
+    AgentLaunchTool.geminiCli => _stripArgumentPatterns(
+      trimmedAdditionalArguments,
+      [_geminiYoloPattern],
+    ),
   };
 
-  if (sanitizedAdditionalArguments == null ||
-      sanitizedAdditionalArguments.isEmpty) {
-    return yoloArgument;
-  }
-
-  if (sanitizedAdditionalArguments.contains(yoloArgument)) {
+  final yoloArguments = tool.yoloArguments;
+  if (yoloArguments.isEmpty) {
     return sanitizedAdditionalArguments;
   }
 
-  return '$yoloArgument $sanitizedAdditionalArguments';
+  if (sanitizedAdditionalArguments == null ||
+      sanitizedAdditionalArguments.isEmpty) {
+    return yoloArguments.join(' ');
+  }
+
+  return '${yoloArguments.join(' ')} $sanitizedAdditionalArguments';
 }
 
-String? _stripCodexApprovalModeArguments(String? additionalArguments) {
+List<String> _buildAgentToolEnvironmentAssignments(
+  AgentLaunchTool tool, {
+  required bool startInYoloMode,
+}) => !startInYoloMode
+    ? const []
+    : tool.yoloEnvironment.entries
+          .map(
+            (entry) => _quoteShellEnvironmentAssignment(entry.key, entry.value),
+          )
+          .toList(growable: false);
+
+String? _stripCodexYoloConflicts(String? additionalArguments) =>
+    _stripArgumentPatterns(additionalArguments, [
+      _codexApprovalModeEqualsPattern,
+      _codexApprovalModeSeparatedPattern,
+      _codexAskForApprovalEqualsPattern,
+      _codexAskForApprovalSeparatedPattern,
+      _codexShortApprovalPattern,
+      _codexSandboxEqualsPattern,
+      _codexSandboxSeparatedPattern,
+      _codexShortSandboxPattern,
+      _codexFullAutoPattern,
+      _codexYoloPattern,
+      _codexDangerousBypassPattern,
+    ]);
+
+String? _stripArgumentPatterns(
+  String? additionalArguments,
+  List<RegExp> patterns,
+) {
   final trimmedAdditionalArguments = additionalArguments?.trim();
   if (trimmedAdditionalArguments == null ||
       trimmedAdditionalArguments.isEmpty) {
     return null;
   }
 
-  final normalizedArguments = trimmedAdditionalArguments
-      .replaceAll(_codexApprovalModeEqualsPattern, ' ')
-      .replaceAll(_codexApprovalModeSeparatedPattern, ' ')
+  final normalizedArguments = patterns
+      .fold<String>(
+        trimmedAdditionalArguments,
+        (value, pattern) => value.replaceAll(pattern, ' '),
+      )
       .replaceAll(RegExp(r'\s+'), ' ')
       .trim();
   return normalizedArguments.isEmpty ? null : normalizedArguments;
@@ -409,6 +525,9 @@ String _quoteShellPath(String value) {
 
 String _quoteShellArgument(String value) =>
     '\'${value.replaceAll('\'', '\'"\'"\'')}\'';
+
+String _quoteShellEnvironmentAssignment(String key, String value) =>
+    '$key="${_escapeForDoubleQuotedShellContent(value)}"';
 
 String _escapeForDoubleQuotedShellContent(String value) => value
     .replaceAll(RegExp(r'\\'), r'\\')

--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -8,9 +8,6 @@ enum AgentLaunchTool {
   /// GitHub Copilot CLI.
   copilotCli,
 
-  /// Aider.
-  aider,
-
   /// OpenAI Codex CLI.
   codex,
 
@@ -27,7 +24,6 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
   String get label => switch (this) {
     AgentLaunchTool.claudeCode => 'Claude Code',
     AgentLaunchTool.copilotCli => 'Copilot CLI',
-    AgentLaunchTool.aider => 'Aider',
     AgentLaunchTool.codex => 'Codex',
     AgentLaunchTool.openCode => 'OpenCode',
     AgentLaunchTool.geminiCli => 'Gemini CLI',
@@ -37,7 +33,6 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
   String get commandName => switch (this) {
     AgentLaunchTool.claudeCode => 'claude',
     AgentLaunchTool.copilotCli => 'copilot',
-    AgentLaunchTool.aider => 'aider',
     AgentLaunchTool.codex => 'codex',
     AgentLaunchTool.openCode => 'opencode',
     AgentLaunchTool.geminiCli => 'gemini',
@@ -47,7 +42,6 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
   bool get supportsResume => switch (this) {
     AgentLaunchTool.claudeCode => true,
     AgentLaunchTool.copilotCli => true,
-    AgentLaunchTool.aider => true,
     AgentLaunchTool.codex => true,
     AgentLaunchTool.openCode => true,
     AgentLaunchTool.geminiCli => true,
@@ -58,7 +52,6 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
   String? get discoveredSessionToolName => switch (this) {
     AgentLaunchTool.claudeCode => 'Claude Code',
     AgentLaunchTool.copilotCli => 'Copilot CLI',
-    AgentLaunchTool.aider => null,
     AgentLaunchTool.codex => 'Codex',
     AgentLaunchTool.openCode => 'OpenCode',
     AgentLaunchTool.geminiCli => 'Gemini CLI',
@@ -72,7 +65,6 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
   List<String> get yoloArguments => switch (this) {
     AgentLaunchTool.claudeCode => const ['--dangerously-skip-permissions'],
     AgentLaunchTool.copilotCli => const ['--yolo'],
-    AgentLaunchTool.aider => const ['--yes'],
     AgentLaunchTool.codex => const ['--yolo'],
     AgentLaunchTool.openCode => const [],
     AgentLaunchTool.geminiCli => const ['--yolo'],
@@ -102,10 +94,7 @@ class AgentLaunchPreset {
     final rawTool = _readTrimmedString(json['tool']);
     final tool = AgentLaunchTool.values.firstWhere(
       (value) => value.name == rawTool,
-      orElse: () => switch (rawTool) {
-        'aider' => AgentLaunchTool.aider,
-        _ => AgentLaunchTool.claudeCode,
-      },
+      orElse: () => AgentLaunchTool.claudeCode,
     );
     return AgentLaunchPreset(
       tool: tool,
@@ -227,8 +216,6 @@ final _copilotAllowAllPathsPattern = RegExp(
   r'(?<!\S)--allow-all-paths(?=\s|$)',
 );
 final _copilotAllowAllUrlsPattern = RegExp(r'(?<!\S)--allow-all-urls(?=\s|$)');
-final _aiderYesPattern = RegExp(r'(?<!\S)--yes(?=\s|$)');
-final _aiderYesAlwaysPattern = RegExp(r'(?<!\S)--yes-always(?=\s|$)');
 final _geminiYoloPattern = RegExp(r'(?<!\S)(?:--yolo|-y)(?=\s|$)');
 final _openCodeDangerouslySkipPermissionsPattern = RegExp(
   r'(?<!\S)--dangerously-skip-permissions(?=\s|$)',
@@ -316,10 +303,6 @@ String? _normalizeAgentToolArguments({
         _copilotAllowAllPathsPattern,
         _copilotAllowAllUrlsPattern,
       ]),
-    AgentLaunchTool.aider => _stripArgumentPatterns(
-      trimmedAdditionalArguments,
-      [_aiderYesPattern, _aiderYesAlwaysPattern],
-    ),
     AgentLaunchTool.codex => _stripCodexYoloConflicts(
       trimmedAdditionalArguments,
     ),

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -813,7 +813,6 @@ final tmuxServiceProvider = Provider<TmuxService>((ref) => const TmuxService());
 /// or `null` if it does not correspond to a supported CLI.
 AgentLaunchTool? agentToolForBinaryName(String binaryName) =>
     switch (binaryName) {
-      'aider' => AgentLaunchTool.aider,
       'claude' => AgentLaunchTool.claudeCode,
       'copilot' => AgentLaunchTool.copilotCli,
       'codex' => AgentLaunchTool.codex,

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -668,7 +668,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
           title: const Text('Start supported coding CLIs in YOLO mode'),
           subtitle: Text(
             hasAgentPresetAccess
-                ? 'Applies to coding CLI launches on this host. Claude Code, Codex, Gemini CLI, and Aider support startup YOLO mode.'
+                ? 'Applies to coding CLI launches on this host. Claude Code, Copilot CLI, Aider, Codex, OpenCode, and Gemini CLI support startup YOLO mode.'
                 : 'MonkeySSH Pro unlocks host-specific coding CLI defaults like YOLO mode.',
           ),
           onChanged: hasAgentPresetAccess

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -668,7 +668,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
           title: const Text('Start supported coding CLIs in YOLO mode'),
           subtitle: Text(
             hasAgentPresetAccess
-                ? 'Applies to coding CLI launches on this host. Claude Code, Copilot CLI, Aider, Codex, OpenCode, and Gemini CLI support startup YOLO mode.'
+                ? 'Applies to coding CLI launches on this host. Claude Code, Copilot CLI, Codex, OpenCode, and Gemini CLI support startup YOLO mode.'
                 : 'MonkeySSH Pro unlocks host-specific coding CLI defaults like YOLO mode.',
           ),
           onChanged: hasAgentPresetAccess

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2438,6 +2438,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   // Theme state
   Host? _host;
+  AgentLaunchPreset? _autoConnectAgentPreset;
   bool _startClisInYoloMode = false;
   TerminalThemeData? _currentTheme;
   TerminalThemeData? _sessionThemeOverride;
@@ -3021,6 +3022,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     // Load host data first for theme
     final hostRepo = ref.read(hostRepositoryProvider);
     _host = await hostRepo.getById(widget.hostId);
+    _autoConnectAgentPreset = await ref
+        .read(agentLaunchPresetServiceProvider)
+        .getPresetForHost(widget.hostId);
     final cliLaunchPreferences = await ref
         .read(hostCliLaunchPreferencesServiceProvider)
         .getPreferencesForHost(widget.hostId);
@@ -3468,8 +3472,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
+    final resolvedStoredCommand = _resolveStoredAutoConnectCommand(host);
     final mode = resolveAutoConnectCommandMode(
-      command: host.autoConnectCommand,
+      command: resolvedStoredCommand,
       snippetId: host.autoConnectSnippetId,
     );
     if (mode == AutoConnectCommandMode.none) {
@@ -3494,7 +3499,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     final command = resolveAutoConnectCommandText(
       mode: mode,
-      storedCommand: host.autoConnectCommand,
+      storedCommand: resolvedStoredCommand,
       snippetCommand: snippetCommand,
     );
     if (command == null) {
@@ -3531,7 +3536,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final host = _host;
     final preferredSessionName = resolvePreferredTmuxSessionName(
       structuredSessionName: host?.tmuxSessionName,
-      autoConnectCommand: host?.autoConnectCommand,
+      autoConnectCommand: _resolveStoredAutoConnectCommand(host),
     );
     if (!mounted || preferredSessionName == null) {
       return;
@@ -3558,7 +3563,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final host = _host;
     final preferredSessionName = resolvePreferredTmuxSessionName(
       structuredSessionName: host?.tmuxSessionName,
-      autoConnectCommand: host?.autoConnectCommand,
+      autoConnectCommand: _resolveStoredAutoConnectCommand(host),
     );
     final preferredWorkingDirectory = host?.tmuxWorkingDirectory;
 
@@ -3651,6 +3656,27 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       });
     } on Object {
       // Silently ignore — tmux detection is best-effort.
+    }
+  }
+
+  String? _resolveStoredAutoConnectCommand(Host? host) {
+    if (host == null) {
+      return null;
+    }
+    if (host.autoConnectSnippetId != null) {
+      return host.autoConnectCommand;
+    }
+    final preset = _autoConnectAgentPreset;
+    if (preset == null) {
+      return host.autoConnectCommand;
+    }
+    try {
+      return buildAgentLaunchCommand(
+        preset,
+        startInYoloMode: _startClisInYoloMode,
+      );
+    } on FormatException {
+      return host.autoConnectCommand;
     }
   }
 

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -655,7 +655,6 @@ class TmuxToolPickerSheet extends StatelessWidget {
 
   /// All tools that can be shown in the picker, in display order.
   static const _allTools = [
-    AgentLaunchTool.aider,
     AgentLaunchTool.claudeCode,
     AgentLaunchTool.copilotCli,
     AgentLaunchTool.codex,
@@ -779,7 +778,6 @@ class TmuxToolPickerSheet extends StatelessWidget {
 
   static Widget _iconForTool(AgentLaunchTool tool, ThemeData theme) {
     final iconData = switch (tool) {
-      AgentLaunchTool.aider => Icons.chat_bubble_outline,
       AgentLaunchTool.claudeCode => Icons.auto_awesome,
       AgentLaunchTool.copilotCli => Icons.flight,
       AgentLaunchTool.codex => Icons.code,

--- a/test/domain/models/agent_launch_preset_test.dart
+++ b/test/domain/models/agent_launch_preset_test.dart
@@ -32,10 +32,6 @@ void main() {
         buildAgentToolCommand(AgentLaunchTool.geminiCli, startInYoloMode: true),
         'gemini --yolo',
       );
-      expect(
-        buildAgentToolCommand(AgentLaunchTool.aider, startInYoloMode: true),
-        'aider --yes',
-      );
     });
   });
 
@@ -224,18 +220,6 @@ void main() {
         );
       },
     );
-
-    test('normalizes legacy aider yolo flags', () {
-      const preset = AgentLaunchPreset(
-        tool: AgentLaunchTool.aider,
-        additionalArguments: '--yes-always --model sonnet',
-      );
-
-      expect(
-        buildAgentLaunchCommand(preset, startInYoloMode: true),
-        'aider --yes --model sonnet',
-      );
-    });
   });
 
   test('round-trips preset json', () {

--- a/test/domain/models/agent_launch_preset_test.dart
+++ b/test/domain/models/agent_launch_preset_test.dart
@@ -14,8 +14,19 @@ void main() {
         'claude --dangerously-skip-permissions',
       );
       expect(
+        buildAgentToolCommand(
+          AgentLaunchTool.copilotCli,
+          startInYoloMode: true,
+        ),
+        'copilot --yolo',
+      );
+      expect(
         buildAgentToolCommand(AgentLaunchTool.codex, startInYoloMode: true),
-        'codex --approval-mode never',
+        'codex --yolo',
+      );
+      expect(
+        buildAgentToolCommand(AgentLaunchTool.openCode, startInYoloMode: true),
+        r'OPENCODE_PERMISSION="{\"*\":\"allow\"}" opencode',
       );
       expect(
         buildAgentToolCommand(AgentLaunchTool.geminiCli, startInYoloMode: true),
@@ -23,21 +34,7 @@ void main() {
       );
       expect(
         buildAgentToolCommand(AgentLaunchTool.aider, startInYoloMode: true),
-        'aider --yes-always',
-      );
-    });
-
-    test('leaves unsupported tools unchanged in yolo mode', () {
-      expect(
-        buildAgentToolCommand(
-          AgentLaunchTool.copilotCli,
-          startInYoloMode: true,
-        ),
-        'copilot',
-      );
-      expect(
-        buildAgentToolCommand(AgentLaunchTool.openCode, startInYoloMode: true),
-        'opencode',
+        'aider --yes',
       );
     });
   });
@@ -62,13 +59,13 @@ void main() {
         workingDirectory: '~/src/app',
         tmuxSessionName: 'nightly review',
         tmuxExtraFlags: '-x 160 -y 48',
-        additionalArguments: '--yes-always',
+        additionalArguments: '--message "hello"',
       );
 
       expect(
         buildAgentLaunchCommand(preset),
         'tmux new-session -A -s \'nightly review\' -c '
-        '"\$HOME/src/app" -x 160 -y 48 \'codex --yes-always\'',
+        '"\$HOME/src/app" -x 160 -y 48 \'codex --message "hello"\'',
       );
     });
 
@@ -76,10 +73,10 @@ void main() {
       const preset = AgentLaunchPreset(
         tool: AgentLaunchTool.codex,
         tmuxExtraFlags: '-x 160 -y 48',
-        additionalArguments: '--yes-always',
+        additionalArguments: '--message "hello"',
       );
 
-      expect(buildAgentLaunchCommand(preset), 'codex --yes-always');
+      expect(buildAgentLaunchCommand(preset), 'codex --message "hello"');
     });
 
     test(
@@ -181,31 +178,62 @@ void main() {
 
       expect(
         buildAgentLaunchCommand(preset, startInYoloMode: true),
-        r'cd "$HOME/project" && codex --approval-mode never',
+        r'cd "$HOME/project" && codex --yolo',
       );
     });
 
-    test('does not duplicate a yolo flag already in extra arguments', () {
+    test('normalizes existing codex yolo aliases', () {
       const preset = AgentLaunchPreset(
         tool: AgentLaunchTool.codex,
-        additionalArguments: '--approval-mode never --model gpt-5.4',
+        additionalArguments: '--ask-for-approval never --model gpt-5.4',
       );
 
       expect(
         buildAgentLaunchCommand(preset, startInYoloMode: true),
-        'codex --approval-mode never --model gpt-5.4',
+        'codex --yolo --model gpt-5.4',
       );
     });
 
-    test('replaces conflicting codex approval-mode arguments in yolo mode', () {
+    test(
+      'replaces conflicting codex approval and sandbox arguments in yolo mode',
+      () {
+        const preset = AgentLaunchPreset(
+          tool: AgentLaunchTool.codex,
+          additionalArguments:
+              '--ask-for-approval on-request --sandbox workspace-write --model gpt-5.4',
+        );
+
+        expect(
+          buildAgentLaunchCommand(preset, startInYoloMode: true),
+          'codex --yolo --model gpt-5.4',
+        );
+      },
+    );
+
+    test(
+      'rebuilds opencode in yolo mode with an allow-all permission override',
+      () {
+        const preset = AgentLaunchPreset(
+          tool: AgentLaunchTool.openCode,
+          workingDirectory: '~/project',
+        );
+
+        expect(
+          buildAgentLaunchCommand(preset, startInYoloMode: true),
+          r'cd "$HOME/project" && OPENCODE_PERMISSION="{\"*\":\"allow\"}" opencode',
+        );
+      },
+    );
+
+    test('normalizes legacy aider yolo flags', () {
       const preset = AgentLaunchPreset(
-        tool: AgentLaunchTool.codex,
-        additionalArguments: '--approval-mode auto --model gpt-5.4',
+        tool: AgentLaunchTool.aider,
+        additionalArguments: '--yes-always --model sonnet',
       );
 
       expect(
         buildAgentLaunchCommand(preset, startInYoloMode: true),
-        'codex --approval-mode never --model gpt-5.4',
+        'aider --yes --model sonnet',
       );
     });
   });
@@ -282,12 +310,13 @@ void main() {
     });
 
     test('supportsYoloMode is only true for supported tools', () {
-      expect(AgentLaunchTool.claudeCode.supportsYoloMode, isTrue);
-      expect(AgentLaunchTool.aider.supportsYoloMode, isTrue);
-      expect(AgentLaunchTool.codex.supportsYoloMode, isTrue);
-      expect(AgentLaunchTool.geminiCli.supportsYoloMode, isTrue);
-      expect(AgentLaunchTool.copilotCli.supportsYoloMode, isFalse);
-      expect(AgentLaunchTool.openCode.supportsYoloMode, isFalse);
+      for (final tool in AgentLaunchTool.values) {
+        expect(
+          tool.supportsYoloMode,
+          isTrue,
+          reason: '${tool.name} should support yolo mode',
+        );
+      }
     });
   });
 

--- a/test/domain/services/tmux_service_agent_detection_test.dart
+++ b/test/domain/services/tmux_service_agent_detection_test.dart
@@ -53,12 +53,10 @@ void main() {
     test('parses absolute paths to known CLI binaries', () {
       const output =
           '/opt/homebrew/bin/claude\n'
-          '/usr/local/bin/codex\n'
-          '/Users/me/.local/bin/aider\n';
+          '/usr/local/bin/codex\n';
       expect(parseInstalledAgentTools(output), {
         AgentLaunchTool.claudeCode,
         AgentLaunchTool.codex,
-        AgentLaunchTool.aider,
       });
     });
 
@@ -77,7 +75,7 @@ void main() {
       const output =
           'claude\n'
           '/usr/local/bin/copilot\n'
-          'aider: not found\n';
+          'codex: not found\n';
       expect(parseInstalledAgentTools(output), {AgentLaunchTool.copilotCli});
     });
 
@@ -88,7 +86,6 @@ void main() {
 
     test('handles all supported CLIs', () {
       const output =
-          '/b/aider\n'
           '/b/claude\n'
           '/b/copilot\n'
           '/b/codex\n'

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -34,7 +34,6 @@ class _MockSshClient extends Mock implements SSHClient {}
 
 class _MockShellChannel extends Mock implements SSHSession {}
 
-<<<<<<< HEAD
 class _MockMonetizationService extends Mock implements MonetizationService {}
 
 class _MockSftpClient extends Mock implements SftpClient {}

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -13,6 +13,12 @@ import 'package:mocktail/mocktail.dart';
 
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
+import 'package:monkeyssh/domain/models/host_cli_launch_preferences.dart';
+import 'package:monkeyssh/domain/models/monetization.dart';
+import 'package:monkeyssh/domain/services/agent_launch_preset_service.dart';
+import 'package:monkeyssh/domain/services/host_cli_launch_preferences_service.dart';
+import 'package:monkeyssh/domain/services/monetization_service.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
@@ -27,6 +33,9 @@ class _MockHostRepository extends Mock implements HostRepository {}
 class _MockSshClient extends Mock implements SSHClient {}
 
 class _MockShellChannel extends Mock implements SSHSession {}
+
+<<<<<<< HEAD
+class _MockMonetizationService extends Mock implements MonetizationService {}
 
 class _MockSftpClient extends Mock implements SftpClient {}
 
@@ -58,17 +67,26 @@ class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
   Future<void> syncBackgroundStatus() async {}
 }
 
-Host _buildHost({required int id}) => Host(
+Host _buildHost({required int id, String? autoConnectCommand}) => Host(
   id: id,
   label: 'Terminal test host',
   hostname: 'terminal.example.com',
   port: 22,
   username: 'root',
+  autoConnectCommand: autoConnectCommand,
   isFavorite: false,
   createdAt: DateTime(2026),
   updatedAt: DateTime(2026),
   autoConnectRequiresConfirmation: false,
   sortOrder: 0,
+);
+
+const _proMonetizationState = MonetizationState(
+  billingAvailability: MonetizationBillingAvailability.available,
+  entitlements: MonetizationEntitlements.pro(),
+  offers: [],
+  debugUnlockAvailable: false,
+  debugUnlocked: false,
 );
 
 TextEditingValue _editingValue(String text, {required int selectionOffset}) =>
@@ -84,6 +102,7 @@ void main() {
     registerFallbackValue(const SSHPtyConfig());
     registerFallbackValue(<int>[]);
     registerFallbackValue(Uint8List(0));
+    registerFallbackValue(MonetizationFeature.autoConnectAutomation);
   });
 
   group('TerminalScreen mobile IME wiring', () {
@@ -91,6 +110,7 @@ void main() {
     late _MockHostRepository hostRepository;
     late _MockSshClient sshClient;
     late _MockShellChannel shellChannel;
+    late _MockMonetizationService monetizationService;
     late SshSession session;
     late Host host;
     late Completer<void> shellDoneCompleter;
@@ -102,10 +122,22 @@ void main() {
       hostRepository = _MockHostRepository();
       sshClient = _MockSshClient();
       shellChannel = _MockShellChannel();
+      monetizationService = _MockMonetizationService();
       host = _buildHost(id: 1);
       shellDoneCompleter = Completer<void>();
       shellStdoutController = StreamController<Uint8List>.broadcast();
       shellWrites = <List<int>>[];
+
+      when(
+        () => monetizationService.currentState,
+      ).thenReturn(_proMonetizationState);
+      when(
+        () => monetizationService.states,
+      ).thenAnswer((_) => Stream.value(_proMonetizationState));
+      when(() => monetizationService.initialize()).thenAnswer((_) async {});
+      when(
+        () => monetizationService.canUseFeature(any()),
+      ).thenAnswer((_) async => true);
 
       when(() => hostRepository.getById(host.id)).thenAnswer((_) async => host);
       when(
@@ -150,6 +182,10 @@ void main() {
           overrides: [
             databaseProvider.overrideWithValue(db),
             hostRepositoryProvider.overrideWithValue(hostRepository),
+            monetizationServiceProvider.overrideWithValue(monetizationService),
+            monetizationStateProvider.overrideWith(
+              (ref) => Stream.value(_proMonetizationState),
+            ),
             sharedClipboardProvider.overrideWith((ref) async => false),
             activeSessionsProvider.overrideWith(
               () => _TestActiveSessionsNotifier(session),
@@ -167,6 +203,76 @@ void main() {
       await tester.pump();
       await tester.pump();
     }
+
+    testWidgets(
+      'auto-connect rebuilds agent launch commands from the saved preset and host yolo preference',
+      (tester) async {
+        final settingsService = SettingsService(db);
+        final presetService = AgentLaunchPresetService(settingsService);
+        final cliLaunchPreferencesService = HostCliLaunchPreferencesService(
+          settingsService,
+        );
+        session = SshSession(
+          connectionId: 7,
+          hostId: host.id,
+          client: sshClient,
+          config: const SshConnectionConfig(
+            hostname: 'terminal.example.com',
+            port: 22,
+            username: 'root',
+          ),
+        );
+        host = _buildHost(
+          id: host.id,
+          autoConnectCommand: 'codex --approval-mode never',
+        );
+        await presetService.setPresetForHost(
+          host.id,
+          const AgentLaunchPreset(tool: AgentLaunchTool.codex),
+        );
+        await cliLaunchPreferencesService.setPreferencesForHost(
+          host.id,
+          const HostCliLaunchPreferences(startInYoloMode: true),
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              settingsServiceProvider.overrideWithValue(settingsService),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+            ],
+            child: MaterialApp(
+              home: TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        final writtenShellText = utf8.decode(
+          shellWrites.expand((chunk) => chunk).toList(growable: false),
+        );
+        expect(writtenShellText, contains('codex --yolo'));
+        expect(writtenShellText, isNot(contains('--approval-mode never')));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
 
     testWidgets(
       'toolbar navigation keys clear the screen IME buffer',

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -250,7 +250,7 @@ void main() {
           skipOffstage: false,
         );
         await tester.ensureVisible(saveButton);
-        await tester.tap(saveButton, warnIfMissed: false);
+        tester.widget<FilledButton>(saveButton).onPressed!();
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 
@@ -780,10 +780,7 @@ void main() {
         await tester.pump();
 
         expect(
-          find.textContaining(
-            'codex --approval-mode never',
-            findRichText: true,
-          ),
+          find.textContaining('codex --yolo', findRichText: true),
           findsOneWidget,
         );
 
@@ -804,7 +801,7 @@ void main() {
         expect(hostRepository.updatedHost, isNotNull);
         expect(
           hostRepository.updatedHost!.autoConnectCommand,
-          contains('--approval-mode never'),
+          contains('--yolo'),
         );
       },
     );

--- a/test/widget/tmux_tool_picker_sheet_test.dart
+++ b/test/widget/tmux_tool_picker_sheet_test.dart
@@ -55,7 +55,6 @@ void main() {
       expect(find.text('Claude Code'), findsOneWidget);
       expect(find.text('Codex'), findsOneWidget);
       // Tools that aren't installed must not appear.
-      expect(find.text('Aider'), findsNothing);
       expect(find.text('Copilot CLI'), findsNothing);
       expect(find.text('Gemini CLI'), findsNothing);
       expect(find.text('OpenCode'), findsNothing);


### PR DESCRIPTION
## Summary

- audit and update YOLO startup handling for all supported agent CLIs, including Codex, Copilot CLI, OpenCode, Aider, Claude Code, and Gemini
- rebuild saved auto-connect agent commands from the host preset and host YOLO preference at connect time so existing hosts stop using stale legacy flags
- add regression coverage for the updated launch matrix, stale-command rebuild behavior, and host editor save flows

## Validation

- flutter analyze
- flutter test
