### PR TITLE
fix(ci): avoid automatic TestFlight quota exhaustion

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -56,7 +56,12 @@ jobs:
       build-codename: ${{ needs.compute-version.outputs.build-codename }}
       enable-diagnostics: true
       flavor: private
-      deploy-ios-to: testflight
+      # Main can receive many app changes in a day; uploading each one to
+      # TestFlight exhausts App Store Connect's daily upload quota and makes the
+      # whole workflow fail. Keep the iOS build artifact for validation, and
+      # reserve TestFlight uploads for explicit deploy workflows.
+      deploy-ios-to: none
+      build-ios-unsigned-ipa: true
       deploy-android-to: internal
     secrets:
       ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}


### PR DESCRIPTION
## Summary

- Stop the automatic `Deploy Private` workflow on `main` from uploading every iOS build to TestFlight.
- Keep the iOS validation path by producing an unsigned private IPA artifact instead.
- Leave explicit TestFlight deploy paths (`/deploy` PR preview and internal release workflow) unchanged.

## Root cause

The latest failing `main` run failed after the iOS archive succeeded because App Store Connect rejected the TestFlight upload with `409 Upload limit reached`. The automatic private deploy workflow was uploading iOS builds on every app-relevant `main` push, so multiple merges and preview deploys could exhaust Apple's daily app upload quota and fail otherwise healthy workflows.

## Validation

- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/develop.yml')"`
