### PR TITLE
Stop double tap from sending Tab

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1763,7 +1763,6 @@ final _terminalStandalonePathMetadataPattern = RegExp(
 );
 const _terminalSftpPathPrefix = 'monkeyssh-sftp-path:';
 const _terminalPathVerificationTimeout = Duration(seconds: 5);
-const _terminalInputIndicatorDuration = Duration(milliseconds: 700);
 
 typedef _TerminalPathMatch = ({
   String path,
@@ -1853,11 +1852,6 @@ double upgradeSnackBarBottomMargin(
   double keyboardToolbarHeight = 84,
   double baseSpacing = 16,
 }) => (showKeyboardToolbar ? keyboardToolbarHeight : 0) + baseSpacing;
-
-/// Resolves the transient indicator label for a terminal double-tap Tab gesture.
-@visibleForTesting
-String resolveTerminalTabGestureIndicatorLabel({required bool shiftActive}) =>
-    shiftActive ? 'Shift+Tab' : 'Tab';
 
 /// Resolves a readable display name for a picked upload file.
 @visibleForTesting
@@ -3228,7 +3222,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   int? _terminalDoubleTapConsumedPointer;
   Offset? _lastTerminalTapPosition;
   Duration? _lastTerminalTapTimestamp;
-  bool _recentlyHandledTerminalDoubleTap = false;
   int? _pendingTerminalMouseTapPointer;
   Offset? _pendingTerminalMouseTapDownPosition;
   Duration? _pendingTerminalMouseTapDownTimestamp;
@@ -3250,7 +3243,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   late final ProviderSubscription<bool> _sharedClipboardLocalReadSubscription;
   Timer? _localClipboardSyncTimer;
   Timer? _remoteClipboardSyncTimer;
-  Timer? _terminalInputIndicatorTimer;
   Timer? _promptOutputImeResetTimer;
   bool _isPollingRemoteClipboard = false;
   bool _isPushingLocalClipboard = false;
@@ -3259,7 +3251,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   String? _lastObservedRemoteClipboardText;
   String? _lastAppliedLocalClipboardText;
   String? _lastAppliedRemoteClipboardText;
-  String? _terminalInputIndicatorLabel;
 
   // Theme state
   Host? _host;
@@ -3746,44 +3737,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _queueTerminalScrollToBottom();
   }
 
-  void _handleTerminalDoubleTapDown(
-    TapDownDetails tapDetails,
-    CellOffset cellOffset,
-  ) {
-    if (_recentlyHandledTerminalDoubleTap) {
-      return;
-    }
-    _recentlyHandledTerminalDoubleTap = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _recentlyHandledTerminalDoubleTap = false;
-    });
-
-    final shiftActive = _toolbarController.isShiftActive;
-    _terminalTextInputController.suppressNextTouchKeyboardRequest();
-    _terminal.textInput(resolveTerminalTabInput(shiftActive: shiftActive));
-    _followLiveOutput();
-    _toolbarController.consumeOneShot();
-    _showTerminalInputIndicator(
-      resolveTerminalTabGestureIndicatorLabel(shiftActive: shiftActive),
-    );
-  }
-
   void _handleTerminalLinkTapDown(
     TapDownDetails tapDetails,
     CellOffset cellOffset,
   ) {
     _terminalTextInputController.suppressNextTouchKeyboardRequest();
-  }
-
-  void _showTerminalInputIndicator(String label) {
-    _terminalInputIndicatorTimer?.cancel();
-    setState(() => _terminalInputIndicatorLabel = label);
-    _terminalInputIndicatorTimer = Timer(_terminalInputIndicatorDuration, () {
-      if (!mounted) {
-        return;
-      }
-      setState(() => _terminalInputIndicatorLabel = null);
-    });
   }
 
   void _queueTerminalScrollToBottom() {
@@ -5470,7 +5428,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _sharedClipboardSubscription.close();
     _sharedClipboardLocalReadSubscription.close();
     _stopSharedClipboardSync();
-    _terminalInputIndicatorTimer?.cancel();
     _promptOutputImeResetTimer?.cancel();
     _disposeTerminalPathVerificationSftp();
     _observedSession?.removeMetadataListener(_handleSessionMetadataChanged);
@@ -6309,7 +6266,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       resolveLinkTap: _resolveTerminalLinkTap,
       onLinkTapDown: _handleTerminalLinkTapDown,
       onLinkTap: _handleTerminalLinkTap,
-      onDoubleTapDown: isMobile ? _handleTerminalDoubleTapDown : null,
       suppressLongPressDragSelection: isMobile,
       liveOutputAutoScroll: _terminalLiveOutputAutoScrollEnabled,
       useSystemSelection: isMobile,
@@ -6459,34 +6415,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     var mobileTerminalView = terminalView;
 
-    final terminalInputIndicatorLabel = _terminalInputIndicatorLabel;
-    if (_isPinchZooming || terminalInputIndicatorLabel != null) {
+    if (_isPinchZooming) {
       mobileTerminalView = Stack(
         fit: StackFit.expand,
         children: [
           mobileTerminalView,
-          if (terminalInputIndicatorLabel != null)
-            Positioned(
-              top: 12,
-              left: 0,
-              right: 0,
-              child: Align(
-                alignment: Alignment.topCenter,
-                child: _buildTerminalTransientIndicator(
-                  theme: theme,
-                  label: terminalInputIndicatorLabel,
-                ),
-              ),
+          Positioned(
+            top: 12,
+            right: 12,
+            child: _buildTerminalTransientIndicator(
+              theme: theme,
+              label: '${fontSize.toStringAsFixed(0)} pt',
             ),
-          if (_isPinchZooming)
-            Positioned(
-              top: 12,
-              right: 12,
-              child: _buildTerminalTransientIndicator(
-                theme: theme,
-                label: '${fontSize.toStringAsFixed(0)} pt',
-              ),
-            ),
+          ),
         ],
       );
     }
@@ -7583,10 +7524,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         (event.position - lastTapPosition).distance <= kDoubleTapSlop;
 
     if (isDoubleTap) {
+      // Let SelectionArea handle text selection without also forwarding the
+      // second tap as terminal mouse input.
       _terminalDoubleTapConsumedPointer = event.pointer;
       _clearPendingTerminalDoubleTap();
       _clearLastTerminalTap();
-      _triggerTerminalDoubleTap(event.position, event.kind);
       return;
     }
 
@@ -7641,28 +7583,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (_terminalDoubleTapConsumedPointer == event.pointer) {
       _terminalDoubleTapConsumedPointer = null;
     }
-  }
-
-  void _triggerTerminalDoubleTap(
-    Offset globalPosition,
-    PointerDeviceKind kind,
-  ) {
-    final terminalViewState = _terminalViewKey.currentState;
-    if (terminalViewState == null) {
-      return;
-    }
-
-    final localPosition = terminalViewState.renderTerminal.globalToLocal(
-      globalPosition,
-    );
-    _handleTerminalDoubleTapDown(
-      TapDownDetails(
-        kind: kind,
-        globalPosition: globalPosition,
-        localPosition: localPosition,
-      ),
-      terminalViewState.renderTerminal.getCellOffset(localPosition),
-    );
   }
 
   void _handleTerminalPathPointerDown(PointerDownEvent event) {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1082,26 +1082,36 @@ void main() {
     );
 
     testWidgets(
-      'terminal double tap sends Tab while system selection is enabled',
+      'terminal double tap selects text without sending Tab',
       (tester) async {
         await pumpScreen(tester);
+
+        session.terminal!.write('alpha beta');
+        await tester.pumpAndSettle();
 
         expect(find.byType(SelectionArea), findsOneWidget);
         shellWrites.clear();
 
-        final terminalCenter = tester.getCenter(
+        final terminalViewState = tester.state<MonkeyTerminalViewState>(
           find.byType(MonkeyTerminalView),
         );
-        await tester.tapAt(terminalCenter);
+        final renderTerminal = terminalViewState.renderTerminal;
+        final target = renderTerminal.localToGlobal(
+          renderTerminal.getOffset(const CellOffset(2, 0)) +
+              renderTerminal.cellSize.center(Offset.zero),
+        );
+
+        await tester.tapAt(target);
         await tester.pump(const Duration(milliseconds: 80));
-        await tester.tapAt(terminalCenter);
-        await tester.pump();
+        await tester.tapAt(target);
+        await tester.pumpAndSettle();
 
         final writtenShellText = utf8.decode(
           shellWrites.expand((chunk) => chunk).toList(growable: false),
         );
-        expect(writtenShellText, '\t');
-        expect(find.text('Tab'), findsAtLeastNWidgets(1));
+        expect(writtenShellText, isNot(contains('\t')));
+        final selection = terminalViewState.renderTerminal.getSelectedContent();
+        expect(selection?.plainText, 'alpha');
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );

--- a/test/widget/terminal_screen_zoom_test.dart
+++ b/test/widget/terminal_screen_zoom_test.dart
@@ -41,20 +41,4 @@ void main() {
       );
     });
   });
-
-  group('terminal tab gesture indicator helpers', () {
-    test('shows a plain Tab label by default', () {
-      expect(
-        resolveTerminalTabGestureIndicatorLabel(shiftActive: false),
-        'Tab',
-      );
-    });
-
-    test('shows Shift+Tab when the toolbar shift modifier is active', () {
-      expect(
-        resolveTerminalTabGestureIndicatorLabel(shiftActive: true),
-        'Shift+Tab',
-      );
-    });
-  });
 }


### PR DESCRIPTION
## Summary

- Removed the mobile terminal double-tap-to-Tab shortcut so double-tapping can be reserved for text selection.
- Kept double-tap detection only to prevent the second tap from also being forwarded as terminal mouse input.
- Updated terminal tests to assert double-tap selects text without writing a tab.

## Tests

- `dart format .`
- `flutter analyze`
- `flutter test`
