### PR TITLE
fix: keep tmux window state in sync

### DIFF
--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -210,12 +210,29 @@ class TmuxWindow {
   /// tmux updates `window_name` as part of the window-switch snapshot, while
   /// `pane_title` can lag slightly behind focus changes on some hosts. Prefer
   /// the normalized window name here so collapsed labels stay in sync with the
-  /// active window selection.
+  /// active window selection. If the window name is just echoing the current
+  /// command (for example `copilot` or `claude`), prefer the richer pane title
+  /// instead so the collapsed handle still distinguishes agent sessions.
   String get handleTitle {
+    final normalizedPaneTitle = _normalizedTmuxTitle(
+      paneTitle,
+      stripPlaceholderPrefix: true,
+    );
     final normalizedName = _normalizedTmuxTitle(
       name,
       stripPlaceholderPrefix: true,
     );
+    final normalizedCommand = _normalizedTmuxTitle(
+      currentCommand,
+      stripPlaceholderPrefix: true,
+    );
+    if (normalizedPaneTitle != null &&
+        normalizedName != null &&
+        normalizedCommand != null &&
+        normalizedName.toLowerCase() == normalizedCommand.toLowerCase() &&
+        normalizedPaneTitle != normalizedName) {
+      return normalizedPaneTitle;
+    }
     return normalizedName ?? displayTitle;
   }
 

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -163,6 +163,28 @@ class TmuxWindow {
   bool get needsLocalIdleRefresh =>
       !hasAlert && idleSeconds != null && idleSeconds! <= _idleThreshold;
 
+  /// Returns a copy of this window with selectively overridden fields.
+  TmuxWindow copyWith({
+    bool? isActive,
+    String? name,
+    String? currentCommand,
+    String? currentPath,
+    String? flags,
+    String? paneTitle,
+    int? lastActivityEpochSeconds,
+  }) => TmuxWindow(
+    index: index,
+    name: name ?? this.name,
+    isActive: isActive ?? this.isActive,
+    currentCommand: currentCommand ?? this.currentCommand,
+    currentPath: currentPath ?? this.currentPath,
+    flags: flags ?? this.flags,
+    paneTitle: paneTitle ?? this.paneTitle,
+    idleSeconds: _snapshotIdleSeconds,
+    lastActivityEpochSeconds:
+        lastActivityEpochSeconds ?? this.lastActivityEpochSeconds,
+  );
+
   /// A short display title — prefers the richest usable tmux title.
   String get displayTitle {
     final normalizedPaneTitle = _normalizedTmuxTitle(
@@ -243,6 +265,56 @@ class TmuxWindow {
     lastActivityEpochSeconds,
     _snapshotIdleSeconds,
   );
+}
+
+/// Live update emitted while watching a tmux session in control mode.
+sealed class TmuxWindowChangeEvent {
+  /// Creates a new [TmuxWindowChangeEvent].
+  const TmuxWindowChangeEvent();
+}
+
+/// A direct per-window snapshot from tmux's `%subscription-changed` output.
+class TmuxWindowSnapshotEvent extends TmuxWindowChangeEvent {
+  /// Creates a new [TmuxWindowSnapshotEvent].
+  const TmuxWindowSnapshotEvent(this.window);
+
+  /// The latest window snapshot from tmux.
+  final TmuxWindow window;
+}
+
+/// A signal that callers should refetch the full window list.
+class TmuxWindowReloadEvent extends TmuxWindowChangeEvent {
+  /// Creates a new [TmuxWindowReloadEvent].
+  const TmuxWindowReloadEvent();
+}
+
+/// Applies a live tmux window update to an existing window list.
+List<TmuxWindow> applyTmuxWindowChangeEvent(
+  List<TmuxWindow> windows,
+  TmuxWindowChangeEvent event,
+) {
+  switch (event) {
+    case TmuxWindowReloadEvent():
+      return windows;
+    case TmuxWindowSnapshotEvent(window: final window):
+      final updated = windows
+          .map(
+            (existing) => window.isActive && existing.index != window.index
+                ? existing.copyWith(isActive: false)
+                : existing,
+          )
+          .toList(growable: true);
+      final existingIndex = updated.indexWhere(
+        (existing) => existing.index == window.index,
+      );
+      if (existingIndex == -1) {
+        updated.add(window);
+      } else {
+        updated[existingIndex] = window;
+      }
+      updated.sort((a, b) => a.index.compareTo(b.index));
+      return updated;
+  }
 }
 
 /// Metadata for a recent AI coding tool session found on a remote host.

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -74,8 +74,9 @@ class TmuxWindow {
     this.currentPath,
     this.flags,
     this.paneTitle,
-    this.idleSeconds,
-  });
+    int? idleSeconds,
+    this.lastActivityEpochSeconds,
+  }) : _snapshotIdleSeconds = idleSeconds;
 
   /// Parses a [TmuxWindow] from a pipe-delimited tmux format string.
   ///
@@ -87,16 +88,7 @@ class TmuxWindow {
       throw FormatException('Invalid tmux window format: $line');
     }
 
-    // Compute idle seconds from window_activity epoch if available.
-    int? idleSeconds;
-    if (fields.length > 7) {
-      final activityEpoch = int.tryParse(fields[7]);
-      if (activityEpoch != null && activityEpoch > 0) {
-        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-        idleSeconds = now - activityEpoch;
-        if (idleSeconds < 0) idleSeconds = 0;
-      }
-    }
+    final activityEpoch = fields.length > 7 ? int.tryParse(fields[7]) : null;
 
     return TmuxWindow(
       index: int.tryParse(fields[0]) ?? 0,
@@ -106,7 +98,9 @@ class TmuxWindow {
       currentPath: fields.length > 4 ? _nonEmpty(fields[4]) : null,
       flags: fields.length > 5 ? _nonEmpty(fields[5]) : null,
       paneTitle: fields.length > 6 ? _nonEmpty(fields[6]) : null,
-      idleSeconds: idleSeconds,
+      lastActivityEpochSeconds: activityEpoch != null && activityEpoch > 0
+          ? activityEpoch
+          : null,
     );
   }
 
@@ -131,8 +125,21 @@ class TmuxWindow {
   /// The pane title set by the running application, if available.
   final String? paneTitle;
 
+  /// tmux's `window_activity` epoch seconds, if available.
+  final int? lastActivityEpochSeconds;
+
+  final int? _snapshotIdleSeconds;
+
   /// Seconds since last output activity in this window, if available.
-  final int? idleSeconds;
+  int? get idleSeconds {
+    final activityEpoch = lastActivityEpochSeconds;
+    if (activityEpoch == null) {
+      return _snapshotIdleSeconds;
+    }
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final idleSeconds = now - activityEpoch;
+    return idleSeconds < 0 ? 0 : idleSeconds;
+  }
 
   /// Idle threshold (seconds) above which a window is considered "waiting".
   static const _idleThreshold = 15;
@@ -150,6 +157,11 @@ class TmuxWindow {
 
   /// Whether the window appears to be actively running work.
   bool get isRunning => !hasAlert && !isIdle;
+
+  /// Whether the window's status can still change from running to waiting
+  /// without tmux emitting a new control-mode notification.
+  bool get needsLocalIdleRefresh =>
+      !hasAlert && idleSeconds != null && idleSeconds! <= _idleThreshold;
 
   /// A short display title — prefers the richest usable tmux title.
   String get displayTitle {
@@ -216,7 +228,8 @@ class TmuxWindow {
           currentPath == other.currentPath &&
           flags == other.flags &&
           paneTitle == other.paneTitle &&
-          idleSeconds == other.idleSeconds;
+          lastActivityEpochSeconds == other.lastActivityEpochSeconds &&
+          _snapshotIdleSeconds == other._snapshotIdleSeconds;
 
   @override
   int get hashCode => Object.hash(
@@ -227,7 +240,8 @@ class TmuxWindow {
     currentPath,
     flags,
     paneTitle,
-    idleSeconds,
+    lastActivityEpochSeconds,
+    _snapshotIdleSeconds,
   );
 }
 

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -204,6 +204,21 @@ class TmuxWindow {
     return normalizedPaneTitle;
   }
 
+  /// A compact window label for surfaces that should track tmux window
+  /// switches immediately.
+  ///
+  /// tmux updates `window_name` as part of the window-switch snapshot, while
+  /// `pane_title` can lag slightly behind focus changes on some hosts. Prefer
+  /// the normalized window name here so collapsed labels stay in sync with the
+  /// active window selection.
+  String get handleTitle {
+    final normalizedName = _normalizedTmuxTitle(
+      name,
+      stripPlaceholderPrefix: true,
+    );
+    return normalizedName ?? displayTitle;
+  }
+
   /// Secondary context for the window title when both pane and window names
   /// are useful and distinct.
   String? get secondaryTitle {

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -1463,7 +1463,8 @@ class SshSession {
   }
 
   /// Execute a command.
-  Future<SSHSession> execute(String command) => client.execute(command);
+  Future<SSHSession> execute(String command, {SSHPtyConfig? pty}) =>
+      client.execute(command, pty: pty);
 
   /// Start an SFTP session.
   Future<SftpClient> sftp() => client.sftp();

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -511,6 +511,37 @@ String _normalizeTmuxControlLine(String line) {
   return normalized.trim();
 }
 
+/// Returns whether [line] should trigger a debounced reload fallback when a
+/// direct snapshot either does not arrive or cannot be parsed.
+///
+/// tmux normally follows window-change notifications like
+/// `%session-window-changed` with `%subscription-changed` snapshots, but some
+/// hosts intermittently stop delivering the snapshot while still emitting the
+/// lifecycle notification. Treat those lines as a fallback reload trigger so
+/// the UI does not get stuck on stale window metadata.
+@visibleForTesting
+bool shouldScheduleTmuxWindowReloadFallback(
+  String line, {
+  required String subscriptionName,
+}) {
+  final trimmed = _normalizeTmuxControlLine(line);
+  if (trimmed.isEmpty) return false;
+  if (trimmed.startsWith('%subscription-changed $subscriptionName ')) {
+    return true;
+  }
+
+  const notificationPrefixes = <String>[
+    '%pane-mode-changed ',
+    '%session-window-changed ',
+    '%sessions-changed',
+    '%unlinked-window-close ',
+    '%unlinked-window-renamed ',
+    '%window-close ',
+    '%window-renamed ',
+  ];
+  return notificationPrefixes.any(trimmed.startsWith);
+}
+
 /// Parses a control-mode output [line] into a tmux window change event for
 /// the observer using [subscriptionName].
 @visibleForTesting
@@ -719,9 +750,16 @@ class _TmuxWindowChangeObserver {
       subscriptionName: _subscriptionName,
     );
     if (event == null) {
+      if (shouldScheduleTmuxWindowReloadFallback(
+        trimmed,
+        subscriptionName: _subscriptionName,
+      )) {
+        _scheduleReloadEvent();
+      }
       return;
     }
     if (event is TmuxWindowSnapshotEvent) {
+      _cancelScheduledReload();
       _emitEvent(event);
       return;
     }
@@ -739,9 +777,14 @@ class _TmuxWindowChangeObserver {
     _controller.add(event);
   }
 
+  void _cancelScheduledReload() {
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+  }
+
   void _scheduleReloadEvent() {
     if (_disposed) return;
-    _debounceTimer?.cancel();
+    _cancelScheduledReload();
     _debounceTimer = Timer(_eventDebounce, () {
       if (!_disposed && !_controller.isClosed) {
         _controller.add(const TmuxWindowReloadEvent());
@@ -811,8 +854,7 @@ class _TmuxWindowChangeObserver {
 
   void _cleanupControlSession() {
     _stopHeartbeat();
-    _debounceTimer?.cancel();
-    _debounceTimer = null;
+    _cancelScheduledReload();
     unawaited(_stdoutSubscription?.cancel());
     unawaited(_stderrSubscription?.cancel());
     unawaited(_doneSubscription?.cancel());

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -662,6 +662,10 @@ class _TmuxWindowChangeObserver {
           session,
           buildTmuxControlModeAttachCommand(sessionName),
         ),
+        // tmux control mode stays silent over a plain exec channel on some SSH
+        // servers. Request a dedicated PTY so `%subscription-changed` events
+        // stream in real time instead of only catching up on fallback reloads.
+        pty: const SSHPtyConfig(),
       );
       if (_disposed) {
         execSession.close();

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -239,7 +239,10 @@ class TmuxService {
 
   /// Watches tmux control-mode notifications that indicate window state
   /// has changed for [sessionName].
-  Stream<void> watchWindowChanges(SshSession session, String sessionName) {
+  Stream<TmuxWindowChangeEvent> watchWindowChanges(
+    SshSession session,
+    String sessionName,
+  ) {
     final key = _TmuxWindowWatchKey(
       connectionId: session.connectionId,
       sessionName: sessionName,
@@ -501,37 +504,46 @@ String buildTmuxControlModeAttachCommand(String sessionName) =>
 String buildTmuxWindowSubscriptionCommand(String subscriptionName) =>
     "refresh-client -B '$subscriptionName:@*:$_tmuxWindowSubscriptionFormat'";
 
-/// Returns whether a control-mode output [line] should trigger a window
-/// snapshot refresh for the observer using [subscriptionName].
+String _normalizeTmuxControlLine(String line) {
+  var normalized = line.trim();
+  normalized = normalized.replaceFirst(RegExp(r'^\u001bP\d+p'), '');
+  normalized = normalized.replaceFirst(RegExp(r'\u001b\\$'), '');
+  return normalized.trim();
+}
+
+/// Parses a control-mode output [line] into a tmux window change event for
+/// the observer using [subscriptionName].
 @visibleForTesting
-bool shouldReloadTmuxWindowsFromControlLine(
+TmuxWindowChangeEvent? parseTmuxWindowChangeEventFromControlLine(
   String line, {
   required String subscriptionName,
 }) {
-  final trimmed = line.trim();
-  if (trimmed.isEmpty) return false;
+  final trimmed = _normalizeTmuxControlLine(line);
+  if (trimmed.isEmpty) return null;
   if (trimmed.startsWith('%subscription-changed $subscriptionName ')) {
-    return true;
+    final valueSeparator = trimmed.indexOf(' : ');
+    if (valueSeparator == -1 || valueSeparator + 3 >= trimmed.length) {
+      return const TmuxWindowReloadEvent();
+    }
+    final value = trimmed.substring(valueSeparator + 3);
+    try {
+      return TmuxWindowSnapshotEvent(TmuxWindow.fromTmuxFormat(value));
+    } on FormatException {
+      return const TmuxWindowReloadEvent();
+    }
   }
 
   const notificationPrefixes = <String>[
-    '%client-detached ',
-    '%client-session-changed ',
-    '%layout-change ',
     '%pane-mode-changed ',
-    '%session-changed ',
-    '%session-renamed ',
-    '%session-window-changed ',
     '%sessions-changed',
-    '%unlinked-window-add ',
     '%unlinked-window-close ',
     '%unlinked-window-renamed ',
-    '%window-add ',
     '%window-close ',
-    '%window-pane-changed ',
-    '%window-renamed ',
   ];
-  return notificationPrefixes.any(trimmed.startsWith);
+  if (notificationPrefixes.any(trimmed.startsWith)) {
+    return const TmuxWindowReloadEvent();
+  }
+  return null;
 }
 
 /// Action the tmux control-mode heartbeat decides to take based on how
@@ -597,7 +609,7 @@ class _TmuxWindowChangeObserver {
     required this.onDispose,
     DateTime Function()? now,
   }) : _now = now ?? DateTime.now,
-       _controller = StreamController<void>.broadcast() {
+       _controller = StreamController<TmuxWindowChangeEvent>.broadcast() {
     _controller
       ..onListen = _ensureStarted
       ..onCancel = () => unawaited(dispose());
@@ -621,7 +633,7 @@ class _TmuxWindowChangeObserver {
   final String sessionName;
   final VoidCallback onDispose;
   final DateTime Function() _now;
-  final StreamController<void> _controller;
+  final StreamController<TmuxWindowChangeEvent> _controller;
 
   StreamSubscription<String>? _stdoutSubscription;
   StreamSubscription<String>? _stderrSubscription;
@@ -638,7 +650,7 @@ class _TmuxWindowChangeObserver {
   String get _subscriptionName =>
       'flutty-${session.connectionId}-${sessionName.hashCode.abs()}';
 
-  Stream<void> get stream => _controller.stream;
+  Stream<TmuxWindowChangeEvent> get stream => _controller.stream;
 
   Future<void> _ensureStarted() async {
     if (_disposed || _starting || _controlSession != null) return;
@@ -693,18 +705,23 @@ class _TmuxWindowChangeObserver {
   void _handleStdoutLine(String line) {
     if (_disposed) return;
     _lastControlActivity = _now();
-    final trimmed = line.trim();
+    final trimmed = _normalizeTmuxControlLine(line);
     if (trimmed.startsWith('%exit')) {
       _handleControlClosed();
       return;
     }
-    if (!shouldReloadTmuxWindowsFromControlLine(
+    final event = parseTmuxWindowChangeEventFromControlLine(
       trimmed,
       subscriptionName: _subscriptionName,
-    )) {
+    );
+    if (event == null) {
       return;
     }
-    _scheduleEvent();
+    if (event is TmuxWindowSnapshotEvent) {
+      _emitEvent(event);
+      return;
+    }
+    _scheduleReloadEvent();
   }
 
   void _handleStderrLine(String line) {
@@ -713,12 +730,17 @@ class _TmuxWindowChangeObserver {
     _scheduleRestart();
   }
 
-  void _scheduleEvent() {
+  void _emitEvent(TmuxWindowChangeEvent event) {
+    if (_disposed || _controller.isClosed) return;
+    _controller.add(event);
+  }
+
+  void _scheduleReloadEvent() {
     if (_disposed) return;
     _debounceTimer?.cancel();
     _debounceTimer = Timer(_eventDebounce, () {
       if (!_disposed && !_controller.isClosed) {
-        _controller.add(null);
+        _controller.add(const TmuxWindowReloadEvent());
       }
     });
   }
@@ -775,9 +797,11 @@ class _TmuxWindowChangeObserver {
       case TmuxControlHeartbeatAction.noop:
         return;
       case TmuxControlHeartbeatAction.refresh:
-        _scheduleEvent();
+        _scheduleReloadEvent();
+        return;
       case TmuxControlHeartbeatAction.restart:
         _handleControlClosed();
+        return;
     }
   }
 

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -300,10 +300,15 @@ class TmuxService {
   /// clients of the change, so it works correctly regardless of which
   /// channel sends the command.
   ///
-  /// Uses fire-and-forget for instant response — the window switch is
-  /// visible immediately in the interactive terminal PTY.
-  void selectWindow(SshSession session, String sessionName, int windowIndex) {
-    _execFireAndForget(
+  /// Waits for tmux to process the selection before returning so callers can
+  /// safely perform follow-up work (like reattaching the visible PTY) without
+  /// racing the server-side window change.
+  Future<void> selectWindow(
+    SshSession session,
+    String sessionName,
+    int windowIndex,
+  ) async {
+    await _exec(
       session,
       'tmux select-window -t ${_shellQuote(sessionName)}:$windowIndex',
     );
@@ -534,10 +539,31 @@ bool shouldScheduleTmuxWindowReloadFallback(
     '%pane-mode-changed ',
     '%session-window-changed ',
     '%sessions-changed',
+    '%unlinked-window-add ',
     '%unlinked-window-close ',
     '%unlinked-window-renamed ',
+    '%window-add ',
     '%window-close ',
     '%window-renamed ',
+  ];
+  return notificationPrefixes.any(trimmed.startsWith);
+}
+
+/// Returns whether a scheduled tmux reload should be preserved even if a later
+/// snapshot arrives before the debounce fires.
+///
+/// Window add/remove lifecycle events need a full `list-windows` refresh so the
+/// local list can drop removed windows and pick up newly created ones. A later
+/// per-window snapshot is not enough to reconcile those structural changes.
+@visibleForTesting
+bool shouldPreserveTmuxWindowReloadThroughSnapshots(String line) {
+  final trimmed = _normalizeTmuxControlLine(line);
+  const notificationPrefixes = <String>[
+    '%sessions-changed',
+    '%unlinked-window-add ',
+    '%unlinked-window-close ',
+    '%window-add ',
+    '%window-close ',
   ];
   return notificationPrefixes.any(trimmed.startsWith);
 }
@@ -567,8 +593,10 @@ TmuxWindowChangeEvent? parseTmuxWindowChangeEventFromControlLine(
   const notificationPrefixes = <String>[
     '%pane-mode-changed ',
     '%sessions-changed',
+    '%unlinked-window-add ',
     '%unlinked-window-close ',
     '%unlinked-window-renamed ',
+    '%window-add ',
     '%window-close ',
   ];
   if (notificationPrefixes.any(trimmed.startsWith)) {
@@ -675,6 +703,7 @@ class _TmuxWindowChangeObserver {
   SSHSession? _controlSession;
   bool _starting = false;
   bool _disposed = false;
+  bool _preserveScheduledReloadThroughSnapshots = false;
   int _restartAttempts = 0;
   DateTime? _lastControlActivity;
 
@@ -754,16 +783,25 @@ class _TmuxWindowChangeObserver {
         trimmed,
         subscriptionName: _subscriptionName,
       )) {
-        _scheduleReloadEvent();
+        _scheduleReloadEvent(
+          preserveThroughSnapshots:
+              shouldPreserveTmuxWindowReloadThroughSnapshots(trimmed),
+        );
       }
       return;
     }
     if (event is TmuxWindowSnapshotEvent) {
-      _cancelScheduledReload();
+      if (!_preserveScheduledReloadThroughSnapshots) {
+        _cancelScheduledReload();
+      }
       _emitEvent(event);
       return;
     }
-    _scheduleReloadEvent();
+    _scheduleReloadEvent(
+      preserveThroughSnapshots: shouldPreserveTmuxWindowReloadThroughSnapshots(
+        trimmed,
+      ),
+    );
   }
 
   void _handleStderrLine(String line) {
@@ -780,12 +818,17 @@ class _TmuxWindowChangeObserver {
   void _cancelScheduledReload() {
     _debounceTimer?.cancel();
     _debounceTimer = null;
+    _preserveScheduledReloadThroughSnapshots = false;
   }
 
-  void _scheduleReloadEvent() {
+  void _scheduleReloadEvent({bool preserveThroughSnapshots = false}) {
     if (_disposed) return;
-    _cancelScheduledReload();
+    _debounceTimer?.cancel();
+    _preserveScheduledReloadThroughSnapshots =
+        _preserveScheduledReloadThroughSnapshots || preserveThroughSnapshots;
     _debounceTimer = Timer(_eventDebounce, () {
+      _debounceTimer = null;
+      _preserveScheduledReloadThroughSnapshots = false;
       if (!_disposed && !_controller.isClosed) {
         _controller.add(const TmuxWindowReloadEvent());
       }

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -515,6 +515,10 @@ bool shouldReloadTmuxWindowsFromControlLine(
   }
 
   const notificationPrefixes = <String>[
+    '%client-detached ',
+    '%client-session-changed ',
+    '%layout-change ',
+    '%pane-mode-changed ',
     '%session-changed ',
     '%session-renamed ',
     '%session-window-changed ',
@@ -551,14 +555,15 @@ enum TmuxControlHeartbeatAction {
 /// channel is half-open.
 @visibleForTesting
 TmuxControlHeartbeatAction decideTmuxHeartbeatAction({
-  required Duration silence,
+  required Duration controlSilence,
+  required Duration timeSinceLastRefresh,
   required Duration heartbeatInterval,
   required Duration maxSilenceBeforeRestart,
 }) {
-  if (silence >= maxSilenceBeforeRestart) {
+  if (controlSilence >= maxSilenceBeforeRestart) {
     return TmuxControlHeartbeatAction.restart;
   }
-  if (silence >= heartbeatInterval) {
+  if (timeSinceLastRefresh >= heartbeatInterval) {
     return TmuxControlHeartbeatAction.refresh;
   }
   return TmuxControlHeartbeatAction.noop;
@@ -601,11 +606,11 @@ class _TmuxWindowChangeObserver {
 
   static const _eventDebounce = Duration(milliseconds: 150);
 
-  /// How often to check whether the control-mode session has gone silent
-  /// and synthesize a refresh event when it has. Keeps the UI in sync
-  /// even if `%subscription-changed` notifications are dropped (e.g. due
-  /// to a half-open SSH channel that did not surface as `done`).
-  static const _heartbeatInterval = Duration(seconds: 5);
+  /// How often to synthesize a tmux snapshot refresh while the watcher is
+  /// active. This keeps time-based window state (for example `waiting`
+  /// derived from `window_activity`) and any missed control-mode updates in
+  /// sync with the visible tmux UI.
+  static const _heartbeatInterval = Duration(seconds: 1);
 
   /// If no control-mode line arrives for this long, treat the session as
   /// dead and force a reconnect even though the SSH `done` callback never
@@ -630,6 +635,7 @@ class _TmuxWindowChangeObserver {
   bool _disposed = false;
   int _restartAttempts = 0;
   DateTime? _lastControlActivity;
+  DateTime? _lastRefreshSignal;
 
   String get _subscriptionName =>
       'flutty-${session.connectionId}-${sessionName.hashCode.abs()}';
@@ -670,6 +676,7 @@ class _TmuxWindowChangeObserver {
       _configureControlSession();
       _restartAttempts = 0;
       _lastControlActivity = _now();
+      _lastRefreshSignal = _lastControlActivity;
       _startHeartbeat();
     } on Object catch (error, stackTrace) {
       _handleControlFailure(error, stackTrace);
@@ -714,6 +721,7 @@ class _TmuxWindowChangeObserver {
     _debounceTimer?.cancel();
     _debounceTimer = Timer(_eventDebounce, () {
       if (!_disposed && !_controller.isClosed) {
+        _lastRefreshSignal = _now();
         _controller.add(null);
       }
     });
@@ -760,10 +768,13 @@ class _TmuxWindowChangeObserver {
   ///    silence is a strong signal of a dead channel.
   void _onHeartbeat() {
     if (_disposed) return;
-    final lastActivity = _lastControlActivity;
-    if (lastActivity == null) return;
+    final lastControlActivity = _lastControlActivity;
+    final lastRefreshSignal = _lastRefreshSignal;
+    if (lastControlActivity == null || lastRefreshSignal == null) return;
+    final now = _now();
     final action = decideTmuxHeartbeatAction(
-      silence: _now().difference(lastActivity),
+      controlSilence: now.difference(lastControlActivity),
+      timeSinceLastRefresh: now.difference(lastRefreshSignal),
       heartbeatInterval: _heartbeatInterval,
       maxSilenceBeforeRestart: _maxSilenceBeforeRestart,
     );
@@ -790,6 +801,7 @@ class _TmuxWindowChangeObserver {
     _controlSession?.close();
     _controlSession = null;
     _lastControlActivity = null;
+    _lastRefreshSignal = null;
   }
 
   Future<void> dispose() async {

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -555,15 +555,14 @@ enum TmuxControlHeartbeatAction {
 /// channel is half-open.
 @visibleForTesting
 TmuxControlHeartbeatAction decideTmuxHeartbeatAction({
-  required Duration controlSilence,
-  required Duration timeSinceLastRefresh,
+  required Duration silence,
   required Duration heartbeatInterval,
   required Duration maxSilenceBeforeRestart,
 }) {
-  if (controlSilence >= maxSilenceBeforeRestart) {
+  if (silence >= maxSilenceBeforeRestart) {
     return TmuxControlHeartbeatAction.restart;
   }
-  if (timeSinceLastRefresh >= heartbeatInterval) {
+  if (silence >= heartbeatInterval) {
     return TmuxControlHeartbeatAction.refresh;
   }
   return TmuxControlHeartbeatAction.noop;
@@ -606,11 +605,11 @@ class _TmuxWindowChangeObserver {
 
   static const _eventDebounce = Duration(milliseconds: 150);
 
-  /// How often to synthesize a tmux snapshot refresh while the watcher is
-  /// active. This keeps time-based window state (for example `waiting`
-  /// derived from `window_activity`) and any missed control-mode updates in
-  /// sync with the visible tmux UI.
-  static const _heartbeatInterval = Duration(seconds: 1);
+  /// How often to check whether the control-mode session has gone silent
+  /// and synthesize a refresh event when it has. Keeps the UI in sync
+  /// even if `%subscription-changed` notifications are dropped (e.g. due
+  /// to a half-open SSH channel that did not surface as `done`).
+  static const _heartbeatInterval = Duration(seconds: 5);
 
   /// If no control-mode line arrives for this long, treat the session as
   /// dead and force a reconnect even though the SSH `done` callback never
@@ -635,7 +634,6 @@ class _TmuxWindowChangeObserver {
   bool _disposed = false;
   int _restartAttempts = 0;
   DateTime? _lastControlActivity;
-  DateTime? _lastRefreshSignal;
 
   String get _subscriptionName =>
       'flutty-${session.connectionId}-${sessionName.hashCode.abs()}';
@@ -676,7 +674,6 @@ class _TmuxWindowChangeObserver {
       _configureControlSession();
       _restartAttempts = 0;
       _lastControlActivity = _now();
-      _lastRefreshSignal = _lastControlActivity;
       _startHeartbeat();
     } on Object catch (error, stackTrace) {
       _handleControlFailure(error, stackTrace);
@@ -721,7 +718,6 @@ class _TmuxWindowChangeObserver {
     _debounceTimer?.cancel();
     _debounceTimer = Timer(_eventDebounce, () {
       if (!_disposed && !_controller.isClosed) {
-        _lastRefreshSignal = _now();
         _controller.add(null);
       }
     });
@@ -768,13 +764,10 @@ class _TmuxWindowChangeObserver {
   ///    silence is a strong signal of a dead channel.
   void _onHeartbeat() {
     if (_disposed) return;
-    final lastControlActivity = _lastControlActivity;
-    final lastRefreshSignal = _lastRefreshSignal;
-    if (lastControlActivity == null || lastRefreshSignal == null) return;
-    final now = _now();
+    final lastActivity = _lastControlActivity;
+    if (lastActivity == null) return;
     final action = decideTmuxHeartbeatAction(
-      controlSilence: now.difference(lastControlActivity),
-      timeSinceLastRefresh: now.difference(lastRefreshSignal),
+      silence: _now().difference(lastActivity),
       heartbeatInterval: _heartbeatInterval,
       maxSilenceBeforeRestart: _maxSilenceBeforeRestart,
     );
@@ -801,7 +794,6 @@ class _TmuxWindowChangeObserver {
     _controlSession?.close();
     _controlSession = null;
     _lastControlActivity = null;
-    _lastRefreshSignal = null;
   }
 
   Future<void> dispose() async {

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2533,6 +2533,8 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   bool _loadingWindows = false;
   bool _pendingWindowReload = false;
   bool _tmuxQueryScheduled = false;
+  int _windowReloadGeneration = 0;
+  int _windowEventGeneration = 0;
 
   @override
   void initState() {
@@ -2700,10 +2702,12 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     }
 
     await _windowChangeSubscription?.cancel();
+    final generation = ++_windowEventGeneration;
     _windowChangeSubscription = tmux
         .watchWindowChanges(session, sessionName)
         .listen(
-          (event) => _handleWindowChangeEvent(session, sessionName, event),
+          (event) =>
+              _handleWindowChangeEvent(session, sessionName, event, generation),
         );
     await _refreshTmuxWindows(session, sessionName);
   }
@@ -2712,8 +2716,10 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     SshSession session,
     String sessionName,
     TmuxWindowChangeEvent event,
+    int generation,
   ) {
     if (!mounted) return;
+    if (generation != _windowEventGeneration) return;
     if (event is TmuxWindowReloadEvent) {
       _refreshTmuxWindows(session, sessionName);
       return;
@@ -2723,6 +2729,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       _refreshTmuxWindows(session, sessionName);
       return;
     }
+    _windowReloadGeneration += 1;
     _tmuxRetryTimer?.cancel();
     _tmuxRetryTimer = null;
     setState(() {
@@ -2741,11 +2748,13 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       return;
     }
     _loadingWindows = true;
+    final reloadGeneration = ++_windowReloadGeneration;
     try {
       final windows = await ref
           .read(tmuxServiceProvider)
           .listWindows(session, sessionName);
       if (!mounted) return;
+      if (reloadGeneration < _windowReloadGeneration) return;
       if (windows.isEmpty) {
         _scheduleTmuxRetry();
       } else {

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2528,7 +2528,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   bool _showSessions = false;
   bool _hasInitializedSessionProviders = false;
   bool _restoredUiState = false;
-  StreamSubscription<void>? _windowChangeSubscription;
+  StreamSubscription<TmuxWindowChangeEvent>? _windowChangeSubscription;
   Timer? _tmuxRetryTimer;
   bool _loadingWindows = false;
   bool _pendingWindowReload = false;
@@ -2702,11 +2702,34 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     await _windowChangeSubscription?.cancel();
     _windowChangeSubscription = tmux
         .watchWindowChanges(session, sessionName)
-        .listen((_) {
-          if (!mounted) return;
-          _refreshTmuxWindows(session, sessionName);
-        });
+        .listen(
+          (event) => _handleWindowChangeEvent(session, sessionName, event),
+        );
     await _refreshTmuxWindows(session, sessionName);
+  }
+
+  void _handleWindowChangeEvent(
+    SshSession session,
+    String sessionName,
+    TmuxWindowChangeEvent event,
+  ) {
+    if (!mounted) return;
+    if (event is TmuxWindowReloadEvent) {
+      _refreshTmuxWindows(session, sessionName);
+      return;
+    }
+    final currentWindows = _windows;
+    if (currentWindows == null) {
+      _refreshTmuxWindows(session, sessionName);
+      return;
+    }
+    _tmuxRetryTimer?.cancel();
+    _tmuxRetryTimer = null;
+    setState(() {
+      _windows = applyTmuxWindowChangeEvent(currentWindows, event);
+      _sessionName = sessionName;
+      _queried = true;
+    });
   }
 
   Future<void> _refreshTmuxWindows(

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -362,6 +362,8 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   late Animation<double> _bounceAnimation;
   bool _loadingWindows = false;
   bool _pendingWindowReload = false;
+  int _windowReloadGeneration = 0;
+  int _windowEventGeneration = 0;
 
   TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
 
@@ -428,13 +430,15 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   }
 
   void _subscribeToWindowChanges() {
+    final generation = ++_windowEventGeneration;
     _windowChangeSubscription = _tmux
         .watchWindowChanges(widget.session, widget.tmuxSessionName)
-        .listen(_handleWindowChangeEvent);
+        .listen((event) => _handleWindowChangeEvent(event, generation));
   }
 
-  void _handleWindowChangeEvent(TmuxWindowChangeEvent event) {
+  void _handleWindowChangeEvent(TmuxWindowChangeEvent event, int generation) {
     if (!mounted) return;
+    if (generation != _windowEventGeneration) return;
     if (event is TmuxWindowReloadEvent) {
       _loadWindows();
       return;
@@ -444,6 +448,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       _loadWindows();
       return;
     }
+    _windowReloadGeneration += 1;
     final windows = applyTmuxWindowChangeEvent(currentWindows, event);
     _applyWindows(windows);
     if (widget.isProUser) {
@@ -521,12 +526,14 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       return;
     }
     _loadingWindows = true;
+    final reloadGeneration = ++_windowReloadGeneration;
     try {
       final windows = await _tmux.listWindows(
         widget.session,
         widget.tmuxSessionName,
       );
       if (!mounted) return;
+      if (reloadGeneration < _windowReloadGeneration) return;
       _applyWindows(windows);
       if (widget.isProUser) {
         unawaited(_prefetchPreferredSessionProvider(windows: windows));

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -204,6 +204,58 @@ String? resolveTmuxBarActiveWindowTitle(Iterable<TmuxWindow>? windows) {
   return title;
 }
 
+/// Resolves the tmux windows the bar should display, including any local
+/// optimistic selection while the tmux snapshot is still catching up.
+@visibleForTesting
+List<TmuxWindow>? resolveTmuxBarDisplayedWindows(
+  Iterable<TmuxWindow>? windows, {
+  int? pendingSelectedWindowIndex,
+}) {
+  final windowList = windows?.toList(growable: false);
+  if (windowList == null || pendingSelectedWindowIndex == null) {
+    return windowList;
+  }
+  if (!windowList.any((window) => window.index == pendingSelectedWindowIndex)) {
+    return windowList;
+  }
+
+  var didChangeActiveWindow = false;
+  final displayedWindows = <TmuxWindow>[];
+  for (final window in windowList) {
+    final shouldBeActive = window.index == pendingSelectedWindowIndex;
+    if (window.isActive != shouldBeActive) {
+      didChangeActiveWindow = true;
+      displayedWindows.add(window.copyWith(isActive: shouldBeActive));
+      continue;
+    }
+    displayedWindows.add(window);
+  }
+  return didChangeActiveWindow ? displayedWindows : windowList;
+}
+
+/// Resolves whether the tmux bar should keep or clear its optimistic selection
+/// after tmux reports a new window list.
+@visibleForTesting
+int? resolveTmuxBarPendingSelectedWindowIndex(
+  Iterable<TmuxWindow>? windows, {
+  int? pendingSelectedWindowIndex,
+}) {
+  if (pendingSelectedWindowIndex == null || windows == null) {
+    return pendingSelectedWindowIndex;
+  }
+  final windowList = windows.toList(growable: false);
+  if (!windowList.any((window) => window.index == pendingSelectedWindowIndex)) {
+    return null;
+  }
+  final activeWindow = windowList
+      .where((window) => window.isActive)
+      .firstOrNull;
+  if (activeWindow?.index == pendingSelectedWindowIndex) {
+    return null;
+  }
+  return pendingSelectedWindowIndex;
+}
+
 /// Resolves the compact label shown in the tmux bar handle.
 @visibleForTesting
 String resolveTmuxBarHandleLabel(
@@ -348,6 +400,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   static const _denseTilePadding = EdgeInsets.symmetric(horizontal: 12);
   static const _groupTilePadding = EdgeInsets.only(left: 52, right: 12);
   static const _prefetchSessionFetchLimit = 6;
+  static const _pendingSelectionTimeout = Duration(seconds: 2);
 
   List<TmuxWindow>? _windows;
   AgentLaunchTool? _preferredLaunchTool;
@@ -364,11 +417,18 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   bool _pendingWindowReload = false;
   int _windowReloadGeneration = 0;
   int _windowEventGeneration = 0;
+  int? _pendingSelectedWindowIndex;
+  Timer? _pendingSelectionTimer;
 
   TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
 
   AgentSessionDiscoveryService get _discovery =>
       widget.ref.read(agentSessionDiscoveryServiceProvider);
+
+  List<TmuxWindow>? get _displayedWindows => resolveTmuxBarDisplayedWindows(
+    _windows,
+    pendingSelectedWindowIndex: _pendingSelectedWindowIndex,
+  );
 
   @override
   void initState() {
@@ -398,6 +458,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         oldWidget.tmuxSessionName == widget.tmuxSessionName) {
       return;
     }
+    _clearPendingSelectedWindow(notify: false);
     unawaited(_windowChangeSubscription?.cancel());
     _subscribeToWindowChanges();
     unawaited(_loadPreferredLaunchTool());
@@ -406,6 +467,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
 
   @override
   void dispose() {
+    _clearPendingSelectedWindow(notify: false);
     unawaited(_windowChangeSubscription?.cancel());
     for (final windowIndex in _seenAlertWindows) {
       _clearAlertNotification(windowIndex);
@@ -487,10 +549,46 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       _clearAlertNotification(windowIndex);
     }
 
+    final nextPendingSelectedWindowIndex =
+        resolveTmuxBarPendingSelectedWindowIndex(
+          windows,
+          pendingSelectedWindowIndex: _pendingSelectedWindowIndex,
+        );
+    if (_pendingSelectedWindowIndex != null &&
+        nextPendingSelectedWindowIndex == null) {
+      _pendingSelectionTimer?.cancel();
+      _pendingSelectionTimer = null;
+    }
+
     setState(() {
       _windows = windows;
       _isLoading = false;
+      _pendingSelectedWindowIndex = nextPendingSelectedWindowIndex;
     });
+  }
+
+  void _startPendingSelectionTimer(int windowIndex) {
+    _pendingSelectionTimer?.cancel();
+    _pendingSelectionTimer = Timer(_pendingSelectionTimeout, () {
+      _pendingSelectionTimer = null;
+      if (!mounted || _pendingSelectedWindowIndex != windowIndex) {
+        return;
+      }
+      setState(() => _pendingSelectedWindowIndex = null);
+    });
+  }
+
+  void _clearPendingSelectedWindow({required bool notify}) {
+    _pendingSelectionTimer?.cancel();
+    _pendingSelectionTimer = null;
+    if (_pendingSelectedWindowIndex == null) {
+      return;
+    }
+    if (!notify || !mounted) {
+      _pendingSelectedWindowIndex = null;
+      return;
+    }
+    setState(() => _pendingSelectedWindowIndex = null);
   }
 
   String? _resolveRecentSessionScopeWorkingDirectory([
@@ -688,9 +786,10 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   }
 
   Widget _buildHandleBar(ThemeData theme) {
+    final displayedWindows = _displayedWindows;
     final handleLabel = resolveTmuxBarHandleLabel(
       widget.tmuxSessionName,
-      activeWindowTitle: resolveTmuxBarActiveWindowTitle(_windows),
+      activeWindowTitle: resolveTmuxBarActiveWindowTitle(displayedWindows),
     );
     return GestureDetector(
       key: const ValueKey('tmux-handle-bar'),
@@ -767,6 +866,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   }
 
   Widget _buildWindowList(ThemeData theme) {
+    final displayedWindows = _displayedWindows;
     if (_isLoading) {
       return const Padding(
         padding: EdgeInsets.all(16),
@@ -780,7 +880,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       );
     }
 
-    if (_windows == null || _windows!.isEmpty) {
+    if (displayedWindows == null || displayedWindows.isEmpty) {
       return const SizedBox.shrink();
     }
 
@@ -789,7 +889,8 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         mainAxisSize: MainAxisSize.min,
         children: [
           const Divider(height: 1),
-          for (final window in _windows!) _buildWindowTile(theme, window),
+          for (final window in displayedWindows)
+            _buildWindowTile(theme, window),
           const Divider(height: 1),
           ListTile(
             dense: true,
@@ -1053,6 +1154,11 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
                 _windows = _windows
                     ?.where((w) => w.index != window.index)
                     .toList();
+                if (_pendingSelectedWindowIndex == window.index) {
+                  _pendingSelectedWindowIndex = null;
+                  _pendingSelectionTimer?.cancel();
+                  _pendingSelectionTimer = null;
+                }
               });
             },
           ),
@@ -1061,8 +1167,12 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       onTap: isActive
           ? () => setState(() => _expanded = false)
           : () {
-              widget.onAction(TmuxSwitchWindowAction(window.index));
-              setState(() => _expanded = false);
+              setState(() {
+                _pendingSelectedWindowIndex = window.index;
+                _expanded = false;
+              });
+              _startPendingSelectionTimer(window.index);
+              unawaited(widget.onAction(TmuxSwitchWindowAction(window.index)));
             },
     );
   }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -197,7 +197,7 @@ double resolveTmuxBarRevealOpacity(
 @visibleForTesting
 String? resolveTmuxBarActiveWindowTitle(Iterable<TmuxWindow>? windows) {
   final activeWindow = windows?.where((window) => window.isActive).firstOrNull;
-  final title = activeWindow?.displayTitle.trim();
+  final title = activeWindow?.handleTitle.trim();
   if (title == null || title.isEmpty) {
     return null;
   }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -357,7 +357,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   bool _showSessions = false;
   bool _hasInitializedSessionProviders = false;
   double _dragOffset = 0;
-  StreamSubscription<void>? _windowChangeSubscription;
+  StreamSubscription<TmuxWindowChangeEvent>? _windowChangeSubscription;
   late AnimationController _bounceController;
   late Animation<double> _bounceAnimation;
   bool _loadingWindows = false;
@@ -430,10 +430,62 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   void _subscribeToWindowChanges() {
     _windowChangeSubscription = _tmux
         .watchWindowChanges(widget.session, widget.tmuxSessionName)
-        .listen((_) {
-          if (!mounted) return;
-          _loadWindows();
-        });
+        .listen(_handleWindowChangeEvent);
+  }
+
+  void _handleWindowChangeEvent(TmuxWindowChangeEvent event) {
+    if (!mounted) return;
+    if (event is TmuxWindowReloadEvent) {
+      _loadWindows();
+      return;
+    }
+    final currentWindows = _windows;
+    if (currentWindows == null) {
+      _loadWindows();
+      return;
+    }
+    final windows = applyTmuxWindowChangeEvent(currentWindows, event);
+    _applyWindows(windows);
+    if (widget.isProUser) {
+      unawaited(_prefetchPreferredSessionProvider(windows: windows));
+    }
+  }
+
+  void _applyWindows(List<TmuxWindow> windows) {
+    // Detect new alerts that weren't in the previous window list.
+    final newAlerts = windows.where(
+      (w) => w.hasAlert && !w.isActive && !_seenAlertWindows.contains(w.index),
+    );
+    if (newAlerts.isNotEmpty) {
+      unawaited(_bounceController.forward(from: 0));
+      for (final w in newAlerts) {
+        _seenAlertWindows.add(w.index);
+        _sendAlertNotification(w);
+      }
+    }
+
+    final activeAlerts = _seenAlertWindows
+        .where(
+          (idx) =>
+              windows.any((w) => w.index == idx && w.hasAlert && w.isActive),
+        )
+        .toList(growable: false);
+    for (final windowIndex in activeAlerts) {
+      _clearAlertNotification(windowIndex);
+    }
+
+    final clearedAlerts = _seenAlertWindows
+        .where((idx) => !windows.any((w) => w.index == idx && w.hasAlert))
+        .toList(growable: false);
+    for (final windowIndex in clearedAlerts) {
+      _seenAlertWindows.remove(windowIndex);
+      _clearAlertNotification(windowIndex);
+    }
+
+    setState(() {
+      _windows = windows;
+      _isLoading = false;
+    });
   }
 
   String? _resolveRecentSessionScopeWorkingDirectory([
@@ -475,42 +527,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         widget.tmuxSessionName,
       );
       if (!mounted) return;
-
-      // Detect new alerts that weren't in the previous window list.
-      final newAlerts = windows.where(
-        (w) =>
-            w.hasAlert && !w.isActive && !_seenAlertWindows.contains(w.index),
-      );
-      if (newAlerts.isNotEmpty) {
-        unawaited(_bounceController.forward(from: 0));
-        for (final w in newAlerts) {
-          _seenAlertWindows.add(w.index);
-          _sendAlertNotification(w);
-        }
-      }
-
-      final activeAlerts = _seenAlertWindows
-          .where(
-            (idx) =>
-                windows.any((w) => w.index == idx && w.hasAlert && w.isActive),
-          )
-          .toList(growable: false);
-      for (final windowIndex in activeAlerts) {
-        _clearAlertNotification(windowIndex);
-      }
-
-      final clearedAlerts = _seenAlertWindows
-          .where((idx) => !windows.any((w) => w.index == idx && w.hasAlert))
-          .toList(growable: false);
-      for (final windowIndex in clearedAlerts) {
-        _seenAlertWindows.remove(windowIndex);
-        _clearAlertNotification(windowIndex);
-      }
-
-      setState(() {
-        _windows = windows;
-        _isLoading = false;
-      });
+      _applyWindows(windows);
       if (widget.isProUser) {
         unawaited(_prefetchPreferredSessionProvider(windows: windows));
       }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -459,6 +459,10 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       return;
     }
     _clearPendingSelectedWindow(notify: false);
+    setState(() {
+      _windows = null;
+      _isLoading = true;
+    });
     unawaited(_windowChangeSubscription?.cancel());
     _subscribeToWindowChanges();
     unawaited(_loadPreferredLaunchTool());
@@ -3988,7 +3992,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final sessionName = _tmuxSessionName;
     if (sessionName == null) return;
 
-    ref
+    await ref
         .read(tmuxServiceProvider)
         .selectWindow(session, sessionName, windowIndex);
 

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -149,6 +149,8 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   String? _error;
   bool _loadingWindows = false;
   bool _pendingWindowReload = false;
+  int _windowReloadGeneration = 0;
+  int _windowEventGeneration = 0;
 
   TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
 
@@ -160,9 +162,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     super.initState();
     unawaited(_loadPreferredLaunchTool());
     _installedToolsFuture = _tmux.detectInstalledAgentTools(widget.session);
-    _windowChangeSubscription = _tmux
-        .watchWindowChanges(widget.session, widget.tmuxSessionName)
-        .listen(_handleWindowChangeEvent);
+    _subscribeToWindowChanges();
     _loadWindows();
   }
 
@@ -178,6 +178,13 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   void dispose() {
     unawaited(_windowChangeSubscription?.cancel());
     super.dispose();
+  }
+
+  void _subscribeToWindowChanges() {
+    final generation = ++_windowEventGeneration;
+    _windowChangeSubscription = _tmux
+        .watchWindowChanges(widget.session, widget.tmuxSessionName)
+        .listen((event) => _handleWindowChangeEvent(event, generation));
   }
 
   Future<void> _loadPreferredLaunchTool() async {
@@ -222,12 +229,14 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       return;
     }
     _loadingWindows = true;
+    final reloadGeneration = ++_windowReloadGeneration;
     try {
       final windows = await _tmux.listWindows(
         widget.session,
         widget.tmuxSessionName,
       );
       if (!mounted) return;
+      if (reloadGeneration < _windowReloadGeneration) return;
       setState(() {
         _windows = windows;
         _isLoadingWindows = false;
@@ -248,8 +257,9 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     }
   }
 
-  void _handleWindowChangeEvent(TmuxWindowChangeEvent event) {
+  void _handleWindowChangeEvent(TmuxWindowChangeEvent event, int generation) {
     if (!mounted) return;
+    if (generation != _windowEventGeneration) return;
     if (event is TmuxWindowReloadEvent) {
       _loadWindows();
       return;
@@ -259,6 +269,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       _loadWindows();
       return;
     }
+    _windowReloadGeneration += 1;
     setState(() {
       _windows = applyTmuxWindowChangeEvent(currentWindows, event);
       _isLoadingWindows = false;

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -144,7 +144,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   List<TmuxWindow>? _windows;
   AgentLaunchTool? _preferredLaunchTool;
   Future<Set<AgentLaunchTool>>? _installedToolsFuture;
-  StreamSubscription<void>? _windowChangeSubscription;
+  StreamSubscription<TmuxWindowChangeEvent>? _windowChangeSubscription;
   bool _isLoadingWindows = true;
   String? _error;
   bool _loadingWindows = false;
@@ -162,10 +162,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     _installedToolsFuture = _tmux.detectInstalledAgentTools(widget.session);
     _windowChangeSubscription = _tmux
         .watchWindowChanges(widget.session, widget.tmuxSessionName)
-        .listen((_) {
-          if (!mounted) return;
-          _loadWindows();
-        });
+        .listen(_handleWindowChangeEvent);
     _loadWindows();
   }
 
@@ -249,6 +246,23 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         unawaited(_loadWindows());
       }
     }
+  }
+
+  void _handleWindowChangeEvent(TmuxWindowChangeEvent event) {
+    if (!mounted) return;
+    if (event is TmuxWindowReloadEvent) {
+      _loadWindows();
+      return;
+    }
+    final currentWindows = _windows;
+    if (currentWindows == null) {
+      _loadWindows();
+      return;
+    }
+    setState(() {
+      _windows = applyTmuxWindowChangeEvent(currentWindows, event);
+      _isLoadingWindows = false;
+    });
   }
 
   void _switchToWindow(int windowIndex) {

--- a/lib/presentation/widgets/tmux_window_status_badge.dart
+++ b/lib/presentation/widgets/tmux_window_status_badge.dart
@@ -1,9 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../../domain/models/tmux_state.dart';
 
 /// Compact status badge for a tmux window.
-class TmuxWindowStatusBadge extends StatelessWidget {
+class TmuxWindowStatusBadge extends StatefulWidget {
   /// Creates a new [TmuxWindowStatusBadge].
   const TmuxWindowStatusBadge({required this.window, super.key});
 
@@ -11,35 +13,7 @@ class TmuxWindowStatusBadge extends StatelessWidget {
   final TmuxWindow window;
 
   @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final visual = _statusVisual(theme, window);
-
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: visual.backgroundColor,
-        borderRadius: BorderRadius.circular(999),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(visual.icon, size: 12, color: visual.foregroundColor),
-            const SizedBox(width: 3),
-            Text(
-              window.statusLabel,
-              style: theme.textTheme.labelSmall?.copyWith(
-                fontSize: 10,
-                color: visual.foregroundColor,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
+  State<TmuxWindowStatusBadge> createState() => _TmuxWindowStatusBadgeState();
 
   static _TmuxWindowStatusVisual _statusVisual(
     ThemeData theme,
@@ -63,6 +37,76 @@ class TmuxWindowStatusBadge extends StatelessWidget {
       icon: Icons.play_arrow,
       foregroundColor: theme.colorScheme.onPrimaryContainer,
       backgroundColor: theme.colorScheme.primaryContainer,
+    );
+  }
+}
+
+class _TmuxWindowStatusBadgeState extends State<TmuxWindowStatusBadge> {
+  Timer? _idleRefreshTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _updateIdleRefreshTimer();
+  }
+
+  @override
+  void didUpdateWidget(covariant TmuxWindowStatusBadge oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.window == widget.window) return;
+    _updateIdleRefreshTimer();
+  }
+
+  @override
+  void dispose() {
+    _idleRefreshTimer?.cancel();
+    super.dispose();
+  }
+
+  void _updateIdleRefreshTimer() {
+    _idleRefreshTimer?.cancel();
+    if (!widget.window.needsLocalIdleRefresh) {
+      _idleRefreshTimer = null;
+      return;
+    }
+    _idleRefreshTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (!mounted) return;
+      if (!widget.window.needsLocalIdleRefresh) {
+        _idleRefreshTimer?.cancel();
+        _idleRefreshTimer = null;
+      }
+      setState(() {});
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final visual = TmuxWindowStatusBadge._statusVisual(theme, widget.window);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: visual.backgroundColor,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(visual.icon, size: 12, color: visual.foregroundColor),
+            const SizedBox(width: 3),
+            Text(
+              widget.window.statusLabel,
+              style: theme.textTheme.labelSmall?.copyWith(
+                fontSize: 10,
+                color: visual.foregroundColor,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -94,11 +94,12 @@ void main() {
         index: 1,
         name: 'claude',
         isActive: false,
+        currentCommand: 'claude',
         paneTitle: '✨ Editing main.dart',
       );
 
       expect(window.displayTitle, '✨ Editing main.dart');
-      expect(window.handleTitle, 'claude');
+      expect(window.handleTitle, '✨ Editing main.dart');
       expect(window.secondaryTitle, 'claude');
     });
 
@@ -111,6 +112,18 @@ void main() {
       );
 
       expect(window.handleTitle, 'test-emoji');
+    });
+
+    test('handleTitle still prefers the window name when it is distinct', () {
+      const window = TmuxWindow(
+        index: 1,
+        name: 'workspace',
+        isActive: false,
+        currentCommand: 'claude',
+        paneTitle: '✨ Editing main.dart',
+      );
+
+      expect(window.handleTitle, 'workspace');
     });
 
     test(

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -98,7 +98,19 @@ void main() {
       );
 
       expect(window.displayTitle, '✨ Editing main.dart');
+      expect(window.handleTitle, 'claude');
       expect(window.secondaryTitle, 'claude');
+    });
+
+    test('handleTitle falls back to the display title when needed', () {
+      const window = TmuxWindow(
+        index: 1,
+        name: '__ test-emoji',
+        isActive: false,
+        paneTitle: '🔥 test-emoji',
+      );
+
+      expect(window.handleTitle, 'test-emoji');
     });
 
     test(

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -203,6 +203,50 @@ void main() {
     });
   });
 
+  group('applyTmuxWindowChangeEvent', () {
+    test(
+      'replaces an existing window snapshot and clears prior active state',
+      () {
+        const windows = <TmuxWindow>[
+          TmuxWindow(index: 0, name: 'first', isActive: true),
+          TmuxWindow(index: 1, name: 'second', isActive: false),
+        ];
+
+        final updated = applyTmuxWindowChangeEvent(
+          windows,
+          const TmuxWindowSnapshotEvent(
+            TmuxWindow(
+              index: 1,
+              name: 'second-renamed',
+              isActive: true,
+              paneTitle: 'editing',
+            ),
+          ),
+        );
+
+        expect(updated[0].isActive, isFalse);
+        expect(updated[1].isActive, isTrue);
+        expect(updated[1].name, 'second-renamed');
+        expect(updated[1].paneTitle, 'editing');
+      },
+    );
+
+    test('adds a new window snapshot in index order', () {
+      const windows = <TmuxWindow>[
+        TmuxWindow(index: 0, name: 'first', isActive: true),
+      ];
+
+      final updated = applyTmuxWindowChangeEvent(
+        windows,
+        const TmuxWindowSnapshotEvent(
+          TmuxWindow(index: 2, name: 'third', isActive: false),
+        ),
+      );
+
+      expect(updated.map((window) => window.index).toList(), [0, 2]);
+    });
+  });
+
   group('ToolSessionInfo', () {
     test('constructs with all fields', () {
       final info = ToolSessionInfo(

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -143,6 +143,19 @@ void main() {
       expect(window.statusLabel, 'alert');
     });
 
+    test('computes idle state from activity epoch dynamically', () {
+      final activityEpoch =
+          (DateTime.now().millisecondsSinceEpoch ~/ 1000) - 20;
+      final window = TmuxWindow.fromTmuxFormat(
+        '3|claude|1|claude|/tmp|*|Waiting|$activityEpoch',
+      );
+
+      expect(window.lastActivityEpochSeconds, activityEpoch);
+      expect(window.idleSeconds, greaterThanOrEqualTo(20));
+      expect(window.isIdle, isTrue);
+      expect(window.statusLabel, 'waiting');
+    });
+
     test('throws on too few fields', () {
       expect(() => TmuxWindow.fromTmuxFormat('0|vim'), throwsFormatException);
     });

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -72,6 +72,8 @@ class _CountingKeyRepository extends KeyRepository {
 
 class _MockSshClient extends Mock implements SSHClient {}
 
+class _MockExecSession extends Mock implements SSHSession {}
+
 class _FakeHostKeySocket implements SSHSocket, HostKeySource {
   _FakeHostKeySocket(this._hostKeyBytes);
 
@@ -188,6 +190,7 @@ class _FakeActiveSessionsSshService extends SshService {
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+  registerFallbackValue(const SSHPtyConfig());
 
   group('SshConnectionState', () {
     test('has expected values', () {
@@ -533,6 +536,38 @@ void main() {
   });
 
   group('SshSession terminal previews', () {
+    test('forwards execute requests with an optional PTY config', () async {
+      final client = _MockSshClient();
+      final execSession = _MockExecSession();
+      final session = SshSession(
+        connectionId: 1,
+        hostId: 2,
+        client: client,
+        config: const SshConnectionConfig(
+          hostname: 'example.com',
+          port: 22,
+          username: 'tester',
+        ),
+      );
+
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) async => execSession);
+
+      final result = await session.execute(
+        'tmux -CC attach-session -t test',
+        pty: const SSHPtyConfig(width: 120, height: 30),
+      );
+
+      expect(result, same(execSession));
+      verify(
+        () => client.execute(
+          'tmux -CC attach-session -t test',
+          pty: const SSHPtyConfig(width: 120, height: 30),
+        ),
+      ).called(1);
+    });
+
     test('builds preview from the latest non-empty lines', () {
       final terminal = Terminal(maxLines: 100)
         ..write('first line\r\nsecond line\r\n\r\nthird line');

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -139,6 +139,54 @@ void main() {
     );
   });
 
+  group('shouldScheduleTmuxWindowReloadFallback', () {
+    const subscriptionName = 'flutty-1-42';
+
+    test(
+      'schedules fallback reloads for window signals that may miss snapshots',
+      () {
+        expect(
+          shouldScheduleTmuxWindowReloadFallback(
+            r'%subscription-changed flutty-1-42 $1 @1 1 %1 : malformed',
+            subscriptionName: subscriptionName,
+          ),
+          isTrue,
+        );
+        expect(
+          shouldScheduleTmuxWindowReloadFallback(
+            r'%session-window-changed $1 @1',
+            subscriptionName: subscriptionName,
+          ),
+          isTrue,
+        );
+        expect(
+          shouldScheduleTmuxWindowReloadFallback(
+            '%window-renamed @1 renamed-window',
+            subscriptionName: subscriptionName,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('ignores unrelated control-mode noise', () {
+      expect(
+        shouldScheduleTmuxWindowReloadFallback(
+          r'%subscription-changed other-subscription $1 @1 1 %1 : value',
+          subscriptionName: subscriptionName,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldScheduleTmuxWindowReloadFallback(
+          '%output %1 hello',
+          subscriptionName: subscriptionName,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('tmux window action helpers', () {
     test('parses the current pane path from display-message output', () {
       expect(parseTmuxCurrentPanePath('/tmp/project\n'), '/tmp/project');

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -77,6 +77,33 @@ void main() {
       );
     });
 
+    test(
+      'returns true for control-mode notifications carrying window state',
+      () {
+        expect(
+          shouldReloadTmuxWindowsFromControlLine(
+            '%layout-change @1 even-horizontal even-horizontal *',
+            subscriptionName: subscriptionName,
+          ),
+          isTrue,
+        );
+        expect(
+          shouldReloadTmuxWindowsFromControlLine(
+            r'%client-session-changed /dev/ttys001 $1 dev',
+            subscriptionName: subscriptionName,
+          ),
+          isTrue,
+        );
+        expect(
+          shouldReloadTmuxWindowsFromControlLine(
+            '%pane-mode-changed %1',
+            subscriptionName: subscriptionName,
+          ),
+          isTrue,
+        );
+      },
+    );
+
     test('returns false for control block markers and noise', () {
       expect(
         shouldReloadTmuxWindowsFromControlLine(
@@ -127,7 +154,8 @@ void main() {
     test('noop while control-mode notifications are flowing', () {
       expect(
         decideTmuxHeartbeatAction(
-          silence: Duration.zero,
+          controlSilence: Duration.zero,
+          timeSinceLastRefresh: Duration.zero,
           heartbeatInterval: heartbeat,
           maxSilenceBeforeRestart: maxSilence,
         ),
@@ -135,7 +163,8 @@ void main() {
       );
       expect(
         decideTmuxHeartbeatAction(
-          silence: const Duration(milliseconds: 4999),
+          controlSilence: const Duration(milliseconds: 4999),
+          timeSinceLastRefresh: const Duration(milliseconds: 4999),
           heartbeatInterval: heartbeat,
           maxSilenceBeforeRestart: maxSilence,
         ),
@@ -147,7 +176,8 @@ void main() {
         'heartbeat interval', () {
       expect(
         decideTmuxHeartbeatAction(
-          silence: heartbeat,
+          controlSilence: heartbeat,
+          timeSinceLastRefresh: heartbeat,
           heartbeatInterval: heartbeat,
           maxSilenceBeforeRestart: maxSilence,
         ),
@@ -155,7 +185,20 @@ void main() {
       );
       expect(
         decideTmuxHeartbeatAction(
-          silence: const Duration(seconds: 20),
+          controlSilence: const Duration(seconds: 20),
+          timeSinceLastRefresh: const Duration(seconds: 20),
+          heartbeatInterval: heartbeat,
+          maxSilenceBeforeRestart: maxSilence,
+        ),
+        TmuxControlHeartbeatAction.refresh,
+      );
+    });
+
+    test('refreshes even while unrelated control chatter keeps arriving', () {
+      expect(
+        decideTmuxHeartbeatAction(
+          controlSilence: const Duration(milliseconds: 100),
+          timeSinceLastRefresh: heartbeat,
           heartbeatInterval: heartbeat,
           maxSilenceBeforeRestart: maxSilence,
         ),
@@ -167,7 +210,8 @@ void main() {
         'threshold', () {
       expect(
         decideTmuxHeartbeatAction(
-          silence: maxSilence,
+          controlSilence: maxSilence,
+          timeSinceLastRefresh: maxSilence,
           heartbeatInterval: heartbeat,
           maxSilenceBeforeRestart: maxSilence,
         ),
@@ -175,7 +219,8 @@ void main() {
       );
       expect(
         decideTmuxHeartbeatAction(
-          silence: const Duration(minutes: 5),
+          controlSilence: const Duration(minutes: 5),
+          timeSinceLastRefresh: const Duration(minutes: 5),
           heartbeatInterval: heartbeat,
           maxSilenceBeforeRestart: maxSilence,
         ),

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/domain/services/tmux_service.dart';
 
 void main() {
@@ -30,103 +31,112 @@ void main() {
     );
   });
 
-  group('shouldReloadTmuxWindowsFromControlLine', () {
+  group('parseTmuxWindowChangeEventFromControlLine', () {
     const subscriptionName = 'flutty-1-42';
 
-    test('returns true for matching subscription notifications', () {
-      expect(
-        shouldReloadTmuxWindowsFromControlLine(
-          r'%subscription-changed flutty-1-42 $1 @1 1 %1 : updated',
-          subscriptionName: subscriptionName,
-        ),
-        isTrue,
+    test('returns a window snapshot event for matching subscriptions', () {
+      final event = parseTmuxWindowChangeEventFromControlLine(
+        r'%subscription-changed flutty-1-42 $1 @1 1 %1 : 1|renamed|1|sleep|/tmp|*|custom-title|1712930000',
+        subscriptionName: subscriptionName,
       );
+
+      expect(event, isA<TmuxWindowSnapshotEvent>());
+      final snapshot = event! as TmuxWindowSnapshotEvent;
+      expect(snapshot.window.index, 1);
+      expect(snapshot.window.name, 'renamed');
+      expect(snapshot.window.isActive, isTrue);
+      expect(snapshot.window.paneTitle, 'custom-title');
     });
 
-    test('returns false for other subscriptions', () {
+    test('normalizes the wrapped first control-mode line', () {
+      final event = parseTmuxWindowChangeEventFromControlLine(
+        '\u001bP1000p%subscription-changed flutty-1-42 \$1 @1 1 %1 : '
+        '0|shell|1|sleep|/tmp|*|wrapped-title|1712930000',
+        subscriptionName: subscriptionName,
+      );
+
+      expect(event, isA<TmuxWindowSnapshotEvent>());
+      final snapshot = event! as TmuxWindowSnapshotEvent;
+      expect(snapshot.window.displayTitle, 'wrapped-title');
+    });
+
+    test('returns null for other subscriptions', () {
       expect(
-        shouldReloadTmuxWindowsFromControlLine(
+        parseTmuxWindowChangeEventFromControlLine(
           r'%subscription-changed other-subscription $1 @1 1 %1 : updated',
           subscriptionName: subscriptionName,
         ),
-        isFalse,
-      );
-    });
-
-    test('returns true for window lifecycle notifications', () {
-      expect(
-        shouldReloadTmuxWindowsFromControlLine(
-          '%window-renamed @1 🔥 test-emoji',
-          subscriptionName: subscriptionName,
-        ),
-        isTrue,
-      );
-      expect(
-        shouldReloadTmuxWindowsFromControlLine(
-          '%window-close @1',
-          subscriptionName: subscriptionName,
-        ),
-        isTrue,
-      );
-      expect(
-        shouldReloadTmuxWindowsFromControlLine(
-          r'%session-window-changed $1 @1',
-          subscriptionName: subscriptionName,
-        ),
-        isTrue,
+        isNull,
       );
     });
 
     test(
-      'returns true for control-mode notifications carrying window state',
+      'returns reload events for lifecycle notifications without snapshots',
       () {
         expect(
-          shouldReloadTmuxWindowsFromControlLine(
-            '%layout-change @1 even-horizontal even-horizontal *',
+          parseTmuxWindowChangeEventFromControlLine(
+            '%window-close @1',
             subscriptionName: subscriptionName,
           ),
-          isTrue,
+          isA<TmuxWindowReloadEvent>(),
         );
         expect(
-          shouldReloadTmuxWindowsFromControlLine(
-            r'%client-session-changed /dev/ttys001 $1 dev',
+          parseTmuxWindowChangeEventFromControlLine(
+            '%unlinked-window-close @1',
             subscriptionName: subscriptionName,
           ),
-          isTrue,
+          isA<TmuxWindowReloadEvent>(),
         );
         expect(
-          shouldReloadTmuxWindowsFromControlLine(
+          parseTmuxWindowChangeEventFromControlLine(
             '%pane-mode-changed %1',
             subscriptionName: subscriptionName,
           ),
-          isTrue,
+          isA<TmuxWindowReloadEvent>(),
         );
       },
     );
 
-    test('returns false for control block markers and noise', () {
-      expect(
-        shouldReloadTmuxWindowsFromControlLine(
-          '%begin 1 2 0',
-          subscriptionName: subscriptionName,
-        ),
-        isFalse,
-      );
-      expect(
-        shouldReloadTmuxWindowsFromControlLine(
-          '%output %1 hello',
-          subscriptionName: subscriptionName,
-        ),
-        isFalse,
-      );
-      expect(
-        shouldReloadTmuxWindowsFromControlLine(
-          '',
-          subscriptionName: subscriptionName,
-        ),
-        isFalse,
-      );
-    });
+    test(
+      'ignores noise and notifications that should rely on snapshots instead',
+      () {
+        expect(
+          parseTmuxWindowChangeEventFromControlLine(
+            '%window-renamed @1 🔥 test-emoji',
+            subscriptionName: subscriptionName,
+          ),
+          isNull,
+        );
+        expect(
+          parseTmuxWindowChangeEventFromControlLine(
+            r'%session-window-changed $1 @1',
+            subscriptionName: subscriptionName,
+          ),
+          isNull,
+        );
+        expect(
+          parseTmuxWindowChangeEventFromControlLine(
+            '%begin 1 2 0',
+            subscriptionName: subscriptionName,
+          ),
+          isNull,
+        );
+        expect(
+          parseTmuxWindowChangeEventFromControlLine(
+            '%output %1 hello',
+            subscriptionName: subscriptionName,
+          ),
+          isNull,
+        );
+        expect(
+          parseTmuxWindowChangeEventFromControlLine(
+            '',
+            subscriptionName: subscriptionName,
+          ),
+          isNull,
+        );
+      },
+    );
   });
 
   group('tmux window action helpers', () {

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -154,8 +154,7 @@ void main() {
     test('noop while control-mode notifications are flowing', () {
       expect(
         decideTmuxHeartbeatAction(
-          controlSilence: Duration.zero,
-          timeSinceLastRefresh: Duration.zero,
+          silence: Duration.zero,
           heartbeatInterval: heartbeat,
           maxSilenceBeforeRestart: maxSilence,
         ),
@@ -163,8 +162,7 @@ void main() {
       );
       expect(
         decideTmuxHeartbeatAction(
-          controlSilence: const Duration(milliseconds: 4999),
-          timeSinceLastRefresh: const Duration(milliseconds: 4999),
+          silence: const Duration(milliseconds: 4999),
           heartbeatInterval: heartbeat,
           maxSilenceBeforeRestart: maxSilence,
         ),
@@ -176,8 +174,7 @@ void main() {
         'heartbeat interval', () {
       expect(
         decideTmuxHeartbeatAction(
-          controlSilence: heartbeat,
-          timeSinceLastRefresh: heartbeat,
+          silence: heartbeat,
           heartbeatInterval: heartbeat,
           maxSilenceBeforeRestart: maxSilence,
         ),
@@ -185,20 +182,7 @@ void main() {
       );
       expect(
         decideTmuxHeartbeatAction(
-          controlSilence: const Duration(seconds: 20),
-          timeSinceLastRefresh: const Duration(seconds: 20),
-          heartbeatInterval: heartbeat,
-          maxSilenceBeforeRestart: maxSilence,
-        ),
-        TmuxControlHeartbeatAction.refresh,
-      );
-    });
-
-    test('refreshes even while unrelated control chatter keeps arriving', () {
-      expect(
-        decideTmuxHeartbeatAction(
-          controlSilence: const Duration(milliseconds: 100),
-          timeSinceLastRefresh: heartbeat,
+          silence: const Duration(seconds: 20),
           heartbeatInterval: heartbeat,
           maxSilenceBeforeRestart: maxSilence,
         ),
@@ -210,8 +194,7 @@ void main() {
         'threshold', () {
       expect(
         decideTmuxHeartbeatAction(
-          controlSilence: maxSilence,
-          timeSinceLastRefresh: maxSilence,
+          silence: maxSilence,
           heartbeatInterval: heartbeat,
           maxSilenceBeforeRestart: maxSilence,
         ),
@@ -219,8 +202,7 @@ void main() {
       );
       expect(
         decideTmuxHeartbeatAction(
-          controlSilence: const Duration(minutes: 5),
-          timeSinceLastRefresh: const Duration(minutes: 5),
+          silence: const Duration(minutes: 5),
           heartbeatInterval: heartbeat,
           maxSilenceBeforeRestart: maxSilence,
         ),

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -75,7 +75,21 @@ void main() {
       () {
         expect(
           parseTmuxWindowChangeEventFromControlLine(
+            '%window-add @1',
+            subscriptionName: subscriptionName,
+          ),
+          isA<TmuxWindowReloadEvent>(),
+        );
+        expect(
+          parseTmuxWindowChangeEventFromControlLine(
             '%window-close @1',
+            subscriptionName: subscriptionName,
+          ),
+          isA<TmuxWindowReloadEvent>(),
+        );
+        expect(
+          parseTmuxWindowChangeEventFromControlLine(
+            '%unlinked-window-add @1',
             subscriptionName: subscriptionName,
           ),
           isA<TmuxWindowReloadEvent>(),
@@ -161,6 +175,13 @@ void main() {
         );
         expect(
           shouldScheduleTmuxWindowReloadFallback(
+            '%window-add @1',
+            subscriptionName: subscriptionName,
+          ),
+          isTrue,
+        );
+        expect(
+          shouldScheduleTmuxWindowReloadFallback(
             '%window-renamed @1 renamed-window',
             subscriptionName: subscriptionName,
           ),
@@ -181,6 +202,25 @@ void main() {
         shouldScheduleTmuxWindowReloadFallback(
           '%output %1 hello',
           subscriptionName: subscriptionName,
+        ),
+        isFalse,
+      );
+    });
+
+    test('preserves add and close reloads through later snapshots', () {
+      expect(
+        shouldPreserveTmuxWindowReloadThroughSnapshots('%window-add @1'),
+        isTrue,
+      );
+      expect(
+        shouldPreserveTmuxWindowReloadThroughSnapshots(
+          '%unlinked-window-close @1',
+        ),
+        isTrue,
+      );
+      expect(
+        shouldPreserveTmuxWindowReloadThroughSnapshots(
+          r'%session-window-changed $1 @1',
         ),
         isFalse,
       );

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -62,19 +62,20 @@ void main() {
         ),
         TmuxWindow(
           index: 1,
-          name: 'agent',
+          name: 'copilot',
           isActive: true,
+          currentCommand: 'copilot',
           paneTitle: '✨ Editing main.dart',
         ),
       ];
 
-      expect(resolveTmuxBarActiveWindowTitle(windows), 'agent');
+      expect(resolveTmuxBarActiveWindowTitle(windows), '✨ Editing main.dart');
       expect(
         resolveTmuxBarHandleLabel(
           'workspace',
           activeWindowTitle: resolveTmuxBarActiveWindowTitle(windows),
         ),
-        'workspace · agent',
+        'workspace · ✨ Editing main.dart',
       );
     });
 

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -79,6 +79,56 @@ void main() {
       );
     });
 
+    test('optimistically shows the tapped tmux window as active', () {
+      const windows = <TmuxWindow>[
+        TmuxWindow(index: 0, name: 'shell', isActive: true, paneTitle: 'Shell'),
+        TmuxWindow(
+          index: 1,
+          name: 'copilot',
+          isActive: false,
+          currentCommand: 'copilot',
+          paneTitle: '✨ Editing main.dart',
+        ),
+      ];
+
+      final displayedWindows = resolveTmuxBarDisplayedWindows(
+        windows,
+        pendingSelectedWindowIndex: 1,
+      );
+
+      expect(
+        resolveTmuxBarActiveWindowTitle(displayedWindows),
+        '✨ Editing main.dart',
+      );
+      expect(
+        displayedWindows
+            ?.where((window) => window.isActive)
+            .map((window) => window.index),
+        [1],
+      );
+    });
+
+    test('clears optimistic selection once tmux confirms it', () {
+      const windows = <TmuxWindow>[
+        TmuxWindow(index: 0, name: 'shell', isActive: false),
+        TmuxWindow(
+          index: 1,
+          name: 'copilot',
+          isActive: true,
+          currentCommand: 'copilot',
+          paneTitle: '✨ Editing main.dart',
+        ),
+      ];
+
+      expect(
+        resolveTmuxBarPendingSelectedWindowIndex(
+          windows,
+          pendingSelectedWindowIndex: 1,
+        ),
+        isNull,
+      );
+    });
+
     test('omits duplicate or blank tmux window titles in the handle label', () {
       expect(resolveTmuxBarActiveWindowTitle(const <TmuxWindow>[]), isNull);
       expect(

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -68,13 +68,13 @@ void main() {
         ),
       ];
 
-      expect(resolveTmuxBarActiveWindowTitle(windows), '✨ Editing main.dart');
+      expect(resolveTmuxBarActiveWindowTitle(windows), 'agent');
       expect(
         resolveTmuxBarHandleLabel(
           'workspace',
           activeWindowTitle: resolveTmuxBarActiveWindowTitle(windows),
         ),
-        'workspace · ✨ Editing main.dart',
+        'workspace · agent',
       );
     });
 

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -128,7 +128,7 @@ void main() {
       ).thenAnswer((_) async => const <AgentLaunchTool>{});
       when(
         () => tmuxService.watchWindowChanges(session, tmuxSessionName),
-      ).thenAnswer((_) => const Stream<void>.empty());
+      ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
       when(
         () => tmuxService.listWindows(session, tmuxSessionName),
       ).thenAnswer((_) async => windows);


### PR DESCRIPTION
## Summary

- run tmux control mode over a PTY-backed SSH exec channel so `%subscription-changed` events actually stream in real time on hosts where plain exec channels stay silent
- apply tmux `%subscription-changed` payloads directly to the in-app window lists so title and active-window changes stay synchronized in real time instead of racing a follow-up `tmux list-windows` exec
- keep the collapsed bar on the fast `window_name` path for ordinary windows, but prefer the richer pane title when the tmux window name only mirrors the current command so agent sessions still show a distinguishing title
- apply a short-lived optimistic selected-window state inside the terminal tmux bar so tapping a window updates the active highlight and collapsed handle title immediately while tmux confirms the switch
- fall back to a debounced `tmux list-windows` reload when tmux emits window-change notifications without a usable snapshot, so long-running sessions recover instead of freezing on stale bar state
- keep full `tmux list-windows` reloads as a fallback only for lifecycle changes such as window closes or other events that need a complete resync
- guard async tmux reloads and window-change subscriptions so stale `list-windows` results or superseded watchers cannot overwrite newer snapshot-driven state after a session change or later tmux event
- preserve the silence-based control-mode heartbeat fallback instead of polling, so the watcher stays primarily notification-driven over SSH
- derive `waiting` status locally from the cached `window_activity` timestamp so badges stay current without steady remote refreshes
- add regression coverage for wrapped control-mode lines, direct snapshot parsing/application, the PTY exec path, and the revised fallback behavior
