### PR TITLE
fix: preserve tmux bar after transient detection failure

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -100,22 +100,8 @@ class TmuxService {
   /// variable, because SSH exec channels do not share the interactive
   /// shell's environment.
   Future<bool> isTmuxActive(SshSession session) async {
-    DiagnosticsLogService.instance.debug(
-      'tmux.detect',
-      'active_check_start',
-      fields: {'connectionId': session.connectionId},
-    );
     try {
-      // Cache the tmux binary path on first successful detection.
-      await _cacheTmuxPath(session);
-      final output = await _exec(session, 'tmux list-sessions 2>/dev/null');
-      final active = output.trim().isNotEmpty;
-      DiagnosticsLogService.instance.info(
-        'tmux.detect',
-        'active_check_complete',
-        fields: {'connectionId': session.connectionId, 'active': active},
-      );
-      return active;
+      return await isTmuxActiveOrThrow(session);
     } on Exception catch (error) {
       DiagnosticsLogService.instance.warning(
         'tmux.detect',
@@ -127,6 +113,36 @@ class TmuxService {
       );
       return false;
     }
+  }
+
+  /// Returns `true` if tmux has at least one session, and throws when the
+  /// remote check could not complete.
+  ///
+  /// Unlike [isTmuxActive], this distinguishes "no sessions" from
+  /// infrastructure failures so callers can preserve existing UI on
+  /// indeterminate detection results.
+  Future<bool> isTmuxActiveOrThrow(SshSession session) async {
+    DiagnosticsLogService.instance.debug(
+      'tmux.detect',
+      'active_check_start',
+      fields: {'connectionId': session.connectionId},
+    );
+    // Cache the tmux binary path on first successful detection.
+    await _cacheTmuxPath(session);
+    final output = await _exec(
+      session,
+      "tmux list-sessions -F '#{session_name}' 2>/dev/null; "
+      r'status=$?; '
+      r'if [ "$status" -eq 0 ] || [ "$status" -eq 1 ]; then true; '
+      'else false; fi',
+    );
+    final active = output.trim().isNotEmpty;
+    DiagnosticsLogService.instance.info(
+      'tmux.detect',
+      'active_check_complete',
+      fields: {'connectionId': session.connectionId, 'active': active},
+    );
+    return active;
   }
 
   /// Returns `true` if tmux is installed on the remote host.
@@ -392,24 +408,8 @@ class TmuxService {
 
   /// Returns `true` if [sessionName] exists on the remote tmux server.
   Future<bool> hasSession(SshSession session, String sessionName) async {
-    DiagnosticsLogService.instance.debug(
-      'tmux.query',
-      'has_session_start',
-      fields: {'connectionId': session.connectionId},
-    );
     try {
-      await _cacheTmuxPath(session);
-      final output = await _exec(
-        session,
-        'tmux has-session -t ${_shellQuote(sessionName)} 2>/dev/null && printf 1',
-      );
-      final exists = output.trim() == '1';
-      DiagnosticsLogService.instance.info(
-        'tmux.query',
-        'has_session_complete',
-        fields: {'connectionId': session.connectionId, 'exists': exists},
-      );
-      return exists;
+      return await hasSessionOrThrow(session, sessionName);
     } on Exception catch (error) {
       DiagnosticsLogService.instance.warning(
         'tmux.query',
@@ -421,6 +421,35 @@ class TmuxService {
       );
       return false;
     }
+  }
+
+  /// Returns `true` if [sessionName] exists, and throws when the remote check
+  /// could not complete.
+  ///
+  /// Unlike [hasSession], this distinguishes a missing tmux session from
+  /// transient SSH exec/channel failures.
+  Future<bool> hasSessionOrThrow(SshSession session, String sessionName) async {
+    DiagnosticsLogService.instance.debug(
+      'tmux.query',
+      'has_session_start',
+      fields: {'connectionId': session.connectionId},
+    );
+    await _cacheTmuxPath(session);
+    final output = await _exec(
+      session,
+      'tmux has-session -t ${_shellQuote(sessionName)} 2>/dev/null; '
+      r'status=$?; '
+      r'if [ "$status" -eq 0 ]; then printf 1; '
+      r'elif [ "$status" -eq 1 ]; then printf 0; '
+      'else false; fi',
+    );
+    final exists = output.trim() == '1';
+    DiagnosticsLogService.instance.info(
+      'tmux.query',
+      'has_session_complete',
+      fields: {'connectionId': session.connectionId, 'exists': exists},
+    );
+    return exists;
   }
 
   // ── Window queries ─────────────────────────────────────────────────────

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -173,6 +173,23 @@ const _tmuxDetectionRetrySchedule = <Duration>[
 List<Duration> resolveTmuxDetectionRetrySchedule({bool skipDelay = false}) =>
     skipDelay ? const <Duration>[Duration.zero] : _tmuxDetectionRetrySchedule;
 
+/// Returns whether tmux detection should keep the terminal's current tmux UI.
+///
+/// A clean inactive result can clear the bar, but transient detection failures
+/// should not hide a bar that was already visible or primed from host settings.
+@visibleForTesting
+bool shouldPreserveTerminalTmuxStateAfterDetectionFailure({
+  required bool preserveExistingTmuxState,
+  required bool hadVisibleOrPrimedTmuxState,
+  required bool verifiedTmuxSession,
+  required bool hadDetectionFailure,
+}) {
+  if (preserveExistingTmuxState || verifiedTmuxSession) {
+    return true;
+  }
+  return hadVisibleOrPrimedTmuxState && hadDetectionFailure;
+}
+
 /// Resolves the working directory to use when creating a new tmux window.
 @visibleForTesting
 String? resolveTmuxWindowWorkingDirectory({
@@ -4416,7 +4433,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         ? _tmuxSessionName
         : null;
     final candidateSessionName = preferredSessionName ?? existingSessionName;
+    final hadVisibleOrPrimedTmuxState =
+        (_isTmuxActive && _tmuxSessionName != null) ||
+        candidateSessionName != null;
     final preferredWorkingDirectory = host?.tmuxWorkingDirectory;
+    var verifiedTmuxSession = false;
+    var hadDetectionFailure = false;
 
     if (mounted) {
       setState(() {
@@ -4454,9 +4476,32 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           }
         }
 
-        final active = candidateSessionName != null
-            ? await tmux.hasSession(session, candidateSessionName)
-            : await tmux.isTmuxActive(session);
+        final bool active;
+        try {
+          active = candidateSessionName != null
+              ? await tmux.hasSession(session, candidateSessionName)
+              : await tmux.isTmuxActive(session);
+        } on Object catch (error) {
+          hadDetectionFailure = true;
+          DiagnosticsLogService.instance.warning(
+            'tmux.ui',
+            'detection_attempt_failed',
+            fields: {
+              'connectionId': session.connectionId,
+              'hasCandidate': candidateSessionName != null,
+              'errorType': error.runtimeType,
+            },
+          );
+          if (!shouldPreserveTerminalTmuxStateAfterDetectionFailure(
+            preserveExistingTmuxState: preserveExistingTmuxState,
+            hadVisibleOrPrimedTmuxState: hadVisibleOrPrimedTmuxState,
+            verifiedTmuxSession: verifiedTmuxSession,
+            hadDetectionFailure: true,
+          )) {
+            rethrow;
+          }
+          continue;
+        }
         DiagnosticsLogService.instance.debug(
           'tmux.ui',
           'detection_attempt',
@@ -4474,9 +4519,23 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         if (!active) {
           continue;
         }
+        verifiedTmuxSession = true;
 
         var sessionName = candidateSessionName;
-        sessionName ??= await tmux.currentSessionName(session);
+        try {
+          sessionName ??= await tmux.currentSessionName(session);
+        } on Object catch (error) {
+          hadDetectionFailure = true;
+          DiagnosticsLogService.instance.warning(
+            'tmux.ui',
+            'detection_session_name_failed',
+            fields: {
+              'connectionId': session.connectionId,
+              'errorType': error.runtimeType,
+            },
+          );
+          continue;
+        }
         if (!mounted ||
             _connectionId != capturedConnectionId ||
             detectionGeneration != _tmuxDetectionGeneration) {
@@ -4494,7 +4553,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         final List<TmuxWindow> windows;
         try {
           windows = await tmux.listWindows(session, sessionName);
-        } on Object {
+        } on Object catch (error) {
+          hadDetectionFailure = true;
+          DiagnosticsLogService.instance.warning(
+            'tmux.ui',
+            'detection_windows_failed',
+            fields: {
+              'connectionId': session.connectionId,
+              'errorType': error.runtimeType,
+            },
+          );
           continue;
         }
         if (!mounted ||
@@ -4552,6 +4620,24 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         return;
       }
 
+      if (shouldPreserveTerminalTmuxStateAfterDetectionFailure(
+        preserveExistingTmuxState: preserveExistingTmuxState,
+        hadVisibleOrPrimedTmuxState: hadVisibleOrPrimedTmuxState,
+        verifiedTmuxSession: verifiedTmuxSession,
+        hadDetectionFailure: hadDetectionFailure,
+      )) {
+        DiagnosticsLogService.instance.warning(
+          'tmux.ui',
+          'detection_preserved_existing',
+          fields: {
+            'connectionId': session.connectionId,
+            'verifiedTmuxSession': verifiedTmuxSession,
+            'hadDetectionFailure': hadDetectionFailure,
+          },
+        );
+        return;
+      }
+
       if (!preserveExistingTmuxState) {
         setState(_clearTmuxState);
       }
@@ -4572,6 +4658,23 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       if (!mounted ||
           _connectionId != capturedConnectionId ||
           detectionGeneration != _tmuxDetectionGeneration) {
+        return;
+      }
+      if (shouldPreserveTerminalTmuxStateAfterDetectionFailure(
+        preserveExistingTmuxState: preserveExistingTmuxState,
+        hadVisibleOrPrimedTmuxState: hadVisibleOrPrimedTmuxState,
+        verifiedTmuxSession: verifiedTmuxSession,
+        hadDetectionFailure: true,
+      )) {
+        DiagnosticsLogService.instance.warning(
+          'tmux.ui',
+          'detection_preserved_existing',
+          fields: {
+            'connectionId': session.connectionId,
+            'verifiedTmuxSession': verifiedTmuxSession,
+            'hadDetectionFailure': true,
+          },
+        );
         return;
       }
       if (!preserveExistingTmuxState) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -181,10 +181,10 @@ List<Duration> resolveTmuxDetectionRetrySchedule({bool skipDelay = false}) =>
 bool shouldPreserveTerminalTmuxStateAfterDetectionFailure({
   required bool preserveExistingTmuxState,
   required bool hadVisibleOrPrimedTmuxState,
-  required bool verifiedTmuxSession,
+  required bool confirmedTmuxActive,
   required bool hadDetectionFailure,
 }) {
-  if (preserveExistingTmuxState || verifiedTmuxSession) {
+  if (preserveExistingTmuxState || confirmedTmuxActive) {
     return true;
   }
   return hadVisibleOrPrimedTmuxState && hadDetectionFailure;
@@ -4437,7 +4437,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         (_isTmuxActive && _tmuxSessionName != null) ||
         candidateSessionName != null;
     final preferredWorkingDirectory = host?.tmuxWorkingDirectory;
-    var verifiedTmuxSession = false;
+    var confirmedTmuxActive = false;
     var hadDetectionFailure = false;
 
     if (mounted) {
@@ -4479,8 +4479,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         final bool active;
         try {
           active = candidateSessionName != null
-              ? await tmux.hasSession(session, candidateSessionName)
-              : await tmux.isTmuxActive(session);
+              ? await tmux.hasSessionOrThrow(session, candidateSessionName)
+              : await tmux.isTmuxActiveOrThrow(session);
         } on Object catch (error) {
           hadDetectionFailure = true;
           DiagnosticsLogService.instance.warning(
@@ -4495,7 +4495,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           if (!shouldPreserveTerminalTmuxStateAfterDetectionFailure(
             preserveExistingTmuxState: preserveExistingTmuxState,
             hadVisibleOrPrimedTmuxState: hadVisibleOrPrimedTmuxState,
-            verifiedTmuxSession: verifiedTmuxSession,
+            confirmedTmuxActive: confirmedTmuxActive,
             hadDetectionFailure: true,
           )) {
             rethrow;
@@ -4517,9 +4517,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           return;
         }
         if (!active) {
+          confirmedTmuxActive = false;
+          hadDetectionFailure = false;
           continue;
         }
-        verifiedTmuxSession = true;
+        confirmedTmuxActive = true;
 
         var sessionName = candidateSessionName;
         try {
@@ -4623,18 +4625,27 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       if (shouldPreserveTerminalTmuxStateAfterDetectionFailure(
         preserveExistingTmuxState: preserveExistingTmuxState,
         hadVisibleOrPrimedTmuxState: hadVisibleOrPrimedTmuxState,
-        verifiedTmuxSession: verifiedTmuxSession,
+        confirmedTmuxActive: confirmedTmuxActive,
         hadDetectionFailure: hadDetectionFailure,
       )) {
-        DiagnosticsLogService.instance.warning(
-          'tmux.ui',
-          'detection_preserved_existing',
-          fields: {
-            'connectionId': session.connectionId,
-            'verifiedTmuxSession': verifiedTmuxSession,
-            'hadDetectionFailure': hadDetectionFailure,
-          },
-        );
+        final logFields = {
+          'connectionId': session.connectionId,
+          'confirmedTmuxActive': confirmedTmuxActive,
+          'hadDetectionFailure': hadDetectionFailure,
+        };
+        if (hadDetectionFailure) {
+          DiagnosticsLogService.instance.warning(
+            'tmux.ui',
+            'detection_preserved_existing',
+            fields: logFields,
+          );
+        } else {
+          DiagnosticsLogService.instance.info(
+            'tmux.ui',
+            'detection_preserved_existing',
+            fields: logFields,
+          );
+        }
         return;
       }
 
@@ -4663,7 +4674,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       if (shouldPreserveTerminalTmuxStateAfterDetectionFailure(
         preserveExistingTmuxState: preserveExistingTmuxState,
         hadVisibleOrPrimedTmuxState: hadVisibleOrPrimedTmuxState,
-        verifiedTmuxSession: verifiedTmuxSession,
+        confirmedTmuxActive: confirmedTmuxActive,
         hadDetectionFailure: true,
       )) {
         DiagnosticsLogService.instance.warning(
@@ -4671,7 +4682,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           'detection_preserved_existing',
           fields: {
             'connectionId': session.connectionId,
-            'verifiedTmuxSession': verifiedTmuxSession,
+            'confirmedTmuxActive': confirmedTmuxActive,
             'hadDetectionFailure': true,
           },
         );

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -78,6 +78,59 @@ void main() {
       expect(tools, {AgentLaunchTool.geminiCli});
       verify(() => client.execute(any(), pty: any(named: 'pty'))).called(1);
     });
+
+    test(
+      'hasSessionOrThrow returns false for a missing tmux session',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client, connectionId: 30);
+        const service = TmuxService();
+        final execSessions = Queue<SSHSession>.of([
+          _buildOpenExecSession(
+            stdout: 'bash\n/usr/bin/tmux\n${_doneMarker()}',
+          ),
+          _buildOpenExecSession(stdout: '0\n${_doneMarker()}'),
+        ]);
+
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => execSessions.removeFirst());
+
+        final exists = await service.hasSessionOrThrow(session, 'missing');
+
+        expect(exists, isFalse);
+        verify(
+          () => client.execute(
+            any(that: contains('tmux -u has-session')),
+            pty: any(named: 'pty'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'hasSessionOrThrow propagates indeterminate command failures',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client, connectionId: 31);
+        const service = TmuxService();
+        final execSessions = Queue<SSHSession>.of([
+          _buildOpenExecSession(
+            stdout: 'bash\n/usr/bin/tmux\n${_doneMarker()}',
+          ),
+          _buildOpenExecSession(stdout: _doneMarker(2)),
+        ]);
+
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => execSessions.removeFirst());
+
+        await expectLater(
+          service.hasSessionOrThrow(session, 'work'),
+          throwsA(isA<TmuxCommandException>()),
+        );
+      },
+    );
   });
 
   group('parseTmuxWindowChangeEventFromControlLine', () {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -70,13 +70,18 @@ class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
   Future<void> syncBackgroundStatus() async {}
 }
 
-Host _buildHost({required int id, String? autoConnectCommand}) => Host(
+Host _buildHost({
+  required int id,
+  String? autoConnectCommand,
+  String? tmuxSessionName,
+}) => Host(
   id: id,
   label: 'Terminal test host',
   hostname: 'terminal.example.com',
   port: 22,
   username: 'root',
   autoConnectCommand: autoConnectCommand,
+  tmuxSessionName: tmuxSessionName,
   isFavorite: false,
   createdAt: DateTime(2026),
   updatedAt: DateTime(2026),
@@ -322,6 +327,83 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
     }
+
+    testWidgets(
+      'keeps a primed tmux bar visible after transient detection failure',
+      (tester) async {
+        final tmuxService = _MockTmuxService();
+        const tmuxSessionName = 'work';
+        const windows = <TmuxWindow>[
+          TmuxWindow(index: 0, name: 'shell', isActive: true),
+          TmuxWindow(index: 1, name: 'agent', isActive: false),
+        ];
+        session = SshSession(
+          connectionId: 7,
+          hostId: host.id,
+          client: sshClient,
+          config: const SshConnectionConfig(
+            hostname: 'terminal.example.com',
+            port: 22,
+            username: 'root',
+          ),
+        );
+        host = _buildHost(id: host.id, tmuxSessionName: tmuxSessionName);
+        var hasSessionCalls = 0;
+        when(() => tmuxService.hasSession(session, tmuxSessionName)).thenAnswer(
+          (_) async {
+            hasSessionCalls += 1;
+            if (hasSessionCalls == 1) {
+              throw StateError('exec channel temporarily unavailable');
+            }
+            return true;
+          },
+        );
+        when(
+          () => tmuxService.listWindows(session, tmuxSessionName),
+        ).thenAnswer((_) async => windows);
+        when(
+          () => tmuxService.watchWindowChanges(session, tmuxSessionName),
+        ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+        when(
+          () => tmuxService.prefetchInstalledAgentTools(session),
+        ).thenAnswer((_) async {});
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+              tmuxServiceProvider.overrideWithValue(tmuxService),
+            ],
+            child: MaterialApp(
+              home: TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(find.byKey(const ValueKey('tmux-handle-bar')), findsOneWidget);
+        expect(find.textContaining(tmuxSessionName), findsOneWidget);
+        expect(hasSessionCalls, greaterThanOrEqualTo(2));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
 
     testWidgets(
       'initial tmux target selects the alerted window and can start expanded',

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -283,7 +283,7 @@ void main() {
       ];
 
       when(
-        () => tmuxService.hasSession(session, tmuxSessionName),
+        () => tmuxService.hasSessionOrThrow(session, tmuxSessionName),
       ).thenAnswer((_) async => true);
       when(
         () => tmuxService.listWindows(session, tmuxSessionName),
@@ -349,15 +349,15 @@ void main() {
         );
         host = _buildHost(id: host.id, tmuxSessionName: tmuxSessionName);
         var hasSessionCalls = 0;
-        when(() => tmuxService.hasSession(session, tmuxSessionName)).thenAnswer(
-          (_) async {
-            hasSessionCalls += 1;
-            if (hasSessionCalls == 1) {
-              throw StateError('exec channel temporarily unavailable');
-            }
-            return true;
-          },
-        );
+        when(
+          () => tmuxService.hasSessionOrThrow(session, tmuxSessionName),
+        ).thenAnswer((_) async {
+          hasSessionCalls += 1;
+          if (hasSessionCalls == 1) {
+            throw StateError('exec channel temporarily unavailable');
+          }
+          return true;
+        });
         when(
           () => tmuxService.listWindows(session, tmuxSessionName),
         ).thenAnswer((_) async => windows);
@@ -406,6 +406,84 @@ void main() {
     );
 
     testWidgets(
+      'clears a primed tmux bar after later clean inactive detection',
+      (tester) async {
+        final tmuxService = _MockTmuxService();
+        const tmuxSessionName = 'work';
+        const windows = <TmuxWindow>[
+          TmuxWindow(index: 0, name: 'shell', isActive: true),
+          TmuxWindow(index: 1, name: 'agent', isActive: false),
+        ];
+        session = SshSession(
+          connectionId: 7,
+          hostId: host.id,
+          client: sshClient,
+          config: const SshConnectionConfig(
+            hostname: 'terminal.example.com',
+            port: 22,
+            username: 'root',
+          ),
+        );
+        host = _buildHost(id: host.id, tmuxSessionName: tmuxSessionName);
+        var hasSessionCalls = 0;
+        when(
+          () => tmuxService.hasSessionOrThrow(session, tmuxSessionName),
+        ).thenAnswer((_) async {
+          hasSessionCalls += 1;
+          if (hasSessionCalls == 1) {
+            throw StateError('exec channel temporarily unavailable');
+          }
+          return false;
+        });
+        when(
+          () => tmuxService.listWindows(session, tmuxSessionName),
+        ).thenAnswer((_) async => windows);
+        when(
+          () => tmuxService.watchWindowChanges(session, tmuxSessionName),
+        ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+        when(
+          () => tmuxService.prefetchInstalledAgentTools(session),
+        ).thenAnswer((_) async {});
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+              tmuxServiceProvider.overrideWithValue(tmuxService),
+            ],
+            child: MaterialApp(
+              home: TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+        expect(find.byKey(const ValueKey('tmux-handle-bar')), findsOneWidget);
+
+        await tester.pump(const Duration(seconds: 3));
+
+        expect(find.byKey(const ValueKey('tmux-handle-bar')), findsNothing);
+        expect(hasSessionCalls, greaterThanOrEqualTo(2));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
       'initial tmux target selects the alerted window and can start expanded',
       (tester) async {
         final tmuxService = _MockTmuxService();
@@ -416,7 +494,7 @@ void main() {
           const TmuxWindow(index: 3, name: 'agent', isActive: false),
         ];
         when(
-          () => tmuxService.hasSession(session, tmuxSessionName),
+          () => tmuxService.hasSessionOrThrow(session, tmuxSessionName),
         ).thenAnswer((_) async => true);
         when(
           () => tmuxService.listWindows(session, tmuxSessionName),
@@ -506,7 +584,7 @@ void main() {
           return shellChannel;
         });
         when(
-          () => tmuxService.hasSession(session, tmuxSessionName),
+          () => tmuxService.hasSessionOrThrow(session, tmuxSessionName),
         ).thenAnswer((_) async => true);
         when(
           () => tmuxService.listWindows(session, tmuxSessionName),

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -294,6 +294,36 @@ void main() {
       },
     );
 
+    test('preserves visible tmux UI only after non-definitive detection', () {
+      expect(
+        shouldPreserveTerminalTmuxStateAfterDetectionFailure(
+          preserveExistingTmuxState: false,
+          hadVisibleOrPrimedTmuxState: true,
+          verifiedTmuxSession: false,
+          hadDetectionFailure: true,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldPreserveTerminalTmuxStateAfterDetectionFailure(
+          preserveExistingTmuxState: false,
+          hadVisibleOrPrimedTmuxState: true,
+          verifiedTmuxSession: false,
+          hadDetectionFailure: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldPreserveTerminalTmuxStateAfterDetectionFailure(
+          preserveExistingTmuxState: false,
+          hadVisibleOrPrimedTmuxState: false,
+          verifiedTmuxSession: true,
+          hadDetectionFailure: false,
+        ),
+        isTrue,
+      );
+    });
+
     test('resolves preferred tmux session name before remote verification', () {
       expect(
         resolvePreferredTmuxSessionName(

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -299,7 +299,7 @@ void main() {
         shouldPreserveTerminalTmuxStateAfterDetectionFailure(
           preserveExistingTmuxState: false,
           hadVisibleOrPrimedTmuxState: true,
-          verifiedTmuxSession: false,
+          confirmedTmuxActive: false,
           hadDetectionFailure: true,
         ),
         isTrue,
@@ -308,16 +308,19 @@ void main() {
         shouldPreserveTerminalTmuxStateAfterDetectionFailure(
           preserveExistingTmuxState: false,
           hadVisibleOrPrimedTmuxState: true,
-          verifiedTmuxSession: false,
+          confirmedTmuxActive: false,
           hadDetectionFailure: false,
         ),
         isFalse,
       );
+    });
+
+    test('preserves tmux state after tmux is confirmed active', () {
       expect(
         shouldPreserveTerminalTmuxStateAfterDetectionFailure(
           preserveExistingTmuxState: false,
           hadVisibleOrPrimedTmuxState: false,
-          verifiedTmuxSession: true,
+          confirmedTmuxActive: true,
           hadDetectionFailure: false,
         ),
         isTrue,


### PR DESCRIPTION
## Summary

- Preserve the terminal tmux bar when detection hits transient SSH exec/channel failures after tmux UI was already visible or primed from host settings.
- Keep definitive inactive detection behavior so stale/nonexistent tmux sessions still clear the bar.
- Add regression coverage for a primed tmux bar surviving a transient detection failure.

## Validation

- `flutter analyze`
- `flutter test test/widget/terminal_screen_layout_test.dart test/presentation/screens/terminal_screen_test.dart --name "tmux|auto-connect rebuilds agent launch commands"`
- `flutter test`
