### PR TITLE
fix: route tmux alert notification taps

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -5,8 +5,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../data/database/database.dart';
 import '../data/repositories/host_repository.dart';
+import '../domain/services/auth_service.dart';
 import '../domain/services/background_ssh_service.dart';
 import '../domain/services/home_screen_shortcut_service.dart';
+import '../domain/services/local_notification_service.dart';
 import '../domain/services/monetization_service.dart';
 import '../domain/services/settings_service.dart';
 import '../domain/services/ssh_service.dart';
@@ -56,10 +58,14 @@ class _BackgroundLifecycleBridgeState
   late final AppLifecycleCoordinator _lifecycleCoordinator;
   StreamSubscription<List<Host>>? _homeScreenShortcutHostsSubscription;
   StreamSubscription<Set<int>>? _pinnedHomeScreenShortcutHostsSubscription;
+  StreamSubscription<TmuxAlertNotificationPayload>? _tmuxAlertTapSubscription;
+  ProviderSubscription<AuthState>? _authStateSubscription;
   List<Host> _latestHomeScreenShortcutHosts = const <Host>[];
   Set<int> _latestPinnedHomeScreenShortcutHostIds = const <int>{};
   bool _hasLoadedHomeScreenShortcutHosts = false;
   bool _hasLoadedPinnedHomeScreenShortcutHostIds = false;
+  TmuxAlertNotificationPayload? _pendingTmuxAlertNavigation;
+  bool _isTmuxAlertNavigationQueued = false;
 
   @override
   void initState() {
@@ -71,6 +77,7 @@ class _BackgroundLifecycleBridgeState
       syncBackgroundState: () =>
           BackgroundSshService.setForegroundState(isForeground: false),
     );
+    _listenForTmuxAlertNotifications();
     if (supportsHomeScreenShortcutActions) {
       _listenForHomeScreenShortcutChanges();
       _runLifecycleSync(
@@ -97,7 +104,73 @@ class _BackgroundLifecycleBridgeState
     WidgetsBinding.instance.removeObserver(this);
     unawaited(_homeScreenShortcutHostsSubscription?.cancel());
     unawaited(_pinnedHomeScreenShortcutHostsSubscription?.cancel());
+    unawaited(_tmuxAlertTapSubscription?.cancel());
+    _authStateSubscription?.close();
     super.dispose();
+  }
+
+  void _listenForTmuxAlertNotifications() {
+    final notificationService = ref.read(localNotificationServiceProvider);
+    _tmuxAlertTapSubscription = notificationService.tmuxAlertTaps.listen(
+      _handleTmuxAlertNotification,
+    );
+    _authStateSubscription = ref.listenManual<AuthState>(authStateProvider, (
+      previous,
+      next,
+    ) {
+      if (_canOpenTmuxAlertNotification(next)) {
+        _queuePendingTmuxAlertNavigation();
+      }
+    });
+    _runLifecycleSync(
+      () async {
+        await notificationService.initialize();
+        final launchAlert = await notificationService.consumeLaunchTmuxAlert();
+        if (launchAlert != null) {
+          _handleTmuxAlertNotification(launchAlert);
+        }
+      },
+      errorContext:
+          'while initializing tmux alert notification routing during app startup',
+      defer: true,
+    );
+  }
+
+  bool _canOpenTmuxAlertNotification(AuthState authState) =>
+      authState != AuthState.unknown && authState != AuthState.locked;
+
+  void _handleTmuxAlertNotification(TmuxAlertNotificationPayload payload) {
+    _pendingTmuxAlertNavigation = payload;
+    _queuePendingTmuxAlertNavigation();
+  }
+
+  void _queuePendingTmuxAlertNavigation() {
+    if (_isTmuxAlertNavigationQueued ||
+        _pendingTmuxAlertNavigation == null ||
+        !_canOpenTmuxAlertNotification(ref.read(authStateProvider))) {
+      return;
+    }
+
+    _isTmuxAlertNavigationQueued = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _isTmuxAlertNavigationQueued = false;
+      if (!mounted ||
+          !_canOpenTmuxAlertNotification(ref.read(authStateProvider))) {
+        return;
+      }
+      final payload = _pendingTmuxAlertNavigation;
+      if (payload == null) {
+        return;
+      }
+      _pendingTmuxAlertNavigation = null;
+      final targetUri = Uri.parse(buildTmuxAlertTerminalLocation(payload));
+      final queryParameters = Map<String, String>.from(
+        targetUri.queryParameters,
+      )..['notificationTap'] = '${DateTime.now().microsecondsSinceEpoch}';
+      ref
+          .read(routerProvider)
+          .go(targetUri.replace(queryParameters: queryParameters).toString());
+    });
   }
 
   void _listenForHomeScreenShortcutChanges() {

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -61,10 +61,29 @@ final routerProvider = Provider<GoRouter>((ref) {
           final connectionId = int.tryParse(
             state.uri.queryParameters['connectionId'] ?? '',
           );
+          final initialTmuxSessionName =
+              state.uri.queryParameters['tmuxSession'];
+          final initialTmuxWindowIndex = int.tryParse(
+            state.uri.queryParameters['tmuxWindow'] ?? '',
+          );
           if (hostId == null) {
             return const Scaffold(body: Center(child: Text('Invalid host ID')));
           }
-          return TerminalScreen(hostId: hostId, connectionId: connectionId);
+          return TerminalScreen(
+            key: ValueKey<Object>(
+              Object.hash(
+                hostId,
+                connectionId,
+                initialTmuxSessionName,
+                initialTmuxWindowIndex,
+                state.uri.queryParameters['notificationTap'],
+              ),
+            ),
+            hostId: hostId,
+            connectionId: connectionId,
+            initialTmuxSessionName: initialTmuxSessionName,
+            initialTmuxWindowIndex: initialTmuxWindowIndex,
+          );
         },
       ),
       GoRoute(

--- a/lib/domain/services/local_notification_service.dart
+++ b/lib/domain/services/local_notification_service.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -6,6 +9,101 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// Local notification channel used for tmux activity alerts.
 const tmuxAlertNotificationChannelId = 'tmux-alerts';
 const _androidNotificationIcon = 'ic_notification_monkey';
+
+/// Payload attached to a tmux alert notification.
+@immutable
+class TmuxAlertNotificationPayload {
+  /// Creates a new [TmuxAlertNotificationPayload].
+  const TmuxAlertNotificationPayload({
+    required this.hostId,
+    required this.connectionId,
+    required this.tmuxSessionName,
+    required this.windowIndex,
+  });
+
+  static const _type = 'tmux-alert';
+  static const _version = 1;
+
+  /// Host that owns the alerted connection.
+  final int hostId;
+
+  /// Existing SSH connection that produced the alert.
+  final int connectionId;
+
+  /// tmux session containing the alerted window.
+  final String tmuxSessionName;
+
+  /// tmux window index that needs attention.
+  final int windowIndex;
+
+  /// Encodes this payload for the notification plugin.
+  String encode() => jsonEncode(<String, Object>{
+    'type': _type,
+    'version': _version,
+    'hostId': hostId,
+    'connectionId': connectionId,
+    'tmuxSessionName': tmuxSessionName,
+    'windowIndex': windowIndex,
+  });
+
+  /// Decodes a notification payload, returning `null` for other payload types.
+  static TmuxAlertNotificationPayload? decode(String? payload) {
+    if (payload == null || payload.isEmpty) {
+      return null;
+    }
+    try {
+      final decoded = jsonDecode(payload);
+      if (decoded is! Map<String, Object?> ||
+          decoded['type'] != _type ||
+          decoded['version'] != _version) {
+        return null;
+      }
+      final hostId = decoded['hostId'];
+      final connectionId = decoded['connectionId'];
+      final tmuxSessionName = decoded['tmuxSessionName'];
+      final windowIndex = decoded['windowIndex'];
+      if (hostId is! int ||
+          connectionId is! int ||
+          tmuxSessionName is! String ||
+          tmuxSessionName.trim().isEmpty ||
+          windowIndex is! int) {
+        return null;
+      }
+      return TmuxAlertNotificationPayload(
+        hostId: hostId,
+        connectionId: connectionId,
+        tmuxSessionName: tmuxSessionName,
+        windowIndex: windowIndex,
+      );
+    } on FormatException {
+      return null;
+    }
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TmuxAlertNotificationPayload &&
+          hostId == other.hostId &&
+          connectionId == other.connectionId &&
+          tmuxSessionName == other.tmuxSessionName &&
+          windowIndex == other.windowIndex;
+
+  @override
+  int get hashCode =>
+      Object.hash(hostId, connectionId, tmuxSessionName, windowIndex);
+}
+
+/// Builds the terminal route location for a tmux alert notification tap.
+String buildTmuxAlertTerminalLocation(TmuxAlertNotificationPayload payload) =>
+    Uri(
+      path: '/terminal/${payload.hostId}',
+      queryParameters: <String, String>{
+        'connectionId': '${payload.connectionId}',
+        'tmuxSession': payload.tmuxSessionName,
+        'tmuxWindow': '${payload.windowIndex}',
+      },
+    ).toString();
 
 /// Service for showing local notifications inside the app.
 class LocalNotificationService {
@@ -21,16 +119,35 @@ class LocalNotificationService {
   );
 
   final FlutterLocalNotificationsPlugin _plugin;
+  final StreamController<TmuxAlertNotificationPayload> _tmuxAlertTapController =
+      StreamController<TmuxAlertNotificationPayload>.broadcast();
   Future<bool>? _initializeFuture;
+  TmuxAlertNotificationPayload? _launchTmuxAlert;
+  bool _didConsumeLaunchTmuxAlert = false;
+
+  /// Emits whenever the user taps a tmux alert notification.
+  Stream<TmuxAlertNotificationPayload> get tmuxAlertTaps =>
+      _tmuxAlertTapController.stream;
 
   /// Ensures the underlying notification plugin is initialized.
   Future<bool> initialize() => _initializeFuture ??= _initializeInternal();
+
+  /// Returns the tmux alert that launched the app, if one has not been consumed.
+  Future<TmuxAlertNotificationPayload?> consumeLaunchTmuxAlert() async {
+    final didInitialize = await initialize();
+    if (!didInitialize || _didConsumeLaunchTmuxAlert) {
+      return null;
+    }
+    _didConsumeLaunchTmuxAlert = true;
+    return _launchTmuxAlert;
+  }
 
   /// Shows or refreshes a tmux alert notification.
   Future<void> showTmuxAlert({
     required int notificationId,
     required String title,
     required String body,
+    required TmuxAlertNotificationPayload payload,
   }) async {
     final didInitialize = await initialize();
     if (!didInitialize) return;
@@ -60,6 +177,7 @@ class LocalNotificationService {
           iOS: darwinDetails,
           macOS: darwinDetails,
         ),
+        payload: payload.encode(),
       );
     } on MissingPluginException {
       // Widget and unit tests don't register platform notification plugins.
@@ -87,7 +205,17 @@ class LocalNotificationService {
         iOS: DarwinInitializationSettings(),
         macOS: DarwinInitializationSettings(),
       );
-      await _plugin.initialize(settings: initializationSettings);
+      final launchDetails = await _plugin.getNotificationAppLaunchDetails();
+      _launchTmuxAlert = (launchDetails?.didNotificationLaunchApp ?? false)
+          ? TmuxAlertNotificationPayload.decode(
+              launchDetails?.notificationResponse?.payload,
+            )
+          : null;
+
+      await _plugin.initialize(
+        settings: initializationSettings,
+        onDidReceiveNotificationResponse: _handleNotificationResponse,
+      );
 
       final androidImplementation = _plugin
           .resolvePlatformSpecificImplementation<
@@ -102,6 +230,14 @@ class LocalNotificationService {
     } on MissingPluginException {
       return false;
     }
+  }
+
+  void _handleNotificationResponse(NotificationResponse response) {
+    final payload = TmuxAlertNotificationPayload.decode(response.payload);
+    if (payload == null) {
+      return;
+    }
+    _tmuxAlertTapController.add(payload);
   }
 }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -848,7 +848,13 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   }
 
   int _tmuxAlertNotificationId(int windowIndex) =>
-      Object.hash(widget.tmuxSessionName, windowIndex) & 0x7fffffff;
+      Object.hash(
+        widget.session.hostId,
+        widget.session.connectionId,
+        widget.tmuxSessionName,
+        windowIndex,
+      ) &
+      0x7fffffff;
 
   void _sendAlertNotification(TmuxWindow window) {
     unawaited(HapticFeedback.mediumImpact());
@@ -862,6 +868,12 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
             notificationId: _tmuxAlertNotificationId(window.index),
             title: title,
             body: body,
+            payload: TmuxAlertNotificationPayload(
+              hostId: widget.session.hostId,
+              connectionId: widget.session.connectionId,
+              tmuxSessionName: widget.tmuxSessionName,
+              windowIndex: window.index,
+            ),
           ),
     );
   }
@@ -2668,7 +2680,13 @@ bool didTerminalScrollPolicyChange({
 /// Terminal screen for SSH sessions.
 class TerminalScreen extends ConsumerStatefulWidget {
   /// Creates a new [TerminalScreen].
-  const TerminalScreen({required this.hostId, this.connectionId, super.key});
+  const TerminalScreen({
+    required this.hostId,
+    this.connectionId,
+    this.initialTmuxSessionName,
+    this.initialTmuxWindowIndex,
+    super.key,
+  });
 
   /// The host ID to connect to.
   final int hostId;
@@ -2676,8 +2694,24 @@ class TerminalScreen extends ConsumerStatefulWidget {
   /// Optional existing connection ID to reuse.
   final int? connectionId;
 
+  /// Optional tmux session to focus after opening the terminal.
+  final String? initialTmuxSessionName;
+
+  /// Optional tmux window to focus after opening the terminal.
+  final int? initialTmuxWindowIndex;
+
   @override
   ConsumerState<TerminalScreen> createState() => _TerminalScreenState();
+}
+
+class _InitialTmuxWindowTarget {
+  const _InitialTmuxWindowTarget({
+    required this.sessionName,
+    required this.windowIndex,
+  });
+
+  final String sessionName;
+  final int windowIndex;
 }
 
 class _TerminalScreenState extends ConsumerState<TerminalScreen>
@@ -2729,6 +2763,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _showsTerminalMetadata = false;
   bool _isTmuxActive = false;
   String? _tmuxSessionName;
+  _InitialTmuxWindowTarget? _pendingInitialTmuxWindowTarget;
   bool _showTmuxBar = true;
   String? _tmuxLaunchWorkingDirectory;
   String? _tmuxWorkingDirectory;
@@ -2905,6 +2940,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   @override
   void initState() {
     super.initState();
+    _pendingInitialTmuxWindowTarget = _buildInitialTmuxWindowTarget(widget);
     WidgetsBinding.instance.addObserver(this);
     _sharedClipboardSubscription = ref.listenManual<bool>(
       sharedClipboardNotifierProvider,
@@ -2927,6 +2963,23 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _terminalFocusNode = FocusNode();
     // Defer connection to avoid modifying provider state during widget build
     Future.microtask(_loadHostAndConnect);
+  }
+
+  _InitialTmuxWindowTarget? _buildInitialTmuxWindowTarget(
+    TerminalScreen widget,
+  ) {
+    final sessionName = widget.initialTmuxSessionName?.trim();
+    final windowIndex = widget.initialTmuxWindowIndex;
+    if (sessionName == null ||
+        sessionName.isEmpty ||
+        windowIndex == null ||
+        windowIndex < 0) {
+      return null;
+    }
+    return _InitialTmuxWindowTarget(
+      sessionName: sessionName,
+      windowIndex: windowIndex,
+    );
   }
 
   void _onTerminalStateChanged() {
@@ -3741,7 +3794,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     // Structured tmux attach is a first-class connection mode, not a generic
     // automation command. Run it even when Pro-only auto-connect automation is
     // unavailable so tmux-native navigation remains accessible.
-    final tmuxSession = host.tmuxSessionName;
+    final tmuxSession = _initialTmuxSessionName ?? host.tmuxSessionName;
     if (tmuxSession != null && tmuxSession.isNotEmpty) {
       final tmuxCommand = buildTmuxCommand(
         sessionName: tmuxSession,
@@ -3869,10 +3922,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   void _primeTmuxStateFromHost() {
     final host = _host;
-    final preferredSessionName = resolvePreferredTmuxSessionName(
-      structuredSessionName: host?.tmuxSessionName,
-      autoConnectCommand: _resolveStoredAutoConnectCommand(host),
-    );
+    final preferredSessionName = _preferredTmuxSessionName(host);
     if (!mounted || preferredSessionName == null) {
       return;
     }
@@ -3885,6 +3935,18 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _tmuxWorkingDirectory = preferredWorkingDirectory;
     });
   }
+
+  String? get _initialTmuxSessionName {
+    final sessionName = widget.initialTmuxSessionName?.trim();
+    return sessionName == null || sessionName.isEmpty ? null : sessionName;
+  }
+
+  String? _preferredTmuxSessionName(Host? host) =>
+      _initialTmuxSessionName ??
+      resolvePreferredTmuxSessionName(
+        structuredSessionName: host?.tmuxSessionName,
+        autoConnectCommand: _resolveStoredAutoConnectCommand(host),
+      );
 
   void _clearTmuxState() {
     _tmuxDetectionGeneration += 1;
@@ -3908,10 +3970,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final capturedConnectionId = _connectionId;
     final detectionGeneration = ++_tmuxDetectionGeneration;
     final host = _host;
-    final preferredSessionName = resolvePreferredTmuxSessionName(
-      structuredSessionName: host?.tmuxSessionName,
-      autoConnectCommand: _resolveStoredAutoConnectCommand(host),
-    );
+    final preferredSessionName = _preferredTmuxSessionName(host);
     final existingSessionName = preserveExistingTmuxState
         ? _tmuxSessionName
         : null;
@@ -4015,6 +4074,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _tmuxLaunchWorkingDirectory = tmuxLaunchCwd;
           _tmuxWorkingDirectory = tmuxCwd;
         });
+        await _activateInitialTmuxWindowIfNeeded(session, sessionName, windows);
         return;
       }
 
@@ -4036,6 +4096,25 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       if (!preserveExistingTmuxState) {
         setState(_clearTmuxState);
       }
+    }
+  }
+
+  Future<void> _activateInitialTmuxWindowIfNeeded(
+    SshSession session,
+    String sessionName,
+    List<TmuxWindow> windows,
+  ) async {
+    final target = _pendingInitialTmuxWindowTarget;
+    if (target == null ||
+        target.sessionName != sessionName ||
+        !windows.any((window) => window.index == target.windowIndex)) {
+      return;
+    }
+    _pendingInitialTmuxWindowTarget = null;
+    try {
+      await _switchTmuxWindow(session, target.windowIndex);
+    } on Exception catch (error) {
+      _showTmuxActionFailure(error);
     }
   }
 

--- a/test/domain/services/local_notification_service_test.dart
+++ b/test/domain/services/local_notification_service_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:monkeyssh/domain/services/local_notification_service.dart';
+
+void main() {
+  group('TmuxAlertNotificationPayload', () {
+    test('round-trips tmux alert routing fields', () {
+      const payload = TmuxAlertNotificationPayload(
+        hostId: 12,
+        connectionId: 34,
+        tmuxSessionName: 'work',
+        windowIndex: 5,
+      );
+
+      expect(TmuxAlertNotificationPayload.decode(payload.encode()), payload);
+    });
+
+    test('ignores malformed and unrelated payloads', () {
+      expect(TmuxAlertNotificationPayload.decode(null), isNull);
+      expect(TmuxAlertNotificationPayload.decode('not json'), isNull);
+      expect(TmuxAlertNotificationPayload.decode('{"type":"other"}'), isNull);
+      expect(
+        TmuxAlertNotificationPayload.decode(
+          '{"type":"tmux-alert","version":1,"hostId":12}',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  test(
+    'buildTmuxAlertTerminalLocation targets the source connection window',
+    () {
+      final location = buildTmuxAlertTerminalLocation(
+        const TmuxAlertNotificationPayload(
+          hostId: 12,
+          connectionId: 34,
+          tmuxSessionName: 'project main',
+          windowIndex: 5,
+        ),
+      );
+
+      expect(
+        location,
+        '/terminal/12?connectionId=34&tmuxSession=project+main&tmuxWindow=5',
+      );
+    },
+  );
+}

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -16,11 +16,13 @@ import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
 import 'package:monkeyssh/domain/models/host_cli_launch_preferences.dart';
 import 'package:monkeyssh/domain/models/monetization.dart';
+import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/domain/services/agent_launch_preset_service.dart';
 import 'package:monkeyssh/domain/services/host_cli_launch_preferences_service.dart';
 import 'package:monkeyssh/domain/services/monetization_service.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
+import 'package:monkeyssh/domain/services/tmux_service.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
@@ -37,6 +39,8 @@ class _MockShellChannel extends Mock implements SSHSession {}
 class _MockMonetizationService extends Mock implements MonetizationService {}
 
 class _MockSftpClient extends Mock implements SftpClient {}
+
+class _MockTmuxService extends Mock implements TmuxService {}
 
 class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
   _TestActiveSessionsNotifier(this.session);
@@ -202,6 +206,79 @@ void main() {
       await tester.pump();
       await tester.pump();
     }
+
+    testWidgets(
+      'initial tmux target selects the alerted window on the source connection',
+      (tester) async {
+        final tmuxService = _MockTmuxService();
+        const tmuxSessionName = 'alerts';
+        const targetWindowIndex = 3;
+        final windows = <TmuxWindow>[
+          const TmuxWindow(index: 1, name: 'shell', isActive: true),
+          const TmuxWindow(index: 3, name: 'agent', isActive: false),
+        ];
+        when(
+          () => tmuxService.hasSession(session, tmuxSessionName),
+        ).thenAnswer((_) async => true);
+        when(
+          () => tmuxService.listWindows(session, tmuxSessionName),
+        ).thenAnswer((_) async => windows);
+        when(
+          () => tmuxService.selectWindow(
+            session,
+            tmuxSessionName,
+            targetWindowIndex,
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => tmuxService.hasForegroundClient(session, tmuxSessionName),
+        ).thenAnswer((_) async => true);
+        when(
+          () => tmuxService.watchWindowChanges(session, tmuxSessionName),
+        ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+              tmuxServiceProvider.overrideWithValue(tmuxService),
+            ],
+            child: MaterialApp(
+              home: TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+                initialTmuxSessionName: tmuxSessionName,
+                initialTmuxWindowIndex: targetWindowIndex,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        verify(
+          () => tmuxService.selectWindow(
+            session,
+            tmuxSessionName,
+            targetWindowIndex,
+          ),
+        ).called(1);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
 
     testWidgets(
       'auto-connect rebuilds agent launch commands from the saved preset and host yolo preference',


### PR DESCRIPTION
## Summary

- Add tmux alert notification payloads carrying host, connection, session, and window target information.
- Route notification taps through the app to the terminal screen, preserving pending taps until the app is unlocked.
- Select the targeted tmux window once the terminal has opened the source connection and detected the tmux session.
- Add coverage for payload routing and terminal initial tmux window selection.

## Tests

- `flutter analyze`
- `dart format .`
- `flutter test`
