### PR TITLE
Use monkey notification icon on Android

### DIFF
--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/SshConnectionService.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/SshConnectionService.kt
@@ -215,7 +215,7 @@ class SshConnectionService : Service() {
         val notification = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(title)
             .setContentText(summary)
-            .setSmallIcon(android.R.drawable.ic_lock_lock)
+            .setSmallIcon(R.drawable.ic_notification_monkey)
             .setOngoing(true)
             .setAutoCancel(false)
             .setOnlyAlertOnce(true)

--- a/android/app/src/main/res/drawable/ic_notification_monkey.xml
+++ b/android/app/src/main/res/drawable/ic_notification_monkey.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="1024"
+    android:viewportHeight="1024">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M230,291C166.5,291 115,342.5 115,406C115,469.5 166.5,521 230,521C293.5,521 345,469.5 345,406C345,342.5 293.5,291 230,291Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M794,291C730.5,291 679,342.5 679,406C679,469.5 730.5,521 794,521C857.5,521 909,469.5 909,406C909,342.5 857.5,291 794,291Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M512,256C677.7,256 812,385.8 812,546C812,706.2 677.7,836 512,836C346.3,836 212,706.2 212,546C212,385.8 346.3,256 512,256Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M458,294C435,255 438,210 465,193C492,221 492,267 474,304Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M510,286C486,243 493,195 523,178C552,211 552,261 532,297Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M565,289C536,250 548,202 579,184C604,220 598,269 579,302Z" />
+</vector>

--- a/lib/domain/services/local_notification_service.dart
+++ b/lib/domain/services/local_notification_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Local notification channel used for tmux activity alerts.
 const tmuxAlertNotificationChannelId = 'tmux-alerts';
+const _androidNotificationIcon = 'ic_notification_monkey';
 
 /// Service for showing local notifications inside the app.
 class LocalNotificationService {
@@ -40,6 +41,7 @@ class LocalNotificationService {
       channelDescription: 'Window activity alerts for tmux sessions.',
       importance: Importance.high,
       priority: Priority.high,
+      icon: _androidNotificationIcon,
       onlyAlertOnce: true,
     );
     const darwinDetails = DarwinNotificationDetails(
@@ -81,7 +83,7 @@ class LocalNotificationService {
 
     try {
       const initializationSettings = InitializationSettings(
-        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+        android: AndroidInitializationSettings(_androidNotificationIcon),
         iOS: DarwinInitializationSettings(),
         macOS: DarwinInitializationSettings(),
       );


### PR DESCRIPTION
## Summary

- Add a dedicated Android notification small-icon vector using the monkey head silhouette.
- Use that drawable for the native foreground SSH notification and Flutter local tmux alert notifications.
- Stop using the launcher icon as the Android local-notification default icon.

## Validation

- `flutter analyze`
- `flutter test`
- `JAVA_HOME="$(/usr/libexec/java_home -v 17)" flutter build apk --debug --flavor production`
