### PR TITLE
fix: enable diagnostics in beta builds

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -26,6 +26,11 @@ on:
         type: string
         default: ''
         description: 'Pull request title for preview-derived builds'
+      enable-diagnostics:
+        required: false
+        type: boolean
+        default: false
+        description: 'Whether to enable copyable in-app diagnostics logging'
       flavor:
         required: true
         type: string
@@ -183,6 +188,7 @@ jobs:
     env:
       FLUTTY_PR_NUMBER: ${{ inputs.pr-number }}
       FLUTTY_PR_TITLE: ${{ inputs.pr-title }}
+      FLUTTY_DIAGNOSTICS_ENABLED: ${{ inputs.enable-diagnostics || inputs.pr-number != '' }}
     outputs:
       apk-artifact-id: ${{ steps.upload-apk.outputs.artifact-id }}
       source-sha: ${{ steps.resolved-source-sha.outputs.value }}
@@ -313,7 +319,8 @@ jobs:
             --build-name=${{ inputs.build-name }} \
             --build-number=${{ inputs.build-number }} \
             --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
-            --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE"
+            --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE" \
+            --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED"
 
       - name: Build unsigned AAB
         if: inputs.build-android-unsigned-aab && inputs.android-reuse-aab-artifact-name == '' && inputs.deploy-android-to == 'none'
@@ -327,7 +334,8 @@ jobs:
             --build-name=${{ inputs.build-name }} \
             --build-number=${{ inputs.build-number }} \
             --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
-            --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE"
+            --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE" \
+            --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED"
 
       - name: Build debug APK
         if: inputs.deploy-android-to == 'none'
@@ -339,7 +347,8 @@ jobs:
             --build-name=${{ inputs.build-name }} \
             --build-number=${{ inputs.build-number }} \
             --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
-            --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE"
+            --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE" \
+            --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED"
 
       - name: Download reusable AAB artifact
         if: inputs.android-reuse-aab-artifact-name != ''
@@ -507,6 +516,7 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
       FLUTTY_PR_NUMBER: ${{ inputs.pr-number }}
       FLUTTY_PR_TITLE: ${{ inputs.pr-title }}
+      FLUTTY_DIAGNOSTICS_ENABLED: ${{ inputs.enable-diagnostics || inputs.pr-number != '' }}
     outputs:
       source-sha: ${{ steps.resolved-source-sha.outputs.value }}
     steps:
@@ -613,7 +623,8 @@ jobs:
             --build-name=${{ inputs.build-name }} \
             --build-number=${{ inputs.build-number }} \
             --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
-            --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE"
+            --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE" \
+            --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED"
 
       - name: Package unsigned IPA
         if: inputs.build-ios-unsigned-ipa && inputs.ios-reuse-ipa-artifact-name == '' && inputs.deploy-ios-to == 'none'

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -658,6 +658,7 @@ jobs:
       build-codename: ${{ needs.finalize-version.outputs.build-codename }}
       pr-number: ${{ inputs.pr-number }}
       pr-title: ${{ needs.validate-pr.outputs.pr-title }}
+      enable-diagnostics: true
       flavor: private
       source-ref: ${{ needs.validate-pr.outputs.deploy-sha }}
       deploy-ios-to: testflight

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -54,6 +54,7 @@ jobs:
       build-name: ${{ needs.compute-version.outputs.build-name }}
       build-number: ${{ needs.compute-version.outputs.build-number }}
       build-codename: ${{ needs.compute-version.outputs.build-codename }}
+      enable-diagnostics: true
       flavor: private
       deploy-ios-to: testflight
       deploy-android-to: internal

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -139,6 +139,7 @@ jobs:
       build-codename: ${{ needs.compute-version.outputs.build-codename }}
       pr-number: ${{ github.event.pull_request.number }}
       pr-title: ${{ github.event.pull_request.title }}
+      enable-diagnostics: true
       flavor: private
       source-ref: ${{ github.event.pull_request.head.sha }}
       deploy-ios-to: none
@@ -162,6 +163,7 @@ jobs:
       build-codename: ${{ needs.compute-version.outputs.build-codename }}
       pr-number: ${{ github.event.pull_request.number }}
       pr-title: ${{ github.event.pull_request.title }}
+      enable-diagnostics: true
       flavor: private
       source-ref: ${{ github.event.pull_request.head.sha }}
       deploy-ios-to: none

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -64,6 +64,7 @@ jobs:
       build-name: ${{ needs.compute-version.outputs.build-name }}
       build-number: ${{ needs.compute-version.outputs.build-number }}
       build-codename: ${{ needs.compute-version.outputs.build-codename }}
+      enable-diagnostics: true
       flavor: production
       deploy-ios-to: testflight
       deploy-android-to: internal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,9 @@ The script generates a temporary SSH key, authorizes it for localhost, and creat
 
 ## Diagnostics logging
 
-Preview builds expose an in-memory diagnostics log in Settings > Diagnostics. Users can tap **Copy diagnostics log** and paste the sanitized text into an issue or chat for troubleshooting.
+Preview and beta/internal builds expose an in-memory diagnostics log in Settings > Diagnostics. Users can tap **Copy diagnostics log** and paste the sanitized text into an issue or chat for troubleshooting.
 
-When adding diagnostics, use `DiagnosticsLogService.instance` (or `diagnosticsLogServiceProvider` in UI code) and keep entries structured with a short category, short event name, and primitive fields. The logger is gated to preview builds and maintains a bounded ring buffer.
+When adding diagnostics, use `DiagnosticsLogService.instance` (or `diagnosticsLogServiceProvider` in UI code) and keep entries structured with a short category, short event name, and primitive fields. The logger is gated to diagnostics-enabled preview/beta builds and maintains a bounded ring buffer.
 
 Never log secrets or user content. Do not log hostnames, usernames, passwords, passphrases, private keys, tokens, raw commands, terminal output, tmux window/session names, window titles, working directories, file paths, clipboard contents, or raw SSH/tmux stream lines. Prefer safe metadata such as connection ID, host ID, booleans, counts, durations, enum states, retry attempts, error types, exit statuses, and sanitized event categories.
 

--- a/lib/app/app_metadata.dart
+++ b/lib/app/app_metadata.dart
@@ -10,10 +10,16 @@ const _versionCodenameAssetPath = 'assets/version_codenames.json';
 
 const _pullRequestNumber = String.fromEnvironment('FLUTTY_PR_NUMBER');
 const _pullRequestTitle = String.fromEnvironment('FLUTTY_PR_TITLE');
+const _diagnosticsBuildEnabled = bool.fromEnvironment(
+  'FLUTTY_DIAGNOSTICS_ENABLED',
+);
 Future<Map<int, String>>? _versionCodenameLookup;
 
 /// Whether this binary was produced from a pull-request preview build.
 const isPreviewBuild = _pullRequestNumber != '';
+
+/// Whether this binary should retain and expose diagnostics logs.
+const isDiagnosticsLoggingEnabled = isPreviewBuild || _diagnosticsBuildEnabled;
 
 /// Provides the current platform app name with a safe fallback.
 final appDisplayNameProvider = Provider<String>((ref) {

--- a/lib/domain/services/diagnostics_log_service.dart
+++ b/lib/domain/services/diagnostics_log_service.dart
@@ -78,7 +78,7 @@ class DiagnosticsLogEntry {
   }
 }
 
-/// Preview-only diagnostics log with strict field sanitization.
+/// Preview/beta-only diagnostics log with strict field sanitization.
 class DiagnosticsLogService extends ChangeNotifier {
   /// Creates a diagnostics logger.
   DiagnosticsLogService({
@@ -89,7 +89,9 @@ class DiagnosticsLogService extends ChangeNotifier {
        _maxEntries = maxEntries < 1 ? 1 : maxEntries;
 
   /// Shared diagnostics logger used by app services.
-  static final instance = DiagnosticsLogService(enabled: isPreviewBuild);
+  static final instance = DiagnosticsLogService(
+    enabled: isDiagnosticsLoggingEnabled,
+  );
 
   static const _redacted = '[redacted]';
   static const _maxStringLength = 160;

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -42,7 +42,7 @@ class SettingsScreen extends ConsumerWidget {
         const _ImportExportSection(),
         if (BackgroundSshService.supportsBatteryOptimizationControls)
           const _AndroidBackgroundSection(),
-        if (isPreviewBuild) const _DiagnosticsSection(),
+        if (isDiagnosticsLoggingEnabled) const _DiagnosticsSection(),
         const _AboutSection(),
       ],
     ),


### PR DESCRIPTION
## Summary

- enable copyable diagnostics logs with an explicit build flag instead of only PR-number detection
- turn the flag on for PR previews, private/TestFlight beta deploys, and internal releases
- keep App Store/production release builds diagnostics-disabled by default
- update agent guidance to mention beta/internal diagnostics

## Validation

- flutter analyze
- flutter test test/domain/services/diagnostics_log_service_test.dart test/domain/services/tmux_service_control_mode_test.dart
- flutter test
- ruby -ryaml workflow parse check