### PR TITLE
Improve onboarding guidance and paywall messaging

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -75,7 +75,11 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/hosts/add',
         name: 'host-add',
-        builder: (context, state) => const HostEditScreen(),
+        builder: (context, state) => HostEditScreen(
+          initialSshUrl: state.uri.queryParameters['sshUrl'],
+          useLocalhostTemplate:
+              state.uri.queryParameters['template'] == 'local',
+        ),
       ),
       GoRoute(
         path: '/hosts/edit/:hostId',
@@ -93,7 +97,9 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/keys/add',
         name: 'key-add',
-        builder: (context, state) => const KeyAddScreen(),
+        builder: (context, state) => KeyAddScreen(
+          initialTabIndex: state.uri.queryParameters['tab'] == 'import' ? 1 : 0,
+        ),
       ),
       GoRoute(
         path: '/sftp/:hostId',
@@ -167,7 +173,11 @@ final routerProvider = Provider<GoRouter>((ref) {
           final feature = MonetizationFeature.values.firstWhereOrNull(
             (value) => value.name == featureName,
           );
-          return UpgradeScreen(feature: feature);
+          return UpgradeScreen(
+            feature: feature,
+            blockedAction: state.uri.queryParameters['action'],
+            blockedOutcome: state.uri.queryParameters['outcome'],
+          );
         },
       ),
       GoRoute(

--- a/lib/domain/models/monetization.dart
+++ b/lib/domain/models/monetization.dart
@@ -117,6 +117,32 @@ extension MonetizationFeaturePresentation on MonetizationFeature {
     MonetizationFeature.hostSpecificThemes =>
       'Save terminal theme overrides for individual hosts while keeping app-wide defaults unchanged.',
   };
+
+  /// The blocked action shown at the top of feature-triggered paywalls.
+  String get blockedAction => switch (this) {
+    MonetizationFeature.encryptedTransfers =>
+      'Import or export encrypted transfer files',
+    MonetizationFeature.migrationImportExport => 'Import or export app data',
+    MonetizationFeature.autoConnectAutomation =>
+      'Save auto-connect commands and snippets',
+    MonetizationFeature.agentLaunchPresets =>
+      'Save coding-agent launch presets',
+    MonetizationFeature.hostSpecificThemes => 'Save a host-specific theme',
+  };
+
+  /// The outcome unlocked by Pro for this feature.
+  String get blockedOutcome => switch (this) {
+    MonetizationFeature.encryptedTransfers =>
+      'Unlock Pro to move hosts and keys between devices with encrypted files.',
+    MonetizationFeature.migrationImportExport =>
+      'Unlock Pro to restore or migrate all MonkeySSH data in one encrypted package.',
+    MonetizationFeature.autoConnectAutomation =>
+      'Unlock Pro to run a command or saved snippet automatically after connecting.',
+    MonetizationFeature.agentLaunchPresets =>
+      'Unlock Pro to repeat your preferred coding-agent startup flow on each host.',
+    MonetizationFeature.hostSpecificThemes =>
+      'Unlock Pro to keep this host on its own terminal theme while preserving your app defaults.',
+  };
 }
 
 /// Whether store billing can be used on the current device.

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:collection';
 
-import 'package:drift/drift.dart' as drift;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -161,6 +160,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         context: context,
         ref: ref,
         feature: MonetizationFeature.encryptedTransfers,
+        blockedAction: 'Open incoming encrypted transfer',
+        blockedOutcome:
+            'Unlock Pro to decrypt this transfer and import its hosts or keys.',
       );
       if (!hasAccess || !mounted) {
         return;
@@ -576,6 +578,72 @@ class _NavItem extends StatelessWidget {
   }
 }
 
+class _EmptyStateAction {
+  const _EmptyStateAction({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+}
+
+class _GuidedEmptyState extends StatelessWidget {
+  const _GuidedEmptyState({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.primaryLabel,
+    required this.onPrimary,
+    this.primaryIcon = Icons.add,
+    this.secondaryActions = const [],
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final String primaryLabel;
+  final IconData primaryIcon;
+  final VoidCallback onPrimary;
+  final List<_EmptyStateAction> secondaryActions;
+
+  @override
+  Widget build(BuildContext context) => Column(
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      FluttyTheme.buildEmptyState(
+        context: context,
+        icon: icon,
+        title: title,
+        subtitle: subtitle,
+        onAction: onPrimary,
+        actionLabel: primaryLabel,
+        actionIcon: primaryIcon,
+        centered: false,
+        padded: false,
+      ),
+      if (secondaryActions.isNotEmpty) ...[
+        const SizedBox(height: FluttyTheme.spacingMd),
+        Wrap(
+          alignment: WrapAlignment.center,
+          spacing: FluttyTheme.spacingSm,
+          runSpacing: FluttyTheme.spacingSm,
+          children: [
+            for (final action in secondaryActions)
+              OutlinedButton.icon(
+                onPressed: action.onTap,
+                icon: Icon(action.icon, size: 18),
+                label: Text(action.label),
+              ),
+          ],
+        ),
+      ],
+    ],
+  );
+}
+
 /// Panel for displaying and managing hosts inline.
 class HostsPanel extends ConsumerWidget {
   /// Creates a [HostsPanel].
@@ -653,17 +721,73 @@ class HostsPanel extends ConsumerWidget {
   );
 
   Widget _buildEmptyState(BuildContext context) => _buildCenteredHostsState(
-    child: FluttyTheme.buildEmptyState(
-      context: context,
+    child: _GuidedEmptyState(
       icon: Icons.dns_outlined,
       title: 'No hosts yet',
-      subtitle: 'Add a host to get started',
-      onAction: () => context.push('/hosts/add'),
-      actionLabel: 'Add Host',
-      centered: false,
-      padded: false,
+      subtitle:
+          'Add an SSH server, paste an ssh:// URL, or prefill localhost after '
+          'running the local test setup.',
+      primaryLabel: 'Add Host',
+      onPrimary: () => context.push('/hosts/add'),
+      secondaryActions: [
+        _EmptyStateAction(
+          icon: Icons.file_open_outlined,
+          label: 'Import config',
+          onTap: () => _showOpenSshImportMessage(context),
+        ),
+        _EmptyStateAction(
+          icon: Icons.content_paste_go_outlined,
+          label: 'Paste SSH URL',
+          onTap: () => unawaited(_openPastedSshUrl(context)),
+        ),
+        _EmptyStateAction(
+          icon: Icons.computer_outlined,
+          label: 'Try local test host',
+          onTap: () => context.push('/hosts/add?template=local'),
+        ),
+      ],
     ),
   );
+
+  void _showOpenSshImportMessage(BuildContext context) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text(
+          'OpenSSH config import is not available yet. Add a host manually or '
+          'paste an ssh:// URL.',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openPastedSshUrl(BuildContext context) async {
+    final clipboard = await Clipboard.getData(Clipboard.kTextPlain);
+    final sshUrl = clipboard?.text?.trim();
+    if (sshUrl == null || sshUrl.isEmpty) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Copy an ssh:// URL first.')),
+        );
+      }
+      return;
+    }
+    final uri = Uri.tryParse(sshUrl);
+    if (uri == null || uri.scheme != 'ssh' || uri.host.isEmpty) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Clipboard does not contain an ssh:// URL.'),
+          ),
+        );
+      }
+      return;
+    }
+    if (context.mounted) {
+      unawaited(
+        context.push('/hosts/add?sshUrl=${Uri.encodeQueryComponent(sshUrl)}'),
+      );
+    }
+  }
 
   Widget _buildCenteredHostsState({required Widget child}) => CustomScrollView(
     physics: const AlwaysScrollableScrollPhysics(),
@@ -1309,6 +1433,9 @@ class _HostRow extends ConsumerWidget {
       context: context,
       ref: ref,
       feature: MonetizationFeature.encryptedTransfers,
+      blockedAction: 'Export encrypted host file',
+      blockedOutcome:
+          'Unlock Pro to share this host securely with another device.',
     );
     if (!hasAccess || !context.mounted) {
       return;
@@ -1631,7 +1758,9 @@ class _ConnectionsPanel extends ConsumerWidget {
     context: context,
     icon: Icons.link_off,
     title: 'No active connections',
-    subtitle: 'Open a host to create one',
+    subtitle:
+        'Connections appear here while terminals are open. Choose a host to '
+        'connect, then jump back to live sessions from this tab.',
   );
 }
 
@@ -1814,14 +1943,27 @@ class _KeysPanel extends ConsumerWidget {
     );
   }
 
-  Widget _buildEmptyState(BuildContext context) => FluttyTheme.buildEmptyState(
-    context: context,
-    icon: Icons.key_outlined,
-    title: 'No SSH keys yet',
-    subtitle: 'Generate or import a key',
-    onAction: () => context.push('/keys/add'),
-    actionLabel: 'Add Key',
-    actionIcon: Icons.add,
+  Widget _buildEmptyState(BuildContext context) => Center(
+    child: Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: _GuidedEmptyState(
+        icon: Icons.key_outlined,
+        title: 'No SSH keys yet',
+        subtitle:
+            'Keys let you sign in without saving server passwords. Generate a '
+            'new Ed25519 key or import an existing private key.',
+        primaryLabel: 'Generate Key',
+        primaryIcon: Icons.enhanced_encryption,
+        onPrimary: () => context.push('/keys/add'),
+        secondaryActions: [
+          _EmptyStateAction(
+            icon: Icons.upload_file_outlined,
+            label: 'Import Key',
+            onTap: () => context.push('/keys/add?tab=import'),
+          ),
+        ],
+      ),
+    ),
   );
 
   Widget _buildKeysList(
@@ -1944,6 +2086,9 @@ class _KeyRow extends ConsumerWidget {
       context: context,
       ref: ref,
       feature: MonetizationFeature.encryptedTransfers,
+      blockedAction: 'Export encrypted key file',
+      blockedOutcome:
+          'Unlock Pro to move this SSH key securely to another device.',
     );
     if (!hasAccess || !context.mounted) {
       return;
@@ -2126,7 +2271,7 @@ class SnippetsPanel extends ConsumerWidget {
               _ActionButton(
                 icon: Icons.add,
                 label: 'Add Snippet',
-                onTap: () => _showAddEditSnippetDialog(context, ref, null),
+                onTap: () => context.push('/snippets/add'),
                 primary: true,
               ),
             ],
@@ -2153,8 +2298,11 @@ class SnippetsPanel extends ConsumerWidget {
         context: context,
         icon: Icons.code_outlined,
         title: 'No snippets yet',
-        subtitle: 'Save commands you use often',
-        onAction: () => _showAddEditSnippetDialog(context, ref, null),
+        subtitle:
+            'Save commands you run often. Try templates such as '
+            '`tail -f {{log_file}}`, `docker restart {{container}}`, or '
+            '`git pull && {{restart_command}}`.',
+        onAction: () => context.push('/snippets/add'),
         actionLabel: 'Add Snippet',
       );
 
@@ -2197,173 +2345,6 @@ class SnippetsPanel extends ConsumerWidget {
       newIndex: newIndex,
     );
     await ref.read(snippetRepositoryProvider).reorderByIds(reorderedIds);
-  }
-
-  static Future<void> _showAddEditSnippetDialog(
-    BuildContext context,
-    WidgetRef ref,
-    Snippet? existing,
-  ) async {
-    final nameController = TextEditingController(text: existing?.name ?? '');
-    final commandController = TextEditingController(
-      text: existing?.command ?? '',
-    );
-    final descriptionController = TextEditingController(
-      text: existing?.description ?? '',
-    );
-    final formKey = GlobalKey<FormState>();
-
-    final result = await showModalBottomSheet<bool>(
-      context: context,
-      isScrollControlled: true,
-      builder: (context) => Padding(
-        padding: EdgeInsets.only(
-          bottom: MediaQuery.of(context).viewInsets.bottom,
-        ),
-        child: DraggableScrollableSheet(
-          maxChildSize: 0.9,
-          minChildSize: 0.5,
-          initialChildSize: 0.7,
-          expand: false,
-          builder: (context, scrollController) => Form(
-            key: formKey,
-            child: ListView(
-              controller: scrollController,
-              padding: const EdgeInsets.all(20),
-              children: [
-                // Handle bar
-                Center(
-                  child: Container(
-                    width: 40,
-                    height: 4,
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.outline,
-                      borderRadius: BorderRadius.circular(2),
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 20),
-                Text(
-                  existing == null ? 'Add Snippet' : 'Edit Snippet',
-                  style: Theme.of(context).textTheme.titleLarge,
-                ),
-                const SizedBox(height: 20),
-                TextFormField(
-                  controller: nameController,
-                  decoration: const InputDecoration(
-                    labelText: 'Name',
-                    hintText: 'Restart Docker',
-                    prefixIcon: Icon(Icons.label),
-                  ),
-                  textInputAction: TextInputAction.next,
-                  validator: (value) {
-                    if (value == null || value.isEmpty) {
-                      return 'Please enter a name';
-                    }
-                    return null;
-                  },
-                ),
-                const SizedBox(height: 16),
-                TextFormField(
-                  controller: descriptionController,
-                  decoration: const InputDecoration(
-                    labelText: 'Description (optional)',
-                    hintText: 'What this snippet does',
-                    prefixIcon: Icon(Icons.description),
-                  ),
-                  textInputAction: TextInputAction.next,
-                ),
-                const SizedBox(height: 16),
-                TextFormField(
-                  controller: commandController,
-                  decoration: const InputDecoration(
-                    labelText: 'Command',
-                    hintText: 'docker restart {{container}}',
-                    alignLabelWithHint: true,
-                  ),
-                  maxLines: 4,
-                  style: FluttyTheme.monoStyle.copyWith(fontSize: 14),
-                  validator: (value) {
-                    if (value == null || value.isEmpty) {
-                      return 'Please enter a command';
-                    }
-                    return null;
-                  },
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  'Use {{variable}} for substitution',
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.outline,
-                  ),
-                ),
-                const SizedBox(height: 24),
-                Row(
-                  children: [
-                    Expanded(
-                      child: OutlinedButton(
-                        onPressed: () => Navigator.pop(context, false),
-                        child: const Text('Cancel'),
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: FilledButton(
-                        onPressed: () {
-                          if (formKey.currentState!.validate()) {
-                            Navigator.pop(context, true);
-                          }
-                        },
-                        child: Text(existing == null ? 'Add' : 'Save'),
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-
-    if (result ?? false) {
-      final repo = ref.read(snippetRepositoryProvider);
-      final description = descriptionController.text.isEmpty
-          ? null
-          : descriptionController.text;
-
-      if (existing != null) {
-        await repo.update(
-          existing.copyWith(
-            name: nameController.text,
-            command: commandController.text,
-            description: drift.Value(description),
-          ),
-        );
-      } else {
-        await repo.insert(
-          SnippetsCompanion.insert(
-            name: nameController.text,
-            command: commandController.text,
-            description: drift.Value(description),
-          ),
-        );
-      }
-
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              existing == null ? 'Snippet added' : 'Snippet updated',
-            ),
-          ),
-        );
-      }
-    }
-
-    nameController.dispose();
-    commandController.dispose();
-    descriptionController.dispose();
   }
 }
 
@@ -2442,11 +2423,7 @@ class _SnippetRow extends ConsumerWidget {
               _SmallIconButton(
                 icon: Icons.edit_outlined,
                 tooltip: 'Edit',
-                onTap: () => SnippetsPanel._showAddEditSnippetDialog(
-                  context,
-                  ref,
-                  snippet,
-                ),
+                onTap: () => context.push('/snippets/edit/${snippet.id}'),
               ),
               _SmallIconButton(
                 icon: Icons.delete_outline,
@@ -2675,6 +2652,10 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     context: context,
     ref: ref,
     feature: MonetizationFeature.agentLaunchPresets,
+    blockedAction: 'Open coding-agent sessions from tmux',
+    blockedOutcome:
+        'Unlock Pro to discover and jump back into Codex, Claude Code, '
+        'Copilot CLI, or OpenCode sessions.',
   );
 
   String? _resolveRecentSessionScopeWorkingDirectory(SshSession session) {

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -85,10 +85,21 @@ String? _resolveTmuxExtraFlags({
 /// Screen for adding or editing a host.
 class HostEditScreen extends ConsumerStatefulWidget {
   /// Creates a new [HostEditScreen].
-  const HostEditScreen({this.hostId, super.key});
+  const HostEditScreen({
+    this.hostId,
+    this.initialSshUrl,
+    this.useLocalhostTemplate = false,
+    super.key,
+  });
 
   /// The host ID to edit, or null for a new host.
   final int? hostId;
+
+  /// SSH URL used to prefill a new host.
+  final String? initialSshUrl;
+
+  /// Whether to prefill a local SSH test host.
+  final bool useLocalhostTemplate;
 
   @override
   ConsumerState<HostEditScreen> createState() => _HostEditScreenState();
@@ -152,7 +163,33 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
 
     if (widget.hostId != null) {
       _loadHost();
+    } else if (widget.initialSshUrl?.trim().isNotEmpty ?? false) {
+      _applySshUrl(widget.initialSshUrl!.trim());
+    } else if (widget.useLocalhostTemplate) {
+      _applyLocalhostTemplate();
     }
+  }
+
+  void _applySshUrl(String rawUrl) {
+    final uri = Uri.tryParse(rawUrl);
+    if (uri == null || uri.scheme != 'ssh' || uri.host.isEmpty) {
+      return;
+    }
+
+    _labelController.text = uri.host;
+    _hostnameController.text = uri.host;
+    if (uri.hasPort) {
+      _portController.text = uri.port.toString();
+    }
+    if (uri.userInfo.isNotEmpty) {
+      final userInfoParts = uri.userInfo.split(':');
+      _usernameController.text = Uri.decodeComponent(userInfoParts.first);
+    }
+  }
+
+  void _applyLocalhostTemplate() {
+    _labelController.text = 'Local test host';
+    _hostnameController.text = 'localhost';
   }
 
   Future<void> _loadHost() async {
@@ -1352,6 +1389,10 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         context: context,
         ref: ref,
         feature: MonetizationFeature.agentLaunchPresets,
+        blockedAction: 'Save coding-agent startup for this host',
+        blockedOutcome:
+            'Unlock Pro to launch your preferred agent workflow every time you '
+            'connect.',
       );
       if (!hasAccess || !mounted) {
         return;
@@ -1362,6 +1403,10 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         context: context,
         ref: ref,
         feature: MonetizationFeature.autoConnectAutomation,
+        blockedAction: 'Save auto-connect automation for this host',
+        blockedOutcome:
+            'Unlock Pro to run this command or saved snippet automatically '
+            'after connecting.',
       );
       if (!hasAccess || !mounted) {
         return;
@@ -1487,6 +1532,9 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       context: context,
       ref: ref,
       feature: MonetizationFeature.encryptedTransfers,
+      blockedAction: 'Import encrypted host file',
+      blockedOutcome:
+          'Unlock Pro to decrypt this host transfer and prefill the host form.',
     );
     if (!hasAccess) {
       return;
@@ -1637,6 +1685,8 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       context: context,
       ref: ref,
       feature: MonetizationFeature.hostSpecificThemes,
+      blockedAction: 'Save theme overrides on this host',
+      blockedOutcome: 'Unlock Pro to keep this host on its own terminal theme.',
     );
     if (!hasAccess || !mounted) {
       return;

--- a/lib/presentation/screens/key_add_screen.dart
+++ b/lib/presentation/screens/key_add_screen.dart
@@ -16,7 +16,10 @@ import 'transfer_screen.dart';
 /// Screen for adding or importing SSH keys.
 class KeyAddScreen extends ConsumerStatefulWidget {
   /// Creates a new [KeyAddScreen].
-  const KeyAddScreen({super.key});
+  const KeyAddScreen({this.initialTabIndex = 0, super.key});
+
+  /// Initially selected tab index.
+  final int initialTabIndex;
 
   @override
   ConsumerState<KeyAddScreen> createState() => _KeyAddScreenState();
@@ -29,7 +32,15 @@ class _KeyAddScreenState extends ConsumerState<KeyAddScreen>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 2, vsync: this);
+    _tabController = TabController(
+      length: 2,
+      initialIndex: widget.initialTabIndex < 0
+          ? 0
+          : widget.initialTabIndex > 1
+          ? 1
+          : widget.initialTabIndex,
+      vsync: this,
+    );
   }
 
   @override
@@ -493,6 +504,9 @@ class _ImportKeyTabState extends ConsumerState<_ImportKeyTab> {
       context: context,
       ref: ref,
       feature: MonetizationFeature.encryptedTransfers,
+      blockedAction: 'Import encrypted key file',
+      blockedOutcome:
+          'Unlock Pro to decrypt this key transfer and add it to your keyring.',
     );
     if (!hasAccess) {
       return;

--- a/lib/presentation/screens/keys_screen.dart
+++ b/lib/presentation/screens/keys_screen.dart
@@ -58,11 +58,35 @@ class KeysScreen extends ConsumerWidget {
     List<SshKey> keys,
   ) {
     if (keys.isEmpty) {
-      return FluttyTheme.buildEmptyState(
-        context: context,
-        icon: Icons.vpn_key_outlined,
-        title: 'No SSH keys yet',
-        subtitle: 'Tap + to generate or import a key',
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              FluttyTheme.buildEmptyState(
+                context: context,
+                icon: Icons.vpn_key_outlined,
+                title: 'No SSH keys yet',
+                subtitle:
+                    'Keys let you sign in without saving server passwords. '
+                    'Generate a new Ed25519 key or import an existing private '
+                    'key.',
+                onAction: () => context.push('/keys/add'),
+                actionLabel: 'Generate Key',
+                actionIcon: Icons.enhanced_encryption,
+                centered: false,
+                padded: false,
+              ),
+              const SizedBox(height: FluttyTheme.spacingMd),
+              OutlinedButton.icon(
+                onPressed: () => context.push('/keys/add?tab=import'),
+                icon: const Icon(Icons.upload_file_outlined, size: 18),
+                label: const Text('Import Key'),
+              ),
+            ],
+          ),
+        ),
       );
     }
 

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -81,22 +81,37 @@ class _BiometricSettingsState {
 }
 
 class _SectionHeader extends StatelessWidget {
-  const _SectionHeader({required this.title});
+  const _SectionHeader({required this.title, this.subtitle});
 
   final String title;
+  final String? subtitle;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 28, 16, 8),
-      child: Text(
-        title,
-        style: theme.textTheme.labelMedium?.copyWith(
-          color: theme.colorScheme.primary,
-          fontWeight: FontWeight.w700,
-          letterSpacing: 0.5,
-        ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: theme.colorScheme.primary,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.5,
+            ),
+          ),
+          if (subtitle case final subtitle?) ...[
+            const SizedBox(height: 2),
+            Text(
+              subtitle,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ],
       ),
     );
   }
@@ -114,7 +129,10 @@ class _SubscriptionSection extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const _SectionHeader(title: 'MonkeySSH Pro'),
+        const _SectionHeader(
+          title: 'MonkeySSH Pro',
+          subtitle: 'Subscription status and Pro-only workflows',
+        ),
         ListTile(
           leading: Icon(
             state.isProUnlocked
@@ -151,7 +169,10 @@ class _AppearanceSection extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const _SectionHeader(title: 'Appearance'),
+        const _SectionHeader(
+          title: 'Appearance',
+          subtitle: 'App-wide color mode',
+        ),
         ListTile(
           leading: const Icon(Icons.palette_outlined),
           title: const Text('Theme'),
@@ -223,7 +244,10 @@ class _SecuritySection extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const _SectionHeader(title: 'Security'),
+        const _SectionHeader(
+          title: 'Security',
+          subtitle: 'PIN, biometrics, and automatic locking',
+        ),
         if (isAuthConfigured)
           ListTile(
             leading: const Icon(Icons.pin_outlined),
@@ -523,7 +547,10 @@ class _TerminalSection extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const _SectionHeader(title: 'Terminal'),
+        const _SectionHeader(
+          title: 'Terminal',
+          subtitle: 'Themes, fonts, links, keyboard, and clipboard behavior',
+        ),
         ListTile(
           leading: const Icon(Icons.palette_outlined),
           title: const Text('Light Mode Theme'),
@@ -933,7 +960,10 @@ class _AboutSection extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const _SectionHeader(title: 'About'),
+        const _SectionHeader(
+          title: 'About',
+          subtitle: 'Version, source, and licenses',
+        ),
         ListTile(
           leading: const Icon(Icons.info_outline),
           title: const Text('App version'),
@@ -1069,7 +1099,10 @@ class _AndroidBackgroundSectionState
       return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const _SectionHeader(title: 'Background SSH'),
+          const _SectionHeader(
+            title: 'Background SSH',
+            subtitle: 'Keep sessions alive while MonkeySSH is backgrounded',
+          ),
           ListTile(
             leading: Icon(leadingIcon),
             title: const Text('Battery optimization'),
@@ -1095,7 +1128,10 @@ class _ImportExportSection extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) => Column(
     crossAxisAlignment: CrossAxisAlignment.start,
     children: [
-      const _SectionHeader(title: 'Import & Export'),
+      const _SectionHeader(
+        title: 'Import & Export',
+        subtitle: 'Encrypted migration packages for moving devices',
+      ),
       ListTile(
         leading: Icon(useShareSheet ? Icons.share : Icons.save_alt),
         title: const Text('Export app data'),
@@ -1122,6 +1158,10 @@ class _ImportExportSection extends ConsumerWidget {
       context: context,
       ref: ref,
       feature: MonetizationFeature.migrationImportExport,
+      blockedAction: 'Export encrypted app data',
+      blockedOutcome:
+          'Unlock Pro to package hosts, keys, snippets, and settings for '
+          'another device.',
     );
     if (!hasAccess || !context.mounted) {
       return;
@@ -1178,6 +1218,9 @@ class _ImportExportSection extends ConsumerWidget {
       context: context,
       ref: ref,
       feature: MonetizationFeature.migrationImportExport,
+      blockedAction: 'Import encrypted app data',
+      blockedOutcome:
+          'Unlock Pro to restore a MonkeySSH migration package on this device.',
     );
     if (!hasAccess || !context.mounted) {
       return;

--- a/lib/presentation/screens/snippet_edit_screen.dart
+++ b/lib/presentation/screens/snippet_edit_screen.dart
@@ -35,9 +35,16 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
   @override
   void initState() {
     super.initState();
+    _contentController.addListener(_handleCommandChanged);
     unawaited(_loadFolders());
     if (widget.snippetId != null) {
       unawaited(_loadSnippet());
+    }
+  }
+
+  void _handleCommandChanged() {
+    if (mounted) {
+      setState(() {});
     }
   }
 
@@ -67,6 +74,7 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
 
   @override
   void dispose() {
+    _contentController.removeListener(_handleCommandChanged);
     _nameController.dispose();
     _contentController.dispose();
     _descriptionController.dispose();
@@ -167,7 +175,8 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
                   ),
                   const SizedBox(height: 8),
                   Text(
-                    'Use {{variable}} for substitution',
+                    'Use {{variable}} placeholders. Examples: '
+                    '{{container}}, {{branch}}, {{log_file}}.',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: Theme.of(context).colorScheme.outline,
                     ),
@@ -299,8 +308,9 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
               Text('Examples:', style: TextStyle(fontWeight: FontWeight.bold)),
               SizedBox(height: 8),
               Text('• ssh {{user}}@{{host}}'),
-              Text('• docker exec -it {{container}} bash'),
-              Text('• git push origin {{branch}}'),
+              Text('• tail -f {{log_file}}'),
+              Text('• docker restart {{container}}'),
+              Text('• git pull && {{restart_command}}'),
               SizedBox(height: 16),
               Text('When executing, you\'ll be prompted to fill in values.'),
             ],

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3671,7 +3671,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             behavior: SnackBarBehavior.floating,
             margin: EdgeInsets.fromLTRB(16, 0, 16, bottomMargin),
             content: const Text(
-              'MonkeySSH Pro unlocks auto-connect commands and snippets.',
+              'This auto-connect workflow needs MonkeySSH Pro to run.',
             ),
             action: SnackBarAction(
               label: 'Upgrade',
@@ -3679,6 +3679,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 Routes.upgrade,
                 queryParameters: <String, String>{
                   'feature': MonetizationFeature.autoConnectAutomation.name,
+                  'action': 'Run this auto-connect workflow',
+                  'outcome':
+                      'Unlock Pro to run saved commands or snippets '
+                      'automatically when a terminal opens.',
                 },
               ),
             ),
@@ -4957,6 +4961,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       context: context,
       ref: ref,
       feature: MonetizationFeature.hostSpecificThemes,
+      blockedAction: 'Save this theme to the host',
+      blockedOutcome:
+          'Unlock Pro to keep this host on the selected terminal theme.',
     );
     if (!hasAccess || !mounted) {
       return;

--- a/lib/presentation/screens/upgrade_screen.dart
+++ b/lib/presentation/screens/upgrade_screen.dart
@@ -10,10 +10,21 @@ import '../widgets/premium_badge.dart';
 /// Upgrade screen for MonkeySSH Pro.
 class UpgradeScreen extends ConsumerStatefulWidget {
   /// Creates a new [UpgradeScreen].
-  const UpgradeScreen({this.feature, super.key});
+  const UpgradeScreen({
+    this.feature,
+    this.blockedAction,
+    this.blockedOutcome,
+    super.key,
+  });
 
   /// Feature that triggered the upgrade flow, when known.
   final MonetizationFeature? feature;
+
+  /// User action that was blocked by the paywall.
+  final String? blockedAction;
+
+  /// Outcome the user gets after upgrading for the blocked action.
+  final String? blockedOutcome;
 
   @override
   ConsumerState<UpgradeScreen> createState() => _UpgradeScreenState();
@@ -243,7 +254,11 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
           ),
           if (feature != null) ...[
             const SizedBox(height: 20),
-            _UpgradeReasonCard(feature: feature),
+            _UpgradeReasonCard(
+              feature: feature,
+              blockedAction: widget.blockedAction,
+              blockedOutcome: widget.blockedOutcome,
+            ),
           ],
           if (progressMessage case final message?) ...[
             const SizedBox(height: 20),
@@ -680,9 +695,15 @@ class _UpgradeProgressBanner extends StatelessWidget {
 }
 
 class _UpgradeReasonCard extends StatelessWidget {
-  const _UpgradeReasonCard({required this.feature});
+  const _UpgradeReasonCard({
+    required this.feature,
+    this.blockedAction,
+    this.blockedOutcome,
+  });
 
   final MonetizationFeature feature;
+  final String? blockedAction;
+  final String? blockedOutcome;
 
   @override
   Widget build(BuildContext context) => Card(
@@ -692,11 +713,11 @@ class _UpgradeReasonCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            '${feature.label} is part of MonkeySSH Pro',
+            blockedAction ?? feature.blockedAction,
             style: Theme.of(context).textTheme.titleMedium,
           ),
           const SizedBox(height: 8),
-          Text(feature.description),
+          Text(blockedOutcome ?? feature.blockedOutcome),
         ],
       ),
     ),

--- a/lib/presentation/widgets/premium_access.dart
+++ b/lib/presentation/widgets/premium_access.dart
@@ -12,6 +12,8 @@ Future<bool> requireMonetizationFeatureAccess({
   required BuildContext context,
   required WidgetRef ref,
   required MonetizationFeature feature,
+  String? blockedAction,
+  String? blockedOutcome,
 }) async {
   final service = ref.read(monetizationServiceProvider);
   if (await service.canUseFeature(feature)) {
@@ -22,14 +24,22 @@ Future<bool> requireMonetizationFeatureAccess({
   }
   final router = GoRouter.maybeOf(context);
   if (router != null) {
-    await context.pushNamed(
-      Routes.upgrade,
-      queryParameters: {'feature': feature.name},
-    );
+    final queryParameters = <String, String>{'feature': feature.name};
+    if (blockedAction != null) {
+      queryParameters['action'] = blockedAction;
+    }
+    if (blockedOutcome != null) {
+      queryParameters['outcome'] = blockedOutcome;
+    }
+    await context.pushNamed(Routes.upgrade, queryParameters: queryParameters);
   } else {
     await Navigator.of(context).push<void>(
       MaterialPageRoute<void>(
-        builder: (context) => UpgradeScreen(feature: feature),
+        builder: (context) => UpgradeScreen(
+          feature: feature,
+          blockedAction: blockedAction,
+          blockedOutcome: blockedOutcome,
+        ),
       ),
     );
   }

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -477,6 +477,66 @@ void main() {
     });
   });
 
+  group('HomeScreen empty states', () {
+    testWidgets('hosts empty state offers first-run actions', (tester) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      await tester.pumpWidget(
+        buildMobileHomeScreen(
+          db: db,
+          overrides: [
+            activeSessionsProvider.overrideWith(
+              _TestActiveSessionsNotifier.new,
+            ),
+            allHostsProvider.overrideWith(
+              (ref) => Stream.value(const <Host>[]),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('No hosts yet'), findsOneWidget);
+      expect(find.text('Import config'), findsOneWidget);
+      expect(find.text('Paste SSH URL'), findsOneWidget);
+      expect(find.text('Try local test host'), findsOneWidget);
+    });
+
+    testWidgets('connections empty state explains where sessions appear', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      await tester.pumpWidget(
+        buildMobileHomeScreen(
+          db: db,
+          overrides: [
+            activeSessionsProvider.overrideWith(
+              _TestActiveSessionsNotifier.new,
+            ),
+            allHostsProvider.overrideWith(
+              (ref) => Stream.value(const <Host>[]),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.tap(find.text('Connections').first);
+      await tester.pump();
+
+      expect(find.text('No active connections'), findsOneWidget);
+      expect(
+        find.textContaining('Connections appear here while terminals are open'),
+        findsOneWidget,
+      );
+    });
+  });
+
   testWidgets('small icon actions expose semantics labels', (tester) async {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     addTearDown(db.close);

--- a/test/widget/keys_screen_test.dart
+++ b/test/widget/keys_screen_test.dart
@@ -32,6 +32,29 @@ ProviderScope _buildKeyScreen() => ProviderScope(
 
 void main() {
   group('KeysScreen', () {
+    testWidgets('explains key choices in the empty state', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            allKeysProvider.overrideWith(
+              (ref) => Stream.value(const <SshKey>[]),
+            ),
+          ],
+          child: const MaterialApp(home: KeysScreen()),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('No SSH keys yet'), findsOneWidget);
+      expect(
+        find.textContaining('without saving server passwords'),
+        findsOneWidget,
+      );
+      expect(find.text('Generate Key'), findsOneWidget);
+      expect(find.text('Import Key'), findsOneWidget);
+    });
+
     testWidgets(
       'shows loading indicator initially',
       (tester) async {

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -175,6 +175,10 @@ void main() {
       await _pumpSettingsScreen(tester, db: db);
 
       expect(find.text('MonkeySSH Pro'), findsOneWidget);
+      expect(
+        find.text('Subscription status and Pro-only workflows'),
+        findsOneWidget,
+      );
       expect(find.text('Subscription'), findsOneWidget);
       expect(
         find.text('Unlock transfers, automation, and agent launch presets'),
@@ -299,6 +303,13 @@ void main() {
       addTearDown(db.close);
 
       await _pumpSettingsScreen(tester, db: db);
+
+      await tester.scrollUntilVisible(
+        find.text('Clickable file paths'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
 
       expect(find.text('Clickable file paths'), findsOneWidget);
       expect(

--- a/test/widget/snippets_screen_test.dart
+++ b/test/widget/snippets_screen_test.dart
@@ -5,10 +5,12 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/snippet_repository.dart';
+import 'package:monkeyssh/presentation/screens/snippet_edit_screen.dart';
 import 'package:monkeyssh/presentation/screens/snippets_screen.dart';
 
 class _MockSnippetRepository extends Mock implements SnippetRepository {}
@@ -65,6 +67,77 @@ void main() {
       await tester.pump(const Duration(milliseconds: 100));
 
       expect(find.text('Imported snippet'), findsOneWidget);
+    });
+
+    testWidgets('routes empty-state creation to the full snippet editor', (
+      tester,
+    ) async {
+      final snippetRepository = _MockSnippetRepository();
+      when(
+        snippetRepository.watchAll,
+      ).thenAnswer((_) => Stream.value(const <Snippet>[]));
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            snippetRepositoryProvider.overrideWithValue(snippetRepository),
+          ],
+          child: MaterialApp.router(
+            routerConfig: GoRouter(
+              routes: [
+                GoRoute(
+                  path: '/',
+                  builder: (context, state) => const SnippetsScreen(),
+                ),
+                GoRoute(
+                  path: '/snippets/add',
+                  builder: (context, state) =>
+                      const Scaffold(body: Text('Full snippet editor')),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('No snippets yet'), findsOneWidget);
+      expect(find.textContaining('tail -f {{log_file}}'), findsOneWidget);
+
+      await tester.tap(find.text('Add Snippet').last);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Full snippet editor'), findsOneWidget);
+    });
+
+    testWidgets('full editor updates variable preview as command changes', (
+      tester,
+    ) async {
+      final snippetRepository = _MockSnippetRepository();
+      when(
+        snippetRepository.getAllFolders,
+      ).thenAnswer((_) async => const <SnippetFolder>[]);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            snippetRepositoryProvider.overrideWithValue(snippetRepository),
+          ],
+          child: const MaterialApp(home: SnippetEditScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Command'),
+        'docker restart {{container}} && git checkout {{branch}}',
+      );
+      await tester.pump();
+
+      expect(find.text('Variables'), findsOneWidget);
+      expect(find.text('container'), findsOneWidget);
+      expect(find.text('branch'), findsOneWidget);
     });
 
     testWidgets('reordering snippets persists the new order', (tester) async {

--- a/test/widget/upgrade_screen_test.dart
+++ b/test/widget/upgrade_screen_test.dart
@@ -24,6 +24,50 @@ void _stubRestorePurchases(_MockMonetizationService service) {
 }
 
 void main() {
+  testWidgets('feature-triggered paywall leads with the blocked action', (
+    tester,
+  ) async {
+    final service = _MockMonetizationService();
+    const state = MonetizationState(
+      billingAvailability: MonetizationBillingAvailability.available,
+      entitlements: MonetizationEntitlements.free(),
+      offers: [],
+      debugUnlockAvailable: false,
+      debugUnlocked: false,
+    );
+
+    when(() => service.currentState).thenReturn(state);
+    _stubRestorePurchases(service);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          monetizationServiceProvider.overrideWithValue(service),
+          monetizationStateProvider.overrideWith((ref) => Stream.value(state)),
+        ],
+        child: const MaterialApp(
+          home: UpgradeScreen(
+            feature: MonetizationFeature.autoConnectAutomation,
+            blockedAction: 'Run this auto-connect workflow',
+            blockedOutcome:
+                'Unlock Pro to run saved commands or snippets automatically.',
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Run this auto-connect workflow'), findsOneWidget);
+    expect(
+      find.text('Unlock Pro to run saved commands or snippets automatically.'),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Auto-connect automation is part of MonkeySSH Pro'),
+      findsNothing,
+    );
+  });
+
   testWidgets('plan cards stay legible in dark mode', (tester) async {
     final service = _MockMonetizationService();
     const state = MonetizationState(


### PR DESCRIPTION
## Summary

- Improve first-run empty-state guidance for hosts, keys, connections, and snippets.
- Route snippet add/edit from inline lists to the full editor and keep variable help/preview consistent.
- Add settings section subtitles and feature-triggered Pro messaging that leads with the blocked action/outcome.

## Validation

- `dart format ...`
- `flutter analyze`
- `flutter test test/widget/home_screen_test.dart test/widget/keys_screen_test.dart test/widget/snippets_screen_test.dart test/widget/settings_screen_test.dart test/widget/upgrade_screen_test.dart`
- `flutter test --no-pub`
