### PR TITLE
fix: polish release readiness

### DIFF
--- a/integration_test/tmux_ai_sessions_validation_test.dart
+++ b/integration_test/tmux_ai_sessions_validation_test.dart
@@ -144,6 +144,9 @@ void main() {
 
       await tester.binding.setSurfaceSize(const Size(430, 932));
       addTearDown(() => tester.binding.setSurfaceSize(null));
+      if (Platform.isAndroid) {
+        await binding.convertFlutterSurfaceToImage();
+      }
 
       final container = ProviderContainer(
         overrides: [

--- a/integration_test/tmux_bar_expand_validation_test.dart
+++ b/integration_test/tmux_bar_expand_validation_test.dart
@@ -63,6 +63,9 @@ void main() {
 
     await tester.binding.setSurfaceSize(const Size(430, 932));
     addTearDown(() => tester.binding.setSurfaceSize(null));
+    if (Platform.isAndroid) {
+      await binding.convertFlutterSurfaceToImage();
+    }
 
     final container = ProviderContainer(
       overrides: [

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		A2D56B9B41F34E978DB60210 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A2D56B9A41F34E978DB60210 /* PrivacyInfo.xcprivacy */; };
 		DD783BB2BA23C838BCACD3C0 /* AppIcon-private.icon in Resources */ = {isa = PBXBuildFile; fileRef = 47B1DB4833F7FC740D4324B9 /* AppIcon-private.icon */; };
 		E6E3D2D0CB976578F784B54A /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9476D1F8792EFC31903B5B95 /* Pods_Runner.framework */; };
 		F282391CEEDF4515759E057E /* AppIcon-production.icon in Resources */ = {isa = PBXBuildFile; fileRef = 9FEC3F55B80F78C630674143 /* AppIcon-production.icon */; };
@@ -100,6 +101,7 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9FEC3F55B80F78C630674143 /* AppIcon-production.icon */ = {isa = PBXFileReference; lastKnownFileType = "document.icon-composer"; path = "AppIcon-production.icon"; sourceTree = "<group>"; };
+		A2D56B9A41F34E978DB60210 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A7D5024F73DEF28DEBB69428 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		AFA5B966A7A6BA67D7633CB8 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF3AD2B28587AFE0302C016E /* Pods-Runner.release-production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-production.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-production.xcconfig"; sourceTree = "<group>"; };
@@ -203,6 +205,7 @@
 				47B1DB4833F7FC740D4324B9 /* AppIcon-private.icon */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
 				97C147021CF9000F007C117D /* Info.plist */,
+				A2D56B9A41F34E978DB60210 /* PrivacyInfo.xcprivacy */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
@@ -383,6 +386,7 @@
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				F282391CEEDF4515759E057E /* AppIcon-production.icon in Resources */,
+				A2D56B9B41F34E978DB60210 /* PrivacyInfo.xcprivacy in Resources */,
 				DD783BB2BA23C838BCACD3C0 /* AppIcon-private.icon in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 			);

--- a/ios/Runner/PrivacyInfo.xcprivacy
+++ b/ios/Runner/PrivacyInfo.xcprivacy
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -98,11 +98,8 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/hosts/add',
         name: 'host-add',
-        builder: (context, state) => HostEditScreen(
-          initialSshUrl: state.uri.queryParameters['sshUrl'],
-          useLocalhostTemplate:
-              state.uri.queryParameters['template'] == 'local',
-        ),
+        builder: (context, state) =>
+            HostEditScreen(initialSshUrl: state.uri.queryParameters['sshUrl']),
       ),
       GoRoute(
         path: '/hosts/edit/:hostId',

--- a/lib/domain/services/background_ssh_service.dart
+++ b/lib/domain/services/background_ssh_service.dart
@@ -50,14 +50,19 @@ class BackgroundSshService {
         'connectedCount': connectedCount,
       });
     } on PlatformException catch (error) {
-      debugPrint(
-        'Failed to update background SSH status: ${error.message ?? error.code}',
-      );
+      if (kDebugMode) {
+        debugPrint(
+          'Failed to update background SSH status: '
+          '${error.message ?? error.code}',
+        );
+      }
     } on MissingPluginException catch (error) {
-      debugPrint(
-        'Failed to update background SSH status: '
-        '${error.message ?? 'missing plugin'}',
-      );
+      if (kDebugMode) {
+        debugPrint(
+          'Failed to update background SSH status: '
+          '${error.message ?? 'missing plugin'}',
+        );
+      }
     }
   }
 
@@ -71,15 +76,19 @@ class BackgroundSshService {
         'isForeground': isForeground,
       });
     } on PlatformException catch (error) {
-      debugPrint(
-        'Failed to update background SSH lifecycle: '
-        '${error.message ?? error.code}',
-      );
+      if (kDebugMode) {
+        debugPrint(
+          'Failed to update background SSH lifecycle: '
+          '${error.message ?? error.code}',
+        );
+      }
     } on MissingPluginException catch (error) {
-      debugPrint(
-        'Failed to update background SSH lifecycle: '
-        '${error.message ?? 'missing plugin'}',
-      );
+      if (kDebugMode) {
+        debugPrint(
+          'Failed to update background SSH lifecycle: '
+          '${error.message ?? 'missing plugin'}',
+        );
+      }
     }
   }
 
@@ -91,14 +100,18 @@ class BackgroundSshService {
     try {
       await _channel.invokeMethod<void>('stopService');
     } on PlatformException catch (error) {
-      debugPrint(
-        'Failed to stop background SSH status: ${error.message ?? error.code}',
-      );
+      if (kDebugMode) {
+        debugPrint(
+          'Failed to stop background SSH status: ${error.message ?? error.code}',
+        );
+      }
     } on MissingPluginException catch (error) {
-      debugPrint(
-        'Failed to stop background SSH status: '
-        '${error.message ?? 'missing plugin'}',
-      );
+      if (kDebugMode) {
+        debugPrint(
+          'Failed to stop background SSH status: '
+          '${error.message ?? 'missing plugin'}',
+        );
+      }
     }
   }
 
@@ -113,16 +126,20 @@ class BackgroundSshService {
           ) ??
           false;
     } on PlatformException catch (error) {
-      debugPrint(
-        'Failed to read Android battery optimization status: '
-        '${error.message ?? error.code}',
-      );
+      if (kDebugMode) {
+        debugPrint(
+          'Failed to read Android battery optimization status: '
+          '${error.message ?? error.code}',
+        );
+      }
       return null;
     } on MissingPluginException catch (error) {
-      debugPrint(
-        'Failed to read Android battery optimization status: '
-        '${error.message ?? 'missing plugin'}',
-      );
+      if (kDebugMode) {
+        debugPrint(
+          'Failed to read Android battery optimization status: '
+          '${error.message ?? 'missing plugin'}',
+        );
+      }
       return null;
     }
   }
@@ -138,16 +155,20 @@ class BackgroundSshService {
           ) ??
           false;
     } on PlatformException catch (error) {
-      debugPrint(
-        'Failed to open Android battery optimization settings: '
-        '${error.message ?? error.code}',
-      );
+      if (kDebugMode) {
+        debugPrint(
+          'Failed to open Android battery optimization settings: '
+          '${error.message ?? error.code}',
+        );
+      }
       return false;
     } on MissingPluginException catch (error) {
-      debugPrint(
-        'Failed to open Android battery optimization settings: '
-        '${error.message ?? 'missing plugin'}',
-      );
+      if (kDebugMode) {
+        debugPrint(
+          'Failed to open Android battery optimization settings: '
+          '${error.message ?? 'missing plugin'}',
+        );
+      }
       return false;
     }
   }

--- a/lib/domain/services/clipboard_sharing_service.dart
+++ b/lib/domain/services/clipboard_sharing_service.dart
@@ -59,7 +59,9 @@ class ClipboardSharingService {
 
       await _handleSet(payload);
     } on PlatformException catch (e) {
-      debugPrint('OSC 52 clipboard operation failed: $e');
+      if (kDebugMode) {
+        debugPrint('OSC 52 clipboard operation failed: $e');
+      }
     }
     return null;
   }

--- a/lib/domain/services/local_notification_service.dart
+++ b/lib/domain/services/local_notification_service.dart
@@ -135,6 +135,11 @@ class LocalNotificationService {
   /// Ensures the underlying notification plugin is initialized.
   Future<bool> initialize() => _initializeFuture ??= _initializeInternal();
 
+  /// Releases notification routing resources.
+  void dispose() {
+    unawaited(_tmuxAlertTapController.close());
+  }
+
   /// Returns the tmux alert that launched the app, if one has not been consumed.
   Future<TmuxAlertNotificationPayload?> consumeLaunchTmuxAlert() async {
     final didInitialize = await initialize();
@@ -154,6 +159,8 @@ class LocalNotificationService {
   }) async {
     final didInitialize = await initialize();
     if (!didInitialize) return;
+    final hasPermission = await _requestNotificationPermission();
+    if (!hasPermission) return;
 
     const androidDetails = AndroidNotificationDetails(
       tmuxAlertNotificationChannelId,
@@ -206,8 +213,16 @@ class LocalNotificationService {
     try {
       const initializationSettings = InitializationSettings(
         android: AndroidInitializationSettings(_androidNotificationIcon),
-        iOS: DarwinInitializationSettings(),
-        macOS: DarwinInitializationSettings(),
+        iOS: DarwinInitializationSettings(
+          requestAlertPermission: false,
+          requestBadgePermission: false,
+          requestSoundPermission: false,
+        ),
+        macOS: DarwinInitializationSettings(
+          requestAlertPermission: false,
+          requestBadgePermission: false,
+          requestSoundPermission: false,
+        ),
       );
       final launchDetails = await _plugin.getNotificationAppLaunchDetails();
       _launchTmuxAlert = (launchDetails?.didNotificationLaunchApp ?? false)
@@ -228,7 +243,40 @@ class LocalNotificationService {
       await androidImplementation?.createNotificationChannel(
         _tmuxAlertNotificationChannel,
       );
-      await androidImplementation?.requestNotificationsPermission();
+
+      return true;
+    } on MissingPluginException {
+      return false;
+    }
+  }
+
+  Future<bool> _requestNotificationPermission() async {
+    try {
+      final androidImplementation = _plugin
+          .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin
+          >();
+      if (androidImplementation != null) {
+        return await androidImplementation.requestNotificationsPermission() ??
+            false;
+      }
+
+      final iOSImplementation = _plugin
+          .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin
+          >();
+      if (iOSImplementation != null) {
+        return await iOSImplementation.requestPermissions(alert: true) ?? false;
+      }
+
+      final macOSImplementation = _plugin
+          .resolvePlatformSpecificImplementation<
+            MacOSFlutterLocalNotificationsPlugin
+          >();
+      if (macOSImplementation != null) {
+        return await macOSImplementation.requestPermissions(alert: true) ??
+            false;
+      }
 
       return true;
     } on MissingPluginException {
@@ -247,4 +295,8 @@ class LocalNotificationService {
 
 /// Provides access to local notifications.
 final Provider<LocalNotificationService> localNotificationServiceProvider =
-    Provider<LocalNotificationService>((ref) => LocalNotificationService());
+    Provider<LocalNotificationService>((ref) {
+      final service = LocalNotificationService();
+      ref.onDispose(service.dispose);
+      return service;
+    });

--- a/lib/domain/services/monetization_service.dart
+++ b/lib/domain/services/monetization_service.dart
@@ -13,6 +13,12 @@ import 'package:in_app_purchase_storekit/store_kit_wrappers.dart';
 import '../models/monetization.dart';
 import 'settings_service.dart';
 
+const _lifetimeAlreadyActiveMessage =
+    'MonkeySSH Pro Lifetime is already active. Manage your subscription in the '
+    'store if you need to cancel a monthly or annual renewal.';
+const _noActiveStorePurchaseMessage =
+    'No active MonkeySSH Pro purchase could be restored.';
+
 /// Coordinates local premium state and mobile store purchase flows.
 class MonetizationService {
   /// Creates a new [MonetizationService].
@@ -204,15 +210,20 @@ class MonetizationService {
     await initialize();
     if (!_supportsStoreBilling) {
       return const MonetizationActionResult.failure(
-        'Subscriptions are only available through the App Store and Google Play.',
+        'Purchases are only available through the App Store and Google Play.',
       );
     }
     if (_state.isLifetimeUnlocked) {
       return const MonetizationActionResult.failure(
-        'MonkeySSH Pro Lifetime is already active. Manage your subscription in the store if you need to cancel a monthly or annual renewal.',
+        _lifetimeAlreadyActiveMessage,
       );
     }
     await _tryRecoverStaleAndroidPurchaseAttempt();
+    if (_state.isLifetimeUnlocked) {
+      return const MonetizationActionResult.failure(
+        _lifetimeAlreadyActiveMessage,
+      );
+    }
     if (_pendingPurchaseResult != null || _restoreInFlight) {
       return const MonetizationActionResult.failure(
         'Another purchase or restore is already in progress.',
@@ -289,6 +300,11 @@ class MonetizationService {
         'Restoring purchases is only available through the App Store and Google Play.',
       );
     }
+    if (_state.isLifetimeUnlocked) {
+      return const MonetizationActionResult.success(
+        'MonkeySSH Pro Lifetime is already active.',
+      );
+    }
     await _tryRecoverStaleAndroidPurchaseAttempt();
     if (_pendingPurchaseResult != null || _restoreInFlight) {
       return const MonetizationActionResult.failure(
@@ -319,12 +335,12 @@ class MonetizationService {
         _restoreInFlight = false;
         _restoreObservedPurchaseUpdate = false;
         if (!restoreObservedPurchaseUpdate) {
-          await _clearCachedStoreEntitlement();
+          await _clearCachedStoreEntitlement(preserveLifetime: true);
         } else {
           _emit(_state.copyWith(isLoading: false));
         }
         return const MonetizationActionResult.failure(
-          'No active subscription could be restored.',
+          _noActiveStorePurchaseMessage,
         );
       },
     );
@@ -502,7 +518,13 @@ class MonetizationService {
     }
   }
 
-  Future<void> _clearCachedStoreEntitlement() async {
+  Future<void> _clearCachedStoreEntitlement({
+    bool preserveLifetime = false,
+  }) async {
+    if (preserveLifetime && _state.isLifetimeUnlocked) {
+      _emit(_state.copyWith(isLoading: false, lastError: null));
+      return;
+    }
     await _settings.setBool(SettingKeys.monetizationProUnlocked, value: false);
     await _settings.delete(SettingKeys.monetizationActiveProductId);
     await _settings.delete(SettingKeys.monetizationActiveOfferId);
@@ -561,7 +583,7 @@ class MonetizationService {
     try {
       final response = await _playBillingAddition.queryPastPurchases();
       if (response.error != null) {
-        const message = 'Could not check Google Play subscriptions.';
+        const message = 'Could not check Google Play purchases.';
         _emit(_state.copyWith(isLoading: false, lastError: message));
         return const MonetizationActionResult.failure(message);
       }
@@ -575,26 +597,11 @@ class MonetizationService {
       if (purchases.isEmpty) {
         await _clearCachedStoreEntitlement();
         return const MonetizationActionResult.failure(
-          'No active subscription could be restored.',
+          _noActiveStorePurchaseMessage,
         );
       }
 
-      // Lifetime takes precedence over any subscription that might be
-      // returned alongside it, even if the subscription has a newer
-      // purchaseTime. A user who owns lifetime should always see the
-      // "Lifetime" label, regardless of whether they later subscribed.
-      final lifetimePurchase = purchases.firstWhereOrNull(
-        (purchase) => MonetizationProductIds.isLifetime(purchase.productID),
-      );
-      final selectedPurchase =
-          lifetimePurchase ??
-          purchases.reduce(
-            (latest, purchase) =>
-                purchase.billingClientPurchase.purchaseTime >
-                    latest.billingClientPurchase.purchaseTime
-                ? purchase
-                : latest,
-          );
+      final selectedPurchase = _preferredAndroidEntitlementPurchase(purchases);
 
       final isLifetime = MonetizationProductIds.isLifetime(
         selectedPurchase.productID,
@@ -626,24 +633,11 @@ class MonetizationService {
       return;
     }
 
-    // Recompute the active product from the surviving purchase set so
-    // that, e.g., a lapsed subscription leaves the cached active SKU
-    // pointing at the still-owned lifetime non-consumable instead of
-    // the now-defunct sub. Lifetime always takes precedence.
-    final lifetime = knownPurchases.firstWhereOrNull(
-      (purchase) => MonetizationProductIds.isLifetime(purchase.productID),
-    );
-    final selected =
-        lifetime ??
-        knownPurchases.reduce(
-          (latest, purchase) =>
-              purchase.billingClientPurchase.purchaseTime >
-                  latest.billingClientPurchase.purchaseTime
-              ? purchase
-              : latest,
-        );
+    final selected = _preferredAndroidEntitlementPurchase(knownPurchases);
 
-    if (_state.activeProductId == selected.productID) {
+    final isLifetime = MonetizationProductIds.isLifetime(selected.productID);
+    if (_state.activeProductId == selected.productID &&
+        (!isLifetime || _state.activeOfferId == null)) {
       return;
     }
 
@@ -651,7 +645,6 @@ class MonetizationService {
       SettingKeys.monetizationActiveProductId,
       selected.productID,
     );
-    final isLifetime = MonetizationProductIds.isLifetime(selected.productID);
     if (isLifetime) {
       await _settings.delete(SettingKeys.monetizationActiveOfferId);
     }
@@ -691,18 +684,36 @@ class MonetizationService {
       return;
     }
 
-    final latestPurchase = purchases.reduce(
+    final selectedPurchase = _preferredAndroidEntitlementPurchase(purchases);
+    final isLifetime = MonetizationProductIds.isLifetime(
+      selectedPurchase.productID,
+    );
+    final result = await _applySuccessfulPurchase(
+      selectedPurchase,
+      successMessage: isLifetime
+          ? 'MonkeySSH Pro Lifetime activated.'
+          : 'MonkeySSH Pro unlocked.',
+    );
+    _resolvePendingPurchase(result);
+  }
+
+  GooglePlayPurchaseDetails _preferredAndroidEntitlementPurchase(
+    List<GooglePlayPurchaseDetails> purchases,
+  ) {
+    final lifetimePurchase = purchases.firstWhereOrNull(
+      (purchase) => MonetizationProductIds.isLifetime(purchase.productID),
+    );
+    if (lifetimePurchase != null) {
+      return lifetimePurchase;
+    }
+
+    return purchases.reduce(
       (latest, purchase) =>
           purchase.billingClientPurchase.purchaseTime >
               latest.billingClientPurchase.purchaseTime
           ? purchase
           : latest,
     );
-    final result = await _applySuccessfulPurchase(
-      latestPurchase,
-      successMessage: 'MonkeySSH Pro unlocked.',
-    );
-    _resolvePendingPurchase(result);
   }
 
   DateTime? _parseCachedDate(String? rawValue) =>

--- a/lib/domain/services/monetization_service.dart
+++ b/lib/domain/services/monetization_service.dart
@@ -87,8 +87,15 @@ class MonetizationService {
       _purchaseSubscription = _inAppPurchase.purchaseStream.listen(
         _handlePurchaseUpdates,
         onError: (Object error, StackTrace stackTrace) {
-          debugPrint('Purchase stream error: $error');
-          _emit(_state.copyWith(isLoading: false, lastError: '$error'));
+          if (kDebugMode) {
+            debugPrint('Purchase stream error: $error\n$stackTrace');
+          }
+          _emit(
+            _state.copyWith(
+              isLoading: false,
+              lastError: 'Could not update purchase status. Try again.',
+            ),
+          );
         },
       );
 
@@ -179,7 +186,9 @@ class MonetizationService {
         isLoading: false,
         billingAvailability: MonetizationBillingAvailability.available,
         offers: catalog.offers,
-        lastError: response.error?.message,
+        lastError: response.error == null
+            ? null
+            : 'Could not load purchase options. Try again.',
       ),
     );
   }
@@ -377,16 +386,10 @@ class MonetizationService {
           break;
         case PurchaseStatus.error:
           unawaited(_completePurchaseIfNeeded(purchase));
-          _emit(
-            _state.copyWith(
-              isLoading: false,
-              lastError: purchase.error?.message ?? 'Purchase failed.',
-            ),
-          );
+          const failureMessage = 'Purchase failed. Try again.';
+          _emit(_state.copyWith(isLoading: false, lastError: failureMessage));
           _resolvePendingPurchase(
-            MonetizationActionResult.failure(
-              purchase.error?.message ?? 'Purchase failed.',
-            ),
+            const MonetizationActionResult.failure(failureMessage),
           );
           break;
         case PurchaseStatus.canceled:
@@ -484,10 +487,12 @@ class MonetizationService {
       );
       return MonetizationActionResult.success(successMessage);
     } on Object catch (error, stackTrace) {
-      final message = 'Failed to finalize purchase: $error';
-      debugPrint('$message\n$stackTrace');
+      const message = 'Could not finalize purchase. Try again.';
+      if (kDebugMode) {
+        debugPrint('Failed to finalize purchase: $error\n$stackTrace');
+      }
       _emit(_state.copyWith(isLoading: false, lastError: message));
-      return MonetizationActionResult.failure(message);
+      return const MonetizationActionResult.failure(message);
     }
   }
 
@@ -555,12 +560,10 @@ class MonetizationService {
     _emit(_state.copyWith(isLoading: true, lastError: null));
     try {
       final response = await _playBillingAddition.queryPastPurchases();
-      if (response.error case final error?) {
-        final message = error.message.isEmpty
-            ? 'Could not check Google Play subscriptions.'
-            : error.message;
+      if (response.error != null) {
+        const message = 'Could not check Google Play subscriptions.';
         _emit(_state.copyWith(isLoading: false, lastError: message));
-        return MonetizationActionResult.failure(message);
+        return const MonetizationActionResult.failure(message);
       }
 
       final purchases = response.pastPurchases

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -944,7 +944,9 @@ class SshService {
       );
       return presentedHostKey;
     } finally {
-      await probeAuthentication;
+      if (probeAuthentication != null) {
+        await probeAuthentication;
+      }
       probeClient?.close();
       await verificationSocket.socket.close();
     }

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -357,6 +357,7 @@ class SshService {
   /// Keeping this below common server `MaxAuthTries` defaults avoids
   /// "too many authentication failures" disconnects in Auto mode.
   static const _maxAutoKeysPerAttempt = 5;
+  static const _hostKeyProbeSettleTimeout = Duration(seconds: 1);
 
   /// Host repository for looking up hosts.
   final HostRepository? hostRepository;
@@ -883,7 +884,10 @@ class SshService {
       );
       client?.close();
       _closeClients(dependentClients);
-      return SshConnectionResult(success: false, error: 'Connection error: $e');
+      return const SshConnectionResult(
+        success: false,
+        error: 'Connection failed. Check the host settings and try again.',
+      );
     }
   }
 
@@ -910,6 +914,7 @@ class SshService {
   }) async {
     final verificationSocket = _prepareHostKeyCapture(socket);
     SSHClient? probeClient;
+    Future<void>? probeAuthentication;
     String? callbackKeyType;
     String? callbackFingerprint;
 
@@ -923,7 +928,7 @@ class SshService {
           return true;
         },
       );
-      unawaited(probeClient.authenticated.catchError((_) {}));
+      probeAuthentication = _drainHostKeyProbeAuthentication(probeClient);
     }
 
     try {
@@ -939,9 +944,24 @@ class SshService {
       );
       return presentedHostKey;
     } finally {
+      await probeAuthentication;
       probeClient?.close();
       await verificationSocket.socket.close();
     }
+  }
+
+  Future<void> _drainHostKeyProbeAuthentication(SSHClient probeClient) async {
+    final authentication = probeClient.authenticated.then<void>(
+      (_) {},
+      onError: (Object error, StackTrace _) {
+        DiagnosticsLogService.instance.info(
+          'ssh.host_key',
+          'probe_authentication_ended',
+          fields: {'errorType': error.runtimeType},
+        );
+      },
+    );
+    await authentication.timeout(_hostKeyProbeSettleTimeout, onTimeout: () {});
   }
 
   _PreparedHostKeySocket _prepareHostKeyCapture(SSHSocket socket) {
@@ -2043,8 +2063,15 @@ class SshSession {
             }
           })
           .catchError((Object error, StackTrace stackTrace) {
-            debugPrint('Error handling OSC 52 sequence: $error');
-            debugPrint('$stackTrace');
+            DiagnosticsLogService.instance.warning(
+              'ssh.clipboard',
+              'osc52_failed',
+              fields: {'errorType': error.runtimeType},
+            );
+            if (kDebugMode) {
+              debugPrint('Error handling OSC 52 sequence: $error');
+              debugPrint('$stackTrace');
+            }
           }),
     );
   }
@@ -2197,7 +2224,14 @@ class SshSession {
 
           await Future.any<void>([forwardToSocket, socketToForward]);
         } on Exception catch (e) {
-          debugPrint('Port forward connection error: $e');
+          DiagnosticsLogService.instance.warning(
+            'ssh.forward',
+            'local_connection_failed',
+            fields: {'errorType': e.runtimeType},
+          );
+          if (kDebugMode) {
+            debugPrint('Port forward connection error: $e');
+          }
         } finally {
           try {
             await forward?.sink.close();
@@ -2214,7 +2248,14 @@ class SshSession {
 
       return true;
     } on Exception catch (e) {
-      debugPrint('Failed to start local forward: $e');
+      DiagnosticsLogService.instance.warning(
+        'ssh.forward',
+        'local_start_failed',
+        fields: {'errorType': e.runtimeType},
+      );
+      if (kDebugMode) {
+        debugPrint('Failed to start local forward: $e');
+      }
       return false;
     }
   }
@@ -2259,7 +2300,14 @@ class SshSession {
           final localToRemote = socket.cast<List<int>>().pipe(channel.sink);
           await Future.any<void>([remoteToLocal, localToRemote]);
         } on Exception catch (e) {
-          debugPrint('Remote forward connection error: $e');
+          DiagnosticsLogService.instance.warning(
+            'ssh.forward',
+            'remote_connection_failed',
+            fields: {'errorType': e.runtimeType},
+          );
+          if (kDebugMode) {
+            debugPrint('Remote forward connection error: $e');
+          }
         } finally {
           try {
             await channel.sink.close();
@@ -2276,7 +2324,14 @@ class SshSession {
 
       return true;
     } on Exception catch (e) {
-      debugPrint('Failed to start remote forward: $e');
+      DiagnosticsLogService.instance.warning(
+        'ssh.forward',
+        'remote_start_failed',
+        fields: {'errorType': e.runtimeType},
+      );
+      if (kDebugMode) {
+        debugPrint('Failed to start remote forward: $e');
+      }
       return false;
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:google_fonts/google_fonts.dart';
 
 import 'app/app.dart';
 import 'app/host_key_prompt.dart';
@@ -9,7 +8,6 @@ import 'domain/services/host_key_prompt_handler_provider.dart';
 /// Entry point for the MonkeySSH client.
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  GoogleFonts.config.allowRuntimeFetching = false;
   runApp(
     ProviderScope(
       overrides: [

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 import 'app/app.dart';
 import 'app/host_key_prompt.dart';
@@ -8,6 +9,7 @@ import 'domain/services/host_key_prompt_handler_provider.dart';
 /// Entry point for the MonkeySSH client.
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
+  GoogleFonts.config.allowRuntimeFetching = false;
   runApp(
     ProviderScope(
       overrides: [

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -271,13 +271,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Import failed: ${error.message}')),
       );
-    } on Exception catch (error) {
+    } on Exception {
       if (!mounted) {
         return;
       }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Import failed: $error')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Import failed. Check the file and try again.'),
+        ),
+      );
     }
   }
 
@@ -722,7 +724,7 @@ class HostsPanel extends ConsumerWidget {
     loading: () => _buildCenteredHostsState(
       child: const CircularProgressIndicator(strokeWidth: 2),
     ),
-    error: (error, _) => _buildCenteredHostsState(
+    error: (_, _) => _buildCenteredHostsState(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -732,7 +734,7 @@ class HostsPanel extends ConsumerWidget {
             color: Theme.of(context).colorScheme.error,
           ),
           const SizedBox(height: 12),
-          Text('Error: $error'),
+          const Text('Could not load hosts. Pull to refresh or try again.'),
         ],
       ),
     ),
@@ -752,11 +754,6 @@ class HostsPanel extends ConsumerWidget {
       onPrimary: () => context.push('/hosts/add'),
       secondaryActions: [
         _EmptyStateAction(
-          icon: Icons.file_open_outlined,
-          label: 'Import config',
-          onTap: () => _showOpenSshImportMessage(context),
-        ),
-        _EmptyStateAction(
           icon: Icons.content_paste_go_outlined,
           label: 'Paste SSH URL',
           onTap: () => unawaited(_openPastedSshUrl(context)),
@@ -769,17 +766,6 @@ class HostsPanel extends ConsumerWidget {
       ],
     ),
   );
-
-  void _showOpenSshImportMessage(BuildContext context) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text(
-          'OpenSSH config import is not available yet. Add a host manually or '
-          'paste an ssh:// URL.',
-        ),
-      ),
-    );
-  }
 
   Future<void> _openPastedSshUrl(BuildContext context) async {
     final clipboard = await Clipboard.getData(Clipboard.kTextPlain);
@@ -1950,7 +1936,8 @@ class _KeysPanel extends ConsumerWidget {
           child: keysAsync.when(
             loading: () =>
                 const Center(child: CircularProgressIndicator(strokeWidth: 2)),
-            error: (e, _) => Center(child: Text('Error: $e')),
+            error: (_, _) =>
+                const Center(child: Text('Could not load SSH keys.')),
             data: (keys) => keys.isEmpty
                 ? _buildEmptyState(context)
                 : _buildKeysList(context, ref, keys),
@@ -2300,7 +2287,8 @@ class SnippetsPanel extends ConsumerWidget {
           child: snippetsAsync.when(
             loading: () =>
                 const Center(child: CircularProgressIndicator(strokeWidth: 2)),
-            error: (e, _) => Center(child: Text('Error: $e')),
+            error: (_, _) =>
+                const Center(child: Text('Could not load snippets.')),
             data: (snippets) => snippets.isEmpty
                 ? _buildEmptyState(context, ref)
                 : _buildSnippetsList(context, ref, snippets),
@@ -3123,11 +3111,15 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     unawaited(
       action.then<void>(
         (_) {},
-        onError: (Object error, StackTrace _) {
+        onError: (Object _, StackTrace _) {
           if (!mounted) return;
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text('tmux action failed: $error')));
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text(
+                'tmux action failed. Check the session and try again.',
+              ),
+            ),
+          );
         },
       ),
     );

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -747,9 +747,7 @@ class HostsPanel extends ConsumerWidget {
     child: _GuidedEmptyState(
       icon: Icons.dns_outlined,
       title: 'No hosts yet',
-      subtitle:
-          'Add an SSH server, paste an ssh:// URL, or prefill localhost after '
-          'running the local test setup.',
+      subtitle: 'Add an SSH server or paste an ssh:// URL to get started.',
       primaryLabel: 'Add Host',
       onPrimary: () => context.push('/hosts/add'),
       secondaryActions: [
@@ -757,11 +755,6 @@ class HostsPanel extends ConsumerWidget {
           icon: Icons.content_paste_go_outlined,
           label: 'Paste SSH URL',
           onTap: () => unawaited(_openPastedSshUrl(context)),
-        ),
-        _EmptyStateAction(
-          icon: Icons.computer_outlined,
-          label: 'Try local test host',
-          onTap: () => context.push('/hosts/add?template=local'),
         ),
       ],
     ),

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -85,21 +85,13 @@ String? _resolveTmuxExtraFlags({
 /// Screen for adding or editing a host.
 class HostEditScreen extends ConsumerStatefulWidget {
   /// Creates a new [HostEditScreen].
-  const HostEditScreen({
-    this.hostId,
-    this.initialSshUrl,
-    this.useLocalhostTemplate = false,
-    super.key,
-  });
+  const HostEditScreen({this.hostId, this.initialSshUrl, super.key});
 
   /// The host ID to edit, or null for a new host.
   final int? hostId;
 
   /// SSH URL used to prefill a new host.
   final String? initialSshUrl;
-
-  /// Whether to prefill a local SSH test host.
-  final bool useLocalhostTemplate;
 
   @override
   ConsumerState<HostEditScreen> createState() => _HostEditScreenState();
@@ -190,8 +182,6 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       _loadHost();
     } else if (widget.initialSshUrl?.trim().isNotEmpty ?? false) {
       _applySshUrl(widget.initialSshUrl!.trim());
-    } else if (widget.useLocalhostTemplate) {
-      _applyLocalhostTemplate();
     }
   }
 
@@ -210,11 +200,6 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       final userInfoParts = uri.userInfo.split(':');
       _usernameController.text = Uri.decodeComponent(userInfoParts.first);
     }
-  }
-
-  void _applyLocalhostTemplate() {
-    _labelController.text = 'Local test host';
-    _hostnameController.text = 'localhost';
   }
 
   Future<void> _loadHost() async {

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -896,7 +896,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
           controlAffinity: ListTileControlAffinity.leading,
           title: const Text('Hide tmux status bar'),
           subtitle: const Text(
-            'Append `\\; set status off` so Flutty\'s tmux bar is the only one shown.',
+            'Append `\\; set status off` so MonkeySSH\'s tmux bar is the only one shown.',
           ),
           onChanged: (value) {
             setState(() => _disableTmuxStatusBar = value ?? false);
@@ -952,7 +952,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
               child: AgentToolIcon(tool: _selectedAgentLaunchTool),
             ),
             helperText:
-                'Launch an agent directly, or pair it with tmux so Flutty can show extra window navigation.',
+                'Launch an agent directly, or pair it with tmux so MonkeySSH can show extra window navigation.',
           ),
           items: AgentLaunchTool.values
               .map(
@@ -1022,7 +1022,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
           controlAffinity: ListTileControlAffinity.leading,
           title: const Text('Hide tmux status bar'),
           subtitle: const Text(
-            'When a tmux session is set, append `\\; set status off` so Flutty\'s tmux bar is the only one shown.',
+            'When a tmux session is set, append `\\; set status off` so MonkeySSH\'s tmux bar is the only one shown.',
           ),
           onChanged: hasAgentPresetAccess
               ? (value) {
@@ -1459,10 +1459,17 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         );
       }
     } on Exception catch (e) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: e,
+          library: 'hosts',
+          context: ErrorDescription('while saving a host'),
+        ),
+      );
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Error: $e')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not save host. Try again.')),
+        );
       }
     } finally {
       if (mounted) setState(() => _isLoading = false);
@@ -1714,10 +1721,23 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         const SnackBar(content: Text('Connection successful')),
       );
     } on Exception catch (e) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: e,
+          library: 'hosts',
+          context: ErrorDescription('while testing a host connection'),
+        ),
+      );
       if (!mounted) {
         return;
       }
-      messenger.showSnackBar(SnackBar(content: Text('Connection failed: $e')));
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Connection failed. Check the host settings and try again.',
+          ),
+        ),
+      );
     }
   }
 
@@ -1789,12 +1809,21 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         SnackBar(content: Text('Import failed: ${error.message}')),
       );
     } on Exception catch (error) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          library: 'hosts',
+          context: ErrorDescription('while importing a host transfer'),
+        ),
+      );
       if (!mounted) {
         return;
       }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Import failed: $error')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Import failed. Check the file and try again.'),
+        ),
+      );
     }
   }
 

--- a/lib/presentation/screens/key_add_screen.dart
+++ b/lib/presentation/screens/key_add_screen.dart
@@ -259,12 +259,20 @@ class _GenerateKeyTabState extends ConsumerState<_GenerateKeyTab> {
         }
       }
     } on Exception catch (e) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: e,
+          library: 'keys',
+          context: ErrorDescription('while generating an SSH key'),
+        ),
+      );
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Error generating key: $e')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not generate key. Try again.')),
+        );
       }
     } finally {
+      _passphraseController.clear();
       if (mounted) setState(() => _isGenerating = false);
     }
   }
@@ -444,18 +452,27 @@ class _ImportKeyTabState extends ConsumerState<_ImportKeyTab> {
       }
 
       if (mounted) {
+        _privateKeyController.clear();
         context.pop();
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Key imported successfully')),
         );
       }
     } on Exception catch (e) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: e,
+          library: 'keys',
+          context: ErrorDescription('while importing an SSH key'),
+        ),
+      );
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Error importing key: $e')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not import key. Try again.')),
+        );
       }
     } finally {
+      _passphraseController.clear();
       if (mounted) setState(() => _isImporting = false);
     }
   }
@@ -565,12 +582,23 @@ class _ImportKeyTabState extends ConsumerState<_ImportKeyTab> {
         SnackBar(content: Text('Import failed: ${error.message}')),
       );
     } on Exception catch (error) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          library: 'keys',
+          context: ErrorDescription(
+            'while importing an encrypted key transfer',
+          ),
+        ),
+      );
       if (!mounted) {
         return;
       }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Import failed: $error')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Import failed. Check the file and try again.'),
+        ),
+      );
     } finally {
       if (mounted) {
         setState(() => _isImporting = false);

--- a/lib/presentation/screens/keys_screen.dart
+++ b/lib/presentation/screens/keys_screen.dart
@@ -32,7 +32,7 @@ class KeysScreen extends ConsumerWidget {
                 color: theme.colorScheme.error,
               ),
               const SizedBox(height: FluttyTheme.spacingMd),
-              Text('Error loading keys: $error'),
+              const Text('Could not load SSH keys.'),
               const SizedBox(height: FluttyTheme.spacingMd),
               FilledButton.icon(
                 onPressed: () => ref.invalidate(allKeysProvider),

--- a/lib/presentation/screens/port_forward_edit_screen.dart
+++ b/lib/presentation/screens/port_forward_edit_screen.dart
@@ -387,10 +387,19 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
         );
       }
     } on Exception catch (e) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: e,
+          library: 'port forwards',
+          context: ErrorDescription('while saving a port forward'),
+        ),
+      );
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Error: $e')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Could not save port forward. Try again.'),
+          ),
+        );
       }
     } finally {
       if (mounted) setState(() => _isLoading = false);

--- a/lib/presentation/screens/port_forwards_screen.dart
+++ b/lib/presentation/screens/port_forwards_screen.dart
@@ -22,7 +22,7 @@ class PortForwardsScreen extends ConsumerWidget {
       appBar: AppBar(title: const Text('Port Forwards')),
       body: portForwardsAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, stack) => Center(
+        error: (_, _) => Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
@@ -32,7 +32,7 @@ class PortForwardsScreen extends ConsumerWidget {
                 color: theme.colorScheme.error,
               ),
               const SizedBox(height: FluttyTheme.spacingMd),
-              Text('Error: $error'),
+              const Text('Could not load port forwards.'),
               const SizedBox(height: FluttyTheme.spacingMd),
               FilledButton.icon(
                 onPressed: () => ref.invalidate(_allPortForwardsProvider),
@@ -44,7 +44,7 @@ class PortForwardsScreen extends ConsumerWidget {
         ),
         data: (portForwards) => hostsAsync.when(
           loading: () => const Center(child: CircularProgressIndicator()),
-          error: (error, stack) => Center(child: Text('Error: $error')),
+          error: (_, _) => const Center(child: Text('Could not load hosts.')),
           data: (hosts) =>
               _buildPortForwardsList(context, ref, portForwards, hosts),
         ),

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -23,6 +23,8 @@ import '../widgets/premium_badge.dart';
 import '../widgets/terminal_theme_picker.dart';
 import 'transfer_screen.dart';
 
+const _githubUrl = 'https://github.com/depollsoft/MonkeySSH';
+
 /// Settings screen with appearance, security, terminal, import/export,
 /// background and about sections.
 class SettingsScreen extends ConsumerWidget {
@@ -385,145 +387,161 @@ class _SecuritySection extends ConsumerWidget {
       return null;
     }
 
-    showDialog<void>(
-      context: context,
-      builder: (context) => StatefulBuilder(
-        builder: (context, setState) => AlertDialog(
-          title: const Text('Change PIN'),
-          content: Form(
-            key: formKey,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                TextFormField(
-                  controller: currentPinController,
-                  decoration: const InputDecoration(
-                    labelText: 'Current PIN',
-                    counterText: '',
+    unawaited(
+      showDialog<void>(
+        context: context,
+        builder: (context) => StatefulBuilder(
+          builder: (context, setState) => AlertDialog(
+            title: const Text('Change PIN'),
+            content: Form(
+              key: formKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextFormField(
+                    controller: currentPinController,
+                    decoration: const InputDecoration(
+                      labelText: 'Current PIN',
+                      counterText: '',
+                    ),
+                    forceErrorText: currentPinErrorText.isEmpty
+                        ? null
+                        : currentPinErrorText,
+                    obscureText: true,
+                    keyboardType: TextInputType.number,
+                    maxLength: 8,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    validator: validateCurrentPin,
+                    onChanged: (_) {
+                      if (currentPinErrorText.isEmpty) return;
+                      setState(() => currentPinErrorText = '');
+                    },
                   ),
-                  forceErrorText: currentPinErrorText.isEmpty
-                      ? null
-                      : currentPinErrorText,
-                  obscureText: true,
-                  keyboardType: TextInputType.number,
-                  maxLength: 8,
-                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                  validator: validateCurrentPin,
-                  onChanged: (_) {
-                    if (currentPinErrorText.isEmpty) return;
-                    setState(() => currentPinErrorText = '');
-                  },
-                ),
-                const SizedBox(height: 16),
-                TextFormField(
-                  controller: newPinController,
-                  decoration: const InputDecoration(
-                    labelText: 'New PIN',
-                    counterText: '',
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: newPinController,
+                    decoration: const InputDecoration(
+                      labelText: 'New PIN',
+                      counterText: '',
+                    ),
+                    obscureText: true,
+                    keyboardType: TextInputType.number,
+                    maxLength: 8,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    validator: validateNewPin,
                   ),
-                  obscureText: true,
-                  keyboardType: TextInputType.number,
-                  maxLength: 8,
-                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                  validator: validateNewPin,
-                ),
-                const SizedBox(height: 16),
-                TextFormField(
-                  controller: confirmPinController,
-                  decoration: const InputDecoration(
-                    labelText: 'Confirm new PIN',
-                    counterText: '',
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: confirmPinController,
+                    decoration: const InputDecoration(
+                      labelText: 'Confirm new PIN',
+                      counterText: '',
+                    ),
+                    obscureText: true,
+                    keyboardType: TextInputType.number,
+                    maxLength: 8,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    validator: (v) {
+                      final pinValidationError = validateNewPin(v);
+                      if (pinValidationError != null) return pinValidationError;
+                      if (v != newPinController.text) {
+                        return 'PINs do not match';
+                      }
+                      return null;
+                    },
                   ),
-                  obscureText: true,
-                  keyboardType: TextInputType.number,
-                  maxLength: 8,
-                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                  validator: (v) {
-                    final pinValidationError = validateNewPin(v);
-                    if (pinValidationError != null) return pinValidationError;
-                    if (v != newPinController.text) return 'PINs do not match';
-                    return null;
-                  },
-                ),
-              ],
+                ],
+              ),
             ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: isChanging ? null : () => Navigator.pop(context),
-              child: const Text('Cancel'),
-            ),
-            FilledButton(
-              onPressed: isChanging
-                  ? null
-                  : () async {
-                      if (!(formKey.currentState?.validate() ?? false)) return;
+            actions: [
+              TextButton(
+                onPressed: isChanging ? null : () => Navigator.pop(context),
+                child: const Text('Cancel'),
+              ),
+              FilledButton(
+                onPressed: isChanging
+                    ? null
+                    : () async {
+                        if (!(formKey.currentState?.validate() ?? false)) {
+                          return;
+                        }
 
-                      setState(() {
-                        currentPinErrorText = '';
-                        isChanging = true;
-                      });
+                        setState(() {
+                          currentPinErrorText = '';
+                          isChanging = true;
+                        });
 
-                      bool success;
-                      try {
-                        success = await ref
-                            .read(authServiceProvider)
-                            .changePin(
-                              currentPinController.text,
-                              newPinController.text,
-                            );
-                      } on Object catch (error, stackTrace) {
-                        FlutterError.reportError(
-                          FlutterErrorDetails(
-                            exception: error,
-                            stack: stackTrace,
-                            library: 'auth',
-                            context: ErrorDescription(
-                              'while changing the app PIN from settings',
-                            ),
-                          ),
-                        );
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('Could not change PIN. Try again.'),
+                        bool success;
+                        try {
+                          success = await ref
+                              .read(authServiceProvider)
+                              .changePin(
+                                currentPinController.text,
+                                newPinController.text,
+                              );
+                        } on Object catch (error, stackTrace) {
+                          FlutterError.reportError(
+                            FlutterErrorDetails(
+                              exception: error,
+                              stack: stackTrace,
+                              library: 'auth',
+                              context: ErrorDescription(
+                                'while changing the app PIN from settings',
+                              ),
                             ),
                           );
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text(
+                                  'Could not change PIN. Try again.',
+                                ),
+                              ),
+                            );
+                          }
+                          return;
+                        } finally {
+                          if (context.mounted) {
+                            setState(() => isChanging = false);
+                          }
                         }
-                        return;
-                      } finally {
-                        if (context.mounted) {
-                          setState(() => isChanging = false);
+
+                        if (!context.mounted) return;
+
+                        if (success) {
+                          Navigator.pop(context);
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('PIN changed successfully'),
+                            ),
+                          );
+                          return;
                         }
-                      }
 
-                      if (!context.mounted) return;
-
-                      if (success) {
-                        Navigator.pop(context);
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(
-                            content: Text('PIN changed successfully'),
-                          ),
+                        setState(
+                          () =>
+                              currentPinErrorText = 'Current PIN is incorrect',
                         );
-                        return;
-                      }
-
-                      setState(
-                        () => currentPinErrorText = 'Current PIN is incorrect',
-                      );
-                    },
-              child: isChanging
-                  ? const SizedBox(
-                      height: 20,
-                      width: 20,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Text('Change'),
-            ),
-          ],
+                      },
+                child: isChanging
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Change'),
+              ),
+            ],
+          ),
         ),
-      ),
+      ).whenComplete(() {
+        currentPinController.clear();
+        newPinController.clear();
+        confirmPinController.clear();
+        currentPinController.dispose();
+        newPinController.dispose();
+        confirmPinController.dispose();
+      }),
     );
   }
 
@@ -1138,8 +1156,8 @@ class _AboutSection extends ConsumerWidget {
         ListTile(
           leading: const Icon(Icons.code),
           title: const Text('GitHub'),
-          subtitle: const Text('View source code'),
-          onTap: () => _showGitHubInfo(context),
+          subtitle: const Text('Copy source repository URL'),
+          onTap: () => unawaited(_copyGitHubUrl(context)),
         ),
         ListTile(
           leading: const Icon(Icons.description_outlined),
@@ -1161,12 +1179,14 @@ class _AboutSection extends ConsumerWidget {
     error: (_, _) => 'Unavailable',
   );
 
-  void _showGitHubInfo(BuildContext context) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text('GitHub: github.com/monkeyssh-app/monkeyssh'),
-      ),
-    );
+  Future<void> _copyGitHubUrl(BuildContext context) async {
+    await Clipboard.setData(const ClipboardData(text: _githubUrl));
+    if (!context.mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('GitHub URL copied')));
   }
 }
 
@@ -1364,12 +1384,19 @@ class _ImportExportSection extends ConsumerWidget {
         sharePositionOrigin: shareOriginFromContext(context),
       );
     } on Exception catch (error) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          library: 'settings',
+          context: ErrorDescription('while exporting app data'),
+        ),
+      );
       if (!context.mounted) {
         return;
       }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Export failed: $error')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Export failed. Try again.')),
+      );
     }
   }
 
@@ -1472,12 +1499,21 @@ class _ImportExportSection extends ConsumerWidget {
         SnackBar(content: Text('Import failed: ${error.message}')),
       );
     } on Exception catch (error) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          library: 'settings',
+          context: ErrorDescription('while importing app data'),
+        ),
+      );
       if (!context.mounted) {
         return;
       }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Import failed: $error')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Import failed. Check the file and try again.'),
+        ),
+      );
     }
   }
 }

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -17,6 +17,7 @@ import 'package:video_player/video_player.dart';
 import '../../data/repositories/host_repository.dart';
 import '../../domain/models/monetization.dart';
 import '../../domain/models/terminal_themes.dart';
+import '../../domain/services/diagnostics_log_service.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/remote_file_service.dart';
 import '../../domain/services/settings_service.dart';
@@ -568,6 +569,11 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       }
       await _openFallbackDirectory(preferredPath: _fallbackDirectoryPath);
     } on Exception catch (e) {
+      DiagnosticsLogService.instance.warning(
+        'sftp',
+        'connect_failed',
+        fields: {'errorType': e.runtimeType},
+      );
       pendingSftp?.close();
       if (!mounted) {
         return;
@@ -576,7 +582,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         _isLoading = false;
         _error = e is TimeoutException
             ? sftpTimeoutMessage('opening the SFTP browser')
-            : 'SFTP connection failed: $e';
+            : 'SFTP connection failed. Check the connection and try again.';
       });
     }
   }
@@ -699,6 +705,11 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       if (e is TimeoutException && rethrowTimeout) {
         rethrow;
       }
+      DiagnosticsLogService.instance.warning(
+        'sftp',
+        'list_failed',
+        fields: {'errorType': e.runtimeType},
+      );
       if (!mounted) {
         return false;
       }
@@ -706,8 +717,8 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         _isLoading = false;
         if (showError) {
           _error = e is TimeoutException
-              ? sftpTimeoutMessage('listing "$path"')
-              : 'Failed to list directory: $e';
+              ? sftpTimeoutMessage('listing this directory')
+              : 'Failed to list this directory. Try another folder.';
         }
       });
       return false;
@@ -962,6 +973,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: _showUploadDialog,
+        tooltip: 'Upload files',
         child: const Icon(Icons.upload_file),
       ),
     ),
@@ -1258,48 +1270,10 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   }
 
   Future<void> _showCreateDirectoryDialog() async {
-    final controller = TextEditingController();
-
     final name = await showDialog<String>(
       context: context,
-      builder: (context) => ValueListenableBuilder<TextEditingValue>(
-        valueListenable: controller,
-        builder: (context, value, _) {
-          final validationMessage = validateSftpDirectoryName(value.text);
-          final canCreate = validationMessage == null;
-
-          return AlertDialog(
-            title: const Text('Create Folder'),
-            content: TextField(
-              controller: controller,
-              autofocus: true,
-              textInputAction: TextInputAction.done,
-              decoration: InputDecoration(
-                labelText: 'Folder name',
-                helperText: 'Created inside $_currentPath',
-                errorText: value.text.isEmpty ? null : validationMessage,
-              ),
-              onSubmitted: canCreate
-                  ? (value) => Navigator.pop(context, value.trim())
-                  : null,
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(context),
-                child: const Text('Cancel'),
-              ),
-              FilledButton(
-                onPressed: canCreate
-                    ? () => Navigator.pop(context, value.text.trim())
-                    : null,
-                child: const Text('Create'),
-              ),
-            ],
-          );
-        },
-      ),
+      builder: (context) => _CreateDirectoryDialog(currentPath: _currentPath),
     );
-    controller.dispose();
 
     if (name == null || _sftp == null) {
       return;
@@ -1327,37 +1301,18 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         );
       }
     } on Exception catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Could not create "$remotePath": $e')),
-        );
-      }
+      _showSftpFailureSnackBar(
+        message: 'Could not create folder. Check permissions and try again.',
+        eventName: 'create_directory_failed',
+        error: e,
+      );
     }
   }
 
   Future<void> _showRenameDialog(SftpName file) async {
-    final controller = TextEditingController(text: file.filename);
-
     final newName = await showDialog<String>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Rename'),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          decoration: const InputDecoration(labelText: 'New name'),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, controller.text),
-            child: const Text('Rename'),
-          ),
-        ],
-      ),
+      builder: (context) => _RenameDialog(initialName: file.filename),
     );
 
     if (newName != null && newName.isNotEmpty && _sftp != null) {
@@ -1373,11 +1328,11 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
           ).showSnackBar(SnackBar(content: Text('Renamed to "$newName"')));
         }
       } on Exception catch (e) {
-        if (mounted) {
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text('Error: $e')));
-        }
+        _showSftpFailureSnackBar(
+          message: 'Could not rename item. Check permissions and try again.',
+          eventName: 'rename_failed',
+          error: e,
+        );
       }
     }
   }
@@ -1419,11 +1374,11 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
           ).showSnackBar(SnackBar(content: Text('Deleted "${file.filename}"')));
         }
       } on Exception catch (e) {
-        if (mounted) {
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text('Error: $e')));
-        }
+        _showSftpFailureSnackBar(
+          message: 'Could not delete item. Check permissions and try again.',
+          eventName: 'delete_failed',
+          error: e,
+        );
       }
     }
   }
@@ -1457,11 +1412,11 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         );
       }
     } on Exception catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Download failed: $e')));
-      }
+      _showSftpFailureSnackBar(
+        message: 'Download failed. Check the connection and try again.',
+        eventName: 'download_failed',
+        error: e,
+      );
     }
   }
 
@@ -1521,11 +1476,11 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         ).showSnackBar(SnackBar(content: Text(message)));
       }
     } on Exception catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Upload failed: $e')));
-      }
+      _showSftpFailureSnackBar(
+        message: 'Upload failed. Check the connection and try again.',
+        eventName: 'upload_failed',
+        error: e,
+      );
     }
   }
 
@@ -1604,9 +1559,11 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       if (!mounted) {
         return;
       }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Preview failed: $e')));
+      _showSftpFailureSnackBar(
+        message: 'Preview failed. Download the file to open it locally.',
+        eventName: 'preview_failed',
+        error: e,
+      );
     }
   }
 
@@ -1990,16 +1947,147 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         ).showSnackBar(SnackBar(content: Text('Saved "${file.filename}"')));
       }
     } on Exception catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Edit failed: $e')));
-      }
+      _showSftpFailureSnackBar(
+        message: 'Could not save changes. Check permissions and try again.',
+        eventName: 'edit_failed',
+        error: e,
+      );
     }
+  }
+
+  void _showSftpFailureSnackBar({
+    required String message,
+    required String eventName,
+    required Object error,
+  }) {
+    DiagnosticsLogService.instance.warning(
+      'sftp',
+      eventName,
+      fields: {'errorType': error.runtimeType},
+    );
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
   }
 
   String _joinRemotePath(String directory, String name) =>
       joinRemotePath(directory, name);
+}
+
+class _CreateDirectoryDialog extends StatefulWidget {
+  const _CreateDirectoryDialog({required this.currentPath});
+
+  final String currentPath;
+
+  @override
+  State<_CreateDirectoryDialog> createState() => _CreateDirectoryDialogState();
+}
+
+class _CreateDirectoryDialogState extends State<_CreateDirectoryDialog> {
+  late final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      ValueListenableBuilder<TextEditingValue>(
+        valueListenable: _controller,
+        builder: (context, value, _) {
+          final validationMessage = validateSftpDirectoryName(value.text);
+          final canCreate = validationMessage == null;
+
+          return AlertDialog(
+            title: const Text('Create Folder'),
+            content: TextField(
+              controller: _controller,
+              autofocus: true,
+              textInputAction: TextInputAction.done,
+              decoration: InputDecoration(
+                labelText: 'Folder name',
+                helperText: 'Created inside ${widget.currentPath}',
+                errorText: value.text.isEmpty ? null : validationMessage,
+              ),
+              onSubmitted: canCreate ? _submit : null,
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Cancel'),
+              ),
+              FilledButton(
+                onPressed: canCreate ? () => _submit(value.text) : null,
+                child: const Text('Create'),
+              ),
+            ],
+          );
+        },
+      );
+
+  void _submit(String value) {
+    final trimmed = value.trim();
+    if (validateSftpDirectoryName(trimmed) != null) {
+      return;
+    }
+    Navigator.pop(context, trimmed);
+  }
+}
+
+class _RenameDialog extends StatefulWidget {
+  const _RenameDialog({required this.initialName});
+
+  final String initialName;
+
+  @override
+  State<_RenameDialog> createState() => _RenameDialogState();
+}
+
+class _RenameDialogState extends State<_RenameDialog> {
+  late final TextEditingController _controller = TextEditingController(
+    text: widget.initialName,
+  );
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => AlertDialog(
+    title: const Text('Rename'),
+    content: TextField(
+      controller: _controller,
+      autofocus: true,
+      decoration: const InputDecoration(labelText: 'New name'),
+      textInputAction: TextInputAction.done,
+      onSubmitted: _submit,
+    ),
+    actions: [
+      TextButton(
+        onPressed: () => Navigator.pop(context),
+        child: const Text('Cancel'),
+      ),
+      FilledButton(
+        onPressed: () => _submit(_controller.text),
+        child: const Text('Rename'),
+      ),
+    ],
+  );
+
+  void _submit(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return;
+    }
+    Navigator.pop(context, trimmed);
+  }
 }
 
 class _FileListTile extends StatelessWidget {
@@ -2645,9 +2733,9 @@ class _RemoteVideoViewerScreenState extends State<_RemoteVideoViewerScreen> {
     return box.localToGlobal(Offset.zero) & box.size;
   }
 
-  String _playbackErrorMessage(Object error) =>
+  String _playbackErrorMessage(Object _) =>
       'This platform could not decode or play the video. Try saving or '
-      'opening the cached copy in another app. $error';
+      'opening the cached copy in another app.';
 
   String _formatVideoDuration(Duration duration) {
     final hours = duration.inHours;

--- a/lib/presentation/screens/snippet_edit_screen.dart
+++ b/lib/presentation/screens/snippet_edit_screen.dart
@@ -283,10 +283,17 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
         );
       }
     } on Exception catch (e) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: e,
+          library: 'snippets',
+          context: ErrorDescription('while saving a snippet'),
+        ),
+      );
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Error: $e')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not save snippet. Try again.')),
+        );
       }
     } finally {
       if (mounted) setState(() => _isLoading = false);

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1064,6 +1064,8 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       0x7fffffff;
 
   void _sendAlertNotification(TmuxWindow window) {
+    final title = _tmuxAlertNotificationTitle(window);
+    final sessionName = _tmuxAlertNotificationLabel(widget.tmuxSessionName);
     unawaited(HapticFeedback.mediumImpact());
     unawaited(
       widget.ref
@@ -1074,8 +1076,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
               widget.tmuxSessionName,
               window.index,
             ),
-            title: 'tmux window needs attention',
-            body: 'Open MonkeySSH to view the alert.',
+            title: title,
+            body:
+                'tmux window #${window.index} in $sessionName needs attention.',
             payload: TmuxAlertNotificationPayload(
               hostId: widget.session.hostId,
               connectionId: widget.session.connectionId,
@@ -1085,6 +1088,17 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           ),
     );
   }
+
+  String _tmuxAlertNotificationTitle(TmuxWindow window) {
+    final title = _tmuxAlertNotificationLabel(window.displayTitle);
+    if (title.isEmpty) {
+      return 'tmux window #${window.index}';
+    }
+    return title;
+  }
+
+  String _tmuxAlertNotificationLabel(String value) =>
+      value.replaceAll(RegExp(r'\s+'), ' ').trim();
 
   void _clearAlertNotification(int windowIndex) {
     unawaited(

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1019,9 +1019,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
 
   void _sendAlertNotification(TmuxWindow window) {
     unawaited(HapticFeedback.mediumImpact());
-    final title = 'tmux alert · ${widget.tmuxSessionName}';
-    final name = window.displayTitle.trim();
-    final body = name.isEmpty ? 'Window ${window.index} needs attention' : name;
     unawaited(
       widget.ref
           .read(localNotificationServiceProvider)
@@ -1031,8 +1028,8 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
               widget.tmuxSessionName,
               window.index,
             ),
-            title: title,
-            body: body,
+            title: 'tmux window needs attention',
+            body: 'Open MonkeySSH to view the alert.',
             payload: TmuxAlertNotificationPayload(
               hostId: widget.session.hostId,
               connectionId: widget.session.connectionId,
@@ -3996,7 +3993,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       if (!mounted) return;
       setState(() {
         _isConnecting = false;
-        _error = 'Failed to start shell: $e';
+        _error = 'Failed to start shell. Try reconnecting.';
       });
     }
   }
@@ -4017,8 +4014,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _shellStdoutSubscription = session.shellStdoutStream.listen(
       _schedulePromptOutputImeResetCheck,
       onError: (Object error, StackTrace stackTrace) {
-        debugPrint('Terminal stdout stream error: $error');
-        debugPrint('$stackTrace');
+        if (kDebugMode) {
+          debugPrint('Terminal stdout stream error: $error');
+          debugPrint('$stackTrace');
+        }
         DiagnosticsLogService.instance.error(
           'terminal',
           'stdout_listener_error',
@@ -4257,9 +4256,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       final snippetRepo = ref.read(snippetRepositoryProvider);
       final snippet = await snippetRepo.getById(snippetId);
       if (snippet == null) {
-        debugPrint(
-          'Auto-connect snippet $snippetId is unavailable; using cached command.',
-        );
+        if (kDebugMode) {
+          debugPrint(
+            'Auto-connect snippet $snippetId is unavailable; '
+            'using cached command.',
+          );
+        }
       } else {
         snippetCommand = snippet.command;
         resolvedSnippetId = snippet.id;
@@ -4922,7 +4924,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final message = switch (error) {
       TimeoutException() =>
         'Timed out waiting for tmux. Reconnect if actions keep failing.',
-      _ => 'tmux action failed: $error',
+      _ => 'tmux action failed. Check the session and try again.',
     };
     ScaffoldMessenger.of(
       context,
@@ -8297,10 +8299,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       }
       return null;
     } on Object catch (error, stackTrace) {
-      debugPrint(
-        'Failed to resolve terminal file path "$terminalPath": $error',
+      DiagnosticsLogService.instance.warning(
+        'terminal',
+        'sftp_path_resolution_failed',
+        fields: {'errorType': error.runtimeType},
       );
-      debugPrint('$stackTrace');
+      if (kDebugMode) {
+        debugPrint(
+          'Failed to resolve terminal file path "$terminalPath": $error',
+        );
+        debugPrint('$stackTrace');
+      }
       if (showErrors && isExplicitPath) {
         _showTerminalLinkMessage('Could not open "$terminalPath" in SFTP');
       }
@@ -8380,23 +8389,39 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _terminalController.clearSelection();
       _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
     } on PlatformException catch (error) {
-      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
-      _showClipboardMessage(
-        'Clipboard access failed: ${error.message ?? error.code}',
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'paste_failed',
+        fields: {'errorType': error.runtimeType},
       );
+      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+      _showClipboardMessage('Clipboard access failed. Try again.');
     } on FileSystemException catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'file_upload_failed',
+        fields: {'errorType': error.runtimeType},
+      );
+      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+      _showClipboardMessage('Clipboard file upload failed. Try again.');
+    } on SftpError catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'remote_upload_failed',
+        fields: {'errorType': error.runtimeType},
+      );
       _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
       _showClipboardMessage(
-        error.message.isEmpty
-            ? 'Clipboard file upload failed'
-            : 'Clipboard file upload failed: ${error.message}',
+        'Remote upload failed. Check permissions and try again.',
       );
-    } on SftpError catch (error) {
-      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
-      _showClipboardMessage('Remote upload failed: ${error.message}');
     } on Object catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'upload_failed',
+        fields: {'errorType': error.runtimeType},
+      );
       _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
-      _showClipboardMessage('Clipboard upload failed: $error');
+      _showClipboardMessage('Clipboard upload failed. Try again.');
     }
   }
 
@@ -8454,23 +8479,39 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         itemLabelPlural: itemLabelPlural,
       );
     } on PlatformException catch (error) {
-      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
-      _showClipboardMessage(
-        '$failureContext failed: ${error.message ?? error.code}',
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'picker_failed',
+        fields: {'errorType': error.runtimeType},
       );
+      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+      _showClipboardMessage('$failureContext failed. Try again.');
     } on FileSystemException catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'picked_file_failed',
+        fields: {'errorType': error.runtimeType},
+      );
+      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+      _showClipboardMessage('$failureContext failed. Try again.');
+    } on SftpError catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'picked_remote_upload_failed',
+        fields: {'errorType': error.runtimeType},
+      );
       _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
       _showClipboardMessage(
-        error.message.isEmpty
-            ? '$failureContext failed'
-            : '$failureContext failed: ${error.message}',
+        'Remote upload failed. Check permissions and try again.',
       );
-    } on SftpError catch (error) {
-      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
-      _showClipboardMessage('Remote upload failed: ${error.message}');
     } on Object catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'picked_upload_failed',
+        fields: {'errorType': error.runtimeType},
+      );
       _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
-      _showClipboardMessage('$failureContext failed: $error');
+      _showClipboardMessage('$failureContext failed. Try again.');
     }
   }
 

--- a/lib/presentation/screens/theme_editor_screen.dart
+++ b/lib/presentation/screens/theme_editor_screen.dart
@@ -465,10 +465,17 @@ class _ThemeEditorScreenState extends ConsumerState<ThemeEditorScreen> {
         ).showSnackBar(SnackBar(content: Text('Theme "${theme.name}" saved')));
       }
     } on Exception catch (e) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: e,
+          library: 'terminal themes',
+          context: ErrorDescription('while saving a terminal theme'),
+        ),
+      );
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Error saving theme: $e')));
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not save theme. Try again.')),
+        );
       }
     } finally {
       if (mounted) setState(() => _isLoading = false);

--- a/lib/presentation/screens/transfer_screen.dart
+++ b/lib/presentation/screens/transfer_screen.dart
@@ -292,44 +292,52 @@ Future<String?> showTransferPassphraseDialog({
   final controller = TextEditingController();
   var obscureText = true;
 
-  final value = await showDialog<String>(
-    context: context,
-    builder: (dialogContext) => StatefulBuilder(
-      builder: (context, setState) => AlertDialog(
-        title: Text(title),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          obscureText: obscureText,
-          decoration: InputDecoration(
-            labelText: 'Transfer passphrase',
-            helperText: 'Required to encrypt/decrypt transfer data',
-            suffixIcon: IconButton(
-              onPressed: () => setState(() => obscureText = !obscureText),
-              icon: Icon(obscureText ? Icons.visibility : Icons.visibility_off),
+  try {
+    final value = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (context, setState) => AlertDialog(
+          title: Text(title),
+          content: TextField(
+            controller: controller,
+            autofocus: true,
+            obscureText: obscureText,
+            decoration: InputDecoration(
+              labelText: 'Transfer passphrase',
+              helperText: 'Required to encrypt/decrypt transfer data',
+              suffixIcon: IconButton(
+                onPressed: () => setState(() => obscureText = !obscureText),
+                icon: Icon(
+                  obscureText ? Icons.visibility : Icons.visibility_off,
+                ),
+              ),
             ),
           ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () =>
+                  Navigator.pop(dialogContext, controller.text.trim()),
+              child: const Text('Continue'),
+            ),
+          ],
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () =>
-                Navigator.pop(dialogContext, controller.text.trim()),
-            child: const Text('Continue'),
-          ),
-        ],
       ),
-    ),
-  );
+    );
 
-  final trimmed = value?.trim();
-  if (trimmed == null || trimmed.isEmpty) {
-    return null;
+    final trimmed = value?.trim();
+    if (trimmed == null || trimmed.isEmpty) {
+      return null;
+    }
+    return trimmed;
+  } finally {
+    controller
+      ..clear()
+      ..dispose();
   }
-  return trimmed;
 }
 
 /// Requests local authentication for sensitive transfer exports.
@@ -408,28 +416,34 @@ bool _isSensitiveTransferAuthSessionUnlocked(
 
 Future<String?> _showPinDialog(BuildContext context) async {
   final controller = TextEditingController();
-  return showDialog<String>(
-    context: context,
-    builder: (context) => AlertDialog(
-      title: const Text('Enter PIN'),
-      content: TextField(
-        controller: controller,
-        keyboardType: TextInputType.number,
-        obscureText: true,
-        decoration: const InputDecoration(labelText: 'PIN'),
+  try {
+    return await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Enter PIN'),
+        content: TextField(
+          controller: controller,
+          keyboardType: TextInputType.number,
+          obscureText: true,
+          decoration: const InputDecoration(labelText: 'PIN'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, controller.text.trim()),
+            child: const Text('Confirm'),
+          ),
+        ],
       ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: const Text('Cancel'),
-        ),
-        FilledButton(
-          onPressed: () => Navigator.pop(context, controller.text.trim()),
-          child: const Text('Confirm'),
-        ),
-      ],
-    ),
-  );
+    );
+  } finally {
+    controller
+      ..clear()
+      ..dispose();
+  }
 }
 
 /// Shared merge/replace mode chooser for migration imports.

--- a/lib/presentation/widgets/connection_attempt_dialog.dart
+++ b/lib/presentation/widgets/connection_attempt_dialog.dart
@@ -44,8 +44,9 @@ Future<SshConnectionResult> connectToHostWithProgressDialog(
         context: ErrorDescription('while connecting to host ${host.id}'),
       ),
     );
-    sessionsNotifier.reportConnectionAttemptError(host.id, '$error');
-    result = SshConnectionResult(success: false, error: '$error');
+    const message = 'Connection failed. Check the host settings and try again.';
+    sessionsNotifier.reportConnectionAttemptError(host.id, message);
+    result = const SshConnectionResult(success: false, error: message);
   }
 
   if (result.success && result.connectionId != null && navigator.mounted) {

--- a/lib/presentation/widgets/keyboard_toolbar.dart
+++ b/lib/presentation/widgets/keyboard_toolbar.dart
@@ -743,7 +743,11 @@ class _ToolbarButtonState extends State<_ToolbarButton> {
       button = Tooltip(message: tooltip, child: button);
     }
 
-    return button;
+    return Semantics(
+      button: true,
+      label: widget.tooltip ?? widget.label,
+      child: button,
+    );
   }
 }
 
@@ -853,6 +857,16 @@ class _ModifierButtonState extends State<_ModifierButton> {
       button = Tooltip(message: tooltip, child: button);
     }
 
-    return button;
+    return Semantics(
+      button: true,
+      label: widget.tooltip ?? widget.label,
+      toggled: widget.state != null,
+      value: switch (widget.state) {
+        null => 'off',
+        false => 'one-shot',
+        true => 'locked',
+      },
+      child: button,
+    );
   }
 }

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1229,12 +1229,13 @@ class MonkeyRenderTerminal extends RenderBox
   LayerLink? _startHandleLayerLink;
   LayerLink? _endHandleLayerLink;
   SelectionGeometry _selectionGeometry;
+  bool _selectionGeometryNotificationScheduled = false;
   final Set<VoidCallback> _selectionListeners = <VoidCallback>{};
 
   void _onScroll() {
     _stickToBottom = _scrollOffset >= _maxScrollExtent;
     markNeedsLayout();
-    _updateSelectionGeometry();
+    _updateSelectionGeometry(deferNotification: true);
     _notifyEditableRect();
   }
 
@@ -1630,12 +1631,34 @@ class MonkeyRenderTerminal extends RenderBox
     );
   }
 
-  void _updateSelectionGeometry() {
+  void _updateSelectionGeometry({bool deferNotification = false}) {
     final nextGeometry = _computeSelectionGeometry();
     if (nextGeometry == _selectionGeometry) {
       return;
     }
     _selectionGeometry = nextGeometry;
+    if (deferNotification) {
+      _scheduleSelectionGeometryNotification();
+      return;
+    }
+    _notifySelectionGeometryListeners();
+  }
+
+  void _scheduleSelectionGeometryNotification() {
+    if (_selectionGeometryNotificationScheduled) {
+      return;
+    }
+    _selectionGeometryNotificationScheduled = true;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _selectionGeometryNotificationScheduled = false;
+      if (!attached) {
+        return;
+      }
+      _notifySelectionGeometryListeners();
+    });
+  }
+
+  void _notifySelectionGeometryListeners() {
     for (final listener in List<VoidCallback>.of(_selectionListeners)) {
       listener();
     }

--- a/lib/presentation/widgets/terminal_theme_picker.dart
+++ b/lib/presentation/widgets/terminal_theme_picker.dart
@@ -146,7 +146,8 @@ class _TerminalThemePickerState extends ConsumerState<TerminalThemePicker> {
       ],
       body: themesAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('Error: $e')),
+        error: (_, _) =>
+            const Center(child: Text('Could not load terminal themes.')),
         data: (themes) {
           final filtered = _filterThemes(themes);
           if (filtered.isEmpty) {

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -551,6 +551,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
                   const Spacer(),
                   IconButton(
                     icon: const Icon(Icons.close, size: 20),
+                    tooltip: 'Close tmux navigator',
                     onPressed: () => Navigator.pop(context),
                     visualDensity: VisualDensity.compact,
                   ),
@@ -576,7 +577,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
                     Padding(
                       padding: const EdgeInsets.all(16),
                       child: Text(
-                        'Could not load windows: $_error',
+                        'Could not load tmux windows. Check that tmux is still running, then try again.',
                         style: TextStyle(color: theme.colorScheme.error),
                       ),
                     )

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -7,7 +7,7 @@ project(runner LANGUAGES CXX)
 set(BINARY_NAME "monkeyssh")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.monkeyssh.monkeyssh")
+set(APPLICATION_ID "xyz.depollsoft.monkeyssh")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -45,11 +45,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "flutty");
+    gtk_header_bar_set_title(header_bar, "MonkeySSH");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "flutty");
+    gtk_window_set_title(window, "MonkeySSH");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		D9A7B1C12E3F445500A1B2C3 /* AppIcon-production.icon in Resources */ = {isa = PBXBuildFile; fileRef = D9A7B1C22E3F445500A1B2C3 /* AppIcon-production.icon */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		A9E4D6113D7A4E49A3759B11 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A9E4D6103D7A4E49A3759B11 /* PrivacyInfo.xcprivacy */; };
 		A4A077B412831F5432F6354F /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDE1FA30DB0D919D7FDC3D37 /* Pods_RunnerTests.framework */; };
 		B3B71A614E9C3348CB048440 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1BD9AF95FA7E7D3EDEB0DAD /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
@@ -90,6 +91,7 @@
 		DDE1FA30DB0D919D7FDC3D37 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8CA46C3E7B35F4DBF9348AF /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		D9A7B1C22E3F445500A1B2C3 /* AppIcon-production.icon */ = {isa = PBXFileReference; lastKnownFileType = document.icon-composer; path = "Runner/AppIcon-production.icon"; sourceTree = "<group>"; };
+		A9E4D6103D7A4E49A3759B11 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Runner/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -159,6 +161,7 @@
 				D9A7B1C22E3F445500A1B2C3 /* AppIcon-production.icon */,
 				33CC10F42044A3C60003C045 /* MainMenu.xib */,
 				33CC10F72044A3C60003C045 /* Info.plist */,
+				A9E4D6103D7A4E49A3759B11 /* PrivacyInfo.xcprivacy */,
 			);
 			name = Resources;
 			path = ..;
@@ -324,6 +327,7 @@
 				33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */,
 				D9A7B1C12E3F445500A1B2C3 /* AppIcon-production.icon in Resources */,
 				33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */,
+				A9E4D6113D7A4E49A3759B11 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "flutty.app"
+               BuildableName = "MonkeySSH.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "flutty.app"
+            BuildableName = "MonkeySSH.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "flutty.app"
+            BuildableName = "MonkeySSH.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "flutty.app"
+            BuildableName = "MonkeySSH.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -9,6 +9,7 @@ class AppDelegate: FlutterAppDelegate {
   private let maxTransferPayloadBytes = 10 * 1024 * 1024
   private var transferChannel: FlutterMethodChannel?
   private var appleDatabaseChannel: FlutterMethodChannel?
+  private var didSetupFlutterMethodChannels = false
 
   override func applicationDidFinishLaunching(_ notification: Notification) {
     super.applicationDidFinishLaunching(notification)
@@ -18,6 +19,10 @@ class AppDelegate: FlutterAppDelegate {
   }
 
   func setupFlutterMethodChannels(with controller: FlutterViewController) {
+    guard !didSetupFlutterMethodChannels else {
+      return
+    }
+    didSetupFlutterMethodChannels = true
     setupTransferChannel(with: controller)
     setupAppleDatabaseChannel(with: controller)
   }

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -13,9 +13,13 @@ class AppDelegate: FlutterAppDelegate {
   override func applicationDidFinishLaunching(_ notification: Notification) {
     super.applicationDidFinishLaunching(notification)
     if let controller = mainFlutterWindow?.contentViewController as? FlutterViewController {
-      setupTransferChannel(with: controller)
-      setupAppleDatabaseChannel(with: controller)
+      setupFlutterMethodChannels(with: controller)
     }
+  }
+
+  func setupFlutterMethodChannels(with controller: FlutterViewController) {
+    setupTransferChannel(with: controller)
+    setupAppleDatabaseChannel(with: controller)
   }
 
   override func application(_ sender: NSApplication, openFile filename: String) -> Bool {

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -9,6 +9,9 @@ class MainFlutterWindow: NSWindow {
     self.setFrame(windowFrame, display: true)
 
     RegisterGeneratedPlugins(registry: flutterViewController)
+    if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+      appDelegate.setupFlutterMethodChannels(with: flutterViewController)
+    }
 
     super.awakeFromNib()
   }

--- a/macos/Runner/PrivacyInfo.xcprivacy
+++ b/macos/Runner/PrivacyInfo.xcprivacy
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/test/domain/services/monetization_service_test.dart
+++ b/test/domain/services/monetization_service_test.dart
@@ -771,6 +771,45 @@ void main() {
     });
 
     test(
+      'restorePurchases keeps an already active lifetime entitlement',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+        await settings.setBool(
+          SettingKeys.monetizationProUnlocked,
+          value: true,
+        );
+        await settings.setString(
+          SettingKeys.monetizationActiveProductId,
+          MonetizationProductIds.iosProLifetimeProd,
+        );
+
+        final service = MonetizationService(
+          settings,
+          inAppPurchase: inAppPurchase,
+          allowDebugUnlock: false,
+        );
+        addTearDown(service.dispose);
+
+        final result = await service.restorePurchases();
+
+        expect(result.success, isTrue);
+        expect(result.message, contains('Lifetime is already active'));
+        expect(service.currentState.isProUnlocked, isTrue);
+        expect(service.currentState.isLifetimeUnlocked, isTrue);
+        expect(
+          await settings.getBool(SettingKeys.monetizationProUnlocked),
+          isTrue,
+        );
+        expect(
+          await settings.getString(SettingKeys.monetizationActiveProductId),
+          MonetizationProductIds.iosProLifetimeProd,
+        );
+        verifyNever(() => inAppPurchase.restorePurchases());
+      },
+    );
+
+    test(
       'purchase stream updates cached entitlements after a purchase',
       () async {
         final service = MonetizationService(
@@ -919,6 +958,81 @@ void main() {
             purchaseParam: any(named: 'purchaseParam'),
           ),
         );
+      },
+    );
+
+    test(
+      'Android stale checkout recovery honors lifetime before retrying a subscription',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+        when(() => inAppPurchase.isAvailable()).thenAnswer((_) async => true);
+        when(() => inAppPurchase.queryProductDetails(any())).thenAnswer(
+          (_) async => ProductDetailsResponse(
+            productDetails: _androidCatalogDetails(),
+            notFoundIDs: const [],
+          ),
+        );
+        var buyCallCount = 0;
+        when(
+          () => inAppPurchase.buyNonConsumable(
+            purchaseParam: any(named: 'purchaseParam'),
+          ),
+        ).thenAnswer((_) async {
+          buyCallCount += 1;
+          return true;
+        });
+        when(androidPlatformAddition.queryPastPurchases).thenAnswer(
+          (_) async => QueryPurchaseDetailsResponse(
+            pastPurchases: [
+              _androidPastLifetimePurchase(purchaseTimeMillis: 1712732400000),
+              _androidPastPurchase(purchaseTimeMillis: 1712732401000),
+            ],
+          ),
+        );
+
+        final service = MonetizationService(
+          settings,
+          inAppPurchase: inAppPurchase,
+          androidPlatformAddition: androidPlatformAddition,
+          allowDebugUnlock: false,
+        );
+        addTearDown(service.dispose);
+
+        await service.initialize();
+        final monthlyOfferId = service.currentState.offers
+            .firstWhere(
+              (offer) =>
+                  offer.billingPeriod == MonetizationBillingPeriod.monthly,
+            )
+            .id;
+        final annualOfferId = service.currentState.offers
+            .firstWhere(
+              (offer) =>
+                  offer.billingPeriod == MonetizationBillingPeriod.annual,
+            )
+            .id;
+
+        final firstAttempt = service.purchaseOffer(monthlyOfferId);
+        await Future<void>.delayed(Duration.zero);
+
+        final secondResult = await service.purchaseOffer(annualOfferId);
+        final firstResult = await firstAttempt;
+
+        expect(firstResult.success, isTrue);
+        expect(firstResult.message, contains('Lifetime'));
+        expect(secondResult.success, isFalse);
+        expect(secondResult.message, contains('Lifetime is already active'));
+        expect(service.currentState.isProUnlocked, isTrue);
+        expect(service.currentState.isLifetimeUnlocked, isTrue);
+        expect(
+          service.currentState.activeProductId,
+          MonetizationProductIds.androidProLifetime,
+        );
+        expect(service.currentState.activeOfferId, isNull);
+        expect(buyCallCount, 1);
+        verify(androidPlatformAddition.queryPastPurchases).called(1);
       },
     );
 

--- a/test/domain/services/monetization_service_test.dart
+++ b/test/domain/services/monetization_service_test.dart
@@ -1252,11 +1252,11 @@ void main() {
         final result = await resultFuture;
 
         expect(result.success, isFalse);
-        expect(result.message, contains('Failed to finalize purchase'));
+        expect(result.message, 'Could not finalize purchase. Try again.');
         expect(service.currentState.isLoading, isFalse);
         expect(
           service.currentState.lastError,
-          contains('Failed to finalize purchase'),
+          'Could not finalize purchase. Try again.',
         );
       },
     );

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -501,7 +501,7 @@ void main() {
       expect(find.text('No hosts yet'), findsOneWidget);
       expect(find.text('Import config'), findsNothing);
       expect(find.text('Paste SSH URL'), findsOneWidget);
-      expect(find.text('Try local test host'), findsOneWidget);
+      expect(find.text('Try local test host'), findsNothing);
     });
 
     testWidgets('connections empty state explains where sessions appear', (

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -499,7 +499,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 100));
 
       expect(find.text('No hosts yet'), findsOneWidget);
-      expect(find.text('Import config'), findsOneWidget);
+      expect(find.text('Import config'), findsNothing);
       expect(find.text('Paste SSH URL'), findsOneWidget);
       expect(find.text('Try local test host'), findsOneWidget);
     });

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -342,8 +342,7 @@ void main() {
 
       expect(
         find.text(
-          'Could not load windows: '
-          'tmux did not return any windows yet. Retrying...',
+          'Could not load tmux windows. Check that tmux is still running, then try again.',
         ),
         findsOneWidget,
       );

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,0 +1,34 @@
+{
+  "name": "MonkeySSH",
+  "short_name": "MonkeySSH",
+  "description": "A cross-platform SSH client with terminal, SFTP, key management, and port forwarding.",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#0B1020",
+  "theme_color": "#0B1020",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "icons/Icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/Icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/Icon-maskable-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "icons/Icon-maskable-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(flutty LANGUAGES CXX)
+project(monkeyssh LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "flutty")
+set(BINARY_NAME "monkeyssh")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,13 +89,13 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.flutty" "\0"
-            VALUE "FileDescription", "flutty" "\0"
+            VALUE "CompanyName", "DepollSoft" "\0"
+            VALUE "FileDescription", "MonkeySSH" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "flutty" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2026 com.flutty. All rights reserved." "\0"
-            VALUE "OriginalFilename", "flutty.exe" "\0"
-            VALUE "ProductName", "flutty" "\0"
+            VALUE "InternalName", "MonkeySSH" "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2026 DepollSoft. All rights reserved." "\0"
+            VALUE "OriginalFilename", "monkeyssh.exe" "\0"
+            VALUE "ProductName", "MonkeySSH" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END


### PR DESCRIPTION
## Summary

- Defer notification permission prompts until tmux alerts are actually shown, and dispose notification routing resources.
- Remove the local test-host first-run shortcut/prefill path, keeping add-host focused on real SSH hosts and pasted `ssh://` URLs.
- Restore tmux alert notification titles to the tmux window title, with session/window context in the body.
- Harden MonkeySSH Pro lifetime purchase handling so lifetime entitlements win over recurring subscriptions during restore, Android stale-checkout recovery, and cached entitlement flows.
- Harden first-use SSH host-key probing, terminal selection layout, SFTP dialog lifecycles, sensitive controller cleanup, and release-facing error messages.
- Clean release metadata/branding across iOS/macOS privacy manifests, web manifest, Linux, Windows, and macOS scheme artifacts.
- Improve accessibility/tooltips for terminal/tmux/SFTP controls and harden device tmux screenshot tests.

## Validation

- `flutter analyze`
- `dart format --set-exit-if-changed .`
- `flutter test --reporter expanded`
- `flutter test test/domain/services/monetization_service_test.dart test/widget/upgrade_screen_test.dart`
- `git diff --check`
- `plutil -lint ios/Runner/PrivacyInfo.xcprivacy macos/Runner/PrivacyInfo.xcprivacy`
- `ruby -rjson -e 'JSON.parse(File.read("web/manifest.json"))'`
- `flutter build macos --debug`
- Live iOS SSH integration against loopback sshd
- Live Android SSH integration against loopback sshd
- Live iOS tmux-bar integration against loopback sshd/tmux

## Remaining identified polish / follow-ups

- Android structured tmux integration still loses the Flutter VM-service before the test body while the app process remains alive. Android SSH itself passed live validation, so this appears to be device-test harness instability rather than a confirmed product crash.
- macOS startup no longer shows the `apple_file_protection` `MissingPluginException`, but desktop visual smoke is still blocked in this CLI environment by window foregrounding / zero-size invisible-root semantics.
- Post-release polish backlog remains: l10n, `terminal_screen` decomposition, ignore-suppression audit, RSA 2048 labeling/removal, desktop command palette/shortcuts, UIScene migration tracking, bundled-font/offline typography review, and final App Store export-compliance / macOS entitlement review.
