### PR TITLE
Fix store metadata sync Python dependency install

### DIFF
--- a/.github/workflows/sync-metadata.yml
+++ b/.github/workflows/sync-metadata.yml
@@ -93,7 +93,10 @@ jobs:
           persist-credentials: false
 
       - name: Install screenshot validation dependencies
-        run: python3 -m pip install --quiet Pillow
+        run: |
+          python3 -m venv .venv
+          .venv/bin/python -m pip install --quiet --upgrade pip
+          .venv/bin/python -m pip install --quiet Pillow
 
       - name: Validate screenshots with OCR
         shell: bash
@@ -105,7 +108,7 @@ jobs:
           else
             platform=android
           fi
-          python3 scripts/validate_store_screenshots.py "$platform"
+          .venv/bin/python scripts/validate_store_screenshots.py "$platform"
 
   sync-ios:
     name: Sync iOS Metadata
@@ -164,8 +167,10 @@ jobs:
 
       - name: Refresh Play Store icon metadata
         run: |
-          python3 -m pip install --quiet Pillow
-          python3 scripts/sync_play_store_icons.py
+          python3 -m venv .venv
+          .venv/bin/python -m pip install --quiet --upgrade pip
+          .venv/bin/python -m pip install --quiet Pillow
+          .venv/bin/python scripts/sync_play_store_icons.py
 
       - name: Validate Play Store metadata
         run: python3 scripts/validate_play_store_metadata.py ${{ github.event_name == 'push' && 'both' || inputs.app }}


### PR DESCRIPTION
## Summary

- Fixes the failed Sync Store Metadata workflow by installing Pillow inside a local Python virtualenv instead of the macOS runner's externally managed system Python.
- Runs screenshot OCR validation and Play icon syncing with the virtualenv Python so dependencies are available to the scripts that need them.

## Failure addressed

The merge-triggered sync failed in **Validate Store Screenshots** before any store upload:

```text
error: externally-managed-environment
× This environment is externally managed
```

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/sync-metadata.yml')"`
- `git diff --check`

## After merge

The failed run used the old workflow SHA, so rerunning it will still fail. After this PR merges, trigger a fresh manual run:

```bash
gh workflow run sync-metadata.yml --ref main -f platform=both -f app=both
```
