### PR TITLE
test: add seeded release audit coverage

### DIFF
--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -115,6 +115,71 @@ bool isPreviewableImageFileName(String filename) {
 bool isSvgFileName(String filename) =>
     path.extension(filename).toLowerCase() == '.svg';
 
+/// Whether the file name should use the video placeholder treatment.
+@visibleForTesting
+bool isVideoFileName(String filename) {
+  final extension = path.extension(filename).toLowerCase();
+  return {'.mp4', '.mov', '.avi'}.contains(extension);
+}
+
+/// Resolves the icon shown for an SFTP file row.
+@visibleForTesting
+IconData resolveSftpFileIcon({
+  required bool isDirectory,
+  required String filename,
+}) {
+  if (isDirectory) {
+    return Icons.folder;
+  }
+  if (isPreviewableImageFileName(filename)) {
+    return Icons.image;
+  }
+  if (isVideoFileName(filename)) {
+    return Icons.video_file;
+  }
+
+  final ext = filename.split('.').last.toLowerCase();
+  return switch (ext) {
+    'txt' || 'md' || 'log' => Icons.description,
+    'pdf' => Icons.picture_as_pdf,
+    'mp3' || 'wav' || 'flac' => Icons.audio_file,
+    'zip' || 'tar' || 'gz' || 'rar' => Icons.archive,
+    'sh' || 'bash' => Icons.terminal,
+    'py' || 'js' || 'dart' || 'java' || 'go' => Icons.code,
+    'json' || 'yaml' || 'yml' || 'xml' => Icons.data_object,
+    _ => Icons.insert_drive_file,
+  };
+}
+
+/// Builds the shell-safe clipboard text for SFTP "Copy as path".
+@visibleForTesting
+String buildSftpCopyPathClipboardText({
+  required String directory,
+  required String filename,
+}) => shellEscapePosix(joinRemotePath(directory, filename));
+
+/// Returns a user-facing image preview block reason, if preview should stop.
+@visibleForTesting
+String? resolveSftpImagePreviewBlockMessage({required int byteCount}) =>
+    byteCount > _maxPreviewBytes
+    ? 'File is too large to preview here (max 10 MB)'
+    : null;
+
+/// Returns a user-facing text edit block reason, if editing should stop.
+@visibleForTesting
+String? resolveSftpTextEditBlockMessage({
+  required int byteCount,
+  Uint8List? loadedBytes,
+}) {
+  if (byteCount > _maxEditableBytes) {
+    return 'File is too large to edit here (max 1 MB)';
+  }
+  if (loadedBytes != null && looksLikeBinaryContent(loadedBytes)) {
+    return 'Binary files cannot be edited here';
+  }
+  return null;
+}
+
 /// Resolves the picker request used for local SFTP uploads.
 @visibleForTesting
 ({bool allowMultiple, bool withReadStream}) resolveSftpUploadPickerRequest() =>
@@ -1222,8 +1287,14 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   }
 
   Future<void> _copyRemotePath(SftpName file) async {
-    final remotePath = _joinRemotePath(_currentPath, file.filename);
-    await Clipboard.setData(ClipboardData(text: shellEscapePosix(remotePath)));
+    await Clipboard.setData(
+      ClipboardData(
+        text: buildSftpCopyPathClipboardText(
+          directory: _currentPath,
+          filename: file.filename,
+        ),
+      ),
+    );
     if (!mounted) {
       return;
     }
@@ -1237,13 +1308,14 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       return;
     }
 
-    if ((file.attr.size ?? 0) > _maxPreviewBytes) {
+    final preflightMessage = resolveSftpImagePreviewBlockMessage(
+      byteCount: file.attr.size ?? 0,
+    );
+    if (preflightMessage != null) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('File is too large to preview here (max 10 MB)'),
-          ),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(preflightMessage)));
       }
       return;
     }
@@ -1258,13 +1330,14 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         await remoteFile.close();
       }
 
-      if (bytes.length > _maxPreviewBytes) {
+      final loadedMessage = resolveSftpImagePreviewBlockMessage(
+        byteCount: bytes.length,
+      );
+      if (loadedMessage != null) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('File is too large to preview here (max 10 MB)'),
-            ),
-          );
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(loadedMessage)));
         }
         return;
       }
@@ -1298,13 +1371,14 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       return;
     }
 
-    if ((file.attr.size ?? 0) > _maxEditableBytes) {
+    final preflightMessage = resolveSftpTextEditBlockMessage(
+      byteCount: file.attr.size ?? 0,
+    );
+    if (preflightMessage != null) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('File is too large to edit here (max 1 MB)'),
-          ),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(preflightMessage)));
       }
       return;
     }
@@ -1319,22 +1393,15 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         await remoteFile.close();
       }
 
-      if (bytes.length > _maxEditableBytes) {
+      final loadedMessage = resolveSftpTextEditBlockMessage(
+        byteCount: bytes.length,
+        loadedBytes: bytes,
+      );
+      if (loadedMessage != null) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('File is too large to edit here (max 1 MB)'),
-            ),
-          );
-        }
-        return;
-      }
-
-      if (looksLikeBinaryContent(bytes)) {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Binary files cannot be edited here')),
-          );
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(loadedMessage)));
         }
         return;
       }
@@ -1485,7 +1552,7 @@ class _FileListTile extends StatelessWidget {
       tileColor: isHighlighted ? theme.colorScheme.primaryContainer : null,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       leading: Icon(
-        isDirectory ? Icons.folder : _getFileIcon(file.filename),
+        resolveSftpFileIcon(isDirectory: isDirectory, filename: file.filename),
         color: iconColor,
       ),
       title: Text(
@@ -1517,24 +1584,6 @@ class _FileListTile extends StatelessWidget {
       onTap: onTap,
       onLongPress: onLongPress,
     );
-  }
-
-  IconData _getFileIcon(String filename) {
-    if (isPreviewableImageFileName(filename)) {
-      return Icons.image;
-    }
-    final ext = filename.split('.').last.toLowerCase();
-    return switch (ext) {
-      'txt' || 'md' || 'log' => Icons.description,
-      'pdf' => Icons.picture_as_pdf,
-      'mp3' || 'wav' || 'flac' => Icons.audio_file,
-      'mp4' || 'mov' || 'avi' => Icons.video_file,
-      'zip' || 'tar' || 'gz' || 'rar' => Icons.archive,
-      'sh' || 'bash' => Icons.terminal,
-      'py' || 'js' || 'dart' || 'java' || 'go' => Icons.code,
-      'json' || 'yaml' || 'yml' || 'xml' => Icons.data_object,
-      _ => Icons.insert_drive_file,
-    };
   }
 }
 

--- a/test/app/host_key_prompt_test.dart
+++ b/test/app/host_key_prompt_test.dart
@@ -1,0 +1,110 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/app/host_key_prompt.dart';
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/domain/services/host_key_verification.dart';
+
+void main() {
+  group('createHostKeyPromptHandler', () {
+    testWidgets('fails closed for unknown hosts without a navigator', (
+      tester,
+    ) async {
+      final handler = createHostKeyPromptHandler();
+
+      await expectLater(
+        handler(
+          HostKeyVerificationRequest(
+            presentedHostKey: _verifiedHostKey('headless.example.com', 22, [
+              1,
+              2,
+              3,
+            ]),
+            existingKnownHost: null,
+          ),
+        ),
+        throwsA(
+          isA<HostKeyVerificationException>().having(
+            (error) => error.message,
+            'message',
+            allOf(
+              contains('Host key verification is required'),
+              contains('trust prompt could not be shown'),
+            ),
+          ),
+        ),
+      );
+    });
+
+    testWidgets('fails closed for changed hosts without a navigator', (
+      tester,
+    ) async {
+      final currentKey = _verifiedHostKey('changed.example.com', 22, [4, 5, 6]);
+      final replacementKey = _verifiedHostKey('changed.example.com', 22, [
+        7,
+        8,
+        9,
+      ]);
+      final handler = createHostKeyPromptHandler();
+
+      await expectLater(
+        handler(
+          HostKeyVerificationRequest(
+            presentedHostKey: replacementKey,
+            existingKnownHost: KnownHost(
+              id: 1,
+              hostname: currentKey.hostname,
+              port: currentKey.port,
+              keyType: currentKey.keyType,
+              fingerprint: currentKey.fingerprint,
+              hostKey: currentKey.encodedHostKey,
+              firstSeen: DateTime(2026),
+              lastSeen: DateTime(2026),
+            ),
+          ),
+        ),
+        throwsA(
+          isA<HostKeyVerificationException>().having(
+            (error) => error.message,
+            'message',
+            allOf(
+              contains('host key for changed.example.com:22 changed'),
+              contains('trust prompt could not be shown'),
+            ),
+          ),
+        ),
+      );
+    });
+  });
+}
+
+VerifiedHostKey _verifiedHostKey(
+  String hostname,
+  int port,
+  List<int> keyData,
+) => VerifiedHostKey(
+  hostname: hostname,
+  port: port,
+  keyType: 'ssh-ed25519',
+  hostKeyBytes: _ed25519HostKeyBlob(keyData),
+);
+
+Uint8List _ed25519HostKeyBlob(List<int> keyData) {
+  final typeBytes = utf8.encode('ssh-ed25519');
+  final writer = BytesBuilder(copy: false)
+    ..add(_uint32(typeBytes.length))
+    ..add(typeBytes)
+    ..add(_uint32(keyData.length))
+    ..add(keyData);
+  return writer.takeBytes();
+}
+
+Uint8List _uint32(int value) => Uint8List.fromList([
+  (value >> 24) & 0xFF,
+  (value >> 16) & 0xFF,
+  (value >> 8) & 0xFF,
+  value & 0xFF,
+]);

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -597,6 +597,30 @@ cwd: /tmp/demo
         'Could not load Codex and Gemini CLI sessions.',
       );
     });
+
+    test('formats single-tool failures and keeps no-failure states quiet', () {
+      expect(
+        DiscoveredSessionsResult(
+          sessions: const [],
+          failedTools: const {'Claude Code'},
+        ).failureMessage,
+        'Could not load Claude Code sessions.',
+      );
+      expect(
+        DiscoveredSessionsResult(sessions: const []).failureMessage,
+        isNull,
+      );
+    });
+
+    test('tracks attempted tools separately for placeholder rows', () {
+      final result = DiscoveredSessionsResult(
+        sessions: const [],
+        attemptedTools: const {'Claude Code', 'Copilot CLI'},
+      );
+
+      expect(result.hasFailures, isFalse);
+      expect(result.attemptedTools, {'Claude Code', 'Copilot CLI'});
+    });
   });
 
   group('shouldSurfaceDiscoveryFailure', () {
@@ -610,6 +634,13 @@ cwd: /tmp/demo
     test('suppresses partial failures when sessions still loaded', () {
       expect(
         shouldSurfaceDiscoveryFailure(hadError: true, loadedSessionCount: 3),
+        isFalse,
+      );
+    });
+
+    test('suppresses healthy empty discovery results', () {
+      expect(
+        shouldSurfaceDiscoveryFailure(hadError: false, loadedSessionCount: 0),
         isFalse,
       );
     });

--- a/test/domain/services/host_key_verification_test.dart
+++ b/test/domain/services/host_key_verification_test.dart
@@ -43,6 +43,61 @@ void main() {
       expect(storedHost.fingerprint, presentedHostKey.fingerprint);
     });
 
+    test('rejects an unknown host without persisting trust', () async {
+      final service = HostKeyVerificationService(
+        knownHostsRepository: repository,
+        promptHandler: (request) async {
+          expect(request.existingKnownHost, isNull);
+          expect(request.isReplacement, isFalse);
+          return HostKeyTrustDecision.reject;
+        },
+      );
+      final presentedHostKey = _verifiedHostKey('reject.example.com', 22, [
+        1,
+        3,
+        5,
+      ]);
+
+      await expectLater(
+        service.verify(presentedHostKey),
+        throwsA(
+          isA<HostKeyVerificationException>().having(
+            (error) => error.message,
+            'message',
+            contains('not trusted yet'),
+          ),
+        ),
+      );
+
+      expect(await repository.getByHost('reject.example.com', 22), isNull);
+    });
+
+    test(
+      'fails closed for unknown hosts when no prompt is available',
+      () async {
+        final service = HostKeyVerificationService(
+          knownHostsRepository: repository,
+        );
+        final presentedHostKey = _verifiedHostKey('headless.example.com', 22, [
+          2,
+          4,
+          6,
+        ]);
+
+        await expectLater(
+          service.verify(presentedHostKey),
+          throwsA(
+            isA<HostKeyVerificationException>().having(
+              (error) => error.message,
+              'message',
+              allOf(contains('verification is required'), contains('no trust')),
+            ),
+          ),
+        );
+        expect(await repository.getByHost('headless.example.com', 22), isNull);
+      },
+    );
+
     test('rejects changed host keys by default', () async {
       final originalHostKey = _verifiedHostKey('change.example.com', 22, [
         4,
@@ -77,7 +132,57 @@ void main() {
           ),
         ),
       );
+
+      final storedHost = await repository.getByHost('change.example.com', 22);
+      expect(storedHost, isNotNull);
+      expect(storedHost!.hostKey, originalHostKey.encodedHostKey);
+      expect(storedHost.fingerprint, originalHostKey.fingerprint);
     });
+
+    test(
+      'fails closed for changed host keys when no prompt is available',
+      () async {
+        final originalHostKey = _verifiedHostKey('noprompt.example.com', 22, [
+          4,
+          5,
+          6,
+        ]);
+        await repository.upsertTrustedHost(
+          hostname: originalHostKey.hostname,
+          port: originalHostKey.port,
+          keyType: originalHostKey.keyType,
+          fingerprint: originalHostKey.fingerprint,
+          encodedHostKey: originalHostKey.encodedHostKey,
+          resetFirstSeen: true,
+        );
+        final service = HostKeyVerificationService(
+          knownHostsRepository: repository,
+        );
+        final presentedHostKey = _verifiedHostKey('noprompt.example.com', 22, [
+          7,
+          8,
+          9,
+        ]);
+
+        await expectLater(
+          service.verify(presentedHostKey),
+          throwsA(
+            isA<HostKeyVerificationException>().having(
+              (error) => error.message,
+              'message',
+              contains('replacement prompt is not available'),
+            ),
+          ),
+        );
+
+        final storedHost = await repository.getByHost(
+          'noprompt.example.com',
+          22,
+        );
+        expect(storedHost, isNotNull);
+        expect(storedHost!.hostKey, originalHostKey.encodedHostKey);
+      },
+    );
 
     test('allows explicit replacement of a changed trusted host key', () async {
       final originalHostKey = _verifiedHostKey('replace.example.com', 22, [

--- a/test/presentation/screens/sftp_screen_test.dart
+++ b/test/presentation/screens/sftp_screen_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
@@ -105,6 +106,63 @@ void main() {
       expect(isSvgFileName('diagram.svg'), isTrue);
       expect(isSvgFileName('diagram.SVG'), isTrue);
       expect(isSvgFileName('diagram.png'), isFalse);
+    });
+
+    test('detects video fixtures for placeholder icon coverage', () {
+      expect(isVideoFileName('demo.mp4'), isTrue);
+      expect(isVideoFileName('demo.MOV'), isTrue);
+      expect(isVideoFileName('demo.avi'), isTrue);
+      expect(isVideoFileName('demo.png'), isFalse);
+      expect(
+        resolveSftpFileIcon(isDirectory: false, filename: 'demo.mp4'),
+        Icons.video_file,
+      );
+      expect(
+        resolveSftpFileIcon(isDirectory: false, filename: 'diagram.svg'),
+        Icons.image,
+      );
+    });
+
+    test('builds shell-safe clipboard text for copied remote paths', () {
+      expect(
+        buildSftpCopyPathClipboardText(
+          directory: '/home/demo/Project Files',
+          filename: "today's notes.txt",
+        ),
+        r"'/home/demo/Project Files/today'\''s notes.txt'",
+      );
+    });
+
+    test('blocks oversized image previews before reading remote bytes', () {
+      expect(
+        resolveSftpImagePreviewBlockMessage(byteCount: 10 * 1024 * 1024 + 1),
+        'File is too large to preview here (max 10 MB)',
+      );
+      expect(
+        resolveSftpImagePreviewBlockMessage(byteCount: 10 * 1024 * 1024),
+        isNull,
+      );
+    });
+
+    test('blocks oversized and binary text edits', () {
+      expect(
+        resolveSftpTextEditBlockMessage(byteCount: 1024 * 1024 + 1),
+        'File is too large to edit here (max 1 MB)',
+      );
+      expect(
+        resolveSftpTextEditBlockMessage(
+          byteCount: 4,
+          loadedBytes: Uint8List.fromList([0x66, 0x6f, 0x00, 0x6f]),
+        ),
+        'Binary files cannot be edited here',
+      );
+      expect(
+        resolveSftpTextEditBlockMessage(
+          byteCount: 5,
+          loadedBytes: Uint8List.fromList('hello'.codeUnits),
+        ),
+        isNull,
+      );
     });
 
     test('allows selecting multiple files for SFTP uploads', () {


### PR DESCRIPTION
## Summary

- Add fail-closed host-key trust coverage for reject/no-prompt unknown and changed-key scenarios.
- Extract SFTP helper decisions for copy-as-path, preview/edit blockers, and video placeholder detection, with focused tests.
- Add agent session discovery failure/placeholder edge coverage for tmux navigator surfaces.

## Validation

- `dart format .`
- `flutter analyze`
- `flutter test test/domain/services/host_key_verification_test.dart test/app/host_key_prompt_test.dart test/presentation/screens/sftp_screen_test.dart test/domain/services/agent_session_discovery_service_test.dart test/domain/services/tmux_service_agent_detection_test.dart test/domain/services/tmux_service_control_mode_test.dart`
- `flutter test`
