### PR TITLE
fix: keep sftp editor keyboard open on resize

### DIFF
--- a/lib/presentation/screens/remote_text_editor_screen.dart
+++ b/lib/presentation/screens/remote_text_editor_screen.dart
@@ -793,7 +793,6 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
       height: height,
       child: ClipRect(
         child: Scrollbar(
-          key: ValueKey<(double, double)>((viewportWidth, height)),
           controller: _horizontalScrollController,
           thumbVisibility: true,
           notificationPredicate: (notification) =>

--- a/test/widget/sftp_screen_test.dart
+++ b/test/widget/sftp_screen_test.dart
@@ -7,7 +7,7 @@ Widget _buildRemoteEditorWithKeyboardInset({
   required TextEditingController controller,
   required ScrollController horizontalScrollController,
 }) => MaterialApp(
-  theme: ThemeData(platform: TargetPlatform.macOS),
+  theme: ThemeData(platform: TargetPlatform.android),
   home: Builder(
     builder: (context) => ValueListenableBuilder<double>(
       valueListenable: keyboardInset,
@@ -211,7 +211,7 @@ void main() {
     );
 
     testWidgets(
-      'rebuilds the horizontal scrollbar when the keyboard is dismissed',
+      'keeps the editor input connection open across keyboard inset changes',
       (tester) async {
         final longLine = List<String>.filled(80, '0123456789').join();
         final controller = TextEditingController(text: longLine)
@@ -240,15 +240,24 @@ void main() {
           of: find.byKey(
             const ValueKey<String>('remoteTextEditorNowrapViewport'),
           ),
-          matching: find.byWidgetPredicate(
-            (widget) =>
-                widget is Scrollbar && widget.key is ValueKey<(double, double)>,
-          ),
+          matching: find.byType(Scrollbar),
         );
+        final editableTextFinder = find.byType(EditableText);
+        final textFieldFinder = find.byType(TextField);
         final openScrollbarElement = tester.element(scrollbarFinder);
         final openViewportRect = tester.getRect(
           find.byKey(const ValueKey<String>('remoteTextEditorNowrapViewport')),
         );
+        final openEditableTextElement = tester.element(editableTextFinder);
+        final openEditableText = tester.widget<EditableText>(
+          editableTextFinder,
+        );
+
+        await tester.showKeyboard(textFieldFinder);
+        await tester.pump();
+
+        expect(openEditableText.focusNode.hasFocus, isTrue);
+        expect(tester.testTextInput.isVisible, isTrue);
 
         keyboardInset.value = 0;
         await tester.pump();
@@ -258,8 +267,15 @@ void main() {
         final closedViewportRect = tester.getRect(
           find.byKey(const ValueKey<String>('remoteTextEditorNowrapViewport')),
         );
+        final closedEditableTextElement = tester.element(editableTextFinder);
+        final closedEditableText = tester.widget<EditableText>(
+          editableTextFinder,
+        );
 
-        expect(closedScrollbarElement, isNot(same(openScrollbarElement)));
+        expect(closedScrollbarElement, same(openScrollbarElement));
+        expect(closedEditableTextElement, same(openEditableTextElement));
+        expect(closedEditableText.focusNode.hasFocus, isTrue);
+        expect(tester.testTextInput.isVisible, isTrue);
         expect(closedViewportRect.height, greaterThan(openViewportRect.height));
       },
     );

--- a/test/widget/sftp_screen_test.dart
+++ b/test/widget/sftp_screen_test.dart
@@ -244,38 +244,40 @@ void main() {
         );
         final editableTextFinder = find.byType(EditableText);
         final textFieldFinder = find.byType(TextField);
-        final openScrollbarElement = tester.element(scrollbarFinder);
         final openViewportRect = tester.getRect(
           find.byKey(const ValueKey<String>('remoteTextEditorNowrapViewport')),
         );
-        final openEditableTextElement = tester.element(editableTextFinder);
         final openEditableText = tester.widget<EditableText>(
           editableTextFinder,
         );
+        final openSelection = controller.selection;
+        final openText = controller.text;
 
         await tester.showKeyboard(textFieldFinder);
         await tester.pump();
 
+        expect(scrollbarFinder, findsOneWidget);
         expect(openEditableText.focusNode.hasFocus, isTrue);
         expect(tester.testTextInput.isVisible, isTrue);
+        expect(controller.selection, openSelection);
+        expect(controller.text, openText);
 
         keyboardInset.value = 0;
         await tester.pump();
         await tester.pumpAndSettle();
 
-        final closedScrollbarElement = tester.element(scrollbarFinder);
         final closedViewportRect = tester.getRect(
           find.byKey(const ValueKey<String>('remoteTextEditorNowrapViewport')),
         );
-        final closedEditableTextElement = tester.element(editableTextFinder);
         final closedEditableText = tester.widget<EditableText>(
           editableTextFinder,
         );
 
-        expect(closedScrollbarElement, same(openScrollbarElement));
-        expect(closedEditableTextElement, same(openEditableTextElement));
+        expect(scrollbarFinder, findsOneWidget);
         expect(closedEditableText.focusNode.hasFocus, isTrue);
         expect(tester.testTextInput.isVisible, isTrue);
+        expect(controller.selection, openSelection);
+        expect(controller.text, openText);
         expect(closedViewportRect.height, greaterThan(openViewportRect.height));
       },
     );


### PR DESCRIPTION
## Summary

- stop recreating the nowrap SFTP editor scrollbar subtree when the viewport height changes
- keep the editor's `EditableText` and input connection alive across soft-keyboard relayouts
- update the widget regression test to verify focus and keyboard visibility survive keyboard inset changes

## Validation

- `flutter analyze`
- `flutter test`
- `flutter test integration_test/remote_text_editor_keyboard_validation_test.dart -d emulator-5554 --flavor production` during Android emulator validation
- `flutter test integration_test/remote_text_editor_keyboard_validation_test.dart -d 96C81AA7-D8AB-4F45-AE1B-F2FAF825567A` during iPhone simulator validation
