### PR TITLE
feat: preview SFTP videos

### DIFF
--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -10,6 +10,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:video_player/video_player.dart';
 
 import '../../data/repositories/host_repository.dart';
 import '../../domain/models/monetization.dart';
@@ -31,6 +34,7 @@ const _requestedPathLookupTimeout = Duration(seconds: 5);
 const _sftpFileRowExtentEstimate = 64.0;
 const _sftpHighlightedFileScrollPadding = 16.0;
 const _sftpScrollAnimationDuration = Duration(milliseconds: 220);
+const _videoPreviewCacheDirectoryName = 'monkeyssh-sftp-video-preview';
 
 /// Returns the parent directory for a POSIX remote path.
 @visibleForTesting
@@ -115,6 +119,63 @@ bool isPreviewableImageFileName(String filename) {
 bool isSvgFileName(String filename) =>
     path.extension(filename).toLowerCase() == '.svg';
 
+/// Whether the file name should be previewable as a video.
+@visibleForTesting
+bool isPreviewableVideoFileName(String filename) {
+  final extension = path.extension(filename).toLowerCase();
+  return {'.mp4', '.mov', '.m4v', '.webm'}.contains(extension);
+}
+
+/// Returns the best-effort MIME type for a previewable video file name.
+@visibleForTesting
+String? remoteVideoMimeTypeForFileName(String filename) =>
+    switch (path.extension(filename).toLowerCase()) {
+      '.mp4' => 'video/mp4',
+      '.mov' => 'video/quicktime',
+      '.m4v' => 'video/x-m4v',
+      '.webm' => 'video/webm',
+      _ => null,
+    };
+
+/// The preview type supported by the SFTP browser for a file.
+@visibleForTesting
+enum SftpPreviewKind {
+  /// Image preview.
+  image,
+
+  /// Video preview.
+  video,
+}
+
+/// Resolves the available preview kind for an SFTP entry.
+@visibleForTesting
+SftpPreviewKind? resolveSftpPreviewKind({
+  required bool isDirectory,
+  required String filename,
+}) {
+  if (isDirectory) {
+    return null;
+  }
+  if (isPreviewableImageFileName(filename)) {
+    return SftpPreviewKind.image;
+  }
+  if (isPreviewableVideoFileName(filename)) {
+    return SftpPreviewKind.video;
+  }
+  return null;
+}
+
+/// Formats a remote modified time stored as seconds since the Unix epoch.
+@visibleForTesting
+String? formatRemoteModifiedTime(int? modifyTime) {
+  if (modifyTime == null) {
+    return null;
+  }
+  return DateTime.fromMillisecondsSinceEpoch(
+    modifyTime * 1000,
+  ).toString().split('.').first;
+}
+
 /// Resolves the picker request used for local SFTP uploads.
 @visibleForTesting
 ({bool allowMultiple, bool withReadStream}) resolveSftpUploadPickerRequest() =>
@@ -146,6 +207,9 @@ enum SftpFileTapIntent {
   /// Preview a tapped image file.
   preview,
 
+  /// Preview a tapped video file.
+  previewVideo,
+
   /// Open a tapped non-image file in the editor.
   edit,
 }
@@ -159,11 +223,35 @@ SftpFileTapIntent resolveSftpFileTapIntent({
   if (isDirectory) {
     return SftpFileTapIntent.navigate;
   }
-  if (isPreviewableImageFileName(filename)) {
-    return SftpFileTapIntent.preview;
+  switch (resolveSftpPreviewKind(isDirectory: false, filename: filename)) {
+    case SftpPreviewKind.image:
+      return SftpFileTapIntent.preview;
+    case SftpPreviewKind.video:
+      return SftpFileTapIntent.previewVideo;
+    case null:
+      return SftpFileTapIntent.edit;
   }
-  return SftpFileTapIntent.edit;
 }
+
+/// Builds an error-state video preview screen for widget tests.
+@visibleForTesting
+Widget buildRemoteVideoPreviewErrorForTesting({
+  required String fileName,
+  required String remotePath,
+  required String localPath,
+  required String errorMessage,
+  int sizeBytes = 0,
+  DateTime? modifiedAt,
+  String? mimeType,
+}) => _RemoteVideoViewerScreen(
+  fileName: fileName,
+  localFile: File(localPath),
+  remotePath: remotePath,
+  sizeBytes: sizeBytes,
+  modifiedAt: modifiedAt,
+  mimeType: mimeType,
+  initialError: errorMessage,
+);
 
 /// SFTP file browser screen.
 class SftpScreen extends ConsumerStatefulWidget {
@@ -869,12 +957,18 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         unawaited(_navigateTo(_joinRemotePath(_currentPath, file.filename)));
       case SftpFileTapIntent.preview:
         unawaited(_previewImageFile(file));
+      case SftpFileTapIntent.previewVideo:
+        unawaited(_previewVideoFile(file));
       case SftpFileTapIntent.edit:
         unawaited(_editTextFile(file));
     }
   }
 
   void _showFileOptions(SftpName file) {
+    final previewKind = resolveSftpPreviewKind(
+      isDirectory: file.attr.isDirectory,
+      filename: file.filename,
+    );
     showModalBottomSheet<void>(
       context: context,
       builder: (context) => SafeArea(
@@ -889,14 +983,26 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
                 _showFileInfo(file);
               },
             ),
-            if (!file.attr.isDirectory &&
-                isPreviewableImageFileName(file.filename))
+            if (previewKind != null)
               ListTile(
-                leading: const Icon(Icons.image_outlined),
-                title: const Text('View'),
+                leading: Icon(
+                  previewKind == SftpPreviewKind.video
+                      ? Icons.video_file_outlined
+                      : Icons.image_outlined,
+                ),
+                title: Text(
+                  previewKind == SftpPreviewKind.video
+                      ? 'Preview video'
+                      : 'View',
+                ),
                 onTap: () {
                   Navigator.pop(context);
-                  unawaited(_previewImageFile(file));
+                  switch (previewKind) {
+                    case SftpPreviewKind.image:
+                      unawaited(_previewImageFile(file));
+                    case SftpPreviewKind.video:
+                      unawaited(_previewVideoFile(file));
+                  }
                 },
               ),
             if (!file.attr.isDirectory)
@@ -964,12 +1070,10 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
           children: [
             _InfoRow('Type', file.attr.isDirectory ? 'Directory' : 'File'),
             _InfoRow('Size', formatRemoteFileSize(file.attr.size ?? 0)),
-            if (file.attr.modifyTime != null)
+            if (formatRemoteModifiedTime(file.attr.modifyTime) != null)
               _InfoRow(
                 'Modified',
-                DateTime.fromMillisecondsSinceEpoch(
-                  (file.attr.modifyTime ?? 0) * 1000,
-                ).toString().split('.').first,
+                formatRemoteModifiedTime(file.attr.modifyTime)!,
               ),
           ],
         ),
@@ -1293,6 +1397,176 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     }
   }
 
+  Future<void> _previewVideoFile(SftpName file) async {
+    final sftp = _sftp;
+    if (sftp == null) {
+      return;
+    }
+
+    final remotePath = _joinRemotePath(_currentPath, file.filename);
+    final progress = ValueNotifier<_RemoteVideoDownloadProgress>(
+      _RemoteVideoDownloadProgress(
+        remotePath: remotePath,
+        downloadedBytes: 0,
+        totalBytes: file.attr.size ?? 0,
+      ),
+    );
+    final cancelToken = _SftpTransferCancelToken();
+    final downloadFuture = _cacheRemoteVideoFile(
+      sftp: sftp,
+      file: file,
+      remotePath: remotePath,
+      progress: progress,
+      cancelToken: cancelToken,
+    );
+
+    final dialogResult = await showDialog<_RemoteVideoCacheDialogResult>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => _RemoteVideoCachingDialog(
+        fileName: file.filename,
+        progressListenable: progress,
+        downloadFuture: downloadFuture,
+        onCancel: () {
+          cancelToken.cancel();
+          Navigator.of(
+            context,
+          ).pop(const _RemoteVideoCacheDialogResult.cancelled());
+        },
+      ),
+    );
+    progress.dispose();
+
+    if (!mounted || dialogResult == null) {
+      cancelToken.cancel();
+      return;
+    }
+
+    if (dialogResult.cancelled) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Video preview cancelled')));
+      return;
+    }
+
+    final cacheResult = dialogResult.cacheResult;
+    if (cacheResult == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Video preview failed: ${_describePreviewError(dialogResult.error)}',
+          ),
+          action: SnackBarAction(
+            label: 'Download',
+            onPressed: () => unawaited(_downloadFile(file)),
+          ),
+        ),
+      );
+      return;
+    }
+
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute(
+        fullscreenDialog: true,
+        builder: (context) => _RemoteVideoViewerScreen(
+          fileName: file.filename,
+          localFile: cacheResult.localFile,
+          remotePath: remotePath,
+          sizeBytes: file.attr.size ?? cacheResult.downloadedBytes,
+          modifiedAt: file.attr.modifyTime == null
+              ? null
+              : DateTime.fromMillisecondsSinceEpoch(
+                  file.attr.modifyTime! * 1000,
+                ),
+          mimeType: remoteVideoMimeTypeForFileName(file.filename),
+        ),
+      ),
+    );
+  }
+
+  Future<_CachedRemoteVideo> _cacheRemoteVideoFile({
+    required SftpClient sftp,
+    required SftpName file,
+    required String remotePath,
+    required ValueNotifier<_RemoteVideoDownloadProgress> progress,
+    required _SftpTransferCancelToken cancelToken,
+  }) async {
+    final tempDirectory = await getTemporaryDirectory();
+    final cacheDirectory = Directory(
+      path.join(tempDirectory.path, _videoPreviewCacheDirectoryName),
+    );
+    await cacheDirectory.create(recursive: true);
+    cancelToken.throwIfCancelled();
+
+    final cacheFile = File(
+      path.join(
+        cacheDirectory.path,
+        '${DateTime.now().toUtc().microsecondsSinceEpoch}-'
+        '${_sanitizeVideoCacheFileName(file.filename)}',
+      ),
+    );
+
+    SftpFile? remoteFile;
+    IOSink? sink;
+    var downloadedBytes = 0;
+    var completed = false;
+
+    try {
+      remoteFile = await sftp.open(remotePath);
+      cancelToken.onCancel(() {
+        final openFile = remoteFile;
+        if (openFile != null) {
+          unawaited(openFile.close());
+        }
+      });
+      sink = cacheFile.openWrite();
+
+      await for (final chunk in remoteFile.read()) {
+        cancelToken.throwIfCancelled();
+        sink.add(chunk);
+        downloadedBytes += chunk.length;
+        progress.value = progress.value.copyWith(
+          downloadedBytes: downloadedBytes,
+        );
+      }
+
+      completed = true;
+      return _CachedRemoteVideo(
+        localFile: cacheFile,
+        downloadedBytes: downloadedBytes,
+      );
+    } finally {
+      await sink?.close();
+      await remoteFile?.close();
+      if (!completed) {
+        try {
+          await cacheFile.delete();
+        } on FileSystemException {
+          // Best-effort cleanup; failed preview caches live in temp storage.
+        }
+      }
+    }
+  }
+
+  String _sanitizeVideoCacheFileName(String filename) {
+    final sanitized = path.posix
+        .basename(filename)
+        .replaceAll(RegExp('[^A-Za-z0-9._-]+'), '-')
+        .replaceAll(RegExp('-+'), '-')
+        .replaceAll(RegExp(r'^-+|-+$'), '');
+    return sanitized.isEmpty ? 'video' : sanitized;
+  }
+
+  String _describePreviewError(Object? error) {
+    if (error == null) {
+      return 'Unknown error';
+    }
+    if (error is _SftpTransferCancelledException) {
+      return 'Cancelled';
+    }
+    return error.toString().replaceFirst(RegExp('^Exception: '), '');
+  }
+
   Future<void> _editTextFile(SftpName file) async {
     if (_sftp == null) {
       return;
@@ -1562,6 +1836,526 @@ class _InfoRow extends StatelessWidget {
       ],
     ),
   );
+}
+
+class _RemoteVideoDownloadProgress {
+  const _RemoteVideoDownloadProgress({
+    required this.remotePath,
+    required this.downloadedBytes,
+    required this.totalBytes,
+  });
+
+  final String remotePath;
+  final int downloadedBytes;
+  final int totalBytes;
+
+  double? get fraction =>
+      totalBytes <= 0 ? null : (downloadedBytes / totalBytes).clamp(0.0, 1.0);
+
+  _RemoteVideoDownloadProgress copyWith({int? downloadedBytes}) =>
+      _RemoteVideoDownloadProgress(
+        remotePath: remotePath,
+        downloadedBytes: downloadedBytes ?? this.downloadedBytes,
+        totalBytes: totalBytes,
+      );
+}
+
+class _SftpTransferCancelToken {
+  final List<VoidCallback> _cancelCallbacks = [];
+  var _isCancelled = false;
+
+  void cancel() {
+    if (_isCancelled) {
+      return;
+    }
+    _isCancelled = true;
+    for (final callback in _cancelCallbacks) {
+      callback();
+    }
+  }
+
+  void onCancel(VoidCallback callback) {
+    if (_isCancelled) {
+      callback();
+      return;
+    }
+    _cancelCallbacks.add(callback);
+  }
+
+  void throwIfCancelled() {
+    if (_isCancelled) {
+      throw const _SftpTransferCancelledException();
+    }
+  }
+}
+
+class _SftpTransferCancelledException implements Exception {
+  const _SftpTransferCancelledException();
+
+  @override
+  String toString() => 'Video preview cancelled';
+}
+
+class _CachedRemoteVideo {
+  const _CachedRemoteVideo({
+    required this.localFile,
+    required this.downloadedBytes,
+  });
+
+  final File localFile;
+  final int downloadedBytes;
+}
+
+class _RemoteVideoCacheDialogResult {
+  const _RemoteVideoCacheDialogResult.success(this.cacheResult)
+    : error = null,
+      cancelled = false;
+
+  const _RemoteVideoCacheDialogResult.failure(this.error)
+    : cacheResult = null,
+      cancelled = false;
+
+  const _RemoteVideoCacheDialogResult.cancelled()
+    : cacheResult = null,
+      error = null,
+      cancelled = true;
+
+  final _CachedRemoteVideo? cacheResult;
+  final Object? error;
+  final bool cancelled;
+}
+
+class _RemoteVideoCachingDialog extends StatefulWidget {
+  const _RemoteVideoCachingDialog({
+    required this.fileName,
+    required this.progressListenable,
+    required this.downloadFuture,
+    required this.onCancel,
+  });
+
+  final String fileName;
+  final ValueListenable<_RemoteVideoDownloadProgress> progressListenable;
+  final Future<_CachedRemoteVideo> downloadFuture;
+  final VoidCallback onCancel;
+
+  @override
+  State<_RemoteVideoCachingDialog> createState() =>
+      _RemoteVideoCachingDialogState();
+}
+
+class _RemoteVideoCachingDialogState extends State<_RemoteVideoCachingDialog> {
+  @override
+  void initState() {
+    super.initState();
+    widget.downloadFuture.then<void>(
+      (cacheResult) {
+        if (!mounted) {
+          return;
+        }
+        Navigator.of(
+          context,
+        ).pop(_RemoteVideoCacheDialogResult.success(cacheResult));
+      },
+      onError: (Object error, StackTrace _) {
+        if (!mounted) {
+          return;
+        }
+        Navigator.of(context).pop(_RemoteVideoCacheDialogResult.failure(error));
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => AlertDialog(
+    title: const Text('Loading video preview'),
+    content: ValueListenableBuilder<_RemoteVideoDownloadProgress>(
+      valueListenable: widget.progressListenable,
+      builder: (context, progress, _) => Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(widget.fileName, maxLines: 1, overflow: TextOverflow.ellipsis),
+          const SizedBox(height: 8),
+          Text(
+            progress.remotePath,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: 16),
+          LinearProgressIndicator(value: progress.fraction),
+          const SizedBox(height: 8),
+          Text(
+            progress.totalBytes > 0
+                ? '${formatRemoteFileSize(progress.downloadedBytes)} of '
+                      '${formatRemoteFileSize(progress.totalBytes)}'
+                : '${formatRemoteFileSize(progress.downloadedBytes)} loaded',
+          ),
+        ],
+      ),
+    ),
+    actions: [
+      TextButton(onPressed: widget.onCancel, child: const Text('Cancel')),
+    ],
+  );
+}
+
+class _RemoteVideoViewerScreen extends StatefulWidget {
+  const _RemoteVideoViewerScreen({
+    required this.fileName,
+    required this.localFile,
+    required this.remotePath,
+    required this.sizeBytes,
+    this.modifiedAt,
+    this.mimeType,
+    this.initialError,
+  });
+
+  final String fileName;
+  final File localFile;
+  final String remotePath;
+  final int sizeBytes;
+  final DateTime? modifiedAt;
+  final String? mimeType;
+  final String? initialError;
+
+  @override
+  State<_RemoteVideoViewerScreen> createState() =>
+      _RemoteVideoViewerScreenState();
+}
+
+class _RemoteVideoViewerScreenState extends State<_RemoteVideoViewerScreen> {
+  VideoPlayerController? _controller;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _error = widget.initialError;
+    if (_error == null) {
+      unawaited(_initializeController());
+    }
+  }
+
+  Future<void> _initializeController() async {
+    final controller = VideoPlayerController.file(widget.localFile);
+    _controller = controller..addListener(_handleVideoValueChanged);
+    try {
+      await controller.initialize();
+      if (!mounted) {
+        return;
+      }
+      setState(() {});
+    } on Object catch (error, stackTrace) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          library: 'sftp',
+          context: ErrorDescription('while initializing remote video preview'),
+        ),
+      );
+      if (mounted) {
+        setState(() {
+          _error = _playbackErrorMessage(error);
+        });
+      }
+    }
+  }
+
+  void _handleVideoValueChanged() {
+    final controller = _controller;
+    if (!mounted || controller == null) {
+      return;
+    }
+    final value = controller.value;
+    if (value.hasError) {
+      final message = _playbackErrorMessage(
+        value.errorDescription ?? 'Unknown playback error',
+      );
+      if (_error != message) {
+        setState(() {
+          _error = message;
+        });
+      }
+      return;
+    }
+    if (_error == null) {
+      setState(() {});
+    }
+  }
+
+  @override
+  void dispose() {
+    final controller = _controller;
+    if (controller != null) {
+      controller.removeListener(_handleVideoValueChanged);
+      unawaited(controller.dispose());
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final error = _error;
+    final controller = _controller;
+
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.fileName)),
+      body: error != null
+          ? _buildErrorBody(context, error)
+          : controller == null || !controller.value.isInitialized
+          ? _buildLoadingBody(context)
+          : _buildPlayerBody(context, controller),
+    );
+  }
+
+  Widget _buildLoadingBody(BuildContext context) => Center(
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const CircularProgressIndicator(),
+        const SizedBox(height: 16),
+        const Text('Preparing video playback…'),
+        const SizedBox(height: 24),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: _buildMetadataCard(context),
+        ),
+      ],
+    ),
+  );
+
+  Widget _buildPlayerBody(
+    BuildContext context,
+    VideoPlayerController controller,
+  ) {
+    final theme = Theme.of(context);
+    final videoValue = controller.value;
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        DecoratedBox(
+          decoration: const BoxDecoration(color: Colors.black),
+          child: AspectRatio(
+            aspectRatio: videoValue.aspectRatio == 0
+                ? 16 / 9
+                : videoValue.aspectRatio,
+            child: VideoPlayer(controller),
+          ),
+        ),
+        const SizedBox(height: 12),
+        _buildPlaybackControls(context, controller),
+        const SizedBox(height: 16),
+        Text('Remote video', style: theme.textTheme.titleMedium),
+        const SizedBox(height: 8),
+        _buildMetadataCard(context),
+      ],
+    );
+  }
+
+  Widget _buildErrorBody(BuildContext context, String error) => ListView(
+    padding: const EdgeInsets.all(24),
+    children: [
+      Icon(
+        Icons.video_file_outlined,
+        size: 64,
+        color: Theme.of(context).colorScheme.error,
+      ),
+      const SizedBox(height: 16),
+      Text(
+        'Could not play video preview',
+        textAlign: TextAlign.center,
+        style: Theme.of(context).textTheme.titleLarge,
+      ),
+      const SizedBox(height: 8),
+      Text(error, textAlign: TextAlign.center),
+      const SizedBox(height: 16),
+      Text(
+        'The cached file is still available. Save it locally or open/share it '
+        'with another app that supports this codec.',
+        textAlign: TextAlign.center,
+        style: Theme.of(context).textTheme.bodyMedium,
+      ),
+      const SizedBox(height: 24),
+      Wrap(
+        alignment: WrapAlignment.center,
+        spacing: 12,
+        runSpacing: 8,
+        children: [
+          OutlinedButton.icon(
+            onPressed: _saveCachedCopy,
+            icon: const Icon(Icons.download),
+            label: const Text('Save copy'),
+          ),
+          FilledButton.icon(
+            onPressed: _shareCachedCopy,
+            icon: const Icon(Icons.ios_share),
+            label: const Text('Open/Share'),
+          ),
+        ],
+      ),
+      const SizedBox(height: 24),
+      _buildMetadataCard(context),
+    ],
+  );
+
+  Widget _buildPlaybackControls(
+    BuildContext context,
+    VideoPlayerController controller,
+  ) {
+    final value = controller.value;
+    final duration = value.duration;
+    final position = value.position > duration ? duration : value.position;
+    final canSeek = duration.inMilliseconds > 0;
+    final max = canSeek ? duration.inMilliseconds.toDouble() : 1.0;
+    final sliderValue = canSeek
+        ? position.inMilliseconds.clamp(0, duration.inMilliseconds).toDouble()
+        : 0.0;
+
+    return Column(
+      children: [
+        Row(
+          children: [
+            IconButton.filled(
+              onPressed: () {
+                if (value.isPlaying) {
+                  unawaited(controller.pause());
+                } else {
+                  unawaited(controller.play());
+                }
+              },
+              icon: Icon(value.isPlaying ? Icons.pause : Icons.play_arrow),
+              tooltip: value.isPlaying ? 'Pause' : 'Play',
+            ),
+            const SizedBox(width: 12),
+            Text(_formatVideoDuration(position)),
+            Expanded(
+              child: Slider(
+                value: sliderValue,
+                max: max,
+                onChanged: canSeek
+                    ? (value) => unawaited(
+                        controller.seekTo(
+                          Duration(milliseconds: value.round()),
+                        ),
+                      )
+                    : null,
+              ),
+            ),
+            Text(_formatVideoDuration(duration)),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMetadataCard(BuildContext context) => Card(
+    child: Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _InfoRow('Path', widget.remotePath),
+          _InfoRow('Size', formatRemoteFileSize(widget.sizeBytes)),
+          if (widget.modifiedAt != null)
+            _InfoRow(
+              'Modified',
+              widget.modifiedAt!.toString().split('.').first,
+            ),
+          _InfoRow('MIME', widget.mimeType ?? 'Unknown'),
+          _InfoRow('Cached copy', widget.localFile.path),
+        ],
+      ),
+    ),
+  );
+
+  Future<void> _saveCachedCopy() async {
+    final savePath = await FilePicker.saveFile(
+      dialogTitle: 'Save ${widget.fileName}',
+      fileName: widget.fileName,
+    );
+    if (savePath == null) {
+      return;
+    }
+
+    try {
+      await widget.localFile.copy(savePath);
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Saved "${widget.fileName}"')));
+      }
+    } on FileSystemException catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Save failed: ${error.message}')),
+        );
+      }
+    }
+  }
+
+  Future<void> _shareCachedCopy() async {
+    try {
+      final result = await SharePlus.instance.share(
+        ShareParams(
+          files: [
+            XFile(
+              widget.localFile.path,
+              mimeType: widget.mimeType,
+              name: widget.fileName,
+            ),
+          ],
+          sharePositionOrigin: _shareOriginFromContext(context),
+        ),
+      );
+      if (!mounted) {
+        return;
+      }
+      if (result.status == ShareResultStatus.dismissed) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Open/share cancelled')));
+      }
+    } on Object catch (error, stackTrace) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          library: 'sftp',
+          context: ErrorDescription('while sharing remote video preview'),
+        ),
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to open share sheet')),
+        );
+      }
+    }
+  }
+
+  Rect? _shareOriginFromContext(BuildContext context) {
+    final box = context.findRenderObject() as RenderBox?;
+    if (box == null || !box.hasSize) {
+      return null;
+    }
+    return box.localToGlobal(Offset.zero) & box.size;
+  }
+
+  String _playbackErrorMessage(Object error) =>
+      'This platform could not decode or play the video. Try saving or '
+      'opening the cached copy in another app. $error';
+
+  String _formatVideoDuration(Duration duration) {
+    final hours = duration.inHours;
+    final minutes = duration.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final seconds = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
+    if (hours > 0) {
+      return '$hours:$minutes:$seconds';
+    }
+    return '$minutes:$seconds';
+  }
 }
 
 class _RemoteImageViewerScreen extends StatelessWidget {

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -30,6 +30,11 @@ import 'remote_text_editor_screen.dart';
 
 const _maxEditableBytes = 1024 * 1024;
 const _maxPreviewBytes = 10 * 1024 * 1024;
+
+/// Maximum remote video size cached for inline preview playback.
+@visibleForTesting
+const maxRemoteVideoPreviewBytes = 100 * 1024 * 1024;
+
 const _requestedPathLookupTimeout = Duration(seconds: 5);
 const _sftpFileRowExtentEstimate = 64.0;
 const _sftpHighlightedFileScrollPadding = 16.0;
@@ -136,6 +141,35 @@ String? remoteVideoMimeTypeForFileName(String filename) =>
       '.webm' => 'video/webm',
       _ => null,
     };
+
+/// Whether a known remote video size is allowed for inline preview caching.
+@visibleForTesting
+bool isRemoteVideoPreviewSizeAllowed(
+  int? sizeBytes, {
+  int maxBytes = maxRemoteVideoPreviewBytes,
+}) => sizeBytes == null || sizeBytes <= maxBytes;
+
+/// Whether adding a streamed video chunk would exceed the preview byte cap.
+@visibleForTesting
+bool wouldRemoteVideoPreviewExceedByteCap({
+  required int downloadedBytes,
+  required int chunkBytes,
+  int maxBytes = maxRemoteVideoPreviewBytes,
+}) => downloadedBytes + chunkBytes > maxBytes;
+
+/// Describes why a remote video is too large for inline preview.
+@visibleForTesting
+String remoteVideoPreviewTooLargeMessage({
+  int? sizeBytes,
+  int maxBytes = maxRemoteVideoPreviewBytes,
+}) {
+  final sizeDetail = sizeBytes == null
+      ? 'It exceeded the streaming limit'
+      : 'It is ${formatRemoteFileSize(sizeBytes)}';
+  return 'Video is too large to preview here. $sizeDetail; '
+      'the preview limit is ${formatRemoteFileSize(maxBytes)}. '
+      'Download it instead.';
+}
 
 /// The preview type supported by the SFTP browser for a file.
 @visibleForTesting
@@ -1404,11 +1438,20 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     }
 
     final remotePath = _joinRemotePath(_currentPath, file.filename);
+    final knownSize = file.attr.size;
+    if (!isRemoteVideoPreviewSizeAllowed(knownSize)) {
+      _showVideoPreviewFallbackSnackBar(
+        file,
+        remoteVideoPreviewTooLargeMessage(sizeBytes: knownSize),
+      );
+      return;
+    }
+
     final progress = ValueNotifier<_RemoteVideoDownloadProgress>(
       _RemoteVideoDownloadProgress(
         remotePath: remotePath,
         downloadedBytes: 0,
-        totalBytes: file.attr.size ?? 0,
+        totalBytes: knownSize ?? 0,
       ),
     );
     final cancelToken = _SftpTransferCancelToken();
@@ -1420,47 +1463,52 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       cancelToken: cancelToken,
     );
 
-    final dialogResult = await showDialog<_RemoteVideoCacheDialogResult>(
-      context: context,
-      barrierDismissible: false,
-      builder: (context) => _RemoteVideoCachingDialog(
-        fileName: file.filename,
-        progressListenable: progress,
+    _RemoteVideoCacheDialogResult? dialogResult;
+    try {
+      dialogResult = await _showRemoteVideoCacheDialog(
+        file: file,
+        progress: progress,
         downloadFuture: downloadFuture,
-        onCancel: () {
-          cancelToken.cancel();
-          Navigator.of(
-            context,
-          ).pop(const _RemoteVideoCacheDialogResult.cancelled());
-        },
-      ),
-    );
-    progress.dispose();
+        cancelToken: cancelToken,
+      );
+    } on Object {
+      cancelToken.cancel();
+      await _discardRemoteVideoDownload(downloadFuture);
+      progress.dispose();
+      rethrow;
+    }
 
     if (!mounted || dialogResult == null) {
       cancelToken.cancel();
+      final cacheResult = dialogResult?.cacheResult;
+      if (cacheResult == null) {
+        await _discardRemoteVideoDownload(downloadFuture);
+      } else {
+        await _deleteCachedRemoteVideoFile(cacheResult.localFile);
+      }
+      progress.dispose();
       return;
     }
 
     if (dialogResult.cancelled) {
+      cancelToken.cancel();
+      await _discardRemoteVideoDownload(downloadFuture);
+      progress.dispose();
+      if (!mounted) {
+        return;
+      }
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('Video preview cancelled')));
       return;
     }
+    progress.dispose();
 
     final cacheResult = dialogResult.cacheResult;
     if (cacheResult == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            'Video preview failed: ${_describePreviewError(dialogResult.error)}',
-          ),
-          action: SnackBarAction(
-            label: 'Download',
-            onPressed: () => unawaited(_downloadFile(file)),
-          ),
-        ),
+      _showVideoPreviewFallbackSnackBar(
+        file,
+        'Video preview failed: ${_describePreviewError(dialogResult.error)}',
       );
       return;
     }
@@ -1479,6 +1527,53 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
                   file.attr.modifyTime! * 1000,
                 ),
           mimeType: remoteVideoMimeTypeForFileName(file.filename),
+        ),
+      ),
+    );
+  }
+
+  Future<_RemoteVideoCacheDialogResult?> _showRemoteVideoCacheDialog({
+    required SftpName file,
+    required ValueNotifier<_RemoteVideoDownloadProgress> progress,
+    required Future<_CachedRemoteVideo> downloadFuture,
+    required _SftpTransferCancelToken cancelToken,
+  }) async => showDialog<_RemoteVideoCacheDialogResult>(
+    context: context,
+    barrierDismissible: false,
+    builder: (context) => _RemoteVideoCachingDialog(
+      fileName: file.filename,
+      progressListenable: progress,
+      downloadFuture: downloadFuture,
+      onCancel: () {
+        cancelToken.cancel();
+        Navigator.of(
+          context,
+        ).pop(const _RemoteVideoCacheDialogResult.cancelled());
+      },
+    ),
+  );
+
+  Future<void> _discardRemoteVideoDownload(
+    Future<_CachedRemoteVideo> downloadFuture,
+  ) async {
+    try {
+      final cacheResult = await downloadFuture;
+      await _deleteCachedRemoteVideoFile(cacheResult.localFile);
+    } on Object {
+      // Cancellation/errors are surfaced by the preview dialog when relevant.
+    }
+  }
+
+  void _showVideoPreviewFallbackSnackBar(SftpName file, String message) {
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        action: SnackBarAction(
+          label: 'Download',
+          onPressed: () => unawaited(_downloadFile(file)),
         ),
       ),
     );
@@ -1523,8 +1618,17 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
 
       await for (final chunk in remoteFile.read()) {
         cancelToken.throwIfCancelled();
+        final nextDownloadedBytes = downloadedBytes + chunk.length;
+        if (wouldRemoteVideoPreviewExceedByteCap(
+          downloadedBytes: downloadedBytes,
+          chunkBytes: chunk.length,
+        )) {
+          throw Exception(
+            remoteVideoPreviewTooLargeMessage(sizeBytes: nextDownloadedBytes),
+          );
+        }
         sink.add(chunk);
-        downloadedBytes += chunk.length;
+        downloadedBytes = nextDownloadedBytes;
         progress.value = progress.value.copyWith(
           downloadedBytes: downloadedBytes,
         );
@@ -1906,6 +2010,22 @@ class _CachedRemoteVideo {
   final int downloadedBytes;
 }
 
+Future<void> _deleteCachedRemoteVideoFile(File file) async {
+  try {
+    await file.delete();
+  } on FileSystemException {
+    // Best-effort cleanup; temp storage may already have removed the file.
+  }
+}
+
+void _deleteCachedRemoteVideoFileSync(File file) {
+  try {
+    file.deleteSync();
+  } on FileSystemException {
+    // Best-effort cleanup; temp storage may already have removed the file.
+  }
+}
+
 class _RemoteVideoCacheDialogResult {
   const _RemoteVideoCacheDialogResult.success(this.cacheResult)
     : error = null,
@@ -2027,6 +2147,7 @@ class _RemoteVideoViewerScreen extends StatefulWidget {
 class _RemoteVideoViewerScreenState extends State<_RemoteVideoViewerScreen> {
   VideoPlayerController? _controller;
   String? _error;
+  var _keepCachedFile = false;
 
   @override
   void initState() {
@@ -2090,9 +2211,20 @@ class _RemoteVideoViewerScreenState extends State<_RemoteVideoViewerScreen> {
     final controller = _controller;
     if (controller != null) {
       controller.removeListener(_handleVideoValueChanged);
-      unawaited(controller.dispose());
+      unawaited(_disposeControllerAndCachedFile(controller));
+    } else if (!_keepCachedFile) {
+      _deleteCachedRemoteVideoFileSync(widget.localFile);
     }
     super.dispose();
+  }
+
+  Future<void> _disposeControllerAndCachedFile(
+    VideoPlayerController controller,
+  ) async {
+    await controller.dispose();
+    if (!_keepCachedFile) {
+      await _deleteCachedRemoteVideoFile(widget.localFile);
+    }
   }
 
   @override
@@ -2282,6 +2414,7 @@ class _RemoteVideoViewerScreenState extends State<_RemoteVideoViewerScreen> {
 
     try {
       await widget.localFile.copy(savePath);
+      _keepCachedFile = true;
       if (mounted) {
         ScaffoldMessenger.of(
           context,
@@ -2317,6 +2450,8 @@ class _RemoteVideoViewerScreenState extends State<_RemoteVideoViewerScreen> {
         ScaffoldMessenger.of(
           context,
         ).showSnackBar(const SnackBar(content: Text('Open/share cancelled')));
+      } else {
+        _keepCachedFile = true;
       }
     } on Object catch (error, stackTrace) {
       FlutterError.reportError(

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import package_info_plus
 import pasteboard
 import share_plus
 import url_launcher_macos
+import video_player_avfoundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
@@ -25,4 +26,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PasteboardPlugin.register(with: registry.registrar(forPlugin: "PasteboardPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -225,6 +225,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.9.0"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -538,6 +546,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.6"
   http:
     dependency: transitive
     description:
@@ -1380,6 +1396,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  video_player:
+    dependency: "direct main"
+    description:
+      name: video_player
+      sha256: "48a7bdaa38a3d50ec10c78627abdbfad863fdf6f0d6e08c7c3c040cfd80ae36f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      sha256: "877a6c7ba772456077d7bfd71314629b3fe2b73733ce503fc77c3314d43a0ca0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.5"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      sha256: af0e5b8a7a4876fb37e7cc8cb2a011e82bb3ecfa45844ef672e32cb14a1f259e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.4"
+  video_player_platform_interface:
+    dependency: transitive
+    description:
+      name: video_player_platform_interface
+      sha256: "57c5d73173f76d801129d0531c2774052c5a7c11ccb962f1830630decd9f24ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.0"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,7 @@ dependencies:
   in_app_purchase_android: ^0.4.0+10
   in_app_purchase_storekit: ^0.4.8+1
   quick_actions: ^1.1.0
+  video_player: ^2.11.1
 
 dev_dependencies:
   flutter_test:

--- a/test/presentation/screens/sftp_screen_test.dart
+++ b/test/presentation/screens/sftp_screen_test.dart
@@ -120,6 +120,45 @@ void main() {
       expect(remoteVideoMimeTypeForFileName('notes.txt'), isNull);
     });
 
+    test('rejects known oversized video previews', () {
+      expect(
+        isRemoteVideoPreviewSizeAllowed(maxRemoteVideoPreviewBytes),
+        isTrue,
+      );
+      expect(
+        isRemoteVideoPreviewSizeAllowed(maxRemoteVideoPreviewBytes + 1),
+        isFalse,
+      );
+
+      expect(
+        remoteVideoPreviewTooLargeMessage(
+          sizeBytes: maxRemoteVideoPreviewBytes + 1,
+        ),
+        allOf(
+          contains('Video is too large to preview here'),
+          contains('100.0 MB'),
+          contains('Download it instead'),
+        ),
+      );
+    });
+
+    test('detects streaming video preview byte cap overflow', () {
+      expect(
+        wouldRemoteVideoPreviewExceedByteCap(
+          downloadedBytes: maxRemoteVideoPreviewBytes - 1,
+          chunkBytes: 1,
+        ),
+        isFalse,
+      );
+      expect(
+        wouldRemoteVideoPreviewExceedByteCap(
+          downloadedBytes: maxRemoteVideoPreviewBytes,
+          chunkBytes: 1,
+        ),
+        isTrue,
+      );
+    });
+
     test('detects svg file names', () {
       expect(isSvgFileName('diagram.svg'), isTrue);
       expect(isSvgFileName('diagram.SVG'), isTrue);
@@ -278,6 +317,40 @@ void main() {
       expect(find.text('Cached copy'), findsOneWidget);
       expect(find.text('Save copy'), findsOneWidget);
       expect(find.text('Open/Share'), findsOneWidget);
+    });
+
+    testWidgets('video preview deletes cached files when closed', (
+      tester,
+    ) async {
+      final cacheDirectory = Directory('build/sftp-video-preview-test')
+        ..createSync(recursive: true);
+      addTearDown(() {
+        if (cacheDirectory.existsSync()) {
+          cacheDirectory.deleteSync(recursive: true);
+        }
+      });
+
+      final cachedFile = File('${cacheDirectory.path}/cached-preview.mp4')
+        ..writeAsBytesSync([1, 2, 3]);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: buildRemoteVideoPreviewErrorForTesting(
+            fileName: 'cached-preview.mp4',
+            remotePath: '/home/depoll/cached-preview.mp4',
+            localPath: cachedFile.path,
+            errorMessage: 'Unsupported codec',
+            sizeBytes: 3,
+            mimeType: 'video/mp4',
+          ),
+        ),
+      );
+
+      expect(cachedFile.existsSync(), isTrue);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      expect(cachedFile.existsSync(), isFalse);
     });
   });
 }

--- a/test/presentation/screens/sftp_screen_test.dart
+++ b/test/presentation/screens/sftp_screen_test.dart
@@ -101,6 +101,25 @@ void main() {
       expect(isPreviewableImageFileName('notes.txt'), isFalse);
     });
 
+    test('detects previewable video file names', () {
+      expect(isPreviewableVideoFileName('screen-recording.mp4'), isTrue);
+      expect(isPreviewableVideoFileName('clip.MOV'), isTrue);
+      expect(isPreviewableVideoFileName('capture.m4v'), isTrue);
+      expect(isPreviewableVideoFileName('browser.webm'), isTrue);
+      expect(isPreviewableVideoFileName('notes.txt'), isFalse);
+    });
+
+    test('resolves video MIME candidates from file names', () {
+      expect(remoteVideoMimeTypeForFileName('recording.mp4'), 'video/mp4');
+      expect(
+        remoteVideoMimeTypeForFileName('recording.mov'),
+        'video/quicktime',
+      );
+      expect(remoteVideoMimeTypeForFileName('recording.m4v'), 'video/x-m4v');
+      expect(remoteVideoMimeTypeForFileName('recording.webm'), 'video/webm');
+      expect(remoteVideoMimeTypeForFileName('notes.txt'), isNull);
+    });
+
     test('detects svg file names', () {
       expect(isSvgFileName('diagram.svg'), isTrue);
       expect(isSvgFileName('diagram.SVG'), isTrue);
@@ -173,6 +192,35 @@ void main() {
       );
     });
 
+    test('resolves video taps as video preview', () {
+      expect(
+        resolveSftpFileTapIntent(
+          isDirectory: false,
+          filename: 'screen-recording.mp4',
+        ),
+        SftpFileTapIntent.previewVideo,
+      );
+    });
+
+    test('resolves preview kind for row action availability', () {
+      expect(
+        resolveSftpPreviewKind(isDirectory: true, filename: 'clip.mp4'),
+        isNull,
+      );
+      expect(
+        resolveSftpPreviewKind(isDirectory: false, filename: 'diagram.png'),
+        SftpPreviewKind.image,
+      );
+      expect(
+        resolveSftpPreviewKind(isDirectory: false, filename: 'clip.webm'),
+        SftpPreviewKind.video,
+      );
+      expect(
+        resolveSftpPreviewKind(isDirectory: false, filename: 'notes.txt'),
+        isNull,
+      );
+    });
+
     test('resolves other file taps as edit', () {
       expect(
         resolveSftpFileTapIntent(isDirectory: false, filename: 'notes.txt'),
@@ -203,6 +251,33 @@ void main() {
         ),
         closeTo(widths[widerButShorter]! + trailingSlack, 0.001),
       );
+    });
+
+    testWidgets('video preview errors show metadata and fallback actions', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: buildRemoteVideoPreviewErrorForTesting(
+            fileName: 'screen-recording.mp4',
+            remotePath: '/home/depoll/screen-recording.mp4',
+            localPath: 'build/sftp-video-preview-test/screen-recording.mp4',
+            errorMessage: 'Unsupported codec',
+            sizeBytes: 42,
+            modifiedAt: DateTime.utc(2024, 1, 2, 3, 4, 5),
+            mimeType: 'video/mp4',
+          ),
+        ),
+      );
+
+      expect(find.text('Could not play video preview'), findsOneWidget);
+      expect(find.text('Unsupported codec'), findsOneWidget);
+      expect(find.text('/home/depoll/screen-recording.mp4'), findsOneWidget);
+      expect(find.text('42 B'), findsOneWidget);
+      expect(find.text('video/mp4'), findsOneWidget);
+      expect(find.text('Cached copy'), findsOneWidget);
+      expect(find.text('Save copy'), findsOneWidget);
+      expect(find.text('Open/Share'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

- Add SFTP video detection for mp4, mov, m4v, and webm files, including tap and row-action preview entry points.
- Cache remote videos to a temporary local file with progress, cancellation, metadata, playback controls, and explicit fallback actions.
- Add video preview tests for detection, action availability, metadata, and unsupported playback fallback UI.

## Validation

- dart format lib/presentation/screens/sftp_screen.dart test/presentation/screens/sftp_screen_test.dart
- flutter analyze
- flutter test test/presentation/screens/sftp_screen_test.dart
- flutter test
