### PR TITLE
fix: stabilize terminal system selection

### DIFF
--- a/integration_test/terminal_screen_system_selection_test.dart
+++ b/integration_test/terminal_screen_system_selection_test.dart
@@ -77,6 +77,33 @@ Future<double> _waitForKeyboardInset(
   return tester.view.viewInsets.bottom;
 }
 
+Offset _cellCenter(MonkeyRenderTerminal renderTerminal, CellOffset offset) =>
+    renderTerminal.localToGlobal(
+      renderTerminal.getOffset(offset) +
+          renderTerminal.cellSize.center(Offset.zero),
+    );
+
+Future<void> _dragStartHandleToCell(
+  WidgetTester tester,
+  MonkeyRenderTerminal renderTerminal, {
+  required CellOffset targetCell,
+}) async {
+  final startSelectionPoint = renderTerminal.value.startSelectionPoint;
+  expect(startSelectionPoint, isNotNull);
+  final startHandlePosition = renderTerminal.localToGlobal(
+    startSelectionPoint!.localPosition,
+  );
+  final handleDragPosition =
+      startHandlePosition + Offset(0, renderTerminal.cellSize.height);
+
+  await tester.timedDragFrom(
+    handleDragPosition,
+    _cellCenter(renderTerminal, targetCell) - handleDragPosition,
+    const Duration(milliseconds: 600),
+  );
+  await tester.pumpAndSettle();
+}
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -223,6 +250,116 @@ void main() {
       expect(hiddenKeyboardInset, 0);
       expect(renderTerminal.getSelectedContent()?.plainText, 'alpha');
       expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+
+      await _dragStartHandleToCell(
+        tester,
+        renderTerminal,
+        targetCell: const CellOffset(0, 26),
+      );
+      expect(
+        renderTerminal.getSelectedContent()?.plainText,
+        contains('line 26'),
+      );
+      expect(renderTerminal.getSelectedContent()?.plainText, contains('alpha'));
+
+      for (var index = 0; index < 12; index += 1) {
+        session.terminal!.write('\rprogress $index');
+        await tester.pump(const Duration(milliseconds: 50));
+        expect(renderTerminal.getSelectedContent(), isNotNull);
+        expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+      }
     },
   );
+
+  testWidgets('selection survives animated progress on selected line', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(430, 932));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final hostRepository = _MockHostRepository();
+    final sshClient = _MockSshClient();
+    final shellChannel = _MockShellChannel();
+    final host = _buildHost(id: 43);
+    final shellDoneCompleter = Completer<void>();
+
+    when(() => hostRepository.getById(host.id)).thenAnswer((_) async => host);
+    when(
+      () => sshClient.shell(pty: any(named: 'pty')),
+    ).thenAnswer((_) async => shellChannel);
+    when(
+      () => shellChannel.stdout,
+    ).thenAnswer((_) => const Stream<Uint8List>.empty());
+    when(
+      () => shellChannel.stderr,
+    ).thenAnswer((_) => const Stream<Uint8List>.empty());
+    when(() => shellChannel.done).thenAnswer((_) => shellDoneCompleter.future);
+    when(() => shellChannel.write(any())).thenReturn(null);
+
+    final session = SshSession(
+      connectionId: 43,
+      hostId: host.id,
+      client: sshClient,
+      config: const SshConnectionConfig(
+        hostname: 'terminal.example.com',
+        port: 22,
+        username: 'root',
+      ),
+    )..getOrCreateTerminal();
+    final container = ProviderContainer(
+      overrides: [
+        databaseProvider.overrideWithValue(db),
+        hostRepositoryProvider.overrideWithValue(hostRepository),
+        sharedClipboardProvider.overrideWith((ref) async => false),
+        activeSessionsProvider.overrideWith(
+          () => _TestActiveSessionsNotifier(session),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: TerminalScreen(
+            hostId: host.id,
+            connectionId: session.connectionId,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    session.terminal!.write(
+      List<String>.generate(
+        24,
+        (index) => index == 23 ? 'progress 0' : 'line $index',
+      ).join('\r\n'),
+    );
+    await tester.pumpAndSettle();
+
+    final terminalViewState = tester.state<MonkeyTerminalViewState>(
+      find.byType(MonkeyTerminalView),
+    );
+    final renderTerminal = terminalViewState.renderTerminal;
+    final target = _cellCenter(renderTerminal, const CellOffset(3, 23));
+
+    await tester.longPressAt(target);
+    await tester.pumpAndSettle();
+
+    expect(renderTerminal.getSelectedContent()?.plainText, 'progress');
+    expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+
+    for (var index = 1; index <= 12; index += 1) {
+      session.terminal!.write('\r\x1b[2Kprogress $index');
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(renderTerminal.getSelectedContent()?.plainText, 'progress');
+      expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+    }
+  });
 }

--- a/integration_test/terminal_screen_system_selection_test.dart
+++ b/integration_test/terminal_screen_system_selection_test.dart
@@ -243,11 +243,11 @@ void main() {
       await gesture.up();
       await tester.pumpAndSettle();
 
-      final hiddenKeyboardInset = await _waitForKeyboardInset(
+      final selectionKeyboardInset = await _waitForKeyboardInset(
         tester,
-        visible: false,
+        visible: true,
       );
-      expect(hiddenKeyboardInset, 0);
+      expect(selectionKeyboardInset, greaterThan(0));
       expect(renderTerminal.getSelectedContent()?.plainText, 'alpha');
       expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
 

--- a/integration_test/terminal_screen_system_selection_test.dart
+++ b/integration_test/terminal_screen_system_selection_test.dart
@@ -1,0 +1,209 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/domain/services/settings_service.dart';
+import 'package:monkeyssh/domain/services/ssh_service.dart';
+import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
+import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
+import 'package:xterm/xterm.dart';
+
+class _MockHostRepository extends Mock implements HostRepository {}
+
+class _MockSshClient extends Mock implements SSHClient {}
+
+class _MockShellChannel extends Mock implements SSHSession {}
+
+class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
+  _TestActiveSessionsNotifier(this.session);
+
+  final SshSession session;
+
+  @override
+  Map<int, SshConnectionState> build() => <int, SshConnectionState>{
+    session.connectionId: SshConnectionState.connected,
+  };
+
+  @override
+  ConnectionAttemptStatus? getConnectionAttempt(int hostId) => null;
+
+  @override
+  List<int> getConnectionsForHost(int hostId) =>
+      hostId == session.hostId ? <int>[session.connectionId] : const <int>[];
+
+  @override
+  ActiveConnection? getActiveConnection(int connectionId) => null;
+
+  @override
+  SshSession? getSession(int connectionId) =>
+      connectionId == session.connectionId ? session : null;
+
+  @override
+  Future<void> syncBackgroundStatus() async {}
+}
+
+Host _buildHost({required int id}) => Host(
+  id: id,
+  label: 'Terminal selection test host',
+  hostname: 'terminal.example.com',
+  port: 22,
+  username: 'root',
+  isFavorite: false,
+  createdAt: DateTime(2026),
+  updatedAt: DateTime(2026),
+  autoConnectRequiresConfirmation: false,
+  sortOrder: 0,
+);
+
+bool _hasWidgetTypeContaining(WidgetTester tester, String text) => tester
+    .allWidgets
+    .any((widget) => widget.runtimeType.toString().contains(text));
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(const SSHPtyConfig());
+    registerFallbackValue(Uint8List(0));
+  });
+
+  testWidgets(
+    'first long press keeps selection handles visible while output streams',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(430, 932));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final hostRepository = _MockHostRepository();
+      final sshClient = _MockSshClient();
+      final shellChannel = _MockShellChannel();
+      final host = _buildHost(id: 1);
+      final shellDoneCompleter = Completer<void>();
+      final shellStdoutController = StreamController<Uint8List>.broadcast();
+      addTearDown(shellStdoutController.close);
+
+      when(() => hostRepository.getById(host.id)).thenAnswer((_) async => host);
+      when(
+        () => sshClient.shell(pty: any(named: 'pty')),
+      ).thenAnswer((_) async => shellChannel);
+      when(
+        () => shellChannel.stdout,
+      ).thenAnswer((_) => shellStdoutController.stream);
+      when(
+        () => shellChannel.stderr,
+      ).thenAnswer((_) => const Stream<Uint8List>.empty());
+      when(
+        () => shellChannel.done,
+      ).thenAnswer((_) => shellDoneCompleter.future);
+      when(() => shellChannel.write(any())).thenReturn(null);
+
+      final session = SshSession(
+        connectionId: 7,
+        hostId: host.id,
+        client: sshClient,
+        config: const SshConnectionConfig(
+          hostname: 'terminal.example.com',
+          port: 22,
+          username: 'root',
+        ),
+      )..getOrCreateTerminal();
+      session.terminal!
+        ..setMouseMode(MouseMode.upDownScroll)
+        ..setMouseReportMode(MouseReportMode.sgr);
+
+      final container = ProviderContainer(
+        overrides: [
+          databaseProvider.overrideWithValue(db),
+          hostRepositoryProvider.overrideWithValue(hostRepository),
+          sharedClipboardProvider.overrideWith((ref) async => false),
+          activeSessionsProvider.overrideWith(
+            () => _TestActiveSessionsNotifier(session),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: TerminalScreen(
+              hostId: host.id,
+              connectionId: session.connectionId,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      session.terminal!.write(
+        List<String>.generate(
+          28,
+          (index) => index == 27 ? 'alpha bravo' : 'line $index',
+        ).join('\r\n'),
+      );
+      await tester.pumpAndSettle();
+
+      final terminalViewState = tester.state<MonkeyTerminalViewState>(
+        find.byType(MonkeyTerminalView),
+      );
+      final renderTerminal = terminalViewState.renderTerminal;
+      Offset? target;
+      for (
+        var row =
+            (session.terminal!.buffer.lines.length -
+                    session.terminal!.viewHeight)
+                .clamp(0, session.terminal!.buffer.lines.length - 1);
+        row < session.terminal!.buffer.lines.length;
+        row += 1
+      ) {
+        final text = session.terminal!.buffer.lines[row].getText(
+          0,
+          session.terminal!.buffer.viewWidth,
+        );
+        final startColumn = text.indexOf('alpha');
+        if (startColumn == -1) {
+          continue;
+        }
+
+        target = renderTerminal.localToGlobal(
+          renderTerminal.getOffset(CellOffset(startColumn + 2, row)) +
+              renderTerminal.cellSize.center(Offset.zero),
+        );
+        break;
+      }
+      expect(target, isNotNull);
+
+      var streamIndex = 0;
+      final streamTimer = Timer.periodic(const Duration(milliseconds: 16), (_) {
+        session.terminal!.write('\r\nstream $streamIndex');
+        streamIndex += 1;
+      });
+      addTearDown(streamTimer.cancel);
+
+      final gesture = await tester.startGesture(target!);
+      await tester.pump(const Duration(milliseconds: 650));
+      streamTimer.cancel();
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(renderTerminal.getSelectedContent()?.plainText, 'alpha');
+      expect(
+        _hasWidgetTypeContaining(tester, '_SelectionHandleOverlay'),
+        isTrue,
+      );
+      expect(_hasWidgetTypeContaining(tester, 'TextSelectionToolbar'), isTrue);
+    },
+  );
+}

--- a/integration_test/terminal_screen_system_selection_test.dart
+++ b/integration_test/terminal_screen_system_selection_test.dart
@@ -63,6 +63,20 @@ Host _buildHost({required int id}) => Host(
   sortOrder: 0,
 );
 
+Future<double> _waitForKeyboardInset(
+  WidgetTester tester, {
+  required bool visible,
+}) async {
+  for (var attempt = 0; attempt < 30; attempt += 1) {
+    await tester.pump(const Duration(milliseconds: 100));
+    final bottomInset = tester.view.viewInsets.bottom;
+    if (visible ? bottomInset > 0 : bottomInset == 0) {
+      return bottomInset;
+    }
+  }
+  return tester.view.viewInsets.bottom;
+}
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -72,7 +86,7 @@ void main() {
   });
 
   testWidgets(
-    'first long press keeps selection toolbar visible while output streams',
+    'first long press keeps selection toolbar visible after keyboard input',
     (tester) async {
       await tester.binding.setSurfaceSize(const Size(430, 932));
       addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -150,6 +164,14 @@ void main() {
       );
       await tester.pumpAndSettle();
 
+      await tester.tap(find.byType(MonkeyTerminalView));
+      final shownKeyboardInset = await _waitForKeyboardInset(
+        tester,
+        visible: true,
+      );
+      expect(shownKeyboardInset, greaterThan(0));
+      await tester.pumpAndSettle();
+
       final terminalViewState = tester.state<MonkeyTerminalViewState>(
         find.byType(MonkeyTerminalView),
       );
@@ -194,6 +216,11 @@ void main() {
       await gesture.up();
       await tester.pumpAndSettle();
 
+      final hiddenKeyboardInset = await _waitForKeyboardInset(
+        tester,
+        visible: false,
+      );
+      expect(hiddenKeyboardInset, 0);
       expect(renderTerminal.getSelectedContent()?.plainText, 'alpha');
       expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
     },

--- a/integration_test/terminal_screen_system_selection_test.dart
+++ b/integration_test/terminal_screen_system_selection_test.dart
@@ -63,10 +63,6 @@ Host _buildHost({required int id}) => Host(
   sortOrder: 0,
 );
 
-bool _hasWidgetTypeContaining(WidgetTester tester, String text) => tester
-    .allWidgets
-    .any((widget) => widget.runtimeType.toString().contains(text));
-
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -76,7 +72,7 @@ void main() {
   });
 
   testWidgets(
-    'first long press keeps selection handles visible while output streams',
+    'first long press keeps selection toolbar visible while output streams',
     (tester) async {
       await tester.binding.setSurfaceSize(const Size(430, 932));
       addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -199,11 +195,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(renderTerminal.getSelectedContent()?.plainText, 'alpha');
-      expect(
-        _hasWidgetTypeContaining(tester, '_SelectionHandleOverlay'),
-        isTrue,
-      );
-      expect(_hasWidgetTypeContaining(tester, 'TextSelectionToolbar'), isTrue);
+      expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
     },
   );
 }

--- a/integration_test/terminal_system_selection_test.dart
+++ b/integration_test/terminal_system_selection_test.dart
@@ -218,6 +218,31 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  Future<void> dragEndHandleToRow(
+    WidgetTester tester,
+    MonkeyRenderTerminal renderTerminal, {
+    required int targetRow,
+  }) async {
+    final endSelectionPoint = renderTerminal.value.endSelectionPoint!;
+    final endHandlePosition = renderTerminal.localToGlobal(
+      endSelectionPoint.localPosition,
+    );
+    final handleDragPosition =
+        endHandlePosition + Offset(0, renderTerminal.cellSize.height);
+
+    Offset cellCenter(CellOffset offset) => renderTerminal.localToGlobal(
+      renderTerminal.getOffset(offset) +
+          renderTerminal.cellSize.center(Offset.zero),
+    );
+
+    await tester.timedDragFrom(
+      handleDragPosition,
+      cellCenter(CellOffset(0, targetRow)) - handleDragPosition,
+      const Duration(milliseconds: 600),
+    );
+    await tester.pumpAndSettle();
+  }
+
   testWidgets('terminal system selection is visible with soft keyboard open', (
     tester,
   ) async {
@@ -256,6 +281,58 @@ void main() {
         harness.repaintBoundaryKey.currentContext!.findRenderObject()!
             as RenderRepaintBoundary;
     expect(await countSelectionPaintPixels(repaintBoundary), greaterThan(100));
+  });
+
+  testWidgets('terminal system selection can start from whitespace', (
+    tester,
+  ) async {
+    final harness = await pumpKeyboardSelectionHarness(tester);
+    final renderTerminal = harness.terminalViewKey.currentState!.renderTerminal;
+
+    Offset cellCenter(CellOffset offset) => renderTerminal.localToGlobal(
+      renderTerminal.getOffset(offset) +
+          renderTerminal.cellSize.center(Offset.zero),
+    );
+
+    harness.inputController.requestKeyboard();
+    final shownKeyboardInset = await waitForKeyboardInset(
+      tester,
+      visible: true,
+    );
+    expect(shownKeyboardInset, greaterThan(0));
+    await tester.pumpAndSettle();
+
+    final topVisibleRow = renderTerminal.getCellOffset(Offset.zero).y;
+    final selectedRow = topVisibleRow + 20;
+    final targetRow = topVisibleRow + 1;
+    final selectedRowText = rowLabel(selectedRow);
+    final whitespaceColumn = selectedRowText.length + 4;
+    expect(
+      harness.terminal.buffer.getWordBoundary(
+        CellOffset(whitespaceColumn, selectedRow),
+      ),
+      isNull,
+    );
+
+    final gesture = await tester.startGesture(
+      cellCenter(CellOffset(whitespaceColumn, selectedRow)),
+    );
+    await tester.pump(const Duration(milliseconds: 650));
+    await gesture.moveTo(cellCenter(CellOffset(0, selectedRow)));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(harness.controller.selection, isNotNull);
+    expect(renderTerminal.getSelectedContent()?.plainText, selectedRowText);
+    expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+    expect(tester.view.viewInsets.bottom, greaterThan(0));
+
+    await dragEndHandleToRow(tester, renderTerminal, targetRow: targetRow);
+
+    final selectedText = renderTerminal.getSelectedContent()!.plainText;
+    expect(selectedText, contains(rowLabel(targetRow)));
+    expect(selectedText, contains(rowLabel(selectedRow)));
   });
 
   testWidgets('terminal system selection survives soft keyboard resize', (

--- a/integration_test/terminal_system_selection_test.dart
+++ b/integration_test/terminal_system_selection_test.dart
@@ -244,6 +244,7 @@ void main() {
     await tester.longPressAt(cellCenter(CellOffset(5, selectedRow)));
     await tester.pumpAndSettle();
     expect(harness.controller.selection, isNotNull);
+    expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
 
     await dragStartHandleToRow(tester, renderTerminal, targetRow: targetRow);
 
@@ -288,6 +289,7 @@ void main() {
     await tester.longPressAt(cellCenter(CellOffset(5, selectedRow)));
     await tester.pumpAndSettle();
     expect(harness.controller.selection, isNotNull);
+    expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
 
     await dragStartHandleToRow(tester, renderTerminal, targetRow: targetRow);
 

--- a/integration_test/terminal_system_selection_test.dart
+++ b/integration_test/terminal_system_selection_test.dart
@@ -245,6 +245,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(harness.controller.selection, isNotNull);
     expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+    expect(tester.view.viewInsets.bottom, greaterThan(0));
 
     await dragStartHandleToRow(tester, renderTerminal, targetRow: targetRow);
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -6288,7 +6288,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       systemSelectionContextMenuBuilder: isMobile
           ? _buildTerminalSelectionContextMenu
           : null,
-      focusNode: isMobile ? null : _terminalFocusNode,
+      focusNode: _terminalFocusNode,
       theme: terminalTheme.toXtermTheme(),
       textStyle: terminalTextStyle,
       padding: terminalViewportPadding,
@@ -6488,6 +6488,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           !_showsNativeSelectionOverlay &&
           overlayMessage == null,
       showKeyboardOnFocus: false,
+      manageFocus: false,
       child: TerminalPinchZoomGestureHandler(
         onPinchStart: () => _handleTerminalScaleStart(storedFontSize),
         onPinchUpdate: (scale) =>

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3165,6 +3165,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   double? _sessionFontSizeOverride;
   bool _isPinchZooming = false;
   bool _shouldFollowLiveOutput = true;
+  double _lastTerminalScrollOffset = 0;
   bool _isTerminalScrollToBottomQueued = false;
   TerminalHyperlinkTracker? _terminalHyperlinkTracker;
   SshSession? _observedSession;
@@ -3203,6 +3204,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   int? _pendingTerminalMouseTapPointer;
   Offset? _pendingTerminalMouseTapDownPosition;
   Duration? _pendingTerminalMouseTapDownTimestamp;
+  final Set<int> _terminalOutputPauseTouchPointers = <int>{};
   Rect? _hoveredTerminalPathUnderline;
   List<({String path, Rect underlineRect, Rect touchRect})>
   _visibleTerminalPathUnderlines =
@@ -3256,6 +3258,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool get _hasExpandedNativeOverlaySelection =>
       _isNativeSelectionMode &&
       hasActiveNativeOverlaySelection(_nativeSelectionController.selection);
+
+  bool get _hasActiveSystemSelection {
+    final selection = _terminalController.selection;
+    return selection != null && !selection.isCollapsed;
+  }
+
+  bool get _isTerminalOutputFollowPaused =>
+      _terminalOutputPauseTouchPointers.isNotEmpty ||
+      _hasExpandedNativeOverlaySelection ||
+      _hasActiveSystemSelection;
+
+  bool get _terminalLiveOutputAutoScrollEnabled =>
+      !_isTerminalOutputFollowPaused;
 
   bool get _routesTouchScrollToTerminal => shouldRouteTouchScrollToTerminal(
     isMobile: _isMobilePlatform,
@@ -3434,7 +3449,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     _queueVisibleTerminalPathUnderlineRefresh();
 
-    if (_shouldFollowLiveOutput && !_hasExpandedNativeOverlaySelection) {
+    if (_shouldFollowLiveOutput && !_isTerminalOutputFollowPaused) {
       _queueTerminalScrollToBottom();
     }
 
@@ -3680,15 +3695,20 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       }, priority: SshExecPriority.low);
 
   void _handleTerminalScroll() {
-    _shouldFollowLiveOutput = shouldFollowTerminalOutput(
-      hasScrollClients: _terminalScrollController.hasClients,
-      currentOffset: _terminalScrollController.hasClients
-          ? _terminalScrollController.offset
-          : 0,
-      maxScrollExtent: _terminalScrollController.hasClients
-          ? _terminalScrollController.position.maxScrollExtent
-          : 0,
-    );
+    final currentOffset = _terminalScrollController.hasClients
+        ? _terminalScrollController.offset
+        : 0.0;
+    final didScrollOffsetChange = currentOffset != _lastTerminalScrollOffset;
+    _lastTerminalScrollOffset = currentOffset;
+    if (!_isTerminalOutputFollowPaused || didScrollOffsetChange) {
+      _shouldFollowLiveOutput = shouldFollowTerminalOutput(
+        hasScrollClients: _terminalScrollController.hasClients,
+        currentOffset: currentOffset,
+        maxScrollExtent: _terminalScrollController.hasClients
+            ? _terminalScrollController.position.maxScrollExtent
+            : 0,
+      );
+    }
     _syncNativeScrollFromTerminal();
     _refreshVisibleTerminalPathUnderlines();
   }
@@ -3748,6 +3768,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _isTerminalScrollToBottomQueued = false;
       if (!mounted ||
           !_shouldFollowLiveOutput ||
+          _isTerminalOutputFollowPaused ||
           !_terminalScrollController.hasClients) {
         return;
       }
@@ -3770,10 +3791,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
-    final selection = _terminalController.selection;
-    final hasSelection = selection != null;
-    if (hasSelection) {
-      setState(() {});
+    final hasActiveSelection = _hasActiveSystemSelection;
+    _syncTerminalLiveOutputAutoScroll();
+    setState(() {});
+    if (!hasActiveSelection &&
+        _shouldFollowLiveOutput &&
+        !_isTerminalOutputFollowPaused) {
+      _queueTerminalScrollToBottom();
     }
   }
 
@@ -6259,6 +6283,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       onLinkTap: _handleTerminalLinkTap,
       onDoubleTapDown: isMobile ? _handleTerminalDoubleTapDown : null,
       suppressLongPressDragSelection: isMobile,
+      liveOutputAutoScroll: _terminalLiveOutputAutoScrollEnabled,
       useSystemSelection: isMobile,
       systemSelectionContextMenuBuilder: isMobile
           ? _buildTerminalSelectionContextMenu
@@ -7289,7 +7314,48 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _lastTerminalTapTimestamp = null;
   }
 
+  void _pauseTerminalOutputFollowForTouch(PointerDownEvent event) {
+    if (!_isMobilePlatform || event.kind != PointerDeviceKind.touch) {
+      return;
+    }
+
+    if (_terminalOutputPauseTouchPointers.add(event.pointer)) {
+      if (_terminalScrollController.hasClients) {
+        _lastTerminalScrollOffset = _terminalScrollController.offset;
+        _shouldFollowLiveOutput = shouldFollowTerminalOutput(
+          hasScrollClients: true,
+          currentOffset: _terminalScrollController.offset,
+          maxScrollExtent: _terminalScrollController.position.maxScrollExtent,
+        );
+      }
+      _syncTerminalLiveOutputAutoScroll();
+      setState(() {});
+    }
+  }
+
+  void _resumeTerminalOutputFollowForTouch(int pointer) {
+    if (!_terminalOutputPauseTouchPointers.remove(pointer)) {
+      return;
+    }
+
+    _syncTerminalLiveOutputAutoScroll();
+    setState(() {});
+    if (_terminalOutputPauseTouchPointers.isNotEmpty ||
+        !_shouldFollowLiveOutput ||
+        _isTerminalOutputFollowPaused) {
+      return;
+    }
+
+    _queueTerminalScrollToBottom();
+  }
+
+  void _syncTerminalLiveOutputAutoScroll() {
+    _terminalViewKey.currentState?.renderTerminal.liveOutputAutoScroll =
+        _terminalLiveOutputAutoScrollEnabled;
+  }
+
   void _handleTerminalPointerDown(PointerDownEvent event) {
+    _pauseTerminalOutputFollowForTouch(event);
     _handleTerminalLinkPointerDown(event);
     if (_pendingTerminalLinkTap == null) {
       _handleTerminalPathPointerDown(event);
@@ -7328,6 +7394,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _clearPendingTerminalMouseTap(event.pointer);
       _clearLastTerminalTap();
     }
+    _resumeTerminalOutputFollowForTouch(event.pointer);
   }
 
   void _handleTerminalPointerCancel(PointerCancelEvent event) {
@@ -7335,6 +7402,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _handleTerminalPathPointerCancel(event);
     _handleTerminalDoubleTapPointerCancel(event);
     _clearPendingTerminalMouseTap(event.pointer);
+    _resumeTerminalOutputFollowForTouch(event.pointer);
   }
 
   void _handleTerminalLinkPointerDown(PointerDownEvent event) {

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1535,16 +1535,7 @@ class MonkeyRenderTerminal extends RenderBox
     final nextEnd = _clampSelectionOffset(end);
     _selectionStartOffset = nextStart;
     _selectionEndOffset = nextEnd;
-    _isApplyingSelectableSelection = true;
-    try {
-      _controller.setSelection(
-        _terminal.buffer.createAnchorFromOffset(_cellForTextOffset(nextStart)),
-        _terminal.buffer.createAnchorFromOffset(_cellForTextOffset(nextEnd)),
-        mode: SelectionMode.line,
-      );
-    } finally {
-      _isApplyingSelectableSelection = false;
-    }
+    _syncControllerSelectionFromSelectableOffsets();
     markNeedsPaint();
     _updateSelectionGeometry(deferNotification: true);
   }
@@ -1578,7 +1569,36 @@ class MonkeyRenderTerminal extends RenderBox
       _selectionEndOffset = nextEnd;
       markNeedsPaint();
     }
+    _syncControllerSelectionFromSelectableOffsets();
     _updateSelectionGeometry(deferNotification: true, forceNotify: true);
+  }
+
+  void _syncControllerSelectionFromSelectableOffsets() {
+    final start = _selectionStartOffset;
+    final end = _selectionEndOffset;
+    if (start == null || end == null || _terminalSelectionContentLength <= 0) {
+      return;
+    }
+
+    final selection = _controller.selection;
+    final isControllerSelectionCurrent =
+        selection != null &&
+        _textOffsetForCell(selection.begin) == start &&
+        _textOffsetForCell(selection.end) == end;
+    if (isControllerSelectionCurrent) {
+      return;
+    }
+
+    _isApplyingSelectableSelection = true;
+    try {
+      _controller.setSelection(
+        _terminal.buffer.createAnchorFromOffset(_cellForTextOffset(start)),
+        _terminal.buffer.createAnchorFromOffset(_cellForTextOffset(end)),
+        mode: SelectionMode.line,
+      );
+    } finally {
+      _isApplyingSelectableSelection = false;
+    }
   }
 
   void _syncSelectableSelectionFromController() {

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -476,6 +476,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
 
     if (widget.useSystemSelection) {
       child = SelectionArea(
+        focusNode: widget.hardwareKeyboardOnly ? _focusNode : null,
         contextMenuBuilder:
             widget.systemSelectionContextMenuBuilder ??
             _defaultSystemSelectionContextMenu,
@@ -518,7 +519,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
         readOnly: widget.readOnly,
         child: child,
       );
-    } else if (!widget.readOnly) {
+    } else if (!widget.readOnly && !widget.useSystemSelection) {
       // Only listen for key input from a hardware keyboard.
       child = CustomKeyboardListener(
         child: child,

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1790,12 +1790,20 @@ class MonkeyRenderTerminal extends RenderBox
   }
 
   SelectionResult _handleSelectableSelectWord(SelectWordSelectionEvent event) {
-    final before = _controller.selection;
-    selectWord(globalToLocal(event.globalPosition));
-    _syncSelectableSelectionFromController();
-    if (_controller.selection == before) {
+    if (_terminalSelectionContentLength <= 0) {
+      _clearSelectableTextSelection();
       return SelectionResult.none;
     }
+
+    final localPosition = globalToLocal(event.globalPosition);
+    final offsets = _wordTextOffsetsAt(localPosition);
+    if (offsets == null) {
+      final collapsedOffset = _textOffsetForLocalPosition(localPosition);
+      _applySelectableTextSelection(collapsedOffset, collapsedOffset);
+      return SelectionResult.end;
+    }
+
+    _applySelectableTextSelection(offsets.start, offsets.end);
     return SelectionResult.end;
   }
 

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1271,7 +1271,11 @@ class MonkeyRenderTerminal extends RenderBox
   }
 
   void _onTerminalChange() {
-    _syncSelectableSelectionFromController();
+    if (registrar != null && _hasSelectableTextSelection) {
+      _preserveSelectableSelectionAcrossTerminalChange();
+    } else {
+      _syncSelectableSelectionFromController();
+    }
     markNeedsLayout();
     _notifyEditableRect();
   }
@@ -1443,6 +1447,9 @@ class MonkeyRenderTerminal extends RenderBox
   int _clampSelectionOffset(int offset) =>
       offset.clamp(0, _terminalSelectionContentLength);
 
+  bool get _hasSelectableTextSelection =>
+      _selectionStartOffset != null && _selectionEndOffset != null;
+
   int _textOffsetForCell(CellOffset cellOffset) {
     final lineCount = _terminal.buffer.lines.length;
     if (lineCount == 0 || _terminal.viewWidth <= 0) {
@@ -1539,7 +1546,7 @@ class MonkeyRenderTerminal extends RenderBox
       _isApplyingSelectableSelection = false;
     }
     markNeedsPaint();
-    _updateSelectionGeometry();
+    _updateSelectionGeometry(deferNotification: true);
   }
 
   void _clearSelectableTextSelection() {
@@ -1555,7 +1562,23 @@ class MonkeyRenderTerminal extends RenderBox
       _isApplyingSelectableSelection = false;
     }
     markNeedsPaint();
-    _updateSelectionGeometry();
+    _updateSelectionGeometry(deferNotification: true);
+  }
+
+  void _preserveSelectableSelectionAcrossTerminalChange() {
+    if (_terminalSelectionContentLength <= 0) {
+      _clearSelectableTextSelection();
+      return;
+    }
+
+    final nextStart = _clampSelectionOffset(_selectionStartOffset!);
+    final nextEnd = _clampSelectionOffset(_selectionEndOffset!);
+    if (_selectionStartOffset != nextStart || _selectionEndOffset != nextEnd) {
+      _selectionStartOffset = nextStart;
+      _selectionEndOffset = nextEnd;
+      markNeedsPaint();
+    }
+    _updateSelectionGeometry(deferNotification: true, forceNotify: true);
   }
 
   void _syncSelectableSelectionFromController() {
@@ -1565,7 +1588,7 @@ class MonkeyRenderTerminal extends RenderBox
         _selectionStartOffset = null;
         _selectionEndOffset = null;
         markNeedsPaint();
-        _updateSelectionGeometry();
+        _updateSelectionGeometry(deferNotification: true);
       }
       return;
     }
@@ -1577,7 +1600,7 @@ class MonkeyRenderTerminal extends RenderBox
     _selectionStartOffset = nextStart;
     _selectionEndOffset = nextEnd;
     markNeedsPaint();
-    _updateSelectionGeometry();
+    _updateSelectionGeometry(deferNotification: true);
   }
 
   Offset _localPositionForTextOffset(int textOffset) {
@@ -1658,12 +1681,18 @@ class MonkeyRenderTerminal extends RenderBox
     );
   }
 
-  void _updateSelectionGeometry({bool deferNotification = false}) {
+  void _updateSelectionGeometry({
+    bool deferNotification = false,
+    bool forceNotify = false,
+  }) {
     final nextGeometry = _computeSelectionGeometry();
-    if (nextGeometry == _selectionGeometry) {
+    final didChange = nextGeometry != _selectionGeometry;
+    if (!didChange && !forceNotify) {
       return;
     }
-    _selectionGeometry = nextGeometry;
+    if (didChange) {
+      _selectionGeometry = nextGeometry;
+    }
     if (deferNotification) {
       _scheduleSelectionGeometryNotification();
       return;
@@ -1741,7 +1770,7 @@ class MonkeyRenderTerminal extends RenderBox
     };
     if (previousStart != _selectionStartOffset ||
         previousEnd != _selectionEndOffset) {
-      _updateSelectionGeometry();
+      _updateSelectionGeometry(deferNotification: true, forceNotify: true);
     }
     return result;
   }

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -171,6 +171,7 @@ class MonkeyTerminalView extends StatefulWidget {
     this.hardwareKeyboardOnly = false,
     this.simulateScroll = true,
     this.touchScrollToTerminal = false,
+    this.liveOutputAutoScroll = true,
     this.useSystemSelection = false,
     this.systemSelectionContextMenuBuilder,
     this.onSystemSelectionChanged,
@@ -296,6 +297,10 @@ class MonkeyTerminalView extends StatefulWidget {
   /// If true, vertical touch drags are converted into terminal scroll input
   /// instead of scrolling the Flutter viewport.
   final bool touchScrollToTerminal;
+
+  /// If true, the terminal keeps the viewport pinned to the newest output while
+  /// it is already scrolled to the bottom.
+  final bool liveOutputAutoScroll;
 
   /// True when Flutter's [SelectableRegion] should own terminal selection
   /// gestures and handles.
@@ -454,6 +459,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
           padding: EdgeInsets.zero,
           alignToTrailingEdges: shouldAlignTerminalToTrailingEdges(mediaQuery),
           autoResize: widget.autoResize,
+          liveOutputAutoScroll: widget.liveOutputAutoScroll,
           textStyle: widget.textStyle,
           textScaler: widget.textScaler ?? MediaQuery.textScalerOf(context),
           theme: widget.theme,
@@ -980,6 +986,7 @@ class _TerminalView extends LeafRenderObjectWidget {
     required this.padding,
     required this.alignToTrailingEdges,
     required this.autoResize,
+    required this.liveOutputAutoScroll,
     required this.textStyle,
     required this.textScaler,
     required this.theme,
@@ -1002,6 +1009,8 @@ class _TerminalView extends LeafRenderObjectWidget {
   final bool alignToTrailingEdges;
 
   final bool autoResize;
+
+  final bool liveOutputAutoScroll;
 
   final TerminalStyle textStyle;
 
@@ -1030,6 +1039,7 @@ class _TerminalView extends LeafRenderObjectWidget {
       padding: padding,
       alignToTrailingEdges: alignToTrailingEdges,
       autoResize: autoResize,
+      liveOutputAutoScroll: liveOutputAutoScroll,
       textStyle: textStyle,
       textScaler: textScaler,
       theme: theme,
@@ -1054,6 +1064,7 @@ class _TerminalView extends LeafRenderObjectWidget {
       ..padding = padding
       ..alignToTrailingEdges = alignToTrailingEdges
       ..autoResize = autoResize
+      ..liveOutputAutoScroll = liveOutputAutoScroll
       ..textStyle = textStyle
       ..textScaler = textScaler
       ..theme = theme
@@ -1075,6 +1086,7 @@ class MonkeyRenderTerminal extends RenderBox
     required EdgeInsets padding,
     required bool alignToTrailingEdges,
     required bool autoResize,
+    required bool liveOutputAutoScroll,
     required TerminalStyle textStyle,
     required TextScaler textScaler,
     required TerminalTheme theme,
@@ -1090,6 +1102,7 @@ class MonkeyRenderTerminal extends RenderBox
        _padding = padding,
        _alignToTrailingEdges = alignToTrailingEdges,
        _autoResize = autoResize,
+       _liveOutputAutoScroll = liveOutputAutoScroll,
        _focusNode = focusNode,
        _cursorType = cursorType,
        _alwaysShowCursor = alwaysShowCursor,
@@ -1155,6 +1168,20 @@ class MonkeyRenderTerminal extends RenderBox
   set autoResize(bool value) {
     if (value == _autoResize) return;
     _autoResize = value;
+    markNeedsLayout();
+  }
+
+  /// Whether layout should keep the viewport pinned to the newest output while
+  /// the user is already at the bottom.
+  bool get liveOutputAutoScroll => _liveOutputAutoScroll;
+
+  bool _liveOutputAutoScroll;
+  set liveOutputAutoScroll(bool value) {
+    if (value == _liveOutputAutoScroll) {
+      return;
+    }
+
+    _liveOutputAutoScroll = value;
     markNeedsLayout();
   }
 
@@ -1318,10 +1345,10 @@ class MonkeyRenderTerminal extends RenderBox
     _updateViewportSize();
     _updateScrollOffset();
 
-    if (_stickToBottom) {
+    if (_liveOutputAutoScroll && _stickToBottom) {
       _offset.correctBy(_maxScrollExtent - _scrollOffset);
     }
-    _updateSelectionGeometry();
+    _updateSelectionGeometry(deferNotification: true);
   }
 
   double get _terminalHeight =>

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1520,7 +1520,7 @@ class MonkeyRenderTerminal extends RenderBox
     _selectionEndOffset = nextEnd;
     _syncControllerSelectionFromSelectableOffsets();
     markNeedsPaint();
-    _updateSelectionGeometry(deferNotification: true);
+    _updateSelectionGeometry(forceNotify: true);
   }
 
   void _clearSelectableTextSelection() {
@@ -1536,7 +1536,7 @@ class MonkeyRenderTerminal extends RenderBox
       _isApplyingSelectableSelection = false;
     }
     markNeedsPaint();
-    _updateSelectionGeometry(deferNotification: true);
+    _updateSelectionGeometry(forceNotify: true);
   }
 
   void _preserveSelectableSelectionAcrossTerminalChange() {
@@ -1591,7 +1591,7 @@ class MonkeyRenderTerminal extends RenderBox
         _selectionStartOffset = null;
         _selectionEndOffset = null;
         markNeedsPaint();
-        _updateSelectionGeometry(deferNotification: true);
+        _updateSelectionGeometry(forceNotify: true);
       }
       return;
     }
@@ -1603,7 +1603,7 @@ class MonkeyRenderTerminal extends RenderBox
     _selectionStartOffset = nextStart;
     _selectionEndOffset = nextEnd;
     markNeedsPaint();
-    _updateSelectionGeometry(deferNotification: true);
+    _updateSelectionGeometry(forceNotify: true);
   }
 
   Offset _localPositionForTextOffset(int textOffset) {
@@ -1773,7 +1773,7 @@ class MonkeyRenderTerminal extends RenderBox
     };
     if (previousStart != _selectionStartOffset ||
         previousEnd != _selectionEndOffset) {
-      _updateSelectionGeometry(deferNotification: true, forceNotify: true);
+      _updateSelectionGeometry(forceNotify: true);
     }
     return result;
   }

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -187,6 +187,7 @@ class TerminalTextInputHandler extends StatefulWidget {
     this.readOnly = false,
     this.tapToShowKeyboard = true,
     this.showKeyboardOnFocus,
+    this.manageFocus = true,
     super.key,
   });
 
@@ -255,6 +256,12 @@ class TerminalTextInputHandler extends StatefulWidget {
   /// the user explicitly taps the terminal.
   final bool? showKeyboardOnFocus;
 
+  /// Whether this widget should wrap [child] in a [Focus] using [focusNode].
+  ///
+  /// Set this to false when the child already owns the same [focusNode], for
+  /// example a [SelectionArea] that must share focus with the input connection.
+  final bool manageFocus;
+
   @override
   State<TerminalTextInputHandler> createState() =>
       _TerminalTextInputHandlerState();
@@ -310,6 +317,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     super.initState();
     widget.focusNode.addListener(_onFocusChange);
     widget.controller?._attach(this);
+    if (!widget.manageFocus) {
+      HardwareKeyboard.instance.addHandler(_handleGlobalKeyEvent);
+    }
   }
 
   @override
@@ -322,6 +332,13 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (widget.controller != oldWidget.controller) {
       oldWidget.controller?._detach(this);
       widget.controller?._attach(this);
+    }
+    if (widget.manageFocus != oldWidget.manageFocus) {
+      if (widget.manageFocus) {
+        HardwareKeyboard.instance.removeHandler(_handleGlobalKeyEvent);
+      } else {
+        HardwareKeyboard.instance.addHandler(_handleGlobalKeyEvent);
+      }
     }
     if (!_shouldCreateInputConnection) {
       _closeInputConnectionIfNeeded();
@@ -339,6 +356,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   @override
   void dispose() {
     widget.controller?._detach(this);
+    if (!widget.manageFocus) {
+      HardwareKeyboard.instance.removeHandler(_handleGlobalKeyEvent);
+    }
     widget.focusNode.removeListener(_onFocusChange);
     _stopHardwareKeyRepeat();
     _cancelDeferredTrailingBackspaceImeClear();
@@ -356,19 +376,34 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   }
 
   @override
-  Widget build(BuildContext context) => Listener(
-    behavior: HitTestBehavior.translucent,
-    onPointerDown: _handlePointerDown,
-    onPointerMove: _handlePointerMove,
-    onPointerUp: _handlePointerUp,
-    onPointerCancel: _handlePointerCancel,
-    child: Focus(
-      focusNode: widget.focusNode,
-      autofocus: true,
-      onKeyEvent: _onKeyEvent,
-      child: widget.child,
-    ),
-  );
+  Widget build(BuildContext context) {
+    final child = widget.manageFocus
+        ? Focus(
+            focusNode: widget.focusNode,
+            autofocus: true,
+            onKeyEvent: _onKeyEvent,
+            child: widget.child,
+          )
+        : widget.child;
+
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: _handlePointerDown,
+      onPointerMove: _handlePointerMove,
+      onPointerUp: _handlePointerUp,
+      onPointerCancel: _handlePointerCancel,
+      child: child,
+    );
+  }
+
+  bool _handleGlobalKeyEvent(KeyEvent event) {
+    if (widget.manageFocus || !widget.focusNode.hasFocus) {
+      return false;
+    }
+    final result = _onKeyEvent(widget.focusNode, event);
+    return result == KeyEventResult.handled ||
+        result == KeyEventResult.skipRemainingHandlers;
+  }
 
   void _handlePointerDown(PointerDownEvent event) {
     if (event.kind == PointerDeviceKind.touch) {

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -346,7 +346,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       _touchLongPressTimers[event.pointer]?.cancel();
       _touchLongPressTimers[event.pointer] = Timer(
         terminalKeyboardTapLongPressTimeout,
-        () => _touchPointersPressedBeyondLongPressTimeout.add(event.pointer),
+        () {
+          _touchPointersPressedBeyondLongPressTimeout.add(event.pointer);
+          _closeInputConnectionIfNeeded();
+        },
       );
       if (_activeTouchPointers.length > 1) {
         _touchSequenceHadMultiplePointers = true;

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -347,6 +347,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       _touchLongPressTimers[event.pointer] = Timer(
         terminalKeyboardTapLongPressTimeout,
         () {
+          if (!_isTouchSelectionIntentCandidate(event.pointer)) {
+            return;
+          }
           _touchPointersPressedBeyondLongPressTimeout.add(event.pointer);
           _closeInputConnectionIfNeeded();
         },
@@ -356,6 +359,12 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       }
     }
   }
+
+  bool _isTouchSelectionIntentCandidate(int pointer) =>
+      _activeTouchPointers.length == 1 &&
+      _activeTouchPointers.contains(pointer) &&
+      !_touchSequenceHadMultiplePointers &&
+      !_touchPointersMovedBeyondTapSlop.contains(pointer);
 
   void _handlePointerMove(PointerMoveEvent event) {
     if (event.kind != PointerDeviceKind.touch ||

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -383,7 +383,6 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
             return;
           }
           _touchPointersPressedBeyondLongPressTimeout.add(event.pointer);
-          _closeInputConnectionIfNeeded();
         },
       );
       if (_activeTouchPointers.length > 1) {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1504,6 +1504,67 @@ void main() {
     );
 
     testWidgets(
+      'system selectable anchors drags that start in terminal whitespace',
+      (tester) async {
+        await pumpScreen(tester);
+
+        const lineText = 'alpha bravo';
+        session.terminal!.write(lineText);
+        await tester.pumpAndSettle();
+
+        Offset cellCenter(CellOffset offset) {
+          final terminalViewState = tester.state<MonkeyTerminalViewState>(
+            find.byType(MonkeyTerminalView),
+          );
+          final renderTerminal = terminalViewState.renderTerminal;
+          return renderTerminal.localToGlobal(
+            renderTerminal.getOffset(offset) +
+                renderTerminal.cellSize.center(Offset.zero),
+          );
+        }
+
+        final terminalViewState = tester.state<MonkeyTerminalViewState>(
+          find.byType(MonkeyTerminalView),
+        );
+        final renderTerminal = terminalViewState.renderTerminal;
+        const whitespaceCell = CellOffset(lineText.length + 4, 0);
+        expect(
+          session.terminal!.buffer.getWordBoundary(whitespaceCell),
+          isNull,
+        );
+
+        renderTerminal
+          ..dispatchSelectionEvent(
+            SelectWordSelectionEvent(
+              globalPosition: cellCenter(whitespaceCell),
+            ),
+          )
+          ..dispatchSelectionEvent(
+            SelectionEdgeUpdateEvent.forEnd(
+              globalPosition: cellCenter(const CellOffset(0, 0)),
+              granularity: TextGranularity.word,
+            ),
+          );
+        await tester.pumpAndSettle();
+
+        expect(renderTerminal.getSelectedContent()?.plainText, lineText);
+        final terminalView = tester.widget<MonkeyTerminalView>(
+          find.byType(MonkeyTerminalView),
+        );
+        expect(terminalView.controller, isNotNull);
+        expect(
+          trimTerminalSelectionText(
+            session.terminal!.buffer.getText(
+              terminalView.controller!.selection,
+            ),
+          ),
+          lineText,
+        );
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
       'overlay scroll stays fixed while a native selection is active',
       (tester) async {
         await pumpScreen(tester);

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1594,6 +1594,60 @@ void main() {
     );
 
     testWidgets(
+      'touch press pauses live output auto-scroll before long press resolves',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(430, 932));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        session.terminal!
+          ..setMouseMode(MouseMode.upDownScroll)
+          ..setMouseReportMode(MouseReportMode.sgr);
+        await pumpScreen(tester);
+
+        session.terminal!.write(
+          List<String>.generate(
+            60,
+            (index) => index == 59 ? 'alpha bravo' : 'line $index',
+          ).join('\r\n'),
+        );
+        await tester.pumpAndSettle();
+
+        final scrollableFinder = find.descendant(
+          of: find.byType(MonkeyTerminalView),
+          matching: find.byType(Scrollable),
+        );
+        expect(scrollableFinder, findsOneWidget);
+        final scrollableState = tester.state<ScrollableState>(scrollableFinder);
+        final initialOffset = scrollableState.position.pixels;
+        expect(initialOffset, scrollableState.position.maxScrollExtent);
+
+        final gesture = await tester.startGesture(
+          tester.getCenter(find.byType(MonkeyTerminalView)),
+        );
+        await tester.pump();
+        expect(
+          tester
+              .widget<MonkeyTerminalView>(find.byType(MonkeyTerminalView))
+              .liveOutputAutoScroll,
+          isFalse,
+        );
+        session.terminal!.write(
+          '\r\n${List<String>.generate(20, (index) => 'stream $index').join('\r\n')}',
+        );
+        await tester.pump();
+
+        expect(scrollableState.position.pixels, initialOffset);
+
+        await gesture.up();
+        await tester.pumpAndSettle();
+        expect(
+          scrollableState.position.pixels,
+          scrollableState.position.maxScrollExtent,
+        );
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
       'link long press keeps the touched word selected while output streams during the hold',
       (tester) async {
         await pumpScreen(tester);

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1107,7 +1107,7 @@ void main() {
     );
 
     testWidgets(
-      'system selection does not hide an already visible mobile keyboard',
+      'system selection hides an already visible mobile keyboard',
       (tester) async {
         await pumpScreen(tester);
 
@@ -1131,7 +1131,7 @@ void main() {
         await tester.longPressAt(target);
         await tester.pumpAndSettle();
 
-        expect(tester.testTextInput.isVisible, isTrue);
+        expect(tester.testTextInput.isVisible, isFalse);
         final selection = terminalViewState.renderTerminal.getSelectedContent();
         expect(selection?.plainText, 'alpha');
       },

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1107,7 +1107,7 @@ void main() {
     );
 
     testWidgets(
-      'system selection hides an already visible mobile keyboard',
+      'system selection preserves an already visible mobile keyboard',
       (tester) async {
         await pumpScreen(tester);
 
@@ -1131,7 +1131,7 @@ void main() {
         await tester.longPressAt(target);
         await tester.pumpAndSettle();
 
-        expect(tester.testTextInput.isVisible, isFalse);
+        expect(tester.testTextInput.isVisible, isTrue);
         final selection = terminalViewState.renderTerminal.getSelectedContent();
         expect(selection?.plainText, 'alpha');
       },

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -4949,6 +4949,49 @@ void main() {
       focusNode.dispose();
     });
 
+    testWidgets('closes the keyboard when touch becomes selection intent', (
+      tester,
+    ) async {
+      final terminal = Terminal();
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalTextInputHandler(
+              terminal: terminal,
+              focusNode: focusNode,
+              deleteDetection: true,
+              child: const SizedBox.expand(key: ValueKey('terminal-child')),
+            ),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      expect(focusNode.hasFocus, isTrue);
+      expect(tester.testTextInput.isVisible, isTrue);
+
+      final target =
+          tester.getTopLeft(find.byType(TerminalTextInputHandler)) +
+          const Offset(40, 40);
+      final gesture = await tester.createGesture();
+      await gesture.down(target);
+      await tester.pump(terminalKeyboardTapLongPressTimeout);
+
+      expect(focusNode.hasFocus, isTrue);
+      expect(tester.testTextInput.isVisible, isFalse);
+
+      await gesture.up();
+      await tester.pump();
+
+      expect(tester.testTextInput.isVisible, isFalse);
+
+      focusNode.dispose();
+    });
+
     testWidgets('does not open the keyboard after a touch drag', (
       tester,
     ) async {

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -4999,48 +4999,49 @@ void main() {
       focusNode.dispose();
     });
 
-    testWidgets('closes the keyboard when touch becomes selection intent', (
-      tester,
-    ) async {
-      final terminal = Terminal();
-      final focusNode = FocusNode();
+    testWidgets(
+      'keeps the keyboard visible when touch becomes selection intent',
+      (tester) async {
+        final terminal = Terminal();
+        final focusNode = FocusNode();
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: TerminalTextInputHandler(
-              terminal: terminal,
-              focusNode: focusNode,
-              deleteDetection: true,
-              child: const SizedBox.expand(key: ValueKey('terminal-child')),
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TerminalTextInputHandler(
+                terminal: terminal,
+                focusNode: focusNode,
+                deleteDetection: true,
+                child: const SizedBox.expand(key: ValueKey('terminal-child')),
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      focusNode.requestFocus();
-      await tester.pump();
+        focusNode.requestFocus();
+        await tester.pump();
 
-      expect(focusNode.hasFocus, isTrue);
-      expect(tester.testTextInput.isVisible, isTrue);
+        expect(focusNode.hasFocus, isTrue);
+        expect(tester.testTextInput.isVisible, isTrue);
 
-      final target =
-          tester.getTopLeft(find.byType(TerminalTextInputHandler)) +
-          const Offset(40, 40);
-      final gesture = await tester.createGesture();
-      await gesture.down(target);
-      await tester.pump(terminalKeyboardTapLongPressTimeout);
+        final target =
+            tester.getTopLeft(find.byType(TerminalTextInputHandler)) +
+            const Offset(40, 40);
+        final gesture = await tester.createGesture();
+        await gesture.down(target);
+        await tester.pump(terminalKeyboardTapLongPressTimeout);
 
-      expect(focusNode.hasFocus, isTrue);
-      expect(tester.testTextInput.isVisible, isFalse);
+        expect(focusNode.hasFocus, isTrue);
+        expect(tester.testTextInput.isVisible, isTrue);
 
-      await gesture.up();
-      await tester.pump();
+        await gesture.up();
+        await tester.pump();
 
-      expect(tester.testTextInput.isVisible, isFalse);
+        expect(tester.testTextInput.isVisible, isTrue);
 
-      focusNode.dispose();
-    });
+        focusNode.dispose();
+      },
+    );
 
     testWidgets(
       'keeps the keyboard visible when a held touch starts scrolling',

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -4992,6 +4992,62 @@ void main() {
       focusNode.dispose();
     });
 
+    testWidgets(
+      'keeps the keyboard visible when a held touch starts scrolling',
+      (tester) async {
+        final harness = await _pumpTerminalHarness(tester);
+
+        expect(harness.focusNode.hasFocus, isTrue);
+        expect(tester.testTextInput.isVisible, isTrue);
+
+        final target =
+            tester.getTopLeft(find.byType(TerminalTextInputHandler)) +
+            const Offset(40, 40);
+        final gesture = await tester.startGesture(target);
+        await tester.pump();
+        await gesture.moveBy(const Offset(0, 80));
+        await tester.pump(terminalKeyboardTapLongPressTimeout);
+
+        expect(tester.testTextInput.isVisible, isTrue);
+
+        await gesture.up();
+        await tester.pump();
+
+        expect(tester.testTextInput.isVisible, isTrue);
+
+        await _disposeTerminalHarness(tester, harness);
+      },
+    );
+
+    testWidgets('keeps the keyboard visible during held multitouch', (
+      tester,
+    ) async {
+      final harness = await _pumpTerminalHarness(tester);
+
+      expect(harness.focusNode.hasFocus, isTrue);
+      expect(tester.testTextInput.isVisible, isTrue);
+
+      final target =
+          tester.getTopLeft(find.byType(TerminalTextInputHandler)) +
+          const Offset(40, 40);
+      final firstGesture = await tester.createGesture();
+      final secondGesture = await tester.createGesture();
+      await firstGesture.down(target);
+      await tester.pump();
+      await secondGesture.down(target + const Offset(60, 0));
+      await tester.pump(terminalKeyboardTapLongPressTimeout);
+
+      expect(tester.testTextInput.isVisible, isTrue);
+
+      await secondGesture.up();
+      await firstGesture.up();
+      await tester.pump();
+
+      expect(tester.testTextInput.isVisible, isTrue);
+
+      await _disposeTerminalHarness(tester, harness);
+    });
+
     testWidgets('does not open the keyboard after a touch drag', (
       tester,
     ) async {

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -5315,6 +5315,125 @@ void main() {
       },
     );
 
+    testWidgets('routes hardware keys when the child owns focus', (
+      tester,
+    ) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+      final focusNode = FocusNode();
+      final otherFocusNode = FocusNode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                Focus(
+                  focusNode: otherFocusNode,
+                  child: const SizedBox(
+                    width: 50,
+                    height: 50,
+                    key: ValueKey('other-focus-target'),
+                  ),
+                ),
+                Expanded(
+                  child: TerminalTextInputHandler(
+                    terminal: terminal,
+                    focusNode: focusNode,
+                    deleteDetection: true,
+                    manageFocus: false,
+                    child: Focus(
+                      focusNode: focusNode,
+                      child: const SizedBox.expand(
+                        key: ValueKey('terminal-focus-owner'),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      expect(focusNode.hasFocus, isTrue);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+
+      expect(terminalOutput.join(), _terminalKeyOutput(TerminalKey.arrowLeft));
+
+      terminalOutput.clear();
+      otherFocusNode.requestFocus();
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+
+      expect(terminalOutput, isEmpty);
+
+      focusNode.dispose();
+      otherFocusNode.dispose();
+    });
+
+    testWidgets('consumes composing hardware keys when the child owns focus', (
+      tester,
+    ) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalTextInputHandler(
+              terminal: terminal,
+              focusNode: focusNode,
+              deleteDetection: true,
+              manageFocus: false,
+              child: Focus(
+                focusNode: focusNode,
+                child: const SizedBox.expand(
+                  key: ValueKey('terminal-focus-owner'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      tester.testTextInput.updateEditingValue(
+        _editingValue(
+          'hello',
+          selectionOffset: 'hello'.length,
+          composing: const TextRange(start: 0, end: 5),
+        ),
+      );
+      await tester.pump();
+
+      final handledKeyDown = await tester.sendKeyDownEvent(
+        LogicalKeyboardKey.arrowLeft,
+      );
+      final handledKeyUp = await tester.sendKeyUpEvent(
+        LogicalKeyboardKey.arrowLeft,
+      );
+      await tester.pump();
+
+      expect(terminalOutput, isEmpty);
+      expect(handledKeyDown, isTrue);
+      expect(handledKeyUp, isTrue);
+
+      focusNode.dispose();
+    });
+
     testWidgets('does not open the keyboard after a suppressed touch tap', (
       tester,
     ) async {

--- a/test_driver/integration_test.dart
+++ b/test_driver/integration_test.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();


### PR DESCRIPTION
## Summary

- Pause terminal live-output auto-scroll while a mobile touch selection is pending or actively expanded, including the render object's internal stick-to-bottom behavior.
- Defer terminal selection geometry notifications until after layout so Flutter can place the system selection handles and toolbar reliably.
- Add widget and device integration coverage for first long-press selection while output streams.

## Validation

- `flutter analyze`
- `flutter test`
- `flutter drive --driver=test_driver/integration_test.dart --target=integration_test/terminal_screen_system_selection_test.dart -d emulator-5554 --flavor production --profile --no-dds`

## Notes

- Android emulator repro/validation passed on `emulator-5554`.
- iOS simulator launch was attempted on `iPhone 17 Pro (96C81AA7-D8AB-4F45-AE1B-F2FAF825567A)`, but the existing Xcode project schemes do not expose the booted simulator destination in this environment. `Production`/`Private` only listed `Any iOS Device` and failed with a missing iOS 26.4 platform; the default `Runner` scheme only listed macOS destinations.
