### PR TITLE
fix: avoid tmux exec channel exhaustion

### DIFF
--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -1205,6 +1205,34 @@ class _PreparedHostKeySocket {
   final HostKeySource hostKeySource;
 }
 
+Map<String, Object?> _diagnosticSshExecErrorFields(Object error) => {
+  'errorType': error.runtimeType,
+  if (error is SSHChannelOpenError) ...{
+    'channelOpenCode': error.code,
+    'reason': _diagnosticSshChannelOpenReason(error.description),
+  },
+};
+
+String _diagnosticSshChannelOpenReason(String description) {
+  final normalized = description.toLowerCase();
+  if (normalized.contains('administratively prohibited')) {
+    return 'administratively_prohibited';
+  }
+  if (normalized.contains('resource shortage')) {
+    return 'resource_shortage';
+  }
+  if (normalized.contains('connect failed')) {
+    return 'connect_failed';
+  }
+  if (normalized.contains('unknown channel type')) {
+    return 'unknown_channel_type';
+  }
+  if (normalized.contains('open failed')) {
+    return 'open_failed';
+  }
+  return 'channel_open_failed';
+}
+
 String _diagnosticSshResultErrorKind(String? error) {
   if (error == null || error.isEmpty) {
     return 'unknown';
@@ -2074,7 +2102,7 @@ class SshSession {
           'connectionId': connectionId,
           'commandKind': _diagnosticSshCommandKind(command),
           'pty': pty != null,
-          'errorType': error.runtimeType,
+          ..._diagnosticSshExecErrorFields(error),
         },
       );
       rethrow;

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -378,7 +378,10 @@ class TmuxService {
       DiagnosticsLogService.instance.debug(
         'tmux.query',
         'list_windows_join',
-        fields: {'connectionId': session.connectionId},
+        fields: {
+          'connectionId': session.connectionId,
+          'sessionHash': sessionName.hashCode.abs(),
+        },
       );
       return existingRequest;
     }
@@ -410,7 +413,9 @@ class TmuxService {
       '#{pane_current_command}|#{pane_current_path}|'
       "#{window_flags}|#{pane_title}|#{window_activity}'",
     );
-    final windows = _parseLines(output, TmuxWindow.fromTmuxFormat);
+    final windows = List<TmuxWindow>.unmodifiable(
+      _parseLines(output, TmuxWindow.fromTmuxFormat),
+    );
     DiagnosticsLogService.instance.info(
       'tmux.query',
       'list_windows_complete',

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -52,6 +52,8 @@ class TmuxService {
 
   static final Map<_TmuxWindowWatchKey, _TmuxWindowChangeObserver>
   _windowObservers = {};
+  static final Map<_TmuxWindowWatchKey, Future<List<TmuxWindow>>>
+  _windowListRequests = {};
 
   static const _execDoneMarker = '__flutty_tmux_exec_done__';
   static final RegExp _execDoneMarkerLinePattern = RegExp(
@@ -73,6 +75,9 @@ class TmuxService {
     _tmuxPathCache.remove(connectionId);
     _profileSourceCache.remove(connectionId);
     _installedAgentToolsCache.remove(connectionId);
+    _windowListRequests.removeWhere(
+      (key, _) => key.connectionId == connectionId,
+    );
     final observerKeys = _windowObservers.keys
         .where((key) => key.connectionId == connectionId)
         .toList(growable: false);
@@ -361,6 +366,34 @@ class TmuxService {
 
   /// Lists all windows in the given tmux [sessionName].
   Future<List<TmuxWindow>> listWindows(
+    SshSession session,
+    String sessionName,
+  ) async {
+    final key = _TmuxWindowWatchKey(
+      connectionId: session.connectionId,
+      sessionName: sessionName,
+    );
+    final existingRequest = _windowListRequests[key];
+    if (existingRequest != null) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.query',
+        'list_windows_join',
+        fields: {'connectionId': session.connectionId},
+      );
+      return existingRequest;
+    }
+
+    final request = _listWindows(session, sessionName);
+    _windowListRequests[key] = request;
+    request.whenComplete(() {
+      if (identical(_windowListRequests[key], request)) {
+        _windowListRequests.remove(key);
+      }
+    }).ignore();
+    return request;
+  }
+
+  Future<List<TmuxWindow>> _listWindows(
     SshSession session,
     String sessionName,
   ) async {
@@ -1124,34 +1157,25 @@ TmuxWindowChangeEvent? parseTmuxWindowChangeEventFromControlLine(
   return null;
 }
 
-/// Action the tmux control-mode heartbeat decides to take based on how
-/// long the channel has been silent.
+/// Action the tmux control-mode heartbeat decides to take based on how long
+/// the channel has been silent.
 @visibleForTesting
 enum TmuxControlHeartbeatAction {
   /// No action — control-mode notifications have arrived recently.
   noop,
 
-  /// Synthesize a refresh event so listeners refetch window state via a
-  /// separate exec channel.
+  /// Synthesize a refresh event so listeners refetch window state.
   refresh,
-
-  /// Tear down and restart the control session — silence has exceeded
-  /// the dead-channel threshold.
-  restart,
 }
 
 /// Pure decision function used by the control-mode observer's heartbeat
 /// to keep the UI in sync when push notifications are dropped or the SSH
-/// channel is half-open.
+/// channel is quiet.
 @visibleForTesting
 TmuxControlHeartbeatAction decideTmuxHeartbeatAction({
   required Duration silence,
   required Duration heartbeatInterval,
-  required Duration maxSilenceBeforeRestart,
 }) {
-  if (silence >= maxSilenceBeforeRestart) {
-    return TmuxControlHeartbeatAction.restart;
-  }
   if (silence >= heartbeatInterval) {
     return TmuxControlHeartbeatAction.refresh;
   }
@@ -1195,16 +1219,10 @@ class _TmuxWindowChangeObserver {
 
   static const _eventDebounce = Duration(milliseconds: 150);
 
-  /// How often to check whether the control-mode session has gone silent
-  /// and synthesize a refresh event when it has. Keeps the UI in sync
-  /// even if `%subscription-changed` notifications are dropped (e.g. due
-  /// to a half-open SSH channel that did not surface as `done`).
+  /// How often to check whether the control-mode session has gone quiet and
+  /// synthesize a refresh event when it has. Keeps the UI in sync even if
+  /// `%subscription-changed` notifications are dropped.
   static const _heartbeatInterval = Duration(seconds: 5);
-
-  /// If no control-mode line arrives for this long, treat the session as
-  /// dead and force a reconnect even though the SSH `done` callback never
-  /// fired.
-  static const _maxSilenceBeforeRestart = Duration(seconds: 30);
 
   final TmuxService service;
   final SshSession session;
@@ -1460,16 +1478,13 @@ class _TmuxWindowChangeObserver {
     _heartbeatTimer = null;
   }
 
-  /// Heartbeat tick. Two responsibilities:
+  /// Heartbeat tick:
   ///
-  /// 1. If the control session has been silent for [_heartbeatInterval],
-  ///    synthesize a refresh event so listeners refetch window state via
-  ///    a separate exec channel. This keeps alerts visible in real time
-  ///    even when control-mode notifications are dropped or delayed.
-  /// 2. If the silence exceeds [_maxSilenceBeforeRestart], assume the SSH
-  ///    channel is half-open and tear down + restart it; tmux normally
-  ///    emits some traffic at least every few seconds, so prolonged
-  ///    silence is a strong signal of a dead channel.
+  /// If the control session has been quiet for [_heartbeatInterval],
+  /// synthesize a refresh event so listeners refetch window state. Do not
+  /// restart a quiet control session; tmux can legitimately stay silent after
+  /// its initial subscription snapshot, and frequent restarts consume SSH
+  /// session channels on servers with low `MaxSessions` limits.
   void _onHeartbeat() {
     if (_disposed) return;
     final lastActivity = _lastControlActivity;
@@ -1477,7 +1492,6 @@ class _TmuxWindowChangeObserver {
     final action = decideTmuxHeartbeatAction(
       silence: _now().difference(lastActivity),
       heartbeatInterval: _heartbeatInterval,
-      maxSilenceBeforeRestart: _maxSilenceBeforeRestart,
     );
     switch (action) {
       case TmuxControlHeartbeatAction.noop:
@@ -1492,17 +1506,6 @@ class _TmuxWindowChangeObserver {
           },
         );
         _scheduleReloadEvent();
-        return;
-      case TmuxControlHeartbeatAction.restart:
-        DiagnosticsLogService.instance.warning(
-          'tmux.watch',
-          'heartbeat_restart',
-          fields: {
-            'connectionId': session.connectionId,
-            'silenceMs': _now().difference(lastActivity).inMilliseconds,
-          },
-        );
-        _handleControlClosed();
         return;
     }
   }

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -333,8 +333,13 @@ void main() {
       final results = await Future.wait([first, second]);
 
       expect(results[0], hasLength(1));
-      expect(results[1], hasLength(1));
-      expect(identical(results[0], results[1]), isTrue);
+      expect(results[1], orderedEquals(results[0]));
+      expect(
+        () => results[0].add(
+          const TmuxWindow(index: 2, name: 'other', isActive: false),
+        ),
+        throwsUnsupportedError,
+      );
       verify(() => client.execute(any(), pty: any(named: 'pty'))).called(1);
       verify(execSession.close).called(1);
     });

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -311,6 +311,34 @@ void main() {
       },
     );
 
+    test('listWindows coalesces duplicate in-flight reloads', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client);
+      const service = TmuxService();
+      final openCompleter = Completer<SSHSession>();
+      final execSession = _buildOpenExecSession(
+        stdout:
+            '1|editor|1|vim|/tmp|*|vim-title|1712930000\n'
+            '${_doneMarker()}',
+      );
+
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) => openCompleter.future);
+
+      final first = service.listWindows(session, 'main');
+      final second = service.listWindows(session, 'main');
+      openCompleter.complete(execSession);
+
+      final results = await Future.wait([first, second]);
+
+      expect(results[0], hasLength(1));
+      expect(results[1], hasLength(1));
+      expect(identical(results[0], results[1]), isTrue);
+      verify(() => client.execute(any(), pty: any(named: 'pty'))).called(1);
+      verify(execSession.close).called(1);
+    });
+
     test('listWindows ignores done-marker text inside tmux fields', () async {
       final client = _MockSshClient();
       final session = _buildSession(client);
@@ -498,14 +526,12 @@ void main() {
 
   group('decideTmuxHeartbeatAction', () {
     const heartbeat = Duration(seconds: 5);
-    const maxSilence = Duration(seconds: 30);
 
     test('noop while control-mode notifications are flowing', () {
       expect(
         decideTmuxHeartbeatAction(
           silence: Duration.zero,
           heartbeatInterval: heartbeat,
-          maxSilenceBeforeRestart: maxSilence,
         ),
         TmuxControlHeartbeatAction.noop,
       );
@@ -513,7 +539,6 @@ void main() {
         decideTmuxHeartbeatAction(
           silence: const Duration(milliseconds: 4999),
           heartbeatInterval: heartbeat,
-          maxSilenceBeforeRestart: maxSilence,
         ),
         TmuxControlHeartbeatAction.noop,
       );
@@ -525,7 +550,6 @@ void main() {
         decideTmuxHeartbeatAction(
           silence: heartbeat,
           heartbeatInterval: heartbeat,
-          maxSilenceBeforeRestart: maxSilence,
         ),
         TmuxControlHeartbeatAction.refresh,
       );
@@ -533,31 +557,23 @@ void main() {
         decideTmuxHeartbeatAction(
           silence: const Duration(seconds: 20),
           heartbeatInterval: heartbeat,
-          maxSilenceBeforeRestart: maxSilence,
         ),
         TmuxControlHeartbeatAction.refresh,
       );
     });
 
-    test('restarts the control session once silence exceeds the dead-channel '
-        'threshold', () {
-      expect(
-        decideTmuxHeartbeatAction(
-          silence: maxSilence,
-          heartbeatInterval: heartbeat,
-          maxSilenceBeforeRestart: maxSilence,
-        ),
-        TmuxControlHeartbeatAction.restart,
-      );
-      expect(
-        decideTmuxHeartbeatAction(
-          silence: const Duration(minutes: 5),
-          heartbeatInterval: heartbeat,
-          maxSilenceBeforeRestart: maxSilence,
-        ),
-        TmuxControlHeartbeatAction.restart,
-      );
-    });
+    test(
+      'continues refreshing instead of restarting after prolonged silence',
+      () {
+        expect(
+          decideTmuxHeartbeatAction(
+            silence: const Duration(minutes: 5),
+            heartbeatInterval: heartbeat,
+          ),
+          TmuxControlHeartbeatAction.refresh,
+        );
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

- stop restarting tmux control-mode watchers solely because tmux has been quiet; heartbeat reloads still keep the UI fresh without consuming new long-lived SSH channels
- coalesce duplicate in-flight tmux list-windows reloads for the same connection/session so multiple listeners share one exec channel
- enrich diagnostics for SSH channel-open failures with safe channel-open code/reason categories

## Diagnosis

The pasted diagnostics showed the interactive shell and tmux watcher were still alive, but fresh exec channels started failing with SSHChannelOpenError. The log also showed control-mode heartbeat restarts roughly every 30 seconds, plus duplicate list-windows reloads per heartbeat. That pattern can exhaust SSH server session/channel limits and make the tmux menu actions fail even while the terminal stream continues.

## Validation

- flutter analyze
- flutter test test/domain/services/tmux_service_control_mode_test.dart test/domain/services/ssh_service_test.dart
- flutter test