### PR TITLE
fix: clarify biometric app lock readiness

### DIFF
--- a/lib/domain/services/auth_service.dart
+++ b/lib/domain/services/auth_service.dart
@@ -110,8 +110,12 @@ class AuthService {
     return value == 'true';
   }
 
-  /// Check if device has biometric hardware.
-  Future<bool> isBiometricSupported() async => _isBiometricHardwareSupported();
+  /// Check if this device supports local authentication.
+  ///
+  /// This preserves the legacy contract of reporting whether the platform can
+  /// authenticate with device credentials. It can be true even when biometric
+  /// hardware is not present.
+  Future<bool> isBiometricSupported() async => isDeviceAuthSupported();
 
   /// Check if device supports local authentication.
   Future<bool> isDeviceAuthSupported() async {
@@ -124,9 +128,13 @@ class AuthService {
     }
   }
 
+  /// Check if device has biometric hardware.
+  Future<bool> isBiometricHardwareSupported() async =>
+      _isBiometricHardwareSupported();
+
   /// Check if biometrics are enrolled and ready to use.
   Future<bool> isBiometricAvailable() async {
-    if (!await _isBiometricHardwareSupported()) return false;
+    if (!await isBiometricHardwareSupported()) return false;
 
     final biometrics = await getAvailableBiometrics();
     return biometrics.isNotEmpty;
@@ -135,7 +143,7 @@ class AuthService {
   /// Get the current platform biometric readiness.
   Future<BiometricAvailability> getBiometricAvailability() async {
     final deviceAuthSupported = await isDeviceAuthSupported();
-    final biometricHardwareSupported = await _isBiometricHardwareSupported();
+    final biometricHardwareSupported = await isBiometricHardwareSupported();
     final enrolledBiometrics = biometricHardwareSupported
         ? await getAvailableBiometrics()
         : const <BiometricType>[];

--- a/lib/domain/services/auth_service.dart
+++ b/lib/domain/services/auth_service.dart
@@ -41,6 +41,41 @@ enum AuthMethod {
   both,
 }
 
+/// Current platform biometric readiness.
+@immutable
+class BiometricAvailability {
+  /// Creates a new [BiometricAvailability].
+  const BiometricAvailability({
+    required this.isDeviceAuthSupported,
+    required this.isBiometricHardwareSupported,
+    required this.enrolledBiometrics,
+  });
+
+  /// Whether the device supports local authentication at all.
+  ///
+  /// This can be true for device PIN/pattern/passcode even when no biometric
+  /// hardware is present.
+  final bool isDeviceAuthSupported;
+
+  /// Whether biometric hardware is supported on this device.
+  final bool isBiometricHardwareSupported;
+
+  /// Biometrics enrolled and currently available to local_auth.
+  final List<BiometricType> enrolledBiometrics;
+
+  /// Whether biometric authentication can be used without setup elsewhere.
+  bool get canAuthenticateWithBiometrics =>
+      isBiometricHardwareSupported && enrolledBiometrics.isNotEmpty;
+
+  /// Whether biometric hardware exists but the user must enroll first.
+  bool get needsBiometricEnrollment =>
+      isBiometricHardwareSupported && enrolledBiometrics.isEmpty;
+
+  /// Whether only non-biometric device credentials are supported.
+  bool get supportsDeviceCredentialOnly =>
+      isDeviceAuthSupported && !isBiometricHardwareSupported;
+}
+
 /// Service for handling app authentication (PIN/biometric).
 class AuthService {
   /// Creates a new [AuthService].
@@ -75,23 +110,49 @@ class AuthService {
     return value == 'true';
   }
 
-  /// Check if device supports biometric authentication.
-  Future<bool> isBiometricSupported() async {
+  /// Check if device has biometric hardware.
+  Future<bool> isBiometricSupported() async => _isBiometricHardwareSupported();
+
+  /// Check if device supports local authentication.
+  Future<bool> isDeviceAuthSupported() async {
     try {
       return await _localAuth.isDeviceSupported();
     } on PlatformException {
+      return false;
+    } on LocalAuthException {
       return false;
     }
   }
 
   /// Check if biometrics are enrolled and ready to use.
   Future<bool> isBiometricAvailable() async {
-    try {
-      if (!await isBiometricSupported()) return false;
+    if (!await _isBiometricHardwareSupported()) return false;
 
-      final biometrics = await _localAuth.getAvailableBiometrics();
-      return biometrics.isNotEmpty;
+    final biometrics = await getAvailableBiometrics();
+    return biometrics.isNotEmpty;
+  }
+
+  /// Get the current platform biometric readiness.
+  Future<BiometricAvailability> getBiometricAvailability() async {
+    final deviceAuthSupported = await isDeviceAuthSupported();
+    final biometricHardwareSupported = await _isBiometricHardwareSupported();
+    final enrolledBiometrics = biometricHardwareSupported
+        ? await getAvailableBiometrics()
+        : const <BiometricType>[];
+
+    return BiometricAvailability(
+      isDeviceAuthSupported: deviceAuthSupported,
+      isBiometricHardwareSupported: biometricHardwareSupported,
+      enrolledBiometrics: enrolledBiometrics,
+    );
+  }
+
+  Future<bool> _isBiometricHardwareSupported() async {
+    try {
+      return await _localAuth.canCheckBiometrics;
     } on PlatformException {
+      return false;
+    } on LocalAuthException {
       return false;
     }
   }
@@ -101,6 +162,8 @@ class AuthService {
     try {
       return await _localAuth.getAvailableBiometrics();
     } on PlatformException {
+      return [];
+    } on LocalAuthException {
       return [];
     }
   }
@@ -112,7 +175,7 @@ class AuthService {
 
     final hasUsablePin = await _hasUsablePin();
     final biometricEnabled = await isBiometricEnabled();
-    final biometricAvailable = await isBiometricAvailable();
+    final biometricAvailable = biometricEnabled && await isBiometricAvailable();
 
     if (biometricEnabled && biometricAvailable) {
       return hasUsablePin ? AuthMethod.both : AuthMethod.biometric;
@@ -134,7 +197,11 @@ class AuthService {
 
   /// Enable or disable biometric authentication.
   Future<void> setBiometricEnabled({required bool enabled}) async {
-    await _storage.write(key: _biometricEnabledKey, value: enabled.toString());
+    final canEnable = !enabled || await isBiometricAvailable();
+    await _storage.write(
+      key: _biometricEnabledKey,
+      value: (enabled && canEnable).toString(),
+    );
   }
 
   /// Verify PIN.
@@ -169,6 +236,10 @@ class AuthService {
 
   /// Authenticate with biometrics.
   Future<bool> authenticateWithBiometrics({String? reason}) async {
+    if (!await isBiometricAvailable()) {
+      return false;
+    }
+
     try {
       final localizedReason = reason ?? await _defaultLocalizedReason();
       return await _localAuth.authenticate(
@@ -177,6 +248,8 @@ class AuthService {
         persistAcrossBackgrounding: true,
       );
     } on PlatformException {
+      return false;
+    } on LocalAuthException {
       return false;
     }
   }

--- a/lib/presentation/screens/auth_setup_screen.dart
+++ b/lib/presentation/screens/auth_setup_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -18,27 +20,50 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
   final _confirmPinController = TextEditingController();
   int _step = 0; // 0: choose, 1: enter PIN, 2: confirm PIN
   bool _isLoading = false;
+  bool _isCheckingBiometric = true;
   String? _error;
-  bool _biometricSupported = false;
-  bool _biometricAvailable = false;
+  BiometricAvailability? _biometricAvailability;
   bool _enableBiometric = false;
 
   @override
   void initState() {
     super.initState();
-    _checkBiometric();
+    unawaited(_checkBiometric());
   }
 
   Future<void> _checkBiometric() async {
     final authService = ref.read(authServiceProvider);
-    final supported = await authService.isBiometricSupported();
-    final available =
-        supported && (await authService.getAvailableBiometrics()).isNotEmpty;
+    final availability = await authService.getBiometricAvailability();
     if (!mounted) return;
     setState(() {
-      _biometricSupported = supported;
-      _biometricAvailable = available;
+      _biometricAvailability = availability;
+      _isCheckingBiometric = false;
+      if (!availability.canAuthenticateWithBiometrics) {
+        _enableBiometric = false;
+      }
     });
+  }
+
+  bool get _biometricSupported =>
+      _biometricAvailability?.isBiometricHardwareSupported ?? false;
+
+  bool get _biometricAvailable =>
+      _biometricAvailability?.canAuthenticateWithBiometrics ?? false;
+
+  bool get _needsBiometricEnrollment =>
+      _biometricAvailability?.needsBiometricEnrollment ?? false;
+
+  String get _biometricSetupGuidance {
+    if (_isCheckingBiometric) {
+      return 'Checking biometric availability…';
+    }
+    if (!_biometricSupported) {
+      return 'Biometric hardware not supported on this device';
+    }
+    if (_biometricAvailable) {
+      return 'Use fingerprint or face recognition';
+    }
+    return 'Enroll fingerprint or face in system settings, then return and re-check';
   }
 
   Future<void> _setupPin() async {
@@ -161,19 +186,32 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
         onTap: () => setState(() => _step = 1),
       ),
       const SizedBox(height: 12),
-      if (_biometricSupported)
+      if (_isCheckingBiometric || _biometricSupported)
         _OptionCard(
           icon: Icons.fingerprint,
-          title: 'Biometrics',
-          subtitle: _biometricAvailable
-              ? 'Use fingerprint or face recognition'
-              : 'Enable now, then enroll fingerprint or face before first use',
-          trailing: Switch(
-            value: _enableBiometric,
-            onChanged: (v) => setState(() => _enableBiometric = v),
-          ),
-          onTap: () => setState(() => _enableBiometric = !_enableBiometric),
+          title: _biometricAvailable ? 'Biometrics' : 'Biometrics not ready',
+          subtitle: _biometricSetupGuidance,
+          trailing: _biometricAvailable
+              ? Switch(
+                  value: _enableBiometric,
+                  onChanged: (v) => setState(() => _enableBiometric = v),
+                )
+              : null,
+          onTap: _biometricAvailable
+              ? () => setState(() => _enableBiometric = !_enableBiometric)
+              : null,
         ),
+      if (_needsBiometricEnrollment) ...[
+        const SizedBox(height: 8),
+        TextButton.icon(
+          onPressed: () {
+            setState(() => _isCheckingBiometric = true);
+            unawaited(_checkBiometric());
+          },
+          icon: const Icon(Icons.refresh),
+          label: const Text('Re-check biometric status'),
+        ),
+      ],
     ],
   );
 
@@ -234,79 +272,91 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
     ],
   );
 
-  Widget _buildConfirmPinStep(
-    ThemeData theme,
-    ColorScheme colorScheme,
-  ) => Column(
-    crossAxisAlignment: CrossAxisAlignment.start,
-    children: [
-      Text(
-        'Confirm PIN',
-        style: theme.textTheme.headlineSmall?.copyWith(
-          fontWeight: FontWeight.bold,
-        ),
-      ),
-      const SizedBox(height: 8),
-      Text(
-        'Enter your PIN again to confirm.',
-        style: theme.textTheme.bodyLarge?.copyWith(
-          color: colorScheme.onSurface.withValues(alpha: 0.6),
-        ),
-      ),
-      const SizedBox(height: 32),
-      TextField(
-        controller: _confirmPinController,
-        keyboardType: TextInputType.number,
-        obscureText: true,
-        maxLength: 8,
-        autofocus: true,
-        decoration: InputDecoration(
-          labelText: 'Confirm PIN',
-          errorText: _error,
-        ),
-        inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-        onChanged: (_) => setState(() => _error = null),
-        onSubmitted: (_) => _setupPin(),
-      ),
-      if (_biometricSupported) ...[
-        const SizedBox(height: 16),
-        SwitchListTile(
-          value: _enableBiometric,
-          onChanged: (v) => setState(() => _enableBiometric = v),
-          title: const Text('Enable biometrics'),
-          subtitle: Text(
-            _biometricAvailable
-                ? 'Also allow fingerprint/face unlock'
-                : 'Enable now, then enroll fingerprint or face before first use',
-          ),
-          contentPadding: EdgeInsets.zero,
-        ),
-      ],
-      const SizedBox(height: 24),
-      Row(
+  Widget _buildConfirmPinStep(ThemeData theme, ColorScheme colorScheme) =>
+      Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          TextButton(
-            onPressed: () => setState(() {
-              _step = 1;
-              _error = null;
-            }),
-            child: const Text('Back'),
+          Text(
+            'Confirm PIN',
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
           ),
-          const Spacer(),
-          ElevatedButton(
-            onPressed: _isLoading ? null : _setupPin,
-            child: _isLoading
-                ? const SizedBox(
-                    height: 20,
-                    width: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Text('Complete'),
+          const SizedBox(height: 8),
+          Text(
+            'Enter your PIN again to confirm.',
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+          const SizedBox(height: 32),
+          TextField(
+            controller: _confirmPinController,
+            keyboardType: TextInputType.number,
+            obscureText: true,
+            maxLength: 8,
+            autofocus: true,
+            decoration: InputDecoration(
+              labelText: 'Confirm PIN',
+              errorText: _error,
+            ),
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            onChanged: (_) => setState(() => _error = null),
+            onSubmitted: (_) => _setupPin(),
+          ),
+          if (_isCheckingBiometric || _biometricSupported) ...[
+            const SizedBox(height: 16),
+            SwitchListTile(
+              value: _enableBiometric,
+              onChanged: _biometricAvailable
+                  ? (v) => setState(() => _enableBiometric = v)
+                  : null,
+              title: const Text('Enable biometrics'),
+              subtitle: Text(
+                _biometricAvailable
+                    ? 'Also allow fingerprint/face unlock'
+                    : _biometricSetupGuidance,
+              ),
+              contentPadding: EdgeInsets.zero,
+            ),
+            if (_needsBiometricEnrollment)
+              Align(
+                alignment: Alignment.centerLeft,
+                child: TextButton.icon(
+                  onPressed: () {
+                    setState(() => _isCheckingBiometric = true);
+                    unawaited(_checkBiometric());
+                  },
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('Re-check biometric status'),
+                ),
+              ),
+          ],
+          const SizedBox(height: 24),
+          Row(
+            children: [
+              TextButton(
+                onPressed: () => setState(() {
+                  _step = 1;
+                  _error = null;
+                }),
+                child: const Text('Back'),
+              ),
+              const Spacer(),
+              ElevatedButton(
+                onPressed: _isLoading ? null : _setupPin,
+                child: _isLoading
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Complete'),
+              ),
+            ],
           ),
         ],
-      ),
-    ],
-  );
+      );
 }
 
 class _OptionCard extends StatelessWidget {
@@ -314,14 +364,14 @@ class _OptionCard extends StatelessWidget {
     required this.icon,
     required this.title,
     required this.subtitle,
-    required this.onTap,
+    this.onTap,
     this.trailing,
   });
 
   final IconData icon;
   final String title;
   final String subtitle;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
   final Widget? trailing;
 
   @override

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -50,34 +50,33 @@ class SettingsScreen extends ConsumerWidget {
 final _biometricSettingsStateProvider =
     FutureProvider.autoDispose<_BiometricSettingsState>((ref) async {
       final authService = ref.watch(authServiceProvider);
-      final isSupported = await authService.isBiometricSupported();
+      final availability = await authService.getBiometricAvailability();
       final isEnabled = await authService.isBiometricEnabled();
 
-      if (!isSupported) {
-        return _BiometricSettingsState(
-          isSupported: false,
-          isAvailable: false,
-          isEnabled: isEnabled,
-        );
-      }
-
       return _BiometricSettingsState(
-        isSupported: true,
-        isAvailable: (await authService.getAvailableBiometrics()).isNotEmpty,
+        availability: availability,
         isEnabled: isEnabled,
       );
     });
 
 class _BiometricSettingsState {
   const _BiometricSettingsState({
-    required this.isSupported,
-    required this.isAvailable,
+    required this.availability,
     required this.isEnabled,
   });
 
-  final bool isSupported;
-  final bool isAvailable;
+  final BiometricAvailability availability;
   final bool isEnabled;
+
+  bool get canAuthenticateWithBiometrics =>
+      availability.canAuthenticateWithBiometrics;
+
+  bool get isBiometricHardwareSupported =>
+      availability.isBiometricHardwareSupported;
+
+  bool get isDeviceAuthSupported => availability.isDeviceAuthSupported;
+
+  bool get needsBiometricEnrollment => availability.needsBiometricEnrollment;
 }
 
 class _SectionHeader extends StatelessWidget {
@@ -263,23 +262,38 @@ class _SecuritySection extends ConsumerWidget {
             secondary: const Icon(Icons.fingerprint),
             title: const Text('Biometric authentication'),
             subtitle: Text(
-              !isAuthKnown
-                  ? 'Checking security status'
-                  : !state.isSupported
-                  ? 'Not supported on this device'
-                  : !isAuthConfigured
-                  ? 'Set up app lock first'
-                  : state.isAvailable
-                  ? 'Use fingerprint or face to unlock'
-                  : state.isEnabled
-                  ? 'Enabled - enroll fingerprint or face to use it'
-                  : 'Enable now, then enroll fingerprint or face to use it',
+              _biometricSubtitle(
+                isAuthKnown: isAuthKnown,
+                isAuthConfigured: isAuthConfigured,
+                state: state,
+              ),
             ),
-            value: state.isEnabled,
-            onChanged: state.isSupported && isAuthConfigured
+            value: state.isEnabled && state.canAuthenticateWithBiometrics,
+            onChanged: state.canAuthenticateWithBiometrics && isAuthConfigured
                 ? (value) => _toggleBiometric(ref, value)
                 : null,
           ),
+        ),
+        biometricSettings.maybeWhen(
+          data: (state) {
+            if (!isAuthConfigured || !state.needsBiometricEnrollment) {
+              return const SizedBox.shrink();
+            }
+
+            return Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: TextButton.icon(
+                  onPressed: () =>
+                      ref.invalidate(_biometricSettingsStateProvider),
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('Re-check biometric status'),
+                ),
+              ),
+            );
+          },
+          orElse: () => const SizedBox.shrink(),
         ),
         ListTile(
           leading: const Icon(Icons.timer_outlined),
@@ -300,6 +314,30 @@ class _SecuritySection extends ConsumerWidget {
         ),
       ],
     );
+  }
+
+  String _biometricSubtitle({
+    required bool isAuthKnown,
+    required bool isAuthConfigured,
+    required _BiometricSettingsState state,
+  }) {
+    if (!isAuthKnown) {
+      return 'Checking security status';
+    }
+    if (!state.isBiometricHardwareSupported) {
+      return state.isDeviceAuthSupported
+          ? 'Device lock is available, but no biometric hardware was reported'
+          : 'Biometric hardware not supported on this device';
+    }
+    if (!isAuthConfigured) {
+      return state.needsBiometricEnrollment
+          ? 'Enroll fingerprint or face in system settings before enabling'
+          : 'Set up app lock first';
+    }
+    if (state.canAuthenticateWithBiometrics) {
+      return 'Use fingerprint or face to unlock';
+    }
+    return 'Enroll fingerprint or face in system settings, then return and re-check';
   }
 
   void _showChangePinDialog(BuildContext context, WidgetRef ref) {

--- a/test/support/settings_import_test_helpers.dart
+++ b/test/support/settings_import_test_helpers.dart
@@ -99,7 +99,10 @@ class FakeAuthService extends AuthService {
   Future<bool> isBiometricEnabled() async => false;
 
   @override
-  Future<bool> isBiometricSupported() async => false;
+  Future<bool> isDeviceAuthSupported() async => false;
+
+  @override
+  Future<bool> isBiometricHardwareSupported() async => false;
 
   @override
   Future<bool> isBiometricAvailable() async => false;

--- a/test/support/settings_import_test_helpers.dart
+++ b/test/support/settings_import_test_helpers.dart
@@ -106,6 +106,14 @@ class FakeAuthService extends AuthService {
 
   @override
   Future<List<BiometricType>> getAvailableBiometrics() async => [];
+
+  @override
+  Future<BiometricAvailability> getBiometricAvailability() async =>
+      const BiometricAvailability(
+        isDeviceAuthSupported: false,
+        isBiometricHardwareSupported: false,
+        enrolledBiometrics: [],
+      );
 }
 
 class FakeSecureTransferService extends SecureTransferService {

--- a/test/unit/auth_service_test.dart
+++ b/test/unit/auth_service_test.dart
@@ -200,12 +200,37 @@ void main() {
     });
 
     group('isBiometricSupported', () {
+      test('preserves legacy device-auth support semantics', () async {
+        when(
+          () => mockLocalAuth.isDeviceSupported(),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockLocalAuth.canCheckBiometrics,
+        ).thenAnswer((_) async => false);
+
+        final result = await authService.isBiometricSupported();
+
+        expect(result, true);
+      });
+
+      test('returns false when device auth is unsupported', () async {
+        when(
+          () => mockLocalAuth.isDeviceSupported(),
+        ).thenAnswer((_) async => false);
+
+        final result = await authService.isBiometricSupported();
+
+        expect(result, false);
+      });
+    });
+
+    group('isBiometricHardwareSupported', () {
       test('returns true when the device can check biometrics', () async {
         when(
           () => mockLocalAuth.canCheckBiometrics,
         ).thenAnswer((_) async => true);
 
-        final result = await authService.isBiometricSupported();
+        final result = await authService.isBiometricHardwareSupported();
 
         expect(result, true);
       });
@@ -215,7 +240,7 @@ void main() {
           () => mockLocalAuth.canCheckBiometrics,
         ).thenAnswer((_) async => false);
 
-        final result = await authService.isBiometricSupported();
+        final result = await authService.isBiometricHardwareSupported();
 
         expect(result, false);
       });

--- a/test/unit/auth_service_test.dart
+++ b/test/unit/auth_service_test.dart
@@ -202,7 +202,7 @@ void main() {
     group('isBiometricSupported', () {
       test('returns true when the device can check biometrics', () async {
         when(
-          () => mockLocalAuth.isDeviceSupported(),
+          () => mockLocalAuth.canCheckBiometrics,
         ).thenAnswer((_) async => true);
 
         final result = await authService.isBiometricSupported();
@@ -212,7 +212,7 @@ void main() {
 
       test('returns false when the device cannot check biometrics', () async {
         when(
-          () => mockLocalAuth.isDeviceSupported(),
+          () => mockLocalAuth.canCheckBiometrics,
         ).thenAnswer((_) async => false);
 
         final result = await authService.isBiometricSupported();
@@ -224,7 +224,7 @@ void main() {
     group('isBiometricAvailable', () {
       test('returns true when biometrics available', () async {
         when(
-          () => mockLocalAuth.isDeviceSupported(),
+          () => mockLocalAuth.canCheckBiometrics,
         ).thenAnswer((_) async => true);
         when(
           () => mockLocalAuth.getAvailableBiometrics(),
@@ -237,7 +237,7 @@ void main() {
 
       test('returns false when no biometrics', () async {
         when(
-          () => mockLocalAuth.isDeviceSupported(),
+          () => mockLocalAuth.canCheckBiometrics,
         ).thenAnswer((_) async => true);
         when(
           () => mockLocalAuth.getAvailableBiometrics(),
@@ -250,13 +250,84 @@ void main() {
 
       test('returns false when device cannot check biometrics', () async {
         when(
-          () => mockLocalAuth.isDeviceSupported(),
+          () => mockLocalAuth.canCheckBiometrics,
         ).thenAnswer((_) async => false);
 
         final result = await authService.isBiometricAvailable();
 
         expect(result, false);
       });
+    });
+
+    group('getBiometricAvailability', () {
+      test(
+        'distinguishes device credentials from biometric hardware',
+        () async {
+          when(
+            () => mockLocalAuth.isDeviceSupported(),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockLocalAuth.canCheckBiometrics,
+          ).thenAnswer((_) async => false);
+
+          final result = await authService.getBiometricAvailability();
+
+          expect(result.isDeviceAuthSupported, true);
+          expect(result.isBiometricHardwareSupported, false);
+          expect(result.supportsDeviceCredentialOnly, true);
+          expect(result.canAuthenticateWithBiometrics, false);
+          verifyNever(() => mockLocalAuth.getAvailableBiometrics());
+        },
+      );
+    });
+
+    group('setBiometricEnabled', () {
+      test('does not enable biometrics before enrollment is ready', () async {
+        when(
+          () => mockLocalAuth.canCheckBiometrics,
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockLocalAuth.getAvailableBiometrics(),
+        ).thenAnswer((_) async => []);
+
+        await authService.setBiometricEnabled(enabled: true);
+
+        verify(
+          () => mockStorage.write(
+            key: 'flutty_biometric_enabled',
+            value: 'false',
+          ),
+        ).called(1);
+      });
+    });
+
+    group('authenticateWithBiometrics', () {
+      test(
+        'does not open a platform prompt before enrollment is ready',
+        () async {
+          when(
+            () => mockLocalAuth.canCheckBiometrics,
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockLocalAuth.getAvailableBiometrics(),
+          ).thenAnswer((_) async => []);
+
+          final result = await authService.authenticateWithBiometrics(
+            reason: 'Unlock MonkeySSH',
+          );
+
+          expect(result, false);
+          verifyNever(
+            () => mockLocalAuth.authenticate(
+              localizedReason: any(named: 'localizedReason'),
+              biometricOnly: any(named: 'biometricOnly'),
+              persistAcrossBackgrounding: any(
+                named: 'persistAcrossBackgrounding',
+              ),
+            ),
+          );
+        },
+      );
     });
 
     group('getAuthMethod', () {
@@ -402,6 +473,9 @@ void main() {
             () => mockLocalAuth.isDeviceSupported(),
           ).thenAnswer((_) async => true);
           when(
+            () => mockLocalAuth.canCheckBiometrics,
+          ).thenAnswer((_) async => true);
+          when(
             () => mockLocalAuth.getAvailableBiometrics(),
           ).thenAnswer((_) async => [BiometricType.fingerprint]);
 
@@ -434,6 +508,9 @@ void main() {
             () => mockLocalAuth.isDeviceSupported(),
           ).thenAnswer((_) async => true);
           when(
+            () => mockLocalAuth.canCheckBiometrics,
+          ).thenAnswer((_) async => true);
+          when(
             () => mockLocalAuth.getAvailableBiometrics(),
           ).thenAnswer((_) async => [BiometricType.fingerprint]);
 
@@ -462,6 +539,9 @@ void main() {
         ).thenAnswer((_) async => _validPinSalt);
         when(
           () => mockLocalAuth.isDeviceSupported(),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockLocalAuth.canCheckBiometrics,
         ).thenAnswer((_) async => true);
         when(
           () => mockLocalAuth.getAvailableBiometrics(),

--- a/test/widget/auth_setup_screen_test.dart
+++ b/test/widget/auth_setup_screen_test.dart
@@ -13,6 +13,14 @@ class _BiometricAvailableAuthService extends AuthService {
   Future<List<BiometricType>> getAvailableBiometrics() async => [
     BiometricType.fingerprint,
   ];
+
+  @override
+  Future<BiometricAvailability> getBiometricAvailability() async =>
+      const BiometricAvailability(
+        isDeviceAuthSupported: true,
+        isBiometricHardwareSupported: true,
+        enrolledBiometrics: [BiometricType.fingerprint],
+      );
 }
 
 class _BiometricSupportedAuthService extends AuthService {
@@ -21,6 +29,14 @@ class _BiometricSupportedAuthService extends AuthService {
 
   @override
   Future<List<BiometricType>> getAvailableBiometrics() async => [];
+
+  @override
+  Future<BiometricAvailability> getBiometricAvailability() async =>
+      const BiometricAvailability(
+        isDeviceAuthSupported: true,
+        isBiometricHardwareSupported: true,
+        enrolledBiometrics: [],
+      );
 }
 
 void main() {
@@ -49,43 +65,47 @@ void main() {
     expect(tester.widget<ElevatedButton>(nextButton).onPressed, isNotNull);
   });
 
-  testWidgets(
-    'shows biometric opt-in when biometrics are supported but not enrolled',
-    (tester) async {
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            authServiceProvider.overrideWithValue(
-              _BiometricSupportedAuthService(),
-            ),
-          ],
-          child: const MaterialApp(home: AuthSetupScreen()),
-        ),
-      );
-      await tester.pumpAndSettle();
+  testWidgets('explains when biometrics are supported but not enrolled', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authServiceProvider.overrideWithValue(
+            _BiometricSupportedAuthService(),
+          ),
+        ],
+        child: const MaterialApp(home: AuthSetupScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      expect(find.text('Biometrics'), findsOneWidget);
-      expect(
-        find.text(
-          'Enable now, then enroll fingerprint or face before first use',
-        ),
-        findsOneWidget,
-      );
+    expect(find.text('Biometrics not ready'), findsOneWidget);
+    expect(
+      find.text(
+        'Enroll fingerprint or face in system settings, then return and re-check',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Re-check biometric status'), findsOneWidget);
 
-      await tester.tap(find.text('PIN Code'));
-      await tester.pumpAndSettle();
-      await tester.enterText(find.byType(TextField).first, '1234');
-      await tester.pump();
-      await tester.tap(find.widgetWithText(ElevatedButton, 'Next'));
-      await tester.pumpAndSettle();
+    await tester.tap(find.text('PIN Code'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).first, '1234');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Next'));
+    await tester.pumpAndSettle();
 
-      expect(find.text('Enable biometrics'), findsOneWidget);
-      expect(
-        find.text(
-          'Enable now, then enroll fingerprint or face before first use',
-        ),
-        findsOneWidget,
-      );
-    },
-  );
+    expect(find.text('Enable biometrics'), findsOneWidget);
+    final biometricSwitch = tester.widget<SwitchListTile>(
+      find.widgetWithText(SwitchListTile, 'Enable biometrics'),
+    );
+    expect(biometricSwitch.onChanged, isNull);
+    expect(
+      find.text(
+        'Enroll fingerprint or face in system settings, then return and re-check',
+      ),
+      findsOneWidget,
+    );
+  });
 }

--- a/test/widget/auth_setup_screen_test.dart
+++ b/test/widget/auth_setup_screen_test.dart
@@ -7,7 +7,10 @@ import 'package:monkeyssh/presentation/screens/auth_setup_screen.dart';
 
 class _BiometricAvailableAuthService extends AuthService {
   @override
-  Future<bool> isBiometricSupported() async => true;
+  Future<bool> isDeviceAuthSupported() async => true;
+
+  @override
+  Future<bool> isBiometricHardwareSupported() async => true;
 
   @override
   Future<List<BiometricType>> getAvailableBiometrics() async => [
@@ -25,7 +28,10 @@ class _BiometricAvailableAuthService extends AuthService {
 
 class _BiometricSupportedAuthService extends AuthService {
   @override
-  Future<bool> isBiometricSupported() async => true;
+  Future<bool> isDeviceAuthSupported() async => true;
+
+  @override
+  Future<bool> isBiometricHardwareSupported() async => true;
 
   @override
   Future<List<BiometricType>> getAvailableBiometrics() async => [];

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -43,7 +43,10 @@ class _ToggleableBiometricAuthService extends FakeAuthService {
   Future<bool> isAuthEnabled() async => true;
 
   @override
-  Future<bool> isBiometricSupported() async => true;
+  Future<bool> isDeviceAuthSupported() async => true;
+
+  @override
+  Future<bool> isBiometricHardwareSupported() async => true;
 
   @override
   Future<bool> isBiometricAvailable() async => true;

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:local_auth/local_auth.dart';
 import 'package:monkeyssh/app/app_metadata.dart';
 import 'package:monkeyssh/app/routes.dart';
 import 'package:monkeyssh/data/database/database.dart';
@@ -27,7 +28,12 @@ const _backgroundSshChannel = MethodChannel(
 
 class _SupportedButUnavailableAuthService extends FakeAuthService {
   @override
-  Future<bool> isBiometricSupported() async => true;
+  Future<BiometricAvailability> getBiometricAvailability() async =>
+      const BiometricAvailability(
+        isDeviceAuthSupported: true,
+        isBiometricHardwareSupported: true,
+        enrolledBiometrics: [],
+      );
 }
 
 class _ToggleableBiometricAuthService extends FakeAuthService {
@@ -40,10 +46,18 @@ class _ToggleableBiometricAuthService extends FakeAuthService {
   Future<bool> isBiometricSupported() async => true;
 
   @override
-  Future<bool> isBiometricAvailable() async => false;
+  Future<bool> isBiometricAvailable() async => true;
 
   @override
   Future<bool> isBiometricEnabled() async => biometricEnabled;
+
+  @override
+  Future<BiometricAvailability> getBiometricAvailability() async =>
+      const BiometricAvailability(
+        isDeviceAuthSupported: true,
+        isBiometricHardwareSupported: true,
+        enrolledBiometrics: [BiometricType.fingerprint],
+      );
 
   @override
   Future<void> setBiometricEnabled({required bool enabled}) async {
@@ -402,7 +416,10 @@ void main() {
       expect(find.text('Auto-lock timeout'), findsOneWidget);
       expect(find.text('Change PIN'), findsNothing);
       expect(find.text('Set up app lock first'), findsOneWidget);
-      expect(find.text('Not supported on this device'), findsOneWidget);
+      expect(
+        find.text('Biometric hardware not supported on this device'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('keeps setup actions disabled while auth state is loading', (
@@ -472,7 +489,7 @@ void main() {
     });
 
     testWidgets(
-      'keeps biometric toggle visible when support exists but enrollment is missing',
+      'disables biometric toggle when support exists but enrollment is missing',
       (tester) async {
         final db = AppDatabase.forTesting(NativeDatabase.memory());
         addTearDown(db.close);
@@ -498,9 +515,53 @@ void main() {
           'Biometric authentication',
         );
         expect(biometricTile, findsOneWidget);
-        expect(tester.widget<SwitchListTile>(biometricTile).value, isFalse);
+        final tile = tester.widget<SwitchListTile>(biometricTile);
+        expect(tile.value, isFalse);
+        expect(tile.onChanged, isNull);
+        expect(
+          find.text(
+            'Enroll fingerprint or face in system settings before enabling',
+          ),
+          findsOneWidget,
+        );
       },
     );
+
+    testWidgets('shows biometric re-check action after enrollment guidance', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            authServiceProvider.overrideWithValue(
+              _SupportedButUnavailableAuthService(),
+            ),
+            authStateProvider.overrideWith(_UnlockedAuthStateNotifier.new),
+          ],
+          child: const MaterialApp(home: SettingsScreen()),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final biometricTile = find.widgetWithText(
+        SwitchListTile,
+        'Biometric authentication',
+      );
+      final tile = tester.widget<SwitchListTile>(biometricTile);
+      expect(tile.onChanged, isNull);
+      expect(
+        find.text(
+          'Enroll fingerprint or face in system settings, then return and re-check',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Re-check biometric status'), findsOneWidget);
+    });
 
     testWidgets('updates biometric toggle state immediately after tapping', (
       tester,
@@ -533,10 +594,7 @@ void main() {
 
       expect(authService.biometricEnabled, isTrue);
       expect(tester.widget<SwitchListTile>(biometricTile).value, isTrue);
-      expect(
-        find.text('Enabled - enroll fingerprint or face to use it'),
-        findsOneWidget,
-      );
+      expect(find.text('Use fingerprint or face to unlock'), findsOneWidget);
     });
 
     testWidgets(


### PR DESCRIPTION
## Summary

- Distinguish biometric hardware support, device-auth support, and enrolled/ready biometric state.
- Disable biometric setup/toggles until biometrics are enrolled and add in-app guidance with a re-check path instead of prompting users into system settings.
- Guard biometric auth prompts and stored biometric enablement behind the ready state, with unit/widget coverage.

## Validation

- dart format .
- flutter analyze
- flutter test test/unit/auth_service_test.dart test/widget/auth_setup_screen_test.dart test/widget/settings_screen_test.dart test/widget/lock_screen_test.dart
- flutter test
