### PR TITLE
[codex] Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,53 +1,48 @@
 version: 2
+
+multi-ecosystem-groups:
+  all-dependencies:
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+
 updates:
   # Flutter/Dart dependencies
   - package-ecosystem: "pub"
     directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 10
+    patterns:
+      - "*"
     labels:
-      - "dependencies"
       - "dart"
-    commit-message:
-      prefix: "deps(dart)"
+    multi-ecosystem-group: "all-dependencies"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
+    patterns:
+      - "*"
     labels:
-      - "dependencies"
       - "ci"
-    commit-message:
-      prefix: "deps(actions)"
+    multi-ecosystem-group: "all-dependencies"
 
   # Ruby tooling (fastlane, CocoaPods)
   - package-ecosystem: "bundler"
     directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
+    patterns:
+      - "*"
     labels:
-      - "dependencies"
       - "ruby"
-    commit-message:
-      prefix: "deps(ruby)"
+    multi-ecosystem-group: "all-dependencies"
 
   # Android Gradle dependencies
   - package-ecosystem: "gradle"
     directory: "/android"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
+    patterns:
+      - "*"
     labels:
-      - "dependencies"
       - "android"
-    commit-message:
-      prefix: "deps(android)"
+    multi-ecosystem-group: "all-dependencies"


### PR DESCRIPTION
## Summary

- Configure one Dependabot multi-ecosystem group for all dependency updates.
- Include all packages from pub, GitHub Actions, bundler, and Gradle with `patterns: ["*"]`.
- Move shared weekly scheduling, dependency labeling, and commit-message prefix onto the group.

## Impact

Dependabot should open one consolidated dependency update PR across the configured ecosystems instead of separate ecosystem/package PRs on the weekly Monday schedule.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "YAML OK"'`
- Repo pre-commit hook during commit
