### PR TITLE
feat: add preview diagnostics logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,13 @@ The script generates a temporary SSH key, authorizes it for localhost, and creat
 - **PATH**: SSH exec channels use a minimal PATH that excludes Homebrew. The tmux service sources `~/.profile`, `~/.bash_profile`, and `~/.zprofile` before running commands.
 - **Format strings**: tmux's `-F` option does **not** interpret `\t` as tab. Use ASCII Unit Separator (`\x1f`) delimiters instead so window names and titles can still contain `|`.
 - **Environment variables**: Exec channels don't share the interactive shell's environment. Use `tmux list-sessions` / `tmux display-message` instead of `echo $TMUX`.
+
+## Diagnostics logging
+
+Preview builds expose an in-memory diagnostics log in Settings > Diagnostics. Users can tap **Copy diagnostics log** and paste the sanitized text into an issue or chat for troubleshooting.
+
+When adding diagnostics, use `DiagnosticsLogService.instance` (or `diagnosticsLogServiceProvider` in UI code) and keep entries structured with a short category, short event name, and primitive fields. The logger is gated to preview builds and maintains a bounded ring buffer.
+
+Never log secrets or user content. Do not log hostnames, usernames, passwords, passphrases, private keys, tokens, raw commands, terminal output, tmux window/session names, window titles, working directories, file paths, clipboard contents, or raw SSH/tmux stream lines. Prefer safe metadata such as connection ID, host ID, booleans, counts, durations, enum states, retry attempts, error types, exit statuses, and sanitized event categories.
+
+For tmux control-mode logging, log the control marker category (for example `subscription_changed` or `window_add`) and counts/timing only. Do not log the full control-mode line because it can include pane titles, window names, paths, and command output.

--- a/lib/app/app_metadata.dart
+++ b/lib/app/app_metadata.dart
@@ -12,6 +12,9 @@ const _pullRequestNumber = String.fromEnvironment('FLUTTY_PR_NUMBER');
 const _pullRequestTitle = String.fromEnvironment('FLUTTY_PR_TITLE');
 Future<Map<int, String>>? _versionCodenameLookup;
 
+/// Whether this binary was produced from a pull-request preview build.
+const isPreviewBuild = _pullRequestNumber != '';
+
 /// Provides the current platform app name with a safe fallback.
 final appDisplayNameProvider = Provider<String>((ref) {
   final appMetadata = ref.watch(appMetadataProvider);
@@ -98,6 +101,9 @@ class AppMetadata {
 
     return 'PR #$pullRequestNumber: $pullRequestTitle';
   }
+
+  /// Whether the runtime metadata identifies a pull-request preview build.
+  bool get isPreviewBuild => pullRequestNumber != null;
 }
 
 String? _normalizeBuildMetadata(String value) {

--- a/lib/domain/services/diagnostics_log_service.dart
+++ b/lib/domain/services/diagnostics_log_service.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:collection';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -90,6 +93,7 @@ class DiagnosticsLogService extends ChangeNotifier {
 
   static const _redacted = '[redacted]';
   static const _maxStringLength = 160;
+  static const _notifyDebounce = Duration(milliseconds: 250);
 
   static const _sensitiveFieldNames = <String>{
     'command',
@@ -149,7 +153,8 @@ class DiagnosticsLogService extends ChangeNotifier {
 
   final DateTime Function() _now;
   final int _maxEntries;
-  final List<DiagnosticsLogEntry> _entries = [];
+  final Queue<DiagnosticsLogEntry> _entries = Queue<DiagnosticsLogEntry>();
+  Timer? _notifyTimer;
 
   /// Number of retained entries.
   int get entryCount => _entries.length;
@@ -161,7 +166,15 @@ class DiagnosticsLogService extends ChangeNotifier {
   void clear() {
     if (_entries.isEmpty) return;
     _entries.clear();
+    _notifyTimer?.cancel();
+    _notifyTimer = null;
     notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _notifyTimer?.cancel();
+    super.dispose();
   }
 
   /// Records a debug event.
@@ -231,7 +244,7 @@ class DiagnosticsLogService extends ChangeNotifier {
       final key = _sanitizeKey(entry.key);
       sanitizedFields[key] = _sanitizeValue(key, entry.value);
     }
-    _entries.add(
+    _entries.addLast(
       DiagnosticsLogEntry(
         timestamp: _now(),
         level: level,
@@ -240,10 +253,20 @@ class DiagnosticsLogService extends ChangeNotifier {
         fields: Map.unmodifiable(sanitizedFields),
       ),
     );
-    if (_entries.length > _maxEntries) {
-      _entries.removeRange(0, _entries.length - _maxEntries);
+    while (_entries.length > _maxEntries) {
+      _entries.removeFirst();
     }
-    notifyListeners();
+    _scheduleNotifyListeners();
+  }
+
+  void _scheduleNotifyListeners() {
+    if (_notifyTimer?.isActive ?? false) {
+      return;
+    }
+    _notifyTimer = Timer(_notifyDebounce, () {
+      _notifyTimer = null;
+      notifyListeners();
+    });
   }
 
   static String _sanitizeKey(String key) {

--- a/lib/domain/services/diagnostics_log_service.dart
+++ b/lib/domain/services/diagnostics_log_service.dart
@@ -1,0 +1,331 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../app/app_metadata.dart';
+
+/// Severity for a diagnostics log entry.
+enum DiagnosticsLogLevel {
+  /// Verbose diagnostics useful when tracing event flow.
+  debug,
+
+  /// Informational lifecycle event.
+  info,
+
+  /// Recoverable unexpected behavior.
+  warning,
+
+  /// Error or failure path.
+  error,
+}
+
+/// A single sanitized diagnostics log entry.
+@immutable
+class DiagnosticsLogEntry {
+  /// Creates a diagnostics log entry.
+  const DiagnosticsLogEntry({
+    required this.timestamp,
+    required this.level,
+    required this.category,
+    required this.message,
+    this.fields = const <String, Object?>{},
+  });
+
+  /// When the event was recorded.
+  final DateTime timestamp;
+
+  /// Event severity.
+  final DiagnosticsLogLevel level;
+
+  /// Short namespace for the event producer.
+  final String category;
+
+  /// Short event name.
+  final String message;
+
+  /// Sanitized key/value details.
+  final Map<String, Object?> fields;
+
+  /// Formats the entry as a single copy/paste-friendly line.
+  String format() {
+    final buffer = StringBuffer()
+      ..write(timestamp.toUtc().toIso8601String())
+      ..write(' ')
+      ..write(level.name.toUpperCase())
+      ..write(' ')
+      ..write(category)
+      ..write(' ')
+      ..write(message);
+    for (final entry in fields.entries) {
+      buffer
+        ..write(' ')
+        ..write(entry.key)
+        ..write('=')
+        ..write(_formatValue(entry.value));
+    }
+    return buffer.toString();
+  }
+
+  static String _formatValue(Object? value) {
+    if (value == null) return 'null';
+    final text = value.toString();
+    if (text.contains(' ') || text.contains('\n') || text.contains('\t')) {
+      return '"${text.replaceAll('"', r'\"')}"';
+    }
+    return text;
+  }
+}
+
+/// Preview-only diagnostics log with strict field sanitization.
+class DiagnosticsLogService extends ChangeNotifier {
+  /// Creates a diagnostics logger.
+  DiagnosticsLogService({
+    required this.enabled,
+    DateTime Function()? now,
+    int maxEntries = 1200,
+  }) : _now = now ?? DateTime.now,
+       _maxEntries = maxEntries < 1 ? 1 : maxEntries;
+
+  /// Shared diagnostics logger used by app services.
+  static final instance = DiagnosticsLogService(enabled: isPreviewBuild);
+
+  static const _redacted = '[redacted]';
+  static const _maxStringLength = 160;
+
+  static const _sensitiveFieldNames = <String>{
+    'command',
+    'cwd',
+    'host',
+    'hostname',
+    'icon',
+    'key',
+    'name',
+    'output',
+    'pane',
+    'passphrase',
+    'password',
+    'path',
+    'privatekey',
+    'rawcommand',
+    'session',
+    'sessionname',
+    'stderr',
+    'stdin',
+    'stdout',
+    'terminaloutput',
+    'title',
+    'token',
+    'username',
+    'windowname',
+    'windowtitle',
+    'workingdirectory',
+  };
+
+  static const _safeStringFieldNames = <String>{
+    'action',
+    'category',
+    'commandkind',
+    'errortype',
+    'eventtype',
+    'kind',
+    'linekind',
+    'mode',
+    'platform',
+    'reason',
+    'result',
+    'shellstatus',
+    'state',
+    'status',
+  };
+
+  static final _unsafeStringPattern = RegExp(
+    r'(?:BEGIN [A-Z ]*PRIVATE KEY|ssh-[a-z0-9-]+ |\bfile://|/[^ ]+|\\[^ ]+|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+)',
+    caseSensitive: false,
+  );
+  static final _unsafeKeyPattern = RegExp('[^A-Za-z0-9_.-]+');
+  static final _controlCharacterPattern = RegExp(r'[\x00-\x1F\x7F]');
+
+  /// Whether logging is enabled for this build.
+  final bool enabled;
+
+  final DateTime Function() _now;
+  final int _maxEntries;
+  final List<DiagnosticsLogEntry> _entries = [];
+
+  /// Number of retained entries.
+  int get entryCount => _entries.length;
+
+  /// Returns a copy of the currently retained log entries.
+  List<DiagnosticsLogEntry> snapshot() => List.unmodifiable(_entries);
+
+  /// Clears all retained diagnostics entries.
+  void clear() {
+    if (_entries.isEmpty) return;
+    _entries.clear();
+    notifyListeners();
+  }
+
+  /// Records a debug event.
+  void debug(
+    String category,
+    String message, {
+    Map<String, Object?> fields = const <String, Object?>{},
+  }) => _add(DiagnosticsLogLevel.debug, category, message, fields);
+
+  /// Records an informational event.
+  void info(
+    String category,
+    String message, {
+    Map<String, Object?> fields = const <String, Object?>{},
+  }) => _add(DiagnosticsLogLevel.info, category, message, fields);
+
+  /// Records a warning event.
+  void warning(
+    String category,
+    String message, {
+    Map<String, Object?> fields = const <String, Object?>{},
+  }) => _add(DiagnosticsLogLevel.warning, category, message, fields);
+
+  /// Records an error event.
+  void error(
+    String category,
+    String message, {
+    Map<String, Object?> fields = const <String, Object?>{},
+  }) => _add(DiagnosticsLogLevel.error, category, message, fields);
+
+  /// Formats retained diagnostics with a small safe metadata header.
+  String exportText({AppMetadata? appMetadata}) {
+    final buffer = StringBuffer()
+      ..writeln('MonkeySSH diagnostics')
+      ..writeln('generatedAt=${_now().toUtc().toIso8601String()}')
+      ..writeln('entryCount=${_entries.length}')
+      ..writeln('flutterMode=${_flutterMode()}')
+      ..writeln('platform=${defaultTargetPlatform.name}');
+    if (appMetadata != null) {
+      buffer
+        ..writeln('appVersion=${_sanitizeString(appMetadata.versionLabel)}')
+        ..writeln(
+          'previewBuild=${appMetadata.pullRequestNumber == null ? 'no' : 'PR #${appMetadata.pullRequestNumber}'}',
+        );
+    }
+    buffer
+      ..writeln()
+      ..writeln(
+        'Privacy: hostnames, usernames, commands, paths, window titles, terminal output, keys, passwords, and tokens are not recorded.',
+      )
+      ..writeln();
+    for (final entry in _entries) {
+      buffer.writeln(entry.format());
+    }
+    return buffer.toString();
+  }
+
+  void _add(
+    DiagnosticsLogLevel level,
+    String category,
+    String message,
+    Map<String, Object?> fields,
+  ) {
+    if (!enabled) return;
+    final sanitizedFields = <String, Object?>{};
+    for (final entry in fields.entries) {
+      final key = _sanitizeKey(entry.key);
+      sanitizedFields[key] = _sanitizeValue(key, entry.value);
+    }
+    _entries.add(
+      DiagnosticsLogEntry(
+        timestamp: _now(),
+        level: level,
+        category: _sanitizeKey(category),
+        message: _sanitizeMessage(message),
+        fields: Map.unmodifiable(sanitizedFields),
+      ),
+    );
+    if (_entries.length > _maxEntries) {
+      _entries.removeRange(0, _entries.length - _maxEntries);
+    }
+    notifyListeners();
+  }
+
+  static String _sanitizeKey(String key) {
+    final sanitized = key.replaceAll(_unsafeKeyPattern, '_').trim();
+    if (sanitized.isEmpty) return 'field';
+    return sanitized.length > 48 ? sanitized.substring(0, 48) : sanitized;
+  }
+
+  static String _sanitizeMessage(String message) {
+    final sanitized = _sanitizeString(message);
+    return sanitized.replaceAll(' ', '_');
+  }
+
+  static Object? _sanitizeValue(String key, Object? value) {
+    if (value == null || value is bool || value is num) {
+      return value;
+    }
+    if (value is DateTime) {
+      return value.toUtc().toIso8601String();
+    }
+    if (value is Duration) {
+      return '${value.inMilliseconds}ms';
+    }
+    if (value is Enum) {
+      return value.name;
+    }
+    if (value is Iterable<Object?>) {
+      return '${value.length}_items';
+    }
+    if (value is Map<Object?, Object?>) {
+      return '${value.length}_entries';
+    }
+
+    final normalizedKey = key.toLowerCase();
+    if (_isSensitiveKey(normalizedKey)) {
+      return _redacted;
+    }
+
+    final sanitized = _sanitizeString(value.toString());
+    if (!_safeStringFieldNames.contains(normalizedKey) &&
+        _unsafeStringPattern.hasMatch(sanitized)) {
+      return _redacted;
+    }
+    return sanitized;
+  }
+
+  static bool _isSensitiveKey(String key) {
+    if (_sensitiveFieldNames.contains(key)) {
+      return true;
+    }
+    return key.contains('password') ||
+        key.contains('passphrase') ||
+        key.contains('privatekey') ||
+        key.contains('token') ||
+        key.contains('secret') ||
+        key.contains('hostname') ||
+        key == 'username' ||
+        key.endsWith('path') ||
+        key.endsWith('command') ||
+        key.endsWith('title');
+  }
+
+  static String _sanitizeString(String value) {
+    final sanitized = value
+        .replaceAll(_controlCharacterPattern, '')
+        .replaceAll('\n', ' ')
+        .replaceAll('\r', ' ')
+        .trim();
+    if (sanitized.length <= _maxStringLength) {
+      return sanitized;
+    }
+    return '${sanitized.substring(0, _maxStringLength)}...';
+  }
+
+  static String _flutterMode() {
+    if (kReleaseMode) return 'release';
+    if (kProfileMode) return 'profile';
+    return 'debug';
+  }
+}
+
+/// Provider for the preview diagnostics log.
+final diagnosticsLogServiceProvider = Provider<DiagnosticsLogService>(
+  (ref) => DiagnosticsLogService.instance,
+);

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -1450,6 +1450,7 @@ class SshSession {
   }) : createdAt = DateTime.now();
 
   static const _previewRefreshInterval = Duration(milliseconds: 150);
+  static const _shellIoDiagnosticsInterval = Duration(seconds: 1);
   static const _previewLineCount = 3;
   static const _previewMaxChars = 220;
   static final _previewSanitizerPattern = RegExp(r'[\x00-\x08\x0B-\x1F\x7F]');
@@ -1496,6 +1497,13 @@ class SshSession {
   StreamSubscription<String>? _shellStderrSubscription;
   StreamSubscription<void>? _shellDoneSubscription;
   Timer? _previewRefreshTimer;
+  Timer? _shellIoDiagnosticsTimer;
+  int _shellStdoutChunkCount = 0;
+  int _shellStdoutCharCount = 0;
+  int _shellStderrChunkCount = 0;
+  int _shellStderrCharCount = 0;
+  int _shellStdinWriteCount = 0;
+  int _shellStdinCharCount = 0;
 
   /// Persistent terminal that survives screen rebuilds.
   Terminal? _terminal;
@@ -1651,6 +1659,9 @@ class SshSession {
 
   /// Close only the interactive shell channel while keeping the SSH client.
   Future<void> closeShell() async {
+    _flushShellIoDiagnostics();
+    _shellIoDiagnosticsTimer?.cancel();
+    _shellIoDiagnosticsTimer = null;
     DiagnosticsLogService.instance.info(
       'ssh.shell',
       'close_start',
@@ -1703,11 +1714,7 @@ class SshSession {
         .transform(utf8.decoder)
         .listen(
           (data) {
-            DiagnosticsLogService.instance.debug(
-              'ssh.shell',
-              'stdout_chunk',
-              fields: {'connectionId': connectionId, 'charCount': data.length},
-            );
+            _recordShellIo(stdoutChars: data.length);
             terminal.write(data);
             _scheduleTerminalPreviewRefresh();
             _shellStdoutController!.add(data);
@@ -1729,11 +1736,7 @@ class SshSession {
         .transform(utf8.decoder)
         .listen(
           (data) {
-            DiagnosticsLogService.instance.debug(
-              'ssh.shell',
-              'stderr_chunk',
-              fields: {'connectionId': connectionId, 'charCount': data.length},
-            );
+            _recordShellIo(stderrChars: data.length);
             terminal.write(data);
             _scheduleTerminalPreviewRefresh();
             _shellStderrController!.add(data);
@@ -1774,14 +1777,67 @@ class SshSession {
 
     // Wire terminal keyboard output → shell stdin (persistent).
     terminal.onOutput = (data) {
-      DiagnosticsLogService.instance.debug(
-        'ssh.shell',
-        'stdin_write',
-        fields: {'connectionId': connectionId, 'charCount': data.length},
-      );
+      _recordShellIo(stdinChars: data.length);
       shell.write(utf8.encode(data));
     };
     _refreshTerminalPreview();
+  }
+
+  void _recordShellIo({
+    int stdoutChars = 0,
+    int stderrChars = 0,
+    int stdinChars = 0,
+  }) {
+    if (!DiagnosticsLogService.instance.enabled) {
+      return;
+    }
+    if (stdoutChars > 0) {
+      _shellStdoutChunkCount += 1;
+      _shellStdoutCharCount += stdoutChars;
+    }
+    if (stderrChars > 0) {
+      _shellStderrChunkCount += 1;
+      _shellStderrCharCount += stderrChars;
+    }
+    if (stdinChars > 0) {
+      _shellStdinWriteCount += 1;
+      _shellStdinCharCount += stdinChars;
+    }
+    if (!(_shellIoDiagnosticsTimer?.isActive ?? false)) {
+      _shellIoDiagnosticsTimer = Timer(
+        _shellIoDiagnosticsInterval,
+        _flushShellIoDiagnostics,
+      );
+    }
+  }
+
+  void _flushShellIoDiagnostics() {
+    _shellIoDiagnosticsTimer?.cancel();
+    _shellIoDiagnosticsTimer = null;
+    if (_shellStdoutChunkCount == 0 &&
+        _shellStderrChunkCount == 0 &&
+        _shellStdinWriteCount == 0) {
+      return;
+    }
+    DiagnosticsLogService.instance.debug(
+      'ssh.shell',
+      'io_summary',
+      fields: {
+        'connectionId': connectionId,
+        'stdoutChunks': _shellStdoutChunkCount,
+        'stdoutChars': _shellStdoutCharCount,
+        'stderrChunks': _shellStderrChunkCount,
+        'stderrChars': _shellStderrCharCount,
+        'stdinWrites': _shellStdinWriteCount,
+        'stdinChars': _shellStdinCharCount,
+      },
+    );
+    _shellStdoutChunkCount = 0;
+    _shellStdoutCharCount = 0;
+    _shellStderrChunkCount = 0;
+    _shellStderrCharCount = 0;
+    _shellStdinWriteCount = 0;
+    _shellStdinCharCount = 0;
   }
 
   void _scheduleTerminalPreviewRefresh() {

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -14,6 +14,7 @@ import '../../data/repositories/key_repository.dart';
 import '../../data/repositories/known_hosts_repository.dart';
 import 'background_ssh_service.dart';
 import 'clipboard_sharing_service.dart';
+import 'diagnostics_log_service.dart';
 import 'host_key_prompt_handler_provider.dart';
 import 'host_key_verification.dart';
 import 'terminal_hyperlink_tracker.dart';
@@ -387,7 +388,17 @@ class SshService {
     ConnectionProgressCallback? onProgress,
     bool useHostThemeOverrides = true,
   }) async {
+    DiagnosticsLogService.instance.info(
+      'ssh.connect',
+      'connect_to_host_start',
+      fields: {'hostId': hostId},
+    );
     if (hostRepository == null) {
+      DiagnosticsLogService.instance.warning(
+        'ssh.connect',
+        'connect_to_host_unavailable',
+        fields: {'hostId': hostId, 'reason': 'missing_host_repository'},
+      );
       return const SshConnectionResult(
         success: false,
         error: 'Host repository not available',
@@ -396,6 +407,11 @@ class SshService {
 
     final host = await hostRepository!.getById(hostId);
     if (host == null) {
+      DiagnosticsLogService.instance.warning(
+        'ssh.connect',
+        'connect_to_host_missing_host',
+        fields: {'hostId': hostId},
+      );
       return const SshConnectionResult(success: false, error: 'Host not found');
     }
 
@@ -482,6 +498,17 @@ class SshService {
 
       // Update last connected timestamp
       await hostRepository!.updateLastConnected(hostId);
+      DiagnosticsLogService.instance.info(
+        'ssh.connect',
+        'connect_to_host_success',
+        fields: {
+          'hostId': hostId,
+          'connectionId': connectionId,
+          'usesJumpHost': config.jumpHost != null,
+          'usesPassword': config.password != null,
+          'identityCount': config.identityKeys?.length ?? 0,
+        },
+      );
       return SshConnectionResult(
         success: true,
         client: result.client,
@@ -490,6 +517,14 @@ class SshService {
       );
     }
 
+    DiagnosticsLogService.instance.warning(
+      'ssh.connect',
+      'connect_to_host_failed',
+      fields: {
+        'hostId': hostId,
+        'errorType': _diagnosticSshResultErrorKind(result.error),
+      },
+    );
     return result;
   }
 
@@ -503,12 +538,30 @@ class SshService {
     final dependentClients = <SSHClient>[];
     SSHClient? jumpClient;
     void report(SshConnectionState state, String message) {
+      DiagnosticsLogService.instance.info(
+        'ssh.connect',
+        'progress',
+        fields: {'state': state, 'isJumpHost': isJumpHost},
+      );
       onProgress?.call(
         ConnectionProgressUpdate(state: state, message: message),
       );
     }
 
     try {
+      DiagnosticsLogService.instance.info(
+        'ssh.connect',
+        'connect_start',
+        fields: {
+          'isJumpHost': isJumpHost,
+          'hasJumpHost': config.jumpHost != null,
+          'usesPassword': config.password != null,
+          'identityCount': config.identityKeys?.length ?? 0,
+          'hasExplicitKey': config.privateKey != null,
+          'keepAliveSeconds': config.keepAliveInterval.inSeconds,
+          'timeoutSeconds': config.connectionTimeout.inSeconds,
+        },
+      );
       final verificationService = _createHostKeyVerificationService(config);
 
       // Handle jump host
@@ -616,6 +669,11 @@ class SshService {
         );
         await pendingHostTrustUpdate.commitAfterAuthentication(knownHosts);
 
+        DiagnosticsLogService.instance.info(
+          'ssh.connect',
+          'connect_success',
+          fields: {'isJumpHost': isJumpHost, 'trustedHostKnown': false},
+        );
         return SshConnectionResult(
           success: true,
           client: client,
@@ -726,6 +784,11 @@ class SshService {
         );
         await pendingHostTrustUpdate.commitAfterAuthentication(knownHosts);
 
+        DiagnosticsLogService.instance.info(
+          'ssh.connect',
+          'connect_success',
+          fields: {'isJumpHost': isJumpHost, 'trustedHostKnown': true},
+        );
         return SshConnectionResult(
           success: true,
           client: client,
@@ -745,16 +808,31 @@ class SshService {
         encodedHostKey: trustedHost.hostKey,
       );
 
+      DiagnosticsLogService.instance.info(
+        'ssh.connect',
+        'connect_success',
+        fields: {'isJumpHost': isJumpHost, 'trustedHostKnown': true},
+      );
       return SshConnectionResult(
         success: true,
         client: client,
         dependentClients: dependentClients,
       );
     } on HostKeyVerificationException catch (e) {
+      DiagnosticsLogService.instance.warning(
+        'ssh.connect',
+        'connect_failed',
+        fields: {'isJumpHost': isJumpHost, 'errorType': e.runtimeType},
+      );
       client?.close();
       _closeClients(dependentClients);
       return SshConnectionResult(success: false, error: e.message);
     } on SSHHostkeyError catch (e) {
+      DiagnosticsLogService.instance.warning(
+        'ssh.connect',
+        'connect_failed',
+        fields: {'isJumpHost': isJumpHost, 'errorType': e.runtimeType},
+      );
       client?.close();
       _closeClients(dependentClients);
       return SshConnectionResult(
@@ -762,6 +840,11 @@ class SshService {
         error: 'Host key verification failed: ${e.message}',
       );
     } on SSHAuthFailError catch (e) {
+      DiagnosticsLogService.instance.warning(
+        'ssh.connect',
+        'connect_failed',
+        fields: {'isJumpHost': isJumpHost, 'errorType': e.runtimeType},
+      );
       client?.close();
       _closeClients(dependentClients);
       return SshConnectionResult(
@@ -769,6 +852,11 @@ class SshService {
         error: 'Authentication failed: ${e.message}',
       );
     } on SocketException catch (e) {
+      DiagnosticsLogService.instance.warning(
+        'ssh.connect',
+        'connect_failed',
+        fields: {'isJumpHost': isJumpHost, 'errorType': e.runtimeType},
+      );
       client?.close();
       _closeClients(dependentClients);
       return SshConnectionResult(
@@ -776,6 +864,11 @@ class SshService {
         error: 'Connection failed: ${e.message}',
       );
     } on TimeoutException catch (e) {
+      DiagnosticsLogService.instance.warning(
+        'ssh.connect',
+        'connect_failed',
+        fields: {'isJumpHost': isJumpHost, 'errorType': e.runtimeType},
+      );
       client?.close();
       _closeClients(dependentClients);
       return SshConnectionResult(
@@ -783,6 +876,11 @@ class SshService {
         error: e.message ?? 'Connection timed out',
       );
     } on Exception catch (e) {
+      DiagnosticsLogService.instance.warning(
+        'ssh.connect',
+        'connect_failed',
+        fields: {'isJumpHost': isJumpHost, 'errorType': e.runtimeType},
+      );
       client?.close();
       _closeClients(dependentClients);
       return SshConnectionResult(success: false, error: 'Connection error: $e');
@@ -914,12 +1012,22 @@ class SshService {
 
   /// Disconnect a session by connection ID.
   Future<void> disconnect(int connectionId) async {
+    DiagnosticsLogService.instance.info(
+      'ssh.session',
+      'disconnect',
+      fields: {'connectionId': connectionId},
+    );
     final session = _sessions.remove(connectionId);
     await session?.close();
   }
 
   /// Disconnect all sessions.
   Future<void> disconnectAll() async {
+    DiagnosticsLogService.instance.info(
+      'ssh.session',
+      'disconnect_all',
+      fields: {'connectionCount': _sessions.length},
+    );
     for (final session in _sessions.values) {
       await session.close();
     }
@@ -1095,6 +1203,42 @@ class _PreparedHostKeySocket {
 
   final SSHSocket socket;
   final HostKeySource hostKeySource;
+}
+
+String _diagnosticSshResultErrorKind(String? error) {
+  if (error == null || error.isEmpty) {
+    return 'unknown';
+  }
+  if (error.startsWith('Authentication failed')) {
+    return 'authentication_failed';
+  }
+  if (error.startsWith('Host key verification failed')) {
+    return 'host_key_verification_failed';
+  }
+  if (error.startsWith('Connection failed')) {
+    return 'connection_failed';
+  }
+  if (error.contains('timed out')) {
+    return 'timeout';
+  }
+  return 'connection_error';
+}
+
+String _diagnosticSshCommandKind(String command) {
+  final trimmed = command.trimLeft();
+  if (trimmed.startsWith('tmux ') ||
+      trimmed.startsWith('tmux -u ') ||
+      trimmed.contains(' tmux ') ||
+      trimmed.contains('/tmux ')) {
+    return 'tmux';
+  }
+  if (trimmed.contains('command -v')) {
+    return 'command_detection';
+  }
+  if (trimmed.contains('__flutty_tmux_exec_done__')) {
+    return 'tmux_marked_exec';
+  }
+  return 'ssh_exec';
 }
 
 class _HostKeyCapturingSocket implements SSHSocket, HostKeySource {
@@ -1454,7 +1598,41 @@ class SshSession {
     if (forceNew) {
       await closeShell();
     }
-    _shell ??= await client.shell(pty: pty ?? const SSHPtyConfig());
+    if (_shell == null) {
+      DiagnosticsLogService.instance.info(
+        'ssh.shell',
+        'open_start',
+        fields: {
+          'connectionId': connectionId,
+          'hostId': hostId,
+          'requestedPty': pty != null,
+        },
+      );
+      try {
+        _shell = await client.shell(pty: pty ?? const SSHPtyConfig());
+        DiagnosticsLogService.instance.info(
+          'ssh.shell',
+          'open_success',
+          fields: {'connectionId': connectionId},
+        );
+      } on Object catch (error) {
+        DiagnosticsLogService.instance.error(
+          'ssh.shell',
+          'open_failed',
+          fields: {
+            'connectionId': connectionId,
+            'errorType': error.runtimeType,
+          },
+        );
+        rethrow;
+      }
+    } else {
+      DiagnosticsLogService.instance.debug(
+        'ssh.shell',
+        'reuse_existing',
+        fields: {'connectionId': connectionId},
+      );
+    }
     _ensureShellStreamPipes();
     return _shell!;
   }
@@ -1473,6 +1651,11 @@ class SshSession {
 
   /// Close only the interactive shell channel while keeping the SSH client.
   Future<void> closeShell() async {
+    DiagnosticsLogService.instance.info(
+      'ssh.shell',
+      'close_start',
+      fields: {'connectionId': connectionId, 'hadShell': _shell != null},
+    );
     _previewRefreshTimer?.cancel();
     _previewRefreshTimer = null;
     await _shellStdoutSubscription?.cancel();
@@ -1497,6 +1680,11 @@ class SshSession {
     _terminal = null;
     _terminalPreview = null;
     _windowTitle = null;
+    DiagnosticsLogService.instance.info(
+      'ssh.shell',
+      'close_complete',
+      fields: {'connectionId': connectionId},
+    );
   }
 
   void _ensureShellStreamPipes() {
@@ -1513,26 +1701,84 @@ class SshSession {
     _shellStdoutSubscription = shell.stdout
         .cast<List<int>>()
         .transform(utf8.decoder)
-        .listen((data) {
-          terminal.write(data);
-          _scheduleTerminalPreviewRefresh();
-          _shellStdoutController!.add(data);
-        }, onError: _shellStdoutController!.addError);
+        .listen(
+          (data) {
+            DiagnosticsLogService.instance.debug(
+              'ssh.shell',
+              'stdout_chunk',
+              fields: {'connectionId': connectionId, 'charCount': data.length},
+            );
+            terminal.write(data);
+            _scheduleTerminalPreviewRefresh();
+            _shellStdoutController!.add(data);
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            DiagnosticsLogService.instance.error(
+              'ssh.shell',
+              'stdout_error',
+              fields: {
+                'connectionId': connectionId,
+                'errorType': error.runtimeType,
+              },
+            );
+            _shellStdoutController!.addError(error, stackTrace);
+          },
+        );
     _shellStderrSubscription = shell.stderr
         .cast<List<int>>()
         .transform(utf8.decoder)
-        .listen((data) {
-          terminal.write(data);
-          _scheduleTerminalPreviewRefresh();
-          _shellStderrController!.add(data);
-        }, onError: _shellStderrController!.addError);
+        .listen(
+          (data) {
+            DiagnosticsLogService.instance.debug(
+              'ssh.shell',
+              'stderr_chunk',
+              fields: {'connectionId': connectionId, 'charCount': data.length},
+            );
+            terminal.write(data);
+            _scheduleTerminalPreviewRefresh();
+            _shellStderrController!.add(data);
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            DiagnosticsLogService.instance.error(
+              'ssh.shell',
+              'stderr_error',
+              fields: {
+                'connectionId': connectionId,
+                'errorType': error.runtimeType,
+              },
+            );
+            _shellStderrController!.addError(error, stackTrace);
+          },
+        );
     _shellDoneSubscription = shell.done.asStream().listen(
-      (_) => _shellDoneController!.add(null),
-      onError: _shellDoneController!.addError,
+      (_) {
+        DiagnosticsLogService.instance.info(
+          'ssh.shell',
+          'done',
+          fields: {'connectionId': connectionId},
+        );
+        _shellDoneController!.add(null);
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        DiagnosticsLogService.instance.error(
+          'ssh.shell',
+          'done_error',
+          fields: {
+            'connectionId': connectionId,
+            'errorType': error.runtimeType,
+          },
+        );
+        _shellDoneController!.addError(error, stackTrace);
+      },
     );
 
     // Wire terminal keyboard output → shell stdin (persistent).
     terminal.onOutput = (data) {
+      DiagnosticsLogService.instance.debug(
+        'ssh.shell',
+        'stdin_write',
+        fields: {'connectionId': connectionId, 'charCount': data.length},
+      );
       shell.write(utf8.encode(data));
     };
     _refreshTerminalPreview();
@@ -1556,6 +1802,15 @@ class SshSession {
       return;
     }
     _terminalPreview = nextPreview;
+    DiagnosticsLogService.instance.debug(
+      'ssh.preview',
+      'changed',
+      fields: {
+        'connectionId': connectionId,
+        'hasPreview': nextPreview != null,
+        'charCount': nextPreview?.length ?? 0,
+      },
+    );
     _notifyPreviewChanged();
   }
 
@@ -1565,6 +1820,14 @@ class SshSession {
       return;
     }
     _windowTitle = sanitizedTitle;
+    DiagnosticsLogService.instance.debug(
+      'ssh.metadata',
+      'window_title_changed',
+      fields: {
+        'connectionId': connectionId,
+        'hasTitle': sanitizedTitle != null,
+      },
+    );
     _notifyMetadataChanged();
   }
 
@@ -1574,6 +1837,14 @@ class SshSession {
       return;
     }
     _iconName = sanitizedIconName;
+    DiagnosticsLogService.instance.debug(
+      'ssh.metadata',
+      'icon_name_changed',
+      fields: {
+        'connectionId': connectionId,
+        'hasIcon': sanitizedIconName != null,
+      },
+    );
     _notifyMetadataChanged();
   }
 
@@ -1586,6 +1857,14 @@ class SshSession {
         return;
       }
       _workingDirectory = nextWorkingDirectory;
+      DiagnosticsLogService.instance.debug(
+        'ssh.metadata',
+        'working_directory_changed',
+        fields: {
+          'connectionId': connectionId,
+          'hasWorkingDirectory': nextWorkingDirectory != null,
+        },
+      );
       _notifyMetadataChanged();
       return;
     }
@@ -1607,6 +1886,15 @@ class SshSession {
       }
       _shellStatus = nextShellState.status;
       _lastExitCode = nextShellState.lastExitCode;
+      DiagnosticsLogService.instance.debug(
+        'ssh.metadata',
+        'shell_status_changed',
+        fields: {
+          'connectionId': connectionId,
+          'shellStatus': nextShellState.status,
+          'lastExitCode': nextShellState.lastExitCode,
+        },
+      );
       _notifyMetadataChanged();
     }
   }
@@ -1700,8 +1988,42 @@ class SshSession {
   }
 
   /// Execute a command.
-  Future<SSHSession> execute(String command, {SSHPtyConfig? pty}) =>
-      client.execute(command, pty: pty);
+  Future<SSHSession> execute(String command, {SSHPtyConfig? pty}) async {
+    DiagnosticsLogService.instance.debug(
+      'ssh.exec',
+      'open_start',
+      fields: {
+        'connectionId': connectionId,
+        'commandKind': _diagnosticSshCommandKind(command),
+        'pty': pty != null,
+      },
+    );
+    try {
+      final execSession = await client.execute(command, pty: pty);
+      DiagnosticsLogService.instance.debug(
+        'ssh.exec',
+        'open_success',
+        fields: {
+          'connectionId': connectionId,
+          'commandKind': _diagnosticSshCommandKind(command),
+          'pty': pty != null,
+        },
+      );
+      return execSession;
+    } on Object catch (error) {
+      DiagnosticsLogService.instance.error(
+        'ssh.exec',
+        'open_failed',
+        fields: {
+          'connectionId': connectionId,
+          'commandKind': _diagnosticSshCommandKind(command),
+          'pty': pty != null,
+          'errorType': error.runtimeType,
+        },
+      );
+      rethrow;
+    }
+  }
 
   /// Start an SFTP session.
   Future<SftpClient> sftp() => client.sftp();
@@ -2029,6 +2351,11 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
     if (!forceNew) {
       final existingConnectionId = getPreferredConnectionForHost(hostId);
       if (existingConnectionId != null) {
+        DiagnosticsLogService.instance.info(
+          'ssh.active',
+          'reuse_connection',
+          fields: {'hostId': hostId, 'connectionId': existingConnectionId},
+        );
         unawaited(_queueBackgroundStatusSync());
         return SshConnectionResult(
           success: true,
@@ -2079,11 +2406,26 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
       );
     }
 
+    DiagnosticsLogService.instance.info(
+      'ssh.active',
+      'connect_result',
+      fields: {
+        'hostId': hostId,
+        'success': result.success,
+        'connectionId': result.connectionId,
+        'errorType': _diagnosticSshResultErrorKind(result.error),
+      },
+    );
     return result;
   }
 
   /// Disconnect from a connection.
   Future<void> disconnect(int connectionId) async {
+    DiagnosticsLogService.instance.info(
+      'ssh.active',
+      'disconnect',
+      fields: {'connectionId': connectionId},
+    );
     _detachSessionListeners(connectionId);
     await _sshService.disconnect(connectionId);
     _connectionHostIds.remove(connectionId);
@@ -2094,6 +2436,11 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
 
   /// Disconnect all active sessions.
   Future<void> disconnectAll() async {
+    DiagnosticsLogService.instance.info(
+      'ssh.active',
+      'disconnect_all',
+      fields: {'connectionCount': _sshService.sessions.length},
+    );
     for (final session in _sshService.sessions.values) {
       _detachSessionListeners(session.connectionId, session: session);
     }
@@ -2289,6 +2636,11 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
       latestMessage: update.message,
       logLines: List.unmodifiable(nextLogLines),
     );
+    DiagnosticsLogService.instance.info(
+      'ssh.active',
+      'attempt_update',
+      fields: {'hostId': hostId, 'state': update.state},
+    );
     state = {...state};
   }
 
@@ -2311,9 +2663,19 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
     final hostId = _connectionHostIds[connectionId];
     final session = _sshService.getSession(connectionId);
     if (hostId == null && session == null && !state.containsKey(connectionId)) {
+      DiagnosticsLogService.instance.debug(
+        'ssh.active',
+        'unexpected_disconnect_ignored',
+        fields: {'connectionId': connectionId},
+      );
       return;
     }
 
+    DiagnosticsLogService.instance.warning(
+      'ssh.active',
+      'unexpected_disconnect',
+      fields: {'connectionId': connectionId, 'hostId': hostId},
+    );
     _detachSessionListeners(connectionId, session: session);
     await _sshService.disconnect(connectionId);
     _connectionHostIds.remove(connectionId);

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/agent_launch_preset.dart';
 import '../models/tmux_state.dart';
+import 'diagnostics_log_service.dart';
 import 'ssh_service.dart';
 
 /// Error thrown when a tmux command channel ends before confirming completion.
@@ -59,6 +60,16 @@ class TmuxService {
 
   /// Clears the cached tmux path for a connection.
   void clearCache(int connectionId) {
+    DiagnosticsLogService.instance.info(
+      'tmux.cache',
+      'clear',
+      fields: {
+        'connectionId': connectionId,
+        'observerCount': _windowObservers.keys
+            .where((key) => key.connectionId == connectionId)
+            .length,
+      },
+    );
     _tmuxPathCache.remove(connectionId);
     _profileSourceCache.remove(connectionId);
     _installedAgentToolsCache.remove(connectionId);
@@ -79,26 +90,69 @@ class TmuxService {
   /// variable, because SSH exec channels do not share the interactive
   /// shell's environment.
   Future<bool> isTmuxActive(SshSession session) async {
+    DiagnosticsLogService.instance.debug(
+      'tmux.detect',
+      'active_check_start',
+      fields: {'connectionId': session.connectionId},
+    );
     try {
       // Cache the tmux binary path on first successful detection.
       await _cacheTmuxPath(session);
       final output = await _exec(session, 'tmux list-sessions 2>/dev/null');
-      return output.trim().isNotEmpty;
-    } on Exception {
+      final active = output.trim().isNotEmpty;
+      DiagnosticsLogService.instance.info(
+        'tmux.detect',
+        'active_check_complete',
+        fields: {'connectionId': session.connectionId, 'active': active},
+      );
+      return active;
+    } on Exception catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'tmux.detect',
+        'active_check_failed',
+        fields: {
+          'connectionId': session.connectionId,
+          'errorType': error.runtimeType,
+        },
+      );
       return false;
     }
   }
 
   /// Returns `true` if tmux is installed on the remote host.
   Future<bool> isTmuxInstalled(SshSession session) async {
+    DiagnosticsLogService.instance.debug(
+      'tmux.detect',
+      'installed_check_start',
+      fields: {'connectionId': session.connectionId},
+    );
     try {
       final cachedTmuxPath = _tmuxPathCache[session.connectionId];
       if (cachedTmuxPath != null && cachedTmuxPath.isNotEmpty) {
+        DiagnosticsLogService.instance.info(
+          'tmux.detect',
+          'installed_check_cached',
+          fields: {'connectionId': session.connectionId},
+        );
         return true;
       }
       final output = await _exec(session, 'which tmux');
-      return output.trim().isNotEmpty;
-    } on Exception {
+      final installed = output.trim().isNotEmpty;
+      DiagnosticsLogService.instance.info(
+        'tmux.detect',
+        'installed_check_complete',
+        fields: {'connectionId': session.connectionId, 'installed': installed},
+      );
+      return installed;
+    } on Exception catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'tmux.detect',
+        'installed_check_failed',
+        fields: {
+          'connectionId': session.connectionId,
+          'errorType': error.runtimeType,
+        },
+      );
       return false;
     }
   }
@@ -123,17 +177,45 @@ class TmuxService {
     SshSession session,
   ) async {
     final cached = _installedAgentToolsCache[session.connectionId];
-    if (cached != null) return cached;
+    if (cached != null) {
+      DiagnosticsLogService.instance.info(
+        'tmux.agent',
+        'tool_detection_cached',
+        fields: {
+          'connectionId': session.connectionId,
+          'toolCount': cached.length,
+        },
+      );
+      return cached;
+    }
+    DiagnosticsLogService.instance.info(
+      'tmux.agent',
+      'tool_detection_start',
+      fields: {'connectionId': session.connectionId},
+    );
     final output = await _exec(session, buildAgentToolDetectionCommand());
     final installed = parseInstalledAgentTools(output);
     if (installed.isNotEmpty) {
       _installedAgentToolsCache[session.connectionId] = installed;
     }
+    DiagnosticsLogService.instance.info(
+      'tmux.agent',
+      'tool_detection_complete',
+      fields: {
+        'connectionId': session.connectionId,
+        'toolCount': installed.length,
+      },
+    );
     return installed;
   }
 
   /// Lists all tmux sessions on the remote host.
   Future<List<TmuxSession>> listSessions(SshSession session) async {
+    DiagnosticsLogService.instance.debug(
+      'tmux.query',
+      'list_sessions_start',
+      fields: {'connectionId': session.connectionId},
+    );
     try {
       final output = await _exec(
         session,
@@ -141,8 +223,25 @@ class TmuxService {
         "'#{session_name}|#{session_windows}|"
         "#{session_attached}|#{session_activity}'",
       );
-      return _parseLines(output, TmuxSession.fromTmuxFormat);
-    } on Exception {
+      final sessions = _parseLines(output, TmuxSession.fromTmuxFormat);
+      DiagnosticsLogService.instance.info(
+        'tmux.query',
+        'list_sessions_complete',
+        fields: {
+          'connectionId': session.connectionId,
+          'sessionCount': sessions.length,
+        },
+      );
+      return sessions;
+    } on Exception catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'tmux.query',
+        'list_sessions_failed',
+        fields: {
+          'connectionId': session.connectionId,
+          'errorType': error.runtimeType,
+        },
+      );
       return const [];
     }
   }
@@ -156,6 +255,11 @@ class TmuxService {
   /// the common case where the interactive shell is inside tmux but the
   /// exec channel is not.
   Future<String?> currentSessionName(SshSession session) async {
+    DiagnosticsLogService.instance.debug(
+      'tmux.query',
+      'current_session_start',
+      fields: {'connectionId': session.connectionId},
+    );
     try {
       // Direct approach — works if the exec channel is inside tmux.
       final output = await _exec(
@@ -163,8 +267,23 @@ class TmuxService {
         "tmux display-message -p '#{session_name}'",
       );
       final name = output.trim();
-      if (name.isNotEmpty) return name;
-    } on Exception {
+      if (name.isNotEmpty) {
+        DiagnosticsLogService.instance.info(
+          'tmux.query',
+          'current_session_direct',
+          fields: {'connectionId': session.connectionId},
+        );
+        return name;
+      }
+    } on Exception catch (error) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.query',
+        'current_session_direct_failed',
+        fields: {
+          'connectionId': session.connectionId,
+          'errorType': error.runtimeType,
+        },
+      );
       // Fall through to fallback.
     }
 
@@ -172,26 +291,68 @@ class TmuxService {
     try {
       final sessions = await listSessions(session);
       final attached = sessions.where((s) => s.isAttached).toList();
-      if (attached.length == 1) return attached.first.name;
+      if (attached.length == 1) {
+        DiagnosticsLogService.instance.info(
+          'tmux.query',
+          'current_session_attached_fallback',
+          fields: {'connectionId': session.connectionId},
+        );
+        return attached.first.name;
+      }
       // Multiple attached sessions are ambiguous — we can't determine
       // which one belongs to this terminal connection. Return null to
       // avoid targeting the wrong session with destructive operations.
+      DiagnosticsLogService.instance.info(
+        'tmux.query',
+        'current_session_ambiguous',
+        fields: {
+          'connectionId': session.connectionId,
+          'attachedCount': attached.length,
+        },
+      );
       return null;
-    } on Exception {
+    } on Exception catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'tmux.query',
+        'current_session_failed',
+        fields: {
+          'connectionId': session.connectionId,
+          'errorType': error.runtimeType,
+        },
+      );
       return null;
     }
   }
 
   /// Returns `true` if [sessionName] exists on the remote tmux server.
   Future<bool> hasSession(SshSession session, String sessionName) async {
+    DiagnosticsLogService.instance.debug(
+      'tmux.query',
+      'has_session_start',
+      fields: {'connectionId': session.connectionId},
+    );
     try {
       await _cacheTmuxPath(session);
       final output = await _exec(
         session,
         'tmux has-session -t ${_shellQuote(sessionName)} 2>/dev/null && printf 1',
       );
-      return output.trim() == '1';
-    } on Exception {
+      final exists = output.trim() == '1';
+      DiagnosticsLogService.instance.info(
+        'tmux.query',
+        'has_session_complete',
+        fields: {'connectionId': session.connectionId, 'exists': exists},
+      );
+      return exists;
+    } on Exception catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'tmux.query',
+        'has_session_failed',
+        fields: {
+          'connectionId': session.connectionId,
+          'errorType': error.runtimeType,
+        },
+      );
       return false;
     }
   }
@@ -203,6 +364,11 @@ class TmuxService {
     SshSession session,
     String sessionName,
   ) async {
+    DiagnosticsLogService.instance.debug(
+      'tmux.query',
+      'list_windows_start',
+      fields: {'connectionId': session.connectionId},
+    );
     final quotedName = _shellQuote(sessionName);
     final output = await _exec(
       session,
@@ -211,7 +377,18 @@ class TmuxService {
       '#{pane_current_command}|#{pane_current_path}|'
       "#{window_flags}|#{pane_title}|#{window_activity}'",
     );
-    return _parseLines(output, TmuxWindow.fromTmuxFormat);
+    final windows = _parseLines(output, TmuxWindow.fromTmuxFormat);
+    DiagnosticsLogService.instance.info(
+      'tmux.query',
+      'list_windows_complete',
+      fields: {
+        'connectionId': session.connectionId,
+        'windowCount': windows.length,
+        'activeWindowCount': windows.where((window) => window.isActive).length,
+        'alertWindowCount': windows.where((window) => window.hasAlert).length,
+      },
+    );
+    return windows;
   }
 
   /// Returns the active pane working directory for [sessionName], if tmux
@@ -220,14 +397,33 @@ class TmuxService {
     SshSession session,
     String sessionName,
   ) async {
+    DiagnosticsLogService.instance.debug(
+      'tmux.query',
+      'current_pane_path_start',
+      fields: {'connectionId': session.connectionId},
+    );
     try {
       final output = await _exec(
         session,
         'tmux display-message -p -t ${_shellQuote('$sessionName:')} '
         "'#{pane_current_path}'",
       );
-      return parseTmuxCurrentPanePath(output);
-    } on Exception {
+      final path = parseTmuxCurrentPanePath(output);
+      DiagnosticsLogService.instance.info(
+        'tmux.query',
+        'current_pane_path_complete',
+        fields: {'connectionId': session.connectionId, 'hasPath': path != null},
+      );
+      return path;
+    } on Exception catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'tmux.query',
+        'current_pane_path_failed',
+        fields: {
+          'connectionId': session.connectionId,
+          'errorType': error.runtimeType,
+        },
+      );
       return null;
     }
   }
@@ -241,14 +437,36 @@ class TmuxService {
     SshSession session,
     String sessionName,
   ) async {
+    DiagnosticsLogService.instance.debug(
+      'tmux.query',
+      'foreground_client_start',
+      fields: {'connectionId': session.connectionId},
+    );
     try {
       final output = await _exec(
         session,
         'tmux list-clients -t ${_shellQuote(sessionName)} '
         "-F '#{client_control_mode}' 2>/dev/null",
       );
-      return hasForegroundTmuxClient(output);
-    } on Exception {
+      final hasClient = hasForegroundTmuxClient(output);
+      DiagnosticsLogService.instance.info(
+        'tmux.query',
+        'foreground_client_complete',
+        fields: {
+          'connectionId': session.connectionId,
+          'hasForegroundClient': hasClient,
+        },
+      );
+      return hasClient;
+    } on Exception catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'tmux.query',
+        'foreground_client_failed',
+        fields: {
+          'connectionId': session.connectionId,
+          'errorType': error.runtimeType,
+        },
+      );
       return false;
     }
   }
@@ -272,6 +490,14 @@ class TmuxService {
         onDispose: () => _windowObservers.remove(key),
       ),
     );
+    DiagnosticsLogService.instance.info(
+      'tmux.watch',
+      'watch_requested',
+      fields: {
+        'connectionId': session.connectionId,
+        'observerCount': _windowObservers.length,
+      },
+    );
     return observer.stream;
   }
 
@@ -286,6 +512,16 @@ class TmuxService {
     String? name,
     String? workingDirectory,
   }) async {
+    DiagnosticsLogService.instance.info(
+      'tmux.action',
+      'create_window_start',
+      fields: {
+        'connectionId': session.connectionId,
+        'hasCommand': command?.trim().isNotEmpty ?? false,
+        'hasName': name?.trim().isNotEmpty ?? false,
+        'hasWorkingDirectory': workingDirectory?.trim().isNotEmpty ?? false,
+      },
+    );
     // Don't pass -c unless an explicit workingDirectory was provided
     // (e.g. resuming an AI session in a specific project). Without -c,
     // tmux uses the session's default-directory — matching Ctrl+b,c.
@@ -297,6 +533,11 @@ class TmuxService {
         '-n ${_shellQuote(name.trim())}',
     ];
     await _exec(session, parts.join(' '));
+    DiagnosticsLogService.instance.info(
+      'tmux.action',
+      'create_window_complete',
+      fields: {'connectionId': session.connectionId},
+    );
 
     // If a command was requested, type it into the new window's shell.
     // This ensures the command runs inside the login shell environment
@@ -306,6 +547,11 @@ class TmuxService {
         session,
         'tmux send-keys -t ${_shellQuote(sessionName)} '
         '${_shellQuote(command.trim())} Enter',
+      );
+      DiagnosticsLogService.instance.info(
+        'tmux.action',
+        'create_window_command_sent',
+        fields: {'connectionId': session.connectionId},
       );
     }
   }
@@ -324,9 +570,25 @@ class TmuxService {
     String sessionName,
     int windowIndex,
   ) async {
+    DiagnosticsLogService.instance.info(
+      'tmux.action',
+      'select_window_start',
+      fields: {
+        'connectionId': session.connectionId,
+        'windowIndex': windowIndex,
+      },
+    );
     await _exec(
       session,
       'tmux select-window -t ${_shellQuote(sessionName)}:$windowIndex',
+    );
+    DiagnosticsLogService.instance.info(
+      'tmux.action',
+      'select_window_complete',
+      fields: {
+        'connectionId': session.connectionId,
+        'windowIndex': windowIndex,
+      },
     );
   }
 
@@ -336,9 +598,25 @@ class TmuxService {
     String sessionName,
     int windowIndex,
   ) async {
+    DiagnosticsLogService.instance.info(
+      'tmux.action',
+      'kill_window_start',
+      fields: {
+        'connectionId': session.connectionId,
+        'windowIndex': windowIndex,
+      },
+    );
     await _exec(
       session,
       'tmux kill-window -t ${_shellQuote(sessionName)}:$windowIndex',
+    );
+    DiagnosticsLogService.instance.info(
+      'tmux.action',
+      'kill_window_complete',
+      fields: {
+        'connectionId': session.connectionId,
+        'windowIndex': windowIndex,
+      },
     );
   }
 
@@ -386,10 +664,29 @@ class TmuxService {
     String command, {
     SSHPtyConfig? pty,
   }) {
+    DiagnosticsLogService.instance.debug(
+      'tmux.exec',
+      'open_start',
+      fields: {
+        'connectionId': session.connectionId,
+        'commandKind': _diagnosticTmuxCommandKind(command),
+        'pty': pty != null,
+      },
+    );
     final openFuture = session.execute(command, pty: pty);
     return openFuture.timeout(
       _execOpenTimeout,
       onTimeout: () {
+        DiagnosticsLogService.instance.warning(
+          'tmux.exec',
+          'open_timeout',
+          fields: {
+            'connectionId': session.connectionId,
+            'commandKind': _diagnosticTmuxCommandKind(command),
+            'timeoutMs': _execOpenTimeout.inMilliseconds,
+            'pty': pty != null,
+          },
+        );
         openFuture.then((exec) => exec.close()).ignore();
         throw TimeoutException(
           'Timed out opening SSH exec channel',
@@ -409,6 +706,7 @@ class TmuxService {
   /// command exits, so waiting for stream completion can turn successful tmux
   /// actions into apparent hangs.
   Future<String> _exec(SshSession session, String command) async {
+    final startedAt = DateTime.now();
     final wrappedCommand = _wrapCommand(session, command);
     final execSession = await _openExec(
       session,
@@ -416,7 +714,34 @@ class TmuxService {
     );
     try {
       execSession.stderr.drain<void>().ignore();
-      return await _readStdoutUntilDoneMarker(execSession);
+      final output = await _readStdoutUntilDoneMarker(
+        execSession,
+        connectionId: session.connectionId,
+        commandKind: _diagnosticTmuxCommandKind(command),
+      );
+      DiagnosticsLogService.instance.debug(
+        'tmux.exec',
+        'complete',
+        fields: {
+          'connectionId': session.connectionId,
+          'commandKind': _diagnosticTmuxCommandKind(command),
+          'durationMs': DateTime.now().difference(startedAt).inMilliseconds,
+          'outputChars': output.length,
+        },
+      );
+      return output;
+    } on Object catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'tmux.exec',
+        'failed',
+        fields: {
+          'connectionId': session.connectionId,
+          'commandKind': _diagnosticTmuxCommandKind(command),
+          'durationMs': DateTime.now().difference(startedAt).inMilliseconds,
+          'errorType': error.runtimeType,
+        },
+      );
+      rethrow;
     } finally {
       execSession.close();
     }
@@ -427,13 +752,26 @@ class TmuxService {
       'printf ${_shellQuote('\n$_execDoneMarker:%s\n')} '
       r'"$__flutty_tmux_exec_status__"; }';
 
-  Future<String> _readStdoutUntilDoneMarker(SSHSession execSession) async {
+  Future<String> _readStdoutUntilDoneMarker(
+    SSHSession execSession, {
+    required int connectionId,
+    required String commandKind,
+  }) async {
     final output = StringBuffer();
     await for (final chunk
         in execSession.stdout
             .cast<List<int>>()
             .transform(utf8.decoder)
             .timeout(_execOutputTimeout)) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.exec',
+        'stdout_chunk',
+        fields: {
+          'connectionId': connectionId,
+          'commandKind': commandKind,
+          'charCount': chunk.length,
+        },
+      );
       output.write(chunk);
       final currentOutput = output.toString();
       RegExpMatch? markerMatch;
@@ -446,6 +784,15 @@ class TmuxService {
         final statusText = markerMatch.group(1)!;
         final exitStatus = int.parse(statusText);
         if (exitStatus != 0) {
+          DiagnosticsLogService.instance.warning(
+            'tmux.exec',
+            'nonzero_status',
+            fields: {
+              'connectionId': connectionId,
+              'commandKind': commandKind,
+              'exitStatus': exitStatus,
+            },
+          );
           throw TmuxCommandException(
             'tmux command failed with exit status $statusText',
           );
@@ -453,6 +800,11 @@ class TmuxService {
         return currentOutput.substring(0, markerMatch.start).trimRight();
       }
     }
+    DiagnosticsLogService.instance.warning(
+      'tmux.exec',
+      'closed_before_marker',
+      fields: {'connectionId': connectionId, 'commandKind': commandKind},
+    );
     throw const TmuxCommandException(
       'SSH exec channel closed before tmux command completed',
     );
@@ -465,12 +817,33 @@ class TmuxService {
   /// latency of draining stdout/stderr.
   void _execFireAndForget(SshSession session, String command) {
     final wrappedCommand = _wrapCommand(session, command);
+    DiagnosticsLogService.instance.debug(
+      'tmux.exec',
+      'fire_and_forget_start',
+      fields: {
+        'connectionId': session.connectionId,
+        'commandKind': _diagnosticTmuxCommandKind(command),
+      },
+    );
     // Launch and ignore — the exec channel self-closes on completion.
-    _openExec(session, wrappedCommand).then((exec) {
-      // Drain streams to prevent backpressure, but don't wait.
-      exec.stdout.drain<void>().ignore();
-      exec.stderr.drain<void>().ignore();
-    }).ignore();
+    _openExec(session, wrappedCommand)
+        .then((exec) {
+          // Drain streams to prevent backpressure, but don't wait.
+          exec.stdout.drain<void>().ignore();
+          exec.stderr.drain<void>().ignore();
+        })
+        .catchError((Object error) {
+          DiagnosticsLogService.instance.warning(
+            'tmux.exec',
+            'fire_and_forget_failed',
+            fields: {
+              'connectionId': session.connectionId,
+              'commandKind': _diagnosticTmuxCommandKind(command),
+              'errorType': error.runtimeType,
+            },
+          );
+        })
+        .ignore();
   }
 
   /// Detects the user's login shell and resolves the tmux binary path.
@@ -479,6 +852,11 @@ class TmuxService {
   /// full tmux path for subsequent calls.
   Future<void> _cacheTmuxPath(SshSession session) async {
     if (_tmuxPathCache.containsKey(session.connectionId)) return;
+    DiagnosticsLogService.instance.debug(
+      'tmux.cache',
+      'tmux_path_start',
+      fields: {'connectionId': session.connectionId},
+    );
     try {
       // Detect login shell and resolve tmux path in a single exec.
       // Redirect stdout from profile scripts to /dev/null so greetings,
@@ -509,7 +887,24 @@ class TmuxService {
           _tmuxPathCache[session.connectionId] = path;
         }
       }
-    } on Object {
+      DiagnosticsLogService.instance.info(
+        'tmux.cache',
+        'tmux_path_complete',
+        fields: {
+          'connectionId': session.connectionId,
+          'hasPath': _tmuxPathCache.containsKey(session.connectionId),
+          'hasProfile': _profileSourceCache.containsKey(session.connectionId),
+        },
+      );
+    } on Object catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'tmux.cache',
+        'tmux_path_failed',
+        fields: {
+          'connectionId': session.connectionId,
+          'errorType': error.runtimeType,
+        },
+      );
       // Ignore — we'll fall back to sourcing all profiles.
     }
   }
@@ -532,6 +927,49 @@ class TmuxService {
   /// Single-quotes a value for safe use in shell commands.
   static String _shellQuote(String value) =>
       "'${value.replaceAll("'", "'\"'\"'")}'";
+}
+
+String _diagnosticTmuxCommandKind(String command) {
+  if (command.contains('attach-session')) {
+    return 'control_attach';
+  }
+  if (command.contains('refresh-client')) {
+    return 'control_subscription';
+  }
+  if (command.contains('list-windows')) {
+    return 'list_windows';
+  }
+  if (command.contains('list-sessions')) {
+    return 'list_sessions';
+  }
+  if (command.contains('display-message')) {
+    return 'display_message';
+  }
+  if (command.contains('has-session')) {
+    return 'has_session';
+  }
+  if (command.contains('list-clients')) {
+    return 'list_clients';
+  }
+  if (command.contains('select-window')) {
+    return 'select_window';
+  }
+  if (command.contains('new-window')) {
+    return 'new_window';
+  }
+  if (command.contains('kill-window')) {
+    return 'kill_window';
+  }
+  if (command.contains('send-keys')) {
+    return 'send_keys';
+  }
+  if (command.contains('command -v')) {
+    return 'tool_detection';
+  }
+  if (command.contains('which tmux')) {
+    return 'which_tmux';
+  }
+  return 'tmux_exec';
 }
 
 /// Parses the current pane path reported by `tmux display-message`.
@@ -581,6 +1019,20 @@ String _normalizeTmuxControlLine(String line) {
   normalized = normalized.replaceFirst(RegExp(r'^\u001bP\d+p'), '');
   normalized = normalized.replaceFirst(RegExp(r'\u001b\\$'), '');
   return normalized.trim();
+}
+
+/// Returns a safe category for a tmux control-mode line without exposing the
+/// raw line contents.
+@visibleForTesting
+String diagnosticTmuxControlLineKind(String line) {
+  final trimmed = _normalizeTmuxControlLine(line);
+  if (trimmed.isEmpty) return 'empty';
+  final separator = trimmed.indexOf(' ');
+  final marker = separator == -1 ? trimmed : trimmed.substring(0, separator);
+  if (marker.startsWith('%')) {
+    return marker.substring(1).replaceAll('-', '_');
+  }
+  return 'other';
 }
 
 /// Returns whether [line] should trigger a debounced reload fallback when a
@@ -782,6 +1234,14 @@ class _TmuxWindowChangeObserver {
   Future<void> _ensureStarted() async {
     if (_disposed || _starting || _controlSession != null) return;
     _starting = true;
+    DiagnosticsLogService.instance.info(
+      'tmux.watch',
+      'start',
+      fields: {
+        'connectionId': session.connectionId,
+        'restartAttempts': _restartAttempts,
+      },
+    );
     try {
       await service._cacheTmuxPath(session);
       final execSession = await service._openExec(
@@ -819,6 +1279,11 @@ class _TmuxWindowChangeObserver {
       _restartAttempts = 0;
       _lastControlActivity = _now();
       _startHeartbeat();
+      DiagnosticsLogService.instance.info(
+        'tmux.watch',
+        'started',
+        fields: {'connectionId': session.connectionId},
+      );
     } on Object catch (error, stackTrace) {
       _handleControlFailure(error, stackTrace);
     } finally {
@@ -829,6 +1294,11 @@ class _TmuxWindowChangeObserver {
   void _configureControlSession() {
     final controlSession = _controlSession;
     if (controlSession == null) return;
+    DiagnosticsLogService.instance.debug(
+      'tmux.watch',
+      'subscribe',
+      fields: {'connectionId': session.connectionId},
+    );
     controlSession.write(
       utf8.encode('${buildTmuxWindowSubscriptionCommand(_subscriptionName)}\n'),
     );
@@ -839,6 +1309,11 @@ class _TmuxWindowChangeObserver {
     _lastControlActivity = _now();
     final trimmed = _normalizeTmuxControlLine(line);
     if (trimmed.startsWith('%exit')) {
+      DiagnosticsLogService.instance.info(
+        'tmux.watch',
+        'control_exit',
+        fields: {'connectionId': session.connectionId},
+      );
       _handleControlClosed();
       return;
     }
@@ -851,6 +1326,14 @@ class _TmuxWindowChangeObserver {
         trimmed,
         subscriptionName: _subscriptionName,
       )) {
+        DiagnosticsLogService.instance.debug(
+          'tmux.watch',
+          'fallback_reload_signal',
+          fields: {
+            'connectionId': session.connectionId,
+            'lineKind': diagnosticTmuxControlLineKind(trimmed),
+          },
+        );
         _scheduleReloadEvent(
           preserveThroughSnapshots:
               shouldPreserveTmuxWindowReloadThroughSnapshots(trimmed),
@@ -862,9 +1345,22 @@ class _TmuxWindowChangeObserver {
       if (!_preserveScheduledReloadThroughSnapshots) {
         _cancelScheduledReload();
       }
+      DiagnosticsLogService.instance.debug(
+        'tmux.watch',
+        'snapshot_event',
+        fields: {'connectionId': session.connectionId},
+      );
       _emitEvent(event);
       return;
     }
+    DiagnosticsLogService.instance.debug(
+      'tmux.watch',
+      'reload_event',
+      fields: {
+        'connectionId': session.connectionId,
+        'lineKind': diagnosticTmuxControlLineKind(trimmed),
+      },
+    );
     _scheduleReloadEvent(
       preserveThroughSnapshots: shouldPreserveTmuxWindowReloadThroughSnapshots(
         trimmed,
@@ -875,6 +1371,11 @@ class _TmuxWindowChangeObserver {
   void _handleStderrLine(String line) {
     if (_disposed || line.trim().isEmpty) return;
     _lastControlActivity = _now();
+    DiagnosticsLogService.instance.warning(
+      'tmux.watch',
+      'stderr_line',
+      fields: {'connectionId': session.connectionId, 'charCount': line.length},
+    );
     _scheduleRestart();
   }
 
@@ -898,16 +1399,34 @@ class _TmuxWindowChangeObserver {
       _debounceTimer = null;
       _preserveScheduledReloadThroughSnapshots = false;
       if (!_disposed && !_controller.isClosed) {
+        DiagnosticsLogService.instance.debug(
+          'tmux.watch',
+          'emit_scheduled_reload',
+          fields: {'connectionId': session.connectionId},
+        );
         _controller.add(const TmuxWindowReloadEvent());
       }
     });
   }
 
   void _handleControlFailure(Object error, StackTrace stackTrace) {
+    DiagnosticsLogService.instance.warning(
+      'tmux.watch',
+      'control_failure',
+      fields: {
+        'connectionId': session.connectionId,
+        'errorType': error.runtimeType,
+      },
+    );
     _scheduleRestart();
   }
 
   void _handleControlClosed() {
+    DiagnosticsLogService.instance.info(
+      'tmux.watch',
+      'control_closed',
+      fields: {'connectionId': session.connectionId},
+    );
     _cleanupControlSession();
     _scheduleRestart();
   }
@@ -919,6 +1438,15 @@ class _TmuxWindowChangeObserver {
     final cappedAttempt = _restartAttempts.clamp(0, 4);
     final delay = Duration(seconds: 1 << cappedAttempt);
     _restartAttempts += 1;
+    DiagnosticsLogService.instance.warning(
+      'tmux.watch',
+      'restart_scheduled',
+      fields: {
+        'connectionId': session.connectionId,
+        'attempt': _restartAttempts,
+        'delayMs': delay.inMilliseconds,
+      },
+    );
     _restartTimer = Timer(delay, () => unawaited(_ensureStarted()));
   }
 
@@ -955,9 +1483,25 @@ class _TmuxWindowChangeObserver {
       case TmuxControlHeartbeatAction.noop:
         return;
       case TmuxControlHeartbeatAction.refresh:
+        DiagnosticsLogService.instance.debug(
+          'tmux.watch',
+          'heartbeat_refresh',
+          fields: {
+            'connectionId': session.connectionId,
+            'silenceMs': _now().difference(lastActivity).inMilliseconds,
+          },
+        );
         _scheduleReloadEvent();
         return;
       case TmuxControlHeartbeatAction.restart:
+        DiagnosticsLogService.instance.warning(
+          'tmux.watch',
+          'heartbeat_restart',
+          fields: {
+            'connectionId': session.connectionId,
+            'silenceMs': _now().difference(lastActivity).inMilliseconds,
+          },
+        );
         _handleControlClosed();
         return;
     }
@@ -979,6 +1523,11 @@ class _TmuxWindowChangeObserver {
 
   Future<void> dispose() async {
     if (_disposed) return;
+    DiagnosticsLogService.instance.info(
+      'tmux.watch',
+      'dispose',
+      fields: {'connectionId': session.connectionId},
+    );
     _disposed = true;
     _stopHeartbeat();
     _restartTimer?.cancel();

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -12,6 +12,7 @@ import '../../domain/models/monetization.dart';
 import '../../domain/models/terminal_themes.dart';
 import '../../domain/services/auth_service.dart';
 import '../../domain/services/background_ssh_service.dart';
+import '../../domain/services/diagnostics_log_service.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/secure_transfer_service.dart';
 import '../../domain/services/settings_service.dart';
@@ -41,6 +42,7 @@ class SettingsScreen extends ConsumerWidget {
         const _ImportExportSection(),
         if (BackgroundSshService.supportsBatteryOptimizationControls)
           const _AndroidBackgroundSection(),
+        if (isPreviewBuild) const _DiagnosticsSection(),
         const _AboutSection(),
       ],
     ),
@@ -983,6 +985,92 @@ class _TerminalSection extends ConsumerWidget {
         ),
       ),
     );
+  }
+}
+
+class _DiagnosticsSection extends ConsumerStatefulWidget {
+  const _DiagnosticsSection();
+
+  @override
+  ConsumerState<_DiagnosticsSection> createState() =>
+      _DiagnosticsSectionState();
+}
+
+class _DiagnosticsSectionState extends ConsumerState<_DiagnosticsSection> {
+  late final DiagnosticsLogService _diagnosticsLog;
+
+  @override
+  void initState() {
+    super.initState();
+    _diagnosticsLog = ref.read(diagnosticsLogServiceProvider)
+      ..addListener(_handleDiagnosticsChanged);
+  }
+
+  @override
+  void dispose() {
+    _diagnosticsLog.removeListener(_handleDiagnosticsChanged);
+    super.dispose();
+  }
+
+  void _handleDiagnosticsChanged() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appMetadata = ref.watch(appMetadataProvider).asData?.value;
+    final entryCount = _diagnosticsLog.entryCount;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _SectionHeader(
+          title: 'Diagnostics',
+          subtitle: 'Preview-only troubleshooting logs',
+        ),
+        ListTile(
+          leading: const Icon(Icons.bug_report_outlined),
+          title: const Text('Copy diagnostics log'),
+          subtitle: Text(
+            entryCount == 0
+                ? 'No diagnostic events recorded yet'
+                : '$entryCount sanitized event${entryCount == 1 ? '' : 's'} ready to copy',
+          ),
+          onTap: entryCount == 0
+              ? null
+              : () => _copyDiagnostics(context, appMetadata),
+        ),
+        ListTile(
+          leading: const Icon(Icons.delete_outline),
+          title: const Text('Clear diagnostics log'),
+          subtitle: const Text('Remove the in-memory troubleshooting log'),
+          enabled: entryCount > 0,
+          onTap: entryCount == 0 ? null : () => _clearDiagnostics(context),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _copyDiagnostics(
+    BuildContext context,
+    AppMetadata? appMetadata,
+  ) async {
+    final text = _diagnosticsLog.exportText(appMetadata: appMetadata);
+    await Clipboard.setData(ClipboardData(text: text));
+    if (!context.mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('Diagnostics log copied')));
+  }
+
+  void _clearDiagnostics(BuildContext context) {
+    _diagnosticsLog.clear();
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('Diagnostics log cleared')));
   }
 }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -31,6 +31,7 @@ import '../../domain/models/terminal_themes.dart';
 import '../../domain/models/tmux_state.dart';
 import '../../domain/services/agent_launch_preset_service.dart';
 import '../../domain/services/agent_session_discovery_service.dart';
+import '../../domain/services/diagnostics_log_service.dart';
 import '../../domain/services/host_cli_launch_preferences_service.dart';
 import '../../domain/services/local_notification_service.dart';
 import '../../domain/services/monetization_service.dart';
@@ -607,6 +608,14 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
 
   void _subscribeToWindowChanges() {
     final generation = ++_windowEventGeneration;
+    DiagnosticsLogService.instance.info(
+      'tmux.ui',
+      'bar_subscribe',
+      fields: {
+        'connectionId': widget.session.connectionId,
+        'generation': generation,
+      },
+    );
     _windowChangeSubscription = _tmux
         .watchWindowChanges(widget.session, widget.tmuxSessionName)
         .listen((event) => _handleWindowChangeEvent(event, generation));
@@ -616,17 +625,38 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     if (!mounted) return;
     if (generation != _windowEventGeneration) return;
     if (event is TmuxWindowReloadEvent) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.ui',
+        'bar_reload_event',
+        fields: {
+          'connectionId': widget.session.connectionId,
+          'generation': generation,
+        },
+      );
       _loadWindows();
       return;
     }
     final currentWindows = _windows;
     if (currentWindows == null) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.ui',
+        'bar_snapshot_without_state',
+        fields: {'connectionId': widget.session.connectionId},
+      );
       _loadWindows();
       return;
     }
     _windowReloadGeneration += 1;
     _resetWindowReloadRecovery();
     final windows = applyTmuxWindowChangeEvent(currentWindows, event);
+    DiagnosticsLogService.instance.debug(
+      'tmux.ui',
+      'bar_snapshot_applied',
+      fields: {
+        'connectionId': widget.session.connectionId,
+        'windowCount': windows.length,
+      },
+    );
     _applyWindows(windows);
     if (widget.isProUser) {
       unawaited(_prefetchPreferredSessionProvider(windows: windows));
@@ -724,6 +754,15 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     }
     final delay = resolveTmuxWindowReloadRetryDelay(_windowRetryAttempts);
     _windowRetryAttempts += 1;
+    DiagnosticsLogService.instance.warning(
+      'tmux.ui',
+      'bar_retry_scheduled',
+      fields: {
+        'connectionId': widget.session.connectionId,
+        'attempt': _windowRetryAttempts,
+        'delayMs': delay.inMilliseconds,
+      },
+    );
     _windowRetryTimer = Timer(delay, () {
       _windowRetryTimer = null;
       if (mounted) {
@@ -740,6 +779,11 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       return;
     }
     _windowReloadRecoveryRequested = true;
+    DiagnosticsLogService.instance.warning(
+      'tmux.ui',
+      'bar_recovery_requested',
+      fields: {'connectionId': widget.session.connectionId},
+    );
     final onWindowLoadStalled = widget.onWindowLoadStalled;
     if (onWindowLoadStalled != null) {
       unawaited(onWindowLoadStalled(widget.session, widget.tmuxSessionName));
@@ -788,10 +832,23 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   Future<void> _loadWindows() async {
     if (_loadingWindows) {
       _pendingWindowReload = true;
+      DiagnosticsLogService.instance.debug(
+        'tmux.ui',
+        'bar_reload_queued',
+        fields: {'connectionId': widget.session.connectionId},
+      );
       return;
     }
     _loadingWindows = true;
     final reloadGeneration = ++_windowReloadGeneration;
+    DiagnosticsLogService.instance.debug(
+      'tmux.ui',
+      'bar_reload_start',
+      fields: {
+        'connectionId': widget.session.connectionId,
+        'generation': reloadGeneration,
+      },
+    );
     try {
       final reloadedWindows = await _tmux.listWindows(
         widget.session,
@@ -805,6 +862,16 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       } else {
         _resetWindowReloadRecovery();
       }
+      DiagnosticsLogService.instance.info(
+        'tmux.ui',
+        'bar_reload_result',
+        fields: {
+          'connectionId': widget.session.connectionId,
+          'generation': reloadGeneration,
+          'windowCount': reloadedWindows.length,
+          'consecutiveEmptyReloads': _consecutiveEmptyWindowReloads,
+        },
+      );
       final windows = resolveTmuxReloadedWindows(
         shouldPreserveTmuxWindowSnapshotOnEmptyReload(
               _windows,
@@ -815,6 +882,14 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         reloadedWindows,
       );
       if (windows == null) {
+        DiagnosticsLogService.instance.warning(
+          'tmux.ui',
+          'bar_reload_preserved_previous',
+          fields: {
+            'connectionId': widget.session.connectionId,
+            'generation': reloadGeneration,
+          },
+        );
         final shouldRecover = _shouldRequestWindowReloadRecovery;
         _scheduleWindowRetry();
         if (shouldRecover) {
@@ -844,7 +919,16 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       if (widget.isProUser) {
         unawaited(_prefetchPreferredSessionProvider(windows: windows));
       }
-    } on Object {
+    } on Object catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'tmux.ui',
+        'bar_reload_failed',
+        fields: {
+          'connectionId': widget.session.connectionId,
+          'generation': reloadGeneration,
+          'errorType': error.runtimeType,
+        },
+      );
       if (!mounted) return;
       final shouldRecover = _shouldRequestWindowReloadRecovery;
       _scheduleWindowRetry();
@@ -3880,6 +3964,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           height: _terminal.viewHeight,
         ),
       );
+      DiagnosticsLogService.instance.info(
+        'terminal',
+        'shell_opened',
+        fields: {'connectionId': session.connectionId, 'reusedTerminal': false},
+      );
 
       _wireTerminalCallbacks(session);
       await _applySharedClipboardSetting(
@@ -3907,6 +3996,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       // command launches a tmux session.
       unawaited(_detectTmux(session));
     } on Object catch (e) {
+      DiagnosticsLogService.instance.error(
+        'terminal',
+        'shell_open_failed',
+        fields: {
+          'connectionId': session.connectionId,
+          'errorType': e.runtimeType,
+        },
+      );
       if (!mounted) return;
       setState(() {
         _isConnecting = false;
@@ -3919,6 +4016,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   void _wireTerminalCallbacks(SshSession session) {
     // Listen for shell close events.
     _doneSubscription = session.shellDoneStream.listen((_) {
+      DiagnosticsLogService.instance.warning(
+        'terminal',
+        'shell_done_stream',
+        fields: {'connectionId': session.connectionId},
+      );
       if (mounted) {
         _handleShellClosed();
       }
@@ -3928,6 +4030,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       onError: (Object error, StackTrace stackTrace) {
         debugPrint('Terminal stdout stream error: $error');
         debugPrint('$stackTrace');
+        DiagnosticsLogService.instance.error(
+          'terminal',
+          'stdout_listener_error',
+          fields: {
+            'connectionId': session.connectionId,
+            'errorType': error.runtimeType,
+          },
+        );
       },
     );
 
@@ -4304,6 +4414,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         final active = candidateSessionName != null
             ? await tmux.hasSession(session, candidateSessionName)
             : await tmux.isTmuxActive(session);
+        DiagnosticsLogService.instance.debug(
+          'tmux.ui',
+          'detection_attempt',
+          fields: {
+            'connectionId': session.connectionId,
+            'active': active,
+            'hasCandidate': candidateSessionName != null,
+          },
+        );
         if (!mounted ||
             _connectionId != capturedConnectionId ||
             detectionGeneration != _tmuxDetectionGeneration) {
@@ -4321,6 +4440,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           return;
         }
         if (sessionName == null) {
+          DiagnosticsLogService.instance.debug(
+            'tmux.ui',
+            'detection_no_session_name',
+            fields: {'connectionId': session.connectionId},
+          );
           continue;
         }
 
@@ -4336,6 +4460,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           return;
         }
         if (windows.isEmpty) {
+          DiagnosticsLogService.instance.debug(
+            'tmux.ui',
+            'detection_empty_windows',
+            fields: {'connectionId': session.connectionId},
+          );
           continue;
         }
 
@@ -4362,6 +4491,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _tmuxLaunchWorkingDirectory = tmuxLaunchCwd;
           _tmuxWorkingDirectory = tmuxCwd;
         });
+        DiagnosticsLogService.instance.info(
+          'tmux.ui',
+          'detection_success',
+          fields: {
+            'connectionId': session.connectionId,
+            'windowCount': windows.length,
+          },
+        );
         await _activateInitialTmuxWindowIfNeeded(session, sessionName, windows);
         return;
       }
@@ -4375,7 +4512,20 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       if (!preserveExistingTmuxState) {
         setState(_clearTmuxState);
       }
-    } on Object {
+      DiagnosticsLogService.instance.info(
+        'tmux.ui',
+        'detection_inactive',
+        fields: {'connectionId': session.connectionId},
+      );
+    } on Object catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'tmux.ui',
+        'detection_failed',
+        fields: {
+          'connectionId': session.connectionId,
+          'errorType': error.runtimeType,
+        },
+      );
       if (!mounted ||
           _connectionId != capturedConnectionId ||
           detectionGeneration != _tmuxDetectionGeneration) {
@@ -4579,6 +4729,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final session = _sessionsNotifier?.getSession(connectionId);
     if (session == null) return;
 
+    DiagnosticsLogService.instance.info(
+      'tmux.ui',
+      'navigator_action',
+      fields: {
+        'connectionId': connectionId,
+        'action': diagnosticTmuxNavigatorActionKind(action),
+      },
+    );
     await _performTmuxNavigatorAction(session, action);
   }
 
@@ -4661,6 +4819,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           await _closeTmuxWindow(session, windowIndex);
       }
     } on Exception catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'tmux.ui',
+        'navigator_action_failed',
+        fields: {
+          'connectionId': session.connectionId,
+          'action': diagnosticTmuxNavigatorActionKind(action),
+          'errorType': error.runtimeType,
+        },
+      );
       _showTmuxActionFailure(error);
     }
   }
@@ -4759,6 +4926,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       sessionName,
     );
     if (!mounted || hasForegroundClient) {
+      DiagnosticsLogService.instance.info(
+        'tmux.ui',
+        'reattach_not_needed',
+        fields: {
+          'connectionId': session.connectionId,
+          'hasForegroundClient': hasForegroundClient,
+        },
+      );
       return;
     }
 
@@ -4773,6 +4948,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             'while a command is still running.',
           ),
         ),
+      );
+      DiagnosticsLogService.instance.warning(
+        'tmux.ui',
+        'reattach_skipped_command_running',
+        fields: {'connectionId': session.connectionId},
       );
       return;
     }
@@ -4789,6 +4969,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       extraFlags: host?.tmuxExtraFlags,
     );
     shell.write(utf8.encode(formatAutoConnectCommandForShell(reattachCommand)));
+    DiagnosticsLogService.instance.info(
+      'tmux.ui',
+      'reattach_command_sent',
+      fields: {'connectionId': session.connectionId},
+    );
   }
 
   void _handleTrackedConnectionStateChange(

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -8,6 +8,7 @@ import '../../domain/models/agent_launch_preset.dart';
 import '../../domain/models/tmux_state.dart';
 import '../../domain/services/agent_launch_preset_service.dart';
 import '../../domain/services/agent_session_discovery_service.dart';
+import '../../domain/services/diagnostics_log_service.dart';
 import '../../domain/services/ssh_service.dart';
 import '../../domain/services/tmux_service.dart';
 import 'agent_tool_icon.dart';
@@ -116,6 +117,15 @@ class TmuxCloseWindowAction extends TmuxNavigatorAction {
   final int windowIndex;
 }
 
+/// Returns a safe diagnostics category for a tmux navigator action.
+String diagnosticTmuxNavigatorActionKind(TmuxNavigatorAction action) =>
+    switch (action) {
+      TmuxSwitchWindowAction() => 'switch_window',
+      TmuxNewWindowAction() => 'new_window',
+      TmuxResumeSessionAction() => 'resume_session',
+      TmuxCloseWindowAction() => 'close_window',
+    };
+
 class _TmuxNavigatorSheet extends StatefulWidget {
   const _TmuxNavigatorSheet({
     required this.session,
@@ -188,6 +198,14 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
 
   void _subscribeToWindowChanges() {
     final generation = ++_windowEventGeneration;
+    DiagnosticsLogService.instance.info(
+      'tmux.navigator',
+      'subscribe',
+      fields: {
+        'connectionId': widget.session.connectionId,
+        'generation': generation,
+      },
+    );
     _windowChangeSubscription = _tmux
         .watchWindowChanges(widget.session, widget.tmuxSessionName)
         .listen((event) => _handleWindowChangeEvent(event, generation));
@@ -232,10 +250,23 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   Future<void> _loadWindows() async {
     if (_loadingWindows) {
       _pendingWindowReload = true;
+      DiagnosticsLogService.instance.debug(
+        'tmux.navigator',
+        'reload_queued',
+        fields: {'connectionId': widget.session.connectionId},
+      );
       return;
     }
     _loadingWindows = true;
     final reloadGeneration = ++_windowReloadGeneration;
+    DiagnosticsLogService.instance.debug(
+      'tmux.navigator',
+      'reload_start',
+      fields: {
+        'connectionId': widget.session.connectionId,
+        'generation': reloadGeneration,
+      },
+    );
     try {
       final reloadedWindows = await _tmux.listWindows(
         widget.session,
@@ -249,6 +280,16 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       } else {
         _resetWindowReloadRecovery();
       }
+      DiagnosticsLogService.instance.info(
+        'tmux.navigator',
+        'reload_result',
+        fields: {
+          'connectionId': widget.session.connectionId,
+          'generation': reloadGeneration,
+          'windowCount': reloadedWindows.length,
+          'consecutiveEmptyReloads': _consecutiveEmptyWindowReloads,
+        },
+      );
       final windows = resolveTmuxReloadedWindows(
         shouldPreserveTmuxWindowSnapshotOnEmptyReload(
               _windows,
@@ -259,6 +300,14 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         reloadedWindows,
       );
       if (windows == null) {
+        DiagnosticsLogService.instance.warning(
+          'tmux.navigator',
+          'reload_preserved_previous',
+          fields: {
+            'connectionId': widget.session.connectionId,
+            'generation': reloadGeneration,
+          },
+        );
         final shouldShowRecoveryMessage =
             _shouldStopShowingInitialWindowSpinner;
         _scheduleWindowRetry();
@@ -283,6 +332,15 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       });
       unawaited(_prefetchPreferredSessionProvider(windows: windows));
     } on Exception catch (e) {
+      DiagnosticsLogService.instance.warning(
+        'tmux.navigator',
+        'reload_failed',
+        fields: {
+          'connectionId': widget.session.connectionId,
+          'generation': reloadGeneration,
+          'errorType': e.runtimeType,
+        },
+      );
       if (!mounted) return;
       final shouldShowRecoveryMessage = _shouldStopShowingInitialWindowSpinner;
       _scheduleWindowRetry();
@@ -307,11 +365,24 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     if (!mounted) return;
     if (generation != _windowEventGeneration) return;
     if (event is TmuxWindowReloadEvent) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.navigator',
+        'reload_event',
+        fields: {
+          'connectionId': widget.session.connectionId,
+          'generation': generation,
+        },
+      );
       _loadWindows();
       return;
     }
     final currentWindows = _windows;
     if (currentWindows == null) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.navigator',
+        'snapshot_without_state',
+        fields: {'connectionId': widget.session.connectionId},
+      );
       _loadWindows();
       return;
     }
@@ -322,6 +393,14 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       _error = null;
       _isLoadingWindows = false;
     });
+    DiagnosticsLogService.instance.debug(
+      'tmux.navigator',
+      'snapshot_applied',
+      fields: {
+        'connectionId': widget.session.connectionId,
+        'windowCount': _windows?.length ?? 0,
+      },
+    );
   }
 
   void _cancelWindowRetry() {
@@ -341,6 +420,15 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     }
     final delay = resolveTmuxWindowReloadRetryDelay(_windowRetryAttempts);
     _windowRetryAttempts += 1;
+    DiagnosticsLogService.instance.warning(
+      'tmux.navigator',
+      'retry_scheduled',
+      fields: {
+        'connectionId': widget.session.connectionId,
+        'attempt': _windowRetryAttempts,
+        'delayMs': delay.inMilliseconds,
+      },
+    );
     _windowRetryTimer = Timer(delay, () {
       _windowRetryTimer = null;
       if (mounted) {

--- a/test/domain/services/diagnostics_log_service_test.dart
+++ b/test/domain/services/diagnostics_log_service_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/services/diagnostics_log_service.dart';
+
+void main() {
+  group('DiagnosticsLogService', () {
+    test('does not retain entries when disabled', () {
+      final log = DiagnosticsLogService(enabled: false)
+        ..info('ssh', 'connect_start', fields: {'hostId': 1});
+
+      expect(log.entryCount, 0);
+      expect(log.snapshot(), isEmpty);
+    });
+
+    test('redacts sensitive fields and unsafe string values', () {
+      final log =
+          DiagnosticsLogService(
+            enabled: true,
+            now: () => DateTime.utc(2026, 4, 26, 12),
+          )..info(
+            'ssh',
+            'connect_start',
+            fields: {
+              'hostId': 7,
+              'hostname': 'secret.example.com',
+              'username': 'depoll',
+              'command': 'tmux attach -t private',
+              'path': '/Users/depoll/project',
+              'state': DiagnosticsLogLevel.info,
+              'errorType': 'TimeoutException',
+            },
+          );
+
+      final formatted = log.snapshot().single.format();
+
+      expect(formatted, contains('hostId=7'));
+      expect(formatted, contains('hostname=[redacted]'));
+      expect(formatted, contains('username=[redacted]'));
+      expect(formatted, contains('command=[redacted]'));
+      expect(formatted, contains('path=[redacted]'));
+      expect(formatted, contains('state=info'));
+      expect(formatted, contains('errorType=TimeoutException'));
+      expect(formatted, isNot(contains('secret.example.com')));
+      expect(formatted, isNot(contains('depoll')));
+      expect(formatted, isNot(contains('/Users/depoll/project')));
+    });
+
+    test('keeps a bounded ring buffer', () {
+      final log = DiagnosticsLogService(enabled: true, maxEntries: 2)
+        ..info('test', 'first')
+        ..info('test', 'second')
+        ..info('test', 'third');
+
+      final lines = log.snapshot().map((entry) => entry.message).toList();
+      expect(lines, ['second', 'third']);
+    });
+
+    test('exports a privacy notice with entries', () {
+      final log = DiagnosticsLogService(
+        enabled: true,
+        now: () => DateTime.utc(2026, 4, 26, 12),
+      )..warning('tmux.watch', 'restart_scheduled', fields: {'attempt': 2});
+
+      final exported = log.exportText();
+
+      expect(exported, contains('MonkeySSH diagnostics'));
+      expect(exported, contains('entryCount=1'));
+      expect(exported, contains('Privacy:'));
+      expect(exported, contains('tmux.watch restart_scheduled attempt=2'));
+    });
+  });
+}

--- a/test/domain/services/diagnostics_log_service_test.dart
+++ b/test/domain/services/diagnostics_log_service_test.dart
@@ -54,6 +54,24 @@ void main() {
       expect(lines, ['second', 'third']);
     });
 
+    test('coalesces listener notifications', () async {
+      final log = DiagnosticsLogService(enabled: true);
+      var notificationCount = 0;
+      log.addListener(() => notificationCount += 1);
+      addTearDown(log.dispose);
+
+      log
+        ..info('test', 'first')
+        ..info('test', 'second')
+        ..info('test', 'third');
+
+      expect(notificationCount, 0);
+
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      expect(notificationCount, 1);
+    });
+
     test('exports a privacy notice with entries', () {
       final log = DiagnosticsLogService(
         enabled: true,

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -161,6 +161,23 @@ void main() {
     );
   });
 
+  group('diagnosticTmuxControlLineKind', () {
+    test('returns only the control marker category', () {
+      expect(
+        diagnosticTmuxControlLineKind(
+          r'%subscription-changed flutty-1-42 $1 @1 1 %1 : private details',
+        ),
+        'subscription_changed',
+      );
+      expect(
+        diagnosticTmuxControlLineKind('%window-renamed @1 private-name'),
+        'window_renamed',
+      );
+      expect(diagnosticTmuxControlLineKind(''), 'empty');
+      expect(diagnosticTmuxControlLineKind('unrecognized payload'), 'other');
+    });
+  });
+
   group('shouldScheduleTmuxWindowReloadFallback', () {
     const subscriptionName = 'flutty-1-42';
 


### PR DESCRIPTION
## Summary

- Add preview-only in-memory diagnostics logging with bounded retention and redaction/sanitization.
- Log SSH/tmux lifecycle, control-mode watcher, terminal metadata/preview, retry, recovery, and navigator events using safe metadata only.
- Expose Settings > Diagnostics in preview builds for copying/clearing logs, and document safe logging rules in AGENTS.md.

## Validation

- flutter analyze
- flutter test
