### PR TITLE
fix: back off tmux channel recovery

### DIFF
--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -2139,7 +2139,7 @@ class AgentSessionDiscoveryService {
   // ── Helpers ────────────────────────────────────────────────────────────
 
   Future<String> _exec(SshSession session, String command) =>
-      runQueuedSshExec(session.connectionId, () async {
+      session.runQueuedExec(() async {
         final execSession = await session.execute(
           '$_profileSourcingPrefix$command',
         );

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/tmux_state.dart';
+import 'ssh_exec_queue.dart';
 import 'ssh_service.dart';
 
 const _genericSessionSummaries = <String>{
@@ -2137,20 +2138,21 @@ class AgentSessionDiscoveryService {
 
   // ── Helpers ────────────────────────────────────────────────────────────
 
-  Future<String> _exec(SshSession session, String command) async {
-    final execSession = await session.execute(
-      '$_profileSourcingPrefix$command',
-    );
-    try {
-      final results = await Future.wait([
-        execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
-        execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
-      ]).timeout(const Duration(seconds: 10), onTimeout: () => ['', '']);
-      return results[0];
-    } finally {
-      execSession.close();
-    }
-  }
+  Future<String> _exec(SshSession session, String command) =>
+      runQueuedSshExec(session.connectionId, () async {
+        final execSession = await session.execute(
+          '$_profileSourcingPrefix$command',
+        );
+        try {
+          final results = await Future.wait([
+            execSession.stdout.cast<List<int>>().transform(utf8.decoder).join(),
+            execSession.stderr.cast<List<int>>().transform(utf8.decoder).join(),
+          ]).timeout(const Duration(seconds: 10), onTimeout: () => ['', '']);
+          return results[0];
+        } finally {
+          execSession.close();
+        }
+      }, priority: SshExecPriority.low);
 
   Future<List<String>> _listCopilotWorkspacePaths(
     SshSession session,

--- a/lib/domain/services/ssh_exec_queue.dart
+++ b/lib/domain/services/ssh_exec_queue.dart
@@ -157,6 +157,9 @@ class _SshExecQueue {
           },
         );
         _drain();
+        if (_activeCount == 0 && pendingCount == 0) {
+          _execQueues.remove(connectionId);
+        }
       }),
     );
   }

--- a/lib/domain/services/ssh_exec_queue.dart
+++ b/lib/domain/services/ssh_exec_queue.dart
@@ -1,0 +1,192 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+import 'diagnostics_log_service.dart';
+
+const _maxExecJobsPerConnection = 2;
+const _maxLowPriorityExecJobsPerConnection = 1;
+
+final _execQueues = <int, _SshExecQueue>{};
+
+/// Priority for queued SSH exec jobs.
+enum SshExecPriority {
+  /// User-visible or correctness-critical work.
+  normal,
+
+  /// Background prefetching and discovery work that should not crowd out UI.
+  low,
+}
+
+/// Runs [operation] through a bounded per-connection SSH exec queue.
+///
+/// SSH exec channels are single-use, so this does not reuse a channel. Instead,
+/// it limits how many short-lived exec channels MonkeySSH opens concurrently on
+/// each connection, preserving room for the terminal and tmux watcher channels.
+Future<T> runQueuedSshExec<T>(
+  int connectionId,
+  Future<T> Function() operation, {
+  SshExecPriority priority = SshExecPriority.normal,
+}) {
+  final queue = _execQueues.putIfAbsent(
+    connectionId,
+    () => _SshExecQueue(connectionId),
+  );
+  return queue.run(operation, priority: priority);
+}
+
+/// Clears queued exec state for tests.
+@visibleForTesting
+void resetQueuedSshExecsForTesting() {
+  _execQueues.clear();
+}
+
+/// Returns the number of active queued exec jobs for tests.
+@visibleForTesting
+int activeQueuedSshExecCountForTesting(int connectionId) =>
+    _execQueues[connectionId]?.activeCount ?? 0;
+
+/// Returns the number of pending queued exec jobs for tests.
+@visibleForTesting
+int pendingQueuedSshExecCountForTesting(int connectionId) =>
+    _execQueues[connectionId]?.pendingCount ?? 0;
+
+class _SshExecQueue {
+  _SshExecQueue(this.connectionId);
+
+  final int connectionId;
+  final _normalJobs = Queue<_QueuedSshExecJob<dynamic>>();
+  final _lowJobs = Queue<_QueuedSshExecJob<dynamic>>();
+  int _activeCount = 0;
+  int _activeLowPriorityCount = 0;
+  int _nextJobId = 0;
+
+  int get activeCount => _activeCount;
+
+  int get pendingCount => _normalJobs.length + _lowJobs.length;
+
+  Future<T> run<T>(
+    Future<T> Function() operation, {
+    required SshExecPriority priority,
+  }) {
+    final job = _QueuedSshExecJob<T>(
+      id: _nextJobId++,
+      priority: priority,
+      enqueuedAt: DateTime.now(),
+      operation: operation,
+    );
+    switch (priority) {
+      case SshExecPriority.normal:
+        _normalJobs.add(job);
+      case SshExecPriority.low:
+        _lowJobs.add(job);
+    }
+    if (_activeCount >= _maxExecJobsPerConnection || pendingCount > 1) {
+      DiagnosticsLogService.instance.debug(
+        'ssh.exec_queue',
+        'queued',
+        fields: {
+          'connectionId': connectionId,
+          'jobId': job.id,
+          'priority': priority.name,
+          'activeCount': _activeCount,
+          'pendingCount': pendingCount,
+        },
+      );
+    }
+    _drain();
+    return job.future;
+  }
+
+  void _drain() {
+    while (_activeCount < _maxExecJobsPerConnection) {
+      final job = _takeNextJob();
+      if (job == null) return;
+      _start(job);
+    }
+  }
+
+  _QueuedSshExecJob<dynamic>? _takeNextJob() {
+    if (_normalJobs.isNotEmpty) {
+      return _normalJobs.removeFirst();
+    }
+    if (_lowJobs.isEmpty ||
+        _activeLowPriorityCount >= _maxLowPriorityExecJobsPerConnection) {
+      return null;
+    }
+    return _lowJobs.removeFirst();
+  }
+
+  void _start(_QueuedSshExecJob<dynamic> job) {
+    _activeCount += 1;
+    if (job.priority == SshExecPriority.low) {
+      _activeLowPriorityCount += 1;
+    }
+    final startedAt = DateTime.now();
+    DiagnosticsLogService.instance.debug(
+      'ssh.exec_queue',
+      'start',
+      fields: {
+        'connectionId': connectionId,
+        'jobId': job.id,
+        'priority': job.priority.name,
+        'queuedMs': startedAt.difference(job.enqueuedAt).inMilliseconds,
+        'activeCount': _activeCount,
+        'pendingCount': pendingCount,
+      },
+    );
+    unawaited(
+      Future.sync(
+        job.operation,
+      ).then<void>(job.complete, onError: job.completeError).whenComplete(() {
+        _activeCount -= 1;
+        if (job.priority == SshExecPriority.low) {
+          _activeLowPriorityCount -= 1;
+        }
+        DiagnosticsLogService.instance.debug(
+          'ssh.exec_queue',
+          'complete',
+          fields: {
+            'connectionId': connectionId,
+            'jobId': job.id,
+            'priority': job.priority.name,
+            'durationMs': DateTime.now().difference(startedAt).inMilliseconds,
+            'activeCount': _activeCount,
+            'pendingCount': pendingCount,
+          },
+        );
+        _drain();
+      }),
+    );
+  }
+}
+
+class _QueuedSshExecJob<T> {
+  _QueuedSshExecJob({
+    required this.id,
+    required this.priority,
+    required this.enqueuedAt,
+    required this.operation,
+  });
+
+  final int id;
+  final SshExecPriority priority;
+  final DateTime enqueuedAt;
+  final Future<T> Function() operation;
+  final _completer = Completer<T>();
+
+  Future<T> get future => _completer.future;
+
+  void complete(T value) {
+    if (!_completer.isCompleted) {
+      _completer.complete(value);
+    }
+  }
+
+  void completeError(Object error, StackTrace stackTrace) {
+    if (!_completer.isCompleted) {
+      _completer.completeError(error, stackTrace);
+    }
+  }
+}

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -17,6 +17,7 @@ import 'clipboard_sharing_service.dart';
 import 'diagnostics_log_service.dart';
 import 'host_key_prompt_handler_provider.dart';
 import 'host_key_verification.dart';
+import 'ssh_exec_queue.dart';
 import 'terminal_hyperlink_tracker.dart';
 
 /// Connection state for an SSH session.
@@ -2156,6 +2157,17 @@ class SshSession {
       rethrow;
     }
   }
+
+  /// Runs short-lived exec work through this connection's bounded exec queue.
+  ///
+  /// The callback should open, consume, and close any SSH exec channel it uses.
+  /// Long-lived channels such as the interactive shell and tmux control-mode
+  /// watcher should not use this queue because they would permanently occupy a
+  /// short-command slot.
+  Future<T> runQueuedExec<T>(
+    Future<T> Function() operation, {
+    SshExecPriority priority = SshExecPriority.normal,
+  }) => runQueuedSshExec(connectionId, operation, priority: priority);
 
   /// Start an SFTP session.
   Future<SftpClient> sftp() => client.sftp();

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/agent_launch_preset.dart';
 import '../models/tmux_state.dart';
 import 'diagnostics_log_service.dart';
+import 'ssh_exec_queue.dart';
 import 'ssh_service.dart';
 
 /// Error thrown when a tmux command channel ends before confirming completion.
@@ -246,7 +247,7 @@ class TmuxService {
       return;
     }
     try {
-      await _refreshInstalledAgentTools(session);
+      await _refreshInstalledAgentTools(session, priority: SshExecPriority.low);
     } on Object catch (error) {
       DiagnosticsLogService.instance.debug(
         'tmux.agent',
@@ -259,7 +260,10 @@ class TmuxService {
     }
   }
 
-  Future<Set<AgentLaunchTool>> _refreshInstalledAgentTools(SshSession session) {
+  Future<Set<AgentLaunchTool>> _refreshInstalledAgentTools(
+    SshSession session, {
+    SshExecPriority priority = SshExecPriority.normal,
+  }) {
     final existingRequest = _installedAgentToolRequests[session.connectionId];
     if (existingRequest != null) {
       DiagnosticsLogService.instance.debug(
@@ -276,7 +280,11 @@ class TmuxService {
       fields: {'connectionId': session.connectionId},
     );
     final request = () async {
-      final output = await _exec(session, buildAgentToolDetectionCommand());
+      final output = await _exec(
+        session,
+        buildAgentToolDetectionCommand(),
+        priority: priority,
+      );
       final installed = parseInstalledAgentTools(output);
       _installedAgentToolsCache[session.connectionId] =
           _CachedInstalledAgentTools(
@@ -987,7 +995,17 @@ class TmuxService {
   /// marker arrives. Some SSH servers leave exec streams open after the
   /// command exits, so waiting for stream completion can turn successful tmux
   /// actions into apparent hangs.
-  Future<String> _exec(SshSession session, String command) async {
+  Future<String> _exec(
+    SshSession session,
+    String command, {
+    SshExecPriority priority = SshExecPriority.normal,
+  }) => runQueuedSshExec(
+    session.connectionId,
+    () => _execUnqueued(session, command),
+    priority: priority,
+  );
+
+  Future<String> _execUnqueued(SshSession session, String command) async {
     final startedAt = DateTime.now();
     final wrappedCommand = _wrapCommand(session, command);
     final execSession = await _openExec(

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -57,6 +57,8 @@ class TmuxService {
       <_TmuxWindowWatchKey, _TmuxWindowChangeObserver>{};
   static final _windowListRequests =
       <_TmuxWindowWatchKey, Future<List<TmuxWindow>>>{};
+  static final _windowSnapshotCache = <_TmuxWindowWatchKey, List<TmuxWindow>>{};
+  static final _execChannelBackoffs = <int, _TmuxExecChannelBackoff>{};
 
   static const _execDoneMarker = '__flutty_tmux_exec_done__';
   static const _installedAgentToolsFreshTtl = Duration(minutes: 30);
@@ -80,6 +82,10 @@ class TmuxService {
     _profileSourceCache.remove(connectionId);
     _installedAgentToolsCache.remove(connectionId);
     _installedAgentToolRequests.remove(connectionId);
+    _execChannelBackoffs.remove(connectionId);
+    _windowSnapshotCache.removeWhere(
+      (key, _) => key.connectionId == connectionId,
+    );
     _windowListRequests.removeWhere(
       (key, _) => key.connectionId == connectionId,
     );
@@ -229,6 +235,14 @@ class TmuxService {
     if (cached != null &&
         DateTime.now().difference(cached.cachedAt) <
             _installedAgentToolsFreshTtl) {
+      return;
+    }
+    if (_isExecChannelCoolingDown(session)) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.agent',
+        'tool_detection_prefetch_deferred',
+        fields: {'connectionId': session.connectionId},
+      );
       return;
     }
     try {
@@ -463,6 +477,20 @@ class TmuxService {
       connectionId: session.connectionId,
       sessionName: sessionName,
     );
+    if (_isExecChannelCoolingDown(session)) {
+      final cachedWindows = _windowSnapshotCache[key];
+      if (cachedWindows != null && cachedWindows.isNotEmpty) {
+        DiagnosticsLogService.instance.warning(
+          'tmux.query',
+          'list_windows_cached_during_backoff',
+          fields: {
+            'connectionId': session.connectionId,
+            'windowCount': cachedWindows.length,
+          },
+        );
+        return cachedWindows;
+      }
+    }
     final existingRequest = _windowListRequests[key];
     if (existingRequest != null) {
       DiagnosticsLogService.instance.debug(
@@ -497,29 +525,57 @@ class TmuxService {
     );
     final quotedName = _shellQuote(sessionName);
     const sep = r'${SEP}';
-    final output = await _exec(
-      session,
-      r'SEP=$(printf "\037"); '
-      'tmux -u list-windows -t $quotedName -F '
-      '"#{window_index}$sep#{window_name}$sep#{window_active}$sep'
-      '#{pane_current_command}$sep#{pane_current_path}$sep'
-      '#{window_flags}$sep#{pane_title}$sep#{window_activity}$sep'
-      '#{pane_start_command}$sep#{@flutty_agent_tool}"',
-    );
-    final windows = List<TmuxWindow>.unmodifiable(
-      _parseLines(output, TmuxWindow.fromTmuxFormat),
-    );
-    DiagnosticsLogService.instance.info(
-      'tmux.query',
-      'list_windows_complete',
-      fields: {
-        'connectionId': session.connectionId,
-        'windowCount': windows.length,
-        'activeWindowCount': windows.where((window) => window.isActive).length,
-        'alertWindowCount': windows.where((window) => window.hasAlert).length,
-      },
-    );
-    return windows;
+    try {
+      final output = await _exec(
+        session,
+        r'SEP=$(printf "\037"); '
+        'tmux -u list-windows -t $quotedName -F '
+        '"#{window_index}$sep#{window_name}$sep#{window_active}$sep'
+        '#{pane_current_command}$sep#{pane_current_path}$sep'
+        '#{window_flags}$sep#{pane_title}$sep#{window_activity}$sep'
+        '#{pane_start_command}$sep#{@flutty_agent_tool}"',
+      );
+      final windows = List<TmuxWindow>.unmodifiable(
+        _parseLines(output, TmuxWindow.fromTmuxFormat),
+      );
+      if (windows.isNotEmpty) {
+        _cacheWindowSnapshot(session, sessionName, windows);
+      }
+      DiagnosticsLogService.instance.info(
+        'tmux.query',
+        'list_windows_complete',
+        fields: {
+          'connectionId': session.connectionId,
+          'windowCount': windows.length,
+          'activeWindowCount': windows
+              .where((window) => window.isActive)
+              .length,
+          'alertWindowCount': windows.where((window) => window.hasAlert).length,
+        },
+      );
+      return windows;
+    } on Object catch (error) {
+      final cachedWindows =
+          _windowSnapshotCache[_TmuxWindowWatchKey(
+            connectionId: session.connectionId,
+            sessionName: sessionName,
+          )];
+      if (cachedWindows != null &&
+          cachedWindows.isNotEmpty &&
+          shouldUseCachedTmuxWindowsAfterListFailure(error)) {
+        DiagnosticsLogService.instance.warning(
+          'tmux.query',
+          'list_windows_cached_after_failure',
+          fields: {
+            'connectionId': session.connectionId,
+            'windowCount': cachedWindows.length,
+            'errorType': error.runtimeType,
+          },
+        );
+        return cachedWindows;
+      }
+      rethrow;
+    }
   }
 
   /// Returns the active pane working directory for [sessionName], if tmux
@@ -769,6 +825,76 @@ class TmuxService {
 
   // ── Helpers ────────────────────────────────────────────────────────────
 
+  bool _isExecChannelCoolingDown(SshSession session) {
+    final backoff = _execChannelBackoffs[session.connectionId];
+    if (backoff == null) return false;
+    if (backoff.cooldownUntil.isAfter(DateTime.now())) {
+      return true;
+    }
+    _execChannelBackoffs.remove(session.connectionId);
+    return false;
+  }
+
+  void _recordExecChannelFailure(int connectionId, Object error) {
+    final failureCount =
+        (_execChannelBackoffs[connectionId]?.failureCount ?? 0) + 1;
+    final delay = resolveTmuxExecChannelBackoffDelay(failureCount);
+    _execChannelBackoffs[connectionId] = _TmuxExecChannelBackoff(
+      failureCount: failureCount,
+      cooldownUntil: DateTime.now().add(delay),
+    );
+    DiagnosticsLogService.instance.warning(
+      'tmux.exec',
+      'channel_backoff',
+      fields: {
+        'connectionId': connectionId,
+        'failureCount': failureCount,
+        'delayMs': delay.inMilliseconds,
+        'errorType': error.runtimeType,
+      },
+    );
+  }
+
+  void _clearExecChannelBackoff(int connectionId) {
+    if (_execChannelBackoffs.remove(connectionId) != null) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.exec',
+        'channel_backoff_cleared',
+        fields: {'connectionId': connectionId},
+      );
+    }
+  }
+
+  void _cacheWindowSnapshot(
+    SshSession session,
+    String sessionName,
+    List<TmuxWindow> windows,
+  ) {
+    if (windows.isEmpty) return;
+    _windowSnapshotCache[_TmuxWindowWatchKey(
+      connectionId: session.connectionId,
+      sessionName: sessionName,
+    )] = List<TmuxWindow>.unmodifiable(
+      windows,
+    );
+  }
+
+  void _applyCachedWindowEvent(
+    SshSession session,
+    String sessionName,
+    TmuxWindowChangeEvent event,
+  ) {
+    final key = _TmuxWindowWatchKey(
+      connectionId: session.connectionId,
+      sessionName: sessionName,
+    );
+    final cachedWindows = _windowSnapshotCache[key];
+    if (cachedWindows == null || cachedWindows.isEmpty) return;
+    _windowSnapshotCache[key] = List<TmuxWindow>.unmodifiable(
+      applyTmuxWindowChangeEvent(cachedWindows, event),
+    );
+  }
+
   /// Returns the profile source prefix for this session's login shell.
   ///
   /// Only sources the profile file appropriate for the user's shell:
@@ -810,7 +936,7 @@ class TmuxService {
     SshSession session,
     String command, {
     SSHPtyConfig? pty,
-  }) {
+  }) async {
     DiagnosticsLogService.instance.debug(
       'tmux.exec',
       'open_start',
@@ -821,26 +947,35 @@ class TmuxService {
       },
     );
     final openFuture = session.execute(command, pty: pty);
-    return openFuture.timeout(
-      _execOpenTimeout,
-      onTimeout: () {
-        DiagnosticsLogService.instance.warning(
-          'tmux.exec',
-          'open_timeout',
-          fields: {
-            'connectionId': session.connectionId,
-            'commandKind': _diagnosticTmuxCommandKind(command),
-            'timeoutMs': _execOpenTimeout.inMilliseconds,
-            'pty': pty != null,
-          },
-        );
-        openFuture.then((exec) => exec.close()).ignore();
-        throw TimeoutException(
-          'Timed out opening SSH exec channel',
-          _execOpenTimeout,
-        );
-      },
-    );
+    try {
+      final exec = await openFuture.timeout(
+        _execOpenTimeout,
+        onTimeout: () {
+          DiagnosticsLogService.instance.warning(
+            'tmux.exec',
+            'open_timeout',
+            fields: {
+              'connectionId': session.connectionId,
+              'commandKind': _diagnosticTmuxCommandKind(command),
+              'timeoutMs': _execOpenTimeout.inMilliseconds,
+              'pty': pty != null,
+            },
+          );
+          openFuture.then((exec) => exec.close()).ignore();
+          throw TimeoutException(
+            'Timed out opening SSH exec channel',
+            _execOpenTimeout,
+          );
+        },
+      );
+      _clearExecChannelBackoff(session.connectionId);
+      return exec;
+    } on Object catch (error) {
+      if (shouldBackOffTmuxExecChannelAfterFailure(error)) {
+        _recordExecChannelFailure(session.connectionId, error);
+      }
+      rethrow;
+    }
   }
 
   /// Runs a command via SSH exec channel and returns stdout as a string.
@@ -1090,6 +1225,49 @@ class _CachedInstalledAgentTools {
 
   final Set<AgentLaunchTool> tools;
   final DateTime cachedAt;
+}
+
+class _TmuxExecChannelBackoff {
+  const _TmuxExecChannelBackoff({
+    required this.failureCount,
+    required this.cooldownUntil,
+  });
+
+  final int failureCount;
+  final DateTime cooldownUntil;
+}
+
+/// Returns whether a failed tmux exec open should trigger channel backoff.
+@visibleForTesting
+bool shouldBackOffTmuxExecChannelAfterFailure(Object error) =>
+    error is SSHChannelOpenError || error is TimeoutException;
+
+/// Returns whether stale tmux windows are safer than failing a refresh.
+@visibleForTesting
+bool shouldUseCachedTmuxWindowsAfterListFailure(Object error) =>
+    shouldBackOffTmuxExecChannelAfterFailure(error);
+
+/// Resolves the tmux exec channel cooldown after repeated open failures.
+@visibleForTesting
+Duration resolveTmuxExecChannelBackoffDelay(int failureCount) {
+  final retryAttempt = failureCount <= 1 ? 0 : failureCount - 1;
+  return resolveTmuxWindowReloadRetryDelay(retryAttempt);
+}
+
+/// Resolves how quickly the control-mode watcher should restart.
+@visibleForTesting
+Duration resolveTmuxControlRestartDelay(
+  int restartAttempts, {
+  required bool channelOpenFailure,
+}) {
+  if (channelOpenFailure) {
+    return resolveTmuxWindowReloadRetryDelay(
+      restartAttempts,
+      initialDelay: const Duration(seconds: 5),
+    );
+  }
+  final cappedAttempt = restartAttempts.clamp(0, 4);
+  return Duration(seconds: 1 << cappedAttempt);
 }
 
 String _diagnosticTmuxCommandKind(String command) {
@@ -1500,6 +1678,7 @@ class _TmuxWindowChangeObserver {
       if (!_preserveScheduledReloadThroughSnapshots) {
         _cancelScheduledReload();
       }
+      service._applyCachedWindowEvent(session, sessionName, event);
       DiagnosticsLogService.instance.debug(
         'tmux.watch',
         'snapshot_event',
@@ -1574,7 +1753,9 @@ class _TmuxWindowChangeObserver {
       },
     );
     _cleanupControlSession();
-    _scheduleRestart();
+    _scheduleRestart(
+      channelOpenFailure: shouldBackOffTmuxExecChannelAfterFailure(error),
+    );
   }
 
   void _handleControlClosed() {
@@ -1587,12 +1768,14 @@ class _TmuxWindowChangeObserver {
     _scheduleRestart();
   }
 
-  void _scheduleRestart() {
+  void _scheduleRestart({bool channelOpenFailure = false}) {
     if (_disposed || !_controller.hasListener) return;
     _stopHeartbeat();
     _restartTimer?.cancel();
-    final cappedAttempt = _restartAttempts.clamp(0, 4);
-    final delay = Duration(seconds: 1 << cappedAttempt);
+    final delay = resolveTmuxControlRestartDelay(
+      _restartAttempts,
+      channelOpenFailure: channelOpenFailure,
+    );
     _restartAttempts += 1;
     DiagnosticsLogService.instance.warning(
       'tmux.watch',
@@ -1601,6 +1784,7 @@ class _TmuxWindowChangeObserver {
         'connectionId': session.connectionId,
         'attempt': _restartAttempts,
         'delayMs': delay.inMilliseconds,
+        'channelOpenFailure': channelOpenFailure,
       },
     );
     _restartTimer = Timer(delay, () => unawaited(_ensureStarted()));

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -999,8 +999,7 @@ class TmuxService {
     SshSession session,
     String command, {
     SshExecPriority priority = SshExecPriority.normal,
-  }) => runQueuedSshExec(
-    session.connectionId,
+  }) => session.runQueuedExec(
     () => _execUnqueued(session, command),
     priority: priority,
   );

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -38,6 +38,7 @@ import '../../domain/services/monetization_service.dart';
 import '../../domain/services/remote_clipboard_sync_service.dart';
 import '../../domain/services/remote_file_service.dart';
 import '../../domain/services/settings_service.dart';
+import '../../domain/services/ssh_exec_queue.dart';
 import '../../domain/services/ssh_service.dart';
 import '../../domain/services/terminal_hyperlink_tracker.dart';
 import '../../domain/services/terminal_theme_service.dart';
@@ -3644,21 +3645,28 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     return parsed.text;
   }
 
-  Future<String> _runRemoteCommand(SshSession session, String command) async {
-    final exec = await session.execute(command);
-    final stdout = StringBuffer();
-    final stderr = StringBuffer();
-    final stdoutFuture = exec.stdout
-        .cast<List<int>>()
-        .transform(utf8.decoder)
-        .forEach(stdout.write);
-    final stderrFuture = exec.stderr
-        .cast<List<int>>()
-        .transform(utf8.decoder)
-        .forEach(stderr.write);
-    await Future.wait<void>([stdoutFuture, stderrFuture, exec.done]);
-    return stdout.toString().isNotEmpty ? stdout.toString() : stderr.toString();
-  }
+  Future<String> _runRemoteCommand(SshSession session, String command) =>
+      session.runQueuedExec(() async {
+        final exec = await session.execute(command);
+        try {
+          final stdout = StringBuffer();
+          final stderr = StringBuffer();
+          final stdoutFuture = exec.stdout
+              .cast<List<int>>()
+              .transform(utf8.decoder)
+              .forEach(stdout.write);
+          final stderrFuture = exec.stderr
+              .cast<List<int>>()
+              .transform(utf8.decoder)
+              .forEach(stderr.write);
+          await Future.wait<void>([stdoutFuture, stderrFuture, exec.done]);
+          return stdout.toString().isNotEmpty
+              ? stdout.toString()
+              : stderr.toString();
+        } finally {
+          exec.close();
+        }
+      }, priority: SshExecPriority.low);
 
   void _handleTerminalScroll() {
     _shouldFollowLiveOutput = shouldFollowTerminalOutput(

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -637,8 +637,10 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     } else if (!(_windows?.isNotEmpty ?? false)) {
       setState(() => _isLoading = true);
     }
-    unawaited(_windowChangeSubscription?.cancel());
-    _subscribeToWindowChanges();
+    if (sessionChanged) {
+      unawaited(_windowChangeSubscription?.cancel());
+      _subscribeToWindowChanges();
+    }
     unawaited(_loadPreferredLaunchTool());
     _loadWindows();
   }

--- a/test/domain/services/ssh_exec_queue_test.dart
+++ b/test/domain/services/ssh_exec_queue_test.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/services/ssh_exec_queue.dart';
+
+void main() {
+  tearDown(resetQueuedSshExecsForTesting);
+
+  test('limits normal exec jobs per connection', () async {
+    final startedJobs = <int>[];
+    final completers = List.generate(3, (_) => Completer<int>());
+    final futures = [
+      for (var index = 0; index < completers.length; index++)
+        runQueuedSshExec(1, () {
+          startedJobs.add(index);
+          return completers[index].future;
+        }),
+    ];
+
+    await pumpEventQueue();
+
+    expect(startedJobs, [0, 1]);
+    expect(activeQueuedSshExecCountForTesting(1), 2);
+    expect(pendingQueuedSshExecCountForTesting(1), 1);
+
+    completers[0].complete(0);
+    await pumpEventQueue();
+
+    expect(startedJobs, [0, 1, 2]);
+    expect(activeQueuedSshExecCountForTesting(1), 2);
+    expect(pendingQueuedSshExecCountForTesting(1), 0);
+
+    completers[1].complete(1);
+    completers[2].complete(2);
+
+    expect(await Future.wait(futures), [0, 1, 2]);
+  });
+
+  test('keeps low-priority discovery from occupying every exec slot', () async {
+    final startedJobs = <String>[];
+    final firstLow = Completer<String>();
+    final secondLow = Completer<String>();
+    final normal = Completer<String>();
+
+    final firstLowFuture = runQueuedSshExec(2, () {
+      startedJobs.add('low-1');
+      return firstLow.future;
+    }, priority: SshExecPriority.low);
+    final secondLowFuture = runQueuedSshExec(2, () {
+      startedJobs.add('low-2');
+      return secondLow.future;
+    }, priority: SshExecPriority.low);
+
+    await pumpEventQueue();
+
+    expect(startedJobs, ['low-1']);
+    expect(activeQueuedSshExecCountForTesting(2), 1);
+    expect(pendingQueuedSshExecCountForTesting(2), 1);
+
+    final normalFuture = runQueuedSshExec(2, () {
+      startedJobs.add('normal');
+      return normal.future;
+    });
+
+    await pumpEventQueue();
+
+    expect(startedJobs, ['low-1', 'normal']);
+    expect(activeQueuedSshExecCountForTesting(2), 2);
+    expect(pendingQueuedSshExecCountForTesting(2), 1);
+
+    normal.complete('normal');
+    await pumpEventQueue();
+
+    expect(startedJobs, ['low-1', 'normal']);
+
+    firstLow.complete('low-1');
+    await pumpEventQueue();
+
+    expect(startedJobs, ['low-1', 'normal', 'low-2']);
+
+    secondLow.complete('low-2');
+
+    expect(await Future.wait([firstLowFuture, secondLowFuture, normalFuture]), [
+      'low-1',
+      'low-2',
+      'normal',
+    ]);
+  });
+}

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -19,6 +19,7 @@ import 'package:monkeyssh/data/repositories/known_hosts_repository.dart';
 import 'package:monkeyssh/data/security/secret_encryption_service.dart';
 import 'package:monkeyssh/domain/services/background_ssh_service.dart';
 import 'package:monkeyssh/domain/services/host_key_verification.dart';
+import 'package:monkeyssh/domain/services/ssh_exec_queue.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:xterm/xterm.dart';
 
@@ -536,6 +537,8 @@ void main() {
   });
 
   group('SshSession terminal previews', () {
+    tearDown(resetQueuedSshExecsForTesting);
+
     test('forwards execute requests with an optional PTY config', () async {
       final client = _MockSshClient();
       final execSession = _MockExecSession();
@@ -566,6 +569,45 @@ void main() {
           pty: const SSHPtyConfig(width: 120, height: 30),
         ),
       ).called(1);
+    });
+
+    test('runs queued exec work against the session connection', () async {
+      final client = _MockSshClient();
+      final session = SshSession(
+        connectionId: 9,
+        hostId: 2,
+        client: client,
+        config: const SshConnectionConfig(
+          hostname: 'example.com',
+          port: 22,
+          username: 'tester',
+        ),
+      );
+      final completers = List.generate(3, (_) => Completer<int>());
+      final started = <int>[];
+      final futures = [
+        for (var index = 0; index < completers.length; index++)
+          session.runQueuedExec(() {
+            started.add(index);
+            return completers[index].future;
+          }),
+      ];
+
+      await pumpEventQueue();
+
+      expect(started, [0, 1]);
+      expect(activeQueuedSshExecCountForTesting(9), 2);
+      expect(pendingQueuedSshExecCountForTesting(9), 1);
+
+      completers[0].complete(0);
+      await pumpEventQueue();
+
+      expect(started, [0, 1, 2]);
+
+      completers[1].complete(1);
+      completers[2].complete(2);
+
+      expect(await Future.wait(futures), [0, 1, 2]);
     });
 
     test('builds preview from the latest non-empty lines', () {

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -131,6 +131,52 @@ void main() {
         );
       },
     );
+
+    test(
+      'listWindows serves the last cached snapshot when channels are exhausted',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client, connectionId: 32);
+        const service = TmuxService();
+        const sep = tmuxWindowFieldSeparator;
+        var executeCalls = 0;
+        final windowLine = [
+          '0',
+          'shell',
+          '1',
+          'bash',
+          '/tmp/project',
+          '*',
+          'title',
+          '100',
+          'bash',
+          '',
+        ].join(sep);
+        final execSession = _buildOpenExecSession(
+          stdout: '$windowLine\n${_doneMarker()}',
+        );
+
+        when(() => client.execute(any(), pty: any(named: 'pty'))).thenAnswer((
+          _,
+        ) async {
+          executeCalls += 1;
+          if (executeCalls == 1) {
+            return execSession;
+          }
+          return Future<SSHSession>.error(
+            SSHChannelOpenError(2, 'open failed'),
+          );
+        });
+
+        final initial = await service.listWindows(session, 'main');
+        final cached = await service.listWindows(session, 'main');
+
+        expect(initial, hasLength(1));
+        expect(cached, initial);
+        expect(cached.single.name, 'shell');
+        verify(() => client.execute(any(), pty: any(named: 'pty'))).called(2);
+      },
+    );
   });
 
   group('parseTmuxWindowChangeEventFromControlLine', () {
@@ -760,6 +806,55 @@ void main() {
         );
       },
     );
+  });
+
+  group('channel backoff helpers', () {
+    test('identifies transient channel-open failures', () {
+      expect(
+        shouldBackOffTmuxExecChannelAfterFailure(
+          SSHChannelOpenError(2, 'open failed'),
+        ),
+        isTrue,
+      );
+      expect(
+        shouldUseCachedTmuxWindowsAfterListFailure(
+          SSHChannelOpenError(2, 'open failed'),
+        ),
+        isTrue,
+      );
+      expect(
+        shouldBackOffTmuxExecChannelAfterFailure(StateError('tmux missing')),
+        isFalse,
+      );
+    });
+
+    test('backs off control restarts more slowly after channel failures', () {
+      expect(
+        resolveTmuxControlRestartDelay(0, channelOpenFailure: false),
+        const Duration(seconds: 1),
+      );
+      expect(
+        resolveTmuxControlRestartDelay(0, channelOpenFailure: true),
+        const Duration(seconds: 5),
+      );
+      expect(
+        resolveTmuxControlRestartDelay(2, channelOpenFailure: true),
+        const Duration(seconds: 20),
+      );
+      expect(
+        resolveTmuxControlRestartDelay(4, channelOpenFailure: true),
+        const Duration(seconds: 30),
+      );
+    });
+
+    test('uses capped exec channel cooldowns', () {
+      expect(resolveTmuxExecChannelBackoffDelay(1), const Duration(seconds: 2));
+      expect(resolveTmuxExecChannelBackoffDelay(2), const Duration(seconds: 4));
+      expect(
+        resolveTmuxExecChannelBackoffDelay(6),
+        const Duration(seconds: 30),
+      );
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

- Cache the last known tmux window snapshot per connection/session and serve it when SSH refuses new exec channels, so the tmux UI stays populated during channel exhaustion.
- Add per-connection tmux exec-channel cooldown/backoff after channel-open failures or open timeouts, defer low-priority tool-detection prefetches while cooling down, and slow control-mode watcher restarts after channel-open failures.
- Add a shared per-connection SSH exec queue exposed through `SshSession.runQueuedExec`: normal tmux execs are capped to a small pool, while AI session discovery/tool probing and remote clipboard polling run at low priority and cannot occupy every exec slot.
- Avoid re-subscribing same-session tmux recovery-only updates so recovery attempts do not churn the persistent watcher channel.

## Tests

- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `flutter test test/domain/services/ssh_exec_queue_test.dart test/domain/services/ssh_service_test.dart test/domain/services/tmux_service_control_mode_test.dart test/domain/services/agent_session_discovery_service_test.dart`
- `flutter test`
