### PR TITLE
Use system selection for terminal text

### DIFF
--- a/integration_test/terminal_system_selection_test.dart
+++ b/integration_test/terminal_system_selection_test.dart
@@ -34,7 +34,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    terminal.write('selectable alpha beta gamma');
+    terminal.write('selectable alpha   beta gamma');
     await tester.pumpAndSettle();
 
     final renderTerminal = terminalViewKey.currentState!.renderTerminal;
@@ -48,8 +48,17 @@ void main() {
 
     expect(find.byType(TextField), findsNothing);
     expect(controller.selection, isNotNull);
-    expect(renderTerminal.getSelectedContent()?.plainText.trim(), 'alpha');
+    expect(renderTerminal.getSelectedContent()?.plainText, 'alpha');
     expect(selectionChanges, isNotEmpty);
-    expect(selectionChanges.last?.plainText.trim(), 'alpha');
+    expect(selectionChanges.last?.plainText, 'alpha');
+
+    controller.setSelection(
+      terminal.buffer.createAnchorFromOffset(const CellOffset(11, 0)),
+      terminal.buffer.createAnchorFromOffset(const CellOffset(19, 0)),
+      mode: SelectionMode.line,
+    );
+    await tester.pumpAndSettle();
+
+    expect(renderTerminal.getSelectedContent()?.plainText, 'alpha');
   });
 }

--- a/integration_test/terminal_system_selection_test.dart
+++ b/integration_test/terminal_system_selection_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
+import 'package:xterm/xterm.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('terminal render object supports system selection on device', (
+    tester,
+  ) async {
+    final terminal = Terminal();
+    final controller = TerminalController();
+    final terminalViewKey = GlobalKey<MonkeyTerminalViewState>();
+    final selectionChanges = <SelectedContent?>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox.expand(
+            child: MonkeyTerminalView(
+              terminal,
+              key: terminalViewKey,
+              controller: controller,
+              readOnly: true,
+              useSystemSelection: true,
+              onSystemSelectionChanged: selectionChanges.add,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    terminal.write('selectable alpha beta gamma');
+    await tester.pumpAndSettle();
+
+    final renderTerminal = terminalViewKey.currentState!.renderTerminal;
+    Offset cellCenter(CellOffset offset) => renderTerminal.localToGlobal(
+      renderTerminal.getOffset(offset) +
+          renderTerminal.cellSize.center(Offset.zero),
+    );
+
+    await tester.longPressAt(cellCenter(const CellOffset(13, 0)));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TextField), findsNothing);
+    expect(controller.selection, isNotNull);
+    expect(renderTerminal.getSelectedContent()?.plainText.trim(), 'alpha');
+    expect(selectionChanges, isNotEmpty);
+    expect(selectionChanges.last?.plainText.trim(), 'alpha');
+  });
+}

--- a/integration_test/terminal_system_selection_test.dart
+++ b/integration_test/terminal_system_selection_test.dart
@@ -3,10 +3,75 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
+import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
 import 'package:xterm/xterm.dart';
+
+const _selectionPaintColor = Color(0xFFFF00FF);
+const _testTerminalTheme = TerminalTheme(
+  cursor: Color(0xFFFFFFFF),
+  selection: _selectionPaintColor,
+  foreground: Color(0xFFFFFFFF),
+  background: Color(0xFF000000),
+  black: Color(0xFF000000),
+  red: Color(0xFFFF0000),
+  green: Color(0xFF00FF00),
+  yellow: Color(0xFFFFFF00),
+  blue: Color(0xFF0000FF),
+  magenta: Color(0xFFFF00FF),
+  cyan: Color(0xFF00FFFF),
+  white: Color(0xFFFFFFFF),
+  brightBlack: Color(0xFF808080),
+  brightRed: Color(0xFFFF8080),
+  brightGreen: Color(0xFF80FF80),
+  brightYellow: Color(0xFFFFFF80),
+  brightBlue: Color(0xFF8080FF),
+  brightMagenta: Color(0xFFFF80FF),
+  brightCyan: Color(0xFF80FFFF),
+  brightWhite: Color(0xFFFFFFFF),
+  searchHitBackground: Color(0xFFFFFF00),
+  searchHitBackgroundCurrent: Color(0xFFFFA000),
+  searchHitForeground: Color(0xFF000000),
+);
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  String rowLabel(int row) => 'row ${row.toString().padLeft(2, '0')}';
+
+  Future<double> waitForKeyboardInset(
+    WidgetTester tester, {
+    required bool visible,
+  }) async {
+    for (var attempt = 0; attempt < 30; attempt += 1) {
+      await tester.pump(const Duration(milliseconds: 100));
+      final bottomInset = tester.view.viewInsets.bottom;
+      if (visible ? bottomInset > 0 : bottomInset == 0) {
+        return bottomInset;
+      }
+    }
+    return tester.view.viewInsets.bottom;
+  }
+
+  Future<int> countSelectionPaintPixels(
+    RenderRepaintBoundary repaintBoundary,
+  ) async {
+    final image = await repaintBoundary.toImage();
+    final byteData = await image.toByteData();
+    expect(byteData, isNotNull);
+    final bytes = byteData!.buffer.asUint8List();
+    var pixels = 0;
+    for (var index = 0; index < bytes.length; index += 4) {
+      final red = bytes[index];
+      final green = bytes[index + 1];
+      final blue = bytes[index + 2];
+      final alpha = bytes[index + 3];
+      if (red > 240 && green < 20 && blue > 240 && alpha > 240) {
+        pixels += 1;
+      }
+    }
+    image.dispose();
+    return pixels;
+  }
 
   testWidgets('terminal render object supports system selection on device', (
     tester,
@@ -60,5 +125,178 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(renderTerminal.getSelectedContent()?.plainText, 'alpha');
+  });
+
+  Future<
+    ({
+      Terminal terminal,
+      TerminalController controller,
+      GlobalKey<MonkeyTerminalViewState> terminalViewKey,
+      GlobalKey repaintBoundaryKey,
+      FocusNode focusNode,
+      TerminalTextInputHandlerController inputController,
+    })
+  >
+  pumpKeyboardSelectionHarness(WidgetTester tester) async {
+    final terminal = Terminal(maxLines: 120);
+    final controller = TerminalController();
+    final terminalViewKey = GlobalKey<MonkeyTerminalViewState>();
+    final repaintBoundaryKey = GlobalKey();
+    final focusNode = FocusNode();
+    final inputController = TerminalTextInputHandlerController();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              Expanded(
+                child: TerminalTextInputHandler(
+                  terminal: terminal,
+                  focusNode: focusNode,
+                  controller: inputController,
+                  showKeyboardOnFocus: false,
+                  child: RepaintBoundary(
+                    key: repaintBoundaryKey,
+                    child: MonkeyTerminalView(
+                      terminal,
+                      key: terminalViewKey,
+                      controller: controller,
+                      hardwareKeyboardOnly: true,
+                      theme: _testTerminalTheme,
+                      useSystemSelection: true,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 48),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    for (var row = 0; row < 80; row += 1) {
+      terminal.write('${rowLabel(row)}\r\n');
+    }
+    await tester.pumpAndSettle();
+
+    return (
+      terminal: terminal,
+      controller: controller,
+      terminalViewKey: terminalViewKey,
+      repaintBoundaryKey: repaintBoundaryKey,
+      focusNode: focusNode,
+      inputController: inputController,
+    );
+  }
+
+  Future<void> dragStartHandleToRow(
+    WidgetTester tester,
+    MonkeyRenderTerminal renderTerminal, {
+    required int targetRow,
+  }) async {
+    final startSelectionPoint = renderTerminal.value.startSelectionPoint!;
+    final startHandlePosition = renderTerminal.localToGlobal(
+      startSelectionPoint.localPosition,
+    );
+    final handleDragPosition =
+        startHandlePosition + Offset(0, renderTerminal.cellSize.height);
+
+    Offset cellCenter(CellOffset offset) => renderTerminal.localToGlobal(
+      renderTerminal.getOffset(offset) +
+          renderTerminal.cellSize.center(Offset.zero),
+    );
+
+    await tester.timedDragFrom(
+      handleDragPosition,
+      cellCenter(CellOffset(0, targetRow)) - handleDragPosition,
+      const Duration(milliseconds: 600),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('terminal system selection is visible with soft keyboard open', (
+    tester,
+  ) async {
+    final harness = await pumpKeyboardSelectionHarness(tester);
+    final renderTerminal = harness.terminalViewKey.currentState!.renderTerminal;
+
+    Offset cellCenter(CellOffset offset) => renderTerminal.localToGlobal(
+      renderTerminal.getOffset(offset) +
+          renderTerminal.cellSize.center(Offset.zero),
+    );
+
+    harness.inputController.requestKeyboard();
+    final shownKeyboardInset = await waitForKeyboardInset(
+      tester,
+      visible: true,
+    );
+    expect(shownKeyboardInset, greaterThan(0));
+    await tester.pumpAndSettle();
+
+    final topVisibleRow = renderTerminal.getCellOffset(Offset.zero).y;
+    final selectedRow = topVisibleRow + 20;
+    final targetRow = topVisibleRow + 1;
+
+    await tester.longPressAt(cellCenter(CellOffset(5, selectedRow)));
+    await tester.pumpAndSettle();
+    expect(harness.controller.selection, isNotNull);
+
+    await dragStartHandleToRow(tester, renderTerminal, targetRow: targetRow);
+
+    final selectedText = renderTerminal.getSelectedContent()!.plainText;
+    expect(selectedText, contains(rowLabel(targetRow)));
+    expect(selectedText, contains(rowLabel(selectedRow)));
+    final repaintBoundary =
+        harness.repaintBoundaryKey.currentContext!.findRenderObject()!
+            as RenderRepaintBoundary;
+    expect(await countSelectionPaintPixels(repaintBoundary), greaterThan(100));
+  });
+
+  testWidgets('terminal system selection survives soft keyboard resize', (
+    tester,
+  ) async {
+    final harness = await pumpKeyboardSelectionHarness(tester);
+    final renderTerminal = harness.terminalViewKey.currentState!.renderTerminal;
+
+    Offset cellCenter(CellOffset offset) => renderTerminal.localToGlobal(
+      renderTerminal.getOffset(offset) +
+          renderTerminal.cellSize.center(Offset.zero),
+    );
+
+    harness.inputController.requestKeyboard();
+    final shownKeyboardInset = await waitForKeyboardInset(
+      tester,
+      visible: true,
+    );
+    expect(shownKeyboardInset, greaterThan(0));
+    harness.focusNode.unfocus();
+    final hiddenKeyboardInset = await waitForKeyboardInset(
+      tester,
+      visible: false,
+    );
+    expect(hiddenKeyboardInset, 0);
+    await tester.pumpAndSettle();
+
+    final topVisibleRow = renderTerminal.getCellOffset(Offset.zero).y;
+    final selectedRow = topVisibleRow + 35;
+    final targetRow = topVisibleRow + 1;
+
+    await tester.longPressAt(cellCenter(CellOffset(5, selectedRow)));
+    await tester.pumpAndSettle();
+    expect(harness.controller.selection, isNotNull);
+
+    await dragStartHandleToRow(tester, renderTerminal, targetRow: targetRow);
+
+    final selectedText = renderTerminal.getSelectedContent()!.plainText;
+    expect(selectedText, contains(rowLabel(targetRow)));
+    expect(selectedText, contains(rowLabel(selectedRow)));
+    final repaintBoundary =
+        harness.repaintBoundaryKey.currentContext!.findRenderObject()!
+            as RenderRepaintBoundary;
+    expect(await countSelectionPaintPixels(repaintBoundary), greaterThan(100));
   });
 }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -10,7 +10,6 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -3081,7 +3080,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _isUsingAltBuffer = false;
   bool _terminalReportsMouseWheel = false;
   bool _isNativeSelectionMode = false;
-  bool _hasSystemTerminalSelection = false;
   bool _revealsNativeSelectionOverlayInTouchScrollMode = false;
   bool _isSyncingNativeScroll = false;
   bool _hadNativeOverlaySelection = false;
@@ -3123,6 +3121,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   Offset? _lastTerminalTapPosition;
   Duration? _lastTerminalTapTimestamp;
   bool _recentlyHandledTerminalDoubleTap = false;
+  int? _pendingTerminalMouseTapPointer;
+  Offset? _pendingTerminalMouseTapDownPosition;
+  Duration? _pendingTerminalMouseTapDownTimestamp;
   Rect? _hoveredTerminalPathUnderline;
   List<({String path, Rect underlineRect, Rect touchRect})>
   _visibleTerminalPathUnderlines =
@@ -6056,9 +6057,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       systemSelectionContextMenuBuilder: isMobile
           ? _buildTerminalSelectionContextMenu
           : null,
-      onSystemSelectionChanged: isMobile
-          ? _handleSystemTerminalSelectionChanged
-          : null,
       focusNode: isMobile ? null : _terminalFocusNode,
       theme: terminalTheme.toXtermTheme(),
       textStyle: terminalTextStyle,
@@ -6254,7 +6252,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       readOnly: _showsNativeSelectionOverlay || overlayMessage != null,
       tapToShowKeyboard:
           ref.watch(tapToShowKeyboardNotifierProvider) &&
-          !_hasSystemTerminalSelection &&
           !_showsNativeSelectionOverlay &&
           overlayMessage == null,
       showKeyboardOnFocus: false,
@@ -6297,14 +6294,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       anchors: selectableRegionState.contextMenuAnchors,
       buttonItems: buttonItems,
     );
-  }
-
-  void _handleSystemTerminalSelectionChanged(SelectedContent? selectedContent) {
-    final hasSelection = selectedContent?.plainText.isNotEmpty ?? false;
-    if (_hasSystemTerminalSelection == hasSelection) {
-      return;
-    }
-    setState(() => _hasSystemTerminalSelection = hasSelection);
   }
 
   /// Resolves the terminal text style for the given font family and size.
@@ -7072,23 +7061,95 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       event,
       allowDoubleTap: _pendingTerminalPathTap == null,
     );
+    _handleTerminalMouseTapPointerDown(
+      event,
+      allowTap:
+          _pendingTerminalPathTap == null &&
+          _terminalDoubleTapConsumedPointer != event.pointer,
+    );
   }
 
   void _handleTerminalPointerMove(PointerMoveEvent event) {
     _handleTerminalPathPointerMove(event);
     _handleTerminalDoubleTapPointerMove(event);
+    _handleTerminalMouseTapPointerMove(event);
   }
 
   void _handleTerminalPointerUp(PointerUpEvent event) {
     final pathTapConsumed = _handleTerminalPathPointerUp(event);
     if (!pathTapConsumed) {
       _handleTerminalDoubleTapPointerUp(event);
+      _handleTerminalMouseTapPointerUp(event);
+    } else {
+      _clearPendingTerminalMouseTap(event.pointer);
+      _clearLastTerminalTap();
     }
   }
 
   void _handleTerminalPointerCancel(PointerCancelEvent event) {
     _handleTerminalPathPointerCancel(event);
     _handleTerminalDoubleTapPointerCancel(event);
+    _clearPendingTerminalMouseTap(event.pointer);
+  }
+
+  void _handleTerminalMouseTapPointerDown(
+    PointerDownEvent event, {
+    required bool allowTap,
+  }) {
+    _clearPendingTerminalMouseTap();
+    final terminalViewState = _terminalViewKey.currentState;
+    if (event.kind != PointerDeviceKind.touch ||
+        !allowTap ||
+        terminalViewState == null ||
+        !terminalViewState.shouldSendTerminalTapPointerInput) {
+      return;
+    }
+
+    _pendingTerminalMouseTapPointer = event.pointer;
+    _pendingTerminalMouseTapDownPosition = event.position;
+    _pendingTerminalMouseTapDownTimestamp = event.timeStamp;
+  }
+
+  void _handleTerminalMouseTapPointerMove(PointerMoveEvent event) {
+    if (_pendingTerminalMouseTapPointer != event.pointer) {
+      return;
+    }
+    final downPosition = _pendingTerminalMouseTapDownPosition;
+    if (downPosition != null &&
+        (event.position - downPosition).distance > kTouchSlop) {
+      _clearPendingTerminalMouseTap(event.pointer);
+    }
+  }
+
+  void _handleTerminalMouseTapPointerUp(PointerUpEvent event) {
+    if (event.kind != PointerDeviceKind.touch ||
+        _terminalDoubleTapConsumedPointer == event.pointer) {
+      _clearPendingTerminalMouseTap(event.pointer);
+      return;
+    }
+
+    final downPosition = _pendingTerminalMouseTapDownPosition;
+    final downTimestamp = _pendingTerminalMouseTapDownTimestamp;
+    if (_pendingTerminalMouseTapPointer != event.pointer ||
+        downPosition == null ||
+        downTimestamp == null ||
+        event.timeStamp - downTimestamp > kLongPressTimeout ||
+        (event.position - downPosition).distance > kTouchSlop) {
+      _clearPendingTerminalMouseTap(event.pointer);
+      return;
+    }
+
+    _clearPendingTerminalMouseTap(event.pointer);
+    _terminalViewKey.currentState?.sendTerminalPrimaryTap(event.position);
+  }
+
+  void _clearPendingTerminalMouseTap([int? pointer]) {
+    if (pointer != null && _pendingTerminalMouseTapPointer != pointer) {
+      return;
+    }
+    _pendingTerminalMouseTapPointer = null;
+    _pendingTerminalMouseTapDownPosition = null;
+    _pendingTerminalMouseTapDownTimestamp = null;
   }
 
   void _handleTerminalDoubleTapPointerDown(

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -5715,9 +5715,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           forceShowSystemKeyboard ||
           (showSystemKeyboard && ref.read(tapToShowKeyboardNotifierProvider));
       if (shouldShowKeyboard && _isMobilePlatform) {
-        unawaited(
-          SystemChannels.textInput.invokeMethod<void>('TextInput.show'),
-        );
+        _terminalTextInputController.requestKeyboard();
       }
     });
   }
@@ -6231,11 +6229,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       consumeTerminalKeyModifiers: _toolbarController.consumeOneShot,
       hasActiveToolbarModifier: () =>
           _toolbarController.isCtrlActive || _toolbarController.isAltActive,
-      readOnly:
-          _hasSystemTerminalSelection ||
-          _showsNativeSelectionOverlay ||
-          overlayMessage != null,
-      tapToShowKeyboard: ref.watch(tapToShowKeyboardNotifierProvider),
+      readOnly: _showsNativeSelectionOverlay || overlayMessage != null,
+      tapToShowKeyboard:
+          ref.watch(tapToShowKeyboardNotifierProvider) &&
+          !_hasSystemTerminalSelection &&
+          !_showsNativeSelectionOverlay &&
+          overlayMessage == null,
       showKeyboardOnFocus: false,
       child: TerminalPinchZoomGestureHandler(
         onPinchStart: () => _handleTerminalScaleStart(storedFontSize),

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -10,6 +10,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -365,7 +366,6 @@ const _terminalFollowOutputTolerance = 1.0;
 const _maxVerifiedTerminalPathCacheEntries = 128;
 const _terminalPathTouchHorizontalPadding = 10.0;
 const _terminalPathTouchVerticalPadding = 8.0;
-const _selectionActionsBottomPadding = 12.0;
 const _terminalSelectionNearbySearchColumns = 4;
 const _maxTerminalFilePathVerificationCandidates = 12;
 const _terminalFilePathVerificationExtensions = <String>[
@@ -1737,11 +1737,6 @@ String trimTerminalLinePadding(String line) =>
 String trimTerminalSelectionText(String text) =>
     text.split('\n').map(trimTerminalLinePadding).join('\n');
 
-/// Keeps floating selection actions above the bottom safe area.
-@visibleForTesting
-double selectionActionsBottomOffset(MediaQueryData mediaQuery) =>
-    _selectionActionsBottomPadding + mediaQuery.padding.bottom;
-
 /// Keeps the Pro upsell snackbar tucked just above the visible bottom chrome.
 ///
 /// Flutter's floating [SnackBar] already anchors itself above the keyboard
@@ -2765,9 +2760,7 @@ bool shouldShowNativeSelectionOverlay({
   required bool isNativeSelectionMode,
   required bool routesTouchScrollToTerminal,
   required bool revealOverlayInTouchScrollMode,
-}) =>
-    isNativeSelectionMode &&
-    (!routesTouchScrollToTerminal || revealOverlayInTouchScrollMode);
+}) => isNativeSelectionMode;
 
 /// Whether the native overlay currently holds an expanded text selection.
 @visibleForTesting
@@ -2928,14 +2921,6 @@ bool shouldResolveTerminalTapLinks({
   required bool showsNativeSelectionOverlay,
 }) => !showsNativeSelectionOverlay;
 
-typedef _NativeSelectionSnapshotMetrics = ({
-  List<int> lineStarts,
-  List<List<int>> columnOffsets,
-  int lineCount,
-  int viewWidth,
-  int textLength,
-});
-
 typedef _NativeSelectionSnapshotData = ({
   String text,
   List<int> lineStarts,
@@ -2963,9 +2948,6 @@ enum NativeSelectionOverlayChange {
   /// Leaves the current overlay and selection mode state unchanged.
   none,
 
-  /// Hides only the temporary overlay used during tmux touch-selection flows.
-  hideTemporaryOverlay,
-
   /// Leaves native selection mode entirely so terminal input becomes editable.
   exitSelectionMode,
 }
@@ -2980,10 +2962,6 @@ NativeSelectionOverlayChange resolveNativeSelectionOverlayChange({
 }) {
   if (!isNativeSelectionMode || !selection.isCollapsed) {
     return NativeSelectionOverlayChange.none;
-  }
-
-  if (revealOverlayInTouchScrollMode) {
-    return NativeSelectionOverlayChange.hideTemporaryOverlay;
   }
 
   if (isMobilePlatform) {
@@ -3102,19 +3080,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _showKeyboardToolbar = !_hideStoreScreenshotKeyboardToolbar;
   bool _isUsingAltBuffer = false;
   bool _terminalReportsMouseWheel = false;
-  bool _hasTerminalSelection = false;
   bool _isNativeSelectionMode = false;
+  bool _hasSystemTerminalSelection = false;
   bool _revealsNativeSelectionOverlayInTouchScrollMode = false;
   bool _isSyncingNativeScroll = false;
   bool _hadNativeOverlaySelection = false;
-  _PendingTouchSelectionSnapshot? _pendingTouchSelectionRange;
-  _PendingTouchSelectionSnapshot? _pendingNativeOverlayLongPressSelection;
-  _NativeSelectionSnapshotMetrics? _nativeSelectionSnapshotMetrics;
   _NativeSelectionSnapshotData? _nativeSelectionSnapshotCache;
   Timer? _nativeOverlayCollapseTimer;
-  Timer? _nativeOverlayLongPressTimer;
-  int? _nativeOverlayPointerId;
-  Offset? _nativeOverlayPointerDownPosition;
   int? _connectionId;
   double? _pinchFontSize;
   double? _lastPinchScale;
@@ -3632,7 +3604,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     TapDownDetails tapDetails,
     CellOffset cellOffset,
   ) {
-    _clearPendingTouchSelectionRange();
     final shiftActive = _toolbarController.isShiftActive;
     _terminalTextInputController.suppressNextTouchKeyboardRequest();
     _terminal.textInput(resolveTerminalTabInput(shiftActive: shiftActive));
@@ -3644,65 +3615,25 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   void _handleTerminalTapUp(TapUpDetails tapDetails, CellOffset cellOffset) {
-    _clearPendingTouchSelectionRange();
+    if (!ref.read(tapToShowKeyboardNotifierProvider) ||
+        _hasSystemTerminalSelection ||
+        _terminalController.selection != null ||
+        _showsNativeSelectionOverlay) {
+      return;
+    }
+    _terminalTextInputController.requestKeyboard();
   }
 
   void _handleTerminalTapDown(
     TapDownDetails tapDetails,
     CellOffset cellOffset,
-  ) {
-    _cachePendingTouchSelectionSnapshot(tapDetails, cellOffset);
-  }
+  ) {}
 
   void _handleTerminalLinkTapDown(
     TapDownDetails tapDetails,
     CellOffset cellOffset,
   ) {
     _terminalTextInputController.suppressNextTouchKeyboardRequest();
-    _cachePendingTouchSelectionSnapshot(tapDetails, cellOffset);
-  }
-
-  void _cachePendingTouchSelectionSnapshot(
-    TapDownDetails tapDetails,
-    CellOffset cellOffset,
-  ) {
-    if (!_isMobilePlatform || _showsNativeSelectionOverlay) {
-      _clearPendingTouchSelectionRange();
-      return;
-    }
-
-    final kind = tapDetails.kind;
-    if (kind != null && !_isNativeOverlayTouchPointer(kind)) {
-      _clearPendingTouchSelectionRange();
-      return;
-    }
-
-    final snapshot = _buildPendingTouchSelectionSnapshot(
-      cellOffset,
-      revealOverlayInTouchScrollMode: _routesTouchScrollToTerminal,
-    );
-    _clearPendingTouchSelectionRange();
-    if (snapshot == null) {
-      return;
-    }
-    _pendingTouchSelectionRange = snapshot;
-  }
-
-  void _handleTerminalLongPressStart(
-    LongPressStartDetails details,
-    CellOffset cellOffset,
-  ) {
-    _terminalTextInputController.suppressNextTouchKeyboardRequest();
-    final pendingSnapshot = _pendingTouchSelectionRange;
-    _pendingTouchSelectionRange = null;
-    if (pendingSnapshot != null) {
-      _enterNativeSelectionModeWithSnapshot(pendingSnapshot);
-      return;
-    }
-    _selectNativeOverlayWordAtCellOffset(
-      cellOffset,
-      revealOverlayInTouchScrollMode: _routesTouchScrollToTerminal,
-    );
   }
 
   void _showTerminalInputIndicator(String label) {
@@ -3750,21 +3681,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     final selection = _terminalController.selection;
     final hasSelection = selection != null;
-    if (_isMobilePlatform && hasSelection) {
-      _enterNativeSelectionMode(
-        initialRange: selection,
-        revealOverlayInTouchScrollMode: _routesTouchScrollToTerminal,
-      );
-      return;
+    if (hasSelection) {
+      setState(() {});
     }
-
-    if (_hasTerminalSelection == hasSelection) {
-      return;
-    }
-
-    setState(() {
-      _hasTerminalSelection = hasSelection;
-    });
   }
 
   void _syncNativeScrollFromTerminal({bool force = false}) {
@@ -5306,7 +5225,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       ..removeListener(_onNativeOverlayControllerChanged)
       ..dispose();
     _nativeOverlayCollapseTimer?.cancel();
-    _clearNativeOverlayLongPressState();
     _nativeSelectionFocusNode.dispose();
     _doneSubscription?.cancel();
     _shellStdoutSubscription?.cancel();
@@ -6115,9 +6033,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final globalFont = ref.watch(fontFamilyNotifierProvider);
     final fontFamily = hostFont ?? globalFont;
     final terminalTextStyle = _getTerminalTextStyle(fontFamily, fontSize);
-    final nativeSelectionTextStyle = _getNativeSelectionTextStyle(
-      terminalTextStyle,
-    );
     final routeTouchScrollToTerminal = _routesTouchScrollToTerminal;
     final terminalPathLinksEnabled = ref.watch(
       terminalPathLinksNotifierProvider,
@@ -6125,8 +6040,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final terminalPathLinkUnderlinesEnabled = ref.watch(
       terminalPathLinkUnderlinesNotifierProvider,
     );
-    final tapToShowKeyboard = ref.watch(tapToShowKeyboardNotifierProvider);
-
     Widget terminalView = MonkeyTerminalView(
       key: _terminalViewKey,
       _terminal,
@@ -6138,8 +6051,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       onLinkTapDown: _handleTerminalLinkTapDown,
       onLinkTap: _handleTerminalLinkTap,
       onDoubleTapDown: isMobile ? _handleTerminalDoubleTapDown : null,
-      onLongPressStart: isMobile ? _handleTerminalLongPressStart : null,
       suppressLongPressDragSelection: isMobile,
+      useSystemSelection: isMobile,
+      systemSelectionContextMenuBuilder: isMobile
+          ? _buildTerminalSelectionContextMenu
+          : null,
+      onSystemSelectionChanged: isMobile
+          ? _handleSystemTerminalSelectionChanged
+          : null,
       focusNode: isMobile ? null : _terminalFocusNode,
       theme: terminalTheme.toXtermTheme(),
       textStyle: terminalTextStyle,
@@ -6257,6 +6176,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       }
     }
 
+    if (isMobile) {
+      terminalView = TextSelectionTheme(
+        data: TextSelectionTheme.of(context).copyWith(
+          selectionColor: terminalTheme.selection,
+          selectionHandleColor: terminalTheme.cursor,
+        ),
+        child: terminalView,
+      );
+    }
+
     if (!isMobile) {
       return overlayMessage == null
           ? terminalView
@@ -6269,31 +6198,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
 
     var mobileTerminalView = terminalView;
-
-    // On mobile, wrap with our own text input handler that enables
-    // IME suggestions so swipe typing correctly inserts spaces.
-    if (_showsNativeSelectionOverlay) {
-      mobileTerminalView = Stack(
-        fit: StackFit.expand,
-        children: [
-          mobileTerminalView,
-          _nativeSelectionOverlay(nativeSelectionTextStyle, terminalTheme),
-        ],
-      );
-    } else if (_hasTerminalSelection) {
-      mobileTerminalView = Stack(
-        fit: StackFit.expand,
-        children: [
-          mobileTerminalView,
-          Positioned(
-            left: 12,
-            right: 12,
-            bottom: selectionActionsBottomOffset(MediaQuery.of(context)),
-            child: _selectionActions,
-          ),
-        ],
-      );
-    }
 
     final terminalInputIndicatorLabel = _terminalInputIndicatorLabel;
     if (_isPinchZooming || terminalInputIndicatorLabel != null) {
@@ -6344,8 +6248,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       consumeTerminalKeyModifiers: _toolbarController.consumeOneShot,
       hasActiveToolbarModifier: () =>
           _toolbarController.isCtrlActive || _toolbarController.isAltActive,
-      readOnly: _showsNativeSelectionOverlay || overlayMessage != null,
-      tapToShowKeyboard: tapToShowKeyboard,
+      readOnly:
+          _hasSystemTerminalSelection ||
+          _showsNativeSelectionOverlay ||
+          overlayMessage != null,
+      tapToShowKeyboard: false,
       child: TerminalPinchZoomGestureHandler(
         onPinchStart: () => _handleTerminalScaleStart(storedFontSize),
         onPinchUpdate: (scale) =>
@@ -6367,79 +6274,33 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     return terminalViewWithInput;
   }
 
-  Widget _nativeSelectionOverlay(
-    TextStyle textStyle,
-    TerminalThemeData terminalTheme,
-  ) => Positioned.fill(
-    child: Padding(
-      padding: terminalViewportPadding,
-      child: ValueListenableBuilder<TextEditingValue>(
-        valueListenable: _nativeSelectionController,
-        child: TextSelectionTheme(
-          data: TextSelectionTheme.of(context).copyWith(
-            selectionColor: terminalTheme.selection,
-            selectionHandleColor: terminalTheme.cursor,
-          ),
-          child: Listener(
-            onPointerDown: _handleNativeOverlayPointerDown,
-            onPointerMove: _handleNativeOverlayPointerMove,
-            onPointerUp: _handleNativeOverlayPointerUp,
-            onPointerCancel: _handleNativeOverlayPointerCancel,
-            child: TextField(
-              controller: _nativeSelectionController,
-              focusNode: _nativeSelectionFocusNode,
-              readOnly: true,
-              showCursor: false,
-              cursorColor: Colors.transparent,
-              enableInteractiveSelection: true,
-              contextMenuBuilder: _buildNativeSelectionContextMenu,
-              scrollController: _nativeSelectionScrollController,
-              expands: true,
-              maxLines: null,
-              textAlignVertical: TextAlignVertical.top,
-              style: textStyle,
-              strutStyle: StrutStyle.fromTextStyle(
-                textStyle,
-                forceStrutHeight: true,
-              ),
-              decoration: const InputDecoration(
-                isDense: true,
-                isCollapsed: true,
-                filled: false,
-                fillColor: Colors.transparent,
-                hoverColor: Colors.transparent,
-                border: InputBorder.none,
-                enabledBorder: InputBorder.none,
-                disabledBorder: InputBorder.none,
-                focusedBorder: InputBorder.none,
-                errorBorder: InputBorder.none,
-                focusedErrorBorder: InputBorder.none,
-                contentPadding: EdgeInsets.zero,
-              ),
-            ),
-          ),
-        ),
-        builder: (context, value, child) => IgnorePointer(
-          ignoring: !hasActiveNativeOverlaySelection(value.selection),
-          child: child,
-        ),
-      ),
-    ),
-  );
-
-  Widget _buildNativeSelectionContextMenu(
+  Widget _buildTerminalSelectionContextMenu(
     BuildContext context,
-    EditableTextState editableTextState,
-  ) => AdaptiveTextSelectionToolbar.buttonItems(
-    anchors: editableTextState.contextMenuAnchors,
-    buttonItems: buildNativeSelectionContextMenuButtonItems(
-      defaultItems: editableTextState.contextMenuButtonItems,
-      onPaste: () {
-        editableTextState.hideToolbar();
-        unawaited(_pasteClipboard());
-      },
-    ),
-  );
+    SelectableRegionState selectableRegionState,
+  ) {
+    final buttonItems = <ContextMenuButtonItem>[
+      ...selectableRegionState.contextMenuButtonItems,
+      ContextMenuButtonItem(
+        onPressed: () {
+          selectableRegionState.hideToolbar();
+          unawaited(_pasteClipboard());
+        },
+        type: ContextMenuButtonType.paste,
+      ),
+    ];
+    return AdaptiveTextSelectionToolbar.buttonItems(
+      anchors: selectableRegionState.contextMenuAnchors,
+      buttonItems: buttonItems,
+    );
+  }
+
+  void _handleSystemTerminalSelectionChanged(SelectedContent? selectedContent) {
+    final hasSelection = selectedContent?.plainText.isNotEmpty ?? false;
+    if (_hasSystemTerminalSelection == hasSelection) {
+      return;
+    }
+    setState(() => _hasSystemTerminalSelection = hasSelection);
+  }
 
   /// Resolves the terminal text style for the given font family and size.
   TerminalStyle _getTerminalTextStyle(String fontFamily, double fontSize) {
@@ -6450,17 +6311,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
     return TerminalStyle.fromTextStyle(textStyle);
   }
-
-  TextStyle _getNativeSelectionTextStyle(TerminalStyle terminalTextStyle) =>
-      terminalTextStyle
-          .toTextStyle(color: Colors.transparent)
-          .copyWith(
-            letterSpacing: 0,
-            fontFeatures: const [
-              FontFeature.disable('liga'),
-              FontFeature.disable('calt'),
-            ],
-          );
 
   Size? _measureTerminalPathUnderlineTextSize(String text) {
     if (text.isEmpty) {
@@ -6613,21 +6463,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       text: snapshot.text,
       selection: snapshot.selection,
     );
-    _nativeSelectionSnapshotMetrics = (
-      lineStarts: snapshot.lineStarts,
-      columnOffsets: snapshot.columnOffsets,
-      lineCount: snapshot.lineCount,
-      viewWidth: snapshot.viewWidth,
-      textLength: snapshot.textLength,
-    );
     _hadNativeOverlaySelection = hasActiveNativeOverlaySelection(
       snapshot.selection,
     );
     _nativeOverlayCollapseTimer?.cancel();
-    _clearNativeOverlayLongPressState();
     setState(() {
       _isNativeSelectionMode = true;
-      _hasTerminalSelection = false;
       _revealsNativeSelectionOverlayInTouchScrollMode =
           _revealsNativeSelectionOverlayInTouchScrollMode ||
           snapshot.revealOverlayInTouchScrollMode;
@@ -6654,16 +6495,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _nativeSelectionFocusNode.unfocus();
     setState(() {
       _isNativeSelectionMode = false;
-      _hasTerminalSelection = false;
       _revealsNativeSelectionOverlayInTouchScrollMode = false;
     });
     _nativeSelectionController.clear();
     _terminalController.clearSelection();
     _hadNativeOverlaySelection = false;
-    _clearPendingTouchSelectionRange();
-    _nativeSelectionSnapshotMetrics = null;
     _nativeOverlayCollapseTimer?.cancel();
-    _clearNativeOverlayLongPressState();
     _terminalFocusNode.requestFocus();
   }
 
@@ -6683,13 +6520,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _nativeSelectionController.value = TextEditingValue(
       text: snapshot.text,
       selection: nextSelection,
-    );
-    _nativeSelectionSnapshotMetrics = (
-      lineStarts: snapshot.lineStarts,
-      columnOffsets: snapshot.columnOffsets,
-      lineCount: snapshot.lineCount,
-      viewWidth: snapshot.viewWidth,
-      textLength: snapshot.textLength,
     );
   }
 
@@ -6814,207 +6644,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     return TextSelection(baseOffset: start, extentOffset: end);
   }
 
-  _PendingTouchSelectionSnapshot? _buildPendingTouchSelectionSnapshot(
-    CellOffset cellOffset, {
-    required bool revealOverlayInTouchScrollMode,
-  }) {
-    final selectionRange = resolveNativeTouchSelectionRange(
-      buffer: _terminal.buffer,
-      cellOffset: cellOffset,
-    );
-    if (selectionRange == null) {
-      return null;
-    }
-
-    final snapshot = _buildNativeSelectionSnapshotData();
-    final selection = _bufferRangeToTextSelection(
-      selectionRange,
-      viewWidth: snapshot.viewWidth,
-      lineCount: snapshot.lineCount,
-      lineStarts: snapshot.lineStarts,
-      columnOffsets: snapshot.columnOffsets,
-      textLength: snapshot.textLength,
-    );
-    return (
-      originCellOffset: cellOffset,
-      text: snapshot.text,
-      selection: selection,
-      lineStarts: snapshot.lineStarts,
-      columnOffsets: snapshot.columnOffsets,
-      lineCount: snapshot.lineCount,
-      viewWidth: snapshot.viewWidth,
-      textLength: snapshot.textLength,
-      revealOverlayInTouchScrollMode: revealOverlayInTouchScrollMode,
-    );
-  }
-
-  bool _selectNativeOverlayWordAtCellOffset(
-    CellOffset cellOffset, {
-    bool revealOverlayInTouchScrollMode = false,
-  }) {
-    final snapshot = _buildPendingTouchSelectionSnapshot(
-      cellOffset,
-      revealOverlayInTouchScrollMode: revealOverlayInTouchScrollMode,
-    );
-    if (snapshot == null) {
-      return false;
-    }
-
-    _enterNativeSelectionModeWithSnapshot(snapshot);
-    return true;
-  }
-
-  void _clearPendingTouchSelectionRange() {
-    _pendingTouchSelectionRange = null;
-  }
-
-  CellOffset? _terminalCellOffsetForGlobalPosition(Offset globalPosition) {
-    final terminalViewState = _terminalViewKey.currentState;
-    if (terminalViewState == null) {
-      return null;
-    }
-
-    final renderTerminal = terminalViewState.renderTerminal;
-    final localPosition = renderTerminal.globalToLocal(globalPosition);
-    if (localPosition.dx < 0 ||
-        localPosition.dy < 0 ||
-        localPosition.dx > renderTerminal.size.width ||
-        localPosition.dy > renderTerminal.size.height) {
-      return null;
-    }
-
-    return renderTerminal.getCellOffset(localPosition);
-  }
-
-  bool _isNativeOverlayTouchPointer(PointerDeviceKind kind) =>
-      kind == PointerDeviceKind.touch ||
-      kind == PointerDeviceKind.stylus ||
-      kind == PointerDeviceKind.invertedStylus;
-
-  ({CellOffset? cellOffset, bool pointsOutsideSnapshot})
-  _nativeSelectionSnapshotHitForGlobalPosition(Offset globalPosition) {
-    final metrics = _nativeSelectionSnapshotMetrics;
-    final cellOffset = _terminalCellOffsetForGlobalPosition(globalPosition);
-    if (metrics == null || cellOffset == null) {
-      return (cellOffset: cellOffset, pointsOutsideSnapshot: false);
-    }
-
-    if (cellOffset.y >= metrics.lineCount ||
-        cellOffset.x >= metrics.viewWidth) {
-      return (cellOffset: cellOffset, pointsOutsideSnapshot: true);
-    }
-
-    return (cellOffset: cellOffset, pointsOutsideSnapshot: false);
-  }
-
-  bool _isNativeSelectionCellWithinActiveSelection(CellOffset cellOffset) {
-    final metrics = _nativeSelectionSnapshotMetrics;
-    final selection = _nativeSelectionController.selection;
-    if (metrics == null || !hasActiveNativeOverlaySelection(selection)) {
-      return false;
-    }
-
-    final lineStart = metrics.lineStarts[cellOffset.y];
-    final cellStart =
-        lineStart + metrics.columnOffsets[cellOffset.y][cellOffset.x];
-    final cellEnd =
-        lineStart + metrics.columnOffsets[cellOffset.y][cellOffset.x + 1];
-    if (cellEnd <= cellStart) {
-      return false;
-    }
-
-    final selectionStart = min(selection.baseOffset, selection.extentOffset);
-    final selectionEnd = max(selection.baseOffset, selection.extentOffset);
-    final protectedStart = max(0, selectionStart - 1);
-    final protectedEnd = min(metrics.textLength, selectionEnd + 1);
-    return cellStart < protectedEnd && cellEnd > protectedStart;
-  }
-
-  _PendingTouchSelectionSnapshot? _buildPendingNativeOverlayLongPressSelection(
-    Offset globalPosition,
-  ) {
-    final selection = _nativeSelectionController.selection;
-    if (!hasActiveNativeOverlaySelection(selection)) {
-      return null;
-    }
-
-    final hit = _nativeSelectionSnapshotHitForGlobalPosition(globalPosition);
-    final cellOffset = hit.cellOffset;
-    if (cellOffset == null) {
-      return null;
-    }
-    if (!hit.pointsOutsideSnapshot &&
-        _isNativeSelectionCellWithinActiveSelection(cellOffset)) {
-      return null;
-    }
-    return _buildPendingTouchSelectionSnapshot(
-      cellOffset,
-      revealOverlayInTouchScrollMode: _routesTouchScrollToTerminal,
-    );
-  }
-
-  void _clearNativeOverlayLongPressState() {
-    _nativeOverlayLongPressTimer?.cancel();
-    _nativeOverlayLongPressTimer = null;
-    _nativeOverlayPointerId = null;
-    _nativeOverlayPointerDownPosition = null;
-    _pendingNativeOverlayLongPressSelection = null;
-  }
-
-  void _handleNativeOverlayPointerDown(PointerDownEvent event) {
-    if (!_isMobilePlatform ||
-        !_showsNativeSelectionOverlay ||
-        !_isNativeOverlayTouchPointer(event.kind) ||
-        !hasActiveNativeOverlaySelection(
-          _nativeSelectionController.selection,
-        )) {
-      return;
-    }
-    _clearNativeOverlayLongPressState();
-    final pendingSnapshot = _buildPendingNativeOverlayLongPressSelection(
-      event.position,
-    );
-    if (pendingSnapshot == null) {
-      return;
-    }
-    _pendingNativeOverlayLongPressSelection = pendingSnapshot;
-    _nativeOverlayPointerId = event.pointer;
-    _nativeOverlayPointerDownPosition = event.position;
-    _nativeOverlayLongPressTimer = Timer(kLongPressTimeout, () {
-      final longPressSnapshot = _pendingNativeOverlayLongPressSelection;
-      _clearNativeOverlayLongPressState();
-      if (longPressSnapshot == null) {
-        return;
-      }
-      _enterNativeSelectionModeWithSnapshot(longPressSnapshot);
-    });
-  }
-
-  void _handleNativeOverlayPointerMove(PointerMoveEvent event) {
-    if (event.pointer != _nativeOverlayPointerId) {
-      return;
-    }
-    final downPosition = _nativeOverlayPointerDownPosition;
-    if (downPosition == null) {
-      return;
-    }
-    if ((event.position - downPosition).distance > kTouchSlop) {
-      _clearNativeOverlayLongPressState();
-    }
-  }
-
-  void _handleNativeOverlayPointerUp(PointerUpEvent event) {
-    if (event.pointer == _nativeOverlayPointerId) {
-      _clearNativeOverlayLongPressState();
-    }
-  }
-
-  void _handleNativeOverlayPointerCancel(PointerCancelEvent event) {
-    if (event.pointer == _nativeOverlayPointerId) {
-      _clearNativeOverlayLongPressState();
-    }
-  }
-
   void _onNativeOverlayControllerChanged() {
     if (!mounted || !_isNativeSelectionMode) {
       return;
@@ -7064,39 +6693,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     )) {
       case NativeSelectionOverlayChange.none:
         return;
-      case NativeSelectionOverlayChange.hideTemporaryOverlay:
-        setState(() {
-          _revealsNativeSelectionOverlayInTouchScrollMode = false;
-        });
-        return;
       case NativeSelectionOverlayChange.exitSelectionMode:
         _dismissNativeSelectionOverlayForEditing();
         return;
     }
-  }
-
-  void _dismissTemporaryNativeSelectionOverlay() {
-    if (!_revealsNativeSelectionOverlayInTouchScrollMode) {
-      return;
-    }
-
-    final textLength = _nativeSelectionController.text.length;
-    final collapsedOffset = _nativeSelectionController.selection.extentOffset
-        .clamp(0, textLength);
-    _nativeOverlayCollapseTimer?.cancel();
-    _nativeSelectionController.value = _nativeSelectionController.value
-        .copyWith(selection: TextSelection.collapsed(offset: collapsedOffset));
-    _terminalController.clearSelection();
-    _nativeSelectionFocusNode.unfocus();
-    _hadNativeOverlaySelection = false;
-    _clearPendingTouchSelectionRange();
-    _clearNativeOverlayLongPressState();
-    if (!mounted) {
-      return;
-    }
-    setState(() {
-      _revealsNativeSelectionOverlayInTouchScrollMode = false;
-    });
   }
 
   void _dismissNativeSelectionOverlayForEditing() {
@@ -7108,11 +6708,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
-    if (_revealsNativeSelectionOverlayInTouchScrollMode) {
-      _dismissTemporaryNativeSelectionOverlay();
-      return;
-    }
-
     if (!_isMobilePlatform) {
       return;
     }
@@ -7121,13 +6716,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _nativeSelectionController.clear();
     _terminalController.clearSelection();
     _hadNativeOverlaySelection = false;
-    _clearPendingTouchSelectionRange();
-    _nativeSelectionSnapshotMetrics = null;
     _nativeOverlayCollapseTimer?.cancel();
-    _clearNativeOverlayLongPressState();
     setState(() {
       _isNativeSelectionMode = false;
-      _hasTerminalSelection = false;
       _revealsNativeSelectionOverlayInTouchScrollMode = false;
     });
   }
@@ -7818,7 +7409,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   void _handleTerminalLinkTap(String link) {
-    _clearPendingTouchSelectionRange();
     _clearHoveredTerminalPathUnderline();
     if (link.startsWith(_terminalSftpPathPrefix)) {
       unawaited(
@@ -7892,43 +7482,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     _showTerminalLinkMessage(result);
   }
-
-  Widget get _selectionActions => Material(
-    elevation: 2,
-    borderRadius: BorderRadius.circular(12),
-    color: Theme.of(context).colorScheme.surfaceContainerHigh,
-    child: Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      child: Row(
-        children: [
-          Expanded(
-            child: TextButton.icon(
-              onPressed: () => unawaited(_copySelection()),
-              icon: const Icon(Icons.copy_outlined),
-              label: const Text('Copy'),
-            ),
-          ),
-          Expanded(
-            child: TextButton.icon(
-              onPressed: () => unawaited(_pasteClipboard()),
-              icon: const Icon(Icons.paste_outlined),
-              label: const Text('Paste'),
-            ),
-          ),
-          Expanded(
-            child: TextButton.icon(
-              onPressed: () {
-                _terminalController.clearSelection();
-                _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
-              },
-              icon: const Icon(Icons.close),
-              label: const Text('Clear'),
-            ),
-          ),
-        ],
-      ),
-    ),
-  );
 
   Future<void> _copySelection() async {
     if (_isNativeSelectionMode) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3116,6 +3116,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   Offset? _pendingTerminalPathTapDownPosition;
   Duration? _pendingTerminalPathTapDownTimestamp;
   String? _recentlyOpenedTerminalPathTap;
+  int? _pendingTerminalDoubleTapPointer;
+  Offset? _pendingTerminalDoubleTapDownPosition;
+  Duration? _pendingTerminalDoubleTapDownTimestamp;
+  int? _terminalDoubleTapConsumedPointer;
+  Offset? _lastTerminalTapPosition;
+  Duration? _lastTerminalTapTimestamp;
+  bool _recentlyHandledTerminalDoubleTap = false;
   Rect? _hoveredTerminalPathUnderline;
   List<({String path, Rect underlineRect, Rect touchRect})>
   _visibleTerminalPathUnderlines =
@@ -3608,6 +3615,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     TapDownDetails tapDetails,
     CellOffset cellOffset,
   ) {
+    if (_recentlyHandledTerminalDoubleTap) {
+      return;
+    }
+    _recentlyHandledTerminalDoubleTap = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _recentlyHandledTerminalDoubleTap = false;
+    });
+
     final shiftActive = _toolbarController.isShiftActive;
     _terminalTextInputController.suppressNextTouchKeyboardRequest();
     _terminal.textInput(resolveTerminalTabInput(shiftActive: shiftActive));
@@ -6091,13 +6106,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         );
       });
     }
-    if (terminalPathLinksEnabled) {
+    if (isMobile || terminalPathLinksEnabled) {
       terminalView = Listener(
         behavior: HitTestBehavior.translucent,
-        onPointerDown: _handleTerminalPathPointerDown,
-        onPointerMove: _handleTerminalPathPointerMove,
-        onPointerUp: _handleTerminalPathPointerUp,
-        onPointerCancel: _handleTerminalPathPointerCancel,
+        onPointerDown: _handleTerminalPointerDown,
+        onPointerMove: _handleTerminalPointerMove,
+        onPointerUp: _handleTerminalPointerUp,
+        onPointerCancel: _handleTerminalPointerCancel,
         child: terminalView,
       );
     }
@@ -7040,6 +7055,142 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     return true;
   }
 
+  void _clearPendingTerminalDoubleTap() {
+    _pendingTerminalDoubleTapPointer = null;
+    _pendingTerminalDoubleTapDownPosition = null;
+    _pendingTerminalDoubleTapDownTimestamp = null;
+  }
+
+  void _clearLastTerminalTap() {
+    _lastTerminalTapPosition = null;
+    _lastTerminalTapTimestamp = null;
+  }
+
+  void _handleTerminalPointerDown(PointerDownEvent event) {
+    _handleTerminalPathPointerDown(event);
+    _handleTerminalDoubleTapPointerDown(
+      event,
+      allowDoubleTap: _pendingTerminalPathTap == null,
+    );
+  }
+
+  void _handleTerminalPointerMove(PointerMoveEvent event) {
+    _handleTerminalPathPointerMove(event);
+    _handleTerminalDoubleTapPointerMove(event);
+  }
+
+  void _handleTerminalPointerUp(PointerUpEvent event) {
+    final pathTapConsumed = _handleTerminalPathPointerUp(event);
+    if (!pathTapConsumed) {
+      _handleTerminalDoubleTapPointerUp(event);
+    }
+  }
+
+  void _handleTerminalPointerCancel(PointerCancelEvent event) {
+    _handleTerminalPathPointerCancel(event);
+    _handleTerminalDoubleTapPointerCancel(event);
+  }
+
+  void _handleTerminalDoubleTapPointerDown(
+    PointerDownEvent event, {
+    required bool allowDoubleTap,
+  }) {
+    if (event.kind != PointerDeviceKind.touch || !allowDoubleTap) {
+      _clearPendingTerminalDoubleTap();
+      return;
+    }
+
+    final lastTapPosition = _lastTerminalTapPosition;
+    final lastTapTimestamp = _lastTerminalTapTimestamp;
+    final isDoubleTap =
+        lastTapPosition != null &&
+        lastTapTimestamp != null &&
+        event.timeStamp - lastTapTimestamp <= kDoubleTapTimeout &&
+        (event.position - lastTapPosition).distance <= kDoubleTapSlop;
+
+    if (isDoubleTap) {
+      _terminalDoubleTapConsumedPointer = event.pointer;
+      _clearPendingTerminalDoubleTap();
+      _clearLastTerminalTap();
+      _triggerTerminalDoubleTap(event.position, event.kind);
+      return;
+    }
+
+    _pendingTerminalDoubleTapPointer = event.pointer;
+    _pendingTerminalDoubleTapDownPosition = event.position;
+    _pendingTerminalDoubleTapDownTimestamp = event.timeStamp;
+  }
+
+  void _handleTerminalDoubleTapPointerMove(PointerMoveEvent event) {
+    if (_pendingTerminalDoubleTapPointer != event.pointer) {
+      return;
+    }
+    final downPosition = _pendingTerminalDoubleTapDownPosition;
+    if (downPosition != null &&
+        (event.position - downPosition).distance > kTouchSlop) {
+      _clearPendingTerminalDoubleTap();
+      _clearLastTerminalTap();
+    }
+  }
+
+  void _handleTerminalDoubleTapPointerUp(PointerUpEvent event) {
+    if (event.kind != PointerDeviceKind.touch) {
+      return;
+    }
+    if (_terminalDoubleTapConsumedPointer == event.pointer) {
+      _terminalDoubleTapConsumedPointer = null;
+      _clearPendingTerminalDoubleTap();
+      return;
+    }
+
+    final downPosition = _pendingTerminalDoubleTapDownPosition;
+    final downTimestamp = _pendingTerminalDoubleTapDownTimestamp;
+    if (_pendingTerminalDoubleTapPointer != event.pointer ||
+        downPosition == null ||
+        downTimestamp == null ||
+        event.timeStamp - downTimestamp > kLongPressTimeout ||
+        (event.position - downPosition).distance > kTouchSlop) {
+      _clearPendingTerminalDoubleTap();
+      _clearLastTerminalTap();
+      return;
+    }
+
+    _lastTerminalTapPosition = event.position;
+    _lastTerminalTapTimestamp = event.timeStamp;
+    _clearPendingTerminalDoubleTap();
+  }
+
+  void _handleTerminalDoubleTapPointerCancel(PointerCancelEvent event) {
+    if (_pendingTerminalDoubleTapPointer == event.pointer) {
+      _clearPendingTerminalDoubleTap();
+    }
+    if (_terminalDoubleTapConsumedPointer == event.pointer) {
+      _terminalDoubleTapConsumedPointer = null;
+    }
+  }
+
+  void _triggerTerminalDoubleTap(
+    Offset globalPosition,
+    PointerDeviceKind kind,
+  ) {
+    final terminalViewState = _terminalViewKey.currentState;
+    if (terminalViewState == null) {
+      return;
+    }
+
+    final localPosition = terminalViewState.renderTerminal.globalToLocal(
+      globalPosition,
+    );
+    _handleTerminalDoubleTapDown(
+      TapDownDetails(
+        kind: kind,
+        globalPosition: globalPosition,
+        localPosition: localPosition,
+      ),
+      terminalViewState.renderTerminal.getCellOffset(localPosition),
+    );
+  }
+
   void _handleTerminalPathPointerDown(PointerDownEvent event) {
     final terminalViewState = _terminalViewKey.currentState;
     final pathLinksEnabled = ref.read(terminalPathLinksNotifierProvider);
@@ -7097,9 +7248,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
-  void _handleTerminalPathPointerUp(PointerUpEvent event) {
+  bool _handleTerminalPathPointerUp(PointerUpEvent event) {
     if (event.kind != PointerDeviceKind.touch) {
-      return;
+      return false;
     }
 
     final pendingPath = _pendingTerminalPathTap;
@@ -7112,7 +7263,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         event.timeStamp - downTimestamp > kLongPressTimeout ||
         (event.position - downPosition).distance > kTouchSlop) {
       _clearPendingTerminalPathTap();
-      return;
+      return pendingPath != null;
     }
 
     _clearPendingTerminalPathTap();
@@ -7123,6 +7274,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       }
     });
     _handleTerminalLinkTap('$_terminalSftpPathPrefix$pendingPath');
+    return true;
   }
 
   void _handleTerminalPathPointerCancel(PointerCancelEvent event) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -49,6 +49,7 @@ import '../widgets/keyboard_toolbar.dart';
 import '../widgets/monkey_terminal_view.dart';
 import '../widgets/premium_access.dart';
 import '../widgets/terminal_pinch_zoom_gesture_handler.dart';
+import '../widgets/terminal_selection_text.dart' as terminal_selection_text;
 import '../widgets/terminal_text_input_handler.dart';
 import '../widgets/terminal_text_style.dart';
 import '../widgets/terminal_theme_picker.dart';
@@ -1636,7 +1637,6 @@ class _ExtraKeysToggleKeycap extends StatelessWidget {
 
 final _terminalFilePathVerificationExtensionSet =
     _terminalFilePathVerificationExtensions.toSet();
-final _trailingTerminalPaddingPattern = RegExp(r' +$');
 const _clipboardContentChannel = MethodChannel(
   'xyz.depollsoft.monkeyssh/clipboard_content',
 );
@@ -1730,12 +1730,12 @@ double resolveTerminalFontSize({
 /// Trims terminal cell padding from the end of a rendered line.
 @visibleForTesting
 String trimTerminalLinePadding(String line) =>
-    line.replaceFirst(_trailingTerminalPaddingPattern, '');
+    terminal_selection_text.trimTerminalLinePadding(line);
 
 /// Trims per-line terminal padding from copied or overlaid terminal text.
 @visibleForTesting
 String trimTerminalSelectionText(String text) =>
-    text.split('\n').map(trimTerminalLinePadding).join('\n');
+    terminal_selection_text.trimTerminalSelectionText(text);
 
 /// Keeps the Pro upsell snackbar tucked just above the visible bottom chrome.
 ///
@@ -3613,21 +3613,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       resolveTerminalTabGestureIndicatorLabel(shiftActive: shiftActive),
     );
   }
-
-  void _handleTerminalTapUp(TapUpDetails tapDetails, CellOffset cellOffset) {
-    if (!ref.read(tapToShowKeyboardNotifierProvider) ||
-        _hasSystemTerminalSelection ||
-        _terminalController.selection != null ||
-        _showsNativeSelectionOverlay) {
-      return;
-    }
-    _terminalTextInputController.requestKeyboard();
-  }
-
-  void _handleTerminalTapDown(
-    TapDownDetails tapDetails,
-    CellOffset cellOffset,
-  ) {}
 
   void _handleTerminalLinkTapDown(
     TapDownDetails tapDetails,
@@ -6046,8 +6031,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       controller: _terminalController,
       scrollController: _terminalScrollController,
       resolveLinkTap: _resolveTerminalLinkTap,
-      onTapDown: isMobile ? _handleTerminalTapDown : null,
-      onTapUp: isMobile ? _handleTerminalTapUp : null,
       onLinkTapDown: _handleTerminalLinkTapDown,
       onLinkTap: _handleTerminalLinkTap,
       onDoubleTapDown: isMobile ? _handleTerminalDoubleTapDown : null,
@@ -6252,7 +6235,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _hasSystemTerminalSelection ||
           _showsNativeSelectionOverlay ||
           overlayMessage != null,
-      tapToShowKeyboard: false,
+      tapToShowKeyboard: ref.watch(tapToShowKeyboardNotifierProvider),
+      showKeyboardOnFocus: false,
       child: TerminalPinchZoomGestureHandler(
         onPinchStart: () => _handleTerminalScaleStart(storedFontSize),
         onPinchUpdate: (scale) =>
@@ -6275,7 +6259,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   Widget _buildTerminalSelectionContextMenu(
-    BuildContext context,
+    BuildContext _,
     SelectableRegionState selectableRegionState,
   ) {
     final buttonItems = <ContextMenuButtonItem>[

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3112,6 +3112,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   final Set<String> _verifyingTerminalPathCacheKeys = <String>{};
   String? _terminalPathCacheScope;
   String? _pendingTerminalPathTap;
+  int? _pendingTerminalPathTapPointer;
+  Offset? _pendingTerminalPathTapDownPosition;
+  Duration? _pendingTerminalPathTapDownTimestamp;
+  String? _recentlyOpenedTerminalPathTap;
   Rect? _hoveredTerminalPathUnderline;
   List<({String path, Rect underlineRect, Rect touchRect})>
   _visibleTerminalPathUnderlines =
@@ -6091,6 +6095,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       terminalView = Listener(
         behavior: HitTestBehavior.translucent,
         onPointerDown: _handleTerminalPathPointerDown,
+        onPointerMove: _handleTerminalPathPointerMove,
+        onPointerUp: _handleTerminalPathPointerUp,
+        onPointerCancel: _handleTerminalPathPointerCancel,
         child: terminalView,
       );
     }
@@ -6751,14 +6758,20 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
     if (detectedPath == null) {
       final pendingPath = _pendingTerminalPathTap;
-      _pendingTerminalPathTap = null;
+      _clearPendingTerminalPathTap();
       if (pendingPath == null || !_isInteractiveTerminalFilePath(pendingPath)) {
+        return null;
+      }
+      if (_consumeRecentlyOpenedTerminalPathTap(pendingPath)) {
         return null;
       }
       return '$_terminalSftpPathPrefix$pendingPath';
     }
 
-    _pendingTerminalPathTap = null;
+    _clearPendingTerminalPathTap();
+    if (_consumeRecentlyOpenedTerminalPathTap(detectedPath)) {
+      return null;
+    }
     return '$_terminalSftpPathPrefix$detectedPath';
   }
 
@@ -7012,10 +7025,25 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     setState(() => _hoveredTerminalPathUnderline = underline);
   }
 
+  void _clearPendingTerminalPathTap() {
+    _pendingTerminalPathTap = null;
+    _pendingTerminalPathTapPointer = null;
+    _pendingTerminalPathTapDownPosition = null;
+    _pendingTerminalPathTapDownTimestamp = null;
+  }
+
+  bool _consumeRecentlyOpenedTerminalPathTap(String path) {
+    if (_recentlyOpenedTerminalPathTap != path) {
+      return false;
+    }
+    _recentlyOpenedTerminalPathTap = null;
+    return true;
+  }
+
   void _handleTerminalPathPointerDown(PointerDownEvent event) {
     final terminalViewState = _terminalViewKey.currentState;
     final pathLinksEnabled = ref.read(terminalPathLinksNotifierProvider);
-    _pendingTerminalPathTap = null;
+    _clearPendingTerminalPathTap();
     if (terminalViewState == null || !pathLinksEnabled) {
       if (_hoveredTerminalPathUnderline != null) {
         _clearHoveredTerminalPathUnderline();
@@ -7052,6 +7080,54 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
     if (tappedPath != null && _isInteractiveTerminalFilePath(tappedPath)) {
       _pendingTerminalPathTap = tappedPath;
+      _pendingTerminalPathTapPointer = event.pointer;
+      _pendingTerminalPathTapDownPosition = event.position;
+      _pendingTerminalPathTapDownTimestamp = event.timeStamp;
+    }
+  }
+
+  void _handleTerminalPathPointerMove(PointerMoveEvent event) {
+    if (_pendingTerminalPathTapPointer != event.pointer) {
+      return;
+    }
+    final downPosition = _pendingTerminalPathTapDownPosition;
+    if (downPosition != null &&
+        (event.position - downPosition).distance > kTouchSlop) {
+      _clearPendingTerminalPathTap();
+    }
+  }
+
+  void _handleTerminalPathPointerUp(PointerUpEvent event) {
+    if (event.kind != PointerDeviceKind.touch) {
+      return;
+    }
+
+    final pendingPath = _pendingTerminalPathTap;
+    final downPosition = _pendingTerminalPathTapDownPosition;
+    final downTimestamp = _pendingTerminalPathTapDownTimestamp;
+    if (pendingPath == null ||
+        _pendingTerminalPathTapPointer != event.pointer ||
+        downPosition == null ||
+        downTimestamp == null ||
+        event.timeStamp - downTimestamp > kLongPressTimeout ||
+        (event.position - downPosition).distance > kTouchSlop) {
+      _clearPendingTerminalPathTap();
+      return;
+    }
+
+    _clearPendingTerminalPathTap();
+    _recentlyOpenedTerminalPathTap = pendingPath;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_recentlyOpenedTerminalPathTap == pendingPath) {
+        _recentlyOpenedTerminalPathTap = null;
+      }
+    });
+    _handleTerminalLinkTap('$_terminalSftpPathPrefix$pendingPath');
+  }
+
+  void _handleTerminalPathPointerCancel(PointerCancelEvent event) {
+    if (_pendingTerminalPathTapPointer == event.pointer) {
+      _clearPendingTerminalPathTap();
     }
   }
 

--- a/lib/presentation/widgets/monkey_terminal_gesture_detector.dart
+++ b/lib/presentation/widgets/monkey_terminal_gesture_detector.dart
@@ -165,36 +165,42 @@ class _MonkeyTerminalGestureDetectorState
           },
         );
 
-    gestures[LongPressGestureRecognizer] =
-        GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
-          () => LongPressGestureRecognizer(
-            debugOwner: this,
-            supportedDevices: {
-              PointerDeviceKind.touch,
-              // PointerDeviceKind.mouse, // for debugging purposes only
+    if (widget.onLongPressStart != null ||
+        widget.onLongPressMoveUpdate != null ||
+        widget.onLongPressUp != null) {
+      gestures[LongPressGestureRecognizer] =
+          GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
+            () => LongPressGestureRecognizer(
+              debugOwner: this,
+              supportedDevices: {
+                PointerDeviceKind.touch,
+                // PointerDeviceKind.mouse, // for debugging purposes only
+              },
+            ),
+            (LongPressGestureRecognizer instance) {
+              instance
+                ..onLongPressStart = widget.onLongPressStart
+                ..onLongPressMoveUpdate = widget.onLongPressMoveUpdate
+                ..onLongPressUp = widget.onLongPressUp;
             },
-          ),
-          (LongPressGestureRecognizer instance) {
-            instance
-              ..onLongPressStart = widget.onLongPressStart
-              ..onLongPressMoveUpdate = widget.onLongPressMoveUpdate
-              ..onLongPressUp = widget.onLongPressUp;
-          },
-        );
+          );
+    }
 
-    gestures[PanGestureRecognizer] =
-        GestureRecognizerFactoryWithHandlers<PanGestureRecognizer>(
-          () => PanGestureRecognizer(
-            debugOwner: this,
-            supportedDevices: <PointerDeviceKind>{PointerDeviceKind.mouse},
-          ),
-          (PanGestureRecognizer instance) {
-            instance
-              ..dragStartBehavior = DragStartBehavior.down
-              ..onStart = widget.onDragStart
-              ..onUpdate = widget.onDragUpdate;
-          },
-        );
+    if (widget.onDragStart != null || widget.onDragUpdate != null) {
+      gestures[PanGestureRecognizer] =
+          GestureRecognizerFactoryWithHandlers<PanGestureRecognizer>(
+            () => PanGestureRecognizer(
+              debugOwner: this,
+              supportedDevices: <PointerDeviceKind>{PointerDeviceKind.mouse},
+            ),
+            (PanGestureRecognizer instance) {
+              instance
+                ..dragStartBehavior = DragStartBehavior.down
+                ..onStart = widget.onDragStart
+                ..onUpdate = widget.onDragUpdate;
+            },
+          );
+    }
 
     if (widget.onTouchScrollStart != null ||
         widget.onTouchScrollUpdate != null ||

--- a/lib/presentation/widgets/monkey_terminal_gesture_detector.dart
+++ b/lib/presentation/widgets/monkey_terminal_gesture_detector.dart
@@ -13,7 +13,6 @@ class MonkeyTerminalGestureDetector extends StatefulWidget {
     super.key,
     this.child,
     this.onSingleTapUp,
-    this.onTapUp,
     this.onTapDown,
     this.onTapCancel,
     this.onSecondaryTapDown,
@@ -33,8 +32,6 @@ class MonkeyTerminalGestureDetector extends StatefulWidget {
   });
 
   final Widget? child;
-
-  final GestureTapUpCallback? onTapUp;
 
   final GestureTapUpCallback? onSingleTapUp;
 

--- a/lib/presentation/widgets/monkey_terminal_gesture_handler.dart
+++ b/lib/presentation/widgets/monkey_terminal_gesture_handler.dart
@@ -19,7 +19,6 @@ class MonkeyTerminalGestureHandler extends StatefulWidget {
     required this.terminalView,
     required this.terminalController,
     this.child,
-    this.onTapUp,
     this.onSingleTapUp,
     this.onTapDown,
     this.onDoubleTapDown,
@@ -45,8 +44,6 @@ class MonkeyTerminalGestureHandler extends StatefulWidget {
   final TerminalController terminalController;
 
   final Widget? child;
-
-  final GestureTapUpCallback? onTapUp;
 
   final GestureTapUpCallback? onSingleTapUp;
 
@@ -117,7 +114,6 @@ class _TerminalGestureHandlerState extends State<MonkeyTerminalGestureHandler> {
   Widget build(BuildContext context) {
     return MonkeyTerminalGestureDetector(
       child: widget.child,
-      onTapUp: widget.onTapUp,
       onSingleTapUp: onSingleTapUp,
       onTapDown: onTapDown,
       onTapCancel: _clearPendingLinkTap,

--- a/lib/presentation/widgets/monkey_terminal_gesture_handler.dart
+++ b/lib/presentation/widgets/monkey_terminal_gesture_handler.dart
@@ -136,7 +136,9 @@ class _TerminalGestureHandlerState extends State<MonkeyTerminalGestureHandler> {
       onDragUpdate: widget.enableTerminalSelectionGestures
           ? onDragUpdate
           : null,
-      onDoubleTapDown: widget.enableTerminalSelectionGestures
+      onDoubleTapDown:
+          widget.enableTerminalSelectionGestures ||
+              widget.onDoubleTapDown != null
           ? onDoubleTapDown
           : null,
     );

--- a/lib/presentation/widgets/monkey_terminal_gesture_handler.dart
+++ b/lib/presentation/widgets/monkey_terminal_gesture_handler.dart
@@ -37,6 +37,7 @@ class MonkeyTerminalGestureHandler extends StatefulWidget {
     this.onLinkTap,
     this.readOnly = false,
     this.suppressLongPressDragSelection = false,
+    this.enableTerminalSelectionGestures = true,
   });
 
   final MonkeyTerminalViewState terminalView;
@@ -93,6 +94,9 @@ class MonkeyTerminalGestureHandler extends StatefulWidget {
   /// and doesn't want to be re-entered on every drag update.
   final bool suppressLongPressDragSelection;
 
+  /// Whether this handler should install xterm-owned selection gestures.
+  final bool enableTerminalSelectionGestures;
+
   @override
   State<MonkeyTerminalGestureHandler> createState() =>
       _TerminalGestureHandlerState();
@@ -125,12 +129,20 @@ class _TerminalGestureHandlerState extends State<MonkeyTerminalGestureHandler> {
       onTouchScrollStart: onTouchScrollStart,
       onTouchScrollUpdate: onTouchScrollUpdate,
       onTouchScrollEnd: onTouchScrollEnd,
-      onLongPressStart: onLongPressStart,
-      onLongPressMoveUpdate: onLongPressMoveUpdate,
+      onLongPressStart: widget.enableTerminalSelectionGestures
+          ? onLongPressStart
+          : null,
+      onLongPressMoveUpdate: widget.enableTerminalSelectionGestures
+          ? onLongPressMoveUpdate
+          : null,
       // onLongPressUp: onLongPressUp,
-      onDragStart: onDragStart,
-      onDragUpdate: onDragUpdate,
-      onDoubleTapDown: onDoubleTapDown,
+      onDragStart: widget.enableTerminalSelectionGestures ? onDragStart : null,
+      onDragUpdate: widget.enableTerminalSelectionGestures
+          ? onDragUpdate
+          : null,
+      onDoubleTapDown: widget.enableTerminalSelectionGestures
+          ? onDoubleTapDown
+          : null,
     );
   }
 

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -8,13 +8,13 @@ import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:xterm/src/core/buffer/cell_offset.dart';
 import 'package:xterm/src/core/buffer/range.dart';
+import 'package:xterm/src/core/buffer/range_line.dart';
 import 'package:xterm/src/core/buffer/segment.dart';
 import 'package:xterm/src/core/input/keys.dart';
 import 'package:xterm/src/core/mouse/button.dart';
@@ -69,6 +69,13 @@ bool shouldAlignTerminalToTrailingEdges(MediaQueryData mediaQuery) {
   final viewportHeight = mediaQuery.size.height + mediaQuery.viewInsets.bottom;
   return mediaQuery.size.width > viewportHeight;
 }
+
+Widget _defaultSystemSelectionContextMenu(
+  BuildContext context,
+  SelectableRegionState selectableRegionState,
+) => AdaptiveTextSelectionToolbar.selectableRegion(
+  selectableRegionState: selectableRegionState,
+);
 
 /// Resolves the terminal grid origin inside the viewport.
 @visibleForTesting
@@ -162,6 +169,9 @@ class MonkeyTerminalView extends StatefulWidget {
     this.hardwareKeyboardOnly = false,
     this.simulateScroll = true,
     this.touchScrollToTerminal = false,
+    this.useSystemSelection = false,
+    this.systemSelectionContextMenuBuilder,
+    this.onSystemSelectionChanged,
     this.onInsertText,
     this.onPasteText,
   });
@@ -285,6 +295,16 @@ class MonkeyTerminalView extends StatefulWidget {
   /// instead of scrolling the Flutter viewport.
   final bool touchScrollToTerminal;
 
+  /// True when Flutter's [SelectableRegion] should own terminal selection
+  /// gestures and handles.
+  final bool useSystemSelection;
+
+  /// Builds the context menu for system terminal selection.
+  final SelectableRegionContextMenuBuilder? systemSelectionContextMenuBuilder;
+
+  /// Called when system terminal selection changes.
+  final ValueChanged<SelectedContent?>? onSystemSelectionChanged;
+
   /// Called before inserted text is sent to the terminal.
   final Future<bool> Function(String text)? onInsertText;
 
@@ -316,6 +336,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
   Simulation? _touchScrollInertiaSimulation;
   double _lastTouchScrollInertiaOffset = 0;
   int _lastTerminalViewWidth = 0;
+  bool _clearedSelectionOnTapDown = false;
 
   late TerminalController _controller;
 
@@ -424,7 +445,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
           : null,
       viewportBuilder: (context, offset) {
         final mediaQuery = MediaQuery.of(context);
-        return _TerminalView(
+        Widget buildTerminalLeaf(BuildContext context) => _TerminalView(
           key: _viewportKey,
           terminal: widget.terminal,
           controller: _controller,
@@ -440,7 +461,19 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
           alwaysShowCursor: widget.alwaysShowCursor,
           onEditableRect: _onEditableRect,
           composingText: _composingText,
+          selectionRegistrar: SelectionContainer.maybeOf(context),
         );
+        var terminalLeaf = buildTerminalLeaf(context);
+        if (widget.useSystemSelection) {
+          terminalLeaf = SelectionArea(
+            contextMenuBuilder:
+                widget.systemSelectionContextMenuBuilder ??
+                _defaultSystemSelectionContextMenu,
+            onSelectionChanged: widget.onSystemSelectionChanged,
+            child: Builder(builder: buildTerminalLeaf),
+          );
+        }
+        return terminalLeaf;
       },
     );
 
@@ -575,6 +608,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
           : null,
       onTouchScrollEnd: widget.touchScrollToTerminal ? _onTouchScrollEnd : null,
       readOnly: widget.readOnly,
+      enableTerminalSelectionGestures: !widget.useSystemSelection,
       child: child,
     );
 
@@ -628,22 +662,32 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
   void _onTapUp(TapUpDetails details) {
     final offset = renderTerminal.getCellOffset(details.localPosition);
     widget.onTapUp?.call(details, offset);
+    if (widget.useSystemSelection && !_clearedSelectionOnTapDown) {
+      _requestInputFocus();
+    }
+    _clearedSelectionOnTapDown = false;
   }
 
   void _onTapDown(TapDownDetails details) {
     _stopTouchScrollInertia();
+    _clearedSelectionOnTapDown = false;
     if (_controller.selection != null) {
+      _clearedSelectionOnTapDown = true;
       _controller.clearSelection();
-    } else {
-      if (!widget.hardwareKeyboardOnly) {
-        _customTextEditKey.currentState?.requestKeyboard();
-      } else {
-        _focusNode.requestFocus();
-      }
+    } else if (!widget.useSystemSelection) {
+      _requestInputFocus();
     }
 
     final offset = renderTerminal.getCellOffset(details.localPosition);
     widget.onTapDown?.call(details, offset);
+  }
+
+  void _requestInputFocus() {
+    if (!widget.hardwareKeyboardOnly) {
+      _customTextEditKey.currentState?.requestKeyboard();
+    } else {
+      _focusNode.requestFocus();
+    }
   }
 
   void _onDoubleTapDown(TapDownDetails details) {
@@ -927,6 +971,7 @@ class _TerminalView extends LeafRenderObjectWidget {
     required this.alwaysShowCursor,
     this.onEditableRect,
     this.composingText,
+    this.selectionRegistrar,
   });
 
   final Terminal terminal;
@@ -957,6 +1002,8 @@ class _TerminalView extends LeafRenderObjectWidget {
 
   final String? composingText;
 
+  final SelectionRegistrar? selectionRegistrar;
+
   @override
   MonkeyRenderTerminal createRenderObject(BuildContext context) {
     return MonkeyRenderTerminal(
@@ -974,6 +1021,7 @@ class _TerminalView extends LeafRenderObjectWidget {
       alwaysShowCursor: alwaysShowCursor,
       onEditableRect: onEditableRect,
       composingText: composingText,
+      selectionRegistrar: selectionRegistrar,
     );
   }
 
@@ -996,12 +1044,13 @@ class _TerminalView extends LeafRenderObjectWidget {
       ..cursorType = cursorType
       ..alwaysShowCursor = alwaysShowCursor
       ..onEditableRect = onEditableRect
-      ..composingText = composingText;
+      ..composingText = composingText
+      ..selectionRegistrar = selectionRegistrar;
   }
 }
 
 class MonkeyRenderTerminal extends RenderBox
-    with RelayoutWhenSystemFontsChangeMixin {
+    with RelayoutWhenSystemFontsChangeMixin, Selectable, SelectionRegistrant {
   MonkeyRenderTerminal({
     required Terminal terminal,
     required TerminalController controller,
@@ -1017,6 +1066,7 @@ class MonkeyRenderTerminal extends RenderBox
     required bool alwaysShowCursor,
     EditableRectCallback? onEditableRect,
     String? composingText,
+    SelectionRegistrar? selectionRegistrar,
   }) : _terminal = terminal,
        _controller = controller,
        _offset = offset,
@@ -1028,11 +1078,17 @@ class MonkeyRenderTerminal extends RenderBox
        _alwaysShowCursor = alwaysShowCursor,
        _onEditableRect = onEditableRect,
        _composingText = composingText,
+       _selectionGeometry = SelectionGeometry(
+         status: SelectionStatus.none,
+         hasContent: terminal.buffer.lines.length > 0,
+       ),
        _painter = TerminalPainter(
          theme: theme,
          textStyle: textStyle,
          textScaler: textScaler,
-       );
+       ) {
+    registrar = selectionRegistrar;
+  }
 
   Terminal _terminal;
   set terminal(Terminal terminal) {
@@ -1040,6 +1096,7 @@ class MonkeyRenderTerminal extends RenderBox
     if (attached) _terminal.removeListener(_onTerminalChange);
     _terminal = terminal;
     if (attached) _terminal.addListener(_onTerminalChange);
+    _syncSelectableSelectionFromController();
     _resizeTerminalIfNeeded();
     markNeedsLayout();
   }
@@ -1050,6 +1107,7 @@ class MonkeyRenderTerminal extends RenderBox
     if (attached) _controller.removeListener(_onControllerUpdate);
     _controller = controller;
     if (attached) _controller.addListener(_onControllerUpdate);
+    _syncSelectableSelectionFromController();
     markNeedsLayout();
   }
 
@@ -1138,15 +1196,28 @@ class MonkeyRenderTerminal extends RenderBox
     markNeedsPaint();
   }
 
+  set selectionRegistrar(SelectionRegistrar? value) {
+    registrar = value;
+  }
+
   TerminalSize? _viewportSize;
 
   final TerminalPainter _painter;
 
   var _stickToBottom = true;
 
+  int? _selectionStartOffset;
+  int? _selectionEndOffset;
+  bool _isApplyingSelectableSelection = false;
+  LayerLink? _startHandleLayerLink;
+  LayerLink? _endHandleLayerLink;
+  SelectionGeometry _selectionGeometry;
+  final Set<VoidCallback> _selectionListeners = <VoidCallback>{};
+
   void _onScroll() {
     _stickToBottom = _scrollOffset >= _maxScrollExtent;
     markNeedsLayout();
+    _updateSelectionGeometry();
     _notifyEditableRect();
   }
 
@@ -1155,11 +1226,15 @@ class MonkeyRenderTerminal extends RenderBox
   }
 
   void _onTerminalChange() {
+    _syncSelectableSelectionFromController();
     markNeedsLayout();
     _notifyEditableRect();
   }
 
   void _onControllerUpdate() {
+    if (!_isApplyingSelectableSelection) {
+      _syncSelectableSelectionFromController();
+    }
     markNeedsLayout();
   }
 
@@ -1185,7 +1260,32 @@ class MonkeyRenderTerminal extends RenderBox
   }
 
   @override
+  void dispose() {
+    _selectionListeners.clear();
+    super.dispose();
+  }
+
+  @override
   bool hitTestSelf(Offset position) => true;
+
+  @override
+  SelectionGeometry get value => _selectionGeometry;
+
+  @override
+  int get contentLength => _terminalSelectionContentLength;
+
+  @override
+  List<Rect> get boundingBoxes => <Rect>[Offset.zero & size];
+
+  @override
+  void addListener(VoidCallback listener) {
+    _selectionListeners.add(listener);
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    _selectionListeners.remove(listener);
+  }
 
   @override
   void systemFontsDidChange() {
@@ -1203,6 +1303,7 @@ class MonkeyRenderTerminal extends RenderBox
     if (_stickToBottom) {
       _offset.correctBy(_maxScrollExtent - _scrollOffset);
     }
+    _updateSelectionGeometry();
   }
 
   double get _terminalHeight =>
@@ -1281,6 +1382,457 @@ class MonkeyRenderTerminal extends RenderBox
         _terminal.buffer.createAnchorFromOffset(fromPosition),
         _terminal.buffer.createAnchorFromOffset(toPosition),
       );
+    }
+  }
+
+  int get _lineSelectionStride => _terminal.viewWidth + 1;
+
+  int get _terminalSelectionContentLength {
+    final lineCount = _terminal.buffer.lines.length;
+    if (lineCount == 0 || _terminal.viewWidth <= 0) {
+      return 0;
+    }
+    return (lineCount * _lineSelectionStride) - 1;
+  }
+
+  int _clampSelectionOffset(int offset) =>
+      offset.clamp(0, _terminalSelectionContentLength);
+
+  int _textOffsetForCell(CellOffset cellOffset) {
+    final lineCount = _terminal.buffer.lines.length;
+    if (lineCount == 0 || _terminal.viewWidth <= 0) {
+      return 0;
+    }
+    final row = cellOffset.y.clamp(0, lineCount - 1);
+    final column = cellOffset.x.clamp(0, _terminal.viewWidth);
+    return _clampSelectionOffset((row * _lineSelectionStride) + column);
+  }
+
+  CellOffset _cellForTextOffset(int textOffset) {
+    final lineCount = _terminal.buffer.lines.length;
+    if (lineCount == 0 || _terminal.viewWidth <= 0) {
+      return const CellOffset(0, 0);
+    }
+    final offset = _clampSelectionOffset(textOffset);
+    final row = (offset ~/ _lineSelectionStride).clamp(0, lineCount - 1);
+    final column = (offset % _lineSelectionStride).clamp(
+      0,
+      _terminal.viewWidth,
+    );
+    return CellOffset(column, row);
+  }
+
+  CellOffset _getSelectableCellOffset(Offset offset) {
+    if (_terminal.buffer.lines.length == 0 || _terminal.viewWidth <= 0) {
+      return const CellOffset(0, 0);
+    }
+    final origin = _contentOrigin;
+    final x = offset.dx - origin.dx;
+    final y = offset.dy - origin.dy + _scrollOffset;
+    final row = y ~/ _painter.cellSize.height;
+    final col = x ~/ _painter.cellSize.width;
+    return CellOffset(
+      col.clamp(0, _terminal.viewWidth),
+      row.clamp(0, _terminal.buffer.lines.length - 1),
+    );
+  }
+
+  int _textOffsetForLocalPosition(Offset localPosition) {
+    if (_terminalSelectionContentLength <= 0) {
+      return 0;
+    }
+    return _textOffsetForCell(_getSelectableCellOffset(localPosition));
+  }
+
+  BufferRange _bufferRangeForTextOffsets(int start, int end) {
+    final normalizedStart = math.min(start, end);
+    final normalizedEnd = math.max(start, end);
+    return BufferRangeLine(
+      _cellForTextOffset(normalizedStart),
+      _cellForTextOffset(normalizedEnd),
+    );
+  }
+
+  ({int start, int end})? _wordTextOffsetsAt(Offset localPosition) {
+    final cellOffset = getCellOffset(localPosition);
+    final boundary = _terminal.buffer.getWordBoundary(cellOffset);
+    if (boundary == null) {
+      return null;
+    }
+    return (
+      start: _textOffsetForCell(boundary.begin),
+      end: _textOffsetForCell(boundary.end),
+    );
+  }
+
+  ({int start, int end}) _lineTextOffsetsAt(Offset localPosition) {
+    final cellOffset = _getSelectableCellOffset(localPosition);
+    final row = cellOffset.y.clamp(0, _terminal.buffer.lines.length - 1);
+    return (
+      start: _textOffsetForCell(CellOffset(0, row)),
+      end: _textOffsetForCell(CellOffset(_terminal.viewWidth, row)),
+    );
+  }
+
+  void _applySelectableTextSelection(int start, int end) {
+    if (_terminalSelectionContentLength <= 0) {
+      _clearSelectableTextSelection();
+      return;
+    }
+    final nextStart = _clampSelectionOffset(start);
+    final nextEnd = _clampSelectionOffset(end);
+    _selectionStartOffset = nextStart;
+    _selectionEndOffset = nextEnd;
+    _isApplyingSelectableSelection = true;
+    try {
+      _controller.setSelection(
+        _terminal.buffer.createAnchorFromOffset(_cellForTextOffset(nextStart)),
+        _terminal.buffer.createAnchorFromOffset(_cellForTextOffset(nextEnd)),
+        mode: SelectionMode.line,
+      );
+    } finally {
+      _isApplyingSelectableSelection = false;
+    }
+    markNeedsPaint();
+    _updateSelectionGeometry();
+  }
+
+  void _clearSelectableTextSelection() {
+    if (_selectionStartOffset == null && _selectionEndOffset == null) {
+      return;
+    }
+    _selectionStartOffset = null;
+    _selectionEndOffset = null;
+    _isApplyingSelectableSelection = true;
+    try {
+      _controller.clearSelection();
+    } finally {
+      _isApplyingSelectableSelection = false;
+    }
+    markNeedsPaint();
+    _updateSelectionGeometry();
+  }
+
+  void _syncSelectableSelectionFromController() {
+    final selection = _controller.selection;
+    if (selection == null) {
+      if (_selectionStartOffset != null || _selectionEndOffset != null) {
+        _selectionStartOffset = null;
+        _selectionEndOffset = null;
+        _updateSelectionGeometry();
+      }
+      return;
+    }
+    final nextStart = _textOffsetForCell(selection.begin);
+    final nextEnd = _textOffsetForCell(selection.end);
+    if (_selectionStartOffset == nextStart && _selectionEndOffset == nextEnd) {
+      return;
+    }
+    _selectionStartOffset = nextStart;
+    _selectionEndOffset = nextEnd;
+    _updateSelectionGeometry();
+  }
+
+  Offset _localPositionForTextOffset(int textOffset) {
+    final cellOffset = _cellForTextOffset(textOffset);
+    return getOffset(cellOffset);
+  }
+
+  List<Rect> _selectionRectsForOffsets(int start, int end) {
+    if (start == end || _terminal.buffer.lines.length == 0) {
+      return const <Rect>[];
+    }
+    final begin = _cellForTextOffset(math.min(start, end));
+    final finish = _cellForTextOffset(math.max(start, end));
+    final rects = <Rect>[];
+    for (var row = begin.y; row <= finish.y; row++) {
+      final startColumn = row == begin.y ? begin.x : 0;
+      final endColumn = row == finish.y ? finish.x : _terminal.viewWidth;
+      if (endColumn <= startColumn) {
+        continue;
+      }
+      final topLeft = getOffset(CellOffset(startColumn, row));
+      rects.add(
+        Rect.fromLTWH(
+          topLeft.dx,
+          topLeft.dy,
+          (endColumn - startColumn) * _painter.cellSize.width,
+          _painter.cellSize.height,
+        ),
+      );
+    }
+    return rects;
+  }
+
+  SelectionGeometry _computeSelectionGeometry() {
+    final hasContent = _terminalSelectionContentLength > 0;
+    final start = _selectionStartOffset;
+    final end = _selectionEndOffset;
+    if (!hasContent || start == null || end == null) {
+      return SelectionGeometry(
+        status: SelectionStatus.none,
+        hasContent: hasContent,
+      );
+    }
+
+    final isCollapsed = start == end;
+    final isReversed = start > end;
+    final startHandleType = isCollapsed
+        ? TextSelectionHandleType.collapsed
+        : isReversed
+        ? TextSelectionHandleType.right
+        : TextSelectionHandleType.left;
+    final endHandleType = isCollapsed
+        ? TextSelectionHandleType.collapsed
+        : isReversed
+        ? TextSelectionHandleType.left
+        : TextSelectionHandleType.right;
+
+    return SelectionGeometry(
+      startSelectionPoint: SelectionPoint(
+        localPosition: _localPositionForTextOffset(start),
+        lineHeight: _painter.cellSize.height,
+        handleType: startHandleType,
+      ),
+      endSelectionPoint: SelectionPoint(
+        localPosition: _localPositionForTextOffset(end),
+        lineHeight: _painter.cellSize.height,
+        handleType: endHandleType,
+      ),
+      selectionRects: _selectionRectsForOffsets(start, end),
+      status: isCollapsed
+          ? SelectionStatus.collapsed
+          : SelectionStatus.uncollapsed,
+      hasContent: hasContent,
+    );
+  }
+
+  void _updateSelectionGeometry() {
+    final nextGeometry = _computeSelectionGeometry();
+    if (nextGeometry == _selectionGeometry) {
+      return;
+    }
+    _selectionGeometry = nextGeometry;
+    for (final listener in List<VoidCallback>.of(_selectionListeners)) {
+      listener();
+    }
+  }
+
+  @override
+  SelectedContent? getSelectedContent() {
+    final start = _selectionStartOffset;
+    final end = _selectionEndOffset;
+    if (start == null || end == null || start == end) {
+      return null;
+    }
+    final text = _terminal.buffer.getText(
+      _bufferRangeForTextOffsets(start, end),
+    );
+    return text.isEmpty ? null : SelectedContent(plainText: text);
+  }
+
+  @override
+  SelectedContentRange? getSelection() {
+    final start = _selectionStartOffset;
+    final end = _selectionEndOffset;
+    if (start == null || end == null) {
+      return null;
+    }
+    return SelectedContentRange(startOffset: start, endOffset: end);
+  }
+
+  @override
+  SelectionResult dispatchSelectionEvent(SelectionEvent event) {
+    final previousStart = _selectionStartOffset;
+    final previousEnd = _selectionEndOffset;
+    final result = switch (event.type) {
+      SelectionEventType.clear => _handleSelectableClearSelection(),
+      SelectionEventType.selectAll => _handleSelectableSelectAll(),
+      SelectionEventType.selectWord => _handleSelectableSelectWord(
+        event as SelectWordSelectionEvent,
+      ),
+      SelectionEventType.selectParagraph => _handleSelectableSelectParagraph(
+        event as SelectParagraphSelectionEvent,
+      ),
+      SelectionEventType.startEdgeUpdate || SelectionEventType.endEdgeUpdate =>
+        _handleSelectableEdgeUpdate(event as SelectionEdgeUpdateEvent),
+      SelectionEventType.granularlyExtendSelection =>
+        _handleSelectableGranularExtension(
+          event as GranularlyExtendSelectionEvent,
+        ),
+      SelectionEventType.directionallyExtendSelection =>
+        _handleSelectableDirectionalExtension(
+          event as DirectionallyExtendSelectionEvent,
+        ),
+    };
+    if (previousStart != _selectionStartOffset ||
+        previousEnd != _selectionEndOffset) {
+      _updateSelectionGeometry();
+    }
+    return result;
+  }
+
+  SelectionResult _handleSelectableClearSelection() {
+    _clearSelectableTextSelection();
+    return SelectionResult.none;
+  }
+
+  SelectionResult _handleSelectableSelectAll() {
+    _applySelectableTextSelection(0, _terminalSelectionContentLength);
+    return SelectionResult.none;
+  }
+
+  SelectionResult _handleSelectableSelectWord(SelectWordSelectionEvent event) {
+    final before = _controller.selection;
+    selectWord(globalToLocal(event.globalPosition));
+    _syncSelectableSelectionFromController();
+    if (_controller.selection == before) {
+      return SelectionResult.none;
+    }
+    return SelectionResult.end;
+  }
+
+  SelectionResult _handleSelectableSelectParagraph(
+    SelectParagraphSelectionEvent event,
+  ) {
+    final offsets = _lineTextOffsetsAt(globalToLocal(event.globalPosition));
+    _applySelectableTextSelection(offsets.start, offsets.end);
+    return SelectionResult.end;
+  }
+
+  SelectionResult _handleSelectableEdgeUpdate(SelectionEdgeUpdateEvent event) {
+    final localPosition = globalToLocal(event.globalPosition);
+    final hitRect = Offset.zero & size;
+    final adjustedPosition = SelectionUtils.adjustDragOffset(
+      hitRect,
+      localPosition,
+    );
+    final hitOffset = event.granularity == TextGranularity.word
+        ? _wordEdgeOffsetForPosition(
+            adjustedPosition,
+            updateEnd: event.type == SelectionEventType.endEdgeUpdate,
+          )
+        : _textOffsetForLocalPosition(adjustedPosition);
+    if (event.type == SelectionEventType.startEdgeUpdate) {
+      _applySelectableTextSelection(
+        hitOffset,
+        _selectionEndOffset ?? hitOffset,
+      );
+    } else {
+      _applySelectableTextSelection(
+        _selectionStartOffset ?? hitOffset,
+        hitOffset,
+      );
+    }
+    return SelectionUtils.getResultBasedOnRect(hitRect, localPosition);
+  }
+
+  int _wordEdgeOffsetForPosition(
+    Offset localPosition, {
+    required bool updateEnd,
+  }) {
+    final offsets = _wordTextOffsetsAt(localPosition);
+    if (offsets == null) {
+      return _textOffsetForLocalPosition(localPosition);
+    }
+    final staticEdge = updateEnd ? _selectionStartOffset : _selectionEndOffset;
+    if (staticEdge == null) {
+      return updateEnd ? offsets.end : offsets.start;
+    }
+    final hit = _textOffsetForLocalPosition(localPosition);
+    if (hit < staticEdge) {
+      return offsets.start;
+    }
+    if (hit > staticEdge) {
+      return offsets.end;
+    }
+    return updateEnd ? offsets.end : offsets.start;
+  }
+
+  SelectionResult _handleSelectableGranularExtension(
+    GranularlyExtendSelectionEvent event,
+  ) {
+    final currentStart =
+        _selectionStartOffset ??
+        (event.forward ? 0 : _terminalSelectionContentLength);
+    final currentEnd = _selectionEndOffset ?? currentStart;
+    final movingOffset = event.isEnd ? currentEnd : currentStart;
+    final nextOffset = event.forward
+        ? (movingOffset + 1).clamp(0, _terminalSelectionContentLength)
+        : (movingOffset - 1).clamp(0, _terminalSelectionContentLength);
+    if (event.isEnd) {
+      _applySelectableTextSelection(currentStart, nextOffset);
+    } else {
+      _applySelectableTextSelection(nextOffset, currentEnd);
+    }
+    return nextOffset == 0
+        ? SelectionResult.previous
+        : nextOffset == _terminalSelectionContentLength
+        ? SelectionResult.next
+        : SelectionResult.end;
+  }
+
+  SelectionResult _handleSelectableDirectionalExtension(
+    DirectionallyExtendSelectionEvent event,
+  ) {
+    final currentStart =
+        _selectionStartOffset ??
+        (event.direction == SelectionExtendDirection.backward
+            ? contentLength
+            : 0);
+    final currentEnd = _selectionEndOffset ?? currentStart;
+    final movingOffset = event.isEnd ? currentEnd : currentStart;
+    final movingCell = _cellForTextOffset(movingOffset);
+    final nextCell = switch (event.direction) {
+      SelectionExtendDirection.previousLine => CellOffset(
+        (event.dx / _painter.cellSize.width).round().clamp(
+          0,
+          _terminal.viewWidth,
+        ),
+        (movingCell.y - 1).clamp(0, _terminal.buffer.lines.length - 1),
+      ),
+      SelectionExtendDirection.nextLine => CellOffset(
+        (event.dx / _painter.cellSize.width).round().clamp(
+          0,
+          _terminal.viewWidth,
+        ),
+        (movingCell.y + 1).clamp(0, _terminal.buffer.lines.length - 1),
+      ),
+      SelectionExtendDirection.forward => CellOffset(
+        (movingCell.x + 1).clamp(0, _terminal.viewWidth),
+        movingCell.y,
+      ),
+      SelectionExtendDirection.backward => CellOffset(
+        (movingCell.x - 1).clamp(0, _terminal.viewWidth),
+        movingCell.y,
+      ),
+    };
+    final nextOffset = _textOffsetForCell(nextCell);
+    if (event.isEnd) {
+      _applySelectableTextSelection(currentStart, nextOffset);
+    } else {
+      _applySelectableTextSelection(nextOffset, currentEnd);
+    }
+    return nextOffset == 0
+        ? SelectionResult.previous
+        : nextOffset == _terminalSelectionContentLength
+        ? SelectionResult.next
+        : SelectionResult.end;
+  }
+
+  @override
+  void pushHandleLayers(LayerLink? startHandle, LayerLink? endHandle) {
+    var needsPaint = false;
+    if (_startHandleLayerLink != startHandle) {
+      _startHandleLayerLink = startHandle;
+      needsPaint = true;
+    }
+    if (_endHandleLayerLink != endHandle) {
+      _endHandleLayerLink = endHandle;
+      needsPaint = true;
+    }
+    if (needsPaint && attached) {
+      markNeedsPaint();
     }
   }
 
@@ -1421,6 +1973,31 @@ class MonkeyRenderTerminal extends RenderBox
         _controller.selection!,
         effectFirstLine,
         effectLastLine,
+      );
+    }
+
+    _paintSelectionHandleLayers(context, offset);
+  }
+
+  void _paintSelectionHandleLayers(PaintingContext context, Offset offset) {
+    if (_startHandleLayerLink != null && value.startSelectionPoint != null) {
+      context.pushLayer(
+        LeaderLayer(
+          link: _startHandleLayerLink!,
+          offset: offset + value.startSelectionPoint!.localPosition,
+        ),
+        (context, offset) {},
+        Offset.zero,
+      );
+    }
+    if (_endHandleLayerLink != null && value.endSelectionPoint != null) {
+      context.pushLayer(
+        LeaderLayer(
+          link: _endHandleLayerLink!,
+          offset: offset + value.endSelectionPoint!.localPosition,
+        ),
+        (context, offset) {},
+        Offset.zero,
       );
     }
   }

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1,7 +1,7 @@
 // Adapted from package:xterm 4.0.0 TerminalView internals to keep local
 // terminal layout and trackpad/mobile gesture fixes. Keep this aligned with the
 // pinned xterm dependency when upgrading.
-// ignore_for_file: implementation_imports, public_member_api_docs, directives_ordering, always_put_required_named_parameters_first, cast_nullable_to_non_nullable, prefer_expression_function_bodies, sort_child_properties_last, use_if_null_to_convert_nulls_to_bools, avoid_bool_literals_in_conditional_expressions, avoid_setters_without_getters, prefer_int_literals, cascade_invocations, unnecessary_null_checks
+// ignore_for_file: implementation_imports, public_member_api_docs, directives_ordering, always_put_required_named_parameters_first, cast_nullable_to_non_nullable, prefer_expression_function_bodies, sort_child_properties_last, use_if_null_to_convert_nulls_to_bools, avoid_bool_literals_in_conditional_expressions, avoid_setters_without_getters, prefer_int_literals, cascade_invocations, unnecessary_null_checks, invalid_use_of_internal_member
 
 import 'dart:async';
 import 'dart:math' as math;
@@ -28,6 +28,7 @@ import 'package:xterm/src/ui/input_map.dart';
 import 'package:xterm/src/ui/keyboard_listener.dart';
 import 'package:xterm/src/ui/keyboard_visibility.dart';
 import 'package:xterm/src/ui/painter.dart';
+import 'package:xterm/src/ui/pointer_input.dart';
 import 'package:xterm/src/ui/render.dart';
 import 'package:xterm/src/ui/selection_mode.dart';
 import 'package:xterm/src/ui/shortcut/shortcuts.dart';
@@ -607,7 +608,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
           ? _onTouchScrollUpdate
           : null,
       onTouchScrollEnd: widget.touchScrollToTerminal ? _onTouchScrollEnd : null,
-      readOnly: widget.readOnly,
+      readOnly: widget.readOnly || widget.useSystemSelection,
       enableTerminalSelectionGestures: !widget.useSystemSelection,
       child: child,
     );
@@ -648,6 +649,28 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
 
   void closeKeyboard() {
     _customTextEditKey.currentState?.closeKeyboard();
+  }
+
+  bool get shouldSendTerminalTapPointerInput =>
+      !widget.readOnly && _controller.shouldSendPointerInput(PointerInput.tap);
+
+  bool sendTerminalPrimaryTap(Offset globalPosition) {
+    if (!shouldSendTerminalTapPointerInput) {
+      return false;
+    }
+
+    final localPosition = renderTerminal.globalToLocal(globalPosition);
+    final handledDown = renderTerminal.mouseEvent(
+      TerminalMouseButton.left,
+      TerminalMouseButtonState.down,
+      localPosition,
+    );
+    final handledUp = renderTerminal.mouseEvent(
+      TerminalMouseButton.left,
+      TerminalMouseButtonState.up,
+      localPosition,
+    );
+    return handledDown || handledUp;
   }
 
   Rect get cursorRect {

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -463,18 +463,19 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
           composingText: _composingText,
           selectionRegistrar: SelectionContainer.maybeOf(context),
         );
-        if (!widget.useSystemSelection) {
-          return buildTerminalLeaf(context);
-        }
-        return SelectionArea(
-          contextMenuBuilder:
-              widget.systemSelectionContextMenuBuilder ??
-              _defaultSystemSelectionContextMenu,
-          onSelectionChanged: widget.onSystemSelectionChanged,
-          child: Builder(builder: buildTerminalLeaf),
-        );
+        return Builder(builder: buildTerminalLeaf);
       },
     );
+
+    if (widget.useSystemSelection) {
+      child = SelectionArea(
+        contextMenuBuilder:
+            widget.systemSelectionContextMenuBuilder ??
+            _defaultSystemSelectionContextMenu,
+        onSelectionChanged: widget.onSystemSelectionChanged,
+        child: child,
+      );
+    }
 
     if (!widget.touchScrollToTerminal) {
       child = MonkeyTerminalScrollGestureHandler(
@@ -1512,6 +1513,7 @@ class MonkeyRenderTerminal extends RenderBox
       if (_selectionStartOffset != null || _selectionEndOffset != null) {
         _selectionStartOffset = null;
         _selectionEndOffset = null;
+        markNeedsPaint();
         _updateSelectionGeometry();
       }
       return;
@@ -1523,6 +1525,7 @@ class MonkeyRenderTerminal extends RenderBox
     }
     _selectionStartOffset = nextStart;
     _selectionEndOffset = nextEnd;
+    markNeedsPaint();
     _updateSelectionGeometry();
   }
 

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1531,6 +1531,10 @@ class MonkeyRenderTerminal extends RenderBox
     return getOffset(cellOffset);
   }
 
+  Offset _selectionPointForTextOffset(int textOffset) =>
+      _localPositionForTextOffset(textOffset) +
+      Offset(0, _painter.cellSize.height);
+
   List<Rect> _selectionRectsForOffsets(int start, int end) {
     if (start == end || _terminal.buffer.lines.length == 0) {
       return const <Rect>[];
@@ -1583,12 +1587,12 @@ class MonkeyRenderTerminal extends RenderBox
 
     return SelectionGeometry(
       startSelectionPoint: SelectionPoint(
-        localPosition: _localPositionForTextOffset(start),
+        localPosition: _selectionPointForTextOffset(start),
         lineHeight: _painter.cellSize.height,
         handleType: startHandleType,
       ),
       endSelectionPoint: SelectionPoint(
-        localPosition: _localPositionForTextOffset(end),
+        localPosition: _selectionPointForTextOffset(end),
         lineHeight: _painter.cellSize.height,
         handleType: endHandleType,
       ),
@@ -1695,12 +1699,12 @@ class MonkeyRenderTerminal extends RenderBox
   }
 
   SelectionResult _handleSelectableEdgeUpdate(SelectionEdgeUpdateEvent event) {
+    if (_terminalSelectionContentLength <= 0) {
+      _clearSelectableTextSelection();
+      return SelectionResult.none;
+    }
     final localPosition = globalToLocal(event.globalPosition);
-    final hitRect = Offset.zero & size;
-    final adjustedPosition = SelectionUtils.adjustDragOffset(
-      hitRect,
-      localPosition,
-    );
+    final adjustedPosition = _adjustSelectableDragPosition(localPosition);
     final hitOffset = event.granularity == TextGranularity.word
         ? _wordEdgeOffsetForPosition(
             adjustedPosition,
@@ -1718,7 +1722,48 @@ class MonkeyRenderTerminal extends RenderBox
         hitOffset,
       );
     }
-    return SelectionUtils.getResultBasedOnRect(hitRect, localPosition);
+    return _selectionResultForDragPosition(localPosition, hitOffset);
+  }
+
+  Rect get _selectableContentRect {
+    final origin = _contentOrigin;
+    return Rect.fromLTWH(
+      origin.dx,
+      origin.dy - _scrollOffset,
+      _terminal.viewWidth * _painter.cellSize.width,
+      _terminalHeight,
+    );
+  }
+
+  Offset _adjustSelectableDragPosition(Offset localPosition) {
+    final contentRect = _selectableContentRect;
+    if (contentRect.isEmpty) {
+      return localPosition;
+    }
+    return Offset(
+      localPosition.dx.clamp(contentRect.left, contentRect.right),
+      localPosition.dy.clamp(contentRect.top, contentRect.bottom),
+    );
+  }
+
+  SelectionResult _selectionResultForDragPosition(
+    Offset localPosition,
+    int hitOffset,
+  ) {
+    final contentRect = _selectableContentRect;
+    if (contentRect.isEmpty) {
+      return SelectionResult.none;
+    }
+    if (localPosition.dy < contentRect.top ||
+        (hitOffset == 0 && localPosition.dx < contentRect.left)) {
+      return SelectionResult.previous;
+    }
+    if (localPosition.dy > contentRect.bottom ||
+        (hitOffset == _terminalSelectionContentLength &&
+            localPosition.dx > contentRect.right)) {
+      return SelectionResult.next;
+    }
+    return SelectionResult.end;
   }
 
   int _wordEdgeOffsetForPosition(

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -2009,16 +2009,21 @@ class MonkeyRenderTerminal extends RenderBox
       effectLastLine,
     );
 
-    if (_controller.selection != null) {
-      _paintSelection(
-        canvas,
-        _controller.selection!,
-        effectFirstLine,
-        effectLastLine,
-      );
+    final selection = _selectionRangeForPaint;
+    if (selection != null) {
+      _paintSelection(canvas, selection, effectFirstLine, effectLastLine);
     }
 
     _paintSelectionHandleLayers(context, offset);
+  }
+
+  BufferRange? get _selectionRangeForPaint {
+    final start = _selectionStartOffset;
+    final end = _selectionEndOffset;
+    if (registrar != null && start != null && end != null && start != end) {
+      return _bufferRangeForTextOffsets(start, end);
+    }
+    return _controller.selection;
   }
 
   void _paintSelectionHandleLayers(PaintingContext context, Offset offset) {

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -38,6 +38,7 @@ import 'package:xterm/src/ui/themes.dart';
 
 import 'monkey_terminal_gesture_handler.dart';
 import 'monkey_terminal_scroll_gesture_handler.dart';
+import 'terminal_selection_text.dart';
 
 /// Terminal render padding.
 ///
@@ -71,7 +72,7 @@ bool shouldAlignTerminalToTrailingEdges(MediaQueryData mediaQuery) {
 }
 
 Widget _defaultSystemSelectionContextMenu(
-  BuildContext context,
+  BuildContext _,
   SelectableRegionState selectableRegionState,
 ) => AdaptiveTextSelectionToolbar.selectableRegion(
   selectableRegionState: selectableRegionState,
@@ -336,7 +337,6 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
   Simulation? _touchScrollInertiaSimulation;
   double _lastTouchScrollInertiaOffset = 0;
   int _lastTerminalViewWidth = 0;
-  bool _clearedSelectionOnTapDown = false;
 
   late TerminalController _controller;
 
@@ -463,17 +463,16 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
           composingText: _composingText,
           selectionRegistrar: SelectionContainer.maybeOf(context),
         );
-        var terminalLeaf = buildTerminalLeaf(context);
-        if (widget.useSystemSelection) {
-          terminalLeaf = SelectionArea(
-            contextMenuBuilder:
-                widget.systemSelectionContextMenuBuilder ??
-                _defaultSystemSelectionContextMenu,
-            onSelectionChanged: widget.onSystemSelectionChanged,
-            child: Builder(builder: buildTerminalLeaf),
-          );
+        if (!widget.useSystemSelection) {
+          return buildTerminalLeaf(context);
         }
-        return terminalLeaf;
+        return SelectionArea(
+          contextMenuBuilder:
+              widget.systemSelectionContextMenuBuilder ??
+              _defaultSystemSelectionContextMenu,
+          onSelectionChanged: widget.onSystemSelectionChanged,
+          child: Builder(builder: buildTerminalLeaf),
+        );
       },
     );
 
@@ -580,7 +579,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
     child = MonkeyTerminalGestureHandler(
       terminalView: this,
       terminalController: _controller,
-      onTapUp: _onTapUp,
+      onSingleTapUp: _onTapUp,
       onTapDown: _onTapDown,
       onDoubleTapDown: widget.onDoubleTapDown != null ? _onDoubleTapDown : null,
       onLongPressStart: widget.onLongPressStart != null
@@ -662,17 +661,11 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
   void _onTapUp(TapUpDetails details) {
     final offset = renderTerminal.getCellOffset(details.localPosition);
     widget.onTapUp?.call(details, offset);
-    if (widget.useSystemSelection && !_clearedSelectionOnTapDown) {
-      _requestInputFocus();
-    }
-    _clearedSelectionOnTapDown = false;
   }
 
   void _onTapDown(TapDownDetails details) {
     _stopTouchScrollInertia();
-    _clearedSelectionOnTapDown = false;
     if (_controller.selection != null) {
-      _clearedSelectionOnTapDown = true;
       _controller.clearSelection();
     } else if (!widget.useSystemSelection) {
       _requestInputFocus();
@@ -1628,7 +1621,8 @@ class MonkeyRenderTerminal extends RenderBox
     final text = _terminal.buffer.getText(
       _bufferRangeForTextOffsets(start, end),
     );
-    return text.isEmpty ? null : SelectedContent(plainText: text);
+    final trimmedText = trimTerminalSelectionText(text);
+    return trimmedText.isEmpty ? null : SelectedContent(plainText: trimmedText);
   }
 
   @override

--- a/lib/presentation/widgets/terminal_selection_text.dart
+++ b/lib/presentation/widgets/terminal_selection_text.dart
@@ -1,0 +1,9 @@
+final _trailingTerminalPaddingPattern = RegExp(r' +$');
+
+/// Trims terminal cell padding from the end of a rendered line.
+String trimTerminalLinePadding(String line) =>
+    line.replaceFirst(_trailingTerminalPaddingPattern, '');
+
+/// Trims per-line terminal padding from copied or selected terminal text.
+String trimTerminalSelectionText(String text) =>
+    text.split('\n').map(trimTerminalLinePadding).join('\n');

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -34,6 +34,11 @@ bool _isPromptWhitespaceCodeUnit(int codeUnit) =>
 @visibleForTesting
 const modifierChordFollowUpWindow = Duration(milliseconds: 500);
 
+/// Touch duration at which a terminal touch should be treated as selection
+/// intent rather than a tap-to-focus keyboard request.
+@visibleForTesting
+const terminalKeyboardTapLongPressTimeout = kLongPressTimeout;
+
 DateTime Function()? _modifierChordClockOverride;
 
 DateTime _readModifierChordClock() =>
@@ -73,6 +78,7 @@ bool shouldRequestKeyboardForTerminalPointerUp({
   required int activeTouchPointers,
   required bool hadMultipleTouchPointers,
   required bool movedBeyondTapSlop,
+  required bool pressedBeyondLongPressTimeout,
   required bool readOnly,
 }) {
   if (readOnly) {
@@ -85,7 +91,8 @@ bool shouldRequestKeyboardForTerminalPointerUp({
 
   return activeTouchPointers == 1 &&
       !hadMultipleTouchPointers &&
-      !movedBeyondTapSlop;
+      !movedBeyondTapSlop &&
+      !pressedBeyondLongPressTimeout;
 }
 
 /// Controls a [TerminalTextInputHandler] from an ancestor widget.
@@ -160,6 +167,7 @@ class TerminalTextInputHandler extends StatefulWidget {
     this.hasActiveToolbarModifier,
     this.readOnly = false,
     this.tapToShowKeyboard = true,
+    this.showKeyboardOnFocus,
     super.key,
   });
 
@@ -218,6 +226,13 @@ class TerminalTextInputHandler extends StatefulWidget {
   /// can still be opened via [requestKeyboard] (e.g. from a toolbar button).
   final bool tapToShowKeyboard;
 
+  /// Whether focusing the terminal should show the keyboard.
+  ///
+  /// When omitted, focus follows [tapToShowKeyboard]. Set this to `false` when
+  /// focus should attach an input connection without opening the keyboard until
+  /// the user explicitly taps the terminal.
+  final bool? showKeyboardOnFocus;
+
   @override
   State<TerminalTextInputHandler> createState() =>
       _TerminalTextInputHandlerState();
@@ -228,7 +243,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   TextInputConnection? _connection;
   final Set<int> _activeTouchPointers = <int>{};
   final Map<int, Offset> _touchPointerDownPositions = <int, Offset>{};
+  final Map<int, Timer> _touchLongPressTimers = <int, Timer>{};
   final Set<int> _touchPointersMovedBeyondTapSlop = <int>{};
+  final Set<int> _touchPointersPressedBeyondLongPressTimeout = <int>{};
   bool _touchSequenceHadMultiplePointers = false;
   bool _skipNextTouchKeyboardRequest = false;
   bool _sawImeComposition = false;
@@ -272,7 +289,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (!_shouldCreateInputConnection) {
       _closeInputConnectionIfNeeded();
     } else if (oldWidget.readOnly && widget.focusNode.hasFocus) {
-      _openInputConnection(show: widget.tapToShowKeyboard);
+      _openInputConnection(
+        show: widget.showKeyboardOnFocus ?? widget.tapToShowKeyboard,
+      );
     }
   }
 
@@ -280,9 +299,14 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   void dispose() {
     widget.controller?._detach(this);
     widget.focusNode.removeListener(_onFocusChange);
+    for (final timer in _touchLongPressTimers.values) {
+      timer.cancel();
+    }
     _activeTouchPointers.clear();
     _touchPointerDownPositions.clear();
+    _touchLongPressTimers.clear();
     _touchPointersMovedBeyondTapSlop.clear();
+    _touchPointersPressedBeyondLongPressTimeout.clear();
     _closeInputConnectionIfNeeded();
     super.dispose();
   }
@@ -306,6 +330,11 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (event.kind == PointerDeviceKind.touch) {
       _activeTouchPointers.add(event.pointer);
       _touchPointerDownPositions[event.pointer] = event.position;
+      _touchLongPressTimers[event.pointer]?.cancel();
+      _touchLongPressTimers[event.pointer] = Timer(
+        terminalKeyboardTapLongPressTimeout,
+        () => _touchPointersPressedBeyondLongPressTimeout.add(event.pointer),
+      );
       if (_activeTouchPointers.length > 1) {
         _touchSequenceHadMultiplePointers = true;
       }
@@ -337,6 +366,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       movedBeyondTapSlop: _touchPointersMovedBeyondTapSlop.contains(
         event.pointer,
       ),
+      pressedBeyondLongPressTimeout:
+          event.kind == PointerDeviceKind.touch &&
+          _touchPointersPressedBeyondLongPressTimeout.contains(event.pointer),
       readOnly: widget.readOnly,
     );
     if (event.kind == PointerDeviceKind.touch && shouldRequestKeyboard) {
@@ -371,7 +403,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
 
     _activeTouchPointers.remove(event.pointer);
     _touchPointerDownPositions.remove(event.pointer);
+    _touchLongPressTimers.remove(event.pointer)?.cancel();
     _touchPointersMovedBeyondTapSlop.remove(event.pointer);
+    _touchPointersPressedBeyondLongPressTimeout.remove(event.pointer);
     if (_activeTouchPointers.isEmpty) {
       _touchSequenceHadMultiplePointers = false;
     }
@@ -549,7 +583,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         // Attach the input connection but only show the soft keyboard when
         // tap-to-show is enabled.  Explicit keyboard requests go through
         // requestKeyboard() which always passes show: true.
-        _openInputConnection(show: widget.tapToShowKeyboard);
+        _openInputConnection(
+          show: widget.showKeyboardOnFocus ?? widget.tapToShowKeyboard,
+        );
       }
     } else if (!widget.focusNode.hasFocus) {
       _closeInputConnectionIfNeeded();

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -80,6 +80,7 @@ bool shouldRequestKeyboardForTerminalPointerUp({
   required bool movedBeyondTapSlop,
   required bool pressedBeyondLongPressTimeout,
   required bool readOnly,
+  Duration? touchPressDuration,
 }) {
   if (readOnly) {
     return false;
@@ -92,7 +93,9 @@ bool shouldRequestKeyboardForTerminalPointerUp({
   return activeTouchPointers == 1 &&
       !hadMultipleTouchPointers &&
       !movedBeyondTapSlop &&
-      !pressedBeyondLongPressTimeout;
+      !pressedBeyondLongPressTimeout &&
+      (touchPressDuration == null ||
+          touchPressDuration < terminalKeyboardTapLongPressTimeout);
 }
 
 /// Controls a [TerminalTextInputHandler] from an ancestor widget.
@@ -243,6 +246,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   TextInputConnection? _connection;
   final Set<int> _activeTouchPointers = <int>{};
   final Map<int, Offset> _touchPointerDownPositions = <int, Offset>{};
+  final Map<int, Duration> _touchPointerDownTimestamps = <int, Duration>{};
   final Map<int, Timer> _touchLongPressTimers = <int, Timer>{};
   final Set<int> _touchPointersMovedBeyondTapSlop = <int>{};
   final Set<int> _touchPointersPressedBeyondLongPressTimeout = <int>{};
@@ -304,6 +308,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
     _activeTouchPointers.clear();
     _touchPointerDownPositions.clear();
+    _touchPointerDownTimestamps.clear();
     _touchLongPressTimers.clear();
     _touchPointersMovedBeyondTapSlop.clear();
     _touchPointersPressedBeyondLongPressTimeout.clear();
@@ -330,6 +335,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (event.kind == PointerDeviceKind.touch) {
       _activeTouchPointers.add(event.pointer);
       _touchPointerDownPositions[event.pointer] = event.position;
+      _touchPointerDownTimestamps[event.pointer] = event.timeStamp;
       _touchLongPressTimers[event.pointer]?.cancel();
       _touchLongPressTimers[event.pointer] = Timer(
         terminalKeyboardTapLongPressTimeout,
@@ -370,6 +376,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
           event.kind == PointerDeviceKind.touch &&
           _touchPointersPressedBeyondLongPressTimeout.contains(event.pointer),
       readOnly: widget.readOnly,
+      touchPressDuration: event.kind == PointerDeviceKind.touch
+          ? _touchPressDuration(event)
+          : null,
     );
     if (event.kind == PointerDeviceKind.touch && shouldRequestKeyboard) {
       _clearImeAfterNextTouchCursorMove = true;
@@ -403,12 +412,21 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
 
     _activeTouchPointers.remove(event.pointer);
     _touchPointerDownPositions.remove(event.pointer);
+    _touchPointerDownTimestamps.remove(event.pointer);
     _touchLongPressTimers.remove(event.pointer)?.cancel();
     _touchPointersMovedBeyondTapSlop.remove(event.pointer);
     _touchPointersPressedBeyondLongPressTimeout.remove(event.pointer);
     if (_activeTouchPointers.isEmpty) {
       _touchSequenceHadMultiplePointers = false;
     }
+  }
+
+  Duration? _touchPressDuration(PointerEvent event) {
+    final startTimestamp = _touchPointerDownTimestamps[event.pointer];
+    if (startTimestamp == null) {
+      return null;
+    }
+    return event.timeStamp - startTimestamp;
   }
 
   void _notifyUserInput() {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -304,6 +304,113 @@ void main() {
         expect(selectedText, contains(rowLabel(endRow)));
       },
     );
+
+    testWidgets(
+      'repaints controller-driven selection after keyboard-sized resize',
+      (tester) async {
+        final terminal = Terminal(maxLines: 120);
+        for (var row = 0; row < 60; row += 1) {
+          terminal.write('${rowLabel(row)}\r\n');
+        }
+        final controller = TerminalController();
+
+        var renderTerminal = await pumpSelectableTerminal(
+          tester,
+          terminal: terminal,
+          controller: controller,
+          height: 320,
+        );
+        renderTerminal = await pumpSelectableTerminal(
+          tester,
+          terminal: terminal,
+          controller: controller,
+          height: 160,
+        );
+        renderTerminal = await pumpSelectableTerminal(
+          tester,
+          terminal: terminal,
+          controller: controller,
+          height: 320,
+        );
+
+        expect(renderTerminal.debugNeedsPaint, isFalse);
+
+        renderTerminal.dispatchSelectionEvent(
+          SelectWordSelectionEvent(
+            globalPosition: cellCenter(
+              renderTerminal,
+              CellOffset(4, renderTerminal.getCellOffset(Offset.zero).y + 1),
+            ),
+          ),
+        );
+
+        expect(renderTerminal.debugNeedsPaint, isTrue);
+        await tester.pump();
+        expect(renderTerminal.getSelectedContent()?.plainText, isNotNull);
+      },
+    );
+
+    testWidgets(
+      'handle drag keeps updating after keyboard-sized resize',
+      (tester) async {
+        final terminal = Terminal(maxLines: 120);
+        for (var row = 0; row < 60; row += 1) {
+          terminal.write('${rowLabel(row)}\r\n');
+        }
+        final controller = TerminalController();
+
+        var renderTerminal = await pumpSelectableTerminal(
+          tester,
+          terminal: terminal,
+          controller: controller,
+          height: 320,
+        );
+        renderTerminal = await pumpSelectableTerminal(
+          tester,
+          terminal: terminal,
+          controller: controller,
+          height: 160,
+        );
+        renderTerminal = await pumpSelectableTerminal(
+          tester,
+          terminal: terminal,
+          controller: controller,
+          height: 320,
+        );
+
+        final topVisibleRow = renderTerminal.getCellOffset(Offset.zero).y;
+        final selectedRow = topVisibleRow + 10;
+        final targetRow = topVisibleRow + 1;
+
+        await tester.longPressAt(
+          cellCenter(renderTerminal, CellOffset(5, selectedRow)),
+        );
+        await tester.pumpAndSettle();
+        expect(controller.selection, isNotNull);
+
+        final handleFinder = find.byWidgetPredicate(
+          (widget) =>
+              widget.runtimeType.toString() == '_SelectionHandleOverlay',
+        );
+        expect(handleFinder, findsWidgets);
+
+        final startSelectionPoint = renderTerminal.value.startSelectionPoint!;
+        final startHandlePosition = renderTerminal.localToGlobal(
+          startSelectionPoint.localPosition,
+        );
+        await tester.dragFrom(
+          startHandlePosition,
+          cellCenter(renderTerminal, CellOffset(0, targetRow)) -
+              startHandlePosition,
+        );
+        await tester.pumpAndSettle();
+
+        final selectedText = renderTerminal.getSelectedContent()!.plainText;
+        expect(selectedText, contains(rowLabel(targetRow)));
+        expect(selectedText, contains(rowLabel(selectedRow)));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
   });
 
   group('TerminalScreen mobile IME wiring', () {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -979,6 +979,29 @@ void main() {
     );
 
     testWidgets(
+      'terminal tap sends mouse input while system selection is enabled',
+      (tester) async {
+        await pumpScreen(tester);
+
+        session.terminal!
+          ..setMouseMode(MouseMode.upDownScroll)
+          ..setMouseReportMode(MouseReportMode.sgr)
+          ..write('alpha beta');
+        await tester.pumpAndSettle();
+
+        shellWrites.clear();
+        await tester.tap(find.byType(MonkeyTerminalView));
+        await tester.pump();
+
+        final writtenShellText = utf8.decode(
+          shellWrites.expand((chunk) => chunk).toList(growable: false),
+        );
+        expect(writtenShellText, contains('\x1B[<0;'));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
       'toolbar navigation keys clear the screen IME buffer',
       (tester) async {
         await pumpScreen(tester);

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -678,6 +678,38 @@ void main() {
     );
 
     testWidgets(
+      'system selection does not hide an already visible mobile keyboard',
+      (tester) async {
+        await pumpScreen(tester);
+
+        session.terminal!.write('alpha');
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(MonkeyTerminalView));
+        await tester.pump();
+
+        expect(tester.testTextInput.isVisible, isTrue);
+
+        final terminalViewState = tester.state<MonkeyTerminalViewState>(
+          find.byType(MonkeyTerminalView),
+        );
+        final renderTerminal = terminalViewState.renderTerminal;
+        final target = renderTerminal.localToGlobal(
+          renderTerminal.getOffset(const CellOffset(2, 0)) +
+              renderTerminal.cellSize.center(Offset.zero),
+        );
+
+        await tester.longPressAt(target);
+        await tester.pumpAndSettle();
+
+        expect(tester.testTextInput.isVisible, isTrue);
+        final selection = terminalViewState.renderTerminal.getSelectedContent();
+        expect(selection?.plainText, 'alpha');
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
       'toolbar navigation keys clear the screen IME buffer',
       (tester) async {
         await pumpScreen(tester);

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -656,6 +656,28 @@ void main() {
     );
 
     testWidgets(
+      'terminal tap opens the mobile keyboard when tap-to-show is enabled',
+      (tester) async {
+        await pumpScreen(tester);
+
+        tester.testTextInput.log.clear();
+        expect(tester.testTextInput.isVisible, isFalse);
+
+        await tester.tap(find.byType(MonkeyTerminalView));
+        await tester.pump();
+
+        expect(tester.testTextInput.isVisible, isTrue);
+        expect(
+          tester.testTextInput.log.where(
+            (call) => call.method == 'TextInput.show',
+          ),
+          isNotEmpty,
+        );
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
       'toolbar navigation keys clear the screen IME buffer',
       (tester) async {
         await pumpScreen(tester);

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -10,8 +10,10 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 
+import 'package:monkeyssh/app/routes.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
@@ -1398,6 +1400,85 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(underlineFinder, findsOneWidget);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'mobile path underline taps open SFTP while system selection is enabled',
+      (tester) async {
+        const remotePath = '/var/log/app.log';
+        final sftp = _MockSftpClient();
+        final openedPaths = <String>[];
+
+        when(() => sshClient.sftp()).thenAnswer((_) async => sftp);
+        when(
+          () => sftp.stat(remotePath),
+        ).thenAnswer((_) async => SftpFileAttrs());
+
+        final router = GoRouter(
+          initialLocation:
+              '/terminal/${host.id}?connectionId=${session.connectionId}',
+          routes: [
+            GoRoute(
+              path: '/terminal/:hostId',
+              name: Routes.terminal,
+              builder: (context, state) => TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+              ),
+            ),
+            GoRoute(
+              path: '/sftp/:hostId',
+              name: Routes.sftp,
+              builder: (context, state) {
+                openedPaths.add(state.uri.queryParameters['path'] ?? '');
+                return const Scaffold(body: Text('SFTP opened'));
+              },
+            ),
+          ],
+        );
+        addTearDown(router.dispose);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+            ],
+            child: MaterialApp.router(routerConfig: router),
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        session.terminal!.write('open $remotePath');
+        await tester.pumpAndSettle();
+
+        final underlineFinder = find.byWidgetPredicate((widget) {
+          final key = widget.key;
+          return key is ValueKey<String> &&
+              key.value.contains('terminal-path-underline:') &&
+              key.value.contains(remotePath);
+        });
+        expect(underlineFinder, findsOneWidget);
+        expect(find.byType(SelectionArea), findsOneWidget);
+
+        await tester.tapAt(tester.getCenter(underlineFinder));
+        await tester.pumpAndSettle();
+
+        expect(openedPaths, [remotePath]);
+        verify(() => sftp.stat(remotePath)).called(1);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -922,6 +922,31 @@ void main() {
     );
 
     testWidgets(
+      'terminal double tap sends Tab while system selection is enabled',
+      (tester) async {
+        await pumpScreen(tester);
+
+        expect(find.byType(SelectionArea), findsOneWidget);
+        shellWrites.clear();
+
+        final terminalCenter = tester.getCenter(
+          find.byType(MonkeyTerminalView),
+        );
+        await tester.tapAt(terminalCenter);
+        await tester.pump(const Duration(milliseconds: 80));
+        await tester.tapAt(terminalCenter);
+        await tester.pump();
+
+        final writtenShellText = utf8.decode(
+          shellWrites.expand((chunk) => chunk).toList(growable: false),
+        );
+        expect(writtenShellText, '\t');
+        expect(find.text('Tab'), findsAtLeastNWidgets(1));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
       'system selection does not hide an already visible mobile keyboard',
       (tester) async {
         await pumpScreen(tester);

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'package:dartssh2/dartssh2.dart';
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -855,7 +856,7 @@ void main() {
     );
 
     testWidgets(
-      'overlay long press reselects from the touch-down snapshot while output streams during the hold',
+      'system selectable selects terminal words and ignores later output',
       (tester) async {
         await pumpScreen(tester);
 
@@ -876,23 +877,37 @@ void main() {
         await tester.longPressAt(cellCenter(const CellOffset(2, 0)));
         await tester.pumpAndSettle();
 
-        final overlayField = find.byType(TextField);
-        expect(overlayField, findsOneWidget);
+        expect(find.byType(TextField), findsNothing);
         final terminalView = tester.widget<MonkeyTerminalView>(
           find.byType(MonkeyTerminalView),
         );
         expect(terminalView.controller, isNotNull);
-        expect(terminalView.controller!.selection, isNull);
-        var overlayController = tester
-            .widget<TextField>(overlayField)
-            .controller;
-        expect(overlayController, isNotNull);
-        expect(overlayController!.selection.isCollapsed, isFalse);
-        expect(overlayController.text, contains('alpha'));
+        var terminalSelection = terminalView.controller!.selection;
+        expect(terminalSelection, isNotNull);
+        expect(
+          trimTerminalSelectionText(
+            session.terminal!.buffer.getText(terminalSelection),
+          ),
+          'alpha',
+        );
+        final renderTerminal = tester
+            .state<MonkeyTerminalViewState>(find.byType(MonkeyTerminalView))
+            .renderTerminal;
+        expect(
+          trimTerminalSelectionText(
+            renderTerminal.getSelectedContent()!.plainText,
+          ),
+          'alpha',
+        );
 
         session.terminal!.write('\r\ncharlie');
         await tester.pumpAndSettle();
-        expect(overlayController.text, isNot(contains('charlie')));
+        terminalSelection = terminalView.controller!.selection;
+        expect(terminalSelection, isNotNull);
+        expect(
+          session.terminal!.buffer.getText(terminalSelection),
+          isNot(contains('charlie')),
+        );
 
         var streamIndex = 0;
         final streamTimer = Timer.periodic(const Duration(milliseconds: 16), (
@@ -903,25 +918,23 @@ void main() {
         });
         addTearDown(streamTimer.cancel);
 
-        final gesture = await tester.startGesture(
-          cellCenter(const CellOffset(2, 1)),
+        renderTerminal.dispatchSelectionEvent(
+          SelectWordSelectionEvent(
+            globalPosition: cellCenter(const CellOffset(2, 1)),
+          ),
         );
-        await tester.pump(const Duration(milliseconds: 650));
-        await tester.pumpAndSettle();
-        await gesture.up();
         await tester.pumpAndSettle();
 
         streamTimer.cancel();
 
-        expect(terminalView.controller!.selection, isNull);
-        overlayController = tester.widget<TextField>(overlayField).controller;
-        expect(overlayController, isNotNull);
-        expect(overlayController!.selection.isCollapsed, isFalse);
+        terminalSelection = terminalView.controller!.selection;
+        expect(terminalSelection, isNotNull);
         expect(
-          overlayController.selection.textInside(overlayController.text),
+          trimTerminalSelectionText(
+            session.terminal!.buffer.getText(terminalSelection),
+          ),
           'charlie',
         );
-        expect(overlayController.text, isNot(contains('stream')));
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );
@@ -938,7 +951,7 @@ void main() {
         session.terminal!.write(initialLines);
         await tester.pumpAndSettle();
 
-        Offset? tokenCenter(String token) {
+        ({CellOffset cellOffset, Offset center})? tokenHit(String token) {
           final terminalViewState = tester.state<MonkeyTerminalViewState>(
             find.byType(MonkeyTerminalView),
           );
@@ -966,39 +979,52 @@ void main() {
 
             final tapColumn = startColumn + (token.length ~/ 2);
             final cellOffset = CellOffset(tapColumn, row);
-            return renderTerminal.localToGlobal(
-              renderTerminal.getOffset(cellOffset) +
-                  renderTerminal.cellSize.center(Offset.zero),
+            return (
+              cellOffset: cellOffset,
+              center: renderTerminal.localToGlobal(
+                renderTerminal.getOffset(cellOffset) +
+                    renderTerminal.cellSize.center(Offset.zero),
+              ),
             );
           }
 
           return null;
         }
 
-        final alphaCenter = tokenCenter('alpha');
-        expect(alphaCenter, isNotNull);
+        final alphaHit = tokenHit('alpha');
+        expect(alphaHit, isNotNull);
 
-        await tester.longPressAt(alphaCenter!);
+        final renderTerminal = tester
+            .state<MonkeyTerminalViewState>(find.byType(MonkeyTerminalView))
+            .renderTerminal;
+        renderTerminal.selectWord(
+          renderTerminal.getOffset(alphaHit!.cellOffset) +
+              renderTerminal.cellSize.center(Offset.zero),
+        );
         await tester.pumpAndSettle();
 
-        final overlayField = find.byType(TextField);
-        expect(overlayField, findsOneWidget);
-        final overlayTextField = tester.widget<TextField>(overlayField);
-        final overlayController = overlayTextField.controller;
-        final overlayScrollController = overlayTextField.scrollController;
-        expect(overlayController, isNotNull);
-        expect(overlayController!.selection.isCollapsed, isFalse);
-        expect(overlayScrollController, isNotNull);
-        expect(overlayScrollController!.hasClients, isTrue);
-
-        final initialOverlayOffset = overlayScrollController.offset;
-        expect(initialOverlayOffset, greaterThan(0));
+        expect(find.byType(TextField), findsNothing);
+        expect(find.byType(SelectionArea), findsOneWidget);
+        final terminalView = tester.widget<MonkeyTerminalView>(
+          find.byType(MonkeyTerminalView),
+        );
+        expect(terminalView.controller, isNotNull);
+        var terminalSelection = terminalView.controller!.selection;
+        expect(terminalSelection, isNotNull);
+        final selectedText = trimTerminalSelectionText(
+          session.terminal!.buffer.getText(terminalSelection),
+        );
+        expect(selectedText, 'alpha');
 
         session.terminal!.write('\r\ncharlie');
         await tester.pumpAndSettle();
 
-        expect(overlayController.text, isNot(contains('charlie')));
-        expect(overlayScrollController.offset, initialOverlayOffset);
+        terminalSelection = terminalView.controller!.selection;
+        expect(terminalSelection, isNotNull);
+        expect(
+          session.terminal!.buffer.getText(terminalSelection),
+          isNot(contains('charlie')),
+        );
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );
@@ -1069,28 +1095,28 @@ void main() {
         });
         addTearDown(streamTimer.cancel);
 
-        final gesture = await tester.startGesture(hit.center);
-        await tester.pump(const Duration(milliseconds: 650));
-        await tester.pumpAndSettle();
-        await gesture.up();
+        final renderTerminal = tester
+            .state<MonkeyTerminalViewState>(find.byType(MonkeyTerminalView))
+            .renderTerminal;
+        renderTerminal.selectWord(
+          renderTerminal.getOffset(hit.cellOffset) +
+              renderTerminal.cellSize.center(Offset.zero),
+        );
         await tester.pumpAndSettle();
 
         streamTimer.cancel();
 
-        final overlayField = find.byType(TextField);
-        expect(overlayField, findsOneWidget);
+        expect(find.byType(TextField), findsNothing);
         final terminalView = tester.widget<MonkeyTerminalView>(
           find.byType(MonkeyTerminalView),
         );
         expect(terminalView.controller, isNotNull);
-        expect(terminalView.controller!.selection, isNull);
-        final overlayController = tester
-            .widget<TextField>(overlayField)
-            .controller;
-        expect(overlayController, isNotNull);
-        expect(overlayController!.selection.isCollapsed, isFalse);
         expect(
-          overlayController.selection.textInside(overlayController.text),
+          trimTerminalSelectionText(
+            session.terminal!.buffer.getText(
+              terminalView.controller!.selection,
+            ),
+          ),
           expectedWord,
         );
       },

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -169,6 +169,141 @@ void main() {
     });
   });
 
+  group('MonkeyTerminalView system selection geometry', () {
+    Future<MonkeyRenderTerminal> pumpSelectableTerminal(
+      WidgetTester tester, {
+      required Terminal terminal,
+      required TerminalController controller,
+      required double height,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: 390,
+                height: height,
+                child: MonkeyTerminalView(
+                  terminal,
+                  controller: controller,
+                  hardwareKeyboardOnly: true,
+                  useSystemSelection: true,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return tester
+          .state<MonkeyTerminalViewState>(find.byType(MonkeyTerminalView))
+          .renderTerminal;
+    }
+
+    Offset cellCenter(MonkeyRenderTerminal renderTerminal, CellOffset offset) =>
+        renderTerminal.localToGlobal(
+          renderTerminal.getOffset(offset) +
+              renderTerminal.cellSize.center(Offset.zero),
+        );
+
+    String rowLabel(int row) => 'row ${row.toString().padLeft(2, '0')}';
+
+    testWidgets('anchors selection handles at terminal line bottoms', (
+      tester,
+    ) async {
+      final terminal = Terminal(maxLines: 100)..write('alpha');
+      final controller = TerminalController();
+      final renderTerminal = await pumpSelectableTerminal(
+        tester,
+        terminal: terminal,
+        controller: controller,
+        height: 240,
+      );
+
+      renderTerminal.dispatchSelectionEvent(
+        SelectWordSelectionEvent(
+          globalPosition: cellCenter(renderTerminal, const CellOffset(2, 0)),
+        ),
+      );
+      await tester.pump();
+
+      final lineBottom =
+          renderTerminal.getOffset(const CellOffset(0, 0)).dy +
+          renderTerminal.cellSize.height;
+      expect(
+        renderTerminal.value.startSelectionPoint!.localPosition.dy,
+        closeTo(lineBottom, 0.001),
+      );
+      expect(
+        renderTerminal.value.endSelectionPoint!.localPosition.dy,
+        closeTo(lineBottom, 0.001),
+      );
+    });
+
+    testWidgets(
+      'keeps updating selection when a handle is dragged above the viewport',
+      (tester) async {
+        final terminal = Terminal(maxLines: 120);
+        for (var row = 0; row < 60; row += 1) {
+          terminal.write('${rowLabel(row)}\r\n');
+        }
+        final controller = TerminalController();
+
+        var renderTerminal = await pumpSelectableTerminal(
+          tester,
+          terminal: terminal,
+          controller: controller,
+          height: 320,
+        );
+        renderTerminal = await pumpSelectableTerminal(
+          tester,
+          terminal: terminal,
+          controller: controller,
+          height: 160,
+        );
+        renderTerminal = await pumpSelectableTerminal(
+          tester,
+          terminal: terminal,
+          controller: controller,
+          height: 320,
+        );
+
+        final topVisibleRow = renderTerminal.getCellOffset(Offset.zero).y;
+        expect(topVisibleRow, greaterThan(3));
+        final targetRow = topVisibleRow - 3;
+        final endRow = topVisibleRow + 2;
+
+        renderTerminal
+          ..dispatchSelectionEvent(
+            SelectionEdgeUpdateEvent.forStart(
+              globalPosition: cellCenter(renderTerminal, CellOffset(0, endRow)),
+            ),
+          )
+          ..dispatchSelectionEvent(
+            SelectionEdgeUpdateEvent.forEnd(
+              globalPosition: cellCenter(renderTerminal, CellOffset(6, endRow)),
+            ),
+          );
+        await tester.pump();
+
+        renderTerminal.dispatchSelectionEvent(
+          SelectionEdgeUpdateEvent.forStart(
+            globalPosition: cellCenter(
+              renderTerminal,
+              CellOffset(0, targetRow),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final selectedText = renderTerminal.getSelectedContent()!.plainText;
+        expect(selectedText, contains(rowLabel(targetRow)));
+        expect(selectedText, contains(rowLabel(endRow)));
+      },
+    );
+  });
+
   group('TerminalScreen mobile IME wiring', () {
     late AppDatabase db;
     late _MockHostRepository hostRepository;

--- a/test/widget/monkey_terminal_gesture_handler_test.dart
+++ b/test/widget/monkey_terminal_gesture_handler_test.dart
@@ -182,6 +182,110 @@ void main() {
     expect(doubleTapDowns, 1);
   });
 
+  testWidgets(
+    'double taps invoke explicit callback when selection gestures are disabled',
+    (tester) async {
+      final terminalViewKey = GlobalKey<MonkeyTerminalViewState>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SizedBox(
+            width: 300,
+            height: 200,
+            child: MonkeyTerminalView(
+              key: terminalViewKey,
+              Terminal(),
+              readOnly: true,
+            ),
+          ),
+        ),
+      );
+
+      final terminalViewState = terminalViewKey.currentState!;
+      var doubleTapDowns = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SizedBox(
+            width: 300,
+            height: 200,
+            child: MonkeyTerminalGestureHandler(
+              terminalView: terminalViewState,
+              terminalController: TerminalController(),
+              readOnly: true,
+              enableTerminalSelectionGestures: false,
+              onDoubleTapDown: (_) => doubleTapDowns += 1,
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      final detector = tester.widget<MonkeyTerminalGestureDetector>(
+        find.byType(MonkeyTerminalGestureDetector),
+      );
+      detector.onDoubleTapDown!(
+        TapDownDetails(localPosition: const Offset(10, 10)),
+      );
+
+      expect(doubleTapDowns, 1);
+    },
+  );
+
+  testWidgets('link taps work when selection gestures are disabled', (
+    tester,
+  ) async {
+    final terminalViewKey = GlobalKey<MonkeyTerminalViewState>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 300,
+          height: 200,
+          child: MonkeyTerminalView(
+            key: terminalViewKey,
+            Terminal(),
+            readOnly: true,
+          ),
+        ),
+      ),
+    );
+
+    final terminalViewState = terminalViewKey.currentState!;
+    final openedLinks = <String>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 300,
+          height: 200,
+          child: MonkeyTerminalGestureHandler(
+            terminalView: terminalViewState,
+            terminalController: TerminalController(),
+            readOnly: true,
+            enableTerminalSelectionGestures: false,
+            resolveLinkTap: (_) => 'https://github.com/features/copilot',
+            onLinkTap: openedLinks.add,
+            child: const SizedBox.expand(),
+          ),
+        ),
+      ),
+    );
+
+    final detector = tester.widget<MonkeyTerminalGestureDetector>(
+      find.byType(MonkeyTerminalGestureDetector),
+    );
+    detector.onTapDown!(TapDownDetails(localPosition: const Offset(10, 10)));
+    detector.onSingleTapUp!(
+      TapUpDetails(
+        kind: PointerDeviceKind.touch,
+        localPosition: const Offset(10, 10),
+      ),
+    );
+
+    expect(openedLinks, ['https://github.com/features/copilot']);
+  });
+
   testWidgets('touch scroll clears any pending link tap', (tester) async {
     final terminalViewKey = GlobalKey<MonkeyTerminalViewState>();
 

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -12,12 +12,6 @@ void main() {
       expect(terminalViewportPadding.bottom, 0);
     });
 
-    test('positions selection actions above the bottom safe area', () {
-      const mediaQuery = MediaQueryData(padding: EdgeInsets.only(bottom: 34));
-
-      expect(selectionActionsBottomOffset(mediaQuery), 46);
-    });
-
     test('positions the upsell snackbar above visible bottom chrome only', () {
       const mediaQuery = MediaQueryData(padding: EdgeInsets.only(bottom: 34));
 

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -1416,7 +1416,7 @@ void main() {
     );
 
     test(
-      'keeps overlay hidden during tmux touch scrolling until selection',
+      'keeps overlay visible in native mode during tmux touch scrolling',
       () {
         expect(
           shouldShowNativeSelectionOverlay(
@@ -1424,7 +1424,7 @@ void main() {
             routesTouchScrollToTerminal: true,
             revealOverlayInTouchScrollMode: false,
           ),
-          isFalse,
+          isTrue,
         );
       },
     );
@@ -1443,7 +1443,7 @@ void main() {
       );
     });
 
-    test('hides only the temporary tmux overlay when selection collapses', () {
+    test('exits mobile selection mode when a tmux selection collapses', () {
       expect(
         resolveNativeSelectionOverlayChange(
           isMobilePlatform: true,
@@ -1451,7 +1451,7 @@ void main() {
           revealOverlayInTouchScrollMode: true,
           selection: const TextSelection.collapsed(offset: 3),
         ),
-        NativeSelectionOverlayChange.hideTemporaryOverlay,
+        NativeSelectionOverlayChange.exitSelectionMode,
       );
     });
 

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -6064,6 +6064,21 @@ void main() {
         isFalse,
       );
     });
+
+    test('suppresses the keyboard when touch duration reaches long press', () {
+      expect(
+        shouldRequestKeyboardForTerminalPointerUp(
+          pointerKind: PointerDeviceKind.touch,
+          activeTouchPointers: 1,
+          hadMultipleTouchPointers: false,
+          movedBeyondTapSlop: false,
+          pressedBeyondLongPressTimeout: false,
+          readOnly: false,
+          touchPressDuration: terminalKeyboardTapLongPressTimeout,
+        ),
+        isFalse,
+      );
+    });
   });
 
   group('TerminalTextInputHandler compared with TextField', () {

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -4824,6 +4824,44 @@ void main() {
     });
 
     testWidgets(
+      'opens the keyboard after a touch tap when focus keyboard is disabled',
+      (tester) async {
+        final terminal = Terminal();
+        final focusNode = FocusNode();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TerminalTextInputHandler(
+                terminal: terminal,
+                focusNode: focusNode,
+                deleteDetection: true,
+                showKeyboardOnFocus: false,
+                child: const SizedBox.expand(key: ValueKey('terminal-child')),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(tester.testTextInput.isVisible, isFalse);
+
+        final target =
+            tester.getTopLeft(find.byType(TerminalTextInputHandler)) +
+            const Offset(40, 40);
+        await tester.tapAt(target);
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(tester.testTextInput.isVisible, isTrue);
+
+        focusNode.dispose();
+      },
+    );
+
+    testWidgets(
       'does not reopen the keyboard when the platform closes it while focused',
       (tester) async {
         final terminal = Terminal();
@@ -4863,6 +4901,51 @@ void main() {
         );
       },
     );
+
+    testWidgets('does not open the keyboard after a touch long press', (
+      tester,
+    ) async {
+      final terminal = Terminal();
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalTextInputHandler(
+              terminal: terminal,
+              focusNode: focusNode,
+              deleteDetection: true,
+              child: const SizedBox.expand(key: ValueKey('terminal-child')),
+            ),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      expect(focusNode.hasFocus, isTrue);
+      expect(tester.testTextInput.isVisible, isTrue);
+
+      tester.testTextInput.hide();
+      await tester.pump();
+
+      expect(tester.testTextInput.isVisible, isFalse);
+
+      final target =
+          tester.getTopLeft(find.byType(TerminalTextInputHandler)) +
+          const Offset(40, 40);
+      final gesture = await tester.createGesture();
+      await gesture.down(target);
+      await tester.pump(terminalKeyboardTapLongPressTimeout);
+      await gesture.up();
+      await tester.pump();
+
+      expect(focusNode.hasFocus, isTrue);
+      expect(tester.testTextInput.isVisible, isFalse);
+
+      focusNode.dispose();
+    });
 
     testWidgets('does not open the keyboard after a touch drag', (
       tester,
@@ -5891,6 +5974,7 @@ void main() {
           activeTouchPointers: 1,
           hadMultipleTouchPointers: false,
           movedBeyondTapSlop: false,
+          pressedBeyondLongPressTimeout: false,
           readOnly: false,
         ),
         isTrue,
@@ -5904,6 +5988,7 @@ void main() {
           activeTouchPointers: 1,
           hadMultipleTouchPointers: false,
           movedBeyondTapSlop: true,
+          pressedBeyondLongPressTimeout: false,
           readOnly: false,
         ),
         isFalse,
@@ -5917,6 +6002,7 @@ void main() {
           activeTouchPointers: 2,
           hadMultipleTouchPointers: true,
           movedBeyondTapSlop: false,
+          pressedBeyondLongPressTimeout: false,
           readOnly: false,
         ),
         isFalse,
@@ -5930,6 +6016,7 @@ void main() {
           activeTouchPointers: 1,
           hadMultipleTouchPointers: true,
           movedBeyondTapSlop: false,
+          pressedBeyondLongPressTimeout: false,
           readOnly: false,
         ),
         isFalse,
@@ -5943,6 +6030,7 @@ void main() {
           activeTouchPointers: 0,
           hadMultipleTouchPointers: false,
           movedBeyondTapSlop: false,
+          pressedBeyondLongPressTimeout: true,
           readOnly: false,
         ),
         isTrue,
@@ -5956,7 +6044,22 @@ void main() {
           activeTouchPointers: 1,
           hadMultipleTouchPointers: false,
           movedBeyondTapSlop: false,
+          pressedBeyondLongPressTimeout: false,
           readOnly: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('suppresses the keyboard after a long touch press', () {
+      expect(
+        shouldRequestKeyboardForTerminalPointerUp(
+          pointerKind: PointerDeviceKind.touch,
+          activeTouchPointers: 1,
+          hadMultipleTouchPointers: false,
+          movedBeyondTapSlop: false,
+          pressedBeyondLongPressTimeout: true,
+          readOnly: false,
         ),
         isFalse,
       );


### PR DESCRIPTION
## Summary

- Replaces the mobile terminal copy/paste overlay path with direct Flutter `Selectable` support in `MonkeyRenderTerminal`.
- Wraps mobile terminal content in `SelectionArea` so native system handles/toolbars operate over terminal text.
- Prevents touch long-press selection from opening the mobile keyboard and disables competing xterm selection recognizers while system selection owns gestures.
- Adds a device integration test covering terminal system selection on simulator/emulator.

## Validation

- `flutter analyze`
- `flutter test`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer flutter test integration_test/terminal_system_selection_test.dart -d 64373A13-11D3-4298-B8CA-00AC1C1F7344 --flavor production`
- `JAVA_HOME="$(/usr/libexec/java_home -v 17)" flutter test integration_test/terminal_system_selection_test.dart -d emulator-5554 --flavor production`
