### PR TITLE
Improve tmux agent window titles

### DIFF
--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -95,6 +95,33 @@ AgentLaunchTool? agentLaunchToolForCommandName(String? commandName) {
   return null;
 }
 
+/// Resolves a supported agent CLI from a full shell command.
+///
+/// This accepts commands with environment assignments, paths, and arguments
+/// because tmux can expose wrapper commands rather than a bare executable.
+AgentLaunchTool? agentLaunchToolForCommandText(String? command) {
+  var normalized = command?.trim() ?? '';
+  if (normalized.isEmpty) {
+    return null;
+  }
+
+  while (true) {
+    final cdMatch = _leadingCdCommandPattern.firstMatch(normalized);
+    if (cdMatch == null) break;
+    normalized = normalized.substring(cdMatch.end).trimLeft();
+  }
+
+  while (true) {
+    final assignmentMatch = _leadingEnvironmentAssignmentPattern.firstMatch(
+      normalized,
+    );
+    if (assignmentMatch == null) break;
+    normalized = normalized.substring(assignmentMatch.end).trimLeft();
+  }
+
+  return agentLaunchToolForCommandName(_readLeadingShellToken(normalized));
+}
+
 /// Host-scoped preset for launching a coding agent after connect.
 class AgentLaunchPreset {
   /// Creates a new [AgentLaunchPreset].
@@ -200,7 +227,26 @@ String? _normalizeAgentCommandName(String? commandName) {
   return basename.replaceFirst(RegExp(r'\.exe$'), '');
 }
 
+String? _readLeadingShellToken(String value) {
+  final trimmed = value.trimLeft();
+  if (trimmed.isEmpty) return null;
+  final quote = trimmed.codeUnitAt(0);
+  if (quote == 0x22 || quote == 0x27) {
+    final end = trimmed.indexOf(String.fromCharCode(quote), 1);
+    if (end > 1) {
+      return trimmed.substring(1, end);
+    }
+  }
+  return trimmed.split(RegExp(r'\s+')).first;
+}
+
 final _unquotedTmuxFlagTokenPattern = RegExp(r'^[A-Za-z0-9_./~:=,+-]+$');
+final _leadingCdCommandPattern = RegExp(
+  r'''^cd\s+(?:"[^"]*"|'[^']*'|\S+)\s*&&\s*''',
+);
+final _leadingEnvironmentAssignmentPattern = RegExp(
+  r'''^[A-Za-z_][A-Za-z0-9_]*=(?:"(?:[^"\\]|\\.)*"|'[^']*'|\S+)\s+''',
+);
 final _codexApprovalModeEqualsPattern = RegExp(
   r'''(?<!\S)--approval-mode=(?:"[^"]*"|'[^']*'|\S+)''',
 );

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -84,6 +84,7 @@ class TmuxWindow {
     this.flags,
     this.paneTitle,
     this.paneStartCommand,
+    this.agentTool,
     int? idleSeconds,
     this.lastActivityEpochSeconds,
   }) : _snapshotIdleSeconds = idleSeconds;
@@ -92,7 +93,7 @@ class TmuxWindow {
   ///
   /// Expected format (from `tmux list-windows -F`):
   /// `index<US>name<US>active_flag<US>command<US>path<US>flags<US>`
-  /// `pane_title<US>activity_epoch<US>pane_start_command`
+  /// `pane_title<US>activity_epoch<US>pane_start_command<US>agent_tool`
   ///
   /// Legacy pipe-delimited snapshots are still accepted for older tests and
   /// stale control-mode messages.
@@ -117,6 +118,7 @@ class TmuxWindow {
           ? activityEpoch
           : null,
       paneStartCommand: parsed.paneStartCommand,
+      agentTool: fields.length > 9 ? _agentToolFromMetadata(fields[9]) : null,
     );
   }
 
@@ -143,6 +145,9 @@ class TmuxWindow {
 
   /// The command tmux used when creating the pane, if available.
   final String? paneStartCommand;
+
+  /// App-provided agent tool metadata stored on the tmux window, if available.
+  final AgentLaunchTool? agentTool;
 
   /// tmux's `window_activity` epoch seconds, if available.
   final int? lastActivityEpochSeconds;
@@ -191,6 +196,7 @@ class TmuxWindow {
     String? flags,
     String? paneTitle,
     String? paneStartCommand,
+    AgentLaunchTool? agentTool,
     int? lastActivityEpochSeconds,
   }) => TmuxWindow(
     index: index,
@@ -201,6 +207,7 @@ class TmuxWindow {
     flags: flags ?? this.flags,
     paneTitle: paneTitle ?? this.paneTitle,
     paneStartCommand: paneStartCommand ?? this.paneStartCommand,
+    agentTool: agentTool ?? this.agentTool,
     idleSeconds: _snapshotIdleSeconds,
     lastActivityEpochSeconds:
         lastActivityEpochSeconds ?? this.lastActivityEpochSeconds,
@@ -366,6 +373,7 @@ class TmuxWindow {
 
   /// The supported agent CLI running in the foreground, if one can be inferred.
   AgentLaunchTool? get foregroundAgentTool {
+    if (agentTool != null) return agentTool;
     for (final candidate in [currentCommand, name, paneTitle]) {
       final tool = agentLaunchToolForCommandName(candidate);
       if (tool != null) {
@@ -392,6 +400,7 @@ class TmuxWindow {
           flags == other.flags &&
           paneTitle == other.paneTitle &&
           paneStartCommand == other.paneStartCommand &&
+          agentTool == other.agentTool &&
           lastActivityEpochSeconds == other.lastActivityEpochSeconds &&
           _snapshotIdleSeconds == other._snapshotIdleSeconds;
 
@@ -405,6 +414,7 @@ class TmuxWindow {
     flags,
     paneTitle,
     paneStartCommand,
+    agentTool,
     lastActivityEpochSeconds,
     _snapshotIdleSeconds,
   );
@@ -751,22 +761,12 @@ bool _isAsciiLetterOrDigit(int rune) =>
     (rune >= 0x41 && rune <= 0x5A) ||
     (rune >= 0x61 && rune <= 0x7A);
 
-AgentLaunchTool? _agentToolFromCommandText(String? value) {
-  final command = value?.trim();
-  if (command == null || command.isEmpty) return null;
-  for (final tool in AgentLaunchTool.values) {
-    final pattern = RegExp(
-      '(^|[\\s"\\\'])'
-      '(?:[^\\s"\\\']*/)?'
-      '${RegExp.escape(tool.commandName)}'
-      r'(?:\.exe)?'
-      r'''(?=$|[\s"'])''',
-      caseSensitive: false,
-    );
-    if (pattern.hasMatch(command)) return tool;
-  }
-  return null;
-}
+AgentLaunchTool? _agentToolFromCommandText(String? value) =>
+    agentLaunchToolForCommandText(value);
+
+AgentLaunchTool? _agentToolFromMetadata(String? value) =>
+    agentLaunchToolForCommandName(value) ??
+    agentLaunchToolForCommandText(value);
 
 String? _agentSessionIdFromCommand(
   String? value, {

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -89,9 +89,10 @@ class TmuxWindow {
     this.lastActivityEpochSeconds,
   }) : _snapshotIdleSeconds = idleSeconds;
 
-  /// Parses a [TmuxWindow] from a pipe-delimited tmux format string.
+  /// Parses a [TmuxWindow] from a tmux format string.
   ///
-  /// Expected format (from `tmux list-windows -F`):
+  /// Expected primary format (from `tmux list-windows -F`) is Unit
+  /// Separator-delimited:
   /// `index<US>name<US>active_flag<US>command<US>path<US>flags<US>`
   /// `pane_title<US>activity_epoch<US>pane_start_command<US>agent_tool`
   ///
@@ -267,14 +268,12 @@ class TmuxWindow {
         )) {
       return agentTitle;
     }
-    if (_isUnhelpfulTmuxTitle(
-      normalizedPaneTitle,
-      normalizedName: normalizedName,
-      normalizedCommand: normalizedCommand,
-    )) {
-      return agentTitle ?? normalizedName ?? name;
-    }
-    if (normalizedPaneTitle == null) {
+    if (normalizedPaneTitle == null ||
+        _isUnhelpfulTmuxTitle(
+          normalizedPaneTitle,
+          normalizedName: normalizedName,
+          normalizedCommand: normalizedCommand,
+        )) {
       return agentTitle ?? normalizedName ?? name;
     }
     if (normalizedName == null) return normalizedPaneTitle;
@@ -628,11 +627,17 @@ String? _nonEmpty(String value) {
   }
 
   final fields = line.split('|');
+  if (fields.length <= 7) {
+    return (fields: fields, paneStartCommand: null);
+  }
+
   return (
-    fields: fields,
-    paneStartCommand: fields.length > 8
-        ? _nonEmpty(fields.sublist(8).join('|'))
-        : null,
+    fields: <String>[
+      ...fields.take(6),
+      fields.sublist(6, fields.length - 1).join('|'),
+      fields.last,
+    ],
+    paneStartCommand: null,
   );
 }
 

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -250,6 +250,16 @@ class TmuxWindow {
       stripPlaceholderPrefix: true,
     );
     final agentTitle = agentContextTitle;
+    final foregroundTool = foregroundAgentTool;
+    if (agentTitle != null &&
+        foregroundTool != null &&
+        _isUnhelpfulAgentTitle(
+          normalizedPaneTitle,
+          tool: foregroundTool,
+          contextLabel: _windowContextLabelFromPath(currentPath),
+        )) {
+      return agentTitle;
+    }
     if (_isUnhelpfulTmuxTitle(
       normalizedPaneTitle,
       normalizedName: normalizedName,
@@ -291,6 +301,16 @@ class TmuxWindow {
       stripPlaceholderPrefix: true,
     );
     final agentTitle = agentContextTitle;
+    final foregroundTool = foregroundAgentTool;
+    if (agentTitle != null &&
+        foregroundTool != null &&
+        _isUnhelpfulAgentTitle(
+          normalizedPaneTitle,
+          tool: foregroundTool,
+          contextLabel: _windowContextLabelFromPath(currentPath),
+        )) {
+      return agentTitle;
+    }
     if (_isUnhelpfulTmuxTitle(
       normalizedPaneTitle,
       normalizedName: normalizedName,
@@ -662,6 +682,50 @@ bool _isLikelyDefaultHostTitle(String value) {
     caseSensitive: false,
   ).hasMatch(trimmed);
 }
+
+bool _isUnhelpfulAgentTitle(
+  String? value, {
+  required AgentLaunchTool tool,
+  required String? contextLabel,
+}) {
+  if (value == null || value.isEmpty) return true;
+  final lowered = _normalizeAgentTitleForComparison(value);
+  if (lowered.isEmpty) return true;
+  if (_agentTitleAliases(tool).contains(lowered)) return true;
+
+  final loweredContext = contextLabel?.trim().toLowerCase();
+  if (loweredContext != null &&
+      loweredContext.isNotEmpty &&
+      lowered == loweredContext) {
+    return true;
+  }
+
+  final statusMatch = RegExp(
+    r'^(?:idle|ready|running|thinking|waiting|working)(?:\s+\(([^)]+)\))?$',
+  ).firstMatch(lowered);
+  if (statusMatch == null) return false;
+  final statusContext = statusMatch.group(1)?.trim();
+  return statusContext == null ||
+      statusContext.isEmpty ||
+      statusContext == loweredContext;
+}
+
+String _normalizeAgentTitleForComparison(String value) =>
+    _stripLeadingDecorativePrefix(
+      value,
+    ).replaceAll(RegExp(r'\s+'), ' ').trim().toLowerCase();
+
+Set<String> _agentTitleAliases(AgentLaunchTool tool) => switch (tool) {
+  AgentLaunchTool.claudeCode => const {'claude', 'claude code'},
+  AgentLaunchTool.copilotCli => const {
+    'copilot',
+    'copilot cli',
+    'github copilot',
+  },
+  AgentLaunchTool.codex => const {'codex'},
+  AgentLaunchTool.openCode => const {'opencode', 'open code'},
+  AgentLaunchTool.geminiCli => const {'gemini', 'gemini cli'},
+};
 
 bool _isDecoratedVariantOfTitle(String rawTitle, String? plainTitle) {
   if (plainTitle == null || plainTitle.isEmpty) return false;

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -2,6 +2,13 @@ import 'package:flutter/foundation.dart';
 
 import 'agent_launch_preset.dart';
 
+/// Field separator used for tmux format strings.
+///
+/// tmux's format engine does not expand `\t`, and titles/commands may contain
+/// visible delimiters such as `|`. ASCII Unit Separator keeps parsed snapshots
+/// stable without constraining user-controlled window names.
+const tmuxWindowFieldSeparator = '\x1f';
+
 /// Represents a tmux session on a remote host.
 @immutable
 class TmuxSession {
@@ -76,6 +83,7 @@ class TmuxWindow {
     this.currentPath,
     this.flags,
     this.paneTitle,
+    this.paneStartCommand,
     int? idleSeconds,
     this.lastActivityEpochSeconds,
   }) : _snapshotIdleSeconds = idleSeconds;
@@ -83,9 +91,14 @@ class TmuxWindow {
   /// Parses a [TmuxWindow] from a pipe-delimited tmux format string.
   ///
   /// Expected format (from `tmux list-windows -F`):
-  /// `index|name|active_flag|command|path|flags|pane_title|activity_epoch`
+  /// `index<US>name<US>active_flag<US>command<US>path<US>flags<US>`
+  /// `pane_title<US>activity_epoch<US>pane_start_command`
+  ///
+  /// Legacy pipe-delimited snapshots are still accepted for older tests and
+  /// stale control-mode messages.
   factory TmuxWindow.fromTmuxFormat(String line) {
-    final fields = line.split('|');
+    final parsed = _splitTmuxWindowFormatFields(line);
+    final fields = parsed.fields;
     if (fields.length < 3) {
       throw FormatException('Invalid tmux window format: $line');
     }
@@ -103,6 +116,7 @@ class TmuxWindow {
       lastActivityEpochSeconds: activityEpoch != null && activityEpoch > 0
           ? activityEpoch
           : null,
+      paneStartCommand: parsed.paneStartCommand,
     );
   }
 
@@ -126,6 +140,9 @@ class TmuxWindow {
 
   /// The pane title set by the running application, if available.
   final String? paneTitle;
+
+  /// The command tmux used when creating the pane, if available.
+  final String? paneStartCommand;
 
   /// tmux's `window_activity` epoch seconds, if available.
   final int? lastActivityEpochSeconds;
@@ -173,6 +190,7 @@ class TmuxWindow {
     String? currentPath,
     String? flags,
     String? paneTitle,
+    String? paneStartCommand,
     int? lastActivityEpochSeconds,
   }) => TmuxWindow(
     index: index,
@@ -182,10 +200,40 @@ class TmuxWindow {
     currentPath: currentPath ?? this.currentPath,
     flags: flags ?? this.flags,
     paneTitle: paneTitle ?? this.paneTitle,
+    paneStartCommand: paneStartCommand ?? this.paneStartCommand,
     idleSeconds: _snapshotIdleSeconds,
     lastActivityEpochSeconds:
         lastActivityEpochSeconds ?? this.lastActivityEpochSeconds,
   );
+
+  /// A best-effort coding-agent session identifier found in tmux metadata.
+  String? get agentSessionId {
+    final tool = foregroundAgentTool;
+    if (tool == null) return null;
+    return _agentSessionIdFromCommand(paneStartCommand, tool: tool);
+  }
+
+  /// Short coding-agent session label suitable for secondary UI text.
+  String? get agentSessionLabel {
+    final id = agentSessionId;
+    if (id == null || id.isEmpty) return null;
+    return 'session ${_shortenSessionId(id)}';
+  }
+
+  /// Fallback title for agent windows whose pane title is generic or stale.
+  String? get agentContextTitle {
+    final tool = foregroundAgentTool;
+    if (tool == null) return null;
+    final context = _windowContextLabelFromPath(currentPath);
+    if (context != null) {
+      return '${tool.label} · $context';
+    }
+    final sessionId = agentSessionId;
+    if (sessionId != null && sessionId.isNotEmpty) {
+      return '${tool.label} · ${_shortenSessionId(sessionId)}';
+    }
+    return tool.label;
+  }
 
   /// A short display title — prefers the richest usable tmux title.
   String get displayTitle {
@@ -197,7 +245,21 @@ class TmuxWindow {
       name,
       stripPlaceholderPrefix: true,
     );
-    if (normalizedPaneTitle == null) return normalizedName ?? name;
+    final normalizedCommand = _normalizedTmuxTitle(
+      currentCommand,
+      stripPlaceholderPrefix: true,
+    );
+    final agentTitle = agentContextTitle;
+    if (_isUnhelpfulTmuxTitle(
+      normalizedPaneTitle,
+      normalizedName: normalizedName,
+      normalizedCommand: normalizedCommand,
+    )) {
+      return agentTitle ?? normalizedName ?? name;
+    }
+    if (normalizedPaneTitle == null) {
+      return agentTitle ?? normalizedName ?? name;
+    }
     if (normalizedName == null) return normalizedPaneTitle;
     if (_hasPlaceholderPrefix(name)) return normalizedPaneTitle;
     if (_isDecoratedVariantOfTitle(name, normalizedPaneTitle)) {
@@ -228,6 +290,14 @@ class TmuxWindow {
       currentCommand,
       stripPlaceholderPrefix: true,
     );
+    final agentTitle = agentContextTitle;
+    if (_isUnhelpfulTmuxTitle(
+      normalizedPaneTitle,
+      normalizedName: normalizedName,
+      normalizedCommand: normalizedCommand,
+    )) {
+      return agentTitle ?? normalizedName ?? displayTitle;
+    }
     if (normalizedPaneTitle != null &&
         normalizedName != null &&
         normalizedCommand != null &&
@@ -241,6 +311,12 @@ class TmuxWindow {
   /// Secondary context for the window title when both pane and window names
   /// are useful and distinct.
   String? get secondaryTitle {
+    final display = displayTitle;
+    final agentTitle = agentContextTitle;
+    if (agentTitle != null && display == agentTitle) {
+      return agentSessionLabel;
+    }
+
     final normalizedPaneTitle = _normalizedTmuxTitle(
       paneTitle,
       stripPlaceholderPrefix: true,
@@ -276,7 +352,7 @@ class TmuxWindow {
         return tool;
       }
     }
-    return null;
+    return _agentToolFromCommandText(paneStartCommand);
   }
 
   @override
@@ -295,6 +371,7 @@ class TmuxWindow {
           currentPath == other.currentPath &&
           flags == other.flags &&
           paneTitle == other.paneTitle &&
+          paneStartCommand == other.paneStartCommand &&
           lastActivityEpochSeconds == other.lastActivityEpochSeconds &&
           _snapshotIdleSeconds == other._snapshotIdleSeconds;
 
@@ -307,6 +384,7 @@ class TmuxWindow {
     currentPath,
     flags,
     paneTitle,
+    paneStartCommand,
     lastActivityEpochSeconds,
     _snapshotIdleSeconds,
   );
@@ -508,6 +586,26 @@ String? _nonEmpty(String value) {
   return trimmed.isEmpty ? null : trimmed;
 }
 
+({List<String> fields, String? paneStartCommand}) _splitTmuxWindowFormatFields(
+  String line,
+) {
+  if (line.contains(tmuxWindowFieldSeparator)) {
+    final fields = line.split(tmuxWindowFieldSeparator);
+    return (
+      fields: fields,
+      paneStartCommand: fields.length > 8 ? _nonEmpty(fields[8]) : null,
+    );
+  }
+
+  final fields = line.split('|');
+  return (
+    fields: fields,
+    paneStartCommand: fields.length > 8
+        ? _nonEmpty(fields.sublist(8).join('|'))
+        : null,
+  );
+}
+
 String? _normalizedTmuxTitle(
   String? value, {
   bool stripPlaceholderPrefix = false,
@@ -525,6 +623,45 @@ String? _normalizedTmuxTitle(
 }
 
 bool _hasPlaceholderPrefix(String value) => value.trimLeft().startsWith('_');
+
+const _genericTmuxTitles = <String>{
+  'bash',
+  'fish',
+  'login',
+  'sh',
+  'shell',
+  'terminal',
+  'tmux',
+  'zsh',
+};
+
+bool _isUnhelpfulTmuxTitle(
+  String? value, {
+  String? normalizedName,
+  String? normalizedCommand,
+}) {
+  if (value == null || value.isEmpty) return true;
+  final lowered = value.toLowerCase();
+  if (_genericTmuxTitles.contains(lowered)) return true;
+  if (normalizedName != null && lowered == normalizedName.toLowerCase()) {
+    return true;
+  }
+  if (normalizedCommand != null && lowered == normalizedCommand.toLowerCase()) {
+    return true;
+  }
+  return _isLikelyDefaultHostTitle(value);
+}
+
+bool _isLikelyDefaultHostTitle(String value) {
+  final trimmed = value.trim();
+  if (trimmed.isEmpty || trimmed.contains(RegExp(r'\s'))) return false;
+  final lowered = trimmed.toLowerCase();
+  if (lowered == 'localhost') return true;
+  return RegExp(
+    r'^[a-z0-9][a-z0-9-]*(?:\.[a-z0-9][a-z0-9-]*)+$',
+    caseSensitive: false,
+  ).hasMatch(trimmed);
+}
 
 bool _isDecoratedVariantOfTitle(String rawTitle, String? plainTitle) {
   if (plainTitle == null || plainTitle.isEmpty) return false;
@@ -549,6 +686,81 @@ bool _isAsciiLetterOrDigit(int rune) =>
     (rune >= 0x30 && rune <= 0x39) ||
     (rune >= 0x41 && rune <= 0x5A) ||
     (rune >= 0x61 && rune <= 0x7A);
+
+AgentLaunchTool? _agentToolFromCommandText(String? value) {
+  final command = value?.trim();
+  if (command == null || command.isEmpty) return null;
+  for (final tool in AgentLaunchTool.values) {
+    final pattern = RegExp(
+      '(^|[\\s"\\\'])'
+      '(?:[^\\s"\\\']*/)?'
+      '${RegExp.escape(tool.commandName)}'
+      r'(?:\.exe)?'
+      r'''(?=$|[\s"'])''',
+      caseSensitive: false,
+    );
+    if (pattern.hasMatch(command)) return tool;
+  }
+  return null;
+}
+
+String? _agentSessionIdFromCommand(
+  String? value, {
+  required AgentLaunchTool tool,
+}) {
+  final command = value?.trim();
+  if (command == null || command.isEmpty) return null;
+  final patterns = switch (tool) {
+    AgentLaunchTool.claudeCode => const [
+      r'''(?<!\S)--resume(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(\S+))''',
+    ],
+    AgentLaunchTool.copilotCli => const [
+      r'''(?<!\S)--resume(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(\S+))''',
+    ],
+    AgentLaunchTool.codex => const [
+      r'''(?<!\S)resume\s+(?:"([^"]+)"|'([^']+)'|(\S+))''',
+    ],
+    AgentLaunchTool.geminiCli => const [
+      r'''(?<!\S)--resume(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(\S+))''',
+    ],
+    AgentLaunchTool.openCode => const [
+      r'''(?<!\S)--session(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(\S+))''',
+    ],
+  };
+
+  for (final pattern in patterns) {
+    final match = RegExp(pattern).firstMatch(command);
+    if (match == null) continue;
+    for (var index = 1; index <= match.groupCount; index++) {
+      final value = match.group(index)?.trim();
+      if (value != null && value.isNotEmpty) return value;
+    }
+  }
+  return null;
+}
+
+String _shortenSessionId(String id) {
+  final trimmed = id.trim();
+  if (trimmed.length <= 14) return trimmed;
+  return '${trimmed.substring(0, 8)}...';
+}
+
+String? _windowContextLabelFromPath(String? value) {
+  final trimmed = value?.trim();
+  if (trimmed == null || trimmed.isEmpty) return null;
+  final parts = trimmed
+      .split('/')
+      .where((part) => part.isNotEmpty && part != '.' && part != '~')
+      .toList(growable: false);
+  if (parts.isEmpty) return null;
+  for (var index = 0; index < parts.length - 1; index++) {
+    final segment = parts[index];
+    if (segment.endsWith('.worktrees')) {
+      return parts[index + 1];
+    }
+  }
+  return parts.last;
+}
 
 // ── tmux command helpers ──────────────────────────────────────────────────
 

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -475,12 +475,14 @@ parseCopilotWorkspaceYamlMetadata(String raw) {
 /// Parses Codex rollout metadata from the head of a rollout JSONL file.
 @visibleForTesting
 ({
+  String? sessionId,
   String? summary,
   String? workingDirectory,
   DateTime? updatedAt,
   bool parsedAny,
 })
 parseCodexRolloutMetadata(String raw) {
+  String? sessionId;
   String? summary;
   String? workingDirectory;
   DateTime? updatedAt;
@@ -492,6 +494,8 @@ parseCodexRolloutMetadata(String raw) {
     parsedAny = true;
 
     final payload = _readMapField(decoded, 'payload');
+    sessionId ??=
+        _readStringField(payload, 'id') ?? _readStringField(decoded, 'id');
     workingDirectory ??=
         _readStringField(payload, 'cwd') ?? _readStringField(decoded, 'cwd');
     updatedAt ??= _parseDateTimeValue(decoded['timestamp']);
@@ -509,6 +513,7 @@ parseCodexRolloutMetadata(String raw) {
   }
 
   return (
+    sessionId: sessionId,
     summary: summary,
     workingDirectory: workingDirectory,
     updatedAt: updatedAt,
@@ -1585,6 +1590,7 @@ class AgentSessionDiscoveryService {
             : null;
 
         var summary = threadInfo?.threadName;
+        var sessionId = threadId;
         String? sessionWorkingDirectory;
         var lastActive = threadInfo?.updatedAt;
 
@@ -1597,6 +1603,7 @@ class AgentSessionDiscoveryService {
             if (snapshot.content.trim().isNotEmpty && !metadata.parsedAny) {
               hadError = true;
             }
+            sessionId ??= metadata.sessionId;
             summary ??= metadata.summary;
             sessionWorkingDirectory = metadata.workingDirectory;
             lastActive ??= metadata.updatedAt;
@@ -1609,7 +1616,7 @@ class AgentSessionDiscoveryService {
         sessions.add(
           ToolSessionInfo(
             toolName: 'Codex',
-            sessionId: fileName,
+            sessionId: sessionId ?? fileName,
             workingDirectory: sessionWorkingDirectory,
             lastActive: lastActive,
             summary: summary ?? _truncateId(fileName),

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -414,7 +414,7 @@ class TmuxService {
       '"#{window_index}$sep#{window_name}$sep#{window_active}$sep'
       '#{pane_current_command}$sep#{pane_current_path}$sep'
       '#{window_flags}$sep#{pane_title}$sep#{window_activity}$sep'
-      '#{pane_start_command}"',
+      '#{pane_start_command}$sep#{@flutty_agent_tool}"',
     );
     final windows = List<TmuxWindow>.unmodifiable(
       _parseLines(output, TmuxWindow.fromTmuxFormat),
@@ -567,17 +567,33 @@ class TmuxService {
     // (e.g. resuming an AI session in a specific project). Without -c,
     // tmux uses the session's default-directory — matching Ctrl+b,c.
     final parts = <String>[
-      'tmux new-window -t ${_shellQuote(sessionName)}',
+      "tmux new-window -P -F '#{window_index}' -t ${_shellQuote(sessionName)}",
       if (workingDirectory != null && workingDirectory.trim().isNotEmpty)
         '-c ${_shellQuote(workingDirectory.trim())}',
       if (name != null && name.trim().isNotEmpty)
         '-n ${_shellQuote(name.trim())}',
     ];
-    await _exec(session, parts.join(' '));
+    final createdWindowIndex = _parseCreatedWindowIndex(
+      await _exec(session, parts.join(' ')),
+    );
+    final target = createdWindowIndex == null
+        ? sessionName
+        : '$sessionName:$createdWindowIndex';
+    final agentTool = _agentToolForCreatedWindow(command: command, name: name);
+    if (agentTool != null) {
+      await _exec(
+        session,
+        'tmux set-option -w -t ${_shellQuote(target)} '
+        '@flutty_agent_tool ${_shellQuote(agentTool.commandName)}',
+      );
+    }
     DiagnosticsLogService.instance.info(
       'tmux.action',
       'create_window_complete',
-      fields: {'connectionId': session.connectionId},
+      fields: {
+        'connectionId': session.connectionId,
+        'hasAgentTool': agentTool != null,
+      },
     );
 
     // If a command was requested, type it into the new window's shell.
@@ -586,7 +602,7 @@ class TmuxService {
     if (command != null && command.trim().isNotEmpty) {
       _execFireAndForget(
         session,
-        'tmux send-keys -t ${_shellQuote(sessionName)} '
+        'tmux send-keys -t ${_shellQuote(target)} '
         '${_shellQuote(command.trim())} Enter',
       );
       DiagnosticsLogService.instance.info(
@@ -970,6 +986,21 @@ class TmuxService {
       "'${value.replaceAll("'", "'\"'\"'")}'";
 }
 
+int? _parseCreatedWindowIndex(String output) {
+  for (final rawLine in output.split('\n')) {
+    final index = int.tryParse(rawLine.trim());
+    if (index != null) return index;
+  }
+  return null;
+}
+
+AgentLaunchTool? _agentToolForCreatedWindow({
+  required String? command,
+  required String? name,
+}) =>
+    agentLaunchToolForCommandName(name) ??
+    agentLaunchToolForCommandText(command);
+
 String _diagnosticTmuxCommandKind(String command) {
   if (command.contains('attach-session')) {
     return 'control_attach';
@@ -1046,7 +1077,8 @@ const _tmuxWindowSubscriptionFormat =
     '#{window_flags}$tmuxWindowFieldSeparator'
     '#{pane_title}$tmuxWindowFieldSeparator'
     '#{window_activity}$tmuxWindowFieldSeparator'
-    '#{pane_start_command}';
+    '#{pane_start_command}$tmuxWindowFieldSeparator'
+    '#{@flutty_agent_tool}';
 
 const _tmuxControlModeClientFlags = 'read-only,ignore-size,no-output,wait-exit';
 

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -406,12 +406,15 @@ class TmuxService {
       fields: {'connectionId': session.connectionId},
     );
     final quotedName = _shellQuote(sessionName);
+    const sep = r'${SEP}';
     final output = await _exec(
       session,
-      'tmux list-windows -t $quotedName -F '
-      "'#{window_index}|#{window_name}|#{window_active}|"
-      '#{pane_current_command}|#{pane_current_path}|'
-      "#{window_flags}|#{pane_title}|#{window_activity}'",
+      r'SEP=$(printf "\037"); '
+      'tmux -u list-windows -t $quotedName -F '
+      '"#{window_index}$sep#{window_name}$sep#{window_active}$sep'
+      '#{pane_current_command}$sep#{pane_current_path}$sep'
+      '#{window_flags}$sep#{pane_title}$sep#{window_activity}$sep'
+      '#{pane_start_command}"',
     );
     final windows = List<TmuxWindow>.unmodifiable(
       _parseLines(output, TmuxWindow.fromTmuxFormat),
@@ -1035,9 +1038,15 @@ bool hasForegroundTmuxClient(String output) {
 }
 
 const _tmuxWindowSubscriptionFormat =
-    '#{window_index}|#{window_name}|#{window_active}|'
-    '#{pane_current_command}|#{pane_current_path}|'
-    '#{window_flags}|#{pane_title}|#{window_activity}';
+    '#{window_index}$tmuxWindowFieldSeparator'
+    '#{window_name}$tmuxWindowFieldSeparator'
+    '#{window_active}$tmuxWindowFieldSeparator'
+    '#{pane_current_command}$tmuxWindowFieldSeparator'
+    '#{pane_current_path}$tmuxWindowFieldSeparator'
+    '#{window_flags}$tmuxWindowFieldSeparator'
+    '#{pane_title}$tmuxWindowFieldSeparator'
+    '#{window_activity}$tmuxWindowFieldSeparator'
+    '#{pane_start_command}';
 
 const _tmuxControlModeClientFlags = 'read-only,ignore-size,no-output,wait-exit';
 

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -48,7 +48,11 @@ class TmuxService {
   static final Map<int, String> _profileSourceCache = {};
 
   /// Cached set of installed agent CLIs per SSH session (by connectionId).
-  static final Map<int, Set<AgentLaunchTool>> _installedAgentToolsCache = {};
+  static final Map<int, _CachedInstalledAgentTools> _installedAgentToolsCache =
+      {};
+
+  static final Map<int, Future<Set<AgentLaunchTool>>>
+  _installedAgentToolRequests = {};
 
   static final Map<_TmuxWindowWatchKey, _TmuxWindowChangeObserver>
   _windowObservers = {};
@@ -56,6 +60,7 @@ class TmuxService {
   _windowListRequests = {};
 
   static const _execDoneMarker = '__flutty_tmux_exec_done__';
+  static const _installedAgentToolsFreshTtl = Duration(minutes: 30);
   static final RegExp _execDoneMarkerLinePattern = RegExp(
     '(?:^|\\n)${RegExp.escape(_execDoneMarker)}:([0-9]+)\\n',
   );
@@ -75,6 +80,7 @@ class TmuxService {
     _tmuxPathCache.remove(connectionId);
     _profileSourceCache.remove(connectionId);
     _installedAgentToolsCache.remove(connectionId);
+    _installedAgentToolRequests.remove(connectionId);
     _windowListRequests.removeWhere(
       (key, _) => key.connectionId == connectionId,
     );
@@ -183,35 +189,91 @@ class TmuxService {
   ) async {
     final cached = _installedAgentToolsCache[session.connectionId];
     if (cached != null) {
+      final age = DateTime.now().difference(cached.cachedAt);
       DiagnosticsLogService.instance.info(
         'tmux.agent',
         'tool_detection_cached',
         fields: {
           'connectionId': session.connectionId,
-          'toolCount': cached.length,
+          'toolCount': cached.tools.length,
+          'ageMs': age.inMilliseconds,
         },
       );
-      return cached;
+      if (age >= _installedAgentToolsFreshTtl) {
+        unawaited(_refreshInstalledAgentTools(session));
+      }
+      return cached.tools;
     }
+
+    return _refreshInstalledAgentTools(session);
+  }
+
+  /// Warms the installed agent CLI cache in the background.
+  Future<void> prefetchInstalledAgentTools(SshSession session) async {
+    final cached = _installedAgentToolsCache[session.connectionId];
+    if (cached != null &&
+        DateTime.now().difference(cached.cachedAt) <
+            _installedAgentToolsFreshTtl) {
+      return;
+    }
+    try {
+      await _refreshInstalledAgentTools(session);
+    } on Object catch (error) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.agent',
+        'tool_detection_prefetch_failed',
+        fields: {
+          'connectionId': session.connectionId,
+          'errorType': error.runtimeType,
+        },
+      );
+    }
+  }
+
+  Future<Set<AgentLaunchTool>> _refreshInstalledAgentTools(SshSession session) {
+    final existingRequest = _installedAgentToolRequests[session.connectionId];
+    if (existingRequest != null) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.agent',
+        'tool_detection_join',
+        fields: {'connectionId': session.connectionId},
+      );
+      return existingRequest;
+    }
+
     DiagnosticsLogService.instance.info(
       'tmux.agent',
       'tool_detection_start',
       fields: {'connectionId': session.connectionId},
     );
-    final output = await _exec(session, buildAgentToolDetectionCommand());
-    final installed = parseInstalledAgentTools(output);
-    if (installed.isNotEmpty) {
-      _installedAgentToolsCache[session.connectionId] = installed;
-    }
-    DiagnosticsLogService.instance.info(
-      'tmux.agent',
-      'tool_detection_complete',
-      fields: {
-        'connectionId': session.connectionId,
-        'toolCount': installed.length,
-      },
-    );
-    return installed;
+    final request = () async {
+      final output = await _exec(session, buildAgentToolDetectionCommand());
+      final installed = parseInstalledAgentTools(output);
+      _installedAgentToolsCache[session.connectionId] =
+          _CachedInstalledAgentTools(
+            tools: Set<AgentLaunchTool>.unmodifiable(installed),
+            cachedAt: DateTime.now(),
+          );
+      DiagnosticsLogService.instance.info(
+        'tmux.agent',
+        'tool_detection_complete',
+        fields: {
+          'connectionId': session.connectionId,
+          'toolCount': installed.length,
+        },
+      );
+      return installed;
+    }();
+    _installedAgentToolRequests[session.connectionId] = request;
+    request.whenComplete(() {
+      if (identical(
+        _installedAgentToolRequests[session.connectionId],
+        request,
+      )) {
+        _installedAgentToolRequests.remove(session.connectionId);
+      }
+    }).ignore();
+    return request;
   }
 
   /// Lists all tmux sessions on the remote host.
@@ -1000,6 +1062,16 @@ AgentLaunchTool? _agentToolForCreatedWindow({
 }) =>
     agentLaunchToolForCommandName(name) ??
     agentLaunchToolForCommandText(command);
+
+class _CachedInstalledAgentTools {
+  const _CachedInstalledAgentTools({
+    required this.tools,
+    required this.cachedAt,
+  });
+
+  final Set<AgentLaunchTool> tools;
+  final DateTime cachedAt;
+}
 
 String _diagnosticTmuxCommandKind(String command) {
   if (command.contains('attach-session')) {

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -48,16 +48,15 @@ class TmuxService {
   static final Map<int, String> _profileSourceCache = {};
 
   /// Cached set of installed agent CLIs per SSH session (by connectionId).
-  static final Map<int, _CachedInstalledAgentTools> _installedAgentToolsCache =
-      {};
+  static final _installedAgentToolsCache = <int, _CachedInstalledAgentTools>{};
 
-  static final Map<int, Future<Set<AgentLaunchTool>>>
-  _installedAgentToolRequests = {};
+  static final _installedAgentToolRequests =
+      <int, Future<Set<AgentLaunchTool>>>{};
 
-  static final Map<_TmuxWindowWatchKey, _TmuxWindowChangeObserver>
-  _windowObservers = {};
-  static final Map<_TmuxWindowWatchKey, Future<List<TmuxWindow>>>
-  _windowListRequests = {};
+  static final _windowObservers =
+      <_TmuxWindowWatchKey, _TmuxWindowChangeObserver>{};
+  static final _windowListRequests =
+      <_TmuxWindowWatchKey, Future<List<TmuxWindow>>>{};
 
   static const _execDoneMarker = '__flutty_tmux_exec_done__';
   static const _installedAgentToolsFreshTtl = Duration(minutes: 30);
@@ -181,9 +180,9 @@ class TmuxService {
   /// command is built per-binary so it also works on POSIX-strict
   /// `/bin/sh` (dash), where `command -v` rejects multiple operands.
   ///
-  /// Successful detections are cached per connection. Empty results
-  /// (typically a transient detection failure) are intentionally not
-  /// cached, so a later call can recover.
+  /// Detection results, including empty sets, are cached per connection.
+  /// Stale cached results are returned immediately while a refresh runs in
+  /// the background.
   Future<Set<AgentLaunchTool>> detectInstalledAgentTools(
     SshSession session,
   ) async {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -544,6 +544,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           CurvedAnimation(parent: _bounceController, curve: Curves.easeInOut),
         );
     unawaited(_loadPreferredLaunchTool());
+    unawaited(_tmux.prefetchInstalledAgentTools(widget.session));
     _loadWindows();
     _subscribeToWindowChanges();
   }
@@ -578,6 +579,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     unawaited(_windowChangeSubscription?.cancel());
     _subscribeToWindowChanges();
     unawaited(_loadPreferredLaunchTool());
+    unawaited(_tmux.prefetchInstalledAgentTools(widget.session));
     _loadWindows();
   }
 
@@ -601,9 +603,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     final preferredLaunchTool = preset?.tool;
     if (_preferredLaunchTool == preferredLaunchTool) return;
     setState(() => _preferredLaunchTool = preferredLaunchTool);
-    if (widget.isProUser) {
-      unawaited(_prefetchPreferredSessionProvider());
-    }
   }
 
   void _subscribeToWindowChanges() {
@@ -658,7 +657,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       },
     );
     _applyWindows(windows);
-    if (widget.isProUser) {
+    if (widget.isProUser && _showSessions) {
       unawaited(_prefetchPreferredSessionProvider(windows: windows));
     }
   }
@@ -916,7 +915,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         _resetWindowReloadRecovery();
       }
       _applyWindows(windows);
-      if (widget.isProUser) {
+      if (widget.isProUser && _showSessions) {
         unawaited(_prefetchPreferredSessionProvider(windows: windows));
       }
     } on Object catch (error) {
@@ -1184,7 +1183,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
             // Refresh window list when expanding to get current active state.
             if (!wasExpanded) {
               _loadWindows();
-              if (widget.isProUser) {
+              if (widget.isProUser && _showSessions) {
                 unawaited(_prefetchPreferredSessionProvider());
               }
             }

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -160,6 +160,8 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   String? _error;
   bool _loadingWindows = false;
   bool _pendingWindowReload = false;
+  bool _showSessions = false;
+  bool _hasInitializedSessionProviders = false;
   int _windowReloadGeneration = 0;
   int _windowEventGeneration = 0;
   Timer? _windowRetryTimer;
@@ -175,7 +177,6 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   void initState() {
     super.initState();
     unawaited(_loadPreferredLaunchTool());
-    _installedToolsFuture = _tmux.detectInstalledAgentTools(widget.session);
     _subscribeToWindowChanges();
     _loadWindows();
   }
@@ -185,6 +186,9 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.session.hostId != widget.session.hostId) {
       _resetWindowReloadRecovery();
+      _installedToolsFuture = null;
+      _showSessions = false;
+      _hasInitializedSessionProviders = false;
       unawaited(_loadPreferredLaunchTool());
     }
   }
@@ -221,7 +225,6 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     final preferredLaunchTool = preset?.tool;
     if (_preferredLaunchTool == preferredLaunchTool) return;
     setState(() => _preferredLaunchTool = preferredLaunchTool);
-    unawaited(_prefetchPreferredSessionProvider());
   }
 
   Future<void> _prefetchPreferredSessionProvider({
@@ -330,7 +333,6 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         _error = null;
         _isLoadingWindows = false;
       });
-      unawaited(_prefetchPreferredSessionProvider(windows: windows));
     } on Exception catch (e) {
       DiagnosticsLogService.instance.warning(
         'tmux.navigator',
@@ -492,11 +494,13 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   }
 
   void _showNewWindowPicker() {
+    final installedToolsFuture = _installedToolsFuture ??= _tmux
+        .detectInstalledAgentTools(widget.session);
     showModalBottomSheet<void>(
       context: context,
       builder: (context) => TmuxToolPickerSheet(
         isProUser: widget.isProUser,
-        installedToolsFuture: _installedToolsFuture,
+        installedToolsFuture: installedToolsFuture,
         preferredTool: _preferredLaunchTool,
         onToolSelected: (tool) {
           Navigator.pop(context);
@@ -724,42 +728,66 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         title: const Row(
           children: [Text('Recent AI Sessions'), Spacer(), PremiumBadge()],
         ),
-      ),
-      AiSessionProviderList(
-        key: ValueKey<Object>(
-          Object.hashAll(<Object?>[
-            widget.session.connectionId,
-            widget.tmuxSessionName,
-            widget.scopeWorkingDirectory,
-            _windows
-                ?.where((window) => window.isActive)
-                .firstOrNull
-                ?.currentPath,
-          ]),
+        trailing: Icon(
+          _showSessions ? Icons.expand_less : Icons.expand_more,
+          size: 18,
+          color: theme.colorScheme.onSurfaceVariant,
         ),
-        orderedTools: orderedDiscoveredSessionTools(
-          const <String, List<ToolSessionInfo>>{},
-          const <String>{},
-          preferredToolName: _preferredLaunchTool?.discoveredSessionToolName,
-        ),
-        loadSessionsForTool: (toolName, maxSessions) {
-          final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
-          final scopeWorkingDirectory =
-              widget.scopeWorkingDirectory ??
-              resolveAgentSessionScopeWorkingDirectory(
-                activeWorkingDirectory: activeWindow?.currentPath,
-                sessionWorkingDirectory: widget.session.workingDirectory,
-              );
-          return _discovery.discoverSessionsStream(
-            widget.session,
-            workingDirectory: scopeWorkingDirectory,
-            maxPerTool: maxSessions,
-            toolName: toolName,
-          );
+        onTap: () {
+          final showSessions = !_showSessions;
+          setState(() {
+            _showSessions = showSessions;
+            if (showSessions) {
+              _hasInitializedSessionProviders = true;
+            }
+          });
+          if (showSessions) {
+            unawaited(_prefetchPreferredSessionProvider());
+          }
         },
-        itemBuilder: (context, provider) =>
-            _buildSessionProviderTile(theme, provider),
       ),
+      if (_hasInitializedSessionProviders)
+        Offstage(
+          offstage: !_showSessions,
+          child: AiSessionProviderList(
+            key: ValueKey<Object>(
+              Object.hashAll(<Object?>[
+                widget.session.connectionId,
+                widget.tmuxSessionName,
+                widget.scopeWorkingDirectory,
+                _windows
+                    ?.where((window) => window.isActive)
+                    .firstOrNull
+                    ?.currentPath,
+              ]),
+            ),
+            orderedTools: orderedDiscoveredSessionTools(
+              const <String, List<ToolSessionInfo>>{},
+              const <String>{},
+              preferredToolName:
+                  _preferredLaunchTool?.discoveredSessionToolName,
+            ),
+            loadSessionsForTool: (toolName, maxSessions) {
+              final activeWindow = _windows
+                  ?.where((w) => w.isActive)
+                  .firstOrNull;
+              final scopeWorkingDirectory =
+                  widget.scopeWorkingDirectory ??
+                  resolveAgentSessionScopeWorkingDirectory(
+                    activeWorkingDirectory: activeWindow?.currentPath,
+                    sessionWorkingDirectory: widget.session.workingDirectory,
+                  );
+              return _discovery.discoverSessionsStream(
+                widget.session,
+                workingDirectory: scopeWorkingDirectory,
+                maxPerTool: maxSessions,
+                toolName: toolName,
+              );
+            },
+            itemBuilder: (context, provider) =>
+                _buildSessionProviderTile(theme, provider),
+          ),
+        ),
     ],
   );
 

--- a/test/domain/models/agent_launch_preset_test.dart
+++ b/test/domain/models/agent_launch_preset_test.dart
@@ -35,6 +35,27 @@ void main() {
     });
   });
 
+  group('agentLaunchToolForCommandText', () {
+    test('detects tools in wrapped shell commands', () {
+      expect(
+        agentLaunchToolForCommandText(
+          r'OPENCODE_PERMISSION="{\"*\":\"allow\"}" /opt/bin/opencode -s abc',
+        ),
+        AgentLaunchTool.openCode,
+      );
+      expect(
+        agentLaunchToolForCommandText('cd ~/repo && codex resume abc'),
+        AgentLaunchTool.codex,
+      );
+    });
+
+    test('returns null for commands without supported tools', () {
+      expect(agentLaunchToolForCommandText('node ./script.js'), isNull);
+      expect(agentLaunchToolForCommandText("cd '/tmp/codex' && node"), isNull);
+      expect(agentLaunchToolForCommandText(''), isNull);
+    });
+  });
+
   group('buildAgentLaunchCommand', () {
     test('builds a working-directory command without tmux', () {
       const preset = AgentLaunchPreset(

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -252,6 +252,28 @@ void main() {
       expect(window.secondaryTitle, isNull);
     });
 
+    test('uses app agent metadata when tmux exposes only wrapper names', () {
+      const sep = tmuxWindowFieldSeparator;
+      final line = [
+        '1',
+        'node',
+        '0',
+        'node',
+        '/Users/depoll/Code/flutty',
+        '',
+        'mac-mini.home',
+        '1712930000',
+        'zsh',
+        'gemini',
+      ].join(sep);
+      final window = TmuxWindow.fromTmuxFormat(line);
+
+      expect(window.agentTool, AgentLaunchTool.geminiCli);
+      expect(window.foregroundAgentTool, AgentLaunchTool.geminiCli);
+      expect(window.displayTitle, 'Gemini CLI · flutty');
+      expect(window.handleTitle, 'Gemini CLI · flutty');
+    });
+
     test('shows resumed agent session metadata from pane start commands', () {
       const window = TmuxWindow(
         index: 1,

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -206,6 +206,52 @@ void main() {
       expect(window.secondaryTitle, 'copilot');
     });
 
+    test('uses agent context when Codex only reports the project title', () {
+      const window = TmuxWindow(
+        index: 1,
+        name: 'codex',
+        isActive: false,
+        currentCommand: 'codex-aarch64-apple-darwin',
+        currentPath: '/Users/depoll/Code/flutty',
+        paneTitle: 'flutty',
+      );
+
+      expect(window.displayTitle, 'Codex · flutty');
+      expect(window.handleTitle, 'Codex · flutty');
+      expect(window.secondaryTitle, isNull);
+    });
+
+    test('uses agent context when Claude only reports its brand title', () {
+      const window = TmuxWindow(
+        index: 1,
+        name: 'claude',
+        isActive: false,
+        currentCommand: '2.1.119',
+        currentPath: '/Users/depoll/Code/flutty',
+        paneTitle: '✳ Claude Code',
+      );
+
+      expect(window.displayTitle, 'Claude Code · flutty');
+      expect(window.handleTitle, 'Claude Code · flutty');
+      expect(window.secondaryTitle, isNull);
+    });
+
+    test('uses agent context when Gemini only reports ready status', () {
+      const window = TmuxWindow(
+        index: 1,
+        name: 'gemini',
+        isActive: false,
+        currentCommand: 'node',
+        currentPath: '/Users/depoll/Code/flutty',
+        paneTitle:
+            '◇  Ready (flutty)                                                               ',
+      );
+
+      expect(window.displayTitle, 'Gemini CLI · flutty');
+      expect(window.handleTitle, 'Gemini CLI · flutty');
+      expect(window.secondaryTitle, isNull);
+    });
+
     test('shows resumed agent session metadata from pane start commands', () {
       const window = TmuxWindow(
         index: 1,

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -86,6 +86,15 @@ void main() {
       expect(window.displayTitle, 'Editing main.dart');
     });
 
+    test('preserves pipe characters in legacy pane titles', () {
+      const line = '1|logs|0|tail|/var/log|-|api | worker | errors|1712930000';
+      final window = TmuxWindow.fromTmuxFormat(line);
+
+      expect(window.paneTitle, 'api | worker | errors');
+      expect(window.lastActivityEpochSeconds, 1712930000);
+      expect(window.displayTitle, 'api | worker | errors');
+    });
+
     test('parses with minimal fields', () {
       const line = '2|bash|0';
       final window = TmuxWindow.fromTmuxFormat(line);

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -51,7 +51,18 @@ void main() {
 
   group('TmuxWindow', () {
     test('parses from tmux format string with all fields', () {
-      const line = '0|vim|1|vim|/home/user/project|*|Editing main.dart';
+      const sep = tmuxWindowFieldSeparator;
+      final line = [
+        '0',
+        'vim',
+        '1',
+        'vim',
+        '/home/user/project',
+        '*',
+        'Editing main.dart',
+        '1712930000',
+        'vim main.dart',
+      ].join(sep);
       final window = TmuxWindow.fromTmuxFormat(line);
 
       expect(window.index, 0);
@@ -61,8 +72,18 @@ void main() {
       expect(window.currentPath, '/home/user/project');
       expect(window.flags, '*');
       expect(window.paneTitle, 'Editing main.dart');
+      expect(window.paneStartCommand, 'vim main.dart');
       expect(window.displayTitle, 'Editing main.dart');
       expect(window.hasAlert, false);
+    });
+
+    test('still parses legacy pipe-delimited window snapshots', () {
+      const line = '0|vim|1|vim|/home/user/project|*|Editing main.dart';
+      final window = TmuxWindow.fromTmuxFormat(line);
+
+      expect(window.index, 0);
+      expect(window.name, 'vim');
+      expect(window.displayTitle, 'Editing main.dart');
     });
 
     test('parses with minimal fields', () {
@@ -151,6 +172,54 @@ void main() {
       );
 
       expect(window.displayTitle, 'Test session setup');
+    });
+
+    test(
+      'uses agent and worktree context when pane title is the default host',
+      () {
+        const window = TmuxWindow(
+          index: 1,
+          name: 'codex',
+          isActive: false,
+          currentCommand: 'codex',
+          currentPath: '/Users/depoll/Code/flutty.worktrees/fix-title/lib',
+          paneTitle: 'mac-mini.home',
+        );
+
+        expect(window.displayTitle, 'Codex · fix-title');
+        expect(window.handleTitle, 'Codex · fix-title');
+        expect(window.secondaryTitle, isNull);
+      },
+    );
+
+    test('uses useful CLI-provided pane titles over agent fallbacks', () {
+      const window = TmuxWindow(
+        index: 1,
+        name: 'copilot',
+        isActive: false,
+        currentCommand: 'copilot',
+        currentPath: '/Users/depoll/Code/flutty',
+        paneTitle: '✨ Editing main.dart',
+      );
+
+      expect(window.displayTitle, '✨ Editing main.dart');
+      expect(window.secondaryTitle, 'copilot');
+    });
+
+    test('shows resumed agent session metadata from pane start commands', () {
+      const window = TmuxWindow(
+        index: 1,
+        name: 'agent',
+        isActive: false,
+        currentPath: '/Users/depoll/Code/flutty',
+        paneTitle: 'localhost',
+        paneStartCommand: 'codex resume rollout-2026-04-26-session',
+      );
+
+      expect(window.foregroundAgentTool, AgentLaunchTool.codex);
+      expect(window.agentSessionId, 'rollout-2026-04-26-session');
+      expect(window.displayTitle, 'Codex · flutty');
+      expect(window.secondaryTitle, 'session rollout-...');
     });
 
     test('handles empty command and path', () {

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -38,6 +38,9 @@ SSHSession _buildExecSession({String stdout = '', String stderr = ''}) {
   return session;
 }
 
+String _remoteSnapshotLine(String path, String content, {int mtime = 0}) =>
+    '$path\x1f$mtime\x1f${base64Encode(utf8.encode(content))}\n';
+
 void main() {
   group('normalizeWorkingDirectoryForComparison', () {
     test('strips worktree branch segments from comparable paths', () {
@@ -493,6 +496,22 @@ branch refs/heads/fix/session-resumption
     );
   });
 
+  group('buildResumeCommand', () {
+    test('resumes Codex with the discovered session UUID', () {
+      const info = ToolSessionInfo(
+        toolName: 'Codex',
+        sessionId: '019dcbf6-c80e-7c30-b7fa-3d352bda8c4d',
+        workingDirectory: '/Users/depoll/Code/flutty',
+      );
+
+      expect(
+        AgentSessionDiscoveryService().buildResumeCommand(info),
+        "cd '/Users/depoll/Code/flutty' && "
+        "codex resume '019dcbf6-c80e-7c30-b7fa-3d352bda8c4d'",
+      );
+    });
+  });
+
   group('compareDiscoveredSessionsByRecency', () {
     test('sorts newest first and leaves untimestamped sessions last', () {
       final sessions = [
@@ -649,12 +668,13 @@ cwd: /tmp/demo
   group('parseCodexRolloutMetadata', () {
     test('prefers the structured user_message event over input_text noise', () {
       final metadata = parseCodexRolloutMetadata('''
-{"timestamp":"2026-04-12T21:07:44.781Z","type":"session_meta","cwd":"/Users/depoll/Code/flutty"}
+{"timestamp":"2026-04-12T21:07:44.781Z","type":"session_meta","payload":{"id":"019d8385-487f-72c1-9abf-766ffc76deff","cwd":"/Users/depoll/Code/flutty"}}
 {"timestamp":"2026-04-12T21:07:45.000Z","type":"response_item","payload":{"type":"message","content":[{"type":"input_text","text":"<permissions instructions>"}]}}
 {"timestamp":"2026-04-12T21:07:48.390Z","type":"event_msg","payload":{"type":"user_message","message":"rename this session","images":[]}}
 ''');
 
       expect(metadata.parsedAny, isTrue);
+      expect(metadata.sessionId, '019d8385-487f-72c1-9abf-766ffc76deff');
       expect(metadata.workingDirectory, '/Users/depoll/Code/flutty');
       expect(metadata.summary, 'rename this session');
       expect(metadata.updatedAt, DateTime.parse('2026-04-12T21:07:44.781Z'));
@@ -748,6 +768,54 @@ cwd: /tmp/demo
   });
 
   group('discoverSessionsStream caching', () {
+    test(
+      'Codex discovery uses resumable UUID instead of rollout filename',
+      () async {
+        final client = _MockSshClient();
+        const rolloutPath =
+            '/Users/demo/.codex/sessions/2026/04/26/'
+            'rollout-2026-04-26T15-44-01-'
+            '019dcbf6-c80e-7c30-b7fa-3d352bda8c4d.jsonl';
+        const sessionId = '019dcbf6-c80e-7c30-b7fa-3d352bda8c4d';
+        when(() => client.execute(any())).thenAnswer((invocation) async {
+          final command = invocation.positionalArguments.first as String;
+          if (command.contains('find ~/.codex/sessions')) {
+            return _buildExecSession(stdout: rolloutPath);
+          }
+          if (command.contains('~/.codex/session_index.jsonl')) {
+            return _buildExecSession(
+              stdout:
+                  '{"id":"$sessionId","thread_name":"Fix tmux titles",'
+                  ' "updated_at":"2026-04-26T22:44:35.656609Z"}\n',
+            );
+          }
+          if (command.contains(rolloutPath)) {
+            return _buildExecSession(
+              stdout: _remoteSnapshotLine(rolloutPath, '''
+{"timestamp":"2026-04-26T22:44:20.349Z","type":"session_meta","payload":{"id":"$sessionId","timestamp":"2026-04-26T22:44:01.169Z","cwd":"/Users/depoll/Code/flutty"}}
+{"timestamp":"2026-04-26T22:44:48.390Z","type":"event_msg","payload":{"type":"user_message","message":"fix codex resume","images":[]}}
+''', mtime: 1777243460),
+            );
+          }
+          return _buildExecSession();
+        });
+
+        final discovery = AgentSessionDiscoveryService();
+        final session = _buildDiscoverySession(client);
+        final result = await discovery.discoverSessions(
+          session,
+          toolName: 'Codex',
+        );
+
+        expect(result.sessions, hasLength(1));
+        expect(result.sessions.single.sessionId, sessionId);
+        expect(
+          discovery.buildResumeCommand(result.sessions.single),
+          "cd '/Users/depoll/Code/flutty' && codex resume '$sessionId'",
+        );
+      },
+    );
+
     test('toolName limits discovery to the requested provider', () async {
       final client = _MockSshClient();
       final commands = <String>[];

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -35,7 +36,8 @@ void main() {
           '#{window_index}$sep#{window_name}$sep#{window_active}$sep'
           '#{pane_current_command}$sep#{pane_current_path}$sep'
           '#{window_flags}$sep#{pane_title}$sep#{window_activity}$sep'
-          "#{pane_start_command}'",
+          '#{pane_start_command}$sep'
+          "#{@flutty_agent_tool}'",
         );
       },
     );
@@ -56,6 +58,7 @@ void main() {
         'custom-title',
         '1712930000',
         'sleep 30',
+        'gemini',
       ].join(sep);
       final event = parseTmuxWindowChangeEventFromControlLine(
         '${r'%subscription-changed flutty-1-42 $1 @1 1 %1 : '}$snapshotValue',
@@ -69,6 +72,7 @@ void main() {
       expect(snapshot.window.isActive, isTrue);
       expect(snapshot.window.paneTitle, 'custom-title');
       expect(snapshot.window.paneStartCommand, 'sleep 30');
+      expect(snapshot.window.agentTool, AgentLaunchTool.geminiCli);
     });
 
     test('normalizes the wrapped first control-mode line', () {
@@ -82,6 +86,7 @@ void main() {
         'wrapped-title',
         '1712930000',
         'sleep 30',
+        '',
       ].join(sep);
       final event = parseTmuxWindowChangeEventFromControlLine(
         '\u001bP1000p'
@@ -392,6 +397,65 @@ void main() {
       expect(windows.single.paneTitle, 'title $_execDoneMarker:1');
       verify(execSession.close).called(1);
     });
+
+    test(
+      'createWindow tags agent windows and targets the created index',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client);
+        const service = TmuxService();
+        final execSessions = Queue<SSHSession>.from([
+          _buildOpenExecSession(stdout: '4\n${_doneMarker()}'),
+          _buildOpenExecSession(stdout: _doneMarker()),
+          _buildOpenExecSession(),
+        ]);
+
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => execSessions.removeFirst());
+
+        await service.createWindow(
+          session,
+          'main',
+          command: 'gemini --yolo',
+          name: 'gemini',
+          workingDirectory: '/tmp/project',
+        );
+
+        verify(
+          () => client.execute(
+            any(
+              that: contains(
+                "tmux -u new-window -P -F '#{window_index}' -t "
+                "'main' -c '/tmp/project' -n 'gemini'",
+              ),
+            ),
+            pty: any(named: 'pty'),
+          ),
+        ).called(1);
+        verify(
+          () => client.execute(
+            any(
+              that: contains(
+                "tmux -u set-option -w -t 'main:4' "
+                "@flutty_agent_tool 'gemini'",
+              ),
+            ),
+            pty: any(named: 'pty'),
+          ),
+        ).called(1);
+        verify(
+          () => client.execute(
+            any(
+              that: contains(
+                "tmux -u send-keys -t 'main:4' 'gemini --yolo' Enter",
+              ),
+            ),
+            pty: any(named: 'pty'),
+          ),
+        ).called(1);
+      },
+    );
 
     test(
       'selectWindow completes when stdout stays open after the done marker',

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -27,13 +27,15 @@ void main() {
     test(
       'subscription command watches all windows in the attached session',
       () {
+        const sep = tmuxWindowFieldSeparator;
         expect(
           buildTmuxWindowSubscriptionCommand('flutty-1-42'),
           'refresh-client -B '
           "'flutty-1-42:@*:"
-          '#{window_index}|#{window_name}|#{window_active}|'
-          '#{pane_current_command}|#{pane_current_path}|'
-          "#{window_flags}|#{pane_title}|#{window_activity}'",
+          '#{window_index}$sep#{window_name}$sep#{window_active}$sep'
+          '#{pane_current_command}$sep#{pane_current_path}$sep'
+          '#{window_flags}$sep#{pane_title}$sep#{window_activity}$sep'
+          "#{pane_start_command}'",
         );
       },
     );
@@ -41,10 +43,22 @@ void main() {
 
   group('parseTmuxWindowChangeEventFromControlLine', () {
     const subscriptionName = 'flutty-1-42';
+    const sep = tmuxWindowFieldSeparator;
 
     test('returns a window snapshot event for matching subscriptions', () {
+      final snapshotValue = [
+        '1',
+        'renamed',
+        '1',
+        'sleep',
+        '/tmp',
+        '*',
+        'custom-title',
+        '1712930000',
+        'sleep 30',
+      ].join(sep);
       final event = parseTmuxWindowChangeEventFromControlLine(
-        r'%subscription-changed flutty-1-42 $1 @1 1 %1 : 1|renamed|1|sleep|/tmp|*|custom-title|1712930000',
+        '${r'%subscription-changed flutty-1-42 $1 @1 1 %1 : '}$snapshotValue',
         subscriptionName: subscriptionName,
       );
 
@@ -54,12 +68,25 @@ void main() {
       expect(snapshot.window.name, 'renamed');
       expect(snapshot.window.isActive, isTrue);
       expect(snapshot.window.paneTitle, 'custom-title');
+      expect(snapshot.window.paneStartCommand, 'sleep 30');
     });
 
     test('normalizes the wrapped first control-mode line', () {
+      final snapshotValue = [
+        '0',
+        'shell',
+        '1',
+        'sleep',
+        '/tmp',
+        '*',
+        'wrapped-title',
+        '1712930000',
+        'sleep 30',
+      ].join(sep);
       final event = parseTmuxWindowChangeEventFromControlLine(
-        '\u001bP1000p%subscription-changed flutty-1-42 \$1 @1 1 %1 : '
-        '0|shell|1|sleep|/tmp|*|wrapped-title|1712930000',
+        '\u001bP1000p'
+        '${r'%subscription-changed flutty-1-42 $1 @1 1 %1 : '}'
+        '$snapshotValue',
         subscriptionName: subscriptionName,
       );
 

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -41,6 +41,43 @@ void main() {
         );
       },
     );
+
+    test('detectInstalledAgentTools caches empty results', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client, connectionId: 20);
+      const service = TmuxService();
+      final execSession = _buildOpenExecSession(stdout: _doneMarker());
+
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) async => execSession);
+
+      final first = await service.detectInstalledAgentTools(session);
+      final second = await service.detectInstalledAgentTools(session);
+
+      expect(first, isEmpty);
+      expect(second, isEmpty);
+      verify(() => client.execute(any(), pty: any(named: 'pty'))).called(1);
+    });
+
+    test('prefetchInstalledAgentTools warms the detection cache', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client, connectionId: 21);
+      const service = TmuxService();
+      final execSession = _buildOpenExecSession(
+        stdout: '/opt/homebrew/bin/gemini\n${_doneMarker()}',
+      );
+
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) async => execSession);
+
+      await service.prefetchInstalledAgentTools(session);
+      final tools = await service.detectInstalledAgentTools(session);
+
+      expect(tools, {AgentLaunchTool.geminiCli});
+      verify(() => client.execute(any(), pty: any(named: 'pty'))).called(1);
+    });
   });
 
   group('parseTmuxWindowChangeEventFromControlLine', () {
@@ -673,16 +710,17 @@ void main() {
   });
 }
 
-SshSession _buildSession(SSHClient client) => SshSession(
-  connectionId: 1,
-  hostId: 1,
-  client: client,
-  config: const SshConnectionConfig(
-    hostname: 'example.com',
-    port: 22,
-    username: 'tester',
-  ),
-);
+SshSession _buildSession(SSHClient client, {int connectionId = 1}) =>
+    SshSession(
+      connectionId: connectionId,
+      hostId: 1,
+      client: client,
+      config: const SshConnectionConfig(
+        hostname: 'example.com',
+        port: 22,
+        username: 'tester',
+      ),
+    );
 
 class _MockSshClient extends Mock implements SSHClient {}
 

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -289,6 +289,9 @@ void main() {
       when(
         () => tmuxService.detectInstalledAgentTools(session),
       ).thenAnswer((_) async => const <AgentLaunchTool>{});
+      when(
+        () => tmuxService.prefetchInstalledAgentTools(session),
+      ).thenAnswer((_) async {});
 
       await tester.pumpWidget(
         ProviderScope(
@@ -349,6 +352,9 @@ void main() {
         when(
           () => tmuxService.watchWindowChanges(session, tmuxSessionName),
         ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+        when(
+          () => tmuxService.prefetchInstalledAgentTools(session),
+        ).thenAnswer((_) async {});
 
         await tester.pumpWidget(
           ProviderScope(

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -102,7 +102,7 @@ void main() {
       expect(find.text('Resume'), findsOneWidget);
     });
 
-    testWidgets('shows AI session providers without expanding a section', (
+    testWidgets('loads AI session providers only after expanding the section', (
       tester,
     ) async {
       final tmuxService = _MockTmuxService();
@@ -182,9 +182,33 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Recent AI Sessions'), findsOneWidget);
-      expect(find.text('Claude Code'), findsNWidgets(2));
-      expect(find.byIcon(Icons.expand_more), findsNothing);
+      expect(find.text('Claude Code'), findsOneWidget);
+      expect(find.byIcon(Icons.expand_more), findsOneWidget);
       expect(find.byIcon(Icons.expand_less), findsNothing);
+      verifyNever(
+        () => discoveryService.discoverSessionsStream(
+          session,
+          workingDirectory: any(named: 'workingDirectory'),
+          maxPerTool: any(named: 'maxPerTool'),
+          toolName: any(named: 'toolName'),
+        ),
+      );
+      verifyNever(() => tmuxService.detectInstalledAgentTools(session));
+
+      await tester.ensureVisible(find.text('Recent AI Sessions'));
+      await tester.pump();
+      await tester.tap(find.text('Recent AI Sessions'));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.expand_less), findsOneWidget);
+      verify(
+        () => discoveryService.discoverSessionsStream(
+          session,
+          workingDirectory: any(named: 'workingDirectory'),
+          maxPerTool: any(named: 'maxPerTool'),
+          toolName: any(named: 'toolName'),
+        ),
+      ).called(5);
     });
 
     testWidgets('recovers from a transient empty window reload', (

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -50,7 +50,7 @@ void main() {
       );
 
       expect(find.text('✨ Editing main.dart'), findsOneWidget);
-      expect(find.text('claude'), findsOneWidget);
+      expect(find.text('Claude Code'), findsOneWidget);
       expect(find.text('bash'), findsOneWidget);
       expect(find.text('htop'), findsOneWidget);
       expect(find.text('running'), findsNWidgets(3));
@@ -70,7 +70,7 @@ void main() {
 
       expect(find.text('tmux:'), findsOneWidget);
       expect(find.text('✨ Editing main.dart'), findsOneWidget);
-      expect(find.text('claude'), findsOneWidget);
+      expect(find.text('Claude Code'), findsOneWidget);
       expect(find.text('bash'), findsOneWidget);
     });
 
@@ -182,7 +182,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Recent AI Sessions'), findsOneWidget);
-      expect(find.text('Claude Code'), findsOneWidget);
+      expect(find.text('Claude Code'), findsNWidgets(2));
       expect(find.byIcon(Icons.expand_more), findsNothing);
       expect(find.byIcon(Icons.expand_less), findsNothing);
     });


### PR DESCRIPTION
## Summary

- Improve tmux window labels for agent CLIs that do not set terminal titles
- Add tmux pane start-command metadata and safer Unit Separator parsing for window snapshots
- Fall back to agent + worktree/project context while preserving rich CLI-provided titles

## Validation

- dart format lib/domain/models/tmux_state.dart lib/domain/services/tmux_service.dart test/domain/models/tmux_state_test.dart test/domain/services/tmux_service_control_mode_test.dart test/widget/tmux_window_navigator_test.dart
- flutter analyze
- flutter test
