### PR TITLE
fix: open tmux alert notification target

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -171,6 +171,7 @@ class _BackgroundLifecycleBridgeState
           .read(routerProvider)
           .go(targetUri.replace(queryParameters: queryParameters).toString());
     });
+    WidgetsBinding.instance.ensureVisualUpdate();
   }
 
   void _listenForHomeScreenShortcutChanges() {

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -83,6 +83,8 @@ final routerProvider = Provider<GoRouter>((ref) {
             connectionId: connectionId,
             initialTmuxSessionName: initialTmuxSessionName,
             initialTmuxWindowIndex: initialTmuxWindowIndex,
+            initialTmuxWindowRequiresVisibleSession:
+                state.uri.queryParameters['notificationTap'] != null,
             initiallyExpandTmuxWindows:
                 state.uri.queryParameters['expandTmux'] == '1',
           );

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -1690,7 +1690,7 @@ class SshSession {
       _shellDoneController?.stream ?? const Stream.empty();
 
   /// Close only the interactive shell channel while keeping the SSH client.
-  Future<void> closeShell() async {
+  Future<void> closeShell({bool waitForStreams = true}) async {
     _flushShellIoDiagnostics();
     _shellIoDiagnosticsTimer?.cancel();
     _shellIoDiagnosticsTimer = null;
@@ -1701,18 +1701,32 @@ class SshSession {
     );
     _previewRefreshTimer?.cancel();
     _previewRefreshTimer = null;
-    await _shellStdoutSubscription?.cancel();
-    await _shellStderrSubscription?.cancel();
-    await _shellDoneSubscription?.cancel();
+    if (waitForStreams) {
+      await _shellStdoutSubscription?.cancel();
+      await _shellStderrSubscription?.cancel();
+      await _shellDoneSubscription?.cancel();
+    } else {
+      unawaited(_shellStdoutSubscription?.cancel());
+      unawaited(_shellStderrSubscription?.cancel());
+      unawaited(_shellDoneSubscription?.cancel());
+    }
     _shellStdoutSubscription = null;
     _shellStderrSubscription = null;
     _shellDoneSubscription = null;
-    await _shellStdoutController?.close();
-    await _shellStderrController?.close();
-    await _shellDoneController?.close();
+
+    if (waitForStreams) {
+      await _shellStdoutController?.close();
+      await _shellStderrController?.close();
+      await _shellDoneController?.close();
+    } else {
+      unawaited(_shellStdoutController?.close());
+      unawaited(_shellStderrController?.close());
+      unawaited(_shellDoneController?.close());
+    }
     _shellStdoutController = null;
     _shellStderrController = null;
     _shellDoneController = null;
+
     _shell?.close();
     _shell = null;
     terminalHyperlinkTracker.reset(keepTerminalReference: false);

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -1763,7 +1763,12 @@ class SshSession {
             _recordShellIo(stdoutChars: data.length);
             terminal.write(data);
             _scheduleTerminalPreviewRefresh();
-            _shellStdoutController!.add(data);
+            final stdoutController = _shellStdoutController;
+            if (identical(_shell, shell) &&
+                stdoutController != null &&
+                !stdoutController.isClosed) {
+              stdoutController.add(data);
+            }
           },
           onError: (Object error, StackTrace stackTrace) {
             DiagnosticsLogService.instance.error(
@@ -1774,7 +1779,12 @@ class SshSession {
                 'errorType': error.runtimeType,
               },
             );
-            _shellStdoutController!.addError(error, stackTrace);
+            final stdoutController = _shellStdoutController;
+            if (identical(_shell, shell) &&
+                stdoutController != null &&
+                !stdoutController.isClosed) {
+              stdoutController.addError(error, stackTrace);
+            }
           },
         );
     _shellStderrSubscription = shell.stderr
@@ -1785,7 +1795,12 @@ class SshSession {
             _recordShellIo(stderrChars: data.length);
             terminal.write(data);
             _scheduleTerminalPreviewRefresh();
-            _shellStderrController!.add(data);
+            final stderrController = _shellStderrController;
+            if (identical(_shell, shell) &&
+                stderrController != null &&
+                !stderrController.isClosed) {
+              stderrController.add(data);
+            }
           },
           onError: (Object error, StackTrace stackTrace) {
             DiagnosticsLogService.instance.error(
@@ -1796,7 +1811,12 @@ class SshSession {
                 'errorType': error.runtimeType,
               },
             );
-            _shellStderrController!.addError(error, stackTrace);
+            final stderrController = _shellStderrController;
+            if (identical(_shell, shell) &&
+                stderrController != null &&
+                !stderrController.isClosed) {
+              stderrController.addError(error, stackTrace);
+            }
           },
         );
     _shellDoneSubscription = shell.done.asStream().listen(
@@ -1806,7 +1826,12 @@ class SshSession {
           'done',
           fields: {'connectionId': connectionId},
         );
-        _shellDoneController!.add(null);
+        final doneController = _shellDoneController;
+        if (identical(_shell, shell) &&
+            doneController != null &&
+            !doneController.isClosed) {
+          doneController.add(null);
+        }
       },
       onError: (Object error, StackTrace stackTrace) {
         DiagnosticsLogService.instance.error(
@@ -1817,7 +1842,12 @@ class SshSession {
             'errorType': error.runtimeType,
           },
         );
-        _shellDoneController!.addError(error, stackTrace);
+        final doneController = _shellDoneController;
+        if (identical(_shell, shell) &&
+            doneController != null &&
+            !doneController.isClosed) {
+          doneController.addError(error, stackTrace);
+        }
       },
     );
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3038,6 +3038,7 @@ class TerminalScreen extends ConsumerStatefulWidget {
     this.connectionId,
     this.initialTmuxSessionName,
     this.initialTmuxWindowIndex,
+    this.initialTmuxWindowRequiresVisibleSession = false,
     this.initiallyExpandTmuxWindows = false,
     super.key,
   });
@@ -3054,6 +3055,9 @@ class TerminalScreen extends ConsumerStatefulWidget {
   /// Optional tmux window to focus after opening the terminal.
   final int? initialTmuxWindowIndex;
 
+  /// Whether focusing the initial tmux window must also make tmux visible.
+  final bool initialTmuxWindowRequiresVisibleSession;
+
   /// Whether the tmux window selector should start expanded.
   final bool initiallyExpandTmuxWindows;
 
@@ -3065,10 +3069,12 @@ class _InitialTmuxWindowTarget {
   const _InitialTmuxWindowTarget({
     required this.sessionName,
     required this.windowIndex,
+    required this.requiresVisibleSession,
   });
 
   final String sessionName;
   final int windowIndex;
+  final bool requiresVisibleSession;
 }
 
 class _TerminalScreenState extends ConsumerState<TerminalScreen>
@@ -3353,6 +3359,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     return _InitialTmuxWindowTarget(
       sessionName: sessionName,
       windowIndex: windowIndex,
+      requiresVisibleSession: widget.initialTmuxWindowRequiresVisibleSession,
     );
   }
 
@@ -4586,7 +4593,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
     _pendingInitialTmuxWindowTarget = null;
     try {
-      await _switchTmuxWindow(session, target.windowIndex);
+      await _switchTmuxWindow(
+        session,
+        target.windowIndex,
+        forceVisibleTmux: target.requiresVisibleSession,
+      );
     } on Exception catch (error) {
       _showTmuxActionFailure(error);
     }
@@ -4886,7 +4897,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   /// `tmux select-window` is a server operation — the tmux server
   /// notifies all attached clients of the change. Writing to the PTY
   /// would inject the command as input to whatever program is running.
-  Future<void> _switchTmuxWindow(SshSession session, int windowIndex) async {
+  Future<void> _switchTmuxWindow(
+    SshSession session,
+    int windowIndex, {
+    bool forceVisibleTmux = false,
+  }) async {
     final sessionName = _tmuxSessionName;
     if (sessionName == null) return;
 
@@ -4897,7 +4912,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     // Clear stale working directory — it will be refreshed from
     // OSC 7 or the next tmux query.
     _tmuxWorkingDirectory = null;
-    await _reattachTmuxIfNeeded(session, sessionName);
+    await _reattachTmuxIfNeeded(
+      session,
+      sessionName,
+      forceVisibleTmux: forceVisibleTmux,
+    );
   }
 
   /// Creates a new tmux window via exec channel, then reattaches the visible
@@ -4954,8 +4973,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   Future<void> _reattachTmuxIfNeeded(
     SshSession session,
-    String sessionName,
-  ) async {
+    String sessionName, {
+    bool forceVisibleTmux = false,
+  }) async {
     final tmux = ref.read(tmuxServiceProvider);
     final hasForegroundClient = await tmux.hasForegroundClient(
       session,
@@ -4973,10 +4993,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
-    if (!shouldReattachTmuxAfterWindowAction(
+    final canReattachInCurrentShell = shouldReattachTmuxAfterWindowAction(
       hasForegroundClient: hasForegroundClient,
       shellStatus: _shellStatus,
-    )) {
+    );
+    if (!canReattachInCurrentShell && !forceVisibleTmux) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
@@ -4993,7 +5014,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
-    final shell = _shell;
+    final shell = forceVisibleTmux
+        ? await _reopenShellForVisibleTmux(session)
+        : _shell;
     if (shell == null) {
       return;
     }
@@ -5010,6 +5033,55 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       'reattach_command_sent',
       fields: {'connectionId': session.connectionId},
     );
+  }
+
+  Future<SSHSession?> _reopenShellForVisibleTmux(SshSession session) async {
+    unawaited(_doneSubscription?.cancel());
+    _doneSubscription = null;
+    unawaited(_shellStdoutSubscription?.cancel());
+    _shellStdoutSubscription = null;
+    _promptOutputImeResetTimer?.cancel();
+    _promptOutputImeResetTimer = null;
+    _shell = null;
+
+    final pty = SSHPtyConfig(
+      width: _terminal.viewWidth,
+      height: _terminal.viewHeight,
+    );
+    _terminal.removeListener(_onTerminalStateChanged);
+    await session.closeShell(waitForStreams: false);
+    final shell = await session.getShell(pty: pty);
+    final terminal = session.terminal;
+    if (terminal == null) {
+      return null;
+    }
+
+    _terminal = terminal;
+    _terminalHyperlinkTracker = session.terminalHyperlinkTracker;
+    _isUsingAltBuffer = _terminal.isUsingAltBuffer;
+    _terminalReportsMouseWheel = _terminal.mouseMode.reportScroll;
+    _terminal.addListener(_onTerminalStateChanged);
+    _shell = shell;
+    _wireTerminalCallbacks(session);
+    final sharedClipboardEnabled = await ref.read(
+      sharedClipboardProvider.future,
+    );
+    final sharedClipboardLocalReadEnabled = await ref.read(
+      sharedClipboardLocalReadProvider.future,
+    );
+    await _applySharedClipboardSetting(
+      enabled: sharedClipboardEnabled,
+      allowLocalClipboardRead: sharedClipboardLocalReadEnabled,
+      session: session,
+      waitForInitialSync: false,
+    );
+    if (mounted) {
+      setState(() {
+        _isUsingAltBuffer = _terminal.isUsingAltBuffer;
+        _terminalReportsMouseWheel = _terminal.mouseMode.reportScroll;
+      });
+    }
+    return shell;
   }
 
   void _handleTrackedConnectionStateChange(

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -5014,7 +5014,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
-    final shell = forceVisibleTmux
+    if (forceVisibleTmux && !canReattachInCurrentShell) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Opening tmux alert interrupted the running shell command.',
+          ),
+        ),
+      );
+    }
+
+    final shell = forceVisibleTmux && !canReattachInCurrentShell
         ? await _reopenShellForVisibleTmux(session)
         : _shell;
     if (shell == null) {
@@ -5036,45 +5046,102 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   Future<SSHSession?> _reopenShellForVisibleTmux(SshSession session) async {
+    bool stillOwnsSession() => mounted && _connectionId == session.connectionId;
+
+    final previousTerminal = _terminal;
+    final previousTerminalHyperlinkTracker = _terminalHyperlinkTracker;
+    final previousIsUsingAltBuffer = _isUsingAltBuffer;
+    final previousTerminalReportsMouseWheel = _terminalReportsMouseWheel;
+    final previousShell = _shell;
+    var removedTerminalListener = false;
+    var closedExistingShell = false;
+
+    void restorePreviousTerminalState({required bool restoreShell}) {
+      _terminal = previousTerminal;
+      _terminalHyperlinkTracker = previousTerminalHyperlinkTracker;
+      _isUsingAltBuffer = previousIsUsingAltBuffer;
+      _terminalReportsMouseWheel = previousTerminalReportsMouseWheel;
+      if (removedTerminalListener) {
+        _terminal.addListener(_onTerminalStateChanged);
+        removedTerminalListener = false;
+      }
+      if (restoreShell) {
+        _shell = previousShell;
+      }
+    }
+
     unawaited(_doneSubscription?.cancel());
     _doneSubscription = null;
     unawaited(_shellStdoutSubscription?.cancel());
     _shellStdoutSubscription = null;
     _promptOutputImeResetTimer?.cancel();
     _promptOutputImeResetTimer = null;
-    _shell = null;
 
     final pty = SSHPtyConfig(
       width: _terminal.viewWidth,
       height: _terminal.viewHeight,
     );
-    _terminal.removeListener(_onTerminalStateChanged);
-    await session.closeShell(waitForStreams: false);
-    final shell = await session.getShell(pty: pty);
-    final terminal = session.terminal;
-    if (terminal == null) {
-      return null;
+
+    final SSHSession shell;
+    try {
+      _terminal.removeListener(_onTerminalStateChanged);
+      removedTerminalListener = true;
+      _shell = null;
+
+      await session.closeShell(waitForStreams: false);
+      closedExistingShell = true;
+      if (!stillOwnsSession()) {
+        restorePreviousTerminalState(restoreShell: false);
+        return null;
+      }
+
+      shell = await session.getShell(pty: pty);
+      if (!stillOwnsSession()) {
+        restorePreviousTerminalState(restoreShell: false);
+        return null;
+      }
+      final terminal = session.terminal;
+      if (terminal == null) {
+        return null;
+      }
+
+      _terminal = terminal;
+      _terminalHyperlinkTracker = session.terminalHyperlinkTracker;
+      _isUsingAltBuffer = _terminal.isUsingAltBuffer;
+      _terminalReportsMouseWheel = _terminal.mouseMode.reportScroll;
+      _terminal.addListener(_onTerminalStateChanged);
+      removedTerminalListener = false;
+      _shell = shell;
+      _wireTerminalCallbacks(session);
+    } on Object {
+      restorePreviousTerminalState(restoreShell: !closedExistingShell);
+      rethrow;
     }
 
-    _terminal = terminal;
-    _terminalHyperlinkTracker = session.terminalHyperlinkTracker;
-    _isUsingAltBuffer = _terminal.isUsingAltBuffer;
-    _terminalReportsMouseWheel = _terminal.mouseMode.reportScroll;
-    _terminal.addListener(_onTerminalStateChanged);
-    _shell = shell;
-    _wireTerminalCallbacks(session);
+    if (!stillOwnsSession()) {
+      return null;
+    }
     final sharedClipboardEnabled = await ref.read(
       sharedClipboardProvider.future,
     );
+    if (!stillOwnsSession()) {
+      return null;
+    }
     final sharedClipboardLocalReadEnabled = await ref.read(
       sharedClipboardLocalReadProvider.future,
     );
+    if (!stillOwnsSession()) {
+      return null;
+    }
     await _applySharedClipboardSetting(
       enabled: sharedClipboardEnabled,
       allowLocalClipboardRead: sharedClipboardLocalReadEnabled,
       session: session,
       waitForInitialSync: false,
     );
+    if (!stillOwnsSession()) {
+      return null;
+    }
     if (mounted) {
       setState(() {
         _isUsingAltBuffer = _terminal.isUsingAltBuffer;

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -496,6 +496,12 @@ void main() {
           () => tmuxService.hasForegroundClient(session, tmuxSessionName),
         ).called(1);
         expect(find.textContaining('tmux action failed'), findsNothing);
+        expect(
+          find.text(
+            'Opening tmux alert interrupted the running shell command.',
+          ),
+          findsOneWidget,
+        );
         expect(shellWrites.map(utf8.decode).join(), contains(tmuxSessionName));
         expect(shellOpenCount, greaterThanOrEqualTo(2));
       },

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -403,6 +403,106 @@ void main() {
     );
 
     testWidgets(
+      'notification tmux target reopens a busy shell so the selected window is visible',
+      (tester) async {
+        final tmuxService = _MockTmuxService();
+        const tmuxSessionName = 'alerts';
+        const targetWindowIndex = 3;
+        final windows = <TmuxWindow>[
+          const TmuxWindow(index: 1, name: 'shell', isActive: true),
+          const TmuxWindow(index: 3, name: 'agent', isActive: false),
+        ];
+        final secondShellOpen = Completer<void>();
+        var shellOpenCount = 0;
+        when(() => sshClient.shell(pty: any(named: 'pty'))).thenAnswer((
+          _,
+        ) async {
+          shellOpenCount += 1;
+          if (shellOpenCount == 2 && !secondShellOpen.isCompleted) {
+            secondShellOpen.complete();
+          }
+          return shellChannel;
+        });
+        when(
+          () => tmuxService.hasSession(session, tmuxSessionName),
+        ).thenAnswer((_) async => true);
+        when(
+          () => tmuxService.listWindows(session, tmuxSessionName),
+        ).thenAnswer((_) async => windows);
+        when(
+          () => tmuxService.selectWindow(
+            session,
+            tmuxSessionName,
+            targetWindowIndex,
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => tmuxService.hasForegroundClient(session, tmuxSessionName),
+        ).thenAnswer((_) async => false);
+        when(
+          () => tmuxService.watchWindowChanges(session, tmuxSessionName),
+        ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+        when(
+          () => tmuxService.prefetchInstalledAgentTools(session),
+        ).thenAnswer((_) async {});
+        session.terminal!.write('\u001b]133;C\u0007');
+        expect(session.shellStatus, TerminalShellStatus.runningCommand);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+              tmuxServiceProvider.overrideWithValue(tmuxService),
+            ],
+            child: MaterialApp(
+              home: TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+                initialTmuxSessionName: tmuxSessionName,
+                initialTmuxWindowIndex: targetWindowIndex,
+                initialTmuxWindowRequiresVisibleSession: true,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+        await tester.runAsync(() async {
+          await secondShellOpen.future.timeout(const Duration(seconds: 2));
+        });
+        await tester.pump();
+
+        verify(
+          () => tmuxService.selectWindow(
+            session,
+            tmuxSessionName,
+            targetWindowIndex,
+          ),
+        ).called(1);
+        verify(
+          () => tmuxService.hasForegroundClient(session, tmuxSessionName),
+        ).called(1);
+        expect(find.textContaining('tmux action failed'), findsNothing);
+        expect(shellWrites.map(utf8.decode).join(), contains(tmuxSessionName));
+        expect(shellOpenCount, greaterThanOrEqualTo(2));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
       'touching the terminal dismisses the expanded tmux bar',
       (tester) async {
         final tmuxService = _MockTmuxService();


### PR DESCRIPTION
## Summary

- Route tmux alert notification taps as targets that must make the tmux session visible, not just select the window server-side.
- Reopen the visible shell channel on the same SSH connection when a notification target needs to attach to tmux from a busy/outside-tmux terminal.
- Ensure queued notification-tap navigation schedules a frame so foreground taps route promptly.

## Validation

- `flutter analyze`
- `flutter test test/domain/services/local_notification_service_test.dart test/presentation/screens/terminal_screen_test.dart test/domain/services/ssh_service_test.dart`
- `flutter test`
