### PR TITLE
fix: complete tmux exec commands on markers

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -40,6 +40,8 @@ class TmuxService {
   static final Map<_TmuxWindowWatchKey, _TmuxWindowChangeObserver>
   _windowObservers = {};
 
+  static const _execDoneMarker = '__flutty_tmux_exec_done__';
+
   /// Clears the cached tmux path for a connection.
   void clearCache(int connectionId) {
     _tmuxPathCache.remove(connectionId);
@@ -107,16 +109,12 @@ class TmuxService {
   ) async {
     final cached = _installedAgentToolsCache[session.connectionId];
     if (cached != null) return cached;
-    try {
-      final output = await _exec(session, buildAgentToolDetectionCommand());
-      final installed = parseInstalledAgentTools(output);
-      if (installed.isNotEmpty) {
-        _installedAgentToolsCache[session.connectionId] = installed;
-      }
-      return installed;
-    } on Object {
-      return const <AgentLaunchTool>{};
+    final output = await _exec(session, buildAgentToolDetectionCommand());
+    final installed = parseInstalledAgentTools(output);
+    if (installed.isNotEmpty) {
+      _installedAgentToolsCache[session.connectionId] = installed;
     }
+    return installed;
   }
 
   /// Lists all tmux sessions on the remote host.
@@ -370,13 +368,7 @@ class TmuxService {
     return command.replaceFirst('tmux ', 'tmux -u ');
   }
 
-  /// Runs a command via SSH exec channel and returns stdout as a string.
-  ///
-  /// Uses the cached tmux binary path when available; otherwise sources
-  /// the user's login shell profile to resolve the PATH.
-  ///
-  /// Drains both stdout and stderr to prevent SSH channel flow-control
-  /// deadlocks, and awaits channel completion.
+  /// Opens an SSH exec channel with a bounded wait for channel creation.
   Future<SSHSession> _openExec(
     SshSession session,
     String command, {
@@ -395,18 +387,48 @@ class TmuxService {
     );
   }
 
+  /// Runs a command via SSH exec channel and returns stdout as a string.
+  ///
+  /// Uses the cached tmux binary path when available; otherwise sources
+  /// the user's login shell profile to resolve the PATH.
+  ///
+  /// Appends a marker to the remote command and reads stdout only until that
+  /// marker arrives. Some SSH servers leave exec streams open after the
+  /// command exits, so waiting for stream completion can turn successful tmux
+  /// actions into apparent hangs.
   Future<String> _exec(SshSession session, String command) async {
     final wrappedCommand = _wrapCommand(session, command);
-    final execSession = await _openExec(session, wrappedCommand);
+    final execSession = await _openExec(
+      session,
+      _markCommandDone(wrappedCommand),
+    );
     try {
-      final results = await Future.wait([
-        execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
-        execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
-      ]).timeout(_execOutputTimeout, onTimeout: () => ['', '']);
-      return results[0];
+      execSession.stderr.drain<void>().ignore();
+      return await _readStdoutUntilDoneMarker(execSession);
     } finally {
       execSession.close();
     }
+  }
+
+  String _markCommandDone(String command) =>
+      '$command; printf ${_shellQuote('\n$_execDoneMarker\n')}';
+
+  Future<String> _readStdoutUntilDoneMarker(SSHSession execSession) async {
+    final output = StringBuffer();
+    await for (final chunk
+        in execSession.stdout
+            .cast<List<int>>()
+            .transform(utf8.decoder)
+            .timeout(_execOutputTimeout)) {
+      output.write(chunk);
+      final markerIndex = output.toString().indexOf(_execDoneMarker);
+      if (markerIndex != -1) {
+        return output.toString().substring(0, markerIndex).trimRight();
+      }
+    }
+    throw TimeoutException(
+      'SSH exec channel closed before tmux command completed',
+    );
   }
 
   /// Fire-and-forget: sends a tmux command without waiting for output.
@@ -434,7 +456,7 @@ class TmuxService {
       // Detect login shell and resolve tmux path in a single exec.
       // Redirect stdout from profile scripts to /dev/null so greetings,
       // MOTD, or fortune output don't corrupt our parsed output.
-      final execSession = await _openExec(
+      final output = await _exec(
         session,
         r'SHELL_NAME=$(basename "$SHELL" 2>/dev/null || echo sh); '
         r'case "$SHELL_NAME" in '
@@ -445,28 +467,20 @@ class TmuxService {
         r'echo "$SHELL_NAME"; '
         'command -v tmux',
       );
-      try {
-        final results = await Future.wait([
-          execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
-          execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
-        ]).timeout(_execOutputTimeout, onTimeout: () => ['', '']);
-        final lines = results[0].trim().split('\n');
-        if (lines.isNotEmpty) {
-          final shellName = lines[0].trim();
-          _profileSourceCache[session.connectionId] = switch (shellName) {
-            'zsh' => '{ . ~/.zprofile; } >/dev/null 2>&1; ',
-            'bash' => '{ . ~/.bash_profile; . ~/.profile; } >/dev/null 2>&1; ',
-            _ => '{ . ~/.profile; } >/dev/null 2>&1; ',
-          };
+      final lines = output.trim().split('\n');
+      if (lines.isNotEmpty) {
+        final shellName = lines[0].trim();
+        _profileSourceCache[session.connectionId] = switch (shellName) {
+          'zsh' => '{ . ~/.zprofile; } >/dev/null 2>&1; ',
+          'bash' => '{ . ~/.bash_profile; . ~/.profile; } >/dev/null 2>&1; ',
+          _ => '{ . ~/.profile; } >/dev/null 2>&1; ',
+        };
+      }
+      if (lines.length > 1) {
+        final path = lines[1].trim();
+        if (path.isNotEmpty && path.startsWith('/')) {
+          _tmuxPathCache[session.connectionId] = path;
         }
-        if (lines.length > 1) {
-          final path = lines[1].trim();
-          if (path.isNotEmpty && path.startsWith('/')) {
-            _tmuxPathCache[session.connectionId] = path;
-          }
-        }
-      } finally {
-        execSession.close();
       }
     } on Object {
       // Ignore — we'll fall back to sourcing all profiles.

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -9,6 +9,18 @@ import '../models/agent_launch_preset.dart';
 import '../models/tmux_state.dart';
 import 'ssh_service.dart';
 
+/// Error thrown when a tmux command channel ends before confirming completion.
+class TmuxCommandException implements Exception {
+  /// Creates a [TmuxCommandException].
+  const TmuxCommandException(this.message);
+
+  /// Human-readable description of the command failure.
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
 /// Introspects and controls tmux sessions on remote hosts via SSH exec
 /// channels.
 ///
@@ -320,11 +332,12 @@ class TmuxService {
   }
 
   /// Closes a window in [sessionName] via exec channel.
-  ///
-  /// Uses fire-and-forget — if this was the last window, the tmux session
-  /// ends and the interactive shell exits naturally.
-  void killWindow(SshSession session, String sessionName, int windowIndex) {
-    _execFireAndForget(
+  Future<void> killWindow(
+    SshSession session,
+    String sessionName,
+    int windowIndex,
+  ) async {
+    await _exec(
       session,
       'tmux kill-window -t ${_shellQuote(sessionName)}:$windowIndex',
     );
@@ -421,12 +434,13 @@ class TmuxService {
             .transform(utf8.decoder)
             .timeout(_execOutputTimeout)) {
       output.write(chunk);
-      final markerIndex = output.toString().indexOf(_execDoneMarker);
+      final currentOutput = output.toString();
+      final markerIndex = currentOutput.indexOf(_execDoneMarker);
       if (markerIndex != -1) {
-        return output.toString().substring(0, markerIndex).trimRight();
+        return currentOutput.substring(0, markerIndex).trimRight();
       }
     }
-    throw TimeoutException(
+    throw const TmuxCommandException(
       'SSH exec channel closed before tmux command completed',
     );
   }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -4016,23 +4016,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final session = _sessionsNotifier?.getSession(connectionId);
     if (session == null) return;
 
-    switch (action) {
-      case TmuxSwitchWindowAction(:final windowIndex):
-        await _switchTmuxWindow(session, windowIndex);
-      case TmuxNewWindowAction(:final command, :final windowName):
-        await _createTmuxWindow(session, command: command, name: windowName);
-      case TmuxResumeSessionAction(
-        :final resumeCommand,
-        :final workingDirectory,
-      ):
-        await _createTmuxWindow(
-          session,
-          command: resumeCommand,
-          workingDirectory: workingDirectory,
-        );
-      case TmuxCloseWindowAction(:final windowIndex):
-        _closeTmuxWindow(session, windowIndex);
-    }
+    await _performTmuxNavigatorAction(session, action);
   }
 
   /// Opens the tmux window navigator bottom sheet and handles the
@@ -4067,23 +4051,46 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     if (!mounted || action == null) return;
 
-    switch (action) {
-      case TmuxSwitchWindowAction(:final windowIndex):
-        await _switchTmuxWindow(session, windowIndex);
-      case TmuxNewWindowAction(:final command, :final windowName):
-        await _createTmuxWindow(session, command: command, name: windowName);
-      case TmuxResumeSessionAction(
-        :final resumeCommand,
-        :final workingDirectory,
-      ):
-        await _createTmuxWindow(
-          session,
-          command: resumeCommand,
-          workingDirectory: workingDirectory,
-        );
-      case TmuxCloseWindowAction(:final windowIndex):
-        _closeTmuxWindow(session, windowIndex);
+    await _performTmuxNavigatorAction(session, action);
+  }
+
+  Future<void> _performTmuxNavigatorAction(
+    SshSession session,
+    TmuxNavigatorAction action,
+  ) async {
+    try {
+      switch (action) {
+        case TmuxSwitchWindowAction(:final windowIndex):
+          await _switchTmuxWindow(session, windowIndex);
+        case TmuxNewWindowAction(:final command, :final windowName):
+          await _createTmuxWindow(session, command: command, name: windowName);
+        case TmuxResumeSessionAction(
+          :final resumeCommand,
+          :final workingDirectory,
+        ):
+          await _createTmuxWindow(
+            session,
+            command: resumeCommand,
+            workingDirectory: workingDirectory,
+          );
+        case TmuxCloseWindowAction(:final windowIndex):
+          _closeTmuxWindow(session, windowIndex);
+      }
+    } on Exception catch (error) {
+      _showTmuxActionFailure(error);
     }
+  }
+
+  void _showTmuxActionFailure(Exception error) {
+    if (!mounted) return;
+    final message = switch (error) {
+      TimeoutException() =>
+        'Timed out waiting for tmux. Reconnect if actions keep failing.',
+      _ => 'tmux action failed: $error',
+    };
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
   }
 
   /// Switches to a different tmux window via exec channel.

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -4074,7 +4074,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             workingDirectory: workingDirectory,
           );
         case TmuxCloseWindowAction(:final windowIndex):
-          _closeTmuxWindow(session, windowIndex);
+          await _closeTmuxWindow(session, windowIndex);
       }
     } on Exception catch (error) {
       _showTmuxActionFailure(error);
@@ -4156,11 +4156,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   /// Closes a tmux window via exec channel.
-  void _closeTmuxWindow(SshSession session, int windowIndex) {
+  Future<void> _closeTmuxWindow(SshSession session, int windowIndex) async {
     final sessionName = _tmuxSessionName;
     if (sessionName == null) return;
 
-    ref.read(tmuxServiceProvider).killWindow(session, sessionName, windowIndex);
+    await ref
+        .read(tmuxServiceProvider)
+        .killWindow(session, sessionName, windowIndex);
   }
 
   Future<void> _reattachTmuxIfNeeded(

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -325,6 +325,58 @@ void main() {
       },
     );
 
+    test(
+      'killWindow waits for the done marker so failures can surface',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client);
+        const service = TmuxService();
+        final execSession = _buildOpenExecSession(stdout: '$_execDoneMarker\n');
+
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => execSession);
+
+        await service.killWindow(session, 'main', 2);
+
+        verify(
+          () => client.execute(
+            any(
+              that: contains(
+                'tmux -u kill-window -t '
+                "'main':2",
+              ),
+            ),
+            pty: any(named: 'pty'),
+          ),
+        ).called(1);
+        verify(execSession.close).called(1);
+      },
+    );
+
+    test('killWindow propagates missing marker failures', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client);
+      const service = TmuxService();
+      final execSession = _buildClosedExecSession(stdout: 'tmux failed\n');
+
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) async => execSession);
+
+      await expectLater(
+        service.killWindow(session, 'main', 2),
+        throwsA(
+          isA<TmuxCommandException>().having(
+            (error) => error.message,
+            'message',
+            contains('closed before tmux command completed'),
+          ),
+        ),
+      );
+      verify(execSession.close).called(1);
+    });
+
     test('detectInstalledAgentTools propagates output timeouts', () async {
       final client = _MockSshClient();
       final session = _buildSession(client);
@@ -341,6 +393,26 @@ void main() {
       );
       verify(execSession.close).called(1);
     });
+
+    test(
+      'detectInstalledAgentTools reports EOF before marker separately',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client);
+        const service = TmuxService();
+        final execSession = _buildClosedExecSession(stdout: 'partial output\n');
+
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => execSession);
+
+        await expectLater(
+          service.detectInstalledAgentTools(session),
+          throwsA(isA<TmuxCommandException>()),
+        );
+        verify(execSession.close).called(1);
+      },
+    );
 
     test(
       'detectInstalledAgentTools parses output before an open stdout hangs',
@@ -455,12 +527,25 @@ Stream<Uint8List> _openUtf8Stream(String value) =>
       }
     });
 
+Stream<Uint8List> _closedUtf8Stream(String value) =>
+    Stream<Uint8List>.fromIterable(
+      value.isEmpty ? const [] : [Uint8List.fromList(utf8.encode(value))],
+    );
+
 void _ignoreInvocation(Invocation _) {}
 
 SSHSession _buildOpenExecSession({String stdout = '', String stderr = ''}) {
   final session = _MockExecSession();
   when(() => session.stdout).thenAnswer((_) => _openUtf8Stream(stdout));
   when(() => session.stderr).thenAnswer((_) => _openUtf8Stream(stderr));
+  when(session.close).thenAnswer(_ignoreInvocation);
+  return session;
+}
+
+SSHSession _buildClosedExecSession({String stdout = '', String stderr = ''}) {
+  final session = _MockExecSession();
+  when(() => session.stdout).thenAnswer((_) => _closedUtf8Stream(stdout));
+  when(() => session.stderr).thenAnswer((_) => _closedUtf8Stream(stderr));
   when(session.close).thenAnswer(_ignoreInvocation);
   return session;
 }

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:dartssh2/dartssh2.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
 import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/domain/services/tmux_service.dart';
@@ -267,6 +270,98 @@ void main() {
         expect(windows, isEmpty);
       },
     );
+
+    test(
+      'listWindows completes when stdout stays open after the done marker',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client);
+        const service = TmuxService();
+        final execSession = _buildOpenExecSession(
+          stdout:
+              '1|editor|1|vim|/tmp|*|vim-title|1712930000\n'
+              '$_execDoneMarker\n',
+        );
+
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => execSession);
+
+        final windows = await service.listWindows(session, 'main');
+
+        expect(windows, hasLength(1));
+        expect(windows.single.index, 1);
+        expect(windows.single.name, 'editor');
+        verify(execSession.close).called(1);
+      },
+    );
+
+    test(
+      'selectWindow completes when stdout stays open after the done marker',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client);
+        const service = TmuxService();
+        final execSession = _buildOpenExecSession(stdout: '$_execDoneMarker\n');
+
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => execSession);
+
+        await service.selectWindow(session, 'main', 2);
+
+        verify(
+          () => client.execute(
+            any(
+              that: contains(
+                'tmux -u select-window -t '
+                "'main':2",
+              ),
+            ),
+            pty: any(named: 'pty'),
+          ),
+        ).called(1);
+        verify(execSession.close).called(1);
+      },
+    );
+
+    test('detectInstalledAgentTools propagates output timeouts', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client);
+      const service = TmuxService(execOutputTimeout: Duration(milliseconds: 1));
+      final execSession = _buildOpenExecSession();
+
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) async => execSession);
+
+      await expectLater(
+        service.detectInstalledAgentTools(session),
+        throwsA(isA<TimeoutException>()),
+      );
+      verify(execSession.close).called(1);
+    });
+
+    test(
+      'detectInstalledAgentTools parses output before an open stdout hangs',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client);
+        const service = TmuxService();
+        final execSession = _buildOpenExecSession(
+          stdout: '/opt/homebrew/bin/claude\n$_execDoneMarker\n',
+        );
+
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => execSession);
+
+        final tools = await service.detectInstalledAgentTools(session);
+
+        expect(tools, {AgentLaunchTool.claudeCode});
+        verify(execSession.close).called(1);
+      },
+    );
   });
 
   group('decideTmuxHeartbeatAction', () {
@@ -346,3 +441,26 @@ SshSession _buildSession(SSHClient client) => SshSession(
 );
 
 class _MockSshClient extends Mock implements SSHClient {}
+
+class _MockExecSession extends Mock implements SSHSession {}
+
+const _execDoneMarker = '__flutty_tmux_exec_done__';
+
+Stream<Uint8List> _openUtf8Stream(String value) =>
+    Stream<Uint8List>.multi((controller) {
+      if (value.isNotEmpty) {
+        scheduleMicrotask(
+          () => controller.add(Uint8List.fromList(utf8.encode(value))),
+        );
+      }
+    });
+
+void _ignoreInvocation(Invocation _) {}
+
+SSHSession _buildOpenExecSession({String stdout = '', String stderr = ''}) {
+  final session = _MockExecSession();
+  when(() => session.stdout).thenAnswer((_) => _openUtf8Stream(stdout));
+  when(() => session.stderr).thenAnswer((_) => _openUtf8Stream(stderr));
+  when(session.close).thenAnswer(_ignoreInvocation);
+  return session;
+}

--- a/test/widget/tmux_tool_picker_sheet_test.dart
+++ b/test/widget/tmux_tool_picker_sheet_test.dart
@@ -103,6 +103,27 @@ void main() {
       },
     );
 
+    testWidgets('falls back to all tools when detection fails', (tester) async {
+      final completer = Completer<Set<AgentLaunchTool>>();
+      await tester.pumpWidget(
+        _wrap(
+          TmuxToolPickerSheet(
+            isProUser: true,
+            installedToolsFuture: completer.future,
+            onToolSelected: (_) {},
+            onEmptyWindow: () {},
+          ),
+        ),
+      );
+      completer.completeError(StateError('detection failed'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No supported CLIs found on PATH.'), findsNothing);
+      for (final tool in AgentLaunchTool.values) {
+        expect(find.text(tool.label), findsOneWidget);
+      }
+    });
+
     testWidgets('invokes callback when a detected tool is tapped', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- complete tmux exec calls once a remote completion marker is observed instead of waiting for SSH stdout/stderr to close
- propagate CLI detection failures so the new-window picker falls back to all supported tools instead of reporting an empty PATH
- surface tmux action failures with a snackbar instead of dropping async errors

## Tests

- `flutter analyze`
- `flutter test`
