### PR TITLE
fix: use preferred tmux sessions in connections tab

### DIFF
--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -424,3 +424,18 @@ String? parseTmuxSessionName(String? command) {
 
   return null;
 }
+
+/// Resolves the preferred tmux session name before running remote queries.
+///
+/// Structured host settings win over parsed auto-connect commands because they
+/// are explicit and avoid ambiguous tmux inference when multiple sessions exist.
+String? resolvePreferredTmuxSessionName({
+  String? structuredSessionName,
+  String? autoConnectCommand,
+}) {
+  final structured = structuredSessionName?.trim();
+  if (structured != null && structured.isNotEmpty) {
+    return structured;
+  }
+  return parseTmuxSessionName(autoConnectCommand);
+}

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1555,6 +1555,11 @@ class _ConnectionsPanel extends ConsumerWidget {
                               ? host?.terminalThemeDarkId
                               : null),
                     );
+                    final preferredTmuxSessionName =
+                        resolvePreferredTmuxSessionName(
+                          structuredSessionName: host?.tmuxSessionName,
+                          autoConnectCommand: host?.autoConnectCommand,
+                        );
 
                     return Column(
                       mainAxisSize: MainAxisSize.min,
@@ -1604,6 +1609,7 @@ class _ConnectionsPanel extends ConsumerWidget {
                               'tmux-badge-${connection.connectionId}',
                             ),
                             connectionId: connection.connectionId,
+                            preferredSessionName: preferredTmuxSessionName,
                             onTap: () => unawaited(
                               context.push(
                                 '/terminal/${connection.hostId}'
@@ -2502,10 +2508,12 @@ class _TmuxConnectionBadge extends ConsumerStatefulWidget {
   const _TmuxConnectionBadge({
     required this.connectionId,
     required this.onTap,
+    this.preferredSessionName,
     super.key,
   });
 
   final int connectionId;
+  final String? preferredSessionName;
 
   /// Called when the user taps a window chip — opens the terminal.
   final VoidCallback onTap;
@@ -2533,6 +2541,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   bool _loadingWindows = false;
   bool _pendingWindowReload = false;
   bool _tmuxQueryScheduled = false;
+  int _tmuxQueryGeneration = 0;
 
   @override
   void initState() {
@@ -2544,10 +2553,32 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   @override
   void didUpdateWidget(covariant _TmuxConnectionBadge oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.connectionId != widget.connectionId) {
+    final connectionChanged = oldWidget.connectionId != widget.connectionId;
+    final preferredSessionChanged =
+        oldWidget.preferredSessionName != widget.preferredSessionName;
+    if (connectionChanged) {
       unawaited(_loadPreferredSessionToolName());
     }
+    if (connectionChanged || preferredSessionChanged) {
+      _tmuxQueryGeneration++;
+      _tmuxRetryTimer?.cancel();
+      _tmuxRetryTimer = null;
+      final subscription = _windowChangeSubscription;
+      _windowChangeSubscription = null;
+      unawaited(subscription?.cancel());
+      setState(() {
+        _windows = null;
+        _sessionName = null;
+        _queried = false;
+        _loadingWindows = false;
+        _pendingWindowReload = false;
+      });
+      unawaited(_queryTmux());
+    }
   }
+
+  bool _isCurrentTmuxQuery(int generation) =>
+      mounted && generation == _tmuxQueryGeneration;
 
   @override
   void dispose() {
@@ -2677,6 +2708,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   }
 
   Future<void> _queryTmux({int retries = 3}) async {
+    final queryGeneration = ++_tmuxQueryGeneration;
     final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
     final session = sessionsNotifier.getSession(widget.connectionId);
     if (session == null) {
@@ -2687,14 +2719,27 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     }
 
     final tmux = ref.read(tmuxServiceProvider);
-    final active = await tmux.isTmuxActive(session);
-    if (!mounted || !active) {
+    final preferredSessionName = widget.preferredSessionName?.trim();
+    final active =
+        preferredSessionName != null && preferredSessionName.isNotEmpty
+        ? await tmux.hasSession(session, preferredSessionName)
+        : await tmux.isTmuxActive(session);
+    if (!_isCurrentTmuxQuery(queryGeneration)) {
+      return;
+    }
+    if (!active) {
       await _retryTmuxQuery(retries);
       return;
     }
 
-    final sessionName = await tmux.currentSessionName(session);
-    if (!mounted || sessionName == null) {
+    final sessionName =
+        preferredSessionName != null && preferredSessionName.isNotEmpty
+        ? preferredSessionName
+        : await tmux.currentSessionName(session);
+    if (!_isCurrentTmuxQuery(queryGeneration)) {
+      return;
+    }
+    if (sessionName == null) {
       await _retryTmuxQuery(retries);
       return;
     }
@@ -2703,16 +2748,28 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     _windowChangeSubscription = tmux
         .watchWindowChanges(session, sessionName)
         .listen((_) {
-          if (!mounted) return;
-          _refreshTmuxWindows(session, sessionName);
+          if (!_isCurrentTmuxQuery(queryGeneration)) return;
+          _refreshTmuxWindows(
+            session,
+            sessionName,
+            queryGeneration: queryGeneration,
+          );
         });
-    await _refreshTmuxWindows(session, sessionName);
+    await _refreshTmuxWindows(
+      session,
+      sessionName,
+      queryGeneration: queryGeneration,
+    );
   }
 
   Future<void> _refreshTmuxWindows(
     SshSession session,
-    String sessionName,
-  ) async {
+    String sessionName, {
+    required int queryGeneration,
+  }) async {
+    if (!_isCurrentTmuxQuery(queryGeneration)) {
+      return;
+    }
     if (_loadingWindows) {
       _pendingWindowReload = true;
       return;
@@ -2722,7 +2779,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       final windows = await ref
           .read(tmuxServiceProvider)
           .listWindows(session, sessionName);
-      if (!mounted) return;
+      if (!_isCurrentTmuxQuery(queryGeneration)) {
+        return;
+      }
       if (windows.isEmpty) {
         _scheduleTmuxRetry();
       } else {
@@ -2735,7 +2794,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         _queried = true;
       });
     } on Object {
-      if (!mounted) return;
+      if (!_isCurrentTmuxQuery(queryGeneration)) {
+        return;
+      }
       _scheduleTmuxRetry();
       setState(() {
         _queried = true;
@@ -2744,7 +2805,13 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       _loadingWindows = false;
       if (_pendingWindowReload) {
         _pendingWindowReload = false;
-        unawaited(_refreshTmuxWindows(session, sessionName));
+        unawaited(
+          _refreshTmuxWindows(
+            session,
+            sessionName,
+            queryGeneration: queryGeneration,
+          ),
+        );
       }
     }
   }

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2650,16 +2650,20 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     );
   }
 
-  Future<void> _retryTmuxQuery(int retries) async {
-    if (retries <= 0 || !mounted) {
-      if (mounted) {
-        setState(() => _queried = true);
-        _scheduleTmuxRetry();
-      }
+  Future<void> _retryTmuxQuery(
+    int retries, {
+    required int expectedGeneration,
+  }) async {
+    if (!_isCurrentTmuxQuery(expectedGeneration)) {
+      return;
+    }
+    if (retries <= 0) {
+      setState(() => _queried = true);
+      _scheduleTmuxRetry();
       return;
     }
     await Future<void>.delayed(_tmuxQueryRetryDelay);
-    if (mounted) {
+    if (_isCurrentTmuxQuery(expectedGeneration)) {
       await _queryTmux(retries: retries - 1);
     }
   }
@@ -2714,7 +2718,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     if (session == null) {
       // Session not available yet — retry after a delay so the badge
       // still appears for connections that finish establishing shortly.
-      await _retryTmuxQuery(retries);
+      await _retryTmuxQuery(retries, expectedGeneration: queryGeneration);
       return;
     }
 
@@ -2728,7 +2732,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       return;
     }
     if (!active) {
-      await _retryTmuxQuery(retries);
+      await _retryTmuxQuery(retries, expectedGeneration: queryGeneration);
       return;
     }
 
@@ -2740,7 +2744,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       return;
     }
     if (sessionName == null) {
-      await _retryTmuxQuery(retries);
+      await _retryTmuxQuery(retries, expectedGeneration: queryGeneration);
       return;
     }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -101,13 +101,6 @@ const _tmuxDetectionRetrySchedule = <Duration>[
 List<Duration> resolveTmuxDetectionRetrySchedule({bool skipDelay = false}) =>
     skipDelay ? const <Duration>[Duration.zero] : _tmuxDetectionRetrySchedule;
 
-/// Resolves the tmux session name we can infer before remote verification.
-@visibleForTesting
-String? resolvePreferredTmuxSessionName({
-  String? structuredSessionName,
-  String? autoConnectCommand,
-}) => structuredSessionName ?? parseTmuxSessionName(autoConnectCommand);
-
 /// Resolves the working directory to use when creating a new tmux window.
 @visibleForTesting
 String? resolveTmuxWindowWorkingDirectory({

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -1,5 +1,8 @@
 // ignore_for_file: public_member_api_docs, directives_ordering, avoid_redundant_argument_values
 
+import 'dart:async';
+
+import 'package:dartssh2/dartssh2.dart';
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -10,8 +13,10 @@ import 'package:mocktail/mocktail.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/snippet_repository.dart';
+import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/domain/services/home_screen_shortcut_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
+import 'package:monkeyssh/domain/services/tmux_service.dart';
 import 'package:monkeyssh/domain/services/transfer_intent_service.dart';
 import 'package:monkeyssh/presentation/providers/entity_list_providers.dart';
 import 'package:monkeyssh/presentation/screens/home_screen.dart';
@@ -19,6 +24,10 @@ import 'package:monkeyssh/presentation/screens/home_screen.dart';
 class _MockHostRepository extends Mock implements HostRepository {}
 
 class _MockSnippetRepository extends Mock implements SnippetRepository {}
+
+class _MockSshClient extends Mock implements SSHClient {}
+
+class _MockTmuxService extends Mock implements TmuxService {}
 
 class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
   @override
@@ -37,15 +46,20 @@ class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
 class _MutableActiveSessionsNotifier extends ActiveSessionsNotifier {
   _MutableActiveSessionsNotifier({
     List<ActiveConnection> initialConnections = const <ActiveConnection>[],
+    List<SshSession> initialSessions = const <SshSession>[],
   }) {
     _connections.addEntries(
       initialConnections.map(
         (connection) => MapEntry(connection.connectionId, connection),
       ),
     );
+    _sessions.addEntries(
+      initialSessions.map((session) => MapEntry(session.connectionId, session)),
+    );
   }
 
   final Map<int, ActiveConnection> _connections = <int, ActiveConnection>{};
+  final Map<int, SshSession> _sessions = <int, SshSession>{};
 
   @override
   Map<int, SshConnectionState> build() => {
@@ -67,6 +81,9 @@ class _MutableActiveSessionsNotifier extends ActiveSessionsNotifier {
       _connections[connectionId];
 
   @override
+  SshSession? getSession(int connectionId) => _sessions[connectionId];
+
+  @override
   List<ActiveConnection> getActiveConnections() =>
       _connections.values.toList(growable: false);
 
@@ -82,6 +99,15 @@ class _MutableActiveSessionsNotifier extends ActiveSessionsNotifier {
       for (final connection in connections)
         connection.connectionId: connection.state,
     };
+  }
+
+  void setSessions(List<SshSession> sessions) {
+    _sessions
+      ..clear()
+      ..addEntries(
+        sessions.map((session) => MapEntry(session.connectionId, session)),
+      );
+    state = {...state};
   }
 }
 
@@ -117,6 +143,8 @@ Host _buildHost({
   required int id,
   required String label,
   required int sortOrder,
+  String? autoConnectCommand,
+  String? tmuxSessionName,
 }) => Host(
   id: id,
   label: label,
@@ -137,9 +165,12 @@ Host _buildHost({
   terminalThemeLightId: null,
   terminalThemeDarkId: null,
   terminalFontFamily: null,
-  autoConnectCommand: null,
+  autoConnectCommand: autoConnectCommand,
   autoConnectSnippetId: null,
   autoConnectRequiresConfirmation: false,
+  tmuxSessionName: tmuxSessionName,
+  tmuxWorkingDirectory: null,
+  tmuxExtraFlags: null,
   sortOrder: sortOrder,
 );
 
@@ -475,6 +506,84 @@ void main() {
       ),
       findsOneWidget,
     );
+  });
+
+  testWidgets('updates the tmux badge when host session info loads later', (
+    tester,
+  ) async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final tmuxService = _MockTmuxService();
+    final sshClient = _MockSshClient();
+    final hostsController = StreamController<List<Host>>.broadcast();
+    addTearDown(hostsController.close);
+
+    final session = SshSession(
+      connectionId: 7,
+      hostId: 1,
+      client: sshClient,
+      config: const SshConnectionConfig(
+        hostname: 'alpha.example.com',
+        port: 22,
+        username: 'root',
+      ),
+    );
+    final sessionsNotifier = _MutableActiveSessionsNotifier(
+      initialConnections: [_buildActiveConnection(connectionId: 7, hostId: 1)],
+      initialSessions: [session],
+    );
+
+    when(() => tmuxService.isTmuxActive(session)).thenAnswer((_) async => true);
+    when(
+      () => tmuxService.currentSessionName(session),
+    ).thenAnswer((_) async => 'wrong-session');
+    when(
+      () => tmuxService.hasSession(session, 'correct-session'),
+    ).thenAnswer((_) async => true);
+    when(
+      () => tmuxService.watchWindowChanges(session, any()),
+    ).thenAnswer((_) => const Stream<void>.empty());
+    when(() => tmuxService.listWindows(session, any())).thenAnswer(
+      (_) async => const <TmuxWindow>[
+        TmuxWindow(index: 0, name: 'editor', isActive: true),
+      ],
+    );
+
+    hostsController.add(<Host>[]);
+
+    await tester.pumpWidget(
+      buildMobileHomeScreen(
+        db: db,
+        overrides: [
+          activeSessionsProvider.overrideWith(() => sessionsNotifier),
+          allHostsProvider.overrideWith((ref) => hostsController.stream),
+          tmuxServiceProvider.overrideWithValue(tmuxService),
+        ],
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    await tester.tap(find.text('Connections').first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('wrong-session · 1 windows'), findsOneWidget);
+
+    hostsController.add([
+      _buildHost(
+        id: 1,
+        label: 'Alpha',
+        sortOrder: 0,
+        tmuxSessionName: 'correct-session',
+      ),
+    ]);
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('correct-session · 1 windows'), findsOneWidget);
+    expect(find.text('wrong-session · 1 windows'), findsNothing);
   });
 
   testWidgets('returns to Hosts when the last active connection disappears', (

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -586,6 +586,93 @@ void main() {
     expect(find.text('wrong-session · 1 windows'), findsNothing);
   });
 
+  testWidgets(
+    'ignores stale tmux retries after host session info loads later',
+    (tester) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final tmuxService = _MockTmuxService();
+      final sshClient = _MockSshClient();
+      final hostsController = StreamController<List<Host>>.broadcast();
+      addTearDown(hostsController.close);
+
+      final delayedWindows = Completer<List<TmuxWindow>>();
+      final session = SshSession(
+        connectionId: 7,
+        hostId: 1,
+        client: sshClient,
+        config: const SshConnectionConfig(
+          hostname: 'alpha.example.com',
+          port: 22,
+          username: 'root',
+        ),
+      );
+      final sessionsNotifier = _MutableActiveSessionsNotifier(
+        initialConnections: [
+          _buildActiveConnection(connectionId: 7, hostId: 1),
+        ],
+        initialSessions: [session],
+      );
+
+      when(
+        () => tmuxService.isTmuxActive(session),
+      ).thenAnswer((_) async => true);
+      when(
+        () => tmuxService.currentSessionName(session),
+      ).thenAnswer((_) async => null);
+      when(
+        () => tmuxService.hasSession(session, 'correct-session'),
+      ).thenAnswer((_) async => true);
+      when(
+        () => tmuxService.watchWindowChanges(session, any()),
+      ).thenAnswer((_) => const Stream<void>.empty());
+      when(
+        () => tmuxService.listWindows(session, 'correct-session'),
+      ).thenAnswer((_) => delayedWindows.future);
+
+      hostsController.add(<Host>[]);
+
+      await tester.pumpWidget(
+        buildMobileHomeScreen(
+          db: db,
+          overrides: [
+            activeSessionsProvider.overrideWith(() => sessionsNotifier),
+            allHostsProvider.overrideWith((ref) => hostsController.stream),
+            tmuxServiceProvider.overrideWithValue(tmuxService),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.tap(find.text('Connections').first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      hostsController.add([
+        _buildHost(
+          id: 1,
+          label: 'Alpha',
+          sortOrder: 0,
+          tmuxSessionName: 'correct-session',
+        ),
+      ]);
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.pump(const Duration(seconds: 2));
+
+      delayedWindows.complete(const <TmuxWindow>[
+        TmuxWindow(index: 0, name: 'editor', isActive: true),
+      ]);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('correct-session · 1 windows'), findsOneWidget);
+    },
+  );
+
   testWidgets('returns to Hosts when the last active connection disappears', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

- resolve the connections-tab tmux badge from the host's preferred tmux session before falling back to remote inference
- reset and rerun badge queries when host metadata arrives later so stale tmux lookups do not stick
- add a widget regression test covering the async host-load case
