### PR TITLE
fix: self-heal tmux window reloads

### DIFF
--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -362,6 +362,29 @@ List<TmuxWindow> applyTmuxWindowChangeEvent(
   }
 }
 
+/// Resolves the tmux window list after a full reload query.
+///
+/// A live tmux session should always report at least one window. Treat an
+/// empty reload as transient: preserve the prior non-empty snapshot when
+/// possible so the UI does not collapse into a broken-looking empty state
+/// while a follow-up refresh retries in the background.
+List<TmuxWindow>? resolveTmuxReloadedWindows(
+  Iterable<TmuxWindow>? currentWindows,
+  Iterable<TmuxWindow> reloadedWindows,
+) {
+  final nextWindows = reloadedWindows.toList(growable: false);
+  if (nextWindows.isNotEmpty) {
+    return nextWindows;
+  }
+
+  final previousWindows = currentWindows?.toList(growable: false);
+  if (previousWindows != null && previousWindows.isNotEmpty) {
+    return previousWindows;
+  }
+
+  return null;
+}
+
 /// Metadata for a recent AI coding tool session found on a remote host.
 @immutable
 class ToolSessionInfo {

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -385,6 +385,43 @@ List<TmuxWindow>? resolveTmuxReloadedWindows(
   return null;
 }
 
+/// Returns whether a transient empty tmux reload should keep showing the last
+/// known non-empty window snapshot.
+bool shouldPreserveTmuxWindowSnapshotOnEmptyReload(
+  Iterable<TmuxWindow>? currentWindows, {
+  required int consecutiveEmptyReloads,
+  int maxConsecutiveEmptyReloads = 3,
+}) {
+  if (consecutiveEmptyReloads > maxConsecutiveEmptyReloads) {
+    return false;
+  }
+  return currentWindows?.any((_) => true) ?? false;
+}
+
+/// Resolves the retry delay for tmux window reload recovery.
+///
+/// Uses exponential backoff so dead sessions do not get polled aggressively
+/// forever while still continuing to self-heal if tmux comes back later.
+Duration resolveTmuxWindowReloadRetryDelay(
+  int retryAttempt, {
+  Duration initialDelay = const Duration(seconds: 2),
+  Duration maxDelay = const Duration(seconds: 30),
+}) {
+  if (retryAttempt <= 0) {
+    return initialDelay;
+  }
+
+  var delay = initialDelay;
+  for (var attempt = 0; attempt < retryAttempt; attempt++) {
+    final doubledDelay = Duration(milliseconds: delay.inMilliseconds * 2);
+    if (doubledDelay >= maxDelay) {
+      return maxDelay;
+    }
+    delay = doubledDelay;
+  }
+  return delay;
+}
+
 /// Metadata for a recent AI coding tool session found on a remote host.
 @immutable
 class ToolSessionInfo {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -404,6 +404,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   static const _groupTilePadding = EdgeInsets.only(left: 52, right: 12);
   static const _prefetchSessionFetchLimit = 6;
   static const _pendingSelectionTimeout = Duration(seconds: 2);
+  static const _windowRetryDelay = Duration(seconds: 2);
 
   List<TmuxWindow>? _windows;
   AgentLaunchTool? _preferredLaunchTool;
@@ -422,6 +423,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   int _windowEventGeneration = 0;
   int? _pendingSelectedWindowIndex;
   Timer? _pendingSelectionTimer;
+  Timer? _windowRetryTimer;
 
   TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
 
@@ -462,6 +464,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       return;
     }
     _clearPendingSelectedWindow(notify: false);
+    _cancelWindowRetry();
     setState(() {
       _windows = null;
       _isLoading = true;
@@ -475,6 +478,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   @override
   void dispose() {
     _clearPendingSelectedWindow(notify: false);
+    _cancelWindowRetry();
     unawaited(_windowChangeSubscription?.cancel());
     for (final windowIndex in _seenAlertWindows) {
       _clearAlertNotification(windowIndex);
@@ -519,6 +523,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     }
     _windowReloadGeneration += 1;
     final windows = applyTmuxWindowChangeEvent(currentWindows, event);
+    _cancelWindowRetry();
     _applyWindows(windows);
     if (widget.isProUser) {
       unawaited(_prefetchPreferredSessionProvider(windows: windows));
@@ -598,6 +603,23 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     setState(() => _pendingSelectedWindowIndex = null);
   }
 
+  void _cancelWindowRetry() {
+    _windowRetryTimer?.cancel();
+    _windowRetryTimer = null;
+  }
+
+  void _scheduleWindowRetry() {
+    if (!mounted || (_windowRetryTimer?.isActive ?? false)) {
+      return;
+    }
+    _windowRetryTimer = Timer(_windowRetryDelay, () {
+      _windowRetryTimer = null;
+      if (mounted) {
+        unawaited(_loadWindows());
+      }
+    });
+  }
+
   String? _resolveRecentSessionScopeWorkingDirectory([
     List<TmuxWindow>? windows,
   ]) {
@@ -633,19 +655,39 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     _loadingWindows = true;
     final reloadGeneration = ++_windowReloadGeneration;
     try {
-      final windows = await _tmux.listWindows(
+      final reloadedWindows = await _tmux.listWindows(
         widget.session,
         widget.tmuxSessionName,
       );
       if (!mounted) return;
       if (reloadGeneration < _windowReloadGeneration) return;
+      final windows = resolveTmuxReloadedWindows(_windows, reloadedWindows);
+      if (windows == null) {
+        _scheduleWindowRetry();
+        if (_isLoading) {
+          setState(() => _isLoading = true);
+        }
+        return;
+      }
+      if (reloadedWindows.isEmpty) {
+        _scheduleWindowRetry();
+      } else {
+        _cancelWindowRetry();
+      }
       _applyWindows(windows);
       if (widget.isProUser) {
         unawaited(_prefetchPreferredSessionProvider(windows: windows));
       }
     } on Object {
       if (!mounted) return;
-      if (_isLoading) setState(() => _isLoading = false);
+      _scheduleWindowRetry();
+      if (_windows?.isNotEmpty ?? false) {
+        if (_isLoading) {
+          setState(() => _isLoading = false);
+        }
+      } else {
+        setState(() => _isLoading = true);
+      }
     } finally {
       _loadingWindows = false;
       if (_pendingWindowReload) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -404,7 +404,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   static const _groupTilePadding = EdgeInsets.only(left: 52, right: 12);
   static const _prefetchSessionFetchLimit = 6;
   static const _pendingSelectionTimeout = Duration(seconds: 2);
-  static const _windowRetryDelay = Duration(seconds: 2);
 
   List<TmuxWindow>? _windows;
   AgentLaunchTool? _preferredLaunchTool;
@@ -424,6 +423,8 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   int? _pendingSelectedWindowIndex;
   Timer? _pendingSelectionTimer;
   Timer? _windowRetryTimer;
+  int _windowRetryAttempts = 0;
+  int _consecutiveEmptyWindowReloads = 0;
 
   TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
 
@@ -464,7 +465,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       return;
     }
     _clearPendingSelectedWindow(notify: false);
-    _cancelWindowRetry();
+    _resetWindowReloadRecovery();
     setState(() {
       _windows = null;
       _isLoading = true;
@@ -478,7 +479,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   @override
   void dispose() {
     _clearPendingSelectedWindow(notify: false);
-    _cancelWindowRetry();
+    _resetWindowReloadRecovery();
     unawaited(_windowChangeSubscription?.cancel());
     for (final windowIndex in _seenAlertWindows) {
       _clearAlertNotification(windowIndex);
@@ -522,8 +523,8 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       return;
     }
     _windowReloadGeneration += 1;
+    _resetWindowReloadRecovery();
     final windows = applyTmuxWindowChangeEvent(currentWindows, event);
-    _cancelWindowRetry();
     _applyWindows(windows);
     if (widget.isProUser) {
       unawaited(_prefetchPreferredSessionProvider(windows: windows));
@@ -608,11 +609,19 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     _windowRetryTimer = null;
   }
 
+  void _resetWindowReloadRecovery() {
+    _cancelWindowRetry();
+    _windowRetryAttempts = 0;
+    _consecutiveEmptyWindowReloads = 0;
+  }
+
   void _scheduleWindowRetry() {
     if (!mounted || (_windowRetryTimer?.isActive ?? false)) {
       return;
     }
-    _windowRetryTimer = Timer(_windowRetryDelay, () {
+    final delay = resolveTmuxWindowReloadRetryDelay(_windowRetryAttempts);
+    _windowRetryAttempts += 1;
+    _windowRetryTimer = Timer(delay, () {
       _windowRetryTimer = null;
       if (mounted) {
         unawaited(_loadWindows());
@@ -661,18 +670,35 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       );
       if (!mounted) return;
       if (reloadGeneration < _windowReloadGeneration) return;
-      final windows = resolveTmuxReloadedWindows(_windows, reloadedWindows);
+      final isEmptyReload = reloadedWindows.isEmpty;
+      if (isEmptyReload) {
+        _consecutiveEmptyWindowReloads += 1;
+      } else {
+        _resetWindowReloadRecovery();
+      }
+      final windows = resolveTmuxReloadedWindows(
+        shouldPreserveTmuxWindowSnapshotOnEmptyReload(
+              _windows,
+              consecutiveEmptyReloads: _consecutiveEmptyWindowReloads,
+            )
+            ? _windows
+            : null,
+        reloadedWindows,
+      );
       if (windows == null) {
         _scheduleWindowRetry();
-        if (_isLoading) {
-          setState(() => _isLoading = true);
+        if (_windows != null || !_isLoading) {
+          setState(() {
+            _windows = null;
+            _isLoading = true;
+          });
         }
         return;
       }
-      if (reloadedWindows.isEmpty) {
+      if (isEmptyReload) {
         _scheduleWindowRetry();
       } else {
-        _cancelWindowRetry();
+        _resetWindowReloadRecovery();
       }
       _applyWindows(windows);
       if (widget.isProUser) {

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -141,6 +141,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   /// Maximum number of recent sessions to show per tool.
   static const _maxSessionsPerTool = 16;
   static const _prefetchSessionFetchLimit = 6;
+  static const _windowRetryDelay = Duration(seconds: 2);
 
   List<TmuxWindow>? _windows;
   AgentLaunchTool? _preferredLaunchTool;
@@ -152,6 +153,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   bool _pendingWindowReload = false;
   int _windowReloadGeneration = 0;
   int _windowEventGeneration = 0;
+  Timer? _windowRetryTimer;
 
   TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
 
@@ -177,6 +179,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
   @override
   void dispose() {
+    _cancelWindowRetry();
     unawaited(_windowChangeSubscription?.cancel());
     super.dispose();
   }
@@ -232,21 +235,38 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     _loadingWindows = true;
     final reloadGeneration = ++_windowReloadGeneration;
     try {
-      final windows = await _tmux.listWindows(
+      final reloadedWindows = await _tmux.listWindows(
         widget.session,
         widget.tmuxSessionName,
       );
       if (!mounted) return;
       if (reloadGeneration < _windowReloadGeneration) return;
+      final windows = resolveTmuxReloadedWindows(_windows, reloadedWindows);
+      if (windows == null) {
+        _scheduleWindowRetry();
+        setState(() {
+          _windows = null;
+          _error = null;
+          _isLoadingWindows = true;
+        });
+        return;
+      }
+      if (reloadedWindows.isEmpty) {
+        _scheduleWindowRetry();
+      } else {
+        _cancelWindowRetry();
+      }
       setState(() {
         _windows = windows;
+        _error = null;
         _isLoadingWindows = false;
       });
       unawaited(_prefetchPreferredSessionProvider(windows: windows));
     } on Exception catch (e) {
       if (!mounted) return;
+      _scheduleWindowRetry();
       setState(() {
-        _error = e.toString();
+        _error = _windows?.isEmpty ?? true ? e.toString() : null;
         _isLoadingWindows = false;
       });
     } finally {
@@ -271,9 +291,28 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       return;
     }
     _windowReloadGeneration += 1;
+    _cancelWindowRetry();
     setState(() {
       _windows = applyTmuxWindowChangeEvent(currentWindows, event);
+      _error = null;
       _isLoadingWindows = false;
+    });
+  }
+
+  void _cancelWindowRetry() {
+    _windowRetryTimer?.cancel();
+    _windowRetryTimer = null;
+  }
+
+  void _scheduleWindowRetry() {
+    if (!mounted || (_windowRetryTimer?.isActive ?? false)) {
+      return;
+    }
+    _windowRetryTimer = Timer(_windowRetryDelay, () {
+      _windowRetryTimer = null;
+      if (mounted) {
+        unawaited(_loadWindows());
+      }
     });
   }
 

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -141,7 +141,6 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   /// Maximum number of recent sessions to show per tool.
   static const _maxSessionsPerTool = 16;
   static const _prefetchSessionFetchLimit = 6;
-  static const _windowRetryDelay = Duration(seconds: 2);
 
   List<TmuxWindow>? _windows;
   AgentLaunchTool? _preferredLaunchTool;
@@ -154,6 +153,8 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   int _windowReloadGeneration = 0;
   int _windowEventGeneration = 0;
   Timer? _windowRetryTimer;
+  int _windowRetryAttempts = 0;
+  int _consecutiveEmptyWindowReloads = 0;
 
   TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
 
@@ -173,13 +174,14 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   void didUpdateWidget(covariant _TmuxNavigatorSheet oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.session.hostId != widget.session.hostId) {
+      _resetWindowReloadRecovery();
       unawaited(_loadPreferredLaunchTool());
     }
   }
 
   @override
   void dispose() {
-    _cancelWindowRetry();
+    _resetWindowReloadRecovery();
     unawaited(_windowChangeSubscription?.cancel());
     super.dispose();
   }
@@ -241,7 +243,21 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       );
       if (!mounted) return;
       if (reloadGeneration < _windowReloadGeneration) return;
-      final windows = resolveTmuxReloadedWindows(_windows, reloadedWindows);
+      final isEmptyReload = reloadedWindows.isEmpty;
+      if (isEmptyReload) {
+        _consecutiveEmptyWindowReloads += 1;
+      } else {
+        _resetWindowReloadRecovery();
+      }
+      final windows = resolveTmuxReloadedWindows(
+        shouldPreserveTmuxWindowSnapshotOnEmptyReload(
+              _windows,
+              consecutiveEmptyReloads: _consecutiveEmptyWindowReloads,
+            )
+            ? _windows
+            : null,
+        reloadedWindows,
+      );
       if (windows == null) {
         _scheduleWindowRetry();
         setState(() {
@@ -251,10 +267,10 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         });
         return;
       }
-      if (reloadedWindows.isEmpty) {
+      if (isEmptyReload) {
         _scheduleWindowRetry();
       } else {
-        _cancelWindowRetry();
+        _resetWindowReloadRecovery();
       }
       setState(() {
         _windows = windows;
@@ -291,7 +307,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       return;
     }
     _windowReloadGeneration += 1;
-    _cancelWindowRetry();
+    _resetWindowReloadRecovery();
     setState(() {
       _windows = applyTmuxWindowChangeEvent(currentWindows, event);
       _error = null;
@@ -304,11 +320,19 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     _windowRetryTimer = null;
   }
 
+  void _resetWindowReloadRecovery() {
+    _cancelWindowRetry();
+    _windowRetryAttempts = 0;
+    _consecutiveEmptyWindowReloads = 0;
+  }
+
   void _scheduleWindowRetry() {
     if (!mounted || (_windowRetryTimer?.isActive ?? false)) {
       return;
     }
-    _windowRetryTimer = Timer(_windowRetryDelay, () {
+    final delay = resolveTmuxWindowReloadRetryDelay(_windowRetryAttempts);
+    _windowRetryAttempts += 1;
+    _windowRetryTimer = Timer(delay, () {
       _windowRetryTimer = null;
       if (mounted) {
         unawaited(_loadWindows());

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -304,6 +304,26 @@ void main() {
     });
   });
 
+  group('resolveTmuxReloadedWindows', () {
+    test('preserves the prior non-empty window snapshot on empty reloads', () {
+      const currentWindows = <TmuxWindow>[
+        TmuxWindow(index: 0, name: 'shell', isActive: true),
+      ];
+
+      expect(resolveTmuxReloadedWindows(currentWindows, const <TmuxWindow>[]), [
+        const TmuxWindow(index: 0, name: 'shell', isActive: true),
+      ]);
+    });
+
+    test('keeps loading when no tmux windows have loaded yet', () {
+      expect(resolveTmuxReloadedWindows(null, const <TmuxWindow>[]), isNull);
+      expect(
+        resolveTmuxReloadedWindows(const <TmuxWindow>[], const <TmuxWindow>[]),
+        isNull,
+      );
+    });
+  });
+
   group('ToolSessionInfo', () {
     test('constructs with all fields', () {
       final info = ToolSessionInfo(

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -324,6 +324,64 @@ void main() {
     });
   });
 
+  group('shouldPreserveTmuxWindowSnapshotOnEmptyReload', () {
+    test('preserves non-empty snapshots only up to the retry limit', () {
+      const currentWindows = <TmuxWindow>[
+        TmuxWindow(index: 0, name: 'shell', isActive: true),
+      ];
+
+      expect(
+        shouldPreserveTmuxWindowSnapshotOnEmptyReload(
+          currentWindows,
+          consecutiveEmptyReloads: 1,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldPreserveTmuxWindowSnapshotOnEmptyReload(
+          currentWindows,
+          consecutiveEmptyReloads: 3,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldPreserveTmuxWindowSnapshotOnEmptyReload(
+          currentWindows,
+          consecutiveEmptyReloads: 4,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not preserve empty or missing snapshots', () {
+      expect(
+        shouldPreserveTmuxWindowSnapshotOnEmptyReload(
+          null,
+          consecutiveEmptyReloads: 1,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldPreserveTmuxWindowSnapshotOnEmptyReload(
+          const <TmuxWindow>[],
+          consecutiveEmptyReloads: 1,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('resolveTmuxWindowReloadRetryDelay', () {
+    test('uses exponential backoff with a cap', () {
+      expect(resolveTmuxWindowReloadRetryDelay(0), const Duration(seconds: 2));
+      expect(resolveTmuxWindowReloadRetryDelay(1), const Duration(seconds: 4));
+      expect(resolveTmuxWindowReloadRetryDelay(2), const Duration(seconds: 8));
+      expect(resolveTmuxWindowReloadRetryDelay(3), const Duration(seconds: 16));
+      expect(resolveTmuxWindowReloadRetryDelay(4), const Duration(seconds: 30));
+      expect(resolveTmuxWindowReloadRetryDelay(6), const Duration(seconds: 30));
+    });
+  });
+
   group('ToolSessionInfo', () {
     test('constructs with all fields', () {
       final info = ToolSessionInfo(

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -186,7 +186,121 @@ void main() {
       expect(find.byIcon(Icons.expand_more), findsNothing);
       expect(find.byIcon(Icons.expand_less), findsNothing);
     });
+
+    testWidgets('recovers from a transient empty window reload', (
+      tester,
+    ) async {
+      final tmuxService = _MockTmuxService();
+      final presetService = _MockAgentLaunchPresetService();
+      final discoveryService = _MockAgentSessionDiscoveryService();
+      final session = SshSession(
+        connectionId: 1,
+        hostId: 1,
+        client: _MockSshClient(),
+        config: const SshConnectionConfig(
+          hostname: 'example.com',
+          port: 22,
+          username: 'demo',
+        ),
+      );
+      const tmuxSessionName = 'main';
+      var listWindowsCallCount = 0;
+
+      when(
+        () => presetService.getPresetForHost(session.hostId),
+      ).thenAnswer((_) async => null);
+      when(
+        () => tmuxService.detectInstalledAgentTools(session),
+      ).thenAnswer((_) async => const <AgentLaunchTool>{});
+      when(
+        () => tmuxService.watchWindowChanges(session, tmuxSessionName),
+      ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+      when(() => tmuxService.listWindows(session, tmuxSessionName)).thenAnswer((
+        _,
+      ) {
+        if (listWindowsCallCount++ == 0) {
+          return Future<List<TmuxWindow>>.value(const <TmuxWindow>[]);
+        }
+        return Future<List<TmuxWindow>>.value(windows);
+      });
+      when(
+        () => discoveryService.discoverSessionsStream(
+          session,
+          workingDirectory: any(named: 'workingDirectory'),
+          maxPerTool: any(named: 'maxPerTool'),
+          toolName: any(named: 'toolName'),
+        ),
+      ).thenAnswer(
+        (_) => Stream<DiscoveredSessionsResult>.value(
+          DiscoveredSessionsResult(sessions: const <ToolSessionInfo>[]),
+        ),
+      );
+
+      await _pumpNavigatorHost(
+        tester,
+        tmuxService: tmuxService,
+        presetService: presetService,
+        discoveryService: discoveryService,
+        session: session,
+        tmuxSessionName: tmuxSessionName,
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+
+      expect(find.text('✨ Editing main.dart'), findsNothing);
+
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+
+      expect(find.text('✨ Editing main.dart'), findsOneWidget);
+    });
   });
+}
+
+Future<void> _pumpNavigatorHost(
+  WidgetTester tester, {
+  required TmuxService tmuxService,
+  required AgentLaunchPresetService presetService,
+  required AgentSessionDiscoveryService discoveryService,
+  required SshSession session,
+  required String tmuxSessionName,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tmuxServiceProvider.overrideWithValue(tmuxService),
+        agentLaunchPresetServiceProvider.overrideWithValue(presetService),
+        agentSessionDiscoveryServiceProvider.overrideWithValue(
+          discoveryService,
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Consumer(
+            builder: (context, ref, _) => TextButton(
+              onPressed: () {
+                unawaited(
+                  showTmuxNavigator(
+                    context: context,
+                    ref: ref,
+                    session: session,
+                    tmuxSessionName: tmuxSessionName,
+                    isProUser: true,
+                    startClisInYoloMode: false,
+                  ),
+                );
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  await tester.pump();
+  await tester.pump();
 }
 
 class _MockTmuxService extends Mock implements TmuxService {}


### PR DESCRIPTION
## Summary

- preserve the last non-empty tmux window snapshot when a reload transiently comes back empty
- add short self-healing retry timers to the terminal tmux bar and the tmux navigator sheet
- add focused regression coverage for empty tmux reload recovery

## Validation

- `flutter analyze`
- `flutter test`
