### PR TITLE
fix: sync iOS release configuration

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -501,6 +501,10 @@ jobs:
     if: inputs.build-ios
     runs-on: macos-26
     env:
+      # Keep release validation on the runner Xcode that includes the installed
+      # iOS simulator runtime. Newer side-by-side Xcodes can drift ahead of the
+      # available runtime and fail builds before Flutter starts.
+      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
       FLUTTY_PR_NUMBER: ${{ inputs.pr-number }}
       FLUTTY_PR_TITLE: ${{ inputs.pr-title }}
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,11 @@ jobs:
     needs: [changes, check]
     if: needs.changes.outputs.ios == 'true'
     runs-on: macos-26
+    env:
+      # Keep release validation on the runner Xcode that includes the installed
+      # iOS simulator runtime. Newer side-by-side Xcodes can drift ahead of the
+      # available runtime and fail builds before Flutter starts.
+      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,14 @@ Include:
 
 ### Building flavors locally
 
+For iOS release validation, use the Xcode bundle that matches the installed runtime:
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+```
+
+The current supported release selector is `/Applications/Xcode.app` (Xcode 26.2 on the macOS 26 image). Do not validate with side-by-side Xcode versions unless their iOS runtime is installed.
+
 ```bash
 flutter build apk --flavor private --release
 flutter build apk --flavor production --release

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -202,6 +202,19 @@ Google Play text limits still apply to the repository files: `title.txt` must st
 
 ## Building Flavors Locally
 
+### iOS release validation prerequisites
+
+Use the standard Xcode bundle with the installed iOS runtime when validating iOS releases locally:
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+flutter build ios --flavor production --release --no-codesign
+```
+
+Do not validate releases with a side-by-side Xcode beta or point release unless its selected SDK has a matching installed iOS runtime. For example, Xcode 26.4.1 fails when only the iOS 26.2 simulator runtime is installed; `/Applications/Xcode.app` (Xcode 26.2 on the current release image) is the supported local and CI selector.
+
+Flutter 3.41 also warns that UIScene lifecycle support will soon be required. MonkeySSH has a custom `AppDelegate` for native method channels, document pickers, Live Activities, and foreground/background state, so the automatic Flutter migration is not safe. Track the manual migration as release work: add `UIApplicationSceneManifest`, introduce a `SceneDelegate`/`FlutterSceneDelegate`, switch plugin registration to `FlutterImplicitEngineDelegate`, and move scene foreground/background handling out of `AppDelegate` together.
+
 ```bash
 # Private flavor
 flutter build apk --flavor private --release

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
-# Uncomment this line to define a global platform for your project
-# platform :ios, '13.0'
+# Keep CocoaPods aligned with the Runner deployment target.
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -51,6 +51,8 @@ PODS:
     - Flutter
   - pasteboard (0.0.1):
     - Flutter
+  - quick_actions_ios (0.0.1):
+    - Flutter
   - SDWebImage (5.21.7):
     - SDWebImage/Core (= 5.21.7)
   - SDWebImage/Core (5.21.7)
@@ -70,6 +72,7 @@ DEPENDENCIES:
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - pasteboard (from `.symlinks/plugins/pasteboard/ios`)
+  - quick_actions_ios (from `.symlinks/plugins/quick_actions_ios/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
@@ -99,6 +102,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   pasteboard:
     :path: ".symlinks/plugins/pasteboard/ios"
+  quick_actions_ios:
+    :path: ".symlinks/plugins/quick_actions_ios/ios"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   url_launcher_ios:
@@ -116,11 +121,12 @@ SPEC CHECKSUMS:
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   pasteboard: 3913b69d3f2be214970a8ae94e7e87fe76e47e98
+  quick_actions_ios: 500fcc11711d9f646739093395c4ae8eec25f779
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 
-PODFILE CHECKSUM: 7cd9bb08cae3d7a07fbdfd0ed7ce357b723aae93
+PODFILE CHECKSUM: 92e36c61e971114f3a90fb3f82b72cf0c9f19b95
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## Summary

- Regenerate `ios/Podfile.lock` so `quick_actions_ios` is included.
- Pin the iOS Podfile platform to the Runner deployment target and pin CI iOS jobs to `/Applications/Xcode.app`.
- Document iOS release validation Xcode/runtime requirements and the UIScene manual migration follow-up.

## Validation

- `pod install`
- `flutter analyze`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer flutter build ios --flavor production --release --no-codesign --no-tree-shake-icons`
- `ruby -e "require 'yaml'; %w[.github/workflows/ci.yml .github/workflows/build-deploy.yml].each { |f| YAML.load_file(f); puts \"parsed #{f}\" }"`

## Notes

The iOS build still emits Flutter's UIScene lifecycle warning. This PR documents why automatic migration is unsafe for MonkeySSH's custom `AppDelegate` and records the required manual migration steps.
