### PR TITLE
Remove hosts pull-to-refresh

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -718,30 +718,27 @@ class HostsPanel extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     AsyncValue<List<Host>> hostsAsync,
-  ) => RefreshIndicator(
-    onRefresh: () => _refreshHosts(context, ref),
-    child: hostsAsync.when(
-      loading: () => _buildCenteredHostsState(
-        child: const CircularProgressIndicator(strokeWidth: 2),
-      ),
-      error: (error, _) => _buildCenteredHostsState(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.error_outline,
-              size: 40,
-              color: Theme.of(context).colorScheme.error,
-            ),
-            const SizedBox(height: 12),
-            Text('Error: $error'),
-          ],
-        ),
-      ),
-      data: (hosts) => hosts.isEmpty
-          ? _buildEmptyState(context)
-          : _buildHostsList(context, ref, hosts),
+  ) => hostsAsync.when(
+    loading: () => _buildCenteredHostsState(
+      child: const CircularProgressIndicator(strokeWidth: 2),
     ),
+    error: (error, _) => _buildCenteredHostsState(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.error_outline,
+            size: 40,
+            color: Theme.of(context).colorScheme.error,
+          ),
+          const SizedBox(height: 12),
+          Text('Error: $error'),
+        ],
+      ),
+    ),
+    data: (hosts) => hosts.isEmpty
+        ? _buildEmptyState(context)
+        : _buildHostsList(context, ref, hosts),
   );
 
   Widget _buildEmptyState(BuildContext context) => _buildCenteredHostsState(
@@ -814,7 +811,6 @@ class HostsPanel extends ConsumerWidget {
   }
 
   Widget _buildCenteredHostsState({required Widget child}) => CustomScrollView(
-    physics: const AlwaysScrollableScrollPhysics(),
     slivers: [
       SliverFillRemaining(
         hasScrollBody: false,
@@ -833,7 +829,6 @@ class HostsPanel extends ConsumerWidget {
     WidgetRef ref,
     List<Host> hosts,
   ) => ReorderableListView.builder(
-    physics: const AlwaysScrollableScrollPhysics(),
     padding: const EdgeInsets.symmetric(vertical: 4),
     buildDefaultDragHandles: false,
     itemCount: hosts.length,
@@ -868,11 +863,6 @@ class HostsPanel extends ConsumerWidget {
       newIndex: newIndex,
     );
     await ref.read(hostRepositoryProvider).reorderByIds(reorderedIds);
-  }
-
-  Future<void> _refreshHosts(BuildContext context, WidgetRef ref) async {
-    ref.invalidate(allHostsProvider);
-    await ref.read(allHostsProvider.future);
   }
 }
 

--- a/test/widget/hosts_screen_test.dart
+++ b/test/widget/hosts_screen_test.dart
@@ -157,9 +157,7 @@ void main() {
     expect(find.text('Imported host'), findsOneWidget);
   });
 
-  testWidgets('loading state stays scrollable for pull to refresh', (
-    tester,
-  ) async {
+  testWidgets('loading state remains centered', (tester) async {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     addTearDown(db.close);
 


### PR DESCRIPTION
## Summary

- Removed the dead pull-to-refresh wrapper from the hosts/home list.
- Dropped the always-scrollable physics that existed only to enable that gesture.
- Kept the SFTP browser pull-to-refresh gesture intact.

## Validation

- `flutter analyze`
- `flutter test test/widget/hosts_screen_test.dart`
- `flutter test`
