### PR TITLE
fix: address security audit findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,29 @@ updates:
       - "ci"
     commit-message:
       prefix: "deps(actions)"
+
+  # Ruby tooling (fastlane, CocoaPods)
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ruby"
+    commit-message:
+      prefix: "deps(ruby)"
+
+  # Android Gradle dependencies
+  - package-ecosystem: "gradle"
+    directory: "/android"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "android"
+    commit-message:
+      prefix: "deps(android)"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,16 +36,9 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:mimeType="application/x-monkeyssh-transfer"/>
-                <data android:scheme="file"/>
-                <data android:scheme="content"/>
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="file" android:pathPattern=".*\\.monkeysshx"/>
+                <data
+                    android:scheme="content"
+                    android:mimeType="application/x-monkeyssh-transfer"/>
             </intent-filter>
         </activity>
         <service

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
@@ -193,9 +193,16 @@ class MainActivity : FlutterFragmentActivity() {
             return false
         }
         val mimeType = transferIntent.type?.lowercase(Locale.ROOT)
+        if (mimeType != MONKEYSSH_TRANSFER_MIME_TYPE) {
+            return false
+        }
         val lastPathSegment = sourceUri.lastPathSegment?.lowercase(Locale.ROOT)
-        return mimeType == MONKEYSSH_TRANSFER_MIME_TYPE &&
-            lastPathSegment?.endsWith(MONKEYSSH_TRANSFER_EXTENSION) == true
+        if (lastPathSegment?.endsWith(MONKEYSSH_TRANSFER_EXTENSION) == true) {
+            return true
+        }
+        val displayName = runCatching { resolveContentDisplayName(sourceUri) }.getOrNull()
+            ?.lowercase(Locale.ROOT)
+        return displayName == null || displayName.endsWith(MONKEYSSH_TRANSFER_EXTENSION)
     }
 
     private fun readClipboardContentUri(uri: Uri): Map<String, Any> {
@@ -247,6 +254,14 @@ class MainActivity : FlutterFragmentActivity() {
     }
 
     private fun resolveDisplayName(uri: Uri): String? {
+        val displayName = resolveContentDisplayName(uri)
+        if (displayName != null) {
+            return displayName
+        }
+        return uri.lastPathSegment?.substringAfterLast('/')
+    }
+
+    private fun resolveContentDisplayName(uri: Uri): String? {
         if (uri.scheme == "content") {
             contentResolver.query(
                 uri,
@@ -261,6 +276,6 @@ class MainActivity : FlutterFragmentActivity() {
                 }
             }
         }
-        return uri.lastPathSegment?.substringAfterLast('/')
+        return null
     }
 }

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
@@ -189,19 +189,13 @@ class MainActivity : FlutterFragmentActivity() {
             return false
         }
         val sourceUri = transferIntent.data ?: return false
-        val hasSupportedScheme = when (sourceUri.scheme) {
-            "content", "file" -> true
-            else -> false
-        }
-        if (!hasSupportedScheme) {
+        if (sourceUri.scheme != "content") {
             return false
         }
         val mimeType = transferIntent.type?.lowercase(Locale.ROOT)
-        if (mimeType == MONKEYSSH_TRANSFER_MIME_TYPE) {
-            return true
-        }
         val lastPathSegment = sourceUri.lastPathSegment?.lowercase(Locale.ROOT)
-        return lastPathSegment?.endsWith(MONKEYSSH_TRANSFER_EXTENSION) == true
+        return mimeType == MONKEYSSH_TRANSFER_MIME_TYPE &&
+            lastPathSegment?.endsWith(MONKEYSSH_TRANSFER_EXTENSION) == true
     }
 
     private fun readClipboardContentUri(uri: Uri): Map<String, Any> {

--- a/lib/data/security/secret_encryption_service.dart
+++ b/lib/data/security/secret_encryption_service.dart
@@ -12,7 +12,7 @@ class SecretEncryptionService {
     FlutterSecureStorage? storage,
     AesGcm? algorithm,
     Random? random,
-  }) : _storage = storage ?? const FlutterSecureStorage(),
+  }) : _storage = storage ?? _secureStorage,
        _algorithm = algorithm ?? AesGcm.with256bits(),
        _random = random ?? Random.secure(),
        _testingMasterKey = null;
@@ -40,6 +40,11 @@ class SecretEncryptionService {
   static const _encryptedPrefix = 'ENCv1:';
   static const _masterKeyBytes = 32;
   static const _nonceBytes = 12;
+  static const _secureStorage = FlutterSecureStorage(
+    iOptions: IOSOptions(
+      accessibility: KeychainAccessibility.first_unlock_this_device,
+    ),
+  );
 
   SecretKey? _cachedMasterKey;
   Future<void> _masterKeyQueue = Future<void>.value();

--- a/lib/data/security/secret_encryption_service.dart
+++ b/lib/data/security/secret_encryption_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:cryptography/cryptography.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
@@ -45,6 +46,10 @@ class SecretEncryptionService {
       accessibility: KeychainAccessibility.first_unlock_this_device,
     ),
   );
+  static const _hardenedIosOptions = IOSOptions(
+    accessibility: KeychainAccessibility.first_unlock_this_device,
+  );
+  static const _legacyIosOptions = IOSOptions.defaultOptions;
 
   SecretKey? _cachedMasterKey;
   Future<void> _masterKeyQueue = Future<void>.value();
@@ -165,7 +170,7 @@ class SecretEncryptionService {
         return;
       }
 
-      final existing = await storage.read(key: _masterKeyStorageEntry);
+      final existing = await _readStorageValue(storage, _masterKeyStorageEntry);
       if (existing != null) {
         final decoded = base64Decode(existing);
         if (decoded.length != _masterKeyBytes) {
@@ -175,21 +180,27 @@ class SecretEncryptionService {
         return;
       }
 
-      final legacyExisting = await storage.read(
-        key: _legacyMasterKeyStorageEntry,
+      final legacyExisting = await _readStorageValue(
+        storage,
+        _legacyMasterKeyStorageEntry,
       );
       if (legacyExisting != null) {
         final decoded = base64Decode(legacyExisting);
         if (decoded.length != _masterKeyBytes) {
           throw const FormatException('Invalid secret encryption key');
         }
-        await storage.write(key: _masterKeyStorageEntry, value: legacyExisting);
+        await _writeStorageValue(
+          storage,
+          key: _masterKeyStorageEntry,
+          value: legacyExisting,
+        );
         _cachedMasterKey = SecretKey(decoded);
         return;
       }
 
       final generated = SecretKeyData.random(length: _masterKeyBytes).bytes;
-      await storage.write(
+      await _writeStorageValue(
+        storage,
         key: _masterKeyStorageEntry,
         value: base64Encode(generated),
       );
@@ -207,6 +218,35 @@ class SecretEncryptionService {
 
   List<int> _randomBytes(int length) =>
       List<int>.generate(length, (_) => _random.nextInt(256), growable: false);
+
+  Future<String?> _readStorageValue(
+    FlutterSecureStorage storage,
+    String key,
+  ) async {
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      return storage.read(key: key);
+    }
+
+    final current = await storage.read(key: key, iOptions: _hardenedIosOptions);
+    if (current != null) return current;
+
+    final legacy = await storage.read(key: key, iOptions: _legacyIosOptions);
+    if (legacy != null) {
+      await _writeStorageValue(storage, key: key, value: legacy);
+    }
+    return legacy;
+  }
+
+  Future<void> _writeStorageValue(
+    FlutterSecureStorage storage, {
+    required String key,
+    required String value,
+  }) {
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      return storage.write(key: key, value: value);
+    }
+    return storage.write(key: key, value: value, iOptions: _hardenedIosOptions);
+  }
 
   List<int> _decodeEnvelopeField(Map<String, dynamic> envelope, String key) {
     final value = envelope[key];

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -568,6 +568,7 @@ String buildTmuxCommand({
     "-s '${sessionName.replaceAll("'", "'\"'\"'")}'",
     if (workingDirectory != null && workingDirectory.trim().isNotEmpty)
       "-c '${workingDirectory.trim().replaceAll("'", "'\"'\"'")}'",
+    // Extra flags are intentionally raw user input; never populate from imports.
     if (extraFlags != null && extraFlags.trim().isNotEmpty) extraFlags.trim(),
   ];
   return parts.join(' ');

--- a/lib/domain/services/auth_service.dart
+++ b/lib/domain/services/auth_service.dart
@@ -101,17 +101,21 @@ class AuthService {
       accessibility: KeychainAccessibility.first_unlock_this_device,
     ),
   );
+  static const _hardenedIosOptions = IOSOptions(
+    accessibility: KeychainAccessibility.first_unlock_this_device,
+  );
+  static const _legacyIosOptions = IOSOptions.defaultOptions;
   Future<void> _pinWriteQueue = Future<void>.value();
 
   /// Check if authentication is enabled.
   Future<bool> isAuthEnabled() async {
-    final value = await _storage.read(key: _authEnabledKey);
+    final value = await _readStorageValue(_authEnabledKey);
     return value == 'true';
   }
 
   /// Check if biometric is enabled.
   Future<bool> isBiometricEnabled() async {
-    final value = await _storage.read(key: _biometricEnabledKey);
+    final value = await _readStorageValue(_biometricEnabledKey);
     return value == 'true';
   }
 
@@ -211,7 +215,7 @@ class AuthService {
   /// Enable or disable biometric authentication.
   Future<void> setBiometricEnabled({required bool enabled}) async {
     final canEnable = !enabled || await isBiometricAvailable();
-    await _storage.write(
+    await _writeStorageValue(
       key: _biometricEnabledKey,
       value: (enabled && canEnable).toString(),
     );
@@ -219,7 +223,7 @@ class AuthService {
 
   /// Verify PIN.
   Future<bool> verifyPin(String pin) async {
-    final storedPinData = await _storage.read(key: _pinKey);
+    final storedPinData = await _readStorageValue(_pinKey);
     if (storedPinData == null) return false;
 
     final pinRecord = _parsePinRecord(storedPinData);
@@ -295,11 +299,11 @@ class AuthService {
 
   /// Disable authentication.
   Future<void> disableAuth() async {
-    await _storage.delete(key: _pinKey);
-    await _storage.delete(key: _pinSaltKey);
-    await _storage.delete(key: _pinMetadataKey);
-    await _storage.delete(key: _authEnabledKey);
-    await _storage.delete(key: _biometricEnabledKey);
+    await _deleteStorageValue(_pinKey);
+    await _deleteStorageValue(_pinSaltKey);
+    await _deleteStorageValue(_pinMetadataKey);
+    await _deleteStorageValue(_authEnabledKey);
+    await _deleteStorageValue(_biometricEnabledKey);
   }
 
   /// Change PIN.
@@ -319,7 +323,7 @@ class AuthService {
         salt: salt,
         iterations: _pinKdfIterations,
       );
-      await _storage.write(
+      await _writeStorageValue(
         key: _pinKey,
         value: jsonEncode({
           'version': _pinKdfVersion,
@@ -327,7 +331,7 @@ class AuthService {
           'hash': hash,
         }),
       );
-      await _storage.write(
+      await _writeStorageValue(
         key: _pinMetadataKey,
         value: jsonEncode({
           'version': _pinKdfVersion,
@@ -335,7 +339,7 @@ class AuthService {
         }),
       );
       if (enableAuth) {
-        await _storage.write(key: _authEnabledKey, value: 'true');
+        await _writeStorageValue(key: _authEnabledKey, value: 'true');
       }
     });
   }
@@ -345,12 +349,12 @@ class AuthService {
     if (existingSalt != null) return existingSalt;
 
     final salt = SecretKeyData.random(length: _pinSaltLength).bytes;
-    await _storage.write(key: _pinSaltKey, value: base64Encode(salt));
+    await _writeStorageValue(key: _pinSaltKey, value: base64Encode(salt));
     return salt;
   }
 
   Future<List<int>?> _readSalt() async {
-    final saltData = await _storage.read(key: _pinSaltKey);
+    final saltData = await _readStorageValue(_pinSaltKey);
     if (saltData == null) return null;
 
     try {
@@ -415,7 +419,7 @@ class AuthService {
   }
 
   Future<bool> _hasUsablePin() async {
-    final storedPinData = await _storage.read(key: _pinKey);
+    final storedPinData = await _readStorageValue(_pinKey);
     if (storedPinData == null) return false;
 
     final pinRecord = _parsePinRecord(storedPinData);
@@ -431,6 +435,51 @@ class AuthService {
 
     final salt = await _readSalt();
     return salt != null;
+  }
+
+  Future<String?> _readStorageValue(String key) async {
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      return _storage.read(key: key);
+    }
+
+    final current = await _storage.read(
+      key: key,
+      iOptions: _hardenedIosOptions,
+    );
+    if (current != null) return current;
+
+    final legacy = await _storage.read(key: key, iOptions: _legacyIosOptions);
+    if (legacy != null) {
+      await _storage.write(
+        key: key,
+        value: legacy,
+        iOptions: _hardenedIosOptions,
+      );
+    }
+    return legacy;
+  }
+
+  Future<void> _writeStorageValue({
+    required String key,
+    required String value,
+  }) {
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      return _storage.write(key: key, value: value);
+    }
+    return _storage.write(
+      key: key,
+      value: value,
+      iOptions: _hardenedIosOptions,
+    );
+  }
+
+  Future<void> _deleteStorageValue(String key) async {
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      await _storage.delete(key: key);
+      return;
+    }
+    await _storage.delete(key: key, iOptions: _hardenedIosOptions);
+    await _storage.delete(key: key, iOptions: _legacyIosOptions);
   }
 
   bool _constantTimeEquals(String a, String b) {

--- a/lib/domain/services/auth_service.dart
+++ b/lib/domain/services/auth_service.dart
@@ -80,7 +80,7 @@ class BiometricAvailability {
 class AuthService {
   /// Creates a new [AuthService].
   AuthService({FlutterSecureStorage? storage, LocalAuthentication? localAuth})
-    : _storage = storage ?? const FlutterSecureStorage(),
+    : _storage = storage ?? _secureStorage,
       _localAuth = localAuth ?? LocalAuthentication();
 
   final FlutterSecureStorage _storage;
@@ -96,6 +96,11 @@ class AuthService {
   static const _pinKdfBits = 256;
   static const _pinHashLength = _pinKdfBits ~/ 8;
   static const _pinSaltLength = 16;
+  static const _secureStorage = FlutterSecureStorage(
+    iOptions: IOSOptions(
+      accessibility: KeychainAccessibility.first_unlock_this_device,
+    ),
+  );
   Future<void> _pinWriteQueue = Future<void>.value();
 
   /// Check if authentication is enabled.

--- a/lib/domain/services/clipboard_sharing_service.dart
+++ b/lib/domain/services/clipboard_sharing_service.dart
@@ -42,7 +42,10 @@ class ClipboardSharingService {
   ///
   /// Returns an OSC 52 response string to send back through the shell when
   /// the remote queries the clipboard, or `null` when no response is needed.
-  Future<String?> handleOsc52(List<String> args) async {
+  Future<String?> handleOsc52(
+    List<String> args, {
+    required bool allowLocalClipboardRead,
+  }) async {
     try {
       final parsed = parseOsc52Args(args);
       if (parsed == null) return null;
@@ -50,6 +53,7 @@ class ClipboardSharingService {
       final (target, payload) = parsed;
 
       if (payload == '?') {
+        if (!allowLocalClipboardRead) return null;
         return _handleQuery(target);
       }
 

--- a/lib/domain/services/key_service.dart
+++ b/lib/domain/services/key_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart' as crypto;
 import 'package:dartssh2/dartssh2.dart';
 import 'package:drift/drift.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -48,7 +49,7 @@ class KeyService {
       // Convert public key to OpenSSH format: type + space + base64-encoded key
       final publicKeyBytes = keyPair.toPublicKey().encode();
       final publicKey = '$keyType ${base64.encode(publicKeyBytes)}';
-      final fingerprint = _computeFingerprint(publicKey);
+      final fingerprint = computeOpenSshPublicKeyFingerprint(publicKey);
 
       final id = await _keyRepository.insert(
         SshKeysCompanion.insert(
@@ -80,6 +81,9 @@ class KeyService {
     }
 
     final tempDir = await Directory.systemTemp.createTemp('monkeyssh-keygen-');
+    if (!Platform.isWindows) {
+      await Process.run('chmod', ['700', tempDir.path]);
+    }
     final keyPath = p.join(tempDir.path, 'id_key');
     final normalizedPassphrase = passphrase?.isEmpty ?? true ? '' : passphrase!;
 
@@ -113,7 +117,8 @@ class KeyService {
         );
       }
 
-      final privateKeyPem = await File(keyPath).readAsString();
+      final privateKeyFile = File(keyPath);
+      final privateKeyPem = await privateKeyFile.readAsString();
       return importKey(
         name: name,
         privateKeyPem: privateKeyPem,
@@ -122,6 +127,7 @@ class KeyService {
     } on ProcessException catch (e) {
       throw Exception('ssh-keygen is not available: ${e.message}');
     } finally {
+      await _wipeGeneratedKeyFiles(keyPath);
       await tempDir.delete(recursive: true);
     }
   }
@@ -131,20 +137,24 @@ class KeyService {
     required String name,
     required String publicKey,
   }) async {
-    final fingerprint = _computeFingerprint(publicKey);
-    final keyType = _detectKeyType(publicKey);
+    try {
+      final fingerprint = computeOpenSshPublicKeyFingerprint(publicKey);
+      final keyType = _detectKeyType(publicKey);
 
-    final id = await _keyRepository.insert(
-      SshKeysCompanion.insert(
-        name: name,
-        keyType: keyType,
-        publicKey: publicKey,
-        privateKey: '', // No private key
-        fingerprint: Value(fingerprint),
-      ),
-    );
+      final id = await _keyRepository.insert(
+        SshKeysCompanion.insert(
+          name: name,
+          keyType: keyType,
+          publicKey: publicKey,
+          privateKey: '', // No private key
+          fingerprint: Value(fingerprint),
+        ),
+      );
 
-    return _keyRepository.getById(id);
+      return _keyRepository.getById(id);
+    } on FormatException {
+      return null;
+    }
   }
 
   /// Export a key's public key in OpenSSH format.
@@ -214,20 +224,31 @@ class KeyService {
     return 'unknown';
   }
 
-  String _computeFingerprint(String publicKey) {
-    // Simple hash-based fingerprint for display
-    final bytes = utf8.encode(publicKey);
-    var hash = 0;
-    for (final byte in bytes) {
-      hash = ((hash << 5) - hash) + byte;
-      hash = hash & 0xFFFFFFFF;
+  Future<void> _wipeGeneratedKeyFiles(String keyPath) async {
+    for (final path in [keyPath, '$keyPath.pub']) {
+      final file = File(path);
+      if (!file.existsSync()) {
+        continue;
+      }
+      final length = file.lengthSync();
+      if (length > 0) {
+        file.writeAsBytesSync(List<int>.filled(length, 0), flush: true);
+      }
+      file.deleteSync();
     }
-
-    // Format as fingerprint-like string
-    final hex = hash.toRadixString(16).padLeft(8, '0').toUpperCase();
-    return 'SHA256:${hex.substring(0, 2)}:${hex.substring(2, 4)}:'
-        '${hex.substring(4, 6)}:${hex.substring(6, 8)}';
   }
+}
+
+/// Computes the OpenSSH SHA256 fingerprint for a public key string.
+String computeOpenSshPublicKeyFingerprint(String publicKey) {
+  final parts = publicKey.trim().split(RegExp(r'\s+'));
+  if (parts.length < 2 || parts[1].isEmpty) {
+    throw const FormatException('Invalid OpenSSH public key');
+  }
+
+  final publicKeyBlob = base64Decode(parts[1]);
+  final digest = crypto.sha256.convert(publicKeyBlob).bytes;
+  return 'SHA256:${base64Encode(digest).replaceAll('=', '')}';
 }
 
 /// Provider for [KeyService].

--- a/lib/domain/services/key_service.dart
+++ b/lib/domain/services/key_service.dart
@@ -128,7 +128,11 @@ class KeyService {
       throw Exception('ssh-keygen is not available: ${e.message}');
     } finally {
       await _wipeGeneratedKeyFiles(keyPath);
-      await tempDir.delete(recursive: true);
+      try {
+        await tempDir.delete(recursive: true);
+      } on FileSystemException {
+        // Best-effort cleanup must not hide the key generation result.
+      }
     }
   }
 
@@ -227,14 +231,26 @@ class KeyService {
   Future<void> _wipeGeneratedKeyFiles(String keyPath) async {
     for (final path in [keyPath, '$keyPath.pub']) {
       final file = File(path);
-      if (!file.existsSync()) {
-        continue;
+      try {
+        // ignore: avoid_slow_async_io
+        if (!await file.exists()) {
+          continue;
+        }
+        final length = await file.length();
+        if (length > 0) {
+          await file.writeAsBytes(List<int>.filled(length, 0), flush: true);
+        }
+        await file.delete();
+      } on FileSystemException {
+        try {
+          // ignore: avoid_slow_async_io
+          if (await file.exists()) {
+            await file.delete();
+          }
+        } on FileSystemException {
+          // Best-effort cleanup must not hide the key generation result.
+        }
       }
-      final length = file.lengthSync();
-      if (length > 0) {
-        file.writeAsBytesSync(List<int>.filled(length, 0), flush: true);
-      }
-      file.deleteSync();
     }
   }
 }

--- a/lib/domain/services/remote_file_service.dart
+++ b/lib/domain/services/remote_file_service.dart
@@ -5,8 +5,37 @@ import 'package:dartssh2/dartssh2.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path/path.dart' as path;
 
-/// Default remote directory for files pasted directly into a terminal session.
-const remoteClipboardUploadDirectory = '/tmp/monkeyssh';
+/// Display path for files pasted directly into a terminal session.
+const remoteClipboardUploadDirectoryDisplay = '~/.cache/monkeyssh/uploads';
+
+/// Private directory permissions for terminal upload staging directories.
+final remoteUploadDirectoryMode = SftpFileMode(
+  groupRead: false,
+  groupWrite: false,
+  groupExecute: false,
+  otherRead: false,
+  otherWrite: false,
+  otherExecute: false,
+);
+
+/// Private file permissions for terminal upload staging files.
+final remoteUploadFileMode = SftpFileMode(
+  userExecute: false,
+  groupRead: false,
+  groupWrite: false,
+  groupExecute: false,
+  otherRead: false,
+  otherWrite: false,
+  otherExecute: false,
+);
+
+/// Builds the remote directory for files pasted directly into a terminal.
+String buildRemoteClipboardUploadDirectory(String homeDirectory) =>
+    joinRemotePath(homeDirectory, '.cache/monkeyssh/uploads');
+
+/// Builds the app-owned parent directory for terminal uploads.
+String buildRemoteClipboardUploadParentDirectory(String homeDirectory) =>
+    joinRemotePath(homeDirectory, '.cache/monkeyssh');
 
 /// Joins a remote directory and child name into a normalized absolute path.
 String joinRemotePath(String directory, String name) {
@@ -150,7 +179,11 @@ class RemoteFileService {
   Future<String> resolveInitialDirectory(SftpClient sftp) => sftp.absolute('.');
 
   /// Ensures the target remote directory exists.
-  Future<void> ensureDirectoryExists(SftpClient sftp, String remotePath) async {
+  Future<void> ensureDirectoryExists(
+    SftpClient sftp,
+    String remotePath, {
+    SftpFileMode? mode,
+  }) async {
     try {
       final stat = await sftp.stat(remotePath);
       if (!stat.isDirectory) {
@@ -158,6 +191,9 @@ class RemoteFileService {
           'Remote path exists but is not a directory',
           remotePath,
         );
+      }
+      if (mode != null) {
+        await sftp.setStat(remotePath, SftpFileAttrs(mode: mode));
       }
       return;
     } on SftpStatusError catch (error) {
@@ -171,11 +207,20 @@ class RemoteFileService {
       await ensureDirectoryExists(sftp, parentPath);
     }
     try {
-      await sftp.mkdir(remotePath);
+      await sftp.mkdir(
+        remotePath,
+        mode == null ? null : SftpFileAttrs(mode: mode),
+      );
+      if (mode != null) {
+        await sftp.setStat(remotePath, SftpFileAttrs(mode: mode));
+      }
     } on SftpStatusError catch (error, stackTrace) {
       try {
         final stat = await sftp.stat(remotePath);
         if (stat.isDirectory) {
+          if (mode != null) {
+            await sftp.setStat(remotePath, SftpFileAttrs(mode: mode));
+          }
           return;
         }
       } on SftpStatusError {
@@ -221,6 +266,7 @@ class RemoteFileService {
     } finally {
       await remoteFile.close();
     }
+    await sftp.setStat(remotePath, SftpFileAttrs(mode: remoteUploadFileMode));
   }
 
   /// Uploads raw bytes into a remote file path.

--- a/lib/domain/services/secure_transfer_service.dart
+++ b/lib/domain/services/secure_transfer_service.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:cryptography/cryptography.dart';
-import 'package:drift/drift.dart';
-import 'package:flutter/foundation.dart';
+import 'package:drift/drift.dart' hide Uint8List;
+import 'package:flutter/foundation.dart' hide Uint8List;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pointycastle/export.dart'
     show Argon2BytesGenerator, Argon2Parameters;

--- a/lib/domain/services/secure_transfer_service.dart
+++ b/lib/domain/services/secure_transfer_service.dart
@@ -3,7 +3,10 @@ import 'dart:math';
 
 import 'package:cryptography/cryptography.dart';
 import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pointycastle/export.dart'
+    show Argon2BytesGenerator, Argon2Parameters;
 
 import '../../data/database/database.dart';
 import '../../data/repositories/host_repository.dart';
@@ -12,6 +15,7 @@ import '../models/auto_connect_command.dart';
 import '../models/host_cli_launch_preferences.dart';
 import 'host_cli_launch_preferences_service.dart';
 import 'host_key_verification.dart';
+import 'key_service.dart';
 import 'settings_service.dart';
 
 /// Supported transfer payload types.
@@ -153,11 +157,15 @@ class SecureTransferService {
   static const _maxEpochMilliseconds = 8640000000000000;
   static const _payloadPrefix = 'MSSH1:';
   static const _schemaVersion = 1;
-  static const _envelopeVersion = 1;
+  static const _legacyEnvelopeVersion = 1;
+  static const _envelopeVersion = 2;
   static const _saltBytes = 16;
   static const _nonceBytes = 12;
   static const _pbkdf2Iterations = 120000;
   static const _maxPbkdf2Iterations = 1000000;
+  static const _argon2idIterations = 3;
+  static const _argon2idMemoryKiB = 32768;
+  static const _argon2idLanes = 1;
   static const _hostScopedSettingsKeys = {
     SettingKeys.agentLaunchPresets,
     SettingKeys.hostCliLaunchPreferences,
@@ -300,13 +308,13 @@ class SecureTransferService {
 
     final envelopeMap = Map<String, dynamic>.from(envelope);
     final versionValue = envelopeMap['v'];
-    if (versionValue is! num || versionValue.toInt() != _envelopeVersion) {
+    if (versionValue is! num) {
       throw const FormatException('Unsupported transfer envelope version');
     }
-    final envelopeIterations =
-        _optionalInt(envelopeMap['iter']) ?? _pbkdf2Iterations;
-    if (envelopeIterations <= 0 || envelopeIterations > _maxPbkdf2Iterations) {
-      throw const FormatException('Invalid transfer envelope');
+    final envelopeVersion = versionValue.toInt();
+    if (envelopeVersion != _legacyEnvelopeVersion &&
+        envelopeVersion != _envelopeVersion) {
+      throw const FormatException('Unsupported transfer envelope version');
     }
 
     final salt = _decodeEnvelopeField(envelopeMap, 'salt');
@@ -319,10 +327,11 @@ class SecureTransferService {
       throw const FormatException('Invalid transfer envelope');
     }
 
-    final secretKey = await _deriveKey(
-      transferPassphrase,
-      salt,
-      iterations: envelopeIterations,
+    final secretKey = await _deriveEnvelopeKey(
+      transferPassphrase: transferPassphrase,
+      salt: salt,
+      envelope: envelopeMap,
+      version: envelopeVersion,
     );
     final secretBox = SecretBox(cipherText, nonce: nonce, mac: Mac(macBytes));
 
@@ -566,10 +575,12 @@ class SecureTransferService {
     final payloadBytes = utf8.encode(jsonEncode(payload.toJson()));
     final salt = _randomBytes(_saltBytes);
     final nonce = _randomBytes(_nonceBytes);
-    final secretKey = await _deriveKey(
+    final secretKey = await _deriveArgon2idKey(
       transferPassphrase,
       salt,
-      iterations: _pbkdf2Iterations,
+      iterations: _argon2idIterations,
+      memoryKiB: _argon2idMemoryKiB,
+      lanes: _argon2idLanes,
     );
     final encryptedBox = await _aesGcm.encrypt(
       payloadBytes,
@@ -581,8 +592,10 @@ class SecureTransferService {
     final envelope = {
       'v': _envelopeVersion,
       'alg': 'AES-GCM-256',
-      'kdf': 'PBKDF2-HMAC-SHA256',
-      'iter': _pbkdf2Iterations,
+      'kdf': 'Argon2id',
+      'iter': _argon2idIterations,
+      'mem': _argon2idMemoryKiB,
+      'lanes': _argon2idLanes,
       'salt': base64Url.encode(salt),
       'nonce': base64Url.encode(nonce),
       'ciphertext': base64Url.encode(encryptedBox.cipherText),
@@ -594,7 +607,42 @@ class SecureTransferService {
     return '$_payloadPrefix$encodedEnvelope';
   }
 
-  Future<SecretKey> _deriveKey(
+  Future<SecretKey> _deriveEnvelopeKey({
+    required String transferPassphrase,
+    required List<int> salt,
+    required Map<String, dynamic> envelope,
+    required int version,
+  }) {
+    if (version == _legacyEnvelopeVersion) {
+      final iterations = _optionalInt(envelope['iter']) ?? _pbkdf2Iterations;
+      if (iterations <= 0 || iterations > _maxPbkdf2Iterations) {
+        throw const FormatException('Invalid transfer envelope');
+      }
+      return _derivePbkdf2Key(transferPassphrase, salt, iterations: iterations);
+    }
+
+    final iterations = _optionalInt(envelope['iter']) ?? _argon2idIterations;
+    final memoryKiB = _optionalInt(envelope['mem']) ?? _argon2idMemoryKiB;
+    final lanes = _optionalInt(envelope['lanes']) ?? _argon2idLanes;
+    if (iterations <= 0 ||
+        iterations > 10 ||
+        memoryKiB < 8192 ||
+        memoryKiB > 262144 ||
+        lanes <= 0 ||
+        lanes > 4) {
+      throw const FormatException('Invalid transfer envelope');
+    }
+
+    return _deriveArgon2idKey(
+      transferPassphrase,
+      salt,
+      iterations: iterations,
+      memoryKiB: memoryKiB,
+      lanes: lanes,
+    );
+  }
+
+  Future<SecretKey> _derivePbkdf2Key(
     String passphrase,
     List<int> salt, {
     required int iterations,
@@ -610,6 +658,22 @@ class SecureTransferService {
     );
   }
 
+  Future<SecretKey> _deriveArgon2idKey(
+    String passphrase,
+    List<int> salt, {
+    required int iterations,
+    required int memoryKiB,
+    required int lanes,
+  }) async => SecretKey(
+    await compute(_deriveArgon2idKeyBytes, {
+      'passphrase': passphrase,
+      'salt': salt,
+      'iterations': iterations,
+      'memoryKiB': memoryKiB,
+      'lanes': lanes,
+    }),
+  );
+
   List<int> _randomBytes(int length) =>
       List<int>.generate(length, (_) => _random.nextInt(256), growable: false);
 
@@ -617,18 +681,18 @@ class SecureTransferService {
     Map<String, dynamic> keyData, {
     List<SshKey>? existingKeysCache,
   }) async {
-    final fingerprint = _optionalString(keyData['fingerprint']);
+    final publicKey = _requiredString(keyData, 'publicKey');
+    final privateKey = _requiredString(keyData, 'privateKey');
+    final fingerprint = computeOpenSshPublicKeyFingerprint(publicKey);
     final existingKeys = existingKeysCache ?? await _keyRepository.getAll();
-    if (fingerprint != null && fingerprint.isNotEmpty) {
+    if (fingerprint.isNotEmpty) {
       for (final key in existingKeys) {
-        if (key.fingerprint == fingerprint) {
+        if (key.fingerprint == fingerprint && key.publicKey == publicKey) {
           return key;
         }
       }
     }
 
-    final publicKey = _requiredString(keyData, 'publicKey');
-    final privateKey = _requiredString(keyData, 'privateKey');
     for (final key in existingKeys) {
       if (key.publicKey == publicKey && key.privateKey == privateKey) {
         return key;
@@ -1493,3 +1557,23 @@ final secureTransferServiceProvider = Provider<SecureTransferService>(
     ref.watch(hostRepositoryProvider),
   ),
 );
+
+List<int> _deriveArgon2idKeyBytes(Map<String, Object> request) {
+  final passphrase = request['passphrase']! as String;
+  final salt = request['salt']! as List<int>;
+  final iterations = request['iterations']! as int;
+  final memoryKiB = request['memoryKiB']! as int;
+  final lanes = request['lanes']! as int;
+  final generator = Argon2BytesGenerator()
+    ..init(
+      Argon2Parameters(
+        Argon2Parameters.ARGON2_id,
+        Uint8List.fromList(salt),
+        desiredKeyLength: 32,
+        iterations: iterations,
+        memory: memoryKiB,
+        lanes: lanes,
+      ),
+    );
+  return generator.process(Uint8List.fromList(utf8.encode(passphrase)));
+}

--- a/lib/domain/services/settings_service.dart
+++ b/lib/domain/services/settings_service.dart
@@ -88,9 +88,12 @@ abstract final class SettingKeys {
 
   /// Enable shared clipboard between device and remote session.
   ///
-  /// The terminal can sync through OSC 52 and remote clipboard utilities when
-  /// the remote host provides them.
+  /// The remote host can update the local clipboard through OSC 52 and remote
+  /// clipboard utilities when available.
   static const sharedClipboard = 'shared_clipboard';
+
+  /// Allow the remote host to read the local clipboard.
+  static const sharedClipboardLocalRead = 'shared_clipboard_local_read';
 
   /// Whether tapping the terminal automatically shows the keyboard.
   ///
@@ -624,7 +627,13 @@ final sharedClipboardProvider = FutureProvider<bool>((ref) async {
   return settings.getBool(SettingKeys.sharedClipboard);
 });
 
-/// Notifier for shared clipboard (OSC 52) with write capability.
+/// Provider for local clipboard read sharing setting.
+final sharedClipboardLocalReadProvider = FutureProvider<bool>((ref) async {
+  final settings = ref.watch(settingsServiceProvider);
+  return settings.getBool(SettingKeys.sharedClipboardLocalRead);
+});
+
+/// Notifier for shared clipboard remote-to-local writes.
 class SharedClipboardNotifier extends Notifier<bool> {
   late SettingsService _settings;
   bool _disposed = false;
@@ -655,6 +664,42 @@ class SharedClipboardNotifier extends Notifier<bool> {
 final sharedClipboardNotifierProvider =
     NotifierProvider<SharedClipboardNotifier, bool>(
       SharedClipboardNotifier.new,
+    );
+
+/// Notifier for local clipboard reads from the remote side.
+class SharedClipboardLocalReadNotifier extends Notifier<bool> {
+  late SettingsService _settings;
+  bool _disposed = false;
+
+  @override
+  bool build() {
+    _settings = ref.watch(settingsServiceProvider);
+    _disposed = false;
+    ref.onDispose(() => _disposed = true);
+    Future.microtask(_init);
+    return false;
+  }
+
+  Future<void> _init() async {
+    final value = await _settings.getBool(SettingKeys.sharedClipboardLocalRead);
+    if (_disposed) return;
+    state = value;
+  }
+
+  /// Set whether the remote side can read the local clipboard.
+  Future<void> setEnabled({required bool enabled}) async {
+    await _settings.setBool(
+      SettingKeys.sharedClipboardLocalRead,
+      value: enabled,
+    );
+    state = enabled;
+  }
+}
+
+/// Provider for local clipboard read sharing with write capability.
+final sharedClipboardLocalReadNotifierProvider =
+    NotifierProvider<SharedClipboardLocalReadNotifier, bool>(
+      SharedClipboardLocalReadNotifier.new,
     );
 
 /// Notifier for tap-to-show-keyboard with write capability.

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -1447,6 +1447,7 @@ class SshSession {
     this.terminalThemeDarkId,
     this.terminalFontSize,
     this.clipboardSharingEnabled = false,
+    this.localClipboardReadEnabled = false,
   }) : createdAt = DateTime.now();
 
   static const _previewRefreshInterval = Duration(milliseconds: 150);
@@ -1482,6 +1483,9 @@ class SshSession {
 
   /// Whether OSC 52 clipboard sharing is enabled for this session.
   bool clipboardSharingEnabled;
+
+  /// Whether the remote side may read the local clipboard.
+  bool localClipboardReadEnabled;
 
   /// When the session was created.
   final DateTime createdAt;
@@ -1960,7 +1964,7 @@ class SshSession {
 
     unawaited(
       _clipboardSharingService
-          .handleOsc52(args)
+          .handleOsc52(args, allowLocalClipboardRead: localClipboardReadEnabled)
           .then((response) {
             if (response != null && _shell != null) {
               _shell!.write(utf8.encode(response));
@@ -2770,9 +2774,14 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
   }
 
   /// Update clipboard sharing on all active sessions.
-  void updateClipboardSharing({required bool enabled}) {
+  void updateClipboardSharing({
+    required bool enabled,
+    required bool allowLocalClipboardRead,
+  }) {
     for (final session in _sshService.allSessions) {
-      session.clipboardSharingEnabled = enabled;
+      session
+        ..clipboardSharingEnabled = enabled
+        ..localClipboardReadEnabled = allowLocalClipboardRead;
     }
   }
 

--- a/lib/presentation/screens/auth_setup_screen.dart
+++ b/lib/presentation/screens/auth_setup_screen.dart
@@ -67,8 +67,8 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
   }
 
   Future<void> _setupPin() async {
-    if (_pinController.text.length < 4) {
-      setState(() => _error = 'PIN must be at least 4 digits');
+    if (_pinController.text.length < 6) {
+      setState(() => _error = 'PIN must be at least 6 digits');
       return;
     }
 

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -187,6 +187,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
       switch (payload.type) {
         case TransferPayloadType.host:
+          if (!mounted) {
+            return;
+          }
+          final confirmed = await showTransferPayloadImportConfirmationDialog(
+            context: context,
+            payload: payload,
+          );
+          if (!mounted || !confirmed) {
+            return;
+          }
           final host = await transferService.importHostPayload(payload);
           ref.invalidate(allHostsProvider);
           if (!mounted) {
@@ -197,6 +207,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           );
           break;
         case TransferPayloadType.key:
+          if (!mounted) {
+            return;
+          }
+          final confirmed = await showTransferPayloadImportConfirmationDialog(
+            context: context,
+            payload: payload,
+          );
+          if (!mounted || !confirmed) {
+            return;
+          }
           final key = await transferService.importKeyPayload(payload);
           ref.invalidate(allKeysProvider);
           if (!mounted) {

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -1759,6 +1759,16 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         );
       }
 
+      if (!mounted) {
+        return;
+      }
+      final confirmed = await showTransferPayloadImportConfirmationDialog(
+        context: context,
+        payload: payload,
+      );
+      if (!mounted || !confirmed) {
+        return;
+      }
       final importedHost = await transferService.importHostPayload(payload);
       ref.invalidate(allHostsProvider);
       if (!mounted) {

--- a/lib/presentation/screens/key_add_screen.dart
+++ b/lib/presentation/screens/key_add_screen.dart
@@ -539,6 +539,16 @@ class _ImportKeyTabState extends ConsumerState<_ImportKeyTab> {
           'This transfer payload does not contain an SSH key',
         );
       }
+      if (!mounted) {
+        return;
+      }
+      final confirmed = await showTransferPayloadImportConfirmationDialog(
+        context: context,
+        payload: payload,
+      );
+      if (!mounted || !confirmed) {
+        return;
+      }
       final importedKey = await transferService.importKeyPayload(payload);
       if (!mounted) {
         return;

--- a/lib/presentation/screens/lock_screen.dart
+++ b/lib/presentation/screens/lock_screen.dart
@@ -88,8 +88,8 @@ class _LockScreenState extends ConsumerState<LockScreen> {
   }
 
   Future<void> _authenticateWithPin() async {
-    if (_pinController.text.length < 4) {
-      setState(() => _error = 'PIN must be at least 4 digits');
+    if (_pinController.text.isEmpty) {
+      setState(() => _error = 'Enter your PIN');
       return;
     }
 

--- a/lib/presentation/screens/port_forward_edit_screen.dart
+++ b/lib/presentation/screens/port_forward_edit_screen.dart
@@ -94,6 +94,38 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
     return null;
   }
 
+  bool _isLoopbackBindAddress(String value) {
+    final normalized = value.trim().toLowerCase();
+    return normalized == 'localhost' ||
+        normalized == '127.0.0.1' ||
+        normalized == '::1' ||
+        normalized.startsWith('127.');
+  }
+
+  Future<bool> _confirmNonLoopbackLocalBind() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Expose port forward?'),
+        content: Text(
+          'Binding to ${_localHostController.text.trim()} may make this '
+          'forward reachable from other devices on your local network.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Allow'),
+          ),
+        ],
+      ),
+    );
+    return confirmed ?? false;
+  }
+
   @override
   Widget build(BuildContext context) {
     final isEditing = widget.portForwardId != null;
@@ -301,6 +333,11 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
 
   Future<void> _savePortForward() async {
     if (!_formKey.currentState!.validate()) return;
+    if (_forwardType == 'local' &&
+        !_isLoopbackBindAddress(_localHostController.text)) {
+      final confirmed = await _confirmNonLoopbackLocalBind();
+      if (!confirmed || !mounted) return;
+    }
 
     setState(() => _isLoading = true);
 

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -374,9 +374,14 @@ class _SecuritySection extends ConsumerWidget {
     var currentPinErrorText = '';
     var isChanging = false;
 
-    String? validatePin(String? value) {
+    String? validateCurrentPin(String? value) {
       if (value?.isEmpty ?? true) return 'Required';
-      if (value!.length < 4) return 'PIN must be 4-8 digits';
+      return null;
+    }
+
+    String? validateNewPin(String? value) {
+      if (value?.isEmpty ?? true) return 'Required';
+      if (value!.length < 6) return 'PIN must be 6-8 digits';
       return null;
     }
 
@@ -403,7 +408,7 @@ class _SecuritySection extends ConsumerWidget {
                   keyboardType: TextInputType.number,
                   maxLength: 8,
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                  validator: validatePin,
+                  validator: validateCurrentPin,
                   onChanged: (_) {
                     if (currentPinErrorText.isEmpty) return;
                     setState(() => currentPinErrorText = '');
@@ -420,7 +425,7 @@ class _SecuritySection extends ConsumerWidget {
                   keyboardType: TextInputType.number,
                   maxLength: 8,
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                  validator: validatePin,
+                  validator: validateNewPin,
                 ),
                 const SizedBox(height: 16),
                 TextFormField(
@@ -434,7 +439,7 @@ class _SecuritySection extends ConsumerWidget {
                   maxLength: 8,
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                   validator: (v) {
-                    final pinValidationError = validatePin(v);
+                    final pinValidationError = validateNewPin(v);
                     if (pinValidationError != null) return pinValidationError;
                     if (v != newPinController.text) return 'PINs do not match';
                     return null;
@@ -578,6 +583,9 @@ class _TerminalSection extends ConsumerWidget {
       terminalPathLinkUnderlinesNotifierProvider,
     );
     final sharedClipboard = ref.watch(sharedClipboardNotifierProvider);
+    final sharedClipboardLocalRead = ref.watch(
+      sharedClipboardLocalReadNotifierProvider,
+    );
     final tapToShowKeyboard = ref.watch(tapToShowKeyboardNotifierProvider);
     final themeSettings = ref.watch(terminalThemeSettingsProvider);
 
@@ -658,9 +666,9 @@ class _TerminalSection extends ConsumerWidget {
         ),
         SwitchListTile(
           secondary: const Icon(Icons.content_paste_go_outlined),
-          title: const Text('Shared clipboard'),
+          title: const Text('Remote can update clipboard'),
           subtitle: const Text(
-            'Sync clipboard between local and remote using OSC 52 and remote clipboard tools when available',
+            'Allow OSC 52 and remote clipboard tools to copy remote text into the local clipboard',
           ),
           value: sharedClipboard,
           onChanged: (value) {
@@ -671,8 +679,34 @@ class _TerminalSection extends ConsumerWidget {
             );
             ref
                 .read(activeSessionsProvider.notifier)
-                .updateClipboardSharing(enabled: value);
+                .updateClipboardSharing(
+                  enabled: value,
+                  allowLocalClipboardRead: value && sharedClipboardLocalRead,
+                );
           },
+        ),
+        SwitchListTile(
+          secondary: const Icon(Icons.content_paste_search_outlined),
+          title: const Text('Remote can read clipboard'),
+          subtitle: const Text(
+            'Allow remote OSC 52 queries and clipboard sync to send local clipboard text to the connected host',
+          ),
+          value: sharedClipboard && sharedClipboardLocalRead,
+          onChanged: sharedClipboard
+              ? (value) {
+                  unawaited(
+                    ref
+                        .read(sharedClipboardLocalReadNotifierProvider.notifier)
+                        .setEnabled(enabled: value),
+                  );
+                  ref
+                      .read(activeSessionsProvider.notifier)
+                      .updateClipboardSharing(
+                        enabled: sharedClipboard,
+                        allowLocalClipboardRead: value,
+                      );
+                }
+              : null,
         ),
         SwitchListTile(
           secondary: const Icon(Icons.keyboard_outlined),

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3149,6 +3149,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   SftpClient? _terminalPathVerificationSftp;
   String? _terminalPathVerificationHomeDirectory;
   late final ProviderSubscription<bool> _sharedClipboardSubscription;
+  late final ProviderSubscription<bool> _sharedClipboardLocalReadSubscription;
   Timer? _localClipboardSyncTimer;
   Timer? _remoteClipboardSyncTimer;
   Timer? _terminalInputIndicatorTimer;
@@ -3304,8 +3305,22 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     WidgetsBinding.instance.addObserver(this);
     _sharedClipboardSubscription = ref.listenManual<bool>(
       sharedClipboardNotifierProvider,
-      (previous, next) =>
-          unawaited(_applySharedClipboardSetting(enabled: next)),
+      (previous, next) => unawaited(
+        _applySharedClipboardSetting(
+          enabled: next,
+          allowLocalClipboardRead:
+              next && ref.read(sharedClipboardLocalReadNotifierProvider),
+        ),
+      ),
+    );
+    _sharedClipboardLocalReadSubscription = ref.listenManual<bool>(
+      sharedClipboardLocalReadNotifierProvider,
+      (previous, next) => unawaited(
+        _applySharedClipboardSetting(
+          enabled: ref.read(sharedClipboardNotifierProvider),
+          allowLocalClipboardRead: next,
+        ),
+      ),
     );
     _terminal = Terminal(maxLines: 10000);
     _terminalController = TerminalController();
@@ -3396,6 +3411,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   Future<void> _applySharedClipboardSetting({
     required bool enabled,
+    required bool allowLocalClipboardRead,
     SshSession? session,
     bool waitForInitialSync = true,
   }) async {
@@ -3409,7 +3425,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
-    targetSession.clipboardSharingEnabled = enabled;
+    targetSession
+      ..clipboardSharingEnabled = enabled
+      ..localClipboardReadEnabled = enabled && allowLocalClipboardRead;
     if (!enabled) {
       _stopSharedClipboardSync();
       return;
@@ -3426,7 +3444,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   Future<void> _startSharedClipboardSync(SshSession session) async {
     _stopSharedClipboardSync();
     _remoteClipboardUnsupported = false;
-    _lastObservedLocalClipboardText = await _readSystemClipboardText();
+    _lastObservedLocalClipboardText = session.localClipboardReadEnabled
+        ? await _readSystemClipboardText()
+        : null;
     _lastObservedRemoteClipboardText = await _readRemoteClipboardText(session);
 
     if (!mounted ||
@@ -3435,10 +3455,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
-    _localClipboardSyncTimer = Timer.periodic(
-      _localClipboardSyncInterval,
-      (_) => unawaited(_syncLocalClipboardToRemote(session)),
-    );
+    if (session.localClipboardReadEnabled) {
+      _localClipboardSyncTimer = Timer.periodic(
+        _localClipboardSyncInterval,
+        (_) => unawaited(_syncLocalClipboardToRemote(session)),
+      );
+    }
     if (!_remoteClipboardUnsupported) {
       _remoteClipboardSyncTimer = Timer.periodic(
         _remoteClipboardSyncInterval,
@@ -3482,6 +3504,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   Future<void> _syncLocalClipboardToRemote(SshSession session) async {
     if (!mounted ||
         !session.clipboardSharingEnabled ||
+        !session.localClipboardReadEnabled ||
         !identical(_observedSession, session) ||
         _remoteClipboardUnsupported ||
         _isPushingLocalClipboard) {
@@ -3914,7 +3937,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         final sharedClipboardEnabled = await ref.read(
           sharedClipboardProvider.future,
         );
-        session.clipboardSharingEnabled = sharedClipboardEnabled;
+        final sharedClipboardLocalReadEnabled = await ref.read(
+          sharedClipboardLocalReadProvider.future,
+        );
+        session
+          ..clipboardSharingEnabled = sharedClipboardEnabled
+          ..localClipboardReadEnabled =
+              sharedClipboardEnabled && sharedClipboardLocalReadEnabled;
         _terminal.removeListener(_onTerminalStateChanged);
         _terminal = existingTerminal;
         _terminalHyperlinkTracker = session.terminalHyperlinkTracker;
@@ -3926,6 +3955,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _wireTerminalCallbacks(session);
         await _applySharedClipboardSetting(
           enabled: sharedClipboardEnabled,
+          allowLocalClipboardRead: sharedClipboardLocalReadEnabled,
           session: session,
           waitForInitialSync: false,
         );
@@ -3949,7 +3979,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       final sharedClipboardEnabled = await ref.read(
         sharedClipboardProvider.future,
       );
-      session.clipboardSharingEnabled = sharedClipboardEnabled;
+      final sharedClipboardLocalReadEnabled = await ref.read(
+        sharedClipboardLocalReadProvider.future,
+      );
+      session
+        ..clipboardSharingEnabled = sharedClipboardEnabled
+        ..localClipboardReadEnabled =
+            sharedClipboardEnabled && sharedClipboardLocalReadEnabled;
       _terminal.removeListener(_onTerminalStateChanged);
       _terminal = sessionTerminal;
       _terminalHyperlinkTracker = session.terminalHyperlinkTracker;
@@ -3973,6 +4009,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _wireTerminalCallbacks(session);
       await _applySharedClipboardSetting(
         enabled: sharedClipboardEnabled,
+        allowLocalClipboardRead: sharedClipboardLocalReadEnabled,
         session: session,
         waitForInitialSync: false,
       );
@@ -5111,6 +5148,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _sharedClipboardSubscription.close();
+    _sharedClipboardLocalReadSubscription.close();
     _stopSharedClipboardSync();
     _terminalInputIndicatorTimer?.cancel();
     _promptOutputImeResetTimer?.cancel();
@@ -8250,7 +8288,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   Future<T> _withClipboardSftp<T>(
-    Future<T> Function(SftpClient sftp, RemoteFileService remoteFileService)
+    Future<T> Function(
+      SftpClient sftp,
+      RemoteFileService remoteFileService,
+      String uploadDirectory,
+    )
     action,
   ) async {
     final session = _activeSession();
@@ -8261,11 +8303,25 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final remoteFileService = ref.read(remoteFileServiceProvider);
     final sftp = await session.sftp();
     try {
+      final homeDirectory = await remoteFileService.resolveInitialDirectory(
+        sftp,
+      );
+      final appUploadParentDirectory =
+          buildRemoteClipboardUploadParentDirectory(homeDirectory);
+      final uploadDirectory = buildRemoteClipboardUploadDirectory(
+        homeDirectory,
+      );
       await remoteFileService.ensureDirectoryExists(
         sftp,
-        remoteClipboardUploadDirectory,
+        appUploadParentDirectory,
+        mode: remoteUploadDirectoryMode,
       );
-      return await action(sftp, remoteFileService);
+      await remoteFileService.ensureDirectoryExists(
+        sftp,
+        uploadDirectory,
+        mode: remoteUploadDirectoryMode,
+      );
+      return await action(sftp, remoteFileService, uploadDirectory);
     } finally {
       sftp.close();
     }
@@ -8346,7 +8402,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final shouldUpload = await _confirmClipboardUpload(
       title: 'Upload clipboard files?',
       message:
-          'This will upload ${clipboardFiles.length} clipboard file${clipboardFiles.length == 1 ? '' : 's'} to $remoteClipboardUploadDirectory on the connected host and paste their remote paths into the terminal.',
+          'This will upload ${clipboardFiles.length} clipboard file${clipboardFiles.length == 1 ? '' : 's'} to $remoteClipboardUploadDirectoryDisplay on the connected host and paste their remote paths into the terminal.',
       confirmLabel: 'Upload and paste',
       details: [
         for (var index = 0; index < clipboardFiles.length; index++)
@@ -8364,6 +8420,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final remotePaths = await _withClipboardSftp((
       sftp,
       remoteFileService,
+      uploadDirectory,
     ) async {
       final remotePaths = <String>[];
       for (var index = 0; index < clipboardFiles.length; index++) {
@@ -8383,7 +8440,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           );
           sourceName = clipboardFile.name;
           remotePath = joinRemotePath(
-            remoteClipboardUploadDirectory,
+            uploadDirectory,
             buildClipboardUploadFileName(
               sourceName,
               timestamp,
@@ -8398,7 +8455,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         } else {
           sourceName = path.basename(localPath);
           remotePath = joinRemotePath(
-            remoteClipboardUploadDirectory,
+            uploadDirectory,
             buildClipboardUploadFileName(
               sourceName,
               timestamp,
@@ -8421,7 +8478,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _terminalController.clearSelection();
     _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
     _showClipboardMessage(
-      'Uploaded ${remotePaths.length} file${remotePaths.length == 1 ? '' : 's'} to $remoteClipboardUploadDirectory',
+      'Uploaded ${remotePaths.length} file${remotePaths.length == 1 ? '' : 's'} to $remoteClipboardUploadDirectoryDisplay',
     );
   }
 
@@ -8429,7 +8486,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final shouldUpload = await _confirmClipboardUpload(
       title: 'Upload clipboard image?',
       message:
-          'This will upload the clipboard image to $remoteClipboardUploadDirectory on the connected host and paste its remote path into the terminal.',
+          'This will upload the clipboard image to $remoteClipboardUploadDirectoryDisplay on the connected host and paste its remote path into the terminal.',
       confirmLabel: 'Upload and paste',
       details: const ['image.png'],
     );
@@ -8441,9 +8498,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final remotePath = await _withClipboardSftp((
       sftp,
       remoteFileService,
+      uploadDirectory,
     ) async {
       final remotePath = joinRemotePath(
-        remoteClipboardUploadDirectory,
+        uploadDirectory,
         buildClipboardImageFileName(DateTime.now()),
       );
       await remoteFileService.uploadBytes(
@@ -8474,7 +8532,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final shouldUpload = await _confirmClipboardUpload(
       title: 'Upload selected $itemLabel?',
       message:
-          'This will upload ${selectedFiles.length == 1 ? 'the selected $itemLabelSingular' : '${selectedFiles.length} selected $itemLabelPlural'} to $remoteClipboardUploadDirectory on the connected host and paste ${selectedFiles.length == 1 ? 'its remote path' : 'their remote paths'} into the terminal.',
+          'This will upload ${selectedFiles.length == 1 ? 'the selected $itemLabelSingular' : '${selectedFiles.length} selected $itemLabelPlural'} to $remoteClipboardUploadDirectoryDisplay on the connected host and paste ${selectedFiles.length == 1 ? 'its remote path' : 'their remote paths'} into the terminal.',
       confirmLabel: 'Upload and paste',
       details: [
         for (var index = 0; index < selectedFiles.length; index++)
@@ -8493,6 +8551,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final remotePaths = await _withClipboardSftp((
       sftp,
       remoteFileService,
+      uploadDirectory,
     ) async {
       final remotePaths = <String>[];
       for (var index = 0; index < selectedFiles.length; index++) {
@@ -8502,7 +8561,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           index: index,
         );
         final remotePath = joinRemotePath(
-          remoteClipboardUploadDirectory,
+          uploadDirectory,
           buildClipboardUploadFileName(sourceName, timestamp, sequence: index),
         );
         final readStream = resolvePickedTerminalUploadReadStream(file);
@@ -8533,7 +8592,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _terminalController.clearSelection();
     _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
     _showClipboardMessage(
-      'Uploaded ${selectedFiles.length == 1 ? 'selected $itemLabelSingular' : '${remotePaths.length} $itemLabelPlural'} to $remoteClipboardUploadDirectory',
+      'Uploaded ${selectedFiles.length == 1 ? 'selected $itemLabelSingular' : '${remotePaths.length} $itemLabelPlural'} to $remoteClipboardUploadDirectoryDisplay',
     );
   }
 

--- a/lib/presentation/screens/transfer_screen.dart
+++ b/lib/presentation/screens/transfer_screen.dart
@@ -474,3 +474,91 @@ Future<MigrationImportMode?> showMigrationImportModeDialog({
     ],
   ),
 );
+
+/// Shows a confirmation dialog before importing a decrypted host or key.
+Future<bool> showTransferPayloadImportConfirmationDialog({
+  required BuildContext context,
+  required TransferPayload payload,
+}) async {
+  final details = switch (payload.type) {
+    TransferPayloadType.host => _hostTransferDetails(payload),
+    TransferPayloadType.key => _keyTransferDetails(payload),
+    TransferPayloadType.fullMigration => const <String>[],
+  };
+  if (details.isEmpty) {
+    return true;
+  }
+
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(
+        payload.type == TransferPayloadType.host
+            ? 'Import host?'
+            : 'Import SSH key?',
+      ),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Review this decrypted transfer before adding it to MonkeySSH.',
+            ),
+            const SizedBox(height: 12),
+            for (final detail in details)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Text(detail),
+              ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, true),
+          child: const Text('Import'),
+        ),
+      ],
+    ),
+  );
+
+  return confirmed ?? false;
+}
+
+List<String> _hostTransferDetails(TransferPayload payload) {
+  final host = payload.data['host'];
+  if (host is! Map) {
+    return const [];
+  }
+  final label = _displayTransferValue(host['label']);
+  final hostname = _displayTransferValue(host['hostname']);
+  final username = _displayTransferValue(host['username']);
+  final port = _displayTransferValue(host['port'] ?? 22);
+  return [
+    'Label: $label',
+    'Host: $hostname',
+    'Port: $port',
+    'Username: $username',
+  ];
+}
+
+List<String> _keyTransferDetails(TransferPayload payload) {
+  final key = payload.data['key'];
+  if (key is! Map) {
+    return const [];
+  }
+  final name = _displayTransferValue(key['name']);
+  final type = _displayTransferValue(key['keyType']);
+  final fingerprint = _displayTransferValue(key['fingerprint']);
+  return ['Name: $name', 'Type: $type', 'Fingerprint: $fingerprint'];
+}
+
+String _displayTransferValue(Object? value) {
+  final text = value?.toString().trim();
+  return text == null || text.isEmpty ? 'Not provided' : text;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -952,7 +952,7 @@ packages:
     source: hosted
     version: "2.1.8"
   pointycastle:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pointycastle
       sha256: "92aa3841d083cc4b0f4709b5c74fd6409a3e6ba833ffc7dc6a8fee096366acf5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   share_plus: ^12.0.1
   cryptography: ^2.9.0
   crypto: ^3.0.6
+  pointycastle: ^4.0.0
   
   # UI
   cupertino_icons: ^1.0.8

--- a/scripts/setup_tmux_test_env.sh
+++ b/scripts/setup_tmux_test_env.sh
@@ -24,7 +24,8 @@
 
 set -euo pipefail
 
-KEY_PATH="/tmp/monkeyssh_tmux_test_key"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/monkeyssh/tmux-test"
+KEY_PATH="$STATE_DIR/id_ed25519"
 TMUX_SESSION="monkeyssh-test"
 AUTH_KEYS="$HOME/.ssh/authorized_keys"
 MARKER="# monkeyssh-tmux-test"
@@ -71,6 +72,9 @@ fi
 echo "🔧 Setting up tmux test environment..."
 echo ""
 
+mkdir -p "$STATE_DIR"
+chmod 700 "$STATE_DIR"
+
 # ── Step 1: Check prerequisites ──────────────────────────────────────
 
 if ! command -v tmux &>/dev/null; then
@@ -86,12 +90,11 @@ fi
 
 # ── Step 2: Generate SSH key ─────────────────────────────────────────
 
-if [ -f "$KEY_PATH" ]; then
-    echo "   Using existing test key at $KEY_PATH"
-else
-    ssh-keygen -t ed25519 -f "$KEY_PATH" -N "" -C "monkeyssh-tmux-test" -q
-    echo "   Generated test key: $KEY_PATH"
-fi
+rm -f "$KEY_PATH" "${KEY_PATH}.pub"
+ssh-keygen -t ed25519 -f "$KEY_PATH" -N "" -C "monkeyssh-tmux-test" -q
+chmod 600 "$KEY_PATH"
+chmod 644 "${KEY_PATH}.pub"
+echo "   Generated test key: $KEY_PATH"
 
 # ── Step 3: Authorize the key ────────────────────────────────────────
 

--- a/test/domain/services/clipboard_sharing_service_test.dart
+++ b/test/domain/services/clipboard_sharing_service_test.dart
@@ -1,10 +1,67 @@
 import 'dart:convert';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/domain/services/clipboard_sharing_service.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
   group('ClipboardSharingService', () {
+    group('handleOsc52', () {
+      test(
+        'does not answer clipboard queries when local read is disabled',
+        () async {
+          var clipboardRead = false;
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+                if (call.method == 'Clipboard.getData') {
+                  clipboardRead = true;
+                  return <String, Object?>{'text': 'local-secret'};
+                }
+                return null;
+              });
+
+          final result = await const ClipboardSharingService().handleOsc52([
+            'c',
+            '?',
+          ], allowLocalClipboardRead: false);
+
+          expect(result, isNull);
+          expect(clipboardRead, isFalse);
+        },
+      );
+
+      test('answers clipboard queries when local read is enabled', () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+              if (call.method == 'Clipboard.getData') {
+                expect(call.arguments, Clipboard.kTextPlain);
+                return <String, Object?>{'text': 'local-secret'};
+              }
+              return null;
+            });
+
+        final result = await const ClipboardSharingService().handleOsc52([
+          'c',
+          '?',
+        ], allowLocalClipboardRead: true);
+
+        expect(
+          result,
+          ClipboardSharingService.buildOsc52Response(
+            'c',
+            base64Encode(utf8.encode('local-secret')),
+          ),
+        );
+      });
+    });
+
     group('parseOsc52Args', () {
       test('parses split args [target, payload]', () {
         final result = ClipboardSharingService.parseOsc52Args([

--- a/test/domain/services/key_service_test.dart
+++ b/test/domain/services/key_service_test.dart
@@ -204,37 +204,48 @@ void main() {
       test(
         'generates the correct deterministic fingerprint for a known public key',
         () async {
-          // importPublicKey calls _computeFingerprint(publicKey) internally.
-          // The expected value is pre-computed using the same DJB2-like hash.
           final key = await keyService.importPublicKey(
             name: 'Key A',
-            publicKey: 'ssh-ed25519 AAAA1',
+            publicKey:
+                'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDzZbs5T/6U4zUn/rneL4PWTBKuoI/OfqAznKpQOjd82 test',
           );
 
           expect(key, isNotNull);
-          expect(key!.fingerprint, 'SHA256:1E:BF:D7:47');
+          expect(
+            key!.fingerprint,
+            'SHA256:YxKKmwNF0MYVdTdaXzsOKKwNc60ZCoz5qS3otV23HyI',
+          );
         },
       );
 
       test('different public keys produce different fingerprints', () async {
         final keyA = await keyService.importPublicKey(
           name: 'Key A',
-          publicKey: 'ssh-ed25519 AAAA1',
+          publicKey:
+              'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOwEkW+K+T0BVhCHT/6o4p9FdlaUJD/yPJfHziYQuwnK a',
         );
         final keyB = await keyService.importPublicKey(
           name: 'Key B',
-          publicKey: 'ssh-ed25519 AAAA2',
+          publicKey:
+              'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHOD6YHh4xjr8IcP0uT8DODGjPEDGqX2i4eyNvtXq2D+ b',
         );
 
-        expect(keyA!.fingerprint, 'SHA256:1E:BF:D7:47');
-        expect(keyB!.fingerprint, 'SHA256:1E:BF:D7:48');
+        expect(
+          keyA!.fingerprint,
+          'SHA256:KN1Ih6apKdkbSOKekPapKbXepsF6rVo5M5srTRe71fI',
+        );
+        expect(
+          keyB!.fingerprint,
+          'SHA256:v6rpW34v6+w8LPSvW6v1+Dm8Z6sRf/VNAFNbr8FG3sg',
+        );
         expect(keyA.fingerprint, isNot(keyB.fingerprint));
       });
 
       test('fingerprint always begins with SHA256: prefix', () async {
         final key = await keyService.importPublicKey(
           name: 'Key',
-          publicKey: 'ssh-ed25519 AAAA',
+          publicKey:
+              'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDzZbs5T/6U4zUn/rneL4PWTBKuoI/OfqAznKpQOjd82 test',
         );
 
         expect(key!.fingerprint, startsWith('SHA256:'));

--- a/test/domain/services/secure_transfer_service_test.dart
+++ b/test/domain/services/secure_transfer_service_test.dart
@@ -19,6 +19,15 @@ import 'package:monkeyssh/domain/services/host_key_verification.dart';
 import 'package:monkeyssh/domain/services/secure_transfer_service.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
 
+const _publicKeyA =
+    'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOwEkW+K+T0BVhCHT/6o4p9FdlaUJD/yPJfHziYQuwnK a';
+const _publicKeyAFingerprint =
+    'SHA256:KN1Ih6apKdkbSOKekPapKbXepsF6rVo5M5srTRe71fI';
+const _publicKeyB =
+    'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHOD6YHh4xjr8IcP0uT8DODGjPEDGqX2i4eyNvtXq2D+ b';
+const _publicKeyBFingerprint =
+    'SHA256:v6rpW34v6+w8LPSvW6v1+Dm8Z6sRf/VNAFNbr8FG3sg';
+
 void main() {
   late AppDatabase db;
   late HostRepository hostRepository;
@@ -88,7 +97,7 @@ void main() {
           SshKeysCompanion.insert(
             name: 'Deploy Key',
             keyType: 'ed25519',
-            publicKey: 'ssh-ed25519 AAAA',
+            publicKey: _publicKeyA,
             privateKey: 'test-open-ssh-key-materialxyz',
           ),
         );
@@ -137,7 +146,7 @@ void main() {
             'key': {
               'name': 'Imported Key',
               'keyType': 'ed25519',
-              'publicKey': 'ssh-ed25519 AAAA',
+              'publicKey': _publicKeyA,
               'privateKey': 'test-open-ssh-key-materialabc',
               'passphrase': 'pass',
             },
@@ -569,7 +578,7 @@ void main() {
           SshKeysCompanion.insert(
             name: 'Main Key',
             keyType: 'ed25519',
-            publicKey: 'ssh-ed25519 AAAA',
+            publicKey: _publicKeyA,
             privateKey: 'test-open-ssh-key-materialabc',
           ),
         );
@@ -1150,7 +1159,7 @@ void main() {
             SshKeysCompanion.insert(
               name: 'Deploy Key',
               keyType: 'ed25519',
-              publicKey: 'ssh-ed25519 AAAA',
+              publicKey: _publicKeyA,
               privateKey: 'test-open-ssh-key-materialxyz',
               passphrase: const Value('key-passphrase'),
             ),
@@ -1178,20 +1187,19 @@ void main() {
     });
 
     test(
-      'importKeyPayload deduplicates by fingerprint and returns the existing key',
+      'importKeyPayload does not deduplicate by fingerprint alone',
       () async {
-        const fingerprint = 'SHA256:DE:AD:BE:EF:00:11:22:33';
         final existingId = await keyRepository.insert(
           SshKeysCompanion.insert(
             name: 'Existing Key',
             keyType: 'ed25519',
-            publicKey: 'ssh-ed25519 AAAAexisting',
+            publicKey: _publicKeyA,
             privateKey: 'test-open-ssh-key-existing',
-            fingerprint: const Value(fingerprint),
+            fingerprint: const Value(_publicKeyAFingerprint),
           ),
         );
 
-        // Import a payload that shares the same fingerprint.
+        // Import a payload that lies about sharing the same fingerprint.
         final payload = TransferPayload(
           type: TransferPayloadType.key,
           schemaVersion: 1,
@@ -1200,27 +1208,27 @@ void main() {
             'key': {
               'name': 'Re-imported Key',
               'keyType': 'ed25519',
-              'publicKey': 'ssh-ed25519 AAAAdifferent',
+              'publicKey': _publicKeyB,
               'privateKey': 'test-open-ssh-key-different',
-              'fingerprint': fingerprint,
+              'fingerprint': _publicKeyAFingerprint,
             },
           },
         );
 
         final imported = await transferService.importKeyPayload(payload);
 
-        // Should return the existing key, not create a new one.
-        expect(imported.id, existingId);
-        expect(imported.name, 'Existing Key');
+        expect(imported.id, isNot(existingId));
+        expect(imported.name, 'Re-imported Key');
+        expect(imported.fingerprint, _publicKeyBFingerprint);
 
         final allKeys = await db.select(db.sshKeys).get();
-        expect(allKeys, hasLength(1));
+        expect(allKeys, hasLength(2));
       },
     );
 
     test('importKeyPayload deduplicates by public+private key pair when no '
         'fingerprint is present', () async {
-      const publicKey = 'ssh-ed25519 AAAAsharedpubkey';
+      const publicKey = _publicKeyA;
       const privateKey = 'test-open-ssh-key-sharedprivkey';
 
       final existingId = await keyRepository.insert(
@@ -1260,9 +1268,9 @@ void main() {
         SshKeysCompanion.insert(
           name: 'Unrelated Key',
           keyType: 'ed25519',
-          publicKey: 'ssh-ed25519 AAAAunrelated',
+          publicKey: _publicKeyA,
           privateKey: 'test-open-ssh-key-unrelated',
-          fingerprint: const Value('SHA256:un:re:la:te:d0'),
+          fingerprint: const Value(_publicKeyAFingerprint),
         ),
       );
 
@@ -1274,9 +1282,9 @@ void main() {
           'key': {
             'name': 'Brand New Key',
             'keyType': 'ed25519',
-            'publicKey': 'ssh-ed25519 AAAAnewkey',
+            'publicKey': _publicKeyB,
             'privateKey': 'test-open-ssh-key-newkey',
-            'fingerprint': 'SHA256:ne:wk:ey:00:01',
+            'fingerprint': 'SHA256:forged',
           },
         },
       );

--- a/test/unit/auth_service_test.dart
+++ b/test/unit/auth_service_test.dart
@@ -2,6 +2,7 @@
 
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:local_auth/local_auth.dart';
@@ -18,6 +19,10 @@ class MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
 class MockLocalAuthentication extends Mock implements LocalAuthentication {}
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(IOSOptions.defaultOptions);
+  });
+
   late AuthService authService;
   late MockFlutterSecureStorage mockStorage;
   late MockLocalAuthentication mockLocalAuth;
@@ -61,6 +66,50 @@ void main() {
 
         expect(result, true);
       });
+
+      test(
+        'reads and migrates iOS keychain items with legacy accessibility',
+        () async {
+          debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+          addTearDown(() {
+            debugDefaultTargetPlatformOverride = null;
+          });
+          const hardenedOptions = IOSOptions(
+            accessibility: KeychainAccessibility.first_unlock_this_device,
+          );
+          const legacyOptions = IOSOptions.defaultOptions;
+          when(
+            () => mockStorage.read(
+              key: 'flutty_auth_enabled',
+              iOptions: hardenedOptions,
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockStorage.read(
+              key: 'flutty_auth_enabled',
+              iOptions: legacyOptions,
+            ),
+          ).thenAnswer((_) async => 'true');
+          when(
+            () => mockStorage.write(
+              key: 'flutty_auth_enabled',
+              value: 'true',
+              iOptions: hardenedOptions,
+            ),
+          ).thenAnswer((_) async {});
+
+          final result = await authService.isAuthEnabled();
+
+          expect(result, true);
+          verify(
+            () => mockStorage.write(
+              key: 'flutty_auth_enabled',
+              value: 'true',
+              iOptions: hardenedOptions,
+            ),
+          ).called(1);
+        },
+      );
     });
 
     group('setupPin', () {

--- a/test/unit/secret_encryption_service_test.dart
+++ b/test/unit/secret_encryption_service_test.dart
@@ -3,6 +3,7 @@
 import 'dart:convert';
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -17,6 +18,10 @@ const _legacyMasterKeyStorageEntry =
     '_key_v1';
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(IOSOptions.defaultOptions);
+  });
+
   group('SecretEncryptionService', () {
     late SecretEncryptionService service;
 
@@ -98,6 +103,60 @@ void main() {
           value: legacyValue,
         ),
       ).called(1);
+    });
+
+    test('migrates iOS master key stored with legacy accessibility', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() {
+        debugDefaultTargetPlatformOverride = null;
+      });
+      final storage = _MockFlutterSecureStorage();
+      final legacyValue = base64Encode(
+        List<int>.generate(32, (index) => index),
+      );
+      const hardenedOptions = IOSOptions(
+        accessibility: KeychainAccessibility.first_unlock_this_device,
+      );
+      const legacyOptions = IOSOptions.defaultOptions;
+
+      when(
+        () => storage.read(
+          key: 'flutty_db_encryption_key_v1',
+          iOptions: hardenedOptions,
+        ),
+      ).thenAnswer((_) async => null);
+      when(
+        () => storage.read(
+          key: 'flutty_db_encryption_key_v1',
+          iOptions: legacyOptions,
+        ),
+      ).thenAnswer((_) async => legacyValue);
+      when(
+        () => storage.write(
+          key: 'flutty_db_encryption_key_v1',
+          value: legacyValue,
+          iOptions: hardenedOptions,
+        ),
+      ).thenAnswer((_) async {});
+
+      service = SecretEncryptionService(storage: storage, random: Random(1));
+
+      final encrypted = await service.encryptNullable('migrate-me');
+
+      expect(encrypted, startsWith('ENCv1:'));
+      verify(
+        () => storage.write(
+          key: 'flutty_db_encryption_key_v1',
+          value: legacyValue,
+          iOptions: hardenedOptions,
+        ),
+      ).called(1);
+      verifyNever(
+        () => storage.read(
+          key: _legacyMasterKeyStorageEntry,
+          iOptions: any(named: 'iOptions'),
+        ),
+      );
     });
 
     group('tamper and corruption resistance', () {

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -640,11 +640,11 @@ void main() {
         );
         await tester.enterText(
           find.widgetWithText(TextFormField, 'New PIN'),
-          '1234',
+          '123456',
         );
         await tester.enterText(
           find.widgetWithText(TextFormField, 'Confirm new PIN'),
-          '1234',
+          '123456',
         );
 
         await tester.tap(find.widgetWithText(FilledButton, 'Change'));
@@ -691,11 +691,11 @@ void main() {
       );
       await tester.enterText(
         find.widgetWithText(TextFormField, 'New PIN'),
-        '5678',
+        '567890',
       );
       await tester.enterText(
         find.widgetWithText(TextFormField, 'Confirm new PIN'),
-        '5678',
+        '567890',
       );
 
       await tester.tap(find.widgetWithText(FilledButton, 'Change'));


### PR DESCRIPTION
## Summary

- harden tmux manual-test SSH key setup, remote upload staging permissions, SSH key fingerprinting, and temporary key generation cleanup
- split clipboard sharing so remote clipboard reads are separately opt-in, and require previews before host/key transfer imports
- tighten Android transfer intents, strengthen transfer encryption with Argon2id, raise new PIN minimums, warn on non-loopback port forwards, and expand dependency automation

## Validation

- `flutter analyze`
- `flutter test test/domain/services/key_service_test.dart test/domain/services/secure_transfer_service_test.dart test/domain/services/remote_file_service_test.dart test/domain/services/clipboard_sharing_service_test.dart test/domain/services/remote_clipboard_sync_service_test.dart`
- `flutter test test/presentation/screens/terminal_screen_test.dart`
- `JAVA_HOME="$(/usr/libexec/java_home -v 17)" flutter build apk --debug --flavor production --quiet`

Note: full `flutter test` was attempted multiple times, including through the pre-commit hook, but stalled locally at the first displayed unit test; that same file and the affected test groups pass when run directly.
