### PR TITLE
feat: skip jump host on selected Wi-Fi networks

### DIFF
--- a/.github/workflows/regenerate-ios-profiles.yml
+++ b/.github/workflows/regenerate-ios-profiles.yml
@@ -1,0 +1,54 @@
+name: Regenerate iOS Provisioning Profiles
+
+# Run this workflow manually after changing App ID capabilities in Apple
+# Developer (e.g. enabling "Access WiFi Information"). It force-regenerates
+# the provisioning profiles via fastlane match so that the new entitlements
+# are baked into the profile stored in the match git repo. Subsequent
+# normal builds will then pick up the refreshed profile via setup_signing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      scheme:
+        description: 'Which scheme to regenerate (default: both)'
+        required: false
+        type: choice
+        default: 'both'
+        options:
+          - both
+          - Private
+          - Production
+
+permissions:
+  contents: read
+
+jobs:
+  regenerate:
+    name: Regenerate provisioning profiles
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Regenerate provisioning profiles
+        env:
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
+        run: |
+          cd ios
+          if [ "${{ inputs.scheme }}" = "both" ]; then
+            bundle exec fastlane regenerate_profiles
+          else
+            bundle exec fastlane regenerate_profiles scheme:${{ inputs.scheme }}
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,20 @@
 - Use JDK 17 for Android/Gradle builds in this repo. JDK 25 fails in the Android/Kotlin toolchain with `IllegalArgumentException: 25.0.1`.
 - On macOS, set `JAVA_HOME="$(/usr/libexec/java_home -v 17)"` before running `flutter build ...` or `./gradlew ...` for Android.
 
+## iOS provisioning profiles after capability changes
+
+After enabling a new App ID capability in the Apple Developer portal (e.g. Access WiFi Information, Push Notifications, App Groups), the existing provisioning profiles in the match git repo are stale — they don't include the new entitlement, so signing with the new entitlements file in `ios/Runner/Runner.entitlements` will fail.
+
+Refresh once via the **Regenerate iOS Provisioning Profiles** GitHub Actions workflow (`workflow_dispatch`), or run locally:
+
+```bash
+cd ios
+bundle exec fastlane regenerate_profiles            # both Private + Production
+bundle exec fastlane regenerate_profiles scheme:Private
+```
+
+Local Xcode builds with automatic signing pick up the new entitlement on next build without any extra step (Xcode regenerates dev profiles via the developer portal automatically).
+
 ## Manual testing: tmux navigation
 
 The tmux navigator feature requires a real SSH connection to a host running tmux. Use the setup script to create a local test environment:

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,11 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
+    <!-- Reading the current Wi-Fi SSID for the per-host "skip jump host on
+         Wi-Fi" feature. ACCESS_FINE_LOCATION is required by Android 10+
+         before WifiManager will return the actual SSID. -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <application
         android:label="@string/app_name"
         android:name=".MonkeySshApplication"

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -635,6 +635,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -661,6 +662,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -767,6 +769,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -940,6 +943,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1048,6 +1052,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1302,6 +1307,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1329,6 +1335,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1467,6 +1474,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1684,6 +1692,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -55,6 +55,8 @@
 	<string>$(PRODUCT_NAME) needs camera access to scan sync recovery key QR codes.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>$(PRODUCT_NAME) uses Face ID to unlock your encrypted SSH credentials.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>$(PRODUCT_NAME) reads the current Wi-Fi network name to decide whether to bypass a host's jump host on trusted networks.</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -2,11 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
-	<key>com.apple.security.personal-information.location</key>
+	<key>com.apple.developer.networking.wifi-info</key>
 	<true/>
 </dict>
 </plist>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -43,6 +43,7 @@ platform :ios do
     app_id = options[:app_identifier]
     match_type = options[:type] || 'appstore'
     readonly = options.key?(:readonly) ? options[:readonly] : true
+    force = options[:force] == true
 
     api_key = get_api_key
 
@@ -51,6 +52,7 @@ platform :ios do
       app_identifier: app_id,
       api_key: api_key,
       readonly: readonly,
+      force: force,
     )
   end
 
@@ -244,6 +246,26 @@ platform :ios do
   lane :setup_signing do |options|
     app_id = options[:app_identifier] || 'xyz.depollsoft.monkeyssh.private'
     sync_certs(app_identifier: app_id, type: 'appstore')
+  end
+
+  desc 'Force-regenerate provisioning profiles for both bundle IDs and their ' \
+       'live activity extensions. Run this after enabling a new App ID ' \
+       'capability (e.g. Access WiFi Information) so the new entitlement is ' \
+       'baked into the profile stored in the match git repo.'
+  lane :regenerate_profiles do |options|
+    schemes = options[:scheme] ? [options[:scheme]] : APP_IDS.keys
+    schemes.each do |scheme|
+      app_id = APP_IDS[scheme]
+      live_activity_app_id = LIVE_ACTIVITY_APP_IDS[scheme]
+      UI.user_error!("Unknown scheme '#{scheme}'") unless app_id && live_activity_app_id
+
+      sync_certs(
+        app_identifier: [app_id, live_activity_app_id],
+        type: 'appstore',
+        readonly: false,
+        force: true,
+      )
+    end
   end
 
   desc 'Build and sign an IPA without uploading it'

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -295,6 +295,9 @@ abstract final class FluttyTheme {
         labelStyle: GoogleFonts.inter(
           fontSize: 13,
           fontWeight: FontWeight.w500,
+          // Material 3 InputChip leaves the label transparent if labelStyle
+          // is supplied without a color, so pin one here.
+          color: isDark ? _textPrimary : Colors.black87,
         ),
         side: BorderSide(color: isDark ? _borderDark : _borderLight),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),

--- a/lib/data/database/database.dart
+++ b/lib/data/database/database.dart
@@ -39,6 +39,11 @@ class Hosts extends Table {
   /// Reference to jump host for proxy connections.
   IntColumn get jumpHostId => integer().nullable().references(Hosts, #id)();
 
+  /// Newline-separated list of Wi-Fi SSIDs on which the configured jump host
+  /// should be skipped (the host is reached directly when the device is on
+  /// one of these networks).
+  TextColumn get skipJumpHostOnSsids => text().nullable()();
+
   /// Whether this host is marked as favorite.
   BoolColumn get isFavorite => boolean().withDefault(const Constant(false))();
 
@@ -315,7 +320,7 @@ class AppDatabase extends _$AppDatabase {
   final AppleDatabaseFilePolicyApplier _appleDatabaseFilePolicyApplier;
 
   @override
-  int get schemaVersion => 7;
+  int get schemaVersion => 8;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -374,6 +379,12 @@ class AppDatabase extends _$AppDatabase {
         }
         if (!hostColumnNames.contains(hosts.tmuxExtraFlags.$name)) {
           await m.addColumn(hosts, hosts.tmuxExtraFlags);
+        }
+      }
+      if (from < 8) {
+        final hostColumnNames = await _readColumnNames('hosts');
+        if (!hostColumnNames.contains(hosts.skipJumpHostOnSsids.$name)) {
+          await m.addColumn(hosts, hosts.skipJumpHostOnSsids);
         }
       }
     },

--- a/lib/data/database/database.g.dart
+++ b/lib/data/database/database.g.dart
@@ -2112,6 +2112,17 @@ class $HostsTable extends Hosts with TableInfo<$HostsTable, Host> {
       'REFERENCES hosts (id)',
     ),
   );
+  static const VerificationMeta _skipJumpHostOnSsidsMeta =
+      const VerificationMeta('skipJumpHostOnSsids');
+  @override
+  late final GeneratedColumn<String> skipJumpHostOnSsids =
+      GeneratedColumn<String>(
+        'skip_jump_host_on_ssids',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
   static const VerificationMeta _isFavoriteMeta = const VerificationMeta(
     'isFavorite',
   );
@@ -2318,6 +2329,7 @@ class $HostsTable extends Hosts with TableInfo<$HostsTable, Host> {
     keyId,
     groupId,
     jumpHostId,
+    skipJumpHostOnSsids,
     isFavorite,
     color,
     notes,
@@ -2405,6 +2417,15 @@ class $HostsTable extends Hosts with TableInfo<$HostsTable, Host> {
         jumpHostId.isAcceptableOrUnknown(
           data['jump_host_id']!,
           _jumpHostIdMeta,
+        ),
+      );
+    }
+    if (data.containsKey('skip_jump_host_on_ssids')) {
+      context.handle(
+        _skipJumpHostOnSsidsMeta,
+        skipJumpHostOnSsids.isAcceptableOrUnknown(
+          data['skip_jump_host_on_ssids']!,
+          _skipJumpHostOnSsidsMeta,
         ),
       );
     }
@@ -2585,6 +2606,10 @@ class $HostsTable extends Hosts with TableInfo<$HostsTable, Host> {
         DriftSqlType.int,
         data['${effectivePrefix}jump_host_id'],
       ),
+      skipJumpHostOnSsids: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}skip_jump_host_on_ssids'],
+      ),
       isFavorite: attachedDatabase.typeMapping.read(
         DriftSqlType.bool,
         data['${effectivePrefix}is_favorite'],
@@ -2690,6 +2715,11 @@ class Host extends DataClass implements Insertable<Host> {
   /// Reference to jump host for proxy connections.
   final int? jumpHostId;
 
+  /// Newline-separated list of Wi-Fi SSIDs on which the configured jump host
+  /// should be skipped (the host is reached directly when the device is on
+  /// one of these networks).
+  final String? skipJumpHostOnSsids;
+
   /// Whether this host is marked as favorite.
   final bool isFavorite;
 
@@ -2756,6 +2786,7 @@ class Host extends DataClass implements Insertable<Host> {
     this.keyId,
     this.groupId,
     this.jumpHostId,
+    this.skipJumpHostOnSsids,
     required this.isFavorite,
     this.color,
     this.notes,
@@ -2793,6 +2824,9 @@ class Host extends DataClass implements Insertable<Host> {
     }
     if (!nullToAbsent || jumpHostId != null) {
       map['jump_host_id'] = Variable<int>(jumpHostId);
+    }
+    if (!nullToAbsent || skipJumpHostOnSsids != null) {
+      map['skip_jump_host_on_ssids'] = Variable<String>(skipJumpHostOnSsids);
     }
     map['is_favorite'] = Variable<bool>(isFavorite);
     if (!nullToAbsent || color != null) {
@@ -2859,6 +2893,9 @@ class Host extends DataClass implements Insertable<Host> {
       jumpHostId: jumpHostId == null && nullToAbsent
           ? const Value.absent()
           : Value(jumpHostId),
+      skipJumpHostOnSsids: skipJumpHostOnSsids == null && nullToAbsent
+          ? const Value.absent()
+          : Value(skipJumpHostOnSsids),
       isFavorite: Value(isFavorite),
       color: color == null && nullToAbsent
           ? const Value.absent()
@@ -2916,6 +2953,9 @@ class Host extends DataClass implements Insertable<Host> {
       keyId: serializer.fromJson<int?>(json['keyId']),
       groupId: serializer.fromJson<int?>(json['groupId']),
       jumpHostId: serializer.fromJson<int?>(json['jumpHostId']),
+      skipJumpHostOnSsids: serializer.fromJson<String?>(
+        json['skipJumpHostOnSsids'],
+      ),
       isFavorite: serializer.fromJson<bool>(json['isFavorite']),
       color: serializer.fromJson<String?>(json['color']),
       notes: serializer.fromJson<String?>(json['notes']),
@@ -2962,6 +3002,7 @@ class Host extends DataClass implements Insertable<Host> {
       'keyId': serializer.toJson<int?>(keyId),
       'groupId': serializer.toJson<int?>(groupId),
       'jumpHostId': serializer.toJson<int?>(jumpHostId),
+      'skipJumpHostOnSsids': serializer.toJson<String?>(skipJumpHostOnSsids),
       'isFavorite': serializer.toJson<bool>(isFavorite),
       'color': serializer.toJson<String?>(color),
       'notes': serializer.toJson<String?>(notes),
@@ -2994,6 +3035,7 @@ class Host extends DataClass implements Insertable<Host> {
     Value<int?> keyId = const Value.absent(),
     Value<int?> groupId = const Value.absent(),
     Value<int?> jumpHostId = const Value.absent(),
+    Value<String?> skipJumpHostOnSsids = const Value.absent(),
     bool? isFavorite,
     Value<String?> color = const Value.absent(),
     Value<String?> notes = const Value.absent(),
@@ -3021,6 +3063,9 @@ class Host extends DataClass implements Insertable<Host> {
     keyId: keyId.present ? keyId.value : this.keyId,
     groupId: groupId.present ? groupId.value : this.groupId,
     jumpHostId: jumpHostId.present ? jumpHostId.value : this.jumpHostId,
+    skipJumpHostOnSsids: skipJumpHostOnSsids.present
+        ? skipJumpHostOnSsids.value
+        : this.skipJumpHostOnSsids,
     isFavorite: isFavorite ?? this.isFavorite,
     color: color.present ? color.value : this.color,
     notes: notes.present ? notes.value : this.notes,
@@ -3071,6 +3116,9 @@ class Host extends DataClass implements Insertable<Host> {
       jumpHostId: data.jumpHostId.present
           ? data.jumpHostId.value
           : this.jumpHostId,
+      skipJumpHostOnSsids: data.skipJumpHostOnSsids.present
+          ? data.skipJumpHostOnSsids.value
+          : this.skipJumpHostOnSsids,
       isFavorite: data.isFavorite.present
           ? data.isFavorite.value
           : this.isFavorite,
@@ -3126,6 +3174,7 @@ class Host extends DataClass implements Insertable<Host> {
           ..write('keyId: $keyId, ')
           ..write('groupId: $groupId, ')
           ..write('jumpHostId: $jumpHostId, ')
+          ..write('skipJumpHostOnSsids: $skipJumpHostOnSsids, ')
           ..write('isFavorite: $isFavorite, ')
           ..write('color: $color, ')
           ..write('notes: $notes, ')
@@ -3160,6 +3209,7 @@ class Host extends DataClass implements Insertable<Host> {
     keyId,
     groupId,
     jumpHostId,
+    skipJumpHostOnSsids,
     isFavorite,
     color,
     notes,
@@ -3191,6 +3241,7 @@ class Host extends DataClass implements Insertable<Host> {
           other.keyId == this.keyId &&
           other.groupId == this.groupId &&
           other.jumpHostId == this.jumpHostId &&
+          other.skipJumpHostOnSsids == this.skipJumpHostOnSsids &&
           other.isFavorite == this.isFavorite &&
           other.color == this.color &&
           other.notes == this.notes &&
@@ -3221,6 +3272,7 @@ class HostsCompanion extends UpdateCompanion<Host> {
   final Value<int?> keyId;
   final Value<int?> groupId;
   final Value<int?> jumpHostId;
+  final Value<String?> skipJumpHostOnSsids;
   final Value<bool> isFavorite;
   final Value<String?> color;
   final Value<String?> notes;
@@ -3248,6 +3300,7 @@ class HostsCompanion extends UpdateCompanion<Host> {
     this.keyId = const Value.absent(),
     this.groupId = const Value.absent(),
     this.jumpHostId = const Value.absent(),
+    this.skipJumpHostOnSsids = const Value.absent(),
     this.isFavorite = const Value.absent(),
     this.color = const Value.absent(),
     this.notes = const Value.absent(),
@@ -3276,6 +3329,7 @@ class HostsCompanion extends UpdateCompanion<Host> {
     this.keyId = const Value.absent(),
     this.groupId = const Value.absent(),
     this.jumpHostId = const Value.absent(),
+    this.skipJumpHostOnSsids = const Value.absent(),
     this.isFavorite = const Value.absent(),
     this.color = const Value.absent(),
     this.notes = const Value.absent(),
@@ -3306,6 +3360,7 @@ class HostsCompanion extends UpdateCompanion<Host> {
     Expression<int>? keyId,
     Expression<int>? groupId,
     Expression<int>? jumpHostId,
+    Expression<String>? skipJumpHostOnSsids,
     Expression<bool>? isFavorite,
     Expression<String>? color,
     Expression<String>? notes,
@@ -3334,6 +3389,8 @@ class HostsCompanion extends UpdateCompanion<Host> {
       if (keyId != null) 'key_id': keyId,
       if (groupId != null) 'group_id': groupId,
       if (jumpHostId != null) 'jump_host_id': jumpHostId,
+      if (skipJumpHostOnSsids != null)
+        'skip_jump_host_on_ssids': skipJumpHostOnSsids,
       if (isFavorite != null) 'is_favorite': isFavorite,
       if (color != null) 'color': color,
       if (notes != null) 'notes': notes,
@@ -3371,6 +3428,7 @@ class HostsCompanion extends UpdateCompanion<Host> {
     Value<int?>? keyId,
     Value<int?>? groupId,
     Value<int?>? jumpHostId,
+    Value<String?>? skipJumpHostOnSsids,
     Value<bool>? isFavorite,
     Value<String?>? color,
     Value<String?>? notes,
@@ -3399,6 +3457,7 @@ class HostsCompanion extends UpdateCompanion<Host> {
       keyId: keyId ?? this.keyId,
       groupId: groupId ?? this.groupId,
       jumpHostId: jumpHostId ?? this.jumpHostId,
+      skipJumpHostOnSsids: skipJumpHostOnSsids ?? this.skipJumpHostOnSsids,
       isFavorite: isFavorite ?? this.isFavorite,
       color: color ?? this.color,
       notes: notes ?? this.notes,
@@ -3450,6 +3509,11 @@ class HostsCompanion extends UpdateCompanion<Host> {
     }
     if (jumpHostId.present) {
       map['jump_host_id'] = Variable<int>(jumpHostId.value);
+    }
+    if (skipJumpHostOnSsids.present) {
+      map['skip_jump_host_on_ssids'] = Variable<String>(
+        skipJumpHostOnSsids.value,
+      );
     }
     if (isFavorite.present) {
       map['is_favorite'] = Variable<bool>(isFavorite.value);
@@ -3527,6 +3591,7 @@ class HostsCompanion extends UpdateCompanion<Host> {
           ..write('keyId: $keyId, ')
           ..write('groupId: $groupId, ')
           ..write('jumpHostId: $jumpHostId, ')
+          ..write('skipJumpHostOnSsids: $skipJumpHostOnSsids, ')
           ..write('isFavorite: $isFavorite, ')
           ..write('color: $color, ')
           ..write('notes: $notes, ')
@@ -6639,6 +6704,7 @@ typedef $$HostsTableCreateCompanionBuilder =
       Value<int?> keyId,
       Value<int?> groupId,
       Value<int?> jumpHostId,
+      Value<String?> skipJumpHostOnSsids,
       Value<bool> isFavorite,
       Value<String?> color,
       Value<String?> notes,
@@ -6668,6 +6734,7 @@ typedef $$HostsTableUpdateCompanionBuilder =
       Value<int?> keyId,
       Value<int?> groupId,
       Value<int?> jumpHostId,
+      Value<String?> skipJumpHostOnSsids,
       Value<bool> isFavorite,
       Value<String?> color,
       Value<String?> notes,
@@ -6820,6 +6887,11 @@ class $$HostsTableFilterComposer extends Composer<_$AppDatabase, $HostsTable> {
 
   ColumnFilters<String> get password => $composableBuilder(
     column: $table.password,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get skipJumpHostOnSsids => $composableBuilder(
+    column: $table.skipJumpHostOnSsids,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -7060,6 +7132,11 @@ class $$HostsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get skipJumpHostOnSsids => $composableBuilder(
+    column: $table.skipJumpHostOnSsids,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<bool> get isFavorite => $composableBuilder(
     column: $table.isFavorite,
     builder: (column) => ColumnOrderings(column),
@@ -7260,6 +7337,11 @@ class $$HostsTableAnnotationComposer
 
   GeneratedColumn<String> get password =>
       $composableBuilder(column: $table.password, builder: (column) => column);
+
+  GeneratedColumn<String> get skipJumpHostOnSsids => $composableBuilder(
+    column: $table.skipJumpHostOnSsids,
+    builder: (column) => column,
+  );
 
   GeneratedColumn<bool> get isFavorite => $composableBuilder(
     column: $table.isFavorite,
@@ -7491,6 +7573,7 @@ class $$HostsTableTableManager
                 Value<int?> keyId = const Value.absent(),
                 Value<int?> groupId = const Value.absent(),
                 Value<int?> jumpHostId = const Value.absent(),
+                Value<String?> skipJumpHostOnSsids = const Value.absent(),
                 Value<bool> isFavorite = const Value.absent(),
                 Value<String?> color = const Value.absent(),
                 Value<String?> notes = const Value.absent(),
@@ -7519,6 +7602,7 @@ class $$HostsTableTableManager
                 keyId: keyId,
                 groupId: groupId,
                 jumpHostId: jumpHostId,
+                skipJumpHostOnSsids: skipJumpHostOnSsids,
                 isFavorite: isFavorite,
                 color: color,
                 notes: notes,
@@ -7549,6 +7633,7 @@ class $$HostsTableTableManager
                 Value<int?> keyId = const Value.absent(),
                 Value<int?> groupId = const Value.absent(),
                 Value<int?> jumpHostId = const Value.absent(),
+                Value<String?> skipJumpHostOnSsids = const Value.absent(),
                 Value<bool> isFavorite = const Value.absent(),
                 Value<String?> color = const Value.absent(),
                 Value<String?> notes = const Value.absent(),
@@ -7577,6 +7662,7 @@ class $$HostsTableTableManager
                 keyId: keyId,
                 groupId: groupId,
                 jumpHostId: jumpHostId,
+                skipJumpHostOnSsids: skipJumpHostOnSsids,
                 isFavorite: isFavorite,
                 color: color,
                 notes: notes,

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -19,6 +19,7 @@ import 'host_key_prompt_handler_provider.dart';
 import 'host_key_verification.dart';
 import 'ssh_exec_queue.dart';
 import 'terminal_hyperlink_tracker.dart';
+import 'wifi_network_service.dart';
 
 /// Connection state for an SSH session.
 enum SshConnectionState {
@@ -348,9 +349,11 @@ class SshService {
     this.keyRepository,
     this.knownHostsRepository,
     this.hostKeyPromptHandler,
+    WifiNetworkService? wifiNetworkService,
     SshSocketConnector? socketConnector,
     SshClientFactory? clientFactory,
-  }) : _socketConnector = socketConnector ?? _connectWithKeepAlive,
+  }) : wifiNetworkService = wifiNetworkService ?? WifiNetworkService(),
+       _socketConnector = socketConnector ?? _connectWithKeepAlive,
        _clientFactory = clientFactory ?? _defaultClientFactory;
 
   /// Number of key identities to try per SSH authentication attempt.
@@ -371,6 +374,9 @@ class SshService {
 
   /// UI callback used for TOFU and changed-key prompts.
   final HostKeyPromptHandler? hostKeyPromptHandler;
+
+  /// Service used to read the current Wi-Fi SSID for jump host bypass.
+  final WifiNetworkService wifiNetworkService;
 
   final SshSocketConnector _socketConnector;
   final SshClientFactory _clientFactory;
@@ -450,26 +456,48 @@ class SshService {
       identityKeys = await loadAutoKeys();
     }
 
-    // Get jump host config if specified
+    // Get jump host config if specified, unless the device is currently
+    // connected to a Wi-Fi network on the host's skip list (in which case
+    // the host is reachable directly).
     SshConnectionConfig? jumpHostConfig;
     if (host.jumpHostId != null) {
-      final jumpHost = await hostRepository!.getById(host.jumpHostId!);
-      if (jumpHost != null) {
-        SshKey? jumpKey;
-        List<SshKey>? jumpIdentityKeys;
-        if (jumpHost.keyId != null && keyRepository != null) {
-          jumpKey = await keyRepository!.getById(jumpHost.keyId!);
-          if (jumpKey == null && jumpHost.password == null) {
+      var skipJumpHost = false;
+      if (host.skipJumpHostOnSsids != null &&
+          host.skipJumpHostOnSsids!.isNotEmpty) {
+        final currentSsid = await wifiNetworkService.getCurrentSsid();
+        skipJumpHost = shouldSkipJumpHostForSsid(
+          currentSsid: currentSsid,
+          skipJumpHostOnSsids: host.skipJumpHostOnSsids,
+        );
+        DiagnosticsLogService.instance.info(
+          'ssh.connect',
+          'jump_host_ssid_check',
+          fields: {
+            'hostId': hostId,
+            'hasCurrentSsid': currentSsid != null,
+            'skipJumpHost': skipJumpHost,
+          },
+        );
+      }
+      if (!skipJumpHost) {
+        final jumpHost = await hostRepository!.getById(host.jumpHostId!);
+        if (jumpHost != null) {
+          SshKey? jumpKey;
+          List<SshKey>? jumpIdentityKeys;
+          if (jumpHost.keyId != null && keyRepository != null) {
+            jumpKey = await keyRepository!.getById(jumpHost.keyId!);
+            if (jumpKey == null && jumpHost.password == null) {
+              jumpIdentityKeys = await loadAutoKeys();
+            }
+          } else if (jumpHost.password == null) {
             jumpIdentityKeys = await loadAutoKeys();
           }
-        } else if (jumpHost.password == null) {
-          jumpIdentityKeys = await loadAutoKeys();
+          jumpHostConfig = SshConnectionConfig.fromHost(
+            jumpHost,
+            key: jumpKey,
+            identityKeys: jumpIdentityKeys,
+          );
         }
-        jumpHostConfig = SshConnectionConfig.fromHost(
-          jumpHost,
-          key: jumpKey,
-          identityKeys: jumpIdentityKeys,
-        );
       }
     }
 
@@ -2507,6 +2535,7 @@ final sshServiceProvider = Provider<SshService>(
     keyRepository: ref.watch(keyRepositoryProvider),
     knownHostsRepository: ref.watch(knownHostsRepositoryProvider),
     hostKeyPromptHandler: ref.watch(hostKeyPromptHandlerProvider),
+    wifiNetworkService: ref.watch(wifiNetworkServiceProvider),
   ),
 );
 

--- a/lib/domain/services/wifi_network_service.dart
+++ b/lib/domain/services/wifi_network_service.dart
@@ -18,21 +18,30 @@ class WifiNetworkService {
 
   /// Whether SSID detection is supported on the current platform at all.
   ///
-  /// `network_info_plus` returns SSIDs on Android, iOS, and macOS. Windows,
-  /// Linux, and web are unsupported and return `null` rather than prompting
-  /// for unavailable permissions.
+  /// `network_info_plus` returns SSIDs on Android, iOS, macOS, Windows
+  /// (via Win32 WLAN APIs), and Linux (via NetworkManager over D-Bus). Web
+  /// is the only unsupported target and falls through to `null`.
   static bool get isSupported {
     if (kIsWeb) return false;
     return defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS ||
-        defaultTargetPlatform == TargetPlatform.macOS;
+        defaultTargetPlatform == TargetPlatform.macOS ||
+        defaultTargetPlatform == TargetPlatform.windows ||
+        defaultTargetPlatform == TargetPlatform.linux;
   }
 
   /// Whether SSID detection requires a runtime location-permission grant via
-  /// `permission_handler` on the current platform. Only Android and iOS have
-  /// a working `permission_handler` backend; on macOS the entitlement plus
-  /// CoreLocation handles the first-use prompt natively when
-  /// `network_info_plus` reads the SSID.
+  /// `permission_handler` on the current platform.
+  ///
+  /// - **Android** requires `ACCESS_FINE_LOCATION` for `WifiManager` to
+  ///   return the actual SSID.
+  /// - **iOS** needs the location prompt to back the
+  ///   `com.apple.developer.networking.wifi-info` entitlement.
+  /// - **macOS** uses CoreLocation's first-use prompt natively, fired by
+  ///   `network_info_plus` without a `permission_handler` round-trip.
+  /// - **Windows** and **Linux** read from system services (Win32 WLAN /
+  ///   NetworkManager) that don't require a per-app grant for read-only
+  ///   SSID lookups.
   static bool get _requiresLocationPermission =>
       isSupported &&
       (defaultTargetPlatform == TargetPlatform.android ||

--- a/lib/domain/services/wifi_network_service.dart
+++ b/lib/domain/services/wifi_network_service.dart
@@ -1,0 +1,115 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:network_info_plus/network_info_plus.dart';
+
+import 'diagnostics_log_service.dart';
+
+/// Reads the current Wi-Fi SSID, where supported by the platform.
+///
+/// Returns `null` when the platform cannot report the SSID, when the device is
+/// not on Wi-Fi, or when the necessary OS permissions have not been granted.
+class WifiNetworkService {
+  /// Creates a new [WifiNetworkService].
+  WifiNetworkService({NetworkInfo? networkInfo})
+    : _networkInfo = networkInfo ?? NetworkInfo();
+
+  final NetworkInfo _networkInfo;
+
+  /// Whether SSID detection is supported on the current platform at all.
+  ///
+  /// `network_info_plus` only returns SSIDs on iOS, Android, and macOS. On
+  /// other platforms (Windows, Linux, web) we always return `null` rather
+  /// than prompting for unavailable permissions.
+  static bool get isSupported {
+    if (kIsWeb) return false;
+    return Platform.isAndroid || Platform.isIOS || Platform.isMacOS;
+  }
+
+  /// Returns the current Wi-Fi SSID, or `null` if unavailable.
+  ///
+  /// The raw value from the platform may be wrapped in quotes (`"my-ssid"`),
+  /// which this method strips. Errors and missing permissions are swallowed
+  /// and reported as `null` so callers can treat them as "not on a known
+  /// network".
+  Future<String?> getCurrentSsid() async {
+    if (!isSupported) {
+      return null;
+    }
+    try {
+      final raw = await _networkInfo.getWifiName();
+      return _normalizeSsid(raw);
+    } on Exception catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'wifi.ssid',
+        'lookup_failed',
+        fields: {'errorType': error.runtimeType.toString()},
+      );
+      return null;
+    }
+  }
+
+  static String? _normalizeSsid(String? raw) {
+    if (raw == null) return null;
+    var value = raw.trim();
+    if (value.isEmpty) return null;
+    if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+      value = value.substring(1, value.length - 1);
+    }
+    value = value.trim();
+    if (value.isEmpty) return null;
+    // Some platforms return placeholder strings when permissions are missing.
+    if (value == '<unknown ssid>' || value == '0x') return null;
+    return value;
+  }
+}
+
+/// Provider for [WifiNetworkService].
+final wifiNetworkServiceProvider = Provider<WifiNetworkService>(
+  (ref) => WifiNetworkService(),
+);
+
+/// Encodes a list of SSIDs to the storage format used in the Hosts table.
+///
+/// Newline-separated so SSIDs may legally contain commas, spaces, and most
+/// other printable characters.
+String? encodeSkipJumpHostSsids(Iterable<String> ssids) {
+  final cleaned = <String>[];
+  final seen = <String>{};
+  for (final ssid in ssids) {
+    final trimmed = ssid.trim();
+    if (trimmed.isEmpty) continue;
+    if (seen.add(trimmed)) {
+      cleaned.add(trimmed);
+    }
+  }
+  if (cleaned.isEmpty) return null;
+  return cleaned.join('\n');
+}
+
+/// Decodes the stored SSID list back into a list of unique entries.
+List<String> decodeSkipJumpHostSsids(String? stored) {
+  if (stored == null || stored.isEmpty) return const [];
+  final result = <String>[];
+  final seen = <String>{};
+  for (final line in stored.split('\n')) {
+    final trimmed = line.trim();
+    if (trimmed.isEmpty) continue;
+    if (seen.add(trimmed)) {
+      result.add(trimmed);
+    }
+  }
+  return result;
+}
+
+/// Returns `true` if [currentSsid] is in the host's skip list.
+bool shouldSkipJumpHostForSsid({
+  required String? currentSsid,
+  required String? skipJumpHostOnSsids,
+}) {
+  if (currentSsid == null) return false;
+  final list = decodeSkipJumpHostSsids(skipJumpHostOnSsids);
+  if (list.isEmpty) return false;
+  return list.contains(currentSsid);
+}

--- a/lib/domain/services/wifi_network_service.dart
+++ b/lib/domain/services/wifi_network_service.dart
@@ -84,12 +84,36 @@ class WifiNetworkService {
     if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
       value = value.substring(1, value.length - 1);
     }
-    value = value.trim();
+    value = _stripInvisibleCharacters(value).trim();
     if (value.isEmpty) return null;
     // Some platforms return placeholder strings when permissions are missing.
     if (value == '<unknown ssid>' || value == '0x') return null;
     return value;
   }
+}
+
+/// Removes characters that render as nothing — ASCII control codes (0x00–0x1F,
+/// 0x7F), C1 control codes (0x80–0x9F), zero-width and bidi format characters
+/// (Unicode general category Cf in the BMP), and the Unicode replacement
+/// character. SSIDs containing only such characters would otherwise produce
+/// blank chips in the editor and unmatchable storage values.
+String _stripInvisibleCharacters(String value) {
+  final buffer = StringBuffer();
+  for (final rune in value.runes) {
+    if (rune <= 0x1F || (rune >= 0x7F && rune <= 0x9F)) continue;
+    // Cf characters (zero-width, bidi marks, joiners) plus the
+    // U+FEFF byte order mark and the U+FFFD replacement character.
+    if (rune == 0x00AD ||
+        (rune >= 0x200B && rune <= 0x200F) ||
+        (rune >= 0x2028 && rune <= 0x202F) ||
+        (rune >= 0x2060 && rune <= 0x206F) ||
+        rune == 0xFEFF ||
+        rune == 0xFFFD) {
+      continue;
+    }
+    buffer.writeCharCode(rune);
+  }
+  return buffer.toString();
 }
 
 /// Provider for [WifiNetworkService].
@@ -117,19 +141,26 @@ String? encodeSkipJumpHostSsids(Iterable<String> ssids) {
 }
 
 String _sanitizeSsidForStorage(String raw) =>
-    // Strip CR/LF anywhere in the value before trimming surrounding whitespace.
-    raw.replaceAll(RegExp(r'[\r\n]'), '').trim();
+    _stripInvisibleCharacters(raw).trim();
+
+/// Public helper used by UI code to normalize manual SSID entry to the same
+/// rules the storage layer applies (strip invisibles + trim).
+String sanitizeSsidInput(String raw) => _sanitizeSsidForStorage(raw);
 
 /// Decodes the stored SSID list back into a list of unique entries.
+///
+/// Applies the same invisible-character stripping the encoder uses, so that
+/// any pre-existing rows that contain control or zero-width characters
+/// (e.g. SSIDs captured before the encoder hardening) come back clean.
 List<String> decodeSkipJumpHostSsids(String? stored) {
   if (stored == null || stored.isEmpty) return const [];
   final result = <String>[];
   final seen = <String>{};
   for (final line in stored.split('\n')) {
-    final trimmed = line.trim();
-    if (trimmed.isEmpty) continue;
-    if (seen.add(trimmed)) {
-      result.add(trimmed);
+    final sanitized = _sanitizeSsidForStorage(line);
+    if (sanitized.isEmpty) continue;
+    if (seen.add(sanitized)) {
+      result.add(sanitized);
     }
   }
   return result;

--- a/lib/domain/services/wifi_network_service.dart
+++ b/lib/domain/services/wifi_network_service.dart
@@ -28,17 +28,15 @@ class WifiNetworkService {
         defaultTargetPlatform == TargetPlatform.macOS;
   }
 
-  /// Whether SSID detection requires a runtime location-permission grant on
-  /// the current platform. Android requires `ACCESS_FINE_LOCATION`; iOS and
-  /// macOS only need it when the app does not hold the
-  /// `com.apple.developer.networking.wifi-info` entitlement, but requesting
-  /// it lets us recover when the entitlement is missing in development
-  /// builds, so we still ask there.
+  /// Whether SSID detection requires a runtime location-permission grant via
+  /// `permission_handler` on the current platform. Only Android and iOS have
+  /// a working `permission_handler` backend; on macOS the entitlement plus
+  /// CoreLocation handles the first-use prompt natively when
+  /// `network_info_plus` reads the SSID.
   static bool get _requiresLocationPermission =>
       isSupported &&
       (defaultTargetPlatform == TargetPlatform.android ||
-          defaultTargetPlatform == TargetPlatform.iOS ||
-          defaultTargetPlatform == TargetPlatform.macOS);
+          defaultTargetPlatform == TargetPlatform.iOS);
 
   /// Result of a permission request, surfaced to the UI so it can guide the
   /// user to Settings when the OS has permanently denied access.
@@ -102,20 +100,25 @@ final wifiNetworkServiceProvider = Provider<WifiNetworkService>(
 /// Encodes a list of SSIDs to the storage format used in the Hosts table.
 ///
 /// Newline-separated so SSIDs may legally contain commas, spaces, and most
-/// other printable characters.
+/// other printable characters. Embedded `\n`/`\r` characters (which can sneak
+/// in via paste) are stripped so they cannot corrupt the on-disk format.
 String? encodeSkipJumpHostSsids(Iterable<String> ssids) {
   final cleaned = <String>[];
   final seen = <String>{};
   for (final ssid in ssids) {
-    final trimmed = ssid.trim();
-    if (trimmed.isEmpty) continue;
-    if (seen.add(trimmed)) {
-      cleaned.add(trimmed);
+    final sanitized = _sanitizeSsidForStorage(ssid);
+    if (sanitized.isEmpty) continue;
+    if (seen.add(sanitized)) {
+      cleaned.add(sanitized);
     }
   }
   if (cleaned.isEmpty) return null;
   return cleaned.join('\n');
 }
+
+String _sanitizeSsidForStorage(String raw) =>
+    // Strip CR/LF anywhere in the value before trimming surrounding whitespace.
+    raw.replaceAll(RegExp(r'[\r\n]'), '').trim();
 
 /// Decodes the stored SSID list back into a list of unique entries.
 List<String> decodeSkipJumpHostSsids(String? stored) {

--- a/lib/domain/services/wifi_network_service.dart
+++ b/lib/domain/services/wifi_network_service.dart
@@ -94,27 +94,38 @@ class WifiNetworkService {
 
 /// Removes characters that render as nothing — ASCII control codes (0x00–0x1F,
 /// 0x7F), C1 control codes (0x80–0x9F), zero-width and bidi format characters
-/// (Unicode general category Cf in the BMP), and the Unicode replacement
+/// (Unicode general category Cf in the BMP), variation selectors (FE00–FE0F),
+/// the Mongolian vowel separator, the BOM, and the Unicode replacement
 /// character. SSIDs containing only such characters would otherwise produce
 /// blank chips in the editor and unmatchable storage values.
 String _stripInvisibleCharacters(String value) {
   final buffer = StringBuffer();
   for (final rune in value.runes) {
     if (rune <= 0x1F || (rune >= 0x7F && rune <= 0x9F)) continue;
-    // Cf characters (zero-width, bidi marks, joiners) plus the
-    // U+FEFF byte order mark and the U+FFFD replacement character.
     if (rune == 0x00AD ||
+        rune == 0x034F ||
+        (rune >= 0x180B && rune <= 0x180E) ||
         (rune >= 0x200B && rune <= 0x200F) ||
         (rune >= 0x2028 && rune <= 0x202F) ||
         (rune >= 0x2060 && rune <= 0x206F) ||
+        (rune >= 0xFE00 && rune <= 0xFE0F) ||
         rune == 0xFEFF ||
-        rune == 0xFFFD) {
+        rune == 0xFFFD ||
+        (rune >= 0xE0000 && rune <= 0xE007F) ||
+        (rune >= 0xE0100 && rune <= 0xE01EF)) {
       continue;
     }
     buffer.writeCharCode(rune);
   }
-  return buffer.toString();
+  final stripped = buffer.toString();
+  // Final guard: require at least one Letter / Number / Punctuation / Symbol
+  // rune. If everything left is whitespace or combining marks the chip would
+  // still render blank, so treat the whole value as empty.
+  if (!_visibleContent.hasMatch(stripped)) return '';
+  return stripped;
 }
+
+final RegExp _visibleContent = RegExp(r'[\p{L}\p{N}\p{P}\p{S}]', unicode: true);
 
 /// Provider for [WifiNetworkService].
 final wifiNetworkServiceProvider = Provider<WifiNetworkService>(

--- a/lib/domain/services/wifi_network_service.dart
+++ b/lib/domain/services/wifi_network_service.dart
@@ -1,8 +1,7 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:network_info_plus/network_info_plus.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import 'diagnostics_log_service.dart';
 
@@ -19,12 +18,42 @@ class WifiNetworkService {
 
   /// Whether SSID detection is supported on the current platform at all.
   ///
-  /// `network_info_plus` only returns SSIDs on iOS, Android, and macOS. On
-  /// other platforms (Windows, Linux, web) we always return `null` rather
-  /// than prompting for unavailable permissions.
+  /// `network_info_plus` only returns SSIDs on iOS, Android, and macOS. Web
+  /// and desktop platforms return `null` rather than prompting for
+  /// unavailable permissions.
   static bool get isSupported {
     if (kIsWeb) return false;
-    return Platform.isAndroid || Platform.isIOS || Platform.isMacOS;
+    return defaultTargetPlatform == TargetPlatform.android ||
+        defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.macOS;
+  }
+
+  /// Whether SSID detection requires a runtime location-permission grant on
+  /// the current platform. Android requires `ACCESS_FINE_LOCATION`; iOS and
+  /// macOS only need it when the app does not hold the
+  /// `com.apple.developer.networking.wifi-info` entitlement, but requesting
+  /// it lets us recover when the entitlement is missing in development
+  /// builds, so we still ask there.
+  static bool get _requiresLocationPermission =>
+      isSupported &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.iOS ||
+          defaultTargetPlatform == TargetPlatform.macOS);
+
+  /// Result of a permission request, surfaced to the UI so it can guide the
+  /// user to Settings when the OS has permanently denied access.
+  Future<WifiPermissionStatus> requestPermission() async {
+    if (!_requiresLocationPermission) {
+      return WifiPermissionStatus.granted;
+    }
+    final status = await Permission.locationWhenInUse.request();
+    if (status.isGranted || status.isLimited) {
+      return WifiPermissionStatus.granted;
+    }
+    if (status.isPermanentlyDenied) {
+      return WifiPermissionStatus.permanentlyDenied;
+    }
+    return WifiPermissionStatus.denied;
   }
 
   /// Returns the current Wi-Fi SSID, or `null` if unavailable.
@@ -104,6 +133,11 @@ List<String> decodeSkipJumpHostSsids(String? stored) {
 }
 
 /// Returns `true` if [currentSsid] is in the host's skip list.
+///
+/// The match is case-sensitive. Wi-Fi SSIDs are technically case-sensitive
+/// at the 802.11 layer and the platform APIs return the exact bytes the
+/// router advertises, so this preserves user intent (e.g. distinguishing
+/// `home` from `Home` if a user really set up two networks).
 bool shouldSkipJumpHostForSsid({
   required String? currentSsid,
   required String? skipJumpHostOnSsids,
@@ -112,4 +146,17 @@ bool shouldSkipJumpHostForSsid({
   final list = decodeSkipJumpHostSsids(skipJumpHostOnSsids);
   if (list.isEmpty) return false;
   return list.contains(currentSsid);
+}
+
+/// Outcome of a permission request, used by the UI to differentiate a
+/// "tap again" denial from one that requires going to system Settings.
+enum WifiPermissionStatus {
+  /// Permission granted (or not required on this platform).
+  granted,
+
+  /// Permission was denied this time but can be re-requested.
+  denied,
+
+  /// Permission was permanently denied; user must change it in Settings.
+  permanentlyDenied,
 }

--- a/lib/domain/services/wifi_network_service.dart
+++ b/lib/domain/services/wifi_network_service.dart
@@ -18,9 +18,9 @@ class WifiNetworkService {
 
   /// Whether SSID detection is supported on the current platform at all.
   ///
-  /// `network_info_plus` only returns SSIDs on iOS, Android, and macOS. Web
-  /// and desktop platforms return `null` rather than prompting for
-  /// unavailable permissions.
+  /// `network_info_plus` returns SSIDs on Android, iOS, and macOS. Windows,
+  /// Linux, and web are unsupported and return `null` rather than prompting
+  /// for unavailable permissions.
   static bool get isSupported {
     if (kIsWeb) return false;
     return defaultTargetPlatform == TargetPlatform.android ||
@@ -45,7 +45,7 @@ class WifiNetworkService {
       return WifiPermissionStatus.granted;
     }
     final status = await Permission.locationWhenInUse.request();
-    if (status.isGranted || status.isLimited) {
+    if (status.isGranted) {
       return WifiPermissionStatus.granted;
     }
     if (status.isPermanentlyDenied) {

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -2706,7 +2706,7 @@ class _SkipJumpHostOnWifiSectionState
   }
 
   void _addSsid(String ssid) {
-    final sanitized = ssid.replaceAll(RegExp(r'[\r\n]'), '').trim();
+    final sanitized = sanitizeSsidInput(ssid);
     if (sanitized.isEmpty) return;
     if (widget.ssids.contains(sanitized)) return;
     widget.onChanged([...widget.ssids, sanitized]);
@@ -2763,7 +2763,7 @@ class _SkipJumpHostOnWifiSectionState
               for (final ssid in widget.ssids)
                 InputChip(
                   key: ValueKey('skip-jump-ssid-$ssid'),
-                  label: Text(ssid),
+                  label: Text(ssid.isEmpty ? '(unnamed)' : ssid),
                   avatar: const Icon(Icons.wifi, size: 18),
                   onDeleted: () => _removeSsid(ssid),
                 ),

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -596,12 +596,8 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                                   ),
                                 ),
                               ],
-                              onChanged: (value) => setState(() {
-                                _selectedJumpHostId = value;
-                                if (value == null) {
-                                  _skipJumpHostOnSsids = const [];
-                                }
-                              }),
+                              onChanged: (value) =>
+                                  setState(() => _selectedJumpHostId = value),
                             );
                           },
                         ),
@@ -2703,16 +2699,17 @@ class _SkipJumpHostOnWifiSectionState
       ),
     );
     controller.dispose();
+    if (!mounted) return;
     if (entered != null && entered.isNotEmpty) {
       _addSsid(entered);
     }
   }
 
   void _addSsid(String ssid) {
-    final trimmed = ssid.trim();
-    if (trimmed.isEmpty) return;
-    if (widget.ssids.contains(trimmed)) return;
-    widget.onChanged([...widget.ssids, trimmed]);
+    final sanitized = ssid.replaceAll(RegExp(r'[\r\n]'), '').trim();
+    if (sanitized.isEmpty) return;
+    if (widget.ssids.contains(sanitized)) return;
+    widget.onChanged([...widget.ssids, sanitized]);
   }
 
   void _removeSsid(String ssid) {

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -2639,9 +2639,9 @@ class _SkipJumpHostOnWifiSectionState
               'network name. You can also add the SSID manually.',
             ),
             action: permission == WifiPermissionStatus.permanentlyDenied
-                ? const SnackBarAction(
+                ? SnackBarAction(
                     label: 'Settings',
-                    onPressed: openAppSettings,
+                    onPressed: () => unawaited(openAppSettings()),
                   )
                 : null,
           ),
@@ -2677,11 +2677,9 @@ class _SkipJumpHostOnWifiSectionState
         content: TextField(
           controller: controller,
           autofocus: true,
-          maxLength: 32,
           decoration: const InputDecoration(
             labelText: 'SSID',
             hintText: 'Network name',
-            counterText: '',
           ),
           onSubmitted: (value) => Navigator.of(dialogContext).pop(value.trim()),
         ),

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -4,6 +4,7 @@ import 'package:drift/drift.dart' as drift;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import '../../app/theme.dart';
 import '../../data/database/database.dart';
@@ -595,8 +596,12 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                                   ),
                                 ),
                               ],
-                              onChanged: (value) =>
-                                  setState(() => _selectedJumpHostId = value),
+                              onChanged: (value) => setState(() {
+                                _selectedJumpHostId = value;
+                                if (value == null) {
+                                  _skipJumpHostOnSsids = const [];
+                                }
+                              }),
                             );
                           },
                         ),
@@ -2627,14 +2632,35 @@ class _SkipJumpHostOnWifiSectionState
     setState(() => _detecting = true);
     final messenger = ScaffoldMessenger.of(context);
     try {
-      final ssid = await ref.read(wifiNetworkServiceProvider).getCurrentSsid();
+      final wifiService = ref.read(wifiNetworkServiceProvider);
+      final permission = await wifiService.requestPermission();
+      if (!mounted) return;
+      if (permission != WifiPermissionStatus.granted) {
+        messenger.showSnackBar(
+          SnackBar(
+            content: const Text(
+              'Location permission is required to read the current Wi-Fi '
+              'network name. You can also add the SSID manually.',
+            ),
+            action: permission == WifiPermissionStatus.permanentlyDenied
+                ? const SnackBarAction(
+                    label: 'Settings',
+                    onPressed: openAppSettings,
+                  )
+                : null,
+          ),
+        );
+        return;
+      }
+      final ssid = await wifiService.getCurrentSsid();
       if (!mounted) return;
       if (ssid == null) {
         messenger.showSnackBar(
           const SnackBar(
             content: Text(
-              'Could not detect current Wi-Fi network. Make sure you are '
-              'connected and that location/Wi-Fi permission is granted.',
+              'Could not detect the current Wi-Fi network. Make sure you '
+              'are connected to Wi-Fi and try again, or add the SSID '
+              'manually.',
             ),
           ),
         );
@@ -2655,9 +2681,11 @@ class _SkipJumpHostOnWifiSectionState
         content: TextField(
           controller: controller,
           autofocus: true,
+          maxLength: 32,
           decoration: const InputDecoration(
             labelText: 'SSID',
             hintText: 'Network name',
+            counterText: '',
           ),
           onSubmitted: (value) => Navigator.of(dialogContext).pop(value.trim()),
         ),

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -22,6 +22,7 @@ import '../../domain/services/host_cli_launch_preferences_service.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/secure_transfer_service.dart';
 import '../../domain/services/ssh_service.dart';
+import '../../domain/services/wifi_network_service.dart';
 import '../providers/entity_list_providers.dart';
 import '../widgets/agent_tool_icon.dart';
 import '../widgets/premium_access.dart';
@@ -135,6 +136,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   int? _selectedKeyId;
   int? _selectedGroupId;
   int? _selectedJumpHostId;
+  List<String> _skipJumpHostOnSsids = const [];
   int? _selectedAutoConnectSnippetId;
   String? _selectedLightThemeId;
   String? _selectedDarkThemeId;
@@ -232,6 +234,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       _selectedKeyId = host.keyId;
       _selectedGroupId = host.groupId;
       _selectedJumpHostId = host.jumpHostId;
+      _skipJumpHostOnSsids = decodeSkipJumpHostSsids(host.skipJumpHostOnSsids);
       _selectedAutoConnectSnippetId = host.autoConnectSnippetId;
       _selectedLightThemeId = host.terminalThemeLightId;
       _selectedDarkThemeId = host.terminalThemeDarkId;
@@ -597,6 +600,14 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                             );
                           },
                         ),
+                        if (_selectedJumpHostId != null) ...[
+                          const SizedBox(height: 16),
+                          _SkipJumpHostOnWifiSection(
+                            ssids: _skipJumpHostOnSsids,
+                            onChanged: (next) =>
+                                setState(() => _skipJumpHostOnSsids = next),
+                          ),
+                        ],
                         const SizedBox(height: 24),
                         // Terminal theme section
                         Row(
@@ -1366,6 +1377,11 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
           keyId: drift.Value(_selectedKeyId),
           groupId: drift.Value(_selectedGroupId),
           jumpHostId: drift.Value(_selectedJumpHostId),
+          skipJumpHostOnSsids: drift.Value(
+            _selectedJumpHostId == null
+                ? null
+                : encodeSkipJumpHostSsids(_skipJumpHostOnSsids),
+          ),
           terminalThemeLightId: drift.Value(_selectedLightThemeId),
           terminalThemeDarkId: drift.Value(_selectedDarkThemeId),
           terminalFontFamily: drift.Value(_selectedFontFamily),
@@ -1391,6 +1407,11 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
             keyId: drift.Value(_selectedKeyId),
             groupId: drift.Value(_selectedGroupId),
             jumpHostId: drift.Value(_selectedJumpHostId),
+            skipJumpHostOnSsids: drift.Value(
+              _selectedJumpHostId == null
+                  ? null
+                  : encodeSkipJumpHostSsids(_skipJumpHostOnSsids),
+            ),
             terminalThemeLightId: drift.Value(_selectedLightThemeId),
             terminalThemeDarkId: drift.Value(_selectedDarkThemeId),
             terminalFontFamily: drift.Value(_selectedFontFamily),
@@ -2583,3 +2604,173 @@ final _allSnippetsProvider = StreamProvider<List<Snippet>>((ref) {
   final repo = ref.watch(snippetRepositoryProvider);
   return repo.watchAll();
 });
+
+class _SkipJumpHostOnWifiSection extends ConsumerStatefulWidget {
+  const _SkipJumpHostOnWifiSection({
+    required this.ssids,
+    required this.onChanged,
+  });
+
+  final List<String> ssids;
+  final ValueChanged<List<String>> onChanged;
+
+  @override
+  ConsumerState<_SkipJumpHostOnWifiSection> createState() =>
+      _SkipJumpHostOnWifiSectionState();
+}
+
+class _SkipJumpHostOnWifiSectionState
+    extends ConsumerState<_SkipJumpHostOnWifiSection> {
+  bool _detecting = false;
+
+  Future<void> _addCurrentSsid() async {
+    setState(() => _detecting = true);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final ssid = await ref.read(wifiNetworkServiceProvider).getCurrentSsid();
+      if (!mounted) return;
+      if (ssid == null) {
+        messenger.showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Could not detect current Wi-Fi network. Make sure you are '
+              'connected and that location/Wi-Fi permission is granted.',
+            ),
+          ),
+        );
+        return;
+      }
+      _addSsid(ssid);
+    } finally {
+      if (mounted) setState(() => _detecting = false);
+    }
+  }
+
+  Future<void> _promptForSsid() async {
+    final controller = TextEditingController();
+    final entered = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Add Wi-Fi network'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(
+            labelText: 'SSID',
+            hintText: 'Network name',
+          ),
+          onSubmitted: (value) => Navigator.of(dialogContext).pop(value.trim()),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () =>
+                Navigator.of(dialogContext).pop(controller.text.trim()),
+            child: const Text('Add'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (entered != null && entered.isNotEmpty) {
+      _addSsid(entered);
+    }
+  }
+
+  void _addSsid(String ssid) {
+    final trimmed = ssid.trim();
+    if (trimmed.isEmpty) return;
+    if (widget.ssids.contains(trimmed)) return;
+    widget.onChanged([...widget.ssids, trimmed]);
+  }
+
+  void _removeSsid(String ssid) {
+    widget.onChanged(widget.ssids.where((s) => s != ssid).toList());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.wifi_off, size: 20, color: colorScheme.onSurfaceVariant),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                'Skip jump host on Wi-Fi',
+                style: theme.textTheme.titleSmall,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Connect directly (no jump host) when on these Wi-Fi networks. '
+          'Applies on connect and reconnect.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 12),
+        if (widget.ssids.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: Text(
+              'No networks added. The jump host will always be used.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          )
+        else
+          Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            children: [
+              for (final ssid in widget.ssids)
+                InputChip(
+                  key: ValueKey('skip-jump-ssid-$ssid'),
+                  label: Text(ssid),
+                  avatar: const Icon(Icons.wifi, size: 18),
+                  onDeleted: () => _removeSsid(ssid),
+                ),
+            ],
+          ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 4,
+          children: [
+            if (WifiNetworkService.isSupported)
+              OutlinedButton.icon(
+                key: const Key('skip-jump-add-current-ssid'),
+                onPressed: _detecting ? null : _addCurrentSsid,
+                icon: _detecting
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.my_location, size: 18),
+                label: const Text('Add current Wi-Fi'),
+              ),
+            OutlinedButton.icon(
+              key: const Key('skip-jump-add-manual-ssid'),
+              onPressed: _promptForSsid,
+              icon: const Icon(Icons.add, size: 18),
+              label: const Text('Add manually'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import flutter_local_notifications
 import flutter_secure_storage_darwin
 import in_app_purchase_storekit
 import local_auth_darwin
+import network_info_plus
 import package_info_plus
 import pasteboard
 import share_plus
@@ -22,6 +23,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   InAppPurchasePlugin.register(with: registry.registrar(forPlugin: "InAppPurchasePlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
+  NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PasteboardPlugin.register(with: registry.registrar(forPlugin: "PasteboardPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -13,6 +13,8 @@ PODS:
   - local_auth_darwin (0.0.1):
     - Flutter
     - FlutterMacOS
+  - network_info_plus (0.0.1):
+    - FlutterMacOS
   - package_info_plus (0.0.1):
     - FlutterMacOS
   - pasteboard (0.0.1):
@@ -32,6 +34,7 @@ DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - in_app_purchase_storekit (from `Flutter/ephemeral/.symlinks/plugins/in_app_purchase_storekit/darwin`)
   - local_auth_darwin (from `Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin`)
+  - network_info_plus (from `Flutter/ephemeral/.symlinks/plugins/network_info_plus/macos`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - pasteboard (from `Flutter/ephemeral/.symlinks/plugins/pasteboard/macos`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
@@ -51,6 +54,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/in_app_purchase_storekit/darwin
   local_auth_darwin:
     :path: Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin
+  network_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/network_info_plus/macos
   package_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   pasteboard:
@@ -69,6 +74,7 @@ SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   in_app_purchase_storekit: 22cca7d08eebca9babdf4d07d0baccb73325d3c8
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
+  network_info_plus: 21d1cd6a015ccb2fdff06a1fbfa88d54b4e92f61
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   pasteboard: b594eaf838d930b276d7a35a44a32b4f489170cb
   share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -10,5 +10,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -24,6 +24,10 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>$(PRODUCT_COPYRIGHT)</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>$(PRODUCT_NAME) reads the current Wi-Fi network name to decide whether to bypass a host's jump host on trusted networks.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>$(PRODUCT_NAME) reads the current Wi-Fi network name to decide whether to bypass a host's jump host on trusted networks.</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>CFBundleDocumentTypes</key>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -807,6 +807,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.17.6"
+  network_info_plus:
+    dependency: "direct main"
+    description:
+      name: network_info_plus
+      sha256: f926b2ba86aa0086a0dfbb9e5072089bc213d854135c1712f1d29fc89ba3c877
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.4"
+  network_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: network_info_plus_platform_interface
+      sha256: "7e7496a8a9d8136859b8881affc613c4a21304afeb6c324bcefc4bd0aff6b94b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   node_preamble:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -943,6 +943,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.4.0"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.1.0"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.7"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,7 +69,10 @@ dependencies:
   in_app_purchase_storekit: ^0.4.8+1
   quick_actions: ^1.1.0
   video_player: ^2.11.1
+
+  # Network / connectivity
   network_info_plus: ^6.1.4
+  permission_handler: ^11.3.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,6 +69,7 @@ dependencies:
   in_app_purchase_storekit: ^0.4.8+1
   quick_actions: ^1.1.0
   video_player: ^2.11.1
+  network_info_plus: ^6.1.4
 
 dev_dependencies:
   flutter_test:

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -48,16 +48,13 @@ class _CapturingSshService extends SshService {
   }
 }
 
-class _StubWifiNetworkService implements WifiNetworkService {
+class _StubWifiNetworkService extends WifiNetworkService {
   _StubWifiNetworkService(this.ssid);
 
   final String? ssid;
 
   @override
   Future<String?> getCurrentSsid() async => ssid;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _CountingKeyRepository extends KeyRepository {

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -21,6 +21,7 @@ import 'package:monkeyssh/domain/services/background_ssh_service.dart';
 import 'package:monkeyssh/domain/services/host_key_verification.dart';
 import 'package:monkeyssh/domain/services/ssh_exec_queue.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
+import 'package:monkeyssh/domain/services/wifi_network_service.dart';
 import 'package:xterm/xterm.dart';
 
 const _backgroundSshChannel = MethodChannel(
@@ -31,6 +32,7 @@ class _CapturingSshService extends SshService {
   _CapturingSshService({
     required super.hostRepository,
     required super.keyRepository,
+    super.wifiNetworkService,
   });
 
   SshConnectionConfig? capturedConfig;
@@ -44,6 +46,18 @@ class _CapturingSshService extends SshService {
     capturedConfig = config;
     return const SshConnectionResult(success: false, error: 'stubbed');
   }
+}
+
+class _StubWifiNetworkService implements WifiNetworkService {
+  _StubWifiNetworkService(this.ssid);
+
+  final String? ssid;
+
+  @override
+  Future<String?> getCurrentSsid() async => ssid;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _CountingKeyRepository extends KeyRepository {
@@ -1961,6 +1975,115 @@ void main() {
         () => (sshService.sessions as Map)[1] = 'test',
         throwsA(isA<Error>()),
       );
+    });
+  });
+
+  group('connectToHost SSID-based jump host bypass', () {
+    Future<int> seedHostWithJump(
+      AppDatabase db, {
+      String? skipJumpHostOnSsids,
+    }) async {
+      final jumpHostId = await db
+          .into(db.hosts)
+          .insert(
+            HostsCompanion.insert(
+              label: 'Bastion',
+              hostname: 'bastion.example.com',
+              username: 'bastion',
+            ),
+          );
+      return db
+          .into(db.hosts)
+          .insert(
+            HostsCompanion.insert(
+              label: 'Target',
+              hostname: 'target.example.com',
+              username: 'target',
+              jumpHostId: Value(jumpHostId),
+              skipJumpHostOnSsids: Value(skipJumpHostOnSsids),
+            ),
+          );
+    }
+
+    test('uses jump host when no SSIDs are configured', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final encryption = SecretEncryptionService.forTesting();
+      final hostRepo = HostRepository(db, encryption);
+      final keyRepo = KeyRepository(db, encryption);
+      final service = _CapturingSshService(
+        hostRepository: hostRepo,
+        keyRepository: keyRepo,
+        wifiNetworkService: _StubWifiNetworkService('home'),
+      );
+
+      final hostId = await seedHostWithJump(db);
+      await service.connectToHost(hostId);
+
+      expect(service.capturedConfig?.jumpHost, isNotNull);
+    });
+
+    test('uses jump host when current SSID is not in skip list', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final encryption = SecretEncryptionService.forTesting();
+      final hostRepo = HostRepository(db, encryption);
+      final keyRepo = KeyRepository(db, encryption);
+      final service = _CapturingSshService(
+        hostRepository: hostRepo,
+        keyRepository: keyRepo,
+        wifiNetworkService: _StubWifiNetworkService('cafe'),
+      );
+
+      final hostId = await seedHostWithJump(
+        db,
+        skipJumpHostOnSsids: 'home\noffice',
+      );
+      await service.connectToHost(hostId);
+
+      expect(service.capturedConfig?.jumpHost, isNotNull);
+      expect(service.capturedConfig?.hostname, 'target.example.com');
+    });
+
+    test('skips jump host when current SSID is in skip list', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final encryption = SecretEncryptionService.forTesting();
+      final hostRepo = HostRepository(db, encryption);
+      final keyRepo = KeyRepository(db, encryption);
+      final service = _CapturingSshService(
+        hostRepository: hostRepo,
+        keyRepository: keyRepo,
+        wifiNetworkService: _StubWifiNetworkService('home'),
+      );
+
+      final hostId = await seedHostWithJump(
+        db,
+        skipJumpHostOnSsids: 'home\noffice',
+      );
+      await service.connectToHost(hostId);
+
+      expect(service.capturedConfig, isNotNull);
+      expect(service.capturedConfig!.jumpHost, isNull);
+      expect(service.capturedConfig!.hostname, 'target.example.com');
+    });
+
+    test('uses jump host when SSID detection returns null', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final encryption = SecretEncryptionService.forTesting();
+      final hostRepo = HostRepository(db, encryption);
+      final keyRepo = KeyRepository(db, encryption);
+      final service = _CapturingSshService(
+        hostRepository: hostRepo,
+        keyRepository: keyRepo,
+        wifiNetworkService: _StubWifiNetworkService(null),
+      );
+
+      final hostId = await seedHostWithJump(db, skipJumpHostOnSsids: 'home');
+      await service.connectToHost(hostId);
+
+      expect(service.capturedConfig?.jumpHost, isNotNull);
     });
   });
 }

--- a/test/domain/services/wifi_network_service_test.dart
+++ b/test/domain/services/wifi_network_service_test.dart
@@ -1,0 +1,87 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/services/wifi_network_service.dart';
+
+void main() {
+  group('encodeSkipJumpHostSsids', () {
+    test('returns null for empty input', () {
+      expect(encodeSkipJumpHostSsids(const []), isNull);
+      expect(encodeSkipJumpHostSsids(const ['', '   ']), isNull);
+    });
+
+    test('joins entries with newline and trims', () {
+      expect(
+        encodeSkipJumpHostSsids(const ['home', '  office  ']),
+        'home\noffice',
+      );
+    });
+
+    test('deduplicates entries while preserving order', () {
+      expect(encodeSkipJumpHostSsids(const ['a', 'b', 'a', 'c']), 'a\nb\nc');
+    });
+  });
+
+  group('decodeSkipJumpHostSsids', () {
+    test('returns empty for null/empty', () {
+      expect(decodeSkipJumpHostSsids(null), isEmpty);
+      expect(decodeSkipJumpHostSsids(''), isEmpty);
+    });
+
+    test('splits and trims', () {
+      expect(decodeSkipJumpHostSsids('home\n office \n\nshop'), const [
+        'home',
+        'office',
+        'shop',
+      ]);
+    });
+
+    test('round-trips with encode', () {
+      const input = ['network one', 'two', 'café'];
+      final encoded = encodeSkipJumpHostSsids(input);
+      expect(decodeSkipJumpHostSsids(encoded), input);
+    });
+  });
+
+  group('shouldSkipJumpHostForSsid', () {
+    test('returns false when current SSID is null', () {
+      expect(
+        shouldSkipJumpHostForSsid(
+          currentSsid: null,
+          skipJumpHostOnSsids: 'home',
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when stored list is empty', () {
+      expect(
+        shouldSkipJumpHostForSsid(
+          currentSsid: 'home',
+          skipJumpHostOnSsids: null,
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns true on exact match', () {
+      expect(
+        shouldSkipJumpHostForSsid(
+          currentSsid: 'office',
+          skipJumpHostOnSsids: 'home\noffice',
+        ),
+        isTrue,
+      );
+    });
+
+    test('match is case-sensitive', () {
+      expect(
+        shouldSkipJumpHostForSsid(
+          currentSsid: 'Home',
+          skipJumpHostOnSsids: 'home',
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/domain/services/wifi_network_service_test.dart
+++ b/test/domain/services/wifi_network_service_test.dart
@@ -40,6 +40,20 @@ void main() {
     test('drops entries that contain only invisible characters', () {
       expect(encodeSkipJumpHostSsids(const ['​‎﻿', 'home']), 'home');
     });
+
+    test('drops entries built only from variation selectors', () {
+      // U+FE0F is a variation selector — invisible on its own.
+      expect(encodeSkipJumpHostSsids(const ['️️️', 'home']), 'home');
+    });
+
+    test('drops entries built only from combining marks', () {
+      // U+034F combining grapheme joiner — invisible alone, no Letter/Number.
+      expect(encodeSkipJumpHostSsids(const ['͏͏', 'home']), 'home');
+    });
+
+    test('preserves emoji SSIDs (Symbol category)', () {
+      expect(encodeSkipJumpHostSsids(const ['🏠']), '🏠');
+    });
   });
 
   group('decodeSkipJumpHostSsids', () {

--- a/test/domain/services/wifi_network_service_test.dart
+++ b/test/domain/services/wifi_network_service_test.dart
@@ -21,7 +21,7 @@ void main() {
       expect(encodeSkipJumpHostSsids(const ['a', 'b', 'a', 'c']), 'a\nb\nc');
     });
 
-    test('strips embedded line breaks so storage stays single-line', () {
+    test('strips embedded line breaks so each entry stays single-line', () {
       expect(
         encodeSkipJumpHostSsids(const ['ho\nme', 'shop\rfloor']),
         'home\nshopfloor',

--- a/test/domain/services/wifi_network_service_test.dart
+++ b/test/domain/services/wifi_network_service_test.dart
@@ -20,6 +20,17 @@ void main() {
     test('deduplicates entries while preserving order', () {
       expect(encodeSkipJumpHostSsids(const ['a', 'b', 'a', 'c']), 'a\nb\nc');
     });
+
+    test('strips embedded line breaks so storage stays single-line', () {
+      expect(
+        encodeSkipJumpHostSsids(const ['ho\nme', 'shop\rfloor']),
+        'home\nshopfloor',
+      );
+    });
+
+    test('drops entries that become empty after stripping line breaks', () {
+      expect(encodeSkipJumpHostSsids(const ['\n\r\n', 'home']), 'home');
+    });
   });
 
   group('decodeSkipJumpHostSsids', () {

--- a/test/domain/services/wifi_network_service_test.dart
+++ b/test/domain/services/wifi_network_service_test.dart
@@ -31,6 +31,15 @@ void main() {
     test('drops entries that become empty after stripping line breaks', () {
       expect(encodeSkipJumpHostSsids(const ['\n\r\n', 'home']), 'home');
     });
+
+    test('strips zero-width and bidi format characters from SSIDs', () {
+      // U+200B zero-width space, U+200E left-to-right mark, U+FEFF BOM.
+      expect(encodeSkipJumpHostSsids(const ['​ho‎me﻿']), 'home');
+    });
+
+    test('drops entries that contain only invisible characters', () {
+      expect(encodeSkipJumpHostSsids(const ['​‎﻿', 'home']), 'home');
+    });
   });
 
   group('decodeSkipJumpHostSsids', () {
@@ -51,6 +60,12 @@ void main() {
       const input = ['network one', 'two', 'café'];
       final encoded = encodeSkipJumpHostSsids(input);
       expect(decodeSkipJumpHostSsids(encoded), input);
+    });
+
+    test('cleans invisible characters from previously-stored values', () {
+      // Simulates a row written before encoder hardening that still has a
+      // BOM/ZWSP/LRM lurking in it.
+      expect(decodeSkipJumpHostSsids('﻿ho​m‎e\nshop'), const ['home', 'shop']);
     });
   });
 

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <local_auth_windows/local_auth_plugin.h>
 #include <pasteboard/pasteboard_plugin.h>
+#include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
@@ -19,6 +20,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("LocalAuthPlugin"));
   PasteboardPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PasteboardPlugin"));
+  PermissionHandlerWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
   local_auth_windows
   pasteboard
+  permission_handler_windows
   share_plus
   url_launcher_windows
 )


### PR DESCRIPTION
## Summary

- Adds a per-host list of Wi-Fi SSIDs that bypass the configured jump host when the device is currently connected to one of them. Useful when the host is on the same LAN as the device, but should be reached through a bastion when remote.
- Applies on both initial connect and reconnect (both go through `SshService.connectToHost`, which is where the SSID is checked before the jump host config is built).
- New `WifiNetworkService` wraps `network_info_plus` and normalizes platform quirks (quoted SSIDs, `<unknown ssid>` placeholder, missing permissions).
- Schema bump to v8 adds `Hosts.skipJumpHostOnSsids` (newline-separated list, nullable).
- Host editor exposes the new list under the existing Jump Host section with chips, an "Add current Wi-Fi" button, and a manual entry option.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` — 1646 tests pass, including new SSID encode/decode and connect-flow bypass tests
- [ ] Manual: configure a host with a jump host + your home SSID, verify direct connect on that network and tunneled connect on a different network
- [ ] Manual: verify the same behavior on reconnect after a drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)