### PR TITLE
fix: restore security setup in settings

### DIFF
--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
@@ -9,13 +9,13 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.OpenableColumns
 import androidx.core.content.ContextCompat
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 import java.io.ByteArrayOutputStream
 import java.util.Locale
 
-class MainActivity : FlutterActivity() {
+class MainActivity : FlutterFragmentActivity() {
     companion object {
         private const val NOTIFICATION_PERMISSION_REQUEST_CODE = 1001
         private const val MAX_CLIPBOARD_CONTENT_URI_BYTES = 512 * 1024

--- a/integration_test/security_biometric_device_test.dart
+++ b/integration_test/security_biometric_device_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:monkeyssh/main.dart' as app;
+
+Future<void> _pumpUntilFound(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 30),
+  Duration step = const Duration(milliseconds: 250),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(step);
+    if (finder.evaluate().isNotEmpty) {
+      return;
+    }
+  }
+  fail('Timed out waiting for ${finder.describeMatch(Plurality.many)}');
+}
+
+Future<void> _launchApp(WidgetTester tester) async {
+  app.main();
+  await _pumpUntilFound(tester, find.byIcon(Icons.settings_outlined));
+}
+
+Future<void> _waitForUnlockedApp(WidgetTester tester) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  final biometricButton = find.widgetWithText(TextButton, 'Use biometrics');
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 500));
+    if (find.text('Change PIN').evaluate().isNotEmpty) {
+      return;
+    }
+    if (find.byIcon(Icons.settings_outlined).evaluate().isNotEmpty &&
+        find.text('Settings').evaluate().isEmpty) {
+      return;
+    }
+    if (biometricButton.evaluate().isNotEmpty) {
+      await tester.tap(biometricButton, warnIfMissed: false);
+      await tester.pump();
+    }
+  }
+  fail('Timed out waiting for biometric unlock to return to the home screen');
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('security setup enables biometric unlock end to end', (
+    tester,
+  ) async {
+    await _launchApp(tester);
+
+    await tester.tap(find.byIcon(Icons.settings_outlined));
+    await tester.pumpAndSettle();
+    await _pumpUntilFound(tester, find.text('Set up app lock'));
+
+    await tester.tap(find.text('Set up app lock'));
+    await tester.pumpAndSettle();
+    await _pumpUntilFound(tester, find.text('Security Setup'));
+
+    await tester.tap(find.text('PIN Code'));
+    await tester.pumpAndSettle();
+    await _pumpUntilFound(tester, find.text('Create PIN'));
+
+    await tester.enterText(find.byType(TextField).first, '1234');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Next'));
+    await tester.pumpAndSettle();
+    await _pumpUntilFound(tester, find.text('Confirm PIN'));
+
+    await tester.enterText(find.byType(TextField).first, '1234');
+    await tester.pump();
+    await _pumpUntilFound(tester, find.text('Enable biometrics'));
+    await tester.tap(find.text('Enable biometrics'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Complete'));
+    await tester.pump();
+
+    await _waitForUnlockedApp(tester);
+
+    if (find.text('Change PIN').evaluate().isEmpty) {
+      await tester.tap(find.byIcon(Icons.settings_outlined));
+      await tester.pumpAndSettle();
+    }
+    await _pumpUntilFound(tester, find.text('Change PIN'));
+
+    expect(find.text('Change PIN'), findsOneWidget);
+    expect(find.text('Biometric authentication'), findsOneWidget);
+  });
+}

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -591,7 +591,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MonkeySSH.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/MonkeySSH";
 			};
 			name = "Debug-Production";
 		};
@@ -616,7 +616,6 @@
 				VERSIONING_SYSTEM = "apple-generic";
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.depollsoft.monkeyssh.private.ConnectionStatusLiveActivity;
 				PRODUCT_NAME = ConnectionStatusLiveActivityExtension;
-				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -751,8 +750,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -805,7 +802,6 @@
 				VERSIONING_SYSTEM = "apple-generic";
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.depollsoft.monkeyssh.ConnectionStatusLiveActivity;
 				PRODUCT_NAME = ConnectionStatusLiveActivityExtension;
-				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -826,7 +822,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MonkeySSH.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/MonkeySSH";
 			};
 			name = Debug;
 		};
@@ -842,7 +838,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.depollsoft.monkeyssh.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MonkeySSH.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/MonkeySSH";
 			};
 			name = Release;
 		};
@@ -1238,7 +1234,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1288,8 +1283,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1455,7 +1448,6 @@
 				VERSIONING_SYSTEM = "apple-generic";
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.depollsoft.monkeyssh.ConnectionStatusLiveActivity;
 				PRODUCT_NAME = ConnectionStatusLiveActivityExtension;
-				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Production.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Production.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "97C146ED1CF9000F007C117D"
-               BuildableName = "Runner.app"
+               BuildableName = "MonkeySSH.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -32,7 +32,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "97C146ED1CF9000F007C117D"
-            BuildableName = "Runner.app"
+            BuildableName = "MonkeySSH.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -68,7 +68,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "97C146ED1CF9000F007C117D"
-            BuildableName = "Runner.app"
+            BuildableName = "MonkeySSH.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -85,7 +85,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "97C146ED1CF9000F007C117D"
-            BuildableName = "Runner.app"
+            BuildableName = "MonkeySSH.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -53,6 +53,8 @@
 	<string>$(PRODUCT_NAME) needs photo library access to select files for transfer.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>$(PRODUCT_NAME) needs camera access to scan sync recovery key QR codes.</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>$(PRODUCT_NAME) uses Face ID to unlock your encrypted SSH credentials.</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -50,7 +50,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       ),
       GoRoute(
         path: '/auth-setup',
-        name: 'auth-setup',
+        name: Routes.authSetup,
         builder: (context, state) => const AuthSetupScreen(),
       ),
       GoRoute(

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -27,6 +27,9 @@ abstract final class Routes {
   /// Settings route.
   static const settings = 'settings';
 
+  /// Authentication setup route.
+  static const authSetup = 'auth-setup';
+
   /// Upgrade route.
   static const upgrade = 'upgrade';
 

--- a/lib/domain/services/auth_service.dart
+++ b/lib/domain/services/auth_service.dart
@@ -76,10 +76,18 @@ class AuthService {
   }
 
   /// Check if device supports biometric authentication.
+  Future<bool> isBiometricSupported() async {
+    try {
+      return await _localAuth.canCheckBiometrics;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  /// Check if biometrics are enrolled and ready to use.
   Future<bool> isBiometricAvailable() async {
     try {
-      final isAvailable = await _localAuth.canCheckBiometrics;
-      if (!isAvailable) return false;
+      if (!await isBiometricSupported()) return false;
 
       final biometrics = await _localAuth.getAvailableBiometrics();
       return biometrics.isNotEmpty;

--- a/lib/domain/services/auth_service.dart
+++ b/lib/domain/services/auth_service.dart
@@ -78,7 +78,7 @@ class AuthService {
   /// Check if device supports biometric authentication.
   Future<bool> isBiometricSupported() async {
     try {
-      return await _localAuth.canCheckBiometrics;
+      return await _localAuth.isDeviceSupported();
     } on PlatformException {
       return false;
     }

--- a/lib/presentation/screens/auth_setup_screen.dart
+++ b/lib/presentation/screens/auth_setup_screen.dart
@@ -19,6 +19,7 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
   int _step = 0; // 0: choose, 1: enter PIN, 2: confirm PIN
   bool _isLoading = false;
   String? _error;
+  bool _biometricSupported = false;
   bool _biometricAvailable = false;
   bool _enableBiometric = false;
 
@@ -30,8 +31,12 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
 
   Future<void> _checkBiometric() async {
     final authService = ref.read(authServiceProvider);
+    final supported = await authService.isBiometricSupported();
     final available = await authService.isBiometricAvailable();
-    setState(() => _biometricAvailable = available);
+    setState(() {
+      _biometricSupported = supported;
+      _biometricAvailable = available;
+    });
   }
 
   Future<void> _setupPin() async {
@@ -135,11 +140,13 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
         onTap: () => setState(() => _step = 1),
       ),
       const SizedBox(height: 12),
-      if (_biometricAvailable)
+      if (_biometricSupported)
         _OptionCard(
           icon: Icons.fingerprint,
           title: 'Biometrics',
-          subtitle: 'Use fingerprint or face recognition',
+          subtitle: _biometricAvailable
+              ? 'Use fingerprint or face recognition'
+              : 'Enable now, then enroll fingerprint or face before first use',
           trailing: Switch(
             value: _enableBiometric,
             onChanged: (v) => setState(() => _enableBiometric = v),
@@ -174,6 +181,7 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
         autofocus: true,
         decoration: InputDecoration(labelText: 'PIN', errorText: _error),
         inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+        onChanged: (_) => setState(() => _error = null),
         onSubmitted: (_) {
           if (_pinController.text.length >= 4) {
             setState(() {
@@ -205,72 +213,79 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
     ],
   );
 
-  Widget _buildConfirmPinStep(ThemeData theme, ColorScheme colorScheme) =>
-      Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+  Widget _buildConfirmPinStep(
+    ThemeData theme,
+    ColorScheme colorScheme,
+  ) => Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text(
+        'Confirm PIN',
+        style: theme.textTheme.headlineSmall?.copyWith(
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      const SizedBox(height: 8),
+      Text(
+        'Enter your PIN again to confirm.',
+        style: theme.textTheme.bodyLarge?.copyWith(
+          color: colorScheme.onSurface.withValues(alpha: 0.6),
+        ),
+      ),
+      const SizedBox(height: 32),
+      TextField(
+        controller: _confirmPinController,
+        keyboardType: TextInputType.number,
+        obscureText: true,
+        maxLength: 8,
+        autofocus: true,
+        decoration: InputDecoration(
+          labelText: 'Confirm PIN',
+          errorText: _error,
+        ),
+        inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+        onChanged: (_) => setState(() => _error = null),
+        onSubmitted: (_) => _setupPin(),
+      ),
+      if (_biometricSupported) ...[
+        const SizedBox(height: 16),
+        SwitchListTile(
+          value: _enableBiometric,
+          onChanged: (v) => setState(() => _enableBiometric = v),
+          title: const Text('Enable biometrics'),
+          subtitle: Text(
+            _biometricAvailable
+                ? 'Also allow fingerprint/face unlock'
+                : 'Enable now, then enroll fingerprint or face before first use',
+          ),
+          contentPadding: EdgeInsets.zero,
+        ),
+      ],
+      const SizedBox(height: 24),
+      Row(
         children: [
-          Text(
-            'Confirm PIN',
-            style: theme.textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.bold,
-            ),
+          TextButton(
+            onPressed: () => setState(() {
+              _step = 1;
+              _error = null;
+            }),
+            child: const Text('Back'),
           ),
-          const SizedBox(height: 8),
-          Text(
-            'Enter your PIN again to confirm.',
-            style: theme.textTheme.bodyLarge?.copyWith(
-              color: colorScheme.onSurface.withValues(alpha: 0.6),
-            ),
-          ),
-          const SizedBox(height: 32),
-          TextField(
-            controller: _confirmPinController,
-            keyboardType: TextInputType.number,
-            obscureText: true,
-            maxLength: 8,
-            autofocus: true,
-            decoration: InputDecoration(
-              labelText: 'Confirm PIN',
-              errorText: _error,
-            ),
-            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-            onSubmitted: (_) => _setupPin(),
-          ),
-          if (_biometricAvailable) ...[
-            const SizedBox(height: 16),
-            SwitchListTile(
-              value: _enableBiometric,
-              onChanged: (v) => setState(() => _enableBiometric = v),
-              title: const Text('Enable biometrics'),
-              subtitle: const Text('Also allow fingerprint/face unlock'),
-              contentPadding: EdgeInsets.zero,
-            ),
-          ],
-          const SizedBox(height: 24),
-          Row(
-            children: [
-              TextButton(
-                onPressed: () => setState(() {
-                  _step = 1;
-                  _error = null;
-                }),
-                child: const Text('Back'),
-              ),
-              const Spacer(),
-              ElevatedButton(
-                onPressed: _isLoading ? null : _setupPin,
-                child: _isLoading
-                    ? const SizedBox(
-                        height: 20,
-                        width: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Text('Complete'),
-              ),
-            ],
+          const Spacer(),
+          ElevatedButton(
+            onPressed: _isLoading ? null : _setupPin,
+            child: _isLoading
+                ? const SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Complete'),
           ),
         ],
-      );
+      ),
+    ],
+  );
 }
 
 class _OptionCard extends StatelessWidget {

--- a/lib/presentation/screens/auth_setup_screen.dart
+++ b/lib/presentation/screens/auth_setup_screen.dart
@@ -95,9 +95,19 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
         actions: [TextButton(onPressed: _skip, child: const Text('Skip'))],
       ),
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: _buildStep(theme, colorScheme),
+        child: LayoutBuilder(
+          builder: (context, constraints) => SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Center(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  minHeight: constraints.maxHeight - 48,
+                  maxWidth: 420,
+                ),
+                child: _buildStep(theme, colorScheme),
+              ),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/presentation/screens/auth_setup_screen.dart
+++ b/lib/presentation/screens/auth_setup_screen.dart
@@ -32,7 +32,9 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
   Future<void> _checkBiometric() async {
     final authService = ref.read(authServiceProvider);
     final supported = await authService.isBiometricSupported();
-    final available = await authService.isBiometricAvailable();
+    final available =
+        supported && (await authService.getAvailableBiometrics()).isNotEmpty;
+    if (!mounted) return;
     setState(() {
       _biometricSupported = supported;
       _biometricAvailable = available;
@@ -57,19 +59,21 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
     });
 
     final authService = ref.read(authServiceProvider);
-    await authService.setupPin(_pinController.text);
+    try {
+      await authService.setupPin(_pinController.text);
 
-    if (_enableBiometric) {
-      await authService.setBiometricEnabled(enabled: true);
+      if (_enableBiometric) {
+        await authService.setBiometricEnabled(enabled: true);
+      }
+
+      await ref.read(authStateProvider.notifier).refresh();
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
     }
-
-    await ref.read(authStateProvider.notifier).refresh();
-
-    setState(() => _isLoading = false);
-
-    if (mounted) {
-      Navigator.of(context).pop(true);
-    }
+    if (!mounted) return;
+    Navigator.of(context).pop(true);
   }
 
   void _skip() {
@@ -92,7 +96,12 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Security Setup'),
-        actions: [TextButton(onPressed: _skip, child: const Text('Skip'))],
+        actions: [
+          TextButton(
+            onPressed: _isLoading ? null : _skip,
+            child: const Text('Skip'),
+          ),
+        ],
       ),
       body: SafeArea(
         child: LayoutBuilder(
@@ -101,7 +110,9 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
             child: Center(
               child: ConstrainedBox(
                 constraints: BoxConstraints(
-                  minHeight: constraints.maxHeight - 48,
+                  minHeight: constraints.maxHeight > 48
+                      ? constraints.maxHeight - 48
+                      : 0,
                   maxWidth: 420,
                 ),
                 child: _buildStep(theme, colorScheme),

--- a/lib/presentation/screens/lock_screen.dart
+++ b/lib/presentation/screens/lock_screen.dart
@@ -142,119 +142,153 @@ class _LockScreenState extends ConsumerState<LockScreen> {
 
     return Scaffold(
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              // Logo/icon
-              ClipRRect(
-                borderRadius: BorderRadius.circular(24),
-                child: Image.asset(
-                  'assets/icons/monkeyssh_icon.png',
-                  width: 112,
-                  height: 112,
-                ),
+        child: LayoutBuilder(
+          builder: (context, constraints) => SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                minHeight: constraints.maxHeight - 48,
               ),
-              const SizedBox(height: 32),
-              Text(
-                appName,
-                style: theme.textTheme.headlineMedium?.copyWith(
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                subtitle,
-                style: theme.textTheme.bodyLarge?.copyWith(
-                  color: colorScheme.onSurface.withValues(alpha: 0.6),
-                ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 48),
-
-              if (isInitializing) ...[
-                const CircularProgressIndicator(),
-                const SizedBox(height: 24),
-              ],
-
-              // PIN input
-              if (!isInitializing &&
-                  !showAuthMethodError &&
-                  (_authMethod == AuthMethod.pin ||
-                      _authMethod == AuthMethod.both)) ...[
-                SizedBox(
-                  width: 200,
-                  child: TextField(
-                    controller: _pinController,
-                    focusNode: _focusNode,
-                    keyboardType: TextInputType.number,
-                    textAlign: TextAlign.center,
-                    obscureText: !_showPin,
-                    maxLength: 8,
-                    style: theme.textTheme.headlineSmall?.copyWith(
-                      letterSpacing: 8,
-                    ),
-                    decoration: InputDecoration(
-                      counterText: '',
-                      hintText: '••••',
-                      errorText: _error,
-                      suffixIcon: IconButton(
-                        icon: Icon(
-                          _showPin ? Icons.visibility_off : Icons.visibility,
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 360),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      // Logo/icon
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(24),
+                        child: Image.asset(
+                          'assets/icons/monkeyssh_icon.png',
+                          width: 112,
+                          height: 112,
                         ),
-                        onPressed: () => setState(() => _showPin = !_showPin),
                       ),
-                    ),
-                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                    onSubmitted: (_) => _authenticateWithPin(),
-                  ),
-                ),
-                const SizedBox(height: 24),
-                SizedBox(
-                  width: 200,
-                  child: ElevatedButton(
-                    onPressed: _isLoading ? null : _authenticateWithPin,
-                    child: _isLoading
-                        ? const SizedBox(
-                            height: 20,
-                            width: 20,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Text('Unlock'),
-                  ),
-                ),
-              ],
+                      const SizedBox(height: 32),
+                      Text(
+                        appName,
+                        style: theme.textTheme.headlineMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        subtitle,
+                        style: theme.textTheme.bodyLarge?.copyWith(
+                          color: colorScheme.onSurface.withValues(alpha: 0.6),
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 48),
 
-              // Biometric button
-              if (!isInitializing &&
-                  !showAuthMethodError &&
-                  (_authMethod == AuthMethod.biometric ||
-                      _authMethod == AuthMethod.both)) ...[
-                const SizedBox(height: 24),
-                TextButton.icon(
-                  onPressed: _isLoading ? null : _authenticateWithBiometrics,
-                  icon: const Icon(Icons.fingerprint),
-                  label: const Text('Use biometrics'),
-                ),
-              ],
+                      if (isInitializing) ...[
+                        const CircularProgressIndicator(),
+                        const SizedBox(height: 24),
+                      ],
 
-              if (showAuthMethodError) ...[
-                SizedBox(
-                  width: 200,
-                  child: OutlinedButton(
-                    onPressed: () {
-                      setState(() {
-                        _isCheckingAuthMethod = true;
-                        _authMethodLoadFailed = false;
-                      });
-                      unawaited(_checkAuthMethod(refreshAuthState: true));
-                    },
-                    child: const Text('Retry'),
+                      // PIN input
+                      if (!isInitializing &&
+                          !showAuthMethodError &&
+                          (_authMethod == AuthMethod.pin ||
+                              _authMethod == AuthMethod.both)) ...[
+                        SizedBox(
+                          width: double.infinity,
+                          child: TextField(
+                            controller: _pinController,
+                            focusNode: _focusNode,
+                            keyboardType: TextInputType.number,
+                            textAlign: TextAlign.center,
+                            obscureText: !_showPin,
+                            maxLength: 8,
+                            style: theme.textTheme.headlineSmall?.copyWith(
+                              letterSpacing: 8,
+                            ),
+                            decoration: InputDecoration(
+                              counterText: '',
+                              hintText: '••••',
+                              errorText: _error,
+                              prefixIcon: const SizedBox.shrink(),
+                              prefixIconConstraints:
+                                  const BoxConstraints.tightFor(
+                                    width: 48,
+                                    height: 48,
+                                  ),
+                              suffixIconConstraints:
+                                  const BoxConstraints.tightFor(
+                                    width: 48,
+                                    height: 48,
+                                  ),
+                              suffixIcon: IconButton(
+                                icon: Icon(
+                                  _showPin
+                                      ? Icons.visibility_off
+                                      : Icons.visibility,
+                                ),
+                                onPressed: () =>
+                                    setState(() => _showPin = !_showPin),
+                              ),
+                            ),
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
+                            onSubmitted: (_) => _authenticateWithPin(),
+                          ),
+                        ),
+                        const SizedBox(height: 24),
+                        SizedBox(
+                          width: double.infinity,
+                          child: ElevatedButton(
+                            onPressed: _isLoading ? null : _authenticateWithPin,
+                            child: _isLoading
+                                ? const SizedBox(
+                                    height: 20,
+                                    width: 20,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  )
+                                : const Text('Unlock'),
+                          ),
+                        ),
+                      ],
+
+                      // Biometric button
+                      if (!isInitializing &&
+                          !showAuthMethodError &&
+                          (_authMethod == AuthMethod.biometric ||
+                              _authMethod == AuthMethod.both)) ...[
+                        const SizedBox(height: 24),
+                        TextButton.icon(
+                          onPressed: _isLoading
+                              ? null
+                              : _authenticateWithBiometrics,
+                          icon: const Icon(Icons.fingerprint),
+                          label: const Text('Use biometrics'),
+                        ),
+                      ],
+
+                      if (showAuthMethodError) ...[
+                        SizedBox(
+                          width: double.infinity,
+                          child: OutlinedButton(
+                            onPressed: () {
+                              setState(() {
+                                _isCheckingAuthMethod = true;
+                                _authMethodLoadFailed = false;
+                              });
+                              unawaited(
+                                _checkAuthMethod(refreshAuthState: true),
+                              );
+                            },
+                            child: const Text('Retry'),
+                          ),
+                        ),
+                      ],
+                    ],
                   ),
                 ),
-              ],
-            ],
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/presentation/screens/lock_screen.dart
+++ b/lib/presentation/screens/lock_screen.dart
@@ -147,7 +147,9 @@ class _LockScreenState extends ConsumerState<LockScreen> {
             padding: const EdgeInsets.all(24),
             child: ConstrainedBox(
               constraints: BoxConstraints(
-                minHeight: constraints.maxHeight - 48,
+                minHeight: constraints.maxHeight > 48
+                    ? constraints.maxHeight - 48
+                    : 0,
               ),
               child: Center(
                 child: ConstrainedBox(

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -205,27 +205,37 @@ class _SecuritySection extends ConsumerWidget {
             onTap: () => context.pushNamed(Routes.authSetup),
           ),
         FutureBuilder<bool>(
-          future: ref.read(authServiceProvider).isBiometricAvailable(),
+          future: ref.read(authServiceProvider).isBiometricSupported(),
           builder: (context, snapshot) {
-            final isAvailable = snapshot.data ?? false;
+            final isSupported = snapshot.data ?? false;
             return FutureBuilder<bool>(
-              future: ref.read(authServiceProvider).isBiometricEnabled(),
-              builder: (context, enabledSnapshot) {
-                final isEnabled = enabledSnapshot.data ?? false;
-                return SwitchListTile(
-                  secondary: const Icon(Icons.fingerprint),
-                  title: const Text('Biometric authentication'),
-                  subtitle: Text(
-                    !isAvailable
-                        ? 'Not available on this device'
-                        : isAuthConfigured
-                        ? 'Use fingerprint or face to unlock'
-                        : 'Set up app lock first',
-                  ),
-                  value: isEnabled && isAvailable,
-                  onChanged: isAvailable && isAuthConfigured
-                      ? (value) => _toggleBiometric(ref, value)
-                      : null,
+              future: ref.read(authServiceProvider).isBiometricAvailable(),
+              builder: (context, availableSnapshot) {
+                final isAvailable = availableSnapshot.data ?? false;
+                return FutureBuilder<bool>(
+                  future: ref.read(authServiceProvider).isBiometricEnabled(),
+                  builder: (context, enabledSnapshot) {
+                    final isEnabled = enabledSnapshot.data ?? false;
+                    return SwitchListTile(
+                      secondary: const Icon(Icons.fingerprint),
+                      title: const Text('Biometric authentication'),
+                      subtitle: Text(
+                        !isSupported
+                            ? 'Not supported on this device'
+                            : !isAuthConfigured
+                            ? 'Set up app lock first'
+                            : isAvailable
+                            ? 'Use fingerprint or face to unlock'
+                            : isEnabled
+                            ? 'Enabled - enroll fingerprint or face to use it'
+                            : 'Enable now, then enroll fingerprint or face to use it',
+                      ),
+                      value: isEnabled,
+                      onChanged: isSupported && isAuthConfigured
+                          ? (value) => _toggleBiometric(ref, value)
+                          : null,
+                    );
+                  },
                 );
               },
             );

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -62,7 +63,7 @@ final _biometricSettingsStateProvider =
 
       return _BiometricSettingsState(
         isSupported: true,
-        isAvailable: await authService.isBiometricAvailable(),
+        isAvailable: (await authService.getAvailableBiometrics()).isNotEmpty,
         isEnabled: isEnabled,
       );
     });
@@ -213,6 +214,7 @@ class _SecuritySection extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final authState = ref.watch(authStateProvider);
+    final isAuthKnown = authState != AuthState.unknown;
     final isAuthConfigured =
         authState == AuthState.locked || authState == AuthState.unlocked;
     final autoLockTimeout = ref.watch(autoLockTimeoutNotifierProvider);
@@ -233,10 +235,14 @@ class _SecuritySection extends ConsumerWidget {
           ListTile(
             leading: const Icon(Icons.lock_outline),
             title: const Text('Set up app lock'),
-            subtitle: const Text(
-              'Protect the app with a PIN and optional biometrics',
+            subtitle: Text(
+              isAuthKnown
+                  ? 'Protect the app with a PIN and optional biometrics'
+                  : 'Checking security status',
             ),
-            onTap: () => context.pushNamed(Routes.authSetup),
+            onTap: isAuthKnown
+                ? () => context.pushNamed(Routes.authSetup)
+                : null,
           ),
         biometricSettings.when(
           loading: () => const SwitchListTile(
@@ -257,7 +263,9 @@ class _SecuritySection extends ConsumerWidget {
             secondary: const Icon(Icons.fingerprint),
             title: const Text('Biometric authentication'),
             subtitle: Text(
-              !state.isSupported
+              !isAuthKnown
+                  ? 'Checking security status'
+                  : !state.isSupported
                   ? 'Not supported on this device'
                   : !isAuthConfigured
                   ? 'Set up app lock first'
@@ -277,7 +285,9 @@ class _SecuritySection extends ConsumerWidget {
           leading: const Icon(Icons.timer_outlined),
           title: const Text('Auto-lock timeout'),
           subtitle: Text(
-            isAuthConfigured
+            !isAuthKnown
+                ? 'Checking security status'
+                : isAuthConfigured
                 ? autoLockTimeout == 0
                       ? 'Disabled'
                       : '$autoLockTimeout minute${autoLockTimeout == 1 ? '' : 's'}'
@@ -300,6 +310,12 @@ class _SecuritySection extends ConsumerWidget {
     var currentPinErrorText = '';
     var isChanging = false;
 
+    String? validatePin(String? value) {
+      if (value?.isEmpty ?? true) return 'Required';
+      if (value!.length < 4) return 'PIN must be 4-8 digits';
+      return null;
+    }
+
     showDialog<void>(
       context: context,
       builder: (context) => StatefulBuilder(
@@ -312,15 +328,18 @@ class _SecuritySection extends ConsumerWidget {
               children: [
                 TextFormField(
                   controller: currentPinController,
-                  decoration: InputDecoration(
+                  decoration: const InputDecoration(
                     labelText: 'Current PIN',
-                    errorText: currentPinErrorText.isEmpty
-                        ? null
-                        : currentPinErrorText,
+                    counterText: '',
                   ),
+                  forceErrorText: currentPinErrorText.isEmpty
+                      ? null
+                      : currentPinErrorText,
                   obscureText: true,
                   keyboardType: TextInputType.number,
-                  validator: (v) => v?.isEmpty ?? true ? 'Required' : null,
+                  maxLength: 8,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  validator: validatePin,
                   onChanged: (_) {
                     if (currentPinErrorText.isEmpty) return;
                     setState(() => currentPinErrorText = '');
@@ -329,24 +348,30 @@ class _SecuritySection extends ConsumerWidget {
                 const SizedBox(height: 16),
                 TextFormField(
                   controller: newPinController,
-                  decoration: const InputDecoration(labelText: 'New PIN'),
+                  decoration: const InputDecoration(
+                    labelText: 'New PIN',
+                    counterText: '',
+                  ),
                   obscureText: true,
                   keyboardType: TextInputType.number,
-                  validator: (v) {
-                    if (v?.isEmpty ?? true) return 'Required';
-                    if (v!.length < 4) return 'PIN must be at least 4 digits';
-                    return null;
-                  },
+                  maxLength: 8,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  validator: validatePin,
                 ),
                 const SizedBox(height: 16),
                 TextFormField(
                   controller: confirmPinController,
                   decoration: const InputDecoration(
                     labelText: 'Confirm new PIN',
+                    counterText: '',
                   ),
                   obscureText: true,
                   keyboardType: TextInputType.number,
+                  maxLength: 8,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                   validator: (v) {
+                    final pinValidationError = validatePin(v);
+                    if (pinValidationError != null) return pinValidationError;
                     if (v != newPinController.text) return 'PINs do not match';
                     return null;
                   },
@@ -370,12 +395,38 @@ class _SecuritySection extends ConsumerWidget {
                         isChanging = true;
                       });
 
-                      final success = await ref
-                          .read(authServiceProvider)
-                          .changePin(
-                            currentPinController.text,
-                            newPinController.text,
+                      bool success;
+                      try {
+                        success = await ref
+                            .read(authServiceProvider)
+                            .changePin(
+                              currentPinController.text,
+                              newPinController.text,
+                            );
+                      } on Object catch (error, stackTrace) {
+                        FlutterError.reportError(
+                          FlutterErrorDetails(
+                            exception: error,
+                            stack: stackTrace,
+                            library: 'auth',
+                            context: ErrorDescription(
+                              'while changing the app PIN from settings',
+                            ),
+                          ),
+                        );
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Could not change PIN. Try again.'),
+                            ),
                           );
+                        }
+                        return;
+                      } finally {
+                        if (context.mounted) {
+                          setState(() => isChanging = false);
+                        }
+                      }
 
                       if (!context.mounted) return;
 
@@ -389,10 +440,9 @@ class _SecuritySection extends ConsumerWidget {
                         return;
                       }
 
-                      setState(() {
-                        isChanging = false;
-                        currentPinErrorText = 'Current PIN is incorrect';
-                      });
+                      setState(
+                        () => currentPinErrorText = 'Current PIN is incorrect',
+                      );
                     },
               child: isChanging
                   ? const SizedBox(

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -180,24 +180,30 @@ class _SecuritySection extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final authState = ref.watch(authStateProvider);
-    final isAuthEnabled = authState != AuthState.notConfigured;
+    final isAuthConfigured =
+        authState == AuthState.locked || authState == AuthState.unlocked;
     final autoLockTimeout = ref.watch(autoLockTimeoutNotifierProvider);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const _SectionHeader(title: 'Security'),
-        ListTile(
-          leading: const Icon(Icons.pin_outlined),
-          title: const Text('Change PIN'),
-          subtitle: Text(
-            isAuthEnabled ? 'Update your PIN code' : 'PIN not set',
+        if (isAuthConfigured)
+          ListTile(
+            leading: const Icon(Icons.pin_outlined),
+            title: const Text('Change PIN'),
+            subtitle: const Text('Update your PIN code'),
+            onTap: () => _showChangePinDialog(context, ref),
+          )
+        else
+          ListTile(
+            leading: const Icon(Icons.lock_outline),
+            title: const Text('Set up app lock'),
+            subtitle: const Text(
+              'Protect the app with a PIN and optional biometrics',
+            ),
+            onTap: () => context.pushNamed(Routes.authSetup),
           ),
-          enabled: isAuthEnabled,
-          onTap: isAuthEnabled
-              ? () => _showChangePinDialog(context, ref)
-              : null,
-        ),
         FutureBuilder<bool>(
           future: ref.read(authServiceProvider).isBiometricAvailable(),
           builder: (context, snapshot) {
@@ -210,12 +216,14 @@ class _SecuritySection extends ConsumerWidget {
                   secondary: const Icon(Icons.fingerprint),
                   title: const Text('Biometric authentication'),
                   subtitle: Text(
-                    isAvailable
+                    !isAvailable
+                        ? 'Not available on this device'
+                        : isAuthConfigured
                         ? 'Use fingerprint or face to unlock'
-                        : 'Not available on this device',
+                        : 'Set up app lock first',
                   ),
                   value: isEnabled && isAvailable,
-                  onChanged: isAvailable && isAuthEnabled
+                  onChanged: isAvailable && isAuthConfigured
                       ? (value) => _toggleBiometric(ref, value)
                       : null,
                 );
@@ -227,12 +235,14 @@ class _SecuritySection extends ConsumerWidget {
           leading: const Icon(Icons.timer_outlined),
           title: const Text('Auto-lock timeout'),
           subtitle: Text(
-            autoLockTimeout == 0
-                ? 'Disabled'
-                : '$autoLockTimeout minute${autoLockTimeout == 1 ? '' : 's'}',
+            isAuthConfigured
+                ? autoLockTimeout == 0
+                      ? 'Disabled'
+                      : '$autoLockTimeout minute${autoLockTimeout == 1 ? '' : 's'}'
+                : 'Set up app lock first',
           ),
-          enabled: isAuthEnabled,
-          onTap: isAuthEnabled
+          enabled: isAuthConfigured,
+          onTap: isAuthConfigured
               ? () => _showAutoLockDialog(context, ref, autoLockTimeout)
               : null,
         ),

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -46,6 +46,39 @@ class SettingsScreen extends ConsumerWidget {
   );
 }
 
+final _biometricSettingsStateProvider =
+    FutureProvider.autoDispose<_BiometricSettingsState>((ref) async {
+      final authService = ref.watch(authServiceProvider);
+      final isSupported = await authService.isBiometricSupported();
+      final isEnabled = await authService.isBiometricEnabled();
+
+      if (!isSupported) {
+        return _BiometricSettingsState(
+          isSupported: false,
+          isAvailable: false,
+          isEnabled: isEnabled,
+        );
+      }
+
+      return _BiometricSettingsState(
+        isSupported: true,
+        isAvailable: await authService.isBiometricAvailable(),
+        isEnabled: isEnabled,
+      );
+    });
+
+class _BiometricSettingsState {
+  const _BiometricSettingsState({
+    required this.isSupported,
+    required this.isAvailable,
+    required this.isEnabled,
+  });
+
+  final bool isSupported;
+  final bool isAvailable;
+  final bool isEnabled;
+}
+
 class _SectionHeader extends StatelessWidget {
   const _SectionHeader({required this.title});
 
@@ -183,6 +216,7 @@ class _SecuritySection extends ConsumerWidget {
     final isAuthConfigured =
         authState == AuthState.locked || authState == AuthState.unlocked;
     final autoLockTimeout = ref.watch(autoLockTimeoutNotifierProvider);
+    final biometricSettings = ref.watch(_biometricSettingsStateProvider);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -204,42 +238,40 @@ class _SecuritySection extends ConsumerWidget {
             ),
             onTap: () => context.pushNamed(Routes.authSetup),
           ),
-        FutureBuilder<bool>(
-          future: ref.read(authServiceProvider).isBiometricSupported(),
-          builder: (context, snapshot) {
-            final isSupported = snapshot.data ?? false;
-            return FutureBuilder<bool>(
-              future: ref.read(authServiceProvider).isBiometricAvailable(),
-              builder: (context, availableSnapshot) {
-                final isAvailable = availableSnapshot.data ?? false;
-                return FutureBuilder<bool>(
-                  future: ref.read(authServiceProvider).isBiometricEnabled(),
-                  builder: (context, enabledSnapshot) {
-                    final isEnabled = enabledSnapshot.data ?? false;
-                    return SwitchListTile(
-                      secondary: const Icon(Icons.fingerprint),
-                      title: const Text('Biometric authentication'),
-                      subtitle: Text(
-                        !isSupported
-                            ? 'Not supported on this device'
-                            : !isAuthConfigured
-                            ? 'Set up app lock first'
-                            : isAvailable
-                            ? 'Use fingerprint or face to unlock'
-                            : isEnabled
-                            ? 'Enabled - enroll fingerprint or face to use it'
-                            : 'Enable now, then enroll fingerprint or face to use it',
-                      ),
-                      value: isEnabled,
-                      onChanged: isSupported && isAuthConfigured
-                          ? (value) => _toggleBiometric(ref, value)
-                          : null,
-                    );
-                  },
-                );
-              },
-            );
-          },
+        biometricSettings.when(
+          loading: () => const SwitchListTile(
+            secondary: Icon(Icons.fingerprint),
+            title: Text('Biometric authentication'),
+            subtitle: Text('Checking biometric availability'),
+            value: false,
+            onChanged: null,
+          ),
+          error: (_, _) => const SwitchListTile(
+            secondary: Icon(Icons.fingerprint),
+            title: Text('Biometric authentication'),
+            subtitle: Text('Biometric status unavailable'),
+            value: false,
+            onChanged: null,
+          ),
+          data: (state) => SwitchListTile(
+            secondary: const Icon(Icons.fingerprint),
+            title: const Text('Biometric authentication'),
+            subtitle: Text(
+              !state.isSupported
+                  ? 'Not supported on this device'
+                  : !isAuthConfigured
+                  ? 'Set up app lock first'
+                  : state.isAvailable
+                  ? 'Use fingerprint or face to unlock'
+                  : state.isEnabled
+                  ? 'Enabled - enroll fingerprint or face to use it'
+                  : 'Enable now, then enroll fingerprint or face to use it',
+            ),
+            value: state.isEnabled,
+            onChanged: state.isSupported && isAuthConfigured
+                ? (value) => _toggleBiometric(ref, value)
+                : null,
+          ),
         ),
         ListTile(
           leading: const Icon(Icons.timer_outlined),
@@ -345,7 +377,7 @@ class _SecuritySection extends ConsumerWidget {
 
   Future<void> _toggleBiometric(WidgetRef ref, bool value) async {
     await ref.read(authServiceProvider).setBiometricEnabled(enabled: value);
-    ref.invalidate(authStateProvider);
+    ref.invalidate(_biometricSettingsStateProvider);
   }
 
   void _showAutoLockDialog(BuildContext context, WidgetRef ref, int current) {

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -297,80 +297,113 @@ class _SecuritySection extends ConsumerWidget {
     final newPinController = TextEditingController();
     final confirmPinController = TextEditingController();
     final formKey = GlobalKey<FormState>();
+    var currentPinErrorText = '';
+    var isChanging = false;
 
     showDialog<void>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Change PIN'),
-        content: Form(
-          key: formKey,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              TextFormField(
-                controller: currentPinController,
-                decoration: const InputDecoration(labelText: 'Current PIN'),
-                obscureText: true,
-                keyboardType: TextInputType.number,
-                validator: (v) => v?.isEmpty ?? true ? 'Required' : null,
-              ),
-              const SizedBox(height: 16),
-              TextFormField(
-                controller: newPinController,
-                decoration: const InputDecoration(labelText: 'New PIN'),
-                obscureText: true,
-                keyboardType: TextInputType.number,
-                validator: (v) {
-                  if (v?.isEmpty ?? true) return 'Required';
-                  if (v!.length < 4) return 'PIN must be at least 4 digits';
-                  return null;
-                },
-              ),
-              const SizedBox(height: 16),
-              TextFormField(
-                controller: confirmPinController,
-                decoration: const InputDecoration(labelText: 'Confirm new PIN'),
-                obscureText: true,
-                keyboardType: TextInputType.number,
-                validator: (v) {
-                  if (v != newPinController.text) return 'PINs do not match';
-                  return null;
-                },
-              ),
-            ],
+      builder: (context) => StatefulBuilder(
+        builder: (context, setState) => AlertDialog(
+          title: const Text('Change PIN'),
+          content: Form(
+            key: formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextFormField(
+                  controller: currentPinController,
+                  decoration: InputDecoration(
+                    labelText: 'Current PIN',
+                    errorText: currentPinErrorText.isEmpty
+                        ? null
+                        : currentPinErrorText,
+                  ),
+                  obscureText: true,
+                  keyboardType: TextInputType.number,
+                  validator: (v) => v?.isEmpty ?? true ? 'Required' : null,
+                  onChanged: (_) {
+                    if (currentPinErrorText.isEmpty) return;
+                    setState(() => currentPinErrorText = '');
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: newPinController,
+                  decoration: const InputDecoration(labelText: 'New PIN'),
+                  obscureText: true,
+                  keyboardType: TextInputType.number,
+                  validator: (v) {
+                    if (v?.isEmpty ?? true) return 'Required';
+                    if (v!.length < 4) return 'PIN must be at least 4 digits';
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: confirmPinController,
+                  decoration: const InputDecoration(
+                    labelText: 'Confirm new PIN',
+                  ),
+                  obscureText: true,
+                  keyboardType: TextInputType.number,
+                  validator: (v) {
+                    if (v != newPinController.text) return 'PINs do not match';
+                    return null;
+                  },
+                ),
+              ],
+            ),
           ),
+          actions: [
+            TextButton(
+              onPressed: isChanging ? null : () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: isChanging
+                  ? null
+                  : () async {
+                      if (!(formKey.currentState?.validate() ?? false)) return;
+
+                      setState(() {
+                        currentPinErrorText = '';
+                        isChanging = true;
+                      });
+
+                      final success = await ref
+                          .read(authServiceProvider)
+                          .changePin(
+                            currentPinController.text,
+                            newPinController.text,
+                          );
+
+                      if (!context.mounted) return;
+
+                      if (success) {
+                        Navigator.pop(context);
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text('PIN changed successfully'),
+                          ),
+                        );
+                        return;
+                      }
+
+                      setState(() {
+                        isChanging = false;
+                        currentPinErrorText = 'Current PIN is incorrect';
+                      });
+                    },
+              child: isChanging
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Change'),
+            ),
+          ],
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () async {
-              if (formKey.currentState?.validate() ?? false) {
-                final success = await ref
-                    .read(authServiceProvider)
-                    .changePin(
-                      currentPinController.text,
-                      newPinController.text,
-                    );
-                if (context.mounted) {
-                  Navigator.pop(context);
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(
-                        success
-                            ? 'PIN changed successfully'
-                            : 'Current PIN is incorrect',
-                      ),
-                    ),
-                  );
-                }
-              }
-            },
-            child: const Text('Change'),
-          ),
-        ],
       ),
     );
   }

--- a/test/support/settings_import_test_helpers.dart
+++ b/test/support/settings_import_test_helpers.dart
@@ -98,6 +98,9 @@ class FakeAuthService extends AuthService {
   Future<bool> isBiometricEnabled() async => false;
 
   @override
+  Future<bool> isBiometricSupported() async => false;
+
+  @override
   Future<bool> isBiometricAvailable() async => false;
 }
 

--- a/test/support/settings_import_test_helpers.dart
+++ b/test/support/settings_import_test_helpers.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:local_auth/local_auth.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/key_repository.dart';
@@ -102,6 +103,9 @@ class FakeAuthService extends AuthService {
 
   @override
   Future<bool> isBiometricAvailable() async => false;
+
+  @override
+  Future<List<BiometricType>> getAvailableBiometrics() async => [];
 }
 
 class FakeSecureTransferService extends SecureTransferService {

--- a/test/unit/auth_service_test.dart
+++ b/test/unit/auth_service_test.dart
@@ -202,7 +202,7 @@ void main() {
     group('isBiometricSupported', () {
       test('returns true when the device can check biometrics', () async {
         when(
-          () => mockLocalAuth.canCheckBiometrics,
+          () => mockLocalAuth.isDeviceSupported(),
         ).thenAnswer((_) async => true);
 
         final result = await authService.isBiometricSupported();
@@ -212,7 +212,7 @@ void main() {
 
       test('returns false when the device cannot check biometrics', () async {
         when(
-          () => mockLocalAuth.canCheckBiometrics,
+          () => mockLocalAuth.isDeviceSupported(),
         ).thenAnswer((_) async => false);
 
         final result = await authService.isBiometricSupported();
@@ -224,7 +224,7 @@ void main() {
     group('isBiometricAvailable', () {
       test('returns true when biometrics available', () async {
         when(
-          () => mockLocalAuth.canCheckBiometrics,
+          () => mockLocalAuth.isDeviceSupported(),
         ).thenAnswer((_) async => true);
         when(
           () => mockLocalAuth.getAvailableBiometrics(),
@@ -237,7 +237,7 @@ void main() {
 
       test('returns false when no biometrics', () async {
         when(
-          () => mockLocalAuth.canCheckBiometrics,
+          () => mockLocalAuth.isDeviceSupported(),
         ).thenAnswer((_) async => true);
         when(
           () => mockLocalAuth.getAvailableBiometrics(),
@@ -250,7 +250,7 @@ void main() {
 
       test('returns false when device cannot check biometrics', () async {
         when(
-          () => mockLocalAuth.canCheckBiometrics,
+          () => mockLocalAuth.isDeviceSupported(),
         ).thenAnswer((_) async => false);
 
         final result = await authService.isBiometricAvailable();
@@ -288,7 +288,7 @@ void main() {
           () => mockStorage.read(key: 'flutty_pin_salt'),
         ).thenAnswer((_) async => _validPinSalt);
         when(
-          () => mockLocalAuth.canCheckBiometrics,
+          () => mockLocalAuth.isDeviceSupported(),
         ).thenAnswer((_) async => false);
 
         final result = await authService.getAuthMethod();
@@ -316,7 +316,7 @@ void main() {
             () => mockStorage.read(key: 'flutty_pin_salt'),
           ).thenAnswer((_) async => null);
           when(
-            () => mockLocalAuth.canCheckBiometrics,
+            () => mockLocalAuth.isDeviceSupported(),
           ).thenAnswer((_) async => false);
 
           await expectLater(
@@ -346,7 +346,7 @@ void main() {
             () => mockStorage.read(key: 'flutty_pin_salt'),
           ).thenAnswer((_) async => '');
           when(
-            () => mockLocalAuth.canCheckBiometrics,
+            () => mockLocalAuth.isDeviceSupported(),
           ).thenAnswer((_) async => false);
 
           await expectLater(
@@ -376,7 +376,7 @@ void main() {
             () => mockStorage.read(key: 'flutty_pin_salt'),
           ).thenAnswer((_) async => _validPinSalt);
           when(
-            () => mockLocalAuth.canCheckBiometrics,
+            () => mockLocalAuth.isDeviceSupported(),
           ).thenAnswer((_) async => false);
 
           await expectLater(
@@ -399,7 +399,7 @@ void main() {
             () => mockStorage.read(key: 'flutty_pin_hash'),
           ).thenAnswer((_) async => 'legacy-hash-value');
           when(
-            () => mockLocalAuth.canCheckBiometrics,
+            () => mockLocalAuth.isDeviceSupported(),
           ).thenAnswer((_) async => true);
           when(
             () => mockLocalAuth.getAvailableBiometrics(),
@@ -431,7 +431,7 @@ void main() {
             () => mockStorage.read(key: 'flutty_pin_salt'),
           ).thenAnswer((_) async => _validPinSalt);
           when(
-            () => mockLocalAuth.canCheckBiometrics,
+            () => mockLocalAuth.isDeviceSupported(),
           ).thenAnswer((_) async => true);
           when(
             () => mockLocalAuth.getAvailableBiometrics(),
@@ -461,7 +461,7 @@ void main() {
           () => mockStorage.read(key: 'flutty_pin_salt'),
         ).thenAnswer((_) async => _validPinSalt);
         when(
-          () => mockLocalAuth.canCheckBiometrics,
+          () => mockLocalAuth.isDeviceSupported(),
         ).thenAnswer((_) async => true);
         when(
           () => mockLocalAuth.getAvailableBiometrics(),

--- a/test/unit/auth_service_test.dart
+++ b/test/unit/auth_service_test.dart
@@ -199,6 +199,28 @@ void main() {
       });
     });
 
+    group('isBiometricSupported', () {
+      test('returns true when the device can check biometrics', () async {
+        when(
+          () => mockLocalAuth.canCheckBiometrics,
+        ).thenAnswer((_) async => true);
+
+        final result = await authService.isBiometricSupported();
+
+        expect(result, true);
+      });
+
+      test('returns false when the device cannot check biometrics', () async {
+        when(
+          () => mockLocalAuth.canCheckBiometrics,
+        ).thenAnswer((_) async => false);
+
+        final result = await authService.isBiometricSupported();
+
+        expect(result, false);
+      });
+    });
+
     group('isBiometricAvailable', () {
       test('returns true when biometrics available', () async {
         when(

--- a/test/unit/biometric_platform_configuration_test.dart
+++ b/test/unit/biometric_platform_configuration_test.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('biometric platform configuration', () {
+    test('android uses FlutterFragmentActivity for local_auth', () {
+      final mainActivity = File(
+        'android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt',
+      ).readAsStringSync();
+
+      expect(mainActivity, contains('FlutterFragmentActivity'));
+      expect(
+        mainActivity,
+        isNot(contains('class MainActivity : FlutterActivity')),
+      );
+    });
+
+    test('ios declares a Face ID usage description', () {
+      final infoPlist = File('ios/Runner/Info.plist').readAsStringSync();
+
+      expect(infoPlist, contains('NSFaceIDUsageDescription'));
+      expect(
+        infoPlist,
+        contains('uses Face ID to unlock your encrypted SSH credentials'),
+      );
+    });
+  });
+}

--- a/test/widget/auth_setup_screen_test.dart
+++ b/test/widget/auth_setup_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:local_auth/local_auth.dart';
 import 'package:monkeyssh/domain/services/auth_service.dart';
 import 'package:monkeyssh/presentation/screens/auth_setup_screen.dart';
 
@@ -9,7 +10,9 @@ class _BiometricAvailableAuthService extends AuthService {
   Future<bool> isBiometricSupported() async => true;
 
   @override
-  Future<bool> isBiometricAvailable() async => true;
+  Future<List<BiometricType>> getAvailableBiometrics() async => [
+    BiometricType.fingerprint,
+  ];
 }
 
 class _BiometricSupportedAuthService extends AuthService {
@@ -17,7 +20,7 @@ class _BiometricSupportedAuthService extends AuthService {
   Future<bool> isBiometricSupported() async => true;
 
   @override
-  Future<bool> isBiometricAvailable() async => false;
+  Future<List<BiometricType>> getAvailableBiometrics() async => [];
 }
 
 void main() {

--- a/test/widget/auth_setup_screen_test.dart
+++ b/test/widget/auth_setup_screen_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/services/auth_service.dart';
+import 'package:monkeyssh/presentation/screens/auth_setup_screen.dart';
+
+class _BiometricAvailableAuthService extends AuthService {
+  @override
+  Future<bool> isBiometricSupported() async => true;
+
+  @override
+  Future<bool> isBiometricAvailable() async => true;
+}
+
+class _BiometricSupportedAuthService extends AuthService {
+  @override
+  Future<bool> isBiometricSupported() async => true;
+
+  @override
+  Future<bool> isBiometricAvailable() async => false;
+}
+
+void main() {
+  testWidgets('enables Next after entering a valid PIN', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authServiceProvider.overrideWithValue(
+            _BiometricAvailableAuthService(),
+          ),
+        ],
+        child: const MaterialApp(home: AuthSetupScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('PIN Code'));
+    await tester.pumpAndSettle();
+
+    final nextButton = find.widgetWithText(ElevatedButton, 'Next');
+    expect(tester.widget<ElevatedButton>(nextButton).onPressed, isNull);
+
+    await tester.enterText(find.byType(TextField).first, '1234');
+    await tester.pump();
+
+    expect(tester.widget<ElevatedButton>(nextButton).onPressed, isNotNull);
+  });
+
+  testWidgets(
+    'shows biometric opt-in when biometrics are supported but not enrolled',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authServiceProvider.overrideWithValue(
+              _BiometricSupportedAuthService(),
+            ),
+          ],
+          child: const MaterialApp(home: AuthSetupScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Biometrics'), findsOneWidget);
+      expect(
+        find.text(
+          'Enable now, then enroll fingerprint or face before first use',
+        ),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.text('PIN Code'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).first, '1234');
+      await tester.pump();
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Next'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Enable biometrics'), findsOneWidget);
+      expect(
+        find.text(
+          'Enable now, then enroll fingerprint or face before first use',
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+}

--- a/test/widget/lock_screen_test.dart
+++ b/test/widget/lock_screen_test.dart
@@ -244,7 +244,7 @@ void main() {
               return null;
           }
         });
-        when(() => localAuth.canCheckBiometrics).thenAnswer((_) async => false);
+        when(localAuth.isDeviceSupported).thenAnswer((_) async => false);
 
         await tester.pumpWidget(
           ProviderScope(
@@ -299,7 +299,7 @@ void main() {
               return null;
           }
         });
-        when(() => localAuth.canCheckBiometrics).thenAnswer((_) async => false);
+        when(localAuth.isDeviceSupported).thenAnswer((_) async => false);
 
         await tester.pumpWidget(
           ProviderScope(

--- a/test/widget/lock_screen_test.dart
+++ b/test/widget/lock_screen_test.dart
@@ -324,5 +324,34 @@ void main() {
         expect(find.text('Use biometrics'), findsNothing);
       },
     );
+
+    testWidgets('balances PIN field icon spacing to keep entry centered', (
+      tester,
+    ) async {
+      final authService = _MockAuthService();
+
+      when(authService.getAuthMethod).thenAnswer((_) async => AuthMethod.pin);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authServiceProvider.overrideWithValue(authService),
+            authStateProvider.overrideWith(_LockedAuthStateNotifier.new),
+          ],
+          child: const MaterialApp(home: LockScreen()),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump();
+
+      final pinField = tester.widget<TextField>(find.byType(TextField));
+      final decoration = pinField.decoration!;
+
+      expect(decoration.prefixIcon, isNotNull);
+      expect(decoration.suffixIcon, isNotNull);
+      expect(decoration.prefixIconConstraints?.minWidth, 48);
+      expect(decoration.suffixIconConstraints?.minWidth, 48);
+    });
   });
 }

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -23,6 +23,11 @@ const _backgroundSshChannel = MethodChannel(
   'xyz.depollsoft.monkeyssh/ssh_service',
 );
 
+class _SupportedButUnavailableAuthService extends FakeAuthService {
+  @override
+  Future<bool> isBiometricSupported() async => true;
+}
+
 Future<void> _pumpSettingsScreen(
   WidgetTester tester, {
   required AppDatabase db,
@@ -346,8 +351,39 @@ void main() {
       expect(find.text('Auto-lock timeout'), findsOneWidget);
       expect(find.text('Change PIN'), findsNothing);
       expect(find.text('Set up app lock first'), findsOneWidget);
-      expect(find.text('Not available on this device'), findsOneWidget);
+      expect(find.text('Not supported on this device'), findsOneWidget);
     });
+
+    testWidgets(
+      'keeps biometric toggle visible when support exists but enrollment is missing',
+      (tester) async {
+        final db = AppDatabase.forTesting(NativeDatabase.memory());
+        addTearDown(db.close);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              authServiceProvider.overrideWithValue(
+                _SupportedButUnavailableAuthService(),
+              ),
+              authStateProvider.overrideWith(MockAuthStateNotifier.new),
+            ],
+            child: const MaterialApp(home: SettingsScreen()),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.text('Biometric authentication'), findsOneWidget);
+        final biometricTile = find.widgetWithText(
+          SwitchListTile,
+          'Biometric authentication',
+        );
+        expect(biometricTile, findsOneWidget);
+        expect(tester.widget<SwitchListTile>(biometricTile).value, isFalse);
+      },
+    );
 
     testWidgets('displays Android background reliability controls', (
       tester,

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -54,6 +54,17 @@ class _UnlockedAuthStateNotifier extends AuthStateNotifier {
   AuthState build() => AuthState.unlocked;
 }
 
+class _ChangePinAuthService extends FakeAuthService {
+  bool shouldSucceed = false;
+  int changePinCallCount = 0;
+
+  @override
+  Future<bool> changePin(String currentPin, String newPin) async {
+    changePinCallCount += 1;
+    return shouldSucceed;
+  }
+}
+
 Future<void> _pumpSettingsScreen(
   WidgetTester tester, {
   required AppDatabase db,
@@ -452,6 +463,52 @@ void main() {
         findsOneWidget,
       );
     });
+
+    testWidgets(
+      'keeps change PIN dialog open when the current PIN is incorrect',
+      (tester) async {
+        final db = AppDatabase.forTesting(NativeDatabase.memory());
+        addTearDown(db.close);
+        final authService = _ChangePinAuthService();
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              authServiceProvider.overrideWithValue(authService),
+              authStateProvider.overrideWith(_UnlockedAuthStateNotifier.new),
+            ],
+            child: const MaterialApp(home: SettingsScreen()),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Change PIN'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'Current PIN'),
+          '0000',
+        );
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'New PIN'),
+          '1234',
+        );
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'Confirm new PIN'),
+          '1234',
+        );
+
+        await tester.tap(find.widgetWithText(FilledButton, 'Change'));
+        await tester.pumpAndSettle();
+
+        expect(authService.changePinCallCount, 1);
+        expect(find.byType(AlertDialog), findsOneWidget);
+        expect(find.text('Current PIN is incorrect'), findsOneWidget);
+        expect(find.text('PIN changed successfully'), findsNothing);
+      },
+    );
 
     testWidgets('displays Android background reliability controls', (
       tester,

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -28,6 +28,32 @@ class _SupportedButUnavailableAuthService extends FakeAuthService {
   Future<bool> isBiometricSupported() async => true;
 }
 
+class _ToggleableBiometricAuthService extends FakeAuthService {
+  bool biometricEnabled = false;
+
+  @override
+  Future<bool> isAuthEnabled() async => true;
+
+  @override
+  Future<bool> isBiometricSupported() async => true;
+
+  @override
+  Future<bool> isBiometricAvailable() async => false;
+
+  @override
+  Future<bool> isBiometricEnabled() async => biometricEnabled;
+
+  @override
+  Future<void> setBiometricEnabled({required bool enabled}) async {
+    biometricEnabled = enabled;
+  }
+}
+
+class _UnlockedAuthStateNotifier extends AuthStateNotifier {
+  @override
+  AuthState build() => AuthState.unlocked;
+}
+
 Future<void> _pumpSettingsScreen(
   WidgetTester tester, {
   required AppDatabase db,
@@ -384,6 +410,48 @@ void main() {
         expect(tester.widget<SwitchListTile>(biometricTile).value, isFalse);
       },
     );
+
+    testWidgets('updates biometric toggle state immediately after tapping', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final authService = _ToggleableBiometricAuthService();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            authServiceProvider.overrideWithValue(authService),
+            authStateProvider.overrideWith(_UnlockedAuthStateNotifier.new),
+          ],
+          child: const MaterialApp(home: SettingsScreen()),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final biometricTile = find.widgetWithText(
+        SwitchListTile,
+        'Biometric authentication',
+      );
+      final biometricSwitch = find.descendant(
+        of: biometricTile,
+        matching: find.byType(Switch),
+      );
+
+      expect(tester.widget<SwitchListTile>(biometricTile).value, isFalse);
+
+      await tester.tap(biometricSwitch);
+      await tester.pumpAndSettle();
+
+      expect(authService.biometricEnabled, isTrue);
+      expect(tester.widget<SwitchListTile>(biometricTile).value, isTrue);
+      expect(
+        find.text('Enabled - enroll fingerprint or face to use it'),
+        findsOneWidget,
+      );
+    });
 
     testWidgets('displays Android background reliability controls', (
       tester,

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -7,7 +7,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:monkeyssh/app/app_metadata.dart';
+import 'package:monkeyssh/app/routes.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/domain/models/monetization.dart';
 import 'package:monkeyssh/domain/services/auth_service.dart';
@@ -54,6 +56,11 @@ class _UnlockedAuthStateNotifier extends AuthStateNotifier {
   AuthState build() => AuthState.unlocked;
 }
 
+class _UnknownAuthStateNotifier extends AuthStateNotifier {
+  @override
+  AuthState build() => AuthState.unknown;
+}
+
 class _ChangePinAuthService extends FakeAuthService {
   bool shouldSucceed = false;
   int changePinCallCount = 0;
@@ -62,6 +69,13 @@ class _ChangePinAuthService extends FakeAuthService {
   Future<bool> changePin(String currentPin, String newPin) async {
     changePinCallCount += 1;
     return shouldSucceed;
+  }
+}
+
+class _ThrowingChangePinAuthService extends FakeAuthService {
+  @override
+  Future<bool> changePin(String currentPin, String newPin) async {
+    throw Exception('storage unavailable');
   }
 }
 
@@ -391,6 +405,72 @@ void main() {
       expect(find.text('Not supported on this device'), findsOneWidget);
     });
 
+    testWidgets('keeps setup actions disabled while auth state is loading', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(_UnknownAuthStateNotifier.new),
+          ],
+          child: const MaterialApp(home: SettingsScreen()),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final setupTile = tester.widget<ListTile>(
+        find.widgetWithText(ListTile, 'Set up app lock'),
+      );
+      expect(setupTile.onTap, isNull);
+      expect(find.text('Checking security status'), findsNWidgets(3));
+    });
+
+    testWidgets('navigates to auth setup from the settings entry point', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => const SettingsScreen(),
+          ),
+          GoRoute(
+            path: '/auth-setup',
+            name: Routes.authSetup,
+            builder: (context, state) =>
+                const Scaffold(body: Text('Auth setup destination')),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(MockAuthStateNotifier.new),
+          ],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Set up app lock'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Auth setup destination'), findsOneWidget);
+    });
+
     testWidgets(
       'keeps biometric toggle visible when support exists but enrollment is missing',
       (tester) async {
@@ -446,14 +526,9 @@ void main() {
         SwitchListTile,
         'Biometric authentication',
       );
-      final biometricSwitch = find.descendant(
-        of: biometricTile,
-        matching: find.byType(Switch),
-      );
-
       expect(tester.widget<SwitchListTile>(biometricTile).value, isFalse);
 
-      await tester.tap(biometricSwitch);
+      tester.widget<SwitchListTile>(biometricTile).onChanged!(true);
       await tester.pumpAndSettle();
 
       expect(authService.biometricEnabled, isTrue);
@@ -509,6 +584,59 @@ void main() {
         expect(find.text('PIN changed successfully'), findsNothing);
       },
     );
+
+    testWidgets('recovers the change PIN dialog after unexpected failures', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final reportedErrors = <FlutterErrorDetails>[];
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = reportedErrors.add;
+      addTearDown(() => FlutterError.onError = originalOnError);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            authServiceProvider.overrideWithValue(
+              _ThrowingChangePinAuthService(),
+            ),
+            authStateProvider.overrideWith(_UnlockedAuthStateNotifier.new),
+          ],
+          child: const MaterialApp(home: SettingsScreen()),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Change PIN'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Current PIN'),
+        '1234',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'New PIN'),
+        '5678',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Confirm new PIN'),
+        '5678',
+      );
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Change'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsOneWidget);
+      expect(find.text('Could not change PIN. Try again.'), findsOneWidget);
+      expect(reportedErrors, hasLength(1));
+      final cancelButton = tester.widget<TextButton>(
+        find.widgetWithText(TextButton, 'Cancel'),
+      );
+      expect(cancelButton.onPressed, isNotNull);
+    });
 
     testWidgets('displays Android background reliability controls', (
       tester,

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -333,15 +333,20 @@ void main() {
       );
     });
 
-    testWidgets('displays security options', (tester) async {
+    testWidgets('shows security setup actions when auth is not configured', (
+      tester,
+    ) async {
       final db = AppDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);
 
       await _pumpSettingsScreen(tester, db: db);
 
-      expect(find.text('Change PIN'), findsOneWidget);
+      expect(find.text('Set up app lock'), findsOneWidget);
       expect(find.text('Biometric authentication'), findsOneWidget);
       expect(find.text('Auto-lock timeout'), findsOneWidget);
+      expect(find.text('Change PIN'), findsNothing);
+      expect(find.text('Set up app lock first'), findsOneWidget);
+      expect(find.text('Not available on this device'), findsOneWidget);
     });
 
     testWidgets('displays Android background reliability controls', (


### PR DESCRIPTION
## Summary

- restore a usable security setup path from Settings when auth is not configured
- route the new Settings action through a named auth setup route
- update the settings screen test to cover the unconfigured-auth state

## Testing

- flutter analyze
- flutter test
