### PR TITLE
feat: polish connected terminal UX

### DIFF
--- a/lib/presentation/screens/remote_text_editor_screen.dart
+++ b/lib/presentation/screens/remote_text_editor_screen.dart
@@ -622,6 +622,11 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
       child: Scaffold(
         backgroundColor: colors.background,
         appBar: AppBar(
+          leading: IconButton(
+            icon: const Icon(Icons.close),
+            tooltip: 'Close editor',
+            onPressed: () => Navigator.pop(context),
+          ),
           title: Text('Edit ${widget.fileName}'),
           actions: [
             if (_showDesktopZoomButtons(theme.platform))

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -137,6 +137,32 @@ String resolveUnreadableSftpUploadMessage(List<PlatformFile> files) {
   return 'Unable to read ${files.length} selected files';
 }
 
+/// Returns a validation error for a new remote folder name, or null if valid.
+@visibleForTesting
+String? validateSftpDirectoryName(String name) {
+  final trimmedName = name.trim();
+  if (trimmedName.isEmpty) {
+    return 'Folder name is required';
+  }
+  if (trimmedName == '.' || trimmedName == '..') {
+    return 'Choose a folder name, not a navigation shortcut';
+  }
+  if (trimmedName.contains('/')) {
+    return 'Folder name cannot contain /';
+  }
+  return null;
+}
+
+/// Formats the snackbar message shown after copying a remote path.
+@visibleForTesting
+String sftpCopyPathSnackBarMessage(String remotePath) =>
+    'Copied shell-safe path for "$remotePath"';
+
+/// Formats the snackbar message shown after creating a remote folder.
+@visibleForTesting
+String sftpCreatedDirectorySnackBarMessage(String remotePath) =>
+    'Created folder "$remotePath"';
+
 /// How a file row tap should behave in the SFTP browser.
 @visibleForTesting
 enum SftpFileTapIntent {
@@ -854,6 +880,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
                 _highlightedFileName == file.filename,
             onTap: () => _handleFileTap(file),
             onLongPress: () => _showFileOptions(file),
+            onShowOptions: () => _showFileOptions(file),
           );
         },
       ),
@@ -988,41 +1015,75 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
 
     final name = await showDialog<String>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Create Directory'),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          decoration: const InputDecoration(labelText: 'Directory name'),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, controller.text),
-            child: const Text('Create'),
-          ),
-        ],
+      builder: (context) => ValueListenableBuilder<TextEditingValue>(
+        valueListenable: controller,
+        builder: (context, value, _) {
+          final validationMessage = validateSftpDirectoryName(value.text);
+          final canCreate = validationMessage == null;
+
+          return AlertDialog(
+            title: const Text('Create Folder'),
+            content: TextField(
+              controller: controller,
+              autofocus: true,
+              textInputAction: TextInputAction.done,
+              decoration: InputDecoration(
+                labelText: 'Folder name',
+                helperText: 'Created inside $_currentPath',
+                errorText: value.text.isEmpty ? null : validationMessage,
+              ),
+              onSubmitted: canCreate
+                  ? (value) => Navigator.pop(context, value.trim())
+                  : null,
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Cancel'),
+              ),
+              FilledButton(
+                onPressed: canCreate
+                    ? () => Navigator.pop(context, value.text.trim())
+                    : null,
+                child: const Text('Create'),
+              ),
+            ],
+          );
+        },
       ),
     );
+    controller.dispose();
 
-    if (name != null && name.isNotEmpty && _sftp != null) {
-      try {
-        await _sftp!.mkdir(_joinRemotePath(_currentPath, name));
-        await _loadDirectory(_currentPath);
-        if (mounted) {
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text('Created "$name"')));
-        }
-      } on Exception catch (e) {
-        if (mounted) {
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text('Error: $e')));
-        }
+    if (name == null || _sftp == null) {
+      return;
+    }
+
+    final validationMessage = validateSftpDirectoryName(name);
+    if (validationMessage != null) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(validationMessage)));
+      }
+      return;
+    }
+
+    final remotePath = _joinRemotePath(_currentPath, name.trim());
+    try {
+      await _sftp!.mkdir(remotePath);
+      await _loadDirectory(_currentPath);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(sftpCreatedDirectorySnackBarMessage(remotePath)),
+          ),
+        );
+      }
+    } on Exception catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Could not create "$remotePath": $e')),
+        );
       }
     }
   }
@@ -1227,9 +1288,9 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     if (!mounted) {
       return;
     }
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(const SnackBar(content: Text('Copied shell-safe path')));
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(sftpCopyPathSnackBarMessage(remotePath))),
+    );
   }
 
   Future<void> _previewImageFile(SftpName file) async {
@@ -1456,12 +1517,14 @@ class _FileListTile extends StatelessWidget {
     required this.file,
     required this.onTap,
     required this.onLongPress,
+    required this.onShowOptions,
     this.isHighlighted = false,
   });
 
   final SftpName file;
   final VoidCallback onTap;
   final VoidCallback onLongPress;
+  final VoidCallback onShowOptions;
   final bool isHighlighted;
 
   @override
@@ -1511,9 +1574,19 @@ class _FileListTile extends StatelessWidget {
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),
-      trailing: isDirectory
-          ? Icon(Icons.chevron_right, size: 20, color: trailingIconColor)
-          : null,
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (isDirectory)
+            Icon(Icons.chevron_right, size: 20, color: trailingIconColor),
+          IconButton(
+            onPressed: onShowOptions,
+            icon: const Icon(Icons.more_vert),
+            color: trailingIconColor,
+            tooltip: 'More actions for ${file.filename}',
+          ),
+        ],
+      ),
       onTap: onTap,
       onLongPress: onLongPress,
     );

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -64,11 +64,74 @@ bool _isPromptReturnAsciiLetterOrDigit(int codeUnit) =>
     (codeUnit >= 0x41 && codeUnit <= 0x5A) ||
     (codeUnit >= 0x61 && codeUnit <= 0x7A);
 
+/// Minimum tmux handle touch target used by the collapsed window bar.
+@visibleForTesting
+const double tmuxHandleMinTouchExtent = 44;
+
+/// Returns a short, user-facing label for the terminal connection state.
+@visibleForTesting
+String describeTerminalConnectionState(
+  SshConnectionState state, {
+  required bool isConnecting,
+}) {
+  if (isConnecting &&
+      (state == SshConnectionState.disconnected ||
+          state == SshConnectionState.connecting)) {
+    return 'Connecting';
+  }
+
+  switch (state) {
+    case SshConnectionState.connected:
+      return 'Connected';
+    case SshConnectionState.connecting:
+      return 'Connecting';
+    case SshConnectionState.authenticating:
+      return 'Authenticating';
+    case SshConnectionState.reconnecting:
+      return 'Reconnecting';
+    case SshConnectionState.error:
+      return 'Connection error';
+    case SshConnectionState.disconnected:
+      return 'Disconnected';
+  }
+}
+
+/// Formats the remote host and session identity shown in the terminal title.
+@visibleForTesting
+String? formatTerminalConnectionIdentity({
+  required String? username,
+  required String? hostname,
+  required int? port,
+  required int? connectionId,
+}) {
+  final trimmedUsername = username?.trim();
+  final trimmedHostname = hostname?.trim();
+  final hasUsername = trimmedUsername != null && trimmedUsername.isNotEmpty;
+  final hasHostname = trimmedHostname != null && trimmedHostname.isNotEmpty;
+  final hostIdentity = hasHostname
+      ? '${hasUsername ? '$trimmedUsername@' : ''}$trimmedHostname'
+      : null;
+  final hostWithPort = hostIdentity == null
+      ? null
+      : port == null || port == 22
+      ? hostIdentity
+      : '$hostIdentity:$port';
+  final sessionLabel = connectionId == null ? null : 'session #$connectionId';
+
+  if (hostWithPort == null) {
+    return sessionLabel;
+  }
+  if (sessionLabel == null) {
+    return hostWithPort;
+  }
+  return '$hostWithPort · $sessionLabel';
+}
+
 /// Resolves how much vertical space the tmux bar can safely expand into.
 @visibleForTesting
 double resolveTmuxBarMaxContentHeight(
   double availableHeight, {
-  double handleHeight = 22,
+  double handleHeight = tmuxHandleMinTouchExtent,
   double reservedPadding = 8,
   double fallbackAvailableHeight = 0,
 }) {
@@ -171,14 +234,14 @@ EdgeInsets resolveTmuxBarSafeInsets(MediaQueryData mediaQuery) {
 @visibleForTesting
 double resolveTmuxBarRevealBottomOffset(
   double terminalBottomPadding, {
-  double handleHeight = 22,
+  double handleHeight = tmuxHandleMinTouchExtent,
 }) => terminalBottomPadding - handleHeight;
 
 /// Resolves the tmux bar's reveal opacity from the animated bottom padding.
 @visibleForTesting
 double resolveTmuxBarRevealOpacity(
   double terminalBottomPadding, {
-  double handleHeight = 22,
+  double handleHeight = tmuxHandleMinTouchExtent,
 }) {
   if (handleHeight <= 0) {
     return terminalBottomPadding > 0 ? 1 : 0;
@@ -391,7 +454,7 @@ class _TmuxExpandableBar extends StatefulWidget {
 
   /// Height of the collapsed handle bar. The terminal adds this as
   /// bottom padding so the handle sits over empty space.
-  static const handleHeight = 22.0;
+  static const handleHeight = tmuxHandleMinTouchExtent;
 
   @override
   State<_TmuxExpandableBar> createState() => _TmuxExpandableBarState();
@@ -867,62 +930,78 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       activeWindowTitle: resolveTmuxBarActiveWindowTitle(displayedWindows),
     );
     final activeWindowTool = resolveTmuxBarActiveWindowTool(displayedWindows);
-    return GestureDetector(
-      key: const ValueKey('tmux-handle-bar'),
-      onTap: () {
-        final wasExpanded = _expanded;
-        setState(() => _expanded = !_expanded);
-        // Refresh window list when expanding to get current active state.
-        if (!wasExpanded) {
-          _loadWindows();
-          if (widget.isProUser) {
-            unawaited(_prefetchPreferredSessionProvider());
-          }
-        }
-      },
-      child: SizedBox(
-        height: _TmuxExpandableBar.handleHeight,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12),
-          child: Row(
-            children: [
-              AgentToolIcon(
-                tool: activeWindowTool,
-                size: 12,
-                color: theme.colorScheme.primary,
-                fallbackIcon: Icons.window_outlined,
-              ),
-              const SizedBox(width: 4),
-              Expanded(
-                child: Text(
-                  handleLabel,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: theme.textTheme.labelSmall?.copyWith(
-                    fontSize: 10,
-                    color: theme.colorScheme.onSurfaceVariant,
+    final tooltip = _expanded
+        ? 'Collapse tmux windows'
+        : 'Show tmux windows: $handleLabel';
+
+    return Semantics(
+      button: true,
+      toggled: _expanded,
+      label: 'tmux windows: $handleLabel',
+      hint: _expanded
+          ? 'Double tap to collapse the tmux window list'
+          : 'Double tap to show tmux windows',
+      child: Tooltip(
+        message: tooltip,
+        child: GestureDetector(
+          key: const ValueKey('tmux-handle-bar'),
+          behavior: HitTestBehavior.opaque,
+          onTap: () {
+            final wasExpanded = _expanded;
+            setState(() => _expanded = !_expanded);
+            // Refresh window list when expanding to get current active state.
+            if (!wasExpanded) {
+              _loadWindows();
+              if (widget.isProUser) {
+                unawaited(_prefetchPreferredSessionProvider());
+              }
+            }
+          },
+          child: SizedBox(
+            height: _TmuxExpandableBar.handleHeight,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  AgentToolIcon(
+                    tool: activeWindowTool,
+                    size: 16,
+                    color: theme.colorScheme.primary,
+                    fallbackIcon: Icons.window_outlined,
                   ),
-                ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      handleLabel,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.labelMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.onSurfaceVariant.withAlpha(110),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: const SizedBox(width: 28, height: 4),
+                  ),
+                  const SizedBox(width: 8),
+                  AnimatedRotation(
+                    duration: const Duration(milliseconds: 300),
+                    turns: _expanded ? 0.5 : 0,
+                    child: Icon(
+                      Icons.keyboard_arrow_up,
+                      size: 20,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
               ),
-              const SizedBox(width: 6),
-              DecoratedBox(
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.onSurfaceVariant.withAlpha(90),
-                  borderRadius: BorderRadius.circular(999),
-                ),
-                child: const SizedBox(width: 10, height: 2),
-              ),
-              const SizedBox(width: 6),
-              AnimatedRotation(
-                duration: const Duration(milliseconds: 300),
-                turns: _expanded ? 0.5 : 0,
-                child: Icon(
-                  Icons.keyboard_arrow_up,
-                  size: 14,
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-              ),
-            ],
+            ),
           ),
         ),
       ),
@@ -4488,7 +4567,20 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _sessionThemeOverride ??
         _currentTheme ??
         (isDark ? TerminalThemes.midnightPurple : TerminalThemes.cleanWhite);
+    final connectionLabel = describeTerminalConnectionState(
+      connectionState,
+      isConnecting: _isConnecting,
+    );
+    final connectionIdentity = formatTerminalConnectionIdentity(
+      username: _host?.username,
+      hostname: _host?.hostname,
+      port: _host?.port,
+      connectionId: _connectionId,
+    );
     final titleSubtitleSegments = <String>[];
+    if (connectionIdentity != null) {
+      titleSubtitleSegments.add(connectionIdentity);
+    }
     if ((_iconName ?? '').isNotEmpty) {
       titleSubtitleSegments.add(_iconName!);
     }
@@ -4504,7 +4596,24 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(_host?.label ?? 'Terminal'),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Flexible(
+                  child: Text(
+                    _host?.label ?? 'Terminal',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                _TerminalConnectionStatusPill(
+                  label: connectionLabel,
+                  state: connectionState,
+                  isConnecting: _isConnecting,
+                ),
+              ],
+            ),
             if (titleSubtitle.isNotEmpty)
               Text(
                 titleSubtitle,
@@ -8034,6 +8143,97 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _TerminalConnectionStatusPill extends StatelessWidget {
+  const _TerminalConnectionStatusPill({
+    required this.label,
+    required this.state,
+    required this.isConnecting,
+  });
+
+  final String label;
+  final SshConnectionState state;
+  final bool isConnecting;
+
+  IconData get _icon {
+    if (isConnecting &&
+        (state == SshConnectionState.disconnected ||
+            state == SshConnectionState.connecting)) {
+      return Icons.sync;
+    }
+
+    switch (state) {
+      case SshConnectionState.connected:
+        return Icons.check_circle_outline;
+      case SshConnectionState.connecting:
+      case SshConnectionState.authenticating:
+        return Icons.sync;
+      case SshConnectionState.reconnecting:
+        return Icons.sync_problem_outlined;
+      case SshConnectionState.error:
+        return Icons.error_outline;
+      case SshConnectionState.disconnected:
+        return Icons.link_off;
+    }
+  }
+
+  Color _color(ColorScheme colorScheme) {
+    if (isConnecting &&
+        (state == SshConnectionState.disconnected ||
+            state == SshConnectionState.connecting)) {
+      return colorScheme.tertiary;
+    }
+
+    switch (state) {
+      case SshConnectionState.connected:
+        return colorScheme.primary;
+      case SshConnectionState.connecting:
+      case SshConnectionState.authenticating:
+      case SshConnectionState.reconnecting:
+        return colorScheme.tertiary;
+      case SshConnectionState.error:
+      case SshConnectionState.disconnected:
+        return colorScheme.error;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final statusColor = _color(colorScheme);
+
+    return Semantics(
+      label: 'Terminal connection status: $label',
+      child: Tooltip(
+        message: label,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: statusColor.withAlpha(24),
+            borderRadius: BorderRadius.circular(999),
+            border: Border.all(color: statusColor.withAlpha(150)),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(_icon, size: 13, color: statusColor),
+                const SizedBox(width: 4),
+                Text(
+                  label,
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: statusColor,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/test/presentation/screens/sftp_screen_test.dart
+++ b/test/presentation/screens/sftp_screen_test.dart
@@ -159,6 +159,31 @@ void main() {
       );
     });
 
+    test('validates new folder names before creating directories', () {
+      expect(validateSftpDirectoryName(''), 'Folder name is required');
+      expect(validateSftpDirectoryName('  '), 'Folder name is required');
+      expect(
+        validateSftpDirectoryName('nested/folder'),
+        'Folder name cannot contain /',
+      );
+      expect(
+        validateSftpDirectoryName('..'),
+        'Choose a folder name, not a navigation shortcut',
+      );
+      expect(validateSftpDirectoryName('release'), isNull);
+    });
+
+    test('includes remote paths in copy and create feedback', () {
+      expect(
+        sftpCopyPathSnackBarMessage('/var/www/site config'),
+        'Copied shell-safe path for "/var/www/site config"',
+      );
+      expect(
+        sftpCreatedDirectorySnackBarMessage('/var/www/releases'),
+        'Created folder "/var/www/releases"',
+      );
+    });
+
     test('resolves directory taps as navigation', () {
       expect(
         resolveSftpFileTapIntent(isDirectory: true, filename: 'Documents'),

--- a/test/widget/sftp_screen_test.dart
+++ b/test/widget/sftp_screen_test.dart
@@ -132,6 +132,26 @@ void main() {
       );
     });
 
+    testWidgets('shows an explicit close affordance in the editor app bar', (
+      tester,
+    ) async {
+      final controller = TextEditingController(text: 'alpha');
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: buildRemoteTextEditorScreenForTesting(
+            fileName: 'notes.txt',
+            controller: controller,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip('Close editor'), findsOneWidget);
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
     testWidgets(
       'starts at line 1 when the incoming controller selection is invalid',
       (tester) async {

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -40,17 +40,66 @@ void main() {
       );
     });
 
+    test('tmux handle keeps a full touch target', () {
+      expect(tmuxHandleMinTouchExtent, greaterThanOrEqualTo(44));
+    });
+
+    test('terminal connection labels distinguish connection states', () {
+      expect(
+        describeTerminalConnectionState(
+          SshConnectionState.disconnected,
+          isConnecting: true,
+        ),
+        'Connecting',
+      );
+      expect(
+        describeTerminalConnectionState(
+          SshConnectionState.authenticating,
+          isConnecting: false,
+        ),
+        'Authenticating',
+      );
+      expect(
+        describeTerminalConnectionState(
+          SshConnectionState.error,
+          isConnecting: false,
+        ),
+        'Connection error',
+      );
+    });
+
+    test('terminal identity includes remote host and session id', () {
+      expect(
+        formatTerminalConnectionIdentity(
+          username: 'deploy',
+          hostname: 'example.com',
+          port: 2222,
+          connectionId: 7,
+        ),
+        'deploy@example.com:2222 · session #7',
+      );
+      expect(
+        formatTerminalConnectionIdentity(
+          username: null,
+          hostname: null,
+          port: null,
+          connectionId: 8,
+        ),
+        'session #8',
+      );
+    });
+
     test('tmux bar reveal stays aligned with terminal padding', () {
-      expect(resolveTmuxBarRevealBottomOffset(0), -22);
-      expect(resolveTmuxBarRevealBottomOffset(11), -11);
-      expect(resolveTmuxBarRevealBottomOffset(22), 0);
-      expect(resolveTmuxBarRevealBottomOffset(56), 34);
+      expect(resolveTmuxBarRevealBottomOffset(0), -44);
+      expect(resolveTmuxBarRevealBottomOffset(22), -22);
+      expect(resolveTmuxBarRevealBottomOffset(44), 0);
+      expect(resolveTmuxBarRevealBottomOffset(78), 34);
 
       expect(resolveTmuxBarRevealOpacity(-10), 0);
       expect(resolveTmuxBarRevealOpacity(0), 0);
-      expect(resolveTmuxBarRevealOpacity(11), 0.5);
-      expect(resolveTmuxBarRevealOpacity(22), 1);
-      expect(resolveTmuxBarRevealOpacity(40), 1);
+      expect(resolveTmuxBarRevealOpacity(22), 0.5);
+      expect(resolveTmuxBarRevealOpacity(44), 1);
+      expect(resolveTmuxBarRevealOpacity(60), 1);
     });
 
     test('uses the active tmux window title in the handle label', () {
@@ -441,4 +490,4 @@ void main() {
   });
 }
 
-const double _tmuxExpandableBarHandleHeight = 22;
+const double _tmuxExpandableBarHandleHeight = tmuxHandleMinTouchExtent;


### PR DESCRIPTION
## Summary

- Add visible terminal connection status and remote session identity in the terminal app bar.
- Improve tmux handle discoverability with tooltip/semantics and a 44px touch target while preserving `ValueKey('tmux-handle-bar')`.
- Add explicit SFTP row overflow actions, clearer copy/create-folder feedback, folder-name validation, and a remote editor close button.
- Add focused coverage for terminal/tmux helpers, SFTP feedback/validation, and editor close affordance.

## Validation

- `dart format lib/presentation/screens/terminal_screen.dart lib/presentation/screens/sftp_screen.dart lib/presentation/screens/remote_text_editor_screen.dart test/widget/terminal_screen_layout_test.dart test/presentation/screens/sftp_screen_test.dart test/widget/sftp_screen_test.dart`
- `flutter analyze`
- `flutter test test/widget/terminal_screen_layout_test.dart test/presentation/screens/sftp_screen_test.dart test/widget/sftp_screen_test.dart`
- `flutter test`
