### PR TITLE
fix: correct terminal scroll mouse reporting

### DIFF
--- a/lib/presentation/widgets/monkey_terminal_scroll_gesture_handler.dart
+++ b/lib/presentation/widgets/monkey_terminal_scroll_gesture_handler.dart
@@ -4,6 +4,8 @@ import 'package:flutter/widgets.dart';
 import 'package:xterm/core.dart';
 import 'package:xterm/src/ui/infinite_scroll_view.dart';
 
+import 'terminal_scroll_mouse_input.dart';
+
 /// Handles alt-buffer scrolling while preserving trackpad gesture position.
 class MonkeyTerminalScrollGestureHandler extends StatefulWidget {
   const MonkeyTerminalScrollGestureHandler({
@@ -89,11 +91,14 @@ class _MonkeyTerminalScrollGestureHandlerState
   /// will simulate scroll events by sending up/down arrow keys.
   void _sendScrollEvent(bool up) {
     final position = widget.getCellOffset(lastPointerPosition);
+    final button = up
+        ? TerminalMouseButton.wheelUp
+        : TerminalMouseButton.wheelDown;
 
-    final handled = widget.terminal.mouseInput(
-      up ? TerminalMouseButton.wheelUp : TerminalMouseButton.wheelDown,
-      TerminalMouseButtonState.down,
-      position,
+    final handled = sendTerminalScrollMouseInput(
+      terminal: widget.terminal,
+      button: button,
+      position: position,
     );
 
     if (!handled && widget.simulateScroll) {
@@ -135,14 +140,14 @@ class _MonkeyTerminalScrollGestureHandlerState
     }
 
     return Listener(
-      onPointerSignal: (event) => _rememberPointerPosition(event.position),
-      onPointerHover: (event) => _rememberPointerPosition(event.position),
-      onPointerMove: (event) => _rememberPointerPosition(event.position),
-      onPointerDown: (event) => _rememberPointerPosition(event.position),
+      onPointerSignal: (event) => _rememberPointerPosition(event.localPosition),
+      onPointerHover: (event) => _rememberPointerPosition(event.localPosition),
+      onPointerMove: (event) => _rememberPointerPosition(event.localPosition),
+      onPointerDown: (event) => _rememberPointerPosition(event.localPosition),
       onPointerPanZoomStart: (event) =>
-          _rememberPointerPosition(event.position),
+          _rememberPointerPosition(event.localPosition),
       onPointerPanZoomUpdate: (event) =>
-          _rememberPointerPosition(event.position + event.pan),
+          _rememberPointerPosition(event.localPosition + event.pan),
       child: InfiniteScrollView(onScroll: _onScroll, child: widget.child),
     );
   }

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -19,7 +19,6 @@ import 'package:xterm/src/core/buffer/segment.dart';
 import 'package:xterm/src/core/input/keys.dart';
 import 'package:xterm/src/core/mouse/button.dart';
 import 'package:xterm/src/core/mouse/button_state.dart';
-import 'package:xterm/src/core/mouse/mode.dart';
 import 'package:xterm/src/terminal.dart';
 import 'package:xterm/src/ui/controller.dart';
 import 'package:xterm/src/ui/cursor_type.dart';
@@ -39,6 +38,7 @@ import 'package:xterm/src/ui/themes.dart';
 
 import 'monkey_terminal_gesture_handler.dart';
 import 'monkey_terminal_scroll_gesture_handler.dart';
+import 'terminal_scroll_mouse_input.dart';
 import 'terminal_selection_text.dart';
 
 /// Terminal render padding.
@@ -841,28 +841,11 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
   bool _sendTouchScrollMouseInput(
     TerminalMouseButton button,
     CellOffset position,
-  ) {
-    if (widget.terminal.mouseMode.reportScroll &&
-        widget.terminal.mouseReportMode == MouseReportMode.sgr) {
-      final sgrButtonId = switch (button) {
-        TerminalMouseButton.wheelUp => 64,
-        TerminalMouseButton.wheelDown => 65,
-        TerminalMouseButton.wheelLeft => 66,
-        TerminalMouseButton.wheelRight => 67,
-        _ => button.id,
-      };
-      widget.terminal.onOutput?.call(
-        '\x1b[<$sgrButtonId;${position.x + 1};${position.y + 1}M',
-      );
-      return true;
-    }
-
-    return widget.terminal.mouseInput(
-      button,
-      TerminalMouseButtonState.down,
-      position,
-    );
-  }
+  ) => sendTerminalScrollMouseInput(
+    terminal: widget.terminal,
+    button: button,
+    position: position,
+  );
 
   CellOffset _resolveViewportMousePosition(Offset localPosition) {
     final cellSize = renderTerminal.cellSize;

--- a/lib/presentation/widgets/terminal_scroll_mouse_input.dart
+++ b/lib/presentation/widgets/terminal_scroll_mouse_input.dart
@@ -1,0 +1,25 @@
+import 'package:xterm/core.dart';
+
+/// Sends terminal scroll mouse input with corrected SGR wheel button IDs.
+bool sendTerminalScrollMouseInput({
+  required Terminal terminal,
+  required TerminalMouseButton button,
+  required CellOffset position,
+}) {
+  if (terminal.mouseMode.reportScroll &&
+      terminal.mouseReportMode == MouseReportMode.sgr) {
+    final sgrButtonId = switch (button) {
+      TerminalMouseButton.wheelUp => 64,
+      TerminalMouseButton.wheelDown => 65,
+      TerminalMouseButton.wheelLeft => 66,
+      TerminalMouseButton.wheelRight => 67,
+      _ => button.id,
+    };
+    terminal.onOutput?.call(
+      '\x1b[<$sgrButtonId;${position.x + 1};${position.y + 1}M',
+    );
+    return true;
+  }
+
+  return terminal.mouseInput(button, TerminalMouseButtonState.down, position);
+}

--- a/test/widget/monkey_terminal_scroll_gesture_handler_test.dart
+++ b/test/widget/monkey_terminal_scroll_gesture_handler_test.dart
@@ -51,6 +51,7 @@ void main() {
       final targetRect = tester.getRect(
         find.byKey(const ValueKey('trackpad-target')),
       );
+      final localTargetRect = Offset.zero & targetRect.size;
       final gesture = await tester.createGesture(
         kind: PointerDeviceKind.trackpad,
       );
@@ -66,10 +67,11 @@ void main() {
       await tester.pump();
 
       expect(output, hasLength(2));
+      expect(output, everyElement(startsWith('\x1b[<65;')));
       expect(reportedPositions, hasLength(2));
       for (final position in reportedPositions) {
         expect(position, isNot(Offset.zero));
-        expect(targetRect.contains(position), isTrue);
+        expect(localTargetRect.contains(position), isTrue);
       }
     },
   );
@@ -137,4 +139,59 @@ void main() {
       await tester.pump();
     },
   );
+
+  testWidgets('trackpad scrolling reports SGR wheel up as button 64', (
+    tester,
+  ) async {
+    final terminal = Terminal()
+      ..useAltBuffer()
+      ..setMouseMode(MouseMode.upDownScroll)
+      ..setMouseReportMode(MouseReportMode.sgr);
+    final output = <String>[];
+    terminal.onOutput = output.add;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: 200,
+              height: 200,
+              child: MonkeyTerminalScrollGestureHandler(
+                terminal: terminal,
+                simulateScroll: false,
+                getCellOffset: (_) => const CellOffset(1, 1),
+                getLineHeight: () => 10,
+                child: const ColoredBox(
+                  key: ValueKey('sgr-wheel-up-target'),
+                  color: Colors.black,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final center = tester.getCenter(
+      find.byKey(const ValueKey('sgr-wheel-up-target')),
+    );
+    final gesture = await tester.createGesture(
+      kind: PointerDeviceKind.trackpad,
+    );
+
+    await gesture.panZoomStart(center);
+    await tester.pump();
+    await gesture.panZoomUpdate(
+      center + const Offset(0, 10),
+      pan: const Offset(0, 10),
+    );
+    await tester.pump();
+    await gesture.panZoomEnd();
+    await tester.pump();
+
+    expect(output, hasLength(1));
+    expect(output.single, startsWith('\x1b[<64;'));
+  });
 }


### PR DESCRIPTION
## Summary

- correct SGR wheel button IDs for terminal scroll mouse reporting
- use terminal-local pointer positions for alt-buffer trackpad scrolling
- share the corrected scroll mouse reporting path between trackpad and touch scrolling

## Tests

- flutter test test/widget/monkey_terminal_scroll_gesture_handler_test.dart
- flutter test test/widget/terminal_screen_scroll_policy_test.dart
- flutter analyze
- flutter test
