### PR TITLE
fix: avoid duplicate selected CLI icon

### DIFF
--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -969,6 +969,9 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                 ),
               )
               .toList(growable: false),
+          selectedItemBuilder: (context) => AgentLaunchTool.values
+              .map((tool) => Text(tool.label))
+              .toList(growable: false),
           onChanged: hasAgentPresetAccess
               ? (value) {
                   if (value == null) {

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -20,6 +20,7 @@ import 'package:monkeyssh/domain/models/monetization.dart';
 import 'package:monkeyssh/domain/services/agent_launch_preset_service.dart';
 import 'package:monkeyssh/domain/services/monetization_service.dart';
 import 'package:monkeyssh/presentation/screens/host_edit_screen.dart';
+import 'package:monkeyssh/presentation/widgets/agent_tool_icon.dart';
 
 Host _testHost({
   required int id,
@@ -375,6 +376,25 @@ void main() {
         expect(harness.hostRepository.insertedHost, isNull);
       },
     );
+
+    testWidgets('shows one selected coding agent icon in closed dropdown', (
+      tester,
+    ) async {
+      await _pumpHostCreateScreen(tester, hasPro: true);
+      await _selectStartupMode(tester, 'Launch coding agent');
+
+      final agentField = find.byKey(const Key('host-agent-tool-field'));
+      await tester.ensureVisible(agentField);
+      await tester.tap(agentField);
+      await tester.pump();
+      await tester.tap(find.text('Copilot CLI').last);
+      await tester.pump();
+
+      expect(
+        find.descendant(of: agentField, matching: find.byType(AgentToolIcon)),
+        findsOneWidget,
+      );
+    });
 
     testWidgets('scrolls to missing snippet when saving snippet startup', (
       tester,

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -386,9 +386,11 @@ void main() {
       final agentField = find.byKey(const Key('host-agent-tool-field'));
       await tester.ensureVisible(agentField);
       await tester.tap(agentField);
-      await tester.pump();
-      await tester.tap(find.text('Copilot CLI').last);
-      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(
+        find.widgetWithText(DropdownMenuItem<AgentLaunchTool>, 'Copilot CLI'),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
 
       expect(
         find.descendant(of: agentField, matching: find.byType(AgentToolIcon)),


### PR DESCRIPTION
## Summary

- Render selected coding-agent dropdown values as text-only so the field prefix icon is not duplicated.
- Keep branded icons in the opened dropdown menu.
- Add widget regression coverage for selecting Copilot CLI.

## Validation

- `flutter analyze`
- `flutter test test/widget/host_edit_screen_test.dart`
- `flutter test`
