### PR TITLE
fix: forward terminal resize pixel dimensions

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -4108,7 +4108,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     };
 
     _terminal.onResize = (width, height, pixelWidth, pixelHeight) {
-      _shell?.resizeTerminal(width, height);
+      _shell?.resizeTerminal(width, height, pixelWidth, pixelHeight);
     };
   }
 

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -145,6 +145,10 @@ double resolveTerminalHorizontalFillScale({
   return (width: width.round(), height: height.round());
 }
 
+/// How long to wait for keyboard inset animations to settle before resizing.
+@visibleForTesting
+const terminalKeyboardResizeDebounceDuration = Duration(milliseconds: 180);
+
 /// Adapted xterm terminal view with a trackpad scroll fix for alt-buffer apps.
 class MonkeyTerminalView extends StatefulWidget {
   const MonkeyTerminalView(
@@ -465,6 +469,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
           padding: EdgeInsets.zero,
           alignToTrailingEdges: shouldAlignTerminalToTrailingEdges(mediaQuery),
           autoResize: widget.autoResize,
+          resizeBottomInset: mediaQuery.viewInsets.bottom,
           textStyle: widget.textStyle,
           textScaler: widget.textScaler ?? MediaQuery.textScalerOf(context),
           theme: widget.theme,
@@ -974,6 +979,7 @@ class _TerminalView extends LeafRenderObjectWidget {
     required this.padding,
     required this.alignToTrailingEdges,
     required this.autoResize,
+    required this.resizeBottomInset,
     required this.textStyle,
     required this.textScaler,
     required this.theme,
@@ -996,6 +1002,8 @@ class _TerminalView extends LeafRenderObjectWidget {
   final bool alignToTrailingEdges;
 
   final bool autoResize;
+
+  final double resizeBottomInset;
 
   final TerminalStyle textStyle;
 
@@ -1024,6 +1032,7 @@ class _TerminalView extends LeafRenderObjectWidget {
       padding: padding,
       alignToTrailingEdges: alignToTrailingEdges,
       autoResize: autoResize,
+      resizeBottomInset: resizeBottomInset,
       textStyle: textStyle,
       textScaler: textScaler,
       theme: theme,
@@ -1048,6 +1057,7 @@ class _TerminalView extends LeafRenderObjectWidget {
       ..padding = padding
       ..alignToTrailingEdges = alignToTrailingEdges
       ..autoResize = autoResize
+      ..resizeBottomInset = resizeBottomInset
       ..textStyle = textStyle
       ..textScaler = textScaler
       ..theme = theme
@@ -1069,6 +1079,7 @@ class MonkeyRenderTerminal extends RenderBox
     required EdgeInsets padding,
     required bool alignToTrailingEdges,
     required bool autoResize,
+    required double resizeBottomInset,
     required TerminalStyle textStyle,
     required TextScaler textScaler,
     required TerminalTheme theme,
@@ -1084,6 +1095,7 @@ class MonkeyRenderTerminal extends RenderBox
        _padding = padding,
        _alignToTrailingEdges = alignToTrailingEdges,
        _autoResize = autoResize,
+       _resizeBottomInset = resizeBottomInset,
        _focusNode = focusNode,
        _cursorType = cursorType,
        _alwaysShowCursor = alwaysShowCursor,
@@ -1149,6 +1161,20 @@ class MonkeyRenderTerminal extends RenderBox
   set autoResize(bool value) {
     if (value == _autoResize) return;
     _autoResize = value;
+    if (!_autoResize) {
+      _cancelPendingTerminalResize();
+    }
+    markNeedsLayout();
+  }
+
+  double _resizeBottomInset;
+  set resizeBottomInset(double value) {
+    if (value == _resizeBottomInset) return;
+    final previousInset = _resizeBottomInset;
+    _resizeBottomInset = math.max(0.0, value);
+    if (previousInset > 0 || _resizeBottomInset > 0) {
+      _debounceKeyboardResize();
+    }
     markNeedsLayout();
   }
 
@@ -1213,6 +1239,15 @@ class MonkeyRenderTerminal extends RenderBox
 
   TerminalSize? _viewportSize;
 
+  ({int width, int height})? _viewportPixelSize;
+
+  Timer? _keyboardResizeDebounceTimer;
+
+  bool _isDebouncingKeyboardResize = false;
+
+  ({TerminalSize viewportSize, ({int width, int height}) pixelSize})?
+  _pendingTerminalResize;
+
   final TerminalPainter _painter;
 
   var _stickToBottom = true;
@@ -1273,6 +1308,7 @@ class MonkeyRenderTerminal extends RenderBox
 
   @override
   void dispose() {
+    _cancelPendingTerminalResize();
     _selectionListeners.clear();
     super.dispose();
   }
@@ -1954,26 +1990,85 @@ class MonkeyRenderTerminal extends RenderBox
       availableWidth ~/ _painter.cellSize.width,
       availableHeight ~/ _painter.cellSize.height,
     );
+    final pixelSize = resolveTerminalResizePixelDimensions(
+      viewportSize: size,
+      padding: _padding,
+    );
 
-    if (_viewportSize != viewportSize) {
-      _viewportSize = viewportSize;
-      _resizeTerminalIfNeeded();
+    if (_viewportSize != viewportSize || _viewportPixelSize != pixelSize) {
+      _resizeTerminalIfNeeded(viewportSize: viewportSize, pixelSize: pixelSize);
     }
   }
 
-  void _resizeTerminalIfNeeded() {
-    if (_autoResize && _viewportSize != null) {
-      final pixelDimensions = resolveTerminalResizePixelDimensions(
-        viewportSize: size,
-        padding: _padding,
-      );
-      _terminal.resize(
-        _viewportSize!.width,
-        _viewportSize!.height,
-        pixelDimensions.width,
-        pixelDimensions.height,
-      );
+  void _resizeTerminalIfNeeded({
+    TerminalSize? viewportSize,
+    ({int width, int height})? pixelSize,
+  }) {
+    if (!_autoResize) {
+      return;
     }
+    final nextViewportSize = viewportSize ?? _viewportSize;
+    if (nextViewportSize == null) {
+      return;
+    }
+    final nextPixelSize =
+        pixelSize ??
+        resolveTerminalResizePixelDimensions(
+          viewportSize: size,
+          padding: _padding,
+        );
+
+    if (_isDebouncingKeyboardResize) {
+      _pendingTerminalResize = (
+        viewportSize: nextViewportSize,
+        pixelSize: nextPixelSize,
+      );
+      return;
+    }
+
+    _applyTerminalResize(nextViewportSize, nextPixelSize);
+  }
+
+  void _applyTerminalResize(
+    TerminalSize viewportSize,
+    ({int width, int height}) pixelSize,
+  ) {
+    _viewportSize = viewportSize;
+    _viewportPixelSize = pixelSize;
+    _terminal.resize(
+      viewportSize.width,
+      viewportSize.height,
+      pixelSize.width,
+      pixelSize.height,
+    );
+  }
+
+  void _debounceKeyboardResize() {
+    _isDebouncingKeyboardResize = true;
+    _keyboardResizeDebounceTimer?.cancel();
+    _keyboardResizeDebounceTimer = Timer(
+      terminalKeyboardResizeDebounceDuration,
+      () {
+        _keyboardResizeDebounceTimer = null;
+        _isDebouncingKeyboardResize = false;
+        final pendingResize = _pendingTerminalResize;
+        _pendingTerminalResize = null;
+        if (pendingResize == null || !_autoResize) {
+          return;
+        }
+        _applyTerminalResize(
+          pendingResize.viewportSize,
+          pendingResize.pixelSize,
+        );
+      },
+    );
+  }
+
+  void _cancelPendingTerminalResize() {
+    _keyboardResizeDebounceTimer?.cancel();
+    _keyboardResizeDebounceTimer = null;
+    _isDebouncingKeyboardResize = false;
+    _pendingTerminalResize = null;
   }
 
   void _updateScrollOffset() {

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -134,6 +134,17 @@ double resolveTerminalHorizontalFillScale({
   return (viewportWidth / contentWidth).clamp(1.0, 1.03);
 }
 
+/// Resolves the pixel dimensions to report with terminal resize events.
+@visibleForTesting
+({int width, int height}) resolveTerminalResizePixelDimensions({
+  required Size viewportSize,
+  EdgeInsets padding = EdgeInsets.zero,
+}) {
+  final width = math.max(0.0, viewportSize.width - padding.horizontal);
+  final height = math.max(0.0, viewportSize.height - padding.vertical);
+  return (width: width.round(), height: height.round());
+}
+
 /// Adapted xterm terminal view with a trackpad scroll fix for alt-buffer apps.
 class MonkeyTerminalView extends StatefulWidget {
   const MonkeyTerminalView(
@@ -1952,11 +1963,15 @@ class MonkeyRenderTerminal extends RenderBox
 
   void _resizeTerminalIfNeeded() {
     if (_autoResize && _viewportSize != null) {
+      final pixelDimensions = resolveTerminalResizePixelDimensions(
+        viewportSize: size,
+        padding: _padding,
+      );
       _terminal.resize(
         _viewportSize!.width,
         _viewportSize!.height,
-        _painter.cellSize.width.round(),
-        _painter.cellSize.height.round(),
+        pixelDimensions.width,
+        pixelDimensions.height,
       );
     }
   }

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -189,4 +189,26 @@ void main() {
       );
     });
   });
+
+  group('resolveTerminalResizePixelDimensions', () {
+    test('reports the padded terminal viewport in pixels', () {
+      expect(
+        resolveTerminalResizePixelDimensions(
+          viewportSize: const Size(390.4, 844.6),
+          padding: const EdgeInsets.fromLTRB(4.2, 8.8, 5.4, 10.1),
+        ),
+        (width: 381, height: 826),
+      );
+    });
+
+    test('clamps fully padded viewports to zero', () {
+      expect(
+        resolveTerminalResizePixelDimensions(
+          viewportSize: const Size(10, 12),
+          padding: const EdgeInsets.all(20),
+        ),
+        (width: 0, height: 0),
+      );
+    });
+  });
 }

--- a/test/widget/monkey_terminal_view_resize_test.dart
+++ b/test/widget/monkey_terminal_view_resize_test.dart
@@ -6,6 +6,30 @@ import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
 import 'package:xterm/xterm.dart';
 
 void main() {
+  Widget buildTerminal({
+    required Terminal terminal,
+    required Size size,
+    double keyboardInset = 0,
+  }) => MaterialApp(
+    home: MediaQuery(
+      data: MediaQueryData(
+        size: size,
+        viewInsets: EdgeInsets.only(bottom: keyboardInset),
+      ),
+      child: Center(
+        child: SizedBox(
+          width: size.width,
+          height: size.height,
+          child: MonkeyTerminalView(
+            terminal,
+            hardwareKeyboardOnly: true,
+            readOnly: true,
+          ),
+        ),
+      ),
+    ),
+  );
+
   testWidgets('auto resize reports total viewport pixels', (tester) async {
     final terminal = Terminal();
     final resizeEvents =
@@ -20,19 +44,7 @@ void main() {
     };
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: Center(
-          child: SizedBox(
-            width: 320,
-            height: 240,
-            child: MonkeyTerminalView(
-              terminal,
-              hardwareKeyboardOnly: true,
-              readOnly: true,
-            ),
-          ),
-        ),
-      ),
+      buildTerminal(terminal: terminal, size: const Size(320, 240)),
     );
 
     expect(resizeEvents, isNotEmpty);
@@ -41,5 +53,65 @@ void main() {
     expect(event.height, greaterThan(0));
     expect(event.pixelWidth, 320);
     expect(event.pixelHeight, 240);
+  });
+
+  testWidgets('keyboard inset changes debounce before the final resize', (
+    tester,
+  ) async {
+    final terminal = Terminal();
+    final resizeEvents =
+        <({int width, int height, int pixelWidth, int pixelHeight})>[];
+    terminal.onResize = (width, height, pixelWidth, pixelHeight) {
+      resizeEvents.add((
+        width: width,
+        height: height,
+        pixelWidth: pixelWidth,
+        pixelHeight: pixelHeight,
+      ));
+    };
+
+    await tester.pumpWidget(
+      buildTerminal(terminal: terminal, size: const Size(320, 400)),
+    );
+
+    expect(resizeEvents, isNotEmpty);
+    final initialEvent = resizeEvents.last;
+    final initialCount = resizeEvents.length;
+
+    await tester.pumpWidget(
+      buildTerminal(
+        terminal: terminal,
+        size: const Size(320, 240),
+        keyboardInset: 160,
+      ),
+    );
+
+    expect(resizeEvents, hasLength(initialCount));
+    expect(terminal.viewWidth, initialEvent.width);
+    expect(terminal.viewHeight, initialEvent.height);
+
+    await tester.pump(terminalKeyboardResizeDebounceDuration);
+
+    expect(resizeEvents, hasLength(initialCount + 1));
+    final keyboardShownEvent = resizeEvents.last;
+    expect(keyboardShownEvent.width, initialEvent.width);
+    expect(keyboardShownEvent.height, lessThan(initialEvent.height));
+    expect(keyboardShownEvent.pixelWidth, 320);
+    expect(keyboardShownEvent.pixelHeight, 240);
+
+    await tester.pumpWidget(
+      buildTerminal(terminal: terminal, size: const Size(320, 400)),
+    );
+
+    expect(resizeEvents, hasLength(initialCount + 1));
+    expect(resizeEvents.last, keyboardShownEvent);
+
+    await tester.pump(terminalKeyboardResizeDebounceDuration);
+
+    expect(resizeEvents, hasLength(initialCount + 2));
+    expect(resizeEvents.last.width, initialEvent.width);
+    expect(resizeEvents.last.height, initialEvent.height);
+    expect(resizeEvents.last.pixelWidth, initialEvent.pixelWidth);
+    expect(resizeEvents.last.pixelHeight, initialEvent.pixelHeight);
   });
 }

--- a/test/widget/monkey_terminal_view_resize_test.dart
+++ b/test/widget/monkey_terminal_view_resize_test.dart
@@ -1,0 +1,45 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
+import 'package:xterm/xterm.dart';
+
+void main() {
+  testWidgets('auto resize reports total viewport pixels', (tester) async {
+    final terminal = Terminal();
+    final resizeEvents =
+        <({int width, int height, int pixelWidth, int pixelHeight})>[];
+    terminal.onResize = (width, height, pixelWidth, pixelHeight) {
+      resizeEvents.add((
+        width: width,
+        height: height,
+        pixelWidth: pixelWidth,
+        pixelHeight: pixelHeight,
+      ));
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: 320,
+            height: 240,
+            child: MonkeyTerminalView(
+              terminal,
+              hardwareKeyboardOnly: true,
+              readOnly: true,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(resizeEvents, isNotEmpty);
+    final event = resizeEvents.last;
+    expect(event.width, greaterThan(0));
+    expect(event.height, greaterThan(0));
+    expect(event.pixelWidth, 320);
+    expect(event.pixelHeight, 240);
+  });
+}


### PR DESCRIPTION
## Summary

- report total terminal viewport pixel dimensions during auto-resize
- forward resize pixel dimensions through SSH PTY window-change requests
- debounce keyboard-driven terminal resizes so Codex avoids IME animation resize churn while still receiving the final keyboard-up/down size
- add resize/layout coverage for reported terminal pixel sizes and keyboard inset resize debounce behavior

## Tests

- flutter test test/widget/monkey_terminal_view_layout_test.dart test/widget/monkey_terminal_view_resize_test.dart
- flutter test test/widget/monkey_terminal_view_layout_test.dart test/widget/monkey_terminal_view_resize_test.dart test/widget/monkey_terminal_scroll_gesture_handler_test.dart test/widget/terminal_screen_scroll_policy_test.dart test/presentation/screens/terminal_screen_test.dart
- flutter analyze
- flutter test
