### PR TITLE
fix: recover tmux panel after stale window loads

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -53,6 +53,9 @@ class TmuxService {
   _windowObservers = {};
 
   static const _execDoneMarker = '__flutty_tmux_exec_done__';
+  static final RegExp _execDoneMarkerLinePattern = RegExp(
+    '(?:^|\\n)${RegExp.escape(_execDoneMarker)}:([0-9]+)\\n',
+  );
 
   /// Clears the cached tmux path for a connection.
   void clearCache(int connectionId) {
@@ -433,24 +436,21 @@ class TmuxService {
             .timeout(_execOutputTimeout)) {
       output.write(chunk);
       final currentOutput = output.toString();
-      final markerIndex = currentOutput.indexOf(_execDoneMarker);
-      if (markerIndex != -1) {
-        final markerLineEnd = currentOutput.indexOf('\n', markerIndex);
-        if (markerLineEnd == -1) {
-          continue;
-        }
-        final markerLine = currentOutput.substring(markerIndex, markerLineEnd);
-        final statusText = markerLine
-            .substring(_execDoneMarker.length)
-            .replaceFirst(':', '')
-            .trim();
-        final exitStatus = int.tryParse(statusText);
+      RegExpMatch? markerMatch;
+      for (final match in _execDoneMarkerLinePattern.allMatches(
+        currentOutput,
+      )) {
+        markerMatch = match;
+      }
+      if (markerMatch != null) {
+        final statusText = markerMatch.group(1)!;
+        final exitStatus = int.parse(statusText);
         if (exitStatus != 0) {
           throw TmuxCommandException(
-            'tmux command failed with exit status ${statusText.isEmpty ? 'unknown' : statusText}',
+            'tmux command failed with exit status $statusText',
           );
         }
-        return currentOutput.substring(0, markerIndex).trimRight();
+        return currentOutput.substring(0, markerMatch.start).trimRight();
       }
     }
     throw const TmuxCommandException(

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -200,19 +200,15 @@ class TmuxService {
     SshSession session,
     String sessionName,
   ) async {
-    try {
-      final quotedName = _shellQuote(sessionName);
-      final output = await _exec(
-        session,
-        'tmux list-windows -t $quotedName -F '
-        "'#{window_index}|#{window_name}|#{window_active}|"
-        '#{pane_current_command}|#{pane_current_path}|'
-        "#{window_flags}|#{pane_title}|#{window_activity}'",
-      );
-      return _parseLines(output, TmuxWindow.fromTmuxFormat);
-    } on Exception {
-      return const [];
-    }
+    final quotedName = _shellQuote(sessionName);
+    final output = await _exec(
+      session,
+      'tmux list-windows -t $quotedName -F '
+      "'#{window_index}|#{window_name}|#{window_active}|"
+      '#{pane_current_command}|#{pane_current_path}|'
+      "#{window_flags}|#{pane_title}|#{window_activity}'",
+    );
+    return _parseLines(output, TmuxWindow.fromTmuxFormat);
   }
 
   /// Returns the active pane working directory for [sessionName], if tmux
@@ -424,7 +420,9 @@ class TmuxService {
   }
 
   String _markCommandDone(String command) =>
-      '$command; printf ${_shellQuote('\n$_execDoneMarker\n')}';
+      '{ $command; __flutty_tmux_exec_status__=\$?; '
+      'printf ${_shellQuote('\n$_execDoneMarker:%s\n')} '
+      r'"$__flutty_tmux_exec_status__"; }';
 
   Future<String> _readStdoutUntilDoneMarker(SSHSession execSession) async {
     final output = StringBuffer();
@@ -437,6 +435,21 @@ class TmuxService {
       final currentOutput = output.toString();
       final markerIndex = currentOutput.indexOf(_execDoneMarker);
       if (markerIndex != -1) {
+        final markerLineEnd = currentOutput.indexOf('\n', markerIndex);
+        if (markerLineEnd == -1) {
+          continue;
+        }
+        final markerLine = currentOutput.substring(markerIndex, markerLineEnd);
+        final statusText = markerLine
+            .substring(_execDoneMarker.length)
+            .replaceFirst(':', '')
+            .trim();
+        final exitStatus = int.tryParse(statusText);
+        if (exitStatus != 0) {
+          throw TmuxCommandException(
+            'tmux command failed with exit status ${statusText.isEmpty ? 'unknown' : statusText}',
+          );
+        }
         return currentOutput.substring(0, markerIndex).trimRight();
       }
     }

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -3075,9 +3075,11 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         .getSession(widget.connectionId);
     if (session == null || _sessionName == null) return;
 
-    ref
-        .read(tmuxServiceProvider)
-        .killWindow(session, _sessionName!, windowIndex);
+    _runTmuxPreviewAction(
+      ref
+          .read(tmuxServiceProvider)
+          .killWindow(session, _sessionName!, windowIndex),
+    );
 
     // Optimistically remove from the list.
     setState(() {
@@ -3091,11 +3093,27 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         .read(activeSessionsProvider.notifier)
         .getSession(widget.connectionId);
     if (session != null && _sessionName != null) {
-      ref
-          .read(tmuxServiceProvider)
-          .selectWindow(session, _sessionName!, windowIndex);
+      _runTmuxPreviewAction(
+        ref
+            .read(tmuxServiceProvider)
+            .selectWindow(session, _sessionName!, windowIndex),
+      );
     }
     widget.onTap();
+  }
+
+  void _runTmuxPreviewAction(Future<void> action) {
+    unawaited(
+      action.then<void>(
+        (_) {},
+        onError: (Object error, StackTrace _) {
+          if (!mounted) return;
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text('tmux action failed: $error')));
+        },
+      ),
+    );
   }
 
   void _resumeSession(ToolSessionInfo info) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3898,7 +3898,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   ///
   /// Starts with any structured tmux configuration immediately, then retries
   /// discovery until the shell-side attach command has settled.
-  Future<void> _detectTmux(SshSession session, {bool skipDelay = false}) async {
+  Future<void> _detectTmux(
+    SshSession session, {
+    bool skipDelay = false,
+    bool preserveExistingTmuxState = false,
+  }) async {
     // Capture the connection ID at the start so we can verify it hasn't
     // changed after async gaps (user may have switched connections).
     final capturedConnectionId = _connectionId;
@@ -3908,14 +3912,29 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       structuredSessionName: host?.tmuxSessionName,
       autoConnectCommand: _resolveStoredAutoConnectCommand(host),
     );
+    final existingSessionName = preserveExistingTmuxState
+        ? _tmuxSessionName
+        : null;
+    final candidateSessionName = preferredSessionName ?? existingSessionName;
     final preferredWorkingDirectory = host?.tmuxWorkingDirectory;
 
     if (mounted) {
       setState(() {
-        _isTmuxActive = preferredSessionName != null;
-        _tmuxSessionName = preferredSessionName;
-        _tmuxLaunchWorkingDirectory = preferredWorkingDirectory;
-        _tmuxWorkingDirectory = preferredWorkingDirectory;
+        if (candidateSessionName != null) {
+          _isTmuxActive = true;
+          _tmuxSessionName = candidateSessionName;
+          _tmuxLaunchWorkingDirectory =
+              preferredWorkingDirectory ??
+              (preserveExistingTmuxState ? _tmuxLaunchWorkingDirectory : null);
+          _tmuxWorkingDirectory =
+              preferredWorkingDirectory ??
+              (preserveExistingTmuxState ? _tmuxWorkingDirectory : null);
+        } else if (!preserveExistingTmuxState) {
+          _isTmuxActive = false;
+          _tmuxSessionName = null;
+          _tmuxLaunchWorkingDirectory = null;
+          _tmuxWorkingDirectory = null;
+        }
       });
     }
 
@@ -3935,8 +3954,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           }
         }
 
-        final active = preferredSessionName != null
-            ? await tmux.hasSession(session, preferredSessionName)
+        final active = candidateSessionName != null
+            ? await tmux.hasSession(session, candidateSessionName)
             : await tmux.isTmuxActive(session);
         if (!mounted ||
             _connectionId != capturedConnectionId ||
@@ -3947,7 +3966,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           continue;
         }
 
-        var sessionName = preferredSessionName;
+        var sessionName = candidateSessionName;
         sessionName ??= await tmux.currentSessionName(session);
         if (!mounted ||
             _connectionId != capturedConnectionId ||
@@ -4005,19 +4024,18 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         return;
       }
 
-      setState(() {
-        _isTmuxActive = false;
-        _tmuxSessionName = null;
-        _tmuxLaunchWorkingDirectory = null;
-        _tmuxWorkingDirectory = null;
-      });
+      if (!preserveExistingTmuxState) {
+        setState(_clearTmuxState);
+      }
     } on Object {
       if (!mounted ||
           _connectionId != capturedConnectionId ||
           detectionGeneration != _tmuxDetectionGeneration) {
         return;
       }
-      setState(_clearTmuxState);
+      if (!preserveExistingTmuxState) {
+        setState(_clearTmuxState);
+      }
     }
   }
 
@@ -4179,7 +4197,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
-    await _detectTmux(session);
+    await _detectTmux(session, preserveExistingTmuxState: true);
     if (!mounted ||
         _connectionId != session.connectionId ||
         !_isTmuxActive ||

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -426,6 +426,8 @@ class _TmuxExpandableBar extends StatefulWidget {
     required this.ref,
     required this.onAction,
     this.scopeWorkingDirectory,
+    this.onWindowLoadStalled,
+    super.key,
   });
 
   /// The active SSH session.
@@ -448,6 +450,9 @@ class _TmuxExpandableBar extends StatefulWidget {
 
   /// Callback for navigator actions.
   final Future<void> Function(TmuxNavigatorAction) onAction;
+
+  final Future<void> Function(SshSession session, String sessionName)?
+  onWindowLoadStalled;
 
   /// Best-known project working directory for AI session scoping.
   final String? scopeWorkingDirectory;
@@ -488,6 +493,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   Timer? _windowRetryTimer;
   int _windowRetryAttempts = 0;
   int _consecutiveEmptyWindowReloads = 0;
+  bool _windowReloadRecoveryRequested = false;
 
   TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
 
@@ -676,6 +682,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     _cancelWindowRetry();
     _windowRetryAttempts = 0;
     _consecutiveEmptyWindowReloads = 0;
+    _windowReloadRecoveryRequested = false;
   }
 
   void _scheduleWindowRetry() {
@@ -690,6 +697,20 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         unawaited(_loadWindows());
       }
     });
+  }
+
+  bool get _shouldRequestWindowReloadRecovery =>
+      !(_windows?.isNotEmpty ?? false) && _windowRetryAttempts >= 1;
+
+  void _requestWindowReloadRecovery() {
+    if (_windowReloadRecoveryRequested) {
+      return;
+    }
+    _windowReloadRecoveryRequested = true;
+    final onWindowLoadStalled = widget.onWindowLoadStalled;
+    if (onWindowLoadStalled != null) {
+      unawaited(onWindowLoadStalled(widget.session, widget.tmuxSessionName));
+    }
   }
 
   String? _resolveRecentSessionScopeWorkingDirectory([
@@ -749,8 +770,15 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         reloadedWindows,
       );
       if (windows == null) {
+        final shouldRecover = _shouldRequestWindowReloadRecovery;
         _scheduleWindowRetry();
-        if (_windows != null || !_isLoading) {
+        if (shouldRecover) {
+          setState(() {
+            _expanded = false;
+            _isLoading = false;
+          });
+          _requestWindowReloadRecovery();
+        } else if (_windows != null || !_isLoading) {
           setState(() {
             _windows = null;
             _isLoading = true;
@@ -769,11 +797,18 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       }
     } on Object {
       if (!mounted) return;
+      final shouldRecover = _shouldRequestWindowReloadRecovery;
       _scheduleWindowRetry();
       if (_windows?.isNotEmpty ?? false) {
         if (_isLoading) {
           setState(() => _isLoading = false);
         }
+      } else if (shouldRecover) {
+        setState(() {
+          _expanded = false;
+          _isLoading = false;
+        });
+        _requestWindowReloadRecovery();
       } else {
         setState(() => _isLoading = true);
       }
@@ -2698,6 +2733,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   String? _tmuxLaunchWorkingDirectory;
   String? _tmuxWorkingDirectory;
   int _tmuxDetectionGeneration = 0;
+  int _tmuxBarRecoveryGeneration = 0;
   final Map<String, _VerifiedTerminalPath> _verifiedTerminalPathCache =
       <String, _VerifiedTerminalPath>{};
   final ListQueue<String> _verifiedTerminalPathCacheOrder = ListQueue<String>();
@@ -3850,6 +3886,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     });
   }
 
+  void _clearTmuxState() {
+    _tmuxDetectionGeneration += 1;
+    _isTmuxActive = false;
+    _tmuxSessionName = null;
+    _tmuxLaunchWorkingDirectory = null;
+    _tmuxWorkingDirectory = null;
+  }
+
   /// Detects whether the connected session is inside tmux.
   ///
   /// Starts with any structured tmux configuration immediately, then retries
@@ -3914,11 +3958,25 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           continue;
         }
 
+        final List<TmuxWindow> windows;
+        try {
+          windows = await tmux.listWindows(session, sessionName);
+        } on Object {
+          continue;
+        }
+        if (!mounted ||
+            _connectionId != capturedConnectionId ||
+            detectionGeneration != _tmuxDetectionGeneration) {
+          return;
+        }
+        if (windows.isEmpty) {
+          continue;
+        }
+
         // Get the active window's working directory for SFTP/path resolution.
         var tmuxLaunchCwd = preferredWorkingDirectory;
         var tmuxCwd = preferredWorkingDirectory;
         try {
-          final windows = await tmux.listWindows(session, sessionName);
           final activeWindow = windows.where((w) => w.isActive).firstOrNull;
           tmuxLaunchCwd ??= activeWindow?.currentPath;
           tmuxCwd ??= activeWindow?.currentPath;
@@ -3954,7 +4012,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _tmuxWorkingDirectory = null;
       });
     } on Object {
-      // Silently ignore — tmux detection is best-effort.
+      if (!mounted ||
+          _connectionId != capturedConnectionId ||
+          detectionGeneration != _tmuxDetectionGeneration) {
+        return;
+      }
+      setState(_clearTmuxState);
     }
   }
 
@@ -4077,6 +4140,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
 
     return _TmuxExpandableBar(
+      key: ValueKey<Object>(
+        Object.hash(connectionId, _tmuxSessionName, _tmuxBarRecoveryGeneration),
+      ),
       session: session,
       tmuxSessionName: _tmuxSessionName!,
       availableHeight: availableHeight,
@@ -4084,6 +4150,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       startClisInYoloMode: _startClisInYoloMode,
       ref: ref,
       onAction: _handleTmuxAction,
+      onWindowLoadStalled: _recoverTmuxWindowPanel,
       scopeWorkingDirectory: resolveTmuxAiSessionScopeWorkingDirectory(
         liveTerminalWorkingDirectory: _liveWorkingDirectoryPath,
         tmuxWorkingDirectory: _tmuxWorkingDirectory,
@@ -4100,6 +4167,27 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (session == null) return;
 
     await _performTmuxNavigatorAction(session, action);
+  }
+
+  Future<void> _recoverTmuxWindowPanel(
+    SshSession session,
+    String sessionName,
+  ) async {
+    if (!mounted ||
+        _connectionId != session.connectionId ||
+        _tmuxSessionName != sessionName) {
+      return;
+    }
+
+    await _detectTmux(session);
+    if (!mounted ||
+        _connectionId != session.connectionId ||
+        !_isTmuxActive ||
+        _tmuxSessionName != sessionName) {
+      return;
+    }
+
+    setState(() => _tmuxBarRecoveryGeneration += 1);
   }
 
   /// Opens the tmux window navigator bottom sheet and handles the
@@ -4321,6 +4409,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     unawaited(SystemChannels.textInput.invokeMethod<void>('TextInput.hide'));
     _terminalFocusNode.unfocus();
     setState(() {
+      _clearTmuxState();
       _isConnecting = false;
       _error ??= 'Connection closed';
     });
@@ -4348,6 +4437,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _connectionLostWhileBackgrounded = true;
     } else {
       setState(() {
+        _clearTmuxState();
         _isConnecting = false;
         _error = 'Connection closed';
       });
@@ -4356,6 +4446,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
     // Clean up the session state regardless of background/foreground.
     if (connectionId != null) {
+      ref.read(tmuxServiceProvider).clearCache(connectionId);
       unawaited(
         _sessionsNotifier?.handleUnexpectedDisconnect(
           connectionId,
@@ -4386,10 +4477,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
     if (mounted) {
       setState(() {
+        _clearTmuxState();
         _isConnecting = true;
         _error = null;
       });
     } else {
+      _clearTmuxState();
       _isConnecting = true;
       _error = null;
     }
@@ -4402,6 +4495,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _doneSubscription = null;
       _shell = null;
       if (previousConnectionId != null) {
+        ref.read(tmuxServiceProvider).clearCache(previousConnectionId);
         await _sessionsNotifier?.disconnect(previousConnectionId);
       }
       if (!mounted) {

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -259,11 +259,15 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         reloadedWindows,
       );
       if (windows == null) {
+        final shouldShowRecoveryMessage =
+            _shouldStopShowingInitialWindowSpinner;
         _scheduleWindowRetry();
         setState(() {
           _windows = null;
-          _error = null;
-          _isLoadingWindows = true;
+          _error = shouldShowRecoveryMessage
+              ? 'tmux did not return any windows yet. Retrying...'
+              : null;
+          _isLoadingWindows = !shouldShowRecoveryMessage;
         });
         return;
       }
@@ -280,9 +284,14 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       unawaited(_prefetchPreferredSessionProvider(windows: windows));
     } on Exception catch (e) {
       if (!mounted) return;
+      final shouldShowRecoveryMessage = _shouldStopShowingInitialWindowSpinner;
       _scheduleWindowRetry();
       setState(() {
-        _error = _windows?.isEmpty ?? true ? e.toString() : null;
+        _error = _windows?.isEmpty ?? true
+            ? shouldShowRecoveryMessage
+                  ? 'Could not refresh tmux windows yet. Retrying...'
+                  : e.toString()
+            : null;
         _isLoadingWindows = false;
       });
     } finally {
@@ -339,6 +348,9 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       }
     });
   }
+
+  bool get _shouldStopShowingInitialWindowSpinner =>
+      !(_windows?.isNotEmpty ?? false) && _windowRetryAttempts >= 1;
 
   void _switchToWindow(int windowIndex) {
     Navigator.pop(context, TmuxSwitchWindowAction(windowIndex));

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -294,6 +294,28 @@ void main() {
       },
     );
 
+    test('listWindows ignores done-marker text inside tmux fields', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client);
+      const service = TmuxService();
+      final execSession = _buildOpenExecSession(
+        stdout:
+            '1|$_execDoneMarker|1|vim|/tmp|*|title $_execDoneMarker:1|1712930000\n'
+            '${_doneMarker()}',
+      );
+
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) async => execSession);
+
+      final windows = await service.listWindows(session, 'main');
+
+      expect(windows, hasLength(1));
+      expect(windows.single.name, _execDoneMarker);
+      expect(windows.single.paneTitle, 'title $_execDoneMarker:1');
+      verify(execSession.close).called(1);
+    });
+
     test(
       'selectWindow completes when stdout stays open after the done marker',
       () async {

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -254,22 +254,20 @@ void main() {
   });
 
   group('tmux exec recovery', () {
-    test(
-      'listWindows returns empty when opening the exec channel hangs',
-      () async {
-        final client = _MockSshClient();
-        final session = _buildSession(client);
-        const service = TmuxService(execOpenTimeout: Duration(milliseconds: 1));
+    test('listWindows propagates exec channel open timeouts', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client);
+      const service = TmuxService(execOpenTimeout: Duration(milliseconds: 1));
 
-        when(
-          () => client.execute(any(), pty: any(named: 'pty')),
-        ).thenAnswer((_) => Completer<SSHSession>().future);
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) => Completer<SSHSession>().future);
 
-        final windows = await service.listWindows(session, 'main');
-
-        expect(windows, isEmpty);
-      },
-    );
+      await expectLater(
+        service.listWindows(session, 'main'),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
 
     test(
       'listWindows completes when stdout stays open after the done marker',
@@ -280,7 +278,7 @@ void main() {
         final execSession = _buildOpenExecSession(
           stdout:
               '1|editor|1|vim|/tmp|*|vim-title|1712930000\n'
-              '$_execDoneMarker\n',
+              '${_doneMarker()}',
         );
 
         when(
@@ -302,7 +300,7 @@ void main() {
         final client = _MockSshClient();
         final session = _buildSession(client);
         const service = TmuxService();
-        final execSession = _buildOpenExecSession(stdout: '$_execDoneMarker\n');
+        final execSession = _buildOpenExecSession(stdout: _doneMarker());
 
         when(
           () => client.execute(any(), pty: any(named: 'pty')),
@@ -331,7 +329,7 @@ void main() {
         final client = _MockSshClient();
         final session = _buildSession(client);
         const service = TmuxService();
-        final execSession = _buildOpenExecSession(stdout: '$_execDoneMarker\n');
+        final execSession = _buildOpenExecSession(stdout: _doneMarker());
 
         when(
           () => client.execute(any(), pty: any(named: 'pty')),
@@ -371,6 +369,29 @@ void main() {
             (error) => error.message,
             'message',
             contains('closed before tmux command completed'),
+          ),
+        ),
+      );
+      verify(execSession.close).called(1);
+    });
+
+    test('killWindow propagates non-zero tmux command exit status', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client);
+      const service = TmuxService();
+      final execSession = _buildOpenExecSession(stdout: _doneMarker(1));
+
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) async => execSession);
+
+      await expectLater(
+        service.killWindow(session, 'main', 2),
+        throwsA(
+          isA<TmuxCommandException>().having(
+            (error) => error.message,
+            'message',
+            contains('exit status 1'),
           ),
         ),
       );
@@ -421,7 +442,7 @@ void main() {
         final session = _buildSession(client);
         const service = TmuxService();
         final execSession = _buildOpenExecSession(
-          stdout: '/opt/homebrew/bin/claude\n$_execDoneMarker\n',
+          stdout: '/opt/homebrew/bin/claude\n${_doneMarker()}',
         );
 
         when(
@@ -517,6 +538,8 @@ class _MockSshClient extends Mock implements SSHClient {}
 class _MockExecSession extends Mock implements SSHSession {}
 
 const _execDoneMarker = '__flutty_tmux_exec_done__';
+
+String _doneMarker([int status = 0]) => '$_execDoneMarker:$status\n';
 
 Stream<Uint8List> _openUtf8Stream(String value) =>
     Stream<Uint8List>.multi((controller) {

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -255,6 +255,75 @@ void main() {
 
       expect(find.text('✨ Editing main.dart'), findsOneWidget);
     });
+
+    testWidgets('stops showing an indefinite spinner after repeated empties', (
+      tester,
+    ) async {
+      final tmuxService = _MockTmuxService();
+      final presetService = _MockAgentLaunchPresetService();
+      final discoveryService = _MockAgentSessionDiscoveryService();
+      final session = SshSession(
+        connectionId: 1,
+        hostId: 1,
+        client: _MockSshClient(),
+        config: const SshConnectionConfig(
+          hostname: 'example.com',
+          port: 22,
+          username: 'demo',
+        ),
+      );
+      const tmuxSessionName = 'main';
+
+      when(
+        () => presetService.getPresetForHost(session.hostId),
+      ).thenAnswer((_) async => null);
+      when(
+        () => tmuxService.detectInstalledAgentTools(session),
+      ).thenAnswer((_) async => const <AgentLaunchTool>{});
+      when(
+        () => tmuxService.watchWindowChanges(session, tmuxSessionName),
+      ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+      when(
+        () => tmuxService.listWindows(session, tmuxSessionName),
+      ).thenAnswer((_) async => const <TmuxWindow>[]);
+      when(
+        () => discoveryService.discoverSessionsStream(
+          session,
+          workingDirectory: any(named: 'workingDirectory'),
+          maxPerTool: any(named: 'maxPerTool'),
+          toolName: any(named: 'toolName'),
+        ),
+      ).thenAnswer(
+        (_) => Stream<DiscoveredSessionsResult>.value(
+          DiscoveredSessionsResult(sessions: const <ToolSessionInfo>[]),
+        ),
+      );
+
+      await _pumpNavigatorHost(
+        tester,
+        tmuxService: tmuxService,
+        presetService: presetService,
+        discoveryService: discoveryService,
+        session: session,
+        tmuxSessionName: tmuxSessionName,
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsWidgets);
+
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pump();
+
+      expect(
+        find.text(
+          'Could not load windows: '
+          'tmux did not return any windows yet. Retrying...',
+        ),
+        findsOneWidget,
+      );
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

- propagate tmux window-list exec failures instead of treating failed queries as empty window snapshots
- require a verified non-empty window list before enabling tmux UI after detection/reconnect
- collapse and re-detect the expandable tmux panel if initial loading stalls, with retry messaging in the modal navigator

## Validation

- flutter analyze
- flutter test
