### PR TITLE
fix: restore tmux alert window titles

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -137,6 +137,43 @@ String? formatTerminalConnectionIdentity({
   return '$hostWithPort · $sessionLabel';
 }
 
+/// Resolves the user-visible text for a tmux alert notification.
+@visibleForTesting
+({String title, String body}) resolveTmuxAlertNotificationContent({
+  required String tmuxSessionName,
+  required TmuxWindow window,
+  required Iterable<TmuxWindow> windows,
+}) {
+  final sessionName = _tmuxAlertNotificationLabel(tmuxSessionName);
+  final title = sessionName.isEmpty
+      ? 'tmux alert'
+      : 'tmux alert · $sessionName';
+  final windowTitle = _tmuxAlertNotificationLabel(window.displayTitle);
+  if (windowTitle.isEmpty) {
+    return (title: title, body: 'Window #${window.index} needs attention');
+  }
+
+  final normalizedWindowTitle = windowTitle.toLowerCase();
+  var matchingTitleCount = 0;
+  for (final candidate in windows) {
+    final candidateTitle = _tmuxAlertNotificationLabel(
+      candidate.displayTitle,
+    ).toLowerCase();
+    if (candidateTitle != normalizedWindowTitle) {
+      continue;
+    }
+    matchingTitleCount += 1;
+    if (matchingTitleCount > 1) {
+      return (title: title, body: '$windowTitle (window #${window.index})');
+    }
+  }
+
+  return (title: title, body: windowTitle);
+}
+
+String _tmuxAlertNotificationLabel(String value) =>
+    value.replaceAll(RegExp(r'\s+'), ' ').trim();
+
 /// Resolves how much vertical space the tmux bar can safely expand into.
 @visibleForTesting
 double resolveTmuxBarMaxContentHeight(
@@ -734,7 +771,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       unawaited(_bounceController.forward(from: 0));
       for (final w in newAlerts) {
         _seenAlertWindows.add(w.index);
-        _sendAlertNotification(w);
+        _sendAlertNotification(w, windows);
       }
     }
 
@@ -1063,9 +1100,12 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       ) &
       0x7fffffff;
 
-  void _sendAlertNotification(TmuxWindow window) {
-    final title = _tmuxAlertNotificationTitle(window);
-    final sessionName = _tmuxAlertNotificationLabel(widget.tmuxSessionName);
+  void _sendAlertNotification(TmuxWindow window, List<TmuxWindow> windows) {
+    final content = resolveTmuxAlertNotificationContent(
+      tmuxSessionName: widget.tmuxSessionName,
+      window: window,
+      windows: windows,
+    );
     unawaited(HapticFeedback.mediumImpact());
     unawaited(
       widget.ref
@@ -1076,9 +1116,8 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
               widget.tmuxSessionName,
               window.index,
             ),
-            title: title,
-            body:
-                'tmux window #${window.index} in $sessionName needs attention.',
+            title: content.title,
+            body: content.body,
             payload: TmuxAlertNotificationPayload(
               hostId: widget.session.hostId,
               connectionId: widget.session.connectionId,
@@ -1088,17 +1127,6 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           ),
     );
   }
-
-  String _tmuxAlertNotificationTitle(TmuxWindow window) {
-    final title = _tmuxAlertNotificationLabel(window.displayTitle);
-    if (title.isEmpty) {
-      return 'tmux window #${window.index}';
-    }
-    return title;
-  }
-
-  String _tmuxAlertNotificationLabel(String value) =>
-      value.replaceAll(RegExp(r'\s+'), ' ').trim();
 
   void _clearAlertNotification(int windowIndex) {
     unawaited(

--- a/test/presentation/screens/tmux_alert_notification_content_test.dart
+++ b/test/presentation/screens/tmux_alert_notification_content_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/models/tmux_state.dart';
+import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
+
+void main() {
+  group('resolveTmuxAlertNotificationContent', () {
+    test('uses the session name as title and window title as body', () {
+      const window = TmuxWindow(
+        index: 2,
+        name: 'agent',
+        isActive: false,
+        paneTitle: 'Build finished',
+      );
+
+      final content = resolveTmuxAlertNotificationContent(
+        tmuxSessionName: ' work ',
+        window: window,
+        windows: const <TmuxWindow>[
+          TmuxWindow(index: 0, name: 'shell', isActive: true),
+          window,
+        ],
+      );
+
+      expect(content.title, 'tmux alert · work');
+      expect(content.body, 'Build finished');
+    });
+
+    test('adds the window number when the title is ambiguous', () {
+      const window = TmuxWindow(
+        index: 2,
+        name: 'agent-a',
+        isActive: false,
+        paneTitle: 'Build   finished',
+      );
+
+      final content = resolveTmuxAlertNotificationContent(
+        tmuxSessionName: 'work',
+        window: window,
+        windows: const <TmuxWindow>[
+          window,
+          TmuxWindow(
+            index: 3,
+            name: 'agent-b',
+            isActive: false,
+            paneTitle: 'Build finished',
+          ),
+        ],
+      );
+
+      expect(content.title, 'tmux alert · work');
+      expect(content.body, 'Build finished (window #2)');
+    });
+
+    test('falls back to the window number without a usable title', () {
+      const window = TmuxWindow(index: 4, name: '   ', isActive: false);
+
+      final content = resolveTmuxAlertNotificationContent(
+        tmuxSessionName: '',
+        window: window,
+        windows: const <TmuxWindow>[window],
+      );
+
+      expect(content.title, 'tmux alert');
+      expect(content.body, 'Window #4 needs attention');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Restore tmux alert notifications to show the tmux session in the title and the window title in the body.
- Add the window number only when multiple tmux windows have the same notification title.
- Cover notification content formatting with focused tests.

## Tests

- flutter analyze
- flutter test test/presentation/screens/tmux_alert_notification_content_test.dart
- flutter test
