### PR TITLE
fix: avoid blocking ssh host-key trust during kex

### DIFF
--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -501,6 +501,7 @@ class SshService {
   }) async {
     SSHClient? client;
     final dependentClients = <SSHClient>[];
+    SSHClient? jumpClient;
     void report(SshConnectionState state, String message) {
       onProgress?.call(
         ConnectionProgressUpdate(state: state, message: message),
@@ -508,7 +509,7 @@ class SshService {
     }
 
     try {
-      SSHSocket socket;
+      final verificationService = _createHostKeyVerificationService(config);
 
       // Handle jump host
       if (config.jumpHost != null) {
@@ -527,91 +528,62 @@ class SshService {
         dependentClients
           ..add(jumpResult.client!)
           ..addAll(jumpResult.dependentClients);
+        jumpClient = jumpResult.client;
+      }
 
-        // Create forwarded connection through jump host
-        // SSHForwardChannel implements SSHSocket
-        report(SshConnectionState.connecting, 'Opening tunnel to destination…');
-        socket = await jumpResult.client!.forwardLocal(
-          config.hostname,
-          config.port,
-        );
-      } else {
+      Future<SSHSocket> openEndpointSocket() async {
+        if (jumpClient != null) {
+          // Create forwarded connection through jump host.
+          // SSHForwardChannel implements SSHSocket.
+          report(
+            SshConnectionState.connecting,
+            'Opening tunnel to destination…',
+          );
+          return jumpClient.forwardLocal(config.hostname, config.port);
+        }
+
         report(
           SshConnectionState.connecting,
           isJumpHost
               ? 'Opening jump host connection…'
               : 'Opening network connection…',
         );
-        socket = await _socketConnector(
+        return _socketConnector(
           config.hostname,
           config.port,
           timeout: config.connectionTimeout,
         );
       }
 
-      final verificationSocket = socket is HostKeySource
-          ? socket
-          : _HostKeyCapturingSocket(socket);
-      final hostKeySource = verificationSocket as HostKeySource;
-      PendingHostTrustUpdate? pendingHostTrustUpdate;
+      report(
+        SshConnectionState.connecting,
+        isJumpHost ? 'Verifying jump host key…' : 'Verifying host key…',
+      );
+      final presentedHostKey = await _probeHostKey(
+        await openEndpointSocket(),
+        config: config,
+      );
+      final pendingHostTrustUpdate = await verificationService.verify(
+        presentedHostKey,
+      );
+      await pendingHostTrustUpdate.persistTrustDecision(knownHostsRepository!);
+
+      final socket = await openEndpointSocket();
 
       report(
         SshConnectionState.authenticating,
         isJumpHost ? 'Authenticating with jump host…' : 'Authenticating…',
       );
       client = _clientFactory(
-        verificationSocket,
+        socket,
         username: config.username,
-        onVerifyHostKey: (type, fingerprint) async {
-          report(
-            SshConnectionState.connecting,
-            isJumpHost ? 'Verifying jump host key…' : 'Verifying host key…',
-          );
-          final verificationService = knownHostsRepository == null
-              ? null
-              : HostKeyVerificationService(
-                  knownHostsRepository: knownHostsRepository!,
-                  promptHandler: hostKeyPromptHandler,
-                );
-          if (verificationService == null) {
+        onVerifyHostKey: (_, fingerprint) {
+          if (!_probedHostKeyMatchesCallback(presentedHostKey, fingerprint)) {
             throw HostKeyVerificationException(
-              'SSH host key verification is unavailable for '
-              '${config.hostname}:${config.port}.',
+              'The host key for ${config.hostname}:${config.port} changed '
+              'between verification and authentication.',
             );
           }
-
-          final hostKeyBytes = await hostKeySource.hostKeyBytes.timeout(
-            config.connectionTimeout,
-            onTimeout: () => throw HostKeyVerificationException(
-              'Timed out while reading the host key for '
-              '${config.hostname}:${config.port}.',
-            ),
-          );
-          final presentedHostKey = VerifiedHostKey(
-            hostname: config.hostname,
-            port: config.port,
-            keyType: type,
-            hostKeyBytes: hostKeyBytes,
-          );
-          final legacyFingerprint = formatLegacySshHostKeyFingerprint(
-            hostKeyBytes,
-          );
-          final callbackFingerprint = fingerprint
-              .map((value) => value.toRadixString(16).padLeft(2, '0'))
-              .join(':');
-          if (legacyFingerprint != callbackFingerprint) {
-            throw HostKeyVerificationException(
-              'Failed to confirm the presented host key for '
-              '${config.hostname}:${config.port}.',
-            );
-          }
-
-          pendingHostTrustUpdate = await verificationService.verify(
-            presentedHostKey,
-          );
-          await pendingHostTrustUpdate!.persistTrustDecision(
-            knownHostsRepository!,
-          );
           return true;
         },
         onPasswordRequest: config.password != null
@@ -635,11 +607,9 @@ class SshService {
         SshConnectionState.connected,
         isJumpHost ? 'Jump host connected.' : 'SSH connection established.',
       );
-      if (pendingHostTrustUpdate != null && knownHostsRepository != null) {
-        await pendingHostTrustUpdate!.commitAfterAuthentication(
-          knownHostsRepository!,
-        );
-      }
+      await pendingHostTrustUpdate.commitAfterAuthentication(
+        knownHostsRepository!,
+      );
 
       return SshConnectionResult(
         success: true,
@@ -684,6 +654,90 @@ class SshService {
       return SshConnectionResult(success: false, error: 'Connection error: $e');
     }
   }
+
+  HostKeyVerificationService _createHostKeyVerificationService(
+    SshConnectionConfig config,
+  ) {
+    final repository = knownHostsRepository;
+    if (repository == null) {
+      throw HostKeyVerificationException(
+        'SSH host key verification is unavailable for '
+        '${config.hostname}:${config.port}.',
+      );
+    }
+
+    return HostKeyVerificationService(
+      knownHostsRepository: repository,
+      promptHandler: hostKeyPromptHandler,
+    );
+  }
+
+  Future<VerifiedHostKey> _probeHostKey(
+    SSHSocket socket, {
+    required SshConnectionConfig config,
+  }) async {
+    final verificationSocket = socket is HostKeySource
+        ? socket
+        : _HostKeyCapturingSocket(socket);
+    final hostKeySource = verificationSocket as HostKeySource;
+    SSHClient? probeClient;
+    String? callbackKeyType;
+    String? callbackFingerprint;
+
+    if (socket is! HostKeySource) {
+      probeClient = _clientFactory(
+        verificationSocket,
+        username: config.username,
+        onVerifyHostKey: (type, fingerprint) {
+          callbackKeyType = type;
+          callbackFingerprint = _formatLegacyFingerprintBytes(fingerprint);
+          return true;
+        },
+      );
+      unawaited(probeClient.authenticated.catchError((_) {}));
+    }
+
+    try {
+      final hostKeyBytes = await hostKeySource.hostKeyBytes.timeout(
+        config.connectionTimeout,
+        onTimeout: () => throw HostKeyVerificationException(
+          'Timed out while reading the host key for '
+          '${config.hostname}:${config.port}.',
+        ),
+      );
+      final legacyFingerprint = formatLegacySshHostKeyFingerprint(hostKeyBytes);
+      if (callbackFingerprint != null &&
+          callbackFingerprint != legacyFingerprint) {
+        throw HostKeyVerificationException(
+          'Failed to confirm the presented host key for '
+          '${config.hostname}:${config.port}.',
+        );
+      }
+
+      return VerifiedHostKey(
+        hostname: config.hostname,
+        port: config.port,
+        keyType:
+            callbackKeyType ??
+            canonicalizeSshHostKeyType('', hostKeyBytes: hostKeyBytes),
+        hostKeyBytes: hostKeyBytes,
+      );
+    } finally {
+      probeClient?.close();
+      await verificationSocket.close();
+    }
+  }
+
+  bool _probedHostKeyMatchesCallback(
+    VerifiedHostKey presentedHostKey,
+    Uint8List fingerprint,
+  ) =>
+      presentedHostKey.md5Fingerprint ==
+      _formatLegacyFingerprintBytes(fingerprint);
+
+  String _formatLegacyFingerprintBytes(Uint8List fingerprint) => fingerprint
+      .map((value) => value.toRadixString(16).padLeft(2, '0'))
+      .join(':');
 
   /// Disconnect a session by connection ID.
   Future<void> disconnect(int connectionId) async {

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -555,36 +555,96 @@ class SshService {
         );
       }
 
-      report(
-        SshConnectionState.connecting,
-        isJumpHost ? 'Verifying jump host key…' : 'Verifying host key…',
+      final knownHosts = knownHostsRepository!;
+      final trustedHost = await knownHosts.getByHost(
+        config.hostname,
+        config.port,
       );
-      final presentedHostKey = await _probeHostKey(
-        await openEndpointSocket(),
-        config: config,
-      );
-      final pendingHostTrustUpdate = await verificationService.verify(
-        presentedHostKey,
-      );
-      await pendingHostTrustUpdate.persistTrustDecision(knownHostsRepository!);
 
-      final socket = await openEndpointSocket();
+      if (trustedHost == null) {
+        report(
+          SshConnectionState.connecting,
+          isJumpHost ? 'Verifying jump host key…' : 'Verifying host key…',
+        );
+        final presentedHostKey = await _probeHostKey(
+          await openEndpointSocket(),
+          config: config,
+        );
+        final pendingHostTrustUpdate = await verificationService.verify(
+          presentedHostKey,
+        );
+        await pendingHostTrustUpdate.persistTrustDecision(knownHosts);
+
+        final socket = await openEndpointSocket();
+
+        report(
+          SshConnectionState.authenticating,
+          isJumpHost ? 'Authenticating with jump host…' : 'Authenticating…',
+        );
+        client = _clientFactory(
+          socket,
+          username: config.username,
+          onVerifyHostKey: (_, fingerprint) {
+            if (!_probedHostKeyMatchesCallback(presentedHostKey, fingerprint)) {
+              throw HostKeyVerificationException(
+                'The host key for ${config.hostname}:${config.port} changed '
+                'between verification and authentication.',
+              );
+            }
+            return true;
+          },
+          onPasswordRequest: config.password != null
+              ? () => config.password!
+              : null,
+          identities: _parseIdentities(config),
+          keepAliveInterval: config.keepAliveInterval,
+        );
+
+        // Bound authentication waits so the progress dialog can surface a
+        // recoverable error instead of hanging indefinitely.
+        await client.authenticated.timeout(
+          config.connectionTimeout,
+          onTimeout: () => throw TimeoutException(
+            isJumpHost
+                ? 'Jump host authentication timed out'
+                : 'Authentication timed out',
+          ),
+        );
+        report(
+          SshConnectionState.connected,
+          isJumpHost ? 'Jump host connected.' : 'SSH connection established.',
+        );
+        await pendingHostTrustUpdate.commitAfterAuthentication(knownHosts);
+
+        return SshConnectionResult(
+          success: true,
+          client: client,
+          dependentClients: dependentClients,
+        );
+      }
+
+      final preparedSocket = _prepareHostKeyCapture(await openEndpointSocket());
+      String? callbackKeyType;
+      String? rejectedCallbackFingerprint;
+      var rejectedTrustedHostKey = false;
 
       report(
         SshConnectionState.authenticating,
         isJumpHost ? 'Authenticating with jump host…' : 'Authenticating…',
       );
       client = _clientFactory(
-        socket,
+        preparedSocket.socket,
         username: config.username,
-        onVerifyHostKey: (_, fingerprint) {
-          if (!_probedHostKeyMatchesCallback(presentedHostKey, fingerprint)) {
-            throw HostKeyVerificationException(
-              'The host key for ${config.hostname}:${config.port} changed '
-              'between verification and authentication.',
+        onVerifyHostKey: (type, fingerprint) {
+          callbackKeyType = type;
+          final trusted = _trustedHostMatchesCallback(trustedHost, fingerprint);
+          rejectedTrustedHostKey = !trusted;
+          if (!trusted) {
+            rejectedCallbackFingerprint = _formatLegacyFingerprintBytes(
+              fingerprint,
             );
           }
-          return true;
+          return trusted;
         },
         onPasswordRequest: config.password != null
             ? () => config.password!
@@ -593,22 +653,96 @@ class SshService {
         keepAliveInterval: config.keepAliveInterval,
       );
 
-      // Bound authentication waits so the progress dialog can surface a
-      // recoverable error instead of hanging indefinitely.
-      await client.authenticated.timeout(
-        config.connectionTimeout,
-        onTimeout: () => throw TimeoutException(
-          isJumpHost
-              ? 'Jump host authentication timed out'
-              : 'Authentication timed out',
-        ),
-      );
+      try {
+        await client.authenticated.timeout(
+          config.connectionTimeout,
+          onTimeout: () => throw TimeoutException(
+            isJumpHost
+                ? 'Jump host authentication timed out'
+                : 'Authentication timed out',
+          ),
+        );
+      } on SSHHostkeyError {
+        if (!rejectedTrustedHostKey) {
+          rethrow;
+        }
+
+        client.close();
+        client = null;
+
+        report(
+          SshConnectionState.connecting,
+          isJumpHost ? 'Verifying jump host key…' : 'Verifying host key…',
+        );
+        final changedHostKey = await _readPresentedHostKey(
+          preparedSocket.hostKeySource,
+          config: config,
+          keyType: callbackKeyType,
+        );
+        _confirmCapturedHostKeyMatchesCallback(
+          changedHostKey,
+          rejectedCallbackFingerprint,
+          config: config,
+        );
+        final pendingHostTrustUpdate = await verificationService.verify(
+          changedHostKey,
+        );
+
+        final retrySocket = await openEndpointSocket();
+        report(
+          SshConnectionState.authenticating,
+          isJumpHost ? 'Authenticating with jump host…' : 'Authenticating…',
+        );
+        client = _clientFactory(
+          retrySocket,
+          username: config.username,
+          onVerifyHostKey: (_, fingerprint) {
+            if (!_probedHostKeyMatchesCallback(changedHostKey, fingerprint)) {
+              throw HostKeyVerificationException(
+                'The host key for ${config.hostname}:${config.port} changed '
+                'between verification and authentication.',
+              );
+            }
+            return true;
+          },
+          onPasswordRequest: config.password != null
+              ? () => config.password!
+              : null,
+          identities: _parseIdentities(config),
+          keepAliveInterval: config.keepAliveInterval,
+        );
+
+        await client.authenticated.timeout(
+          config.connectionTimeout,
+          onTimeout: () => throw TimeoutException(
+            isJumpHost
+                ? 'Jump host authentication timed out'
+                : 'Authentication timed out',
+          ),
+        );
+        report(
+          SshConnectionState.connected,
+          isJumpHost ? 'Jump host connected.' : 'SSH connection established.',
+        );
+        await pendingHostTrustUpdate.commitAfterAuthentication(knownHosts);
+
+        return SshConnectionResult(
+          success: true,
+          client: client,
+          dependentClients: dependentClients,
+        );
+      }
+
       report(
         SshConnectionState.connected,
         isJumpHost ? 'Jump host connected.' : 'SSH connection established.',
       );
-      await pendingHostTrustUpdate.commitAfterAuthentication(
-        knownHostsRepository!,
+      await knownHosts.markTrustedHostSeen(
+        hostname: trustedHost.hostname,
+        port: trustedHost.port,
+        keyType: trustedHost.keyType,
+        fingerprint: trustedHost.fingerprint,
+        encodedHostKey: trustedHost.hostKey,
       );
 
       return SshConnectionResult(
@@ -676,17 +810,14 @@ class SshService {
     SSHSocket socket, {
     required SshConnectionConfig config,
   }) async {
-    final verificationSocket = socket is HostKeySource
-        ? socket
-        : _HostKeyCapturingSocket(socket);
-    final hostKeySource = verificationSocket as HostKeySource;
+    final verificationSocket = _prepareHostKeyCapture(socket);
     SSHClient? probeClient;
     String? callbackKeyType;
     String? callbackFingerprint;
 
     if (socket is! HostKeySource) {
       probeClient = _clientFactory(
-        verificationSocket,
+        verificationSocket.socket,
         username: config.username,
         onVerifyHostKey: (type, fingerprint) {
           callbackKeyType = type;
@@ -698,35 +829,77 @@ class SshService {
     }
 
     try {
-      final hostKeyBytes = await hostKeySource.hostKeyBytes.timeout(
-        config.connectionTimeout,
-        onTimeout: () => throw HostKeyVerificationException(
-          'Timed out while reading the host key for '
-          '${config.hostname}:${config.port}.',
-        ),
+      final presentedHostKey = await _readPresentedHostKey(
+        verificationSocket.hostKeySource,
+        config: config,
+        keyType: callbackKeyType,
       );
-      final legacyFingerprint = formatLegacySshHostKeyFingerprint(hostKeyBytes);
-      if (callbackFingerprint != null &&
-          callbackFingerprint != legacyFingerprint) {
-        throw HostKeyVerificationException(
-          'Failed to confirm the presented host key for '
-          '${config.hostname}:${config.port}.',
-        );
-      }
-
-      return VerifiedHostKey(
-        hostname: config.hostname,
-        port: config.port,
-        keyType:
-            callbackKeyType ??
-            canonicalizeSshHostKeyType('', hostKeyBytes: hostKeyBytes),
-        hostKeyBytes: hostKeyBytes,
+      _confirmCapturedHostKeyMatchesCallback(
+        presentedHostKey,
+        callbackFingerprint,
+        config: config,
       );
+      return presentedHostKey;
     } finally {
       probeClient?.close();
-      await verificationSocket.close();
+      await verificationSocket.socket.close();
     }
   }
+
+  _PreparedHostKeySocket _prepareHostKeyCapture(SSHSocket socket) {
+    final verificationSocket = socket is HostKeySource
+        ? socket
+        : _HostKeyCapturingSocket(socket);
+    return _PreparedHostKeySocket(
+      socket: verificationSocket,
+      hostKeySource: verificationSocket as HostKeySource,
+    );
+  }
+
+  Future<VerifiedHostKey> _readPresentedHostKey(
+    HostKeySource hostKeySource, {
+    required SshConnectionConfig config,
+    required String? keyType,
+  }) async {
+    final hostKeyBytes = await hostKeySource.hostKeyBytes.timeout(
+      config.connectionTimeout,
+      onTimeout: () => throw HostKeyVerificationException(
+        'Timed out while reading the host key for '
+        '${config.hostname}:${config.port}.',
+      ),
+    );
+    return VerifiedHostKey(
+      hostname: config.hostname,
+      port: config.port,
+      keyType:
+          keyType ?? canonicalizeSshHostKeyType('', hostKeyBytes: hostKeyBytes),
+      hostKeyBytes: hostKeyBytes,
+    );
+  }
+
+  void _confirmCapturedHostKeyMatchesCallback(
+    VerifiedHostKey presentedHostKey,
+    String? callbackFingerprint, {
+    required SshConnectionConfig config,
+  }) {
+    if (callbackFingerprint != null &&
+        callbackFingerprint != presentedHostKey.md5Fingerprint) {
+      throw HostKeyVerificationException(
+        'Failed to confirm the presented host key for '
+        '${config.hostname}:${config.port}.',
+      );
+    }
+  }
+
+  bool _trustedHostMatchesCallback(
+    KnownHost trustedHost,
+    Uint8List fingerprint,
+  ) => sshHostTrustMatches(
+    firstFingerprint: trustedHost.fingerprint,
+    firstEncodedHostKey: trustedHost.hostKey,
+    secondFingerprint: _formatLegacyFingerprintBytes(fingerprint),
+    secondEncodedHostKey: '',
+  );
 
   bool _probedHostKeyMatchesCallback(
     VerifiedHostKey presentedHostKey,
@@ -912,6 +1085,16 @@ class _FiniteChunkSshSocket implements SSHSocket {
 
   @override
   void destroy() {}
+}
+
+class _PreparedHostKeySocket {
+  const _PreparedHostKeySocket({
+    required this.socket,
+    required this.hostKeySource,
+  });
+
+  final SSHSocket socket;
+  final HostKeySource hostKeySource;
 }
 
 class _HostKeyCapturingSocket implements SSHSocket, HostKeySource {

--- a/test/domain/services/host_key_verification_test.dart
+++ b/test/domain/services/host_key_verification_test.dart
@@ -43,6 +43,25 @@ void main() {
       expect(storedHost.fingerprint, presentedHostKey.fingerprint);
     });
 
+    test('rejects an unknown host without persisting trust', () async {
+      final service = HostKeyVerificationService(
+        knownHostsRepository: repository,
+        promptHandler: (_) async => HostKeyTrustDecision.reject,
+      );
+      final presentedHostKey = _verifiedHostKey('reject.example.com', 22, [
+        1,
+        2,
+        3,
+      ]);
+
+      await expectLater(
+        service.verify(presentedHostKey),
+        throwsA(isA<HostKeyVerificationException>()),
+      );
+
+      expect(await repository.getByHost('reject.example.com', 22), isNull);
+    });
+
     test('rejects changed host keys by default', () async {
       final originalHostKey = _verifiedHostKey('change.example.com', 22, [
         4,
@@ -123,6 +142,39 @@ void main() {
       expect(storedHost, isNotNull);
       expect(storedHost!.hostKey, replacementHostKey.encodedHostKey);
       expect(storedHost.fingerprint, replacementHostKey.fingerprint);
+    });
+
+    test('accepts a pretrusted host key without prompting', () async {
+      final trustedHostKey = _verifiedHostKey('trusted.example.com', 22, [
+        1,
+        2,
+        3,
+      ]);
+      await repository.upsertTrustedHost(
+        hostname: trustedHostKey.hostname,
+        port: trustedHostKey.port,
+        keyType: trustedHostKey.keyType,
+        fingerprint: trustedHostKey.fingerprint,
+        encodedHostKey: trustedHostKey.encodedHostKey,
+        resetFirstSeen: true,
+      );
+
+      var prompted = false;
+      final service = HostKeyVerificationService(
+        knownHostsRepository: repository,
+        promptHandler: (_) async {
+          prompted = true;
+          return HostKeyTrustDecision.reject;
+        },
+      );
+
+      final update = await service.verify(trustedHostKey);
+      await update.commitAfterAuthentication(repository);
+
+      expect(prompted, isFalse);
+      final storedHost = await repository.getByHost('trusted.example.com', 22);
+      expect(storedHost, isNotNull);
+      expect(storedHost!.hostKey, trustedHostKey.encodedHostKey);
     });
 
     test('accepts RSA host keys across signature algorithm variants', () async {

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -1291,13 +1291,11 @@ void main() {
         encodedHostKey: trustedHostKey.encodedHostKey,
         resetFirstSeen: true,
       );
-      final sockets = [
-        _FakeHostKeySocket(hostKeyBytes),
-        _FakeHostKeySocket(hostKeyBytes),
-      ];
+      final sockets = [_FakeHostKeySocket(hostKeyBytes)];
       final client = _MockSshClient();
       var socketIndex = 0;
       var promptCount = 0;
+      var clientFactoryCalls = 0;
 
       when(client.close).thenReturn(null);
 
@@ -1318,6 +1316,7 @@ void main() {
               identities,
               keepAliveInterval,
             }) {
+              clientFactoryCalls++;
               when(() => client.authenticated).thenAnswer((_) async {
                 final bytes = await (socket as HostKeySource).hostKeyBytes;
                 final trusted = await onVerifyHostKey!(
@@ -1339,9 +1338,194 @@ void main() {
       final result = await service.connect(config);
 
       expect(result.success, isTrue);
-      expect(socketIndex, 2);
+      expect(socketIndex, 1);
+      expect(clientFactoryCalls, 1);
       expect(promptCount, 0);
     });
+
+    test('connect replaces a changed trusted host key after prompt', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final knownHostsRepository = KnownHostsRepository(db);
+      final originalHostKey = VerifiedHostKey(
+        hostname: 'replace-success.example.com',
+        port: 22,
+        keyType: 'ssh-ed25519',
+        hostKeyBytes: _ed25519HostKeyBlob([1, 2, 3]),
+      );
+      final changedHostKeyBytes = _ed25519HostKeyBlob([7, 8, 9]);
+      final changedHostKey = VerifiedHostKey(
+        hostname: 'replace-success.example.com',
+        port: 22,
+        keyType: 'ssh-ed25519',
+        hostKeyBytes: changedHostKeyBytes,
+      );
+      await knownHostsRepository.upsertTrustedHost(
+        hostname: originalHostKey.hostname,
+        port: originalHostKey.port,
+        keyType: originalHostKey.trustedKeyType,
+        fingerprint: originalHostKey.fingerprint,
+        encodedHostKey: originalHostKey.encodedHostKey,
+        resetFirstSeen: true,
+      );
+      final sockets = [
+        _FakeHostKeySocket(changedHostKeyBytes),
+        _FakeHostKeySocket(changedHostKeyBytes),
+      ];
+      final firstClient = _MockSshClient();
+      final retryClient = _MockSshClient();
+      var socketIndex = 0;
+      var clientIndex = 0;
+      var promptCount = 0;
+
+      when(firstClient.close).thenReturn(null);
+      when(retryClient.close).thenReturn(null);
+
+      final service = SshService(
+        knownHostsRepository: knownHostsRepository,
+        hostKeyPromptHandler: (request) async {
+          promptCount++;
+          expect(request.isReplacement, isTrue);
+          expect(request.existingKnownHost, isNotNull);
+          return HostKeyTrustDecision.replace;
+        },
+        socketConnector: (host, port, {timeout}) async =>
+            sockets[socketIndex++],
+        clientFactory:
+            (
+              socket, {
+              required username,
+              onVerifyHostKey,
+              onPasswordRequest,
+              identities,
+              keepAliveInterval,
+            }) {
+              final client = clientIndex == 0 ? firstClient : retryClient;
+              clientIndex++;
+              when(() => client.authenticated).thenAnswer((_) async {
+                final bytes = await (socket as HostKeySource).hostKeyBytes;
+                final trusted = await onVerifyHostKey!(
+                  'ssh-ed25519',
+                  Uint8List.fromList(md5.convert(bytes).bytes),
+                );
+                if (!trusted) {
+                  return Future<void>.error(
+                    SSHHostkeyError('Hostkey verification failed'),
+                  );
+                }
+              });
+              return client;
+            },
+      );
+
+      const config = SshConnectionConfig(
+        hostname: 'replace-success.example.com',
+        port: 22,
+        username: 'tester',
+      );
+
+      final result = await service.connect(config);
+
+      expect(result.success, isTrue);
+      expect(socketIndex, 2);
+      expect(clientIndex, 2);
+      expect(promptCount, 1);
+      final storedHost = await knownHostsRepository.getByHost(
+        'replace-success.example.com',
+        22,
+      );
+      expect(storedHost, isNotNull);
+      expect(storedHost!.hostKey, changedHostKey.encodedHostKey);
+      expect(storedHost.fingerprint, changedHostKey.fingerprint);
+    });
+
+    test(
+      'connect rejects a changed trusted host key without retrying',
+      () async {
+        final db = AppDatabase.forTesting(NativeDatabase.memory());
+        addTearDown(db.close);
+        final knownHostsRepository = KnownHostsRepository(db);
+        final originalHostKey = VerifiedHostKey(
+          hostname: 'replace-reject.example.com',
+          port: 22,
+          keyType: 'ssh-ed25519',
+          hostKeyBytes: _ed25519HostKeyBlob([1, 2, 3]),
+        );
+        final changedHostKeyBytes = _ed25519HostKeyBlob([7, 8, 9]);
+        await knownHostsRepository.upsertTrustedHost(
+          hostname: originalHostKey.hostname,
+          port: originalHostKey.port,
+          keyType: originalHostKey.trustedKeyType,
+          fingerprint: originalHostKey.fingerprint,
+          encodedHostKey: originalHostKey.encodedHostKey,
+          resetFirstSeen: true,
+        );
+        final socket = _FakeHostKeySocket(changedHostKeyBytes);
+        final client = _MockSshClient();
+        var socketCount = 0;
+        var clientFactoryCalls = 0;
+        var promptCount = 0;
+
+        when(client.close).thenReturn(null);
+
+        final service = SshService(
+          knownHostsRepository: knownHostsRepository,
+          hostKeyPromptHandler: (request) async {
+            promptCount++;
+            expect(request.isReplacement, isTrue);
+            return HostKeyTrustDecision.reject;
+          },
+          socketConnector: (host, port, {timeout}) async {
+            socketCount++;
+            return socket;
+          },
+          clientFactory:
+              (
+                socket, {
+                required username,
+                onVerifyHostKey,
+                onPasswordRequest,
+                identities,
+                keepAliveInterval,
+              }) {
+                clientFactoryCalls++;
+                when(() => client.authenticated).thenAnswer((_) async {
+                  final bytes = await (socket as HostKeySource).hostKeyBytes;
+                  final trusted = await onVerifyHostKey!(
+                    'ssh-ed25519',
+                    Uint8List.fromList(md5.convert(bytes).bytes),
+                  );
+                  if (!trusted) {
+                    return Future<void>.error(
+                      SSHHostkeyError('Hostkey verification failed'),
+                    );
+                  }
+                });
+                return client;
+              },
+        );
+
+        const config = SshConnectionConfig(
+          hostname: 'replace-reject.example.com',
+          port: 22,
+          username: 'tester',
+        );
+
+        final result = await service.connect(config);
+
+        expect(result.success, isFalse);
+        expect(result.error, contains('changed'));
+        expect(socketCount, 1);
+        expect(clientFactoryCalls, 1);
+        expect(promptCount, 1);
+        final storedHost = await knownHostsRepository.getByHost(
+          'replace-reject.example.com',
+          22,
+        );
+        expect(storedHost, isNotNull);
+        expect(storedHost!.hostKey, originalHostKey.encodedHostKey);
+      },
+    );
 
     test('connect fails if host key changes after trust prompt', () async {
       final db = AppDatabase.forTesting(NativeDatabase.memory());
@@ -1480,6 +1664,109 @@ void main() {
       );
     });
 
+    test('connect uses one connection per pretrusted jump-host hop', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final knownHostsRepository = KnownHostsRepository(db);
+      final jumpHostKeyBytes = _ed25519HostKeyBlob([1, 2, 3]);
+      final targetHostKeyBytes = _ed25519HostKeyBlob([4, 5, 6]);
+      final jumpHostKey = VerifiedHostKey(
+        hostname: 'jump-trusted.example.com',
+        port: 2222,
+        keyType: 'ssh-ed25519',
+        hostKeyBytes: jumpHostKeyBytes,
+      );
+      final targetHostKey = VerifiedHostKey(
+        hostname: 'target-trusted.example.com',
+        port: 22,
+        keyType: 'ssh-ed25519',
+        hostKeyBytes: targetHostKeyBytes,
+      );
+      for (final hostKey in [jumpHostKey, targetHostKey]) {
+        await knownHostsRepository.upsertTrustedHost(
+          hostname: hostKey.hostname,
+          port: hostKey.port,
+          keyType: hostKey.trustedKeyType,
+          fingerprint: hostKey.fingerprint,
+          encodedHostKey: hostKey.encodedHostKey,
+          resetFirstSeen: true,
+        );
+      }
+
+      final jumpSocket = _FakeHostKeySocket(jumpHostKeyBytes);
+      final targetSocket = _FakeForwardHostKeySocket(targetHostKeyBytes);
+      final jumpClient = _MockSshClient();
+      final targetClient = _MockSshClient();
+      var socketConnectCount = 0;
+      var forwardCount = 0;
+      var clientIndex = 0;
+      var promptCount = 0;
+
+      when(
+        () => jumpClient.forwardLocal('target-trusted.example.com', 22),
+      ).thenAnswer((_) async {
+        forwardCount++;
+        return targetSocket;
+      });
+      when(jumpClient.close).thenReturn(null);
+      when(targetClient.close).thenReturn(null);
+
+      final service = SshService(
+        knownHostsRepository: knownHostsRepository,
+        hostKeyPromptHandler: (_) async {
+          promptCount++;
+          return HostKeyTrustDecision.reject;
+        },
+        socketConnector: (host, port, {timeout}) async {
+          expect(host, 'jump-trusted.example.com');
+          expect(port, 2222);
+          socketConnectCount++;
+          return jumpSocket;
+        },
+        clientFactory:
+            (
+              socket, {
+              required username,
+              onVerifyHostKey,
+              onPasswordRequest,
+              identities,
+              keepAliveInterval,
+            }) {
+              final client = clientIndex == 0 ? jumpClient : targetClient;
+              final hostKeyBytes = (socket as HostKeySource).hostKeyBytes;
+              clientIndex++;
+              when(() => client.authenticated).thenAnswer((_) async {
+                final bytes = await hostKeyBytes;
+                final trusted = await onVerifyHostKey!(
+                  'ssh-ed25519',
+                  Uint8List.fromList(md5.convert(bytes).bytes),
+                );
+                expect(trusted, isTrue);
+              });
+              return client;
+            },
+      );
+
+      const config = SshConnectionConfig(
+        hostname: 'target-trusted.example.com',
+        port: 22,
+        username: 'target',
+        jumpHost: SshConnectionConfig(
+          hostname: 'jump-trusted.example.com',
+          port: 2222,
+          username: 'jump',
+        ),
+      );
+
+      final result = await service.connect(config);
+
+      expect(result.success, isTrue);
+      expect(socketConnectCount, 1);
+      expect(forwardCount, 1);
+      expect(clientIndex, 2);
+      expect(promptCount, 0);
+    });
+
     test(
       'connect persists accepted TOFU trust before authentication succeeds',
       () async {
@@ -1555,15 +1842,24 @@ void main() {
           resetFirstSeen: true,
         );
 
-        final socket = _FakeHostKeySocket(_ed25519HostKeyBlob([7, 8, 9]));
-        final client = _MockSshClient();
+        final changedHostKeyBytes = _ed25519HostKeyBlob([7, 8, 9]);
+        final sockets = [
+          _FakeHostKeySocket(changedHostKeyBytes),
+          _FakeHostKeySocket(changedHostKeyBytes),
+        ];
+        final firstClient = _MockSshClient();
+        final retryClient = _MockSshClient();
+        var socketIndex = 0;
+        var clientIndex = 0;
 
-        when(client.close).thenReturn(null);
+        when(firstClient.close).thenReturn(null);
+        when(retryClient.close).thenReturn(null);
 
         final service = SshService(
           knownHostsRepository: knownHostsRepository,
           hostKeyPromptHandler: (_) async => HostKeyTrustDecision.replace,
-          socketConnector: (host, port, {timeout}) async => socket,
+          socketConnector: (host, port, {timeout}) async =>
+              sockets[socketIndex++],
           clientFactory:
               (
                 socket, {
@@ -1573,15 +1869,25 @@ void main() {
                 identities,
                 keepAliveInterval,
               }) {
+                final client = clientIndex == 0 ? firstClient : retryClient;
+                final shouldFailAuth = clientIndex == 1;
+                clientIndex++;
                 when(() => client.authenticated).thenAnswer((_) async {
                   final bytes = await (socket as HostKeySource).hostKeyBytes;
-                  await onVerifyHostKey!(
+                  final trusted = await onVerifyHostKey!(
                     'ssh-ed25519',
                     Uint8List.fromList(md5.convert(bytes).bytes),
                   );
-                  return Future<void>.error(
-                    SSHAuthFailError('Authentication failed'),
-                  );
+                  if (!trusted) {
+                    return Future<void>.error(
+                      SSHHostkeyError('Hostkey verification failed'),
+                    );
+                  }
+                  if (shouldFailAuth) {
+                    return Future<void>.error(
+                      SSHAuthFailError('Authentication failed'),
+                    );
+                  }
                 });
                 return client;
               },
@@ -1596,6 +1902,8 @@ void main() {
         final result = await service.connect(config);
 
         expect(result.success, isFalse);
+        expect(socketIndex, 2);
+        expect(clientIndex, 2);
         final storedHost = await knownHostsRepository.getByHost(
           'replace.example.com',
           22,

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -92,8 +92,8 @@ class _FakeHostKeySocket implements SSHSocket, HostKeySource {
 
   @override
   Future<void> close() async {
-    await _streamController.close();
-    await _sinkController.close();
+    unawaited(_streamController.close());
+    unawaited(_sinkController.close());
   }
 
   @override
@@ -121,8 +121,8 @@ class _FakeForwardHostKeySocket implements SSHForwardChannel, HostKeySource {
 
   @override
   Future<void> close() async {
-    await _streamController.close();
-    await _sinkController.close();
+    unawaited(_streamController.close());
+    unawaited(_sinkController.close());
   }
 
   @override
@@ -1156,6 +1156,243 @@ void main() {
 
       expect(result.success, isFalse);
       expect(result.error, isNotNull);
+    });
+
+    test(
+      'connect prompts for unknown host before auth client creation',
+      () async {
+        final db = AppDatabase.forTesting(NativeDatabase.memory());
+        addTearDown(db.close);
+        final knownHostsRepository = KnownHostsRepository(db);
+        final hostKeyBytes = _ed25519HostKeyBlob([1, 2, 3]);
+        final sockets = [
+          _FakeHostKeySocket(hostKeyBytes),
+          _FakeHostKeySocket(hostKeyBytes),
+        ];
+        final client = _MockSshClient();
+        var socketIndex = 0;
+        var promptCount = 0;
+        var clientFactoryCalls = 0;
+
+        when(client.close).thenReturn(null);
+
+        final service = SshService(
+          knownHostsRepository: knownHostsRepository,
+          hostKeyPromptHandler: (request) async {
+            promptCount++;
+            expect(request.isReplacement, isFalse);
+            expect(clientFactoryCalls, 0);
+            return HostKeyTrustDecision.trust;
+          },
+          socketConnector: (host, port, {timeout}) async {
+            expect(host, 'new.example.com');
+            expect(port, 22);
+            return sockets[socketIndex++];
+          },
+          clientFactory:
+              (
+                socket, {
+                required username,
+                onVerifyHostKey,
+                onPasswordRequest,
+                identities,
+                keepAliveInterval,
+              }) {
+                clientFactoryCalls++;
+                when(() => client.authenticated).thenAnswer((_) async {
+                  final bytes = await (socket as HostKeySource).hostKeyBytes;
+                  final trusted = await onVerifyHostKey!(
+                    'ssh-ed25519',
+                    Uint8List.fromList(md5.convert(bytes).bytes),
+                  );
+                  expect(trusted, isTrue);
+                });
+                return client;
+              },
+        );
+
+        const config = SshConnectionConfig(
+          hostname: 'new.example.com',
+          port: 22,
+          username: 'tester',
+        );
+
+        final result = await service.connect(config);
+
+        expect(result.success, isTrue);
+        expect(socketIndex, 2);
+        expect(promptCount, 1);
+        expect(clientFactoryCalls, 1);
+        expect(
+          await knownHostsRepository.getByHost('new.example.com', 22),
+          isNotNull,
+        );
+      },
+    );
+
+    test('connect rejects unknown host without starting auth', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final knownHostsRepository = KnownHostsRepository(db);
+      final socket = _FakeHostKeySocket(_ed25519HostKeyBlob([1, 2, 3]));
+      var clientFactoryCalls = 0;
+
+      final service = SshService(
+        knownHostsRepository: knownHostsRepository,
+        hostKeyPromptHandler: (_) async => HostKeyTrustDecision.reject,
+        socketConnector: (host, port, {timeout}) async => socket,
+        clientFactory:
+            (
+              socket, {
+              required username,
+              onVerifyHostKey,
+              onPasswordRequest,
+              identities,
+              keepAliveInterval,
+            }) {
+              clientFactoryCalls++;
+              return _MockSshClient();
+            },
+      );
+
+      const config = SshConnectionConfig(
+        hostname: 'reject.example.com',
+        port: 22,
+        username: 'tester',
+      );
+
+      final result = await service.connect(config);
+
+      expect(result.success, isFalse);
+      expect(result.error, contains('not trusted yet'));
+      expect(clientFactoryCalls, 0);
+      expect(
+        await knownHostsRepository.getByHost('reject.example.com', 22),
+        isNull,
+      );
+    });
+
+    test('connect accepts pretrusted host without prompting', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final knownHostsRepository = KnownHostsRepository(db);
+      final hostKeyBytes = _ed25519HostKeyBlob([4, 5, 6]);
+      final trustedHostKey = VerifiedHostKey(
+        hostname: 'trusted.example.com',
+        port: 22,
+        keyType: 'ssh-ed25519',
+        hostKeyBytes: hostKeyBytes,
+      );
+      await knownHostsRepository.upsertTrustedHost(
+        hostname: trustedHostKey.hostname,
+        port: trustedHostKey.port,
+        keyType: trustedHostKey.trustedKeyType,
+        fingerprint: trustedHostKey.fingerprint,
+        encodedHostKey: trustedHostKey.encodedHostKey,
+        resetFirstSeen: true,
+      );
+      final sockets = [
+        _FakeHostKeySocket(hostKeyBytes),
+        _FakeHostKeySocket(hostKeyBytes),
+      ];
+      final client = _MockSshClient();
+      var socketIndex = 0;
+      var promptCount = 0;
+
+      when(client.close).thenReturn(null);
+
+      final service = SshService(
+        knownHostsRepository: knownHostsRepository,
+        hostKeyPromptHandler: (_) async {
+          promptCount++;
+          return HostKeyTrustDecision.reject;
+        },
+        socketConnector: (host, port, {timeout}) async =>
+            sockets[socketIndex++],
+        clientFactory:
+            (
+              socket, {
+              required username,
+              onVerifyHostKey,
+              onPasswordRequest,
+              identities,
+              keepAliveInterval,
+            }) {
+              when(() => client.authenticated).thenAnswer((_) async {
+                final bytes = await (socket as HostKeySource).hostKeyBytes;
+                final trusted = await onVerifyHostKey!(
+                  'ssh-ed25519',
+                  Uint8List.fromList(md5.convert(bytes).bytes),
+                );
+                expect(trusted, isTrue);
+              });
+              return client;
+            },
+      );
+
+      const config = SshConnectionConfig(
+        hostname: 'trusted.example.com',
+        port: 22,
+        username: 'tester',
+      );
+
+      final result = await service.connect(config);
+
+      expect(result.success, isTrue);
+      expect(socketIndex, 2);
+      expect(promptCount, 0);
+    });
+
+    test('connect fails if host key changes after trust prompt', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final knownHostsRepository = KnownHostsRepository(db);
+      final probeHostKeyBytes = _ed25519HostKeyBlob([1, 2, 3]);
+      final changedHostKeyBytes = _ed25519HostKeyBlob([7, 8, 9]);
+      final sockets = [
+        _FakeHostKeySocket(probeHostKeyBytes),
+        _FakeHostKeySocket(changedHostKeyBytes),
+      ];
+      final client = _MockSshClient();
+      var socketIndex = 0;
+
+      when(client.close).thenReturn(null);
+
+      final service = SshService(
+        knownHostsRepository: knownHostsRepository,
+        hostKeyPromptHandler: (_) async => HostKeyTrustDecision.trust,
+        socketConnector: (host, port, {timeout}) async =>
+            sockets[socketIndex++],
+        clientFactory:
+            (
+              socket, {
+              required username,
+              onVerifyHostKey,
+              onPasswordRequest,
+              identities,
+              keepAliveInterval,
+            }) {
+              when(() => client.authenticated).thenAnswer((_) async {
+                final bytes = await (socket as HostKeySource).hostKeyBytes;
+                await onVerifyHostKey!(
+                  'ssh-ed25519',
+                  Uint8List.fromList(md5.convert(bytes).bytes),
+                );
+              });
+              return client;
+            },
+      );
+
+      const config = SshConnectionConfig(
+        hostname: 'race.example.com',
+        port: 22,
+        username: 'tester',
+      );
+
+      final result = await service.connect(config);
+
+      expect(result.success, isFalse);
+      expect(result.error, contains('changed between verification'));
     });
 
     test('connect verifies jump-host and destination host keys', () async {


### PR DESCRIPTION
## Summary

- Probe SSH host keys on a disposable transport before showing TOFU or changed-key trust prompts.
- Start a fresh authenticated SSH connection pinned to the probed key so dartssh2 KEX is not blocked by modal UI.
- Add regression coverage for accept, reject, changed/replacement, pretrusted, and post-prompt transport-change flows.

## Validation

- `dart format lib/domain/services/ssh_service.dart test/domain/services/host_key_verification_test.dart test/domain/services/ssh_service_test.dart`
- `flutter analyze --no-pub`
- `flutter test --no-pub --reporter expanded test/domain/services/host_key_verification_test.dart test/domain/services/ssh_service_test.dart --name host`
- `flutter test --no-pub --reporter expanded`
