### PR TITLE
fix: apply toolbar modifiers before terminal text output

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -4107,12 +4107,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       // keyInput(TerminalKey.enter) path already produces '\r', so we
       // only normalize single-'\n' to avoid rewriting legitimate LF
       // characters in pasted or multi-char input.
-      var output = data == '\n' ? '\r' : data;
-
-      // Apply toolbar modifier state to system keyboard input.
-      // When the user toggles Ctrl on the toolbar then types on the system
-      // keyboard, we convert the character to the corresponding control code.
-      output = _toolbarController.applySystemKeyboardModifiers(output);
+      final output = data == '\n' ? '\r' : data;
 
       _shell?.write(utf8.encode(output));
     };
@@ -6456,6 +6451,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         shift: _toolbarController.isShiftActive,
       ),
       consumeTerminalKeyModifiers: _toolbarController.consumeOneShot,
+      applyTerminalTextInputModifiers:
+          _toolbarController.applySystemKeyboardModifiers,
       hasActiveToolbarModifier: () =>
           _toolbarController.isCtrlActive || _toolbarController.isAltActive,
       readOnly: _showsNativeSelectionOverlay || overlayMessage != null,

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -892,10 +892,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
 
     final appendedText = delta.appendedText;
     if (appendedText.isNotEmpty) {
-      final terminalText =
-          widget.applyTerminalTextInputModifiers?.call(appendedText) ??
-          appendedText;
-      widget.terminal.textInput(terminalText);
+      widget.terminal.textInput(_applyTerminalTextInputModifiers(appendedText));
     }
 
     _lastSentText = currentText;
@@ -1447,6 +1444,16 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       delta.deleteCursorOffset -
       delta.deletedCount +
       delta.appendedText.characters.length;
+
+  String _applyTerminalTextInputModifiers(String text) {
+    final applyModifiers = widget.applyTerminalTextInputModifiers;
+    if (applyModifiers == null) {
+      return text;
+    }
+
+    final normalizedText = text == '\n' ? '\r' : text;
+    return applyModifiers(normalizedText);
+  }
 
   int _deltaCursorScore(
     ({int deletedCount, String appendedText, int deleteCursorOffset}) delta,

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -63,6 +63,9 @@ typedef TerminalTextBeforeCursorResolver = String? Function();
 typedef TerminalKeyModifierResolver =
     ({bool ctrl, bool alt, bool shift}) Function();
 
+/// Applies active toolbar modifiers to soft-keyboard terminal text.
+typedef TerminalTextInputModifierApplier = String Function(String text);
+
 /// Whether a pointer-up event should request the terminal soft keyboard.
 ///
 /// Touch input should only open the keyboard after a tap-like gesture. Scrolls
@@ -157,6 +160,7 @@ class TerminalTextInputHandler extends StatefulWidget {
     this.resolveTextBeforeCursor,
     this.resolveTerminalKeyModifiers,
     this.consumeTerminalKeyModifiers,
+    this.applyTerminalTextInputModifiers,
     this.hasActiveToolbarModifier,
     this.readOnly = false,
     this.tapToShowKeyboard = true,
@@ -201,6 +205,9 @@ class TerminalTextInputHandler extends StatefulWidget {
 
   /// Consumes one-shot toolbar modifiers after a terminal key action.
   final VoidCallback? consumeTerminalKeyModifiers;
+
+  /// Applies toolbar modifiers before text reaches the terminal output stream.
+  final TerminalTextInputModifierApplier? applyTerminalTextInputModifiers;
 
   /// Whether a toolbar modifier (Ctrl or Alt) is currently active.
   ///
@@ -885,7 +892,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
 
     final appendedText = delta.appendedText;
     if (appendedText.isNotEmpty) {
-      widget.terminal.textInput(appendedText);
+      final terminalText =
+          widget.applyTerminalTextInputModifiers?.call(appendedText) ??
+          appendedText;
+      widget.terminal.textInput(terminalText);
     }
 
     _lastSentText = currentText;

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -7242,6 +7242,31 @@ void main() {
       await _disposeTerminalHarness(tester, harness);
     });
 
+    testWidgets('normalizes soft-keyboard newline before applying modifiers', (
+      tester,
+    ) async {
+      var modifierActive = true;
+      final harness = await _pumpTerminalHarness(
+        tester,
+        hasActiveToolbarModifier: () => modifierActive,
+        applyTerminalTextInputModifiers: (text) {
+          expect(text, '\r');
+          modifierActive = false;
+          return '\x1b\r';
+        },
+      );
+
+      tester.testTextInput.updateEditingValue(
+        _editingValue('\n', selectionOffset: 1),
+      );
+      await tester.pump();
+
+      expect(harness.terminalOutput, <String>['\x1b\r']);
+      expect(modifierActive, isFalse);
+
+      await _disposeTerminalHarness(tester, harness);
+    });
+
     testWidgets(
       'controller clears the IME buffer after external terminal actions',
       (tester) async {

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -740,6 +740,7 @@ Future<_TerminalHarness> _pumpTerminalHarness(
   String Function()? resolveTextBeforeCursor,
   TerminalKeyModifierResolver? resolveTerminalKeyModifiers,
   VoidCallback? consumeTerminalKeyModifiers,
+  TerminalTextInputModifierApplier? applyTerminalTextInputModifiers,
   ValueGetter<bool>? hasActiveToolbarModifier,
   TerminalTextInputHandlerController? controller,
 }) async {
@@ -762,6 +763,7 @@ Future<_TerminalHarness> _pumpTerminalHarness(
           resolveTextBeforeCursor: resolveTextBeforeCursor,
           resolveTerminalKeyModifiers: resolveTerminalKeyModifiers,
           consumeTerminalKeyModifiers: consumeTerminalKeyModifiers,
+          applyTerminalTextInputModifiers: applyTerminalTextInputModifiers,
           hasActiveToolbarModifier: hasActiveToolbarModifier,
           child: const SizedBox.expand(),
         ),
@@ -7206,6 +7208,38 @@ void main() {
       );
 
       focusNode.dispose();
+    });
+
+    testWidgets('applies modifiers before soft-keyboard text is emitted', (
+      tester,
+    ) async {
+      var modifierActive = true;
+      final harness = await _pumpTerminalHarness(
+        tester,
+        hasActiveToolbarModifier: () => modifierActive,
+        applyTerminalTextInputModifiers: (text) {
+          expect(text, 'q');
+          modifierActive = false;
+          return '\x11';
+        },
+      );
+
+      tester.testTextInput.updateEditingValue(
+        _editingValue('q', selectionOffset: 1),
+      );
+      await tester.pump();
+
+      expect(harness.terminalOutput, <String>['\x11']);
+      expect(modifierActive, isFalse);
+      expect(
+        _terminalTextInputClient(tester).currentTextEditingValue,
+        const TextEditingValue(
+          text: _deleteDetectionMarker,
+          selection: TextSelection.collapsed(offset: 2),
+        ),
+      );
+
+      await _disposeTerminalHarness(tester, harness);
     });
 
     testWidgets(


### PR DESCRIPTION
## Summary

- Apply toolbar modifiers inside `TerminalTextInputHandler` before soft-keyboard text is emitted through the terminal output stream.
- Stop re-applying toolbar modifiers in `TerminalScreen`'s `Terminal.onOutput` callback, which could miss the active one-shot modifier after synchronous terminal output.
- Add a regression test covering Ctrl+Q-style soft-keyboard text being emitted as the control character immediately.

## Validation

- `flutter analyze`
- `flutter test`
