### PR TITLE
fix: respect tmuxExtraFlags in all TmuxService queries and actions

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -106,9 +106,9 @@ class TmuxService {
   /// Uses `tmux list-sessions` rather than checking the `TMUX` environment
   /// variable, because SSH exec channels do not share the interactive
   /// shell's environment.
-  Future<bool> isTmuxActive(SshSession session) async {
+  Future<bool> isTmuxActive(SshSession session, {String? extraFlags}) async {
     try {
-      return await isTmuxActiveOrThrow(session);
+      return await isTmuxActiveOrThrow(session, extraFlags: extraFlags);
     } on Exception catch (error) {
       DiagnosticsLogService.instance.warning(
         'tmux.detect',
@@ -128,7 +128,10 @@ class TmuxService {
   /// Unlike [isTmuxActive], this distinguishes "no sessions" from
   /// infrastructure failures so callers can preserve existing UI on
   /// indeterminate detection results.
-  Future<bool> isTmuxActiveOrThrow(SshSession session) async {
+  Future<bool> isTmuxActiveOrThrow(
+    SshSession session, {
+    String? extraFlags,
+  }) async {
     DiagnosticsLogService.instance.debug(
       'tmux.detect',
       'active_check_start',
@@ -138,7 +141,7 @@ class TmuxService {
     await _cacheTmuxPath(session);
     final output = await _exec(
       session,
-      "tmux list-sessions -F '#{session_name}' 2>/dev/null; "
+      "tmux ${extraFlags != null ? '$extraFlags ' : ''}list-sessions -F '#{session_name}' 2>/dev/null; "
       r'status=$?; '
       r'if [ "$status" -eq 0 ] || [ "$status" -eq 1 ]; then true; '
       'else false; fi',
@@ -207,8 +210,9 @@ class TmuxService {
   /// Stale cached results are returned immediately while a refresh runs in
   /// the background.
   Future<Set<AgentLaunchTool>> detectInstalledAgentTools(
-    SshSession session,
-  ) async {
+    SshSession session, {
+    String? extraFlags,
+  }) async {
     final cached = _installedAgentToolsCache[session.connectionId];
     if (cached != null) {
       final age = DateTime.now().difference(cached.cachedAt);
@@ -222,16 +226,19 @@ class TmuxService {
         },
       );
       if (age >= _installedAgentToolsFreshTtl) {
-        unawaited(_refreshInstalledAgentTools(session));
+        unawaited(_refreshInstalledAgentTools(session, extraFlags: extraFlags));
       }
       return cached.tools;
     }
 
-    return _refreshInstalledAgentTools(session);
+    return _refreshInstalledAgentTools(session, extraFlags: extraFlags);
   }
 
   /// Warms the installed agent CLI cache in the background.
-  Future<void> prefetchInstalledAgentTools(SshSession session) async {
+  Future<void> prefetchInstalledAgentTools(
+    SshSession session, {
+    String? extraFlags,
+  }) async {
     final cached = _installedAgentToolsCache[session.connectionId];
     if (cached != null &&
         DateTime.now().difference(cached.cachedAt) <
@@ -247,7 +254,11 @@ class TmuxService {
       return;
     }
     try {
-      await _refreshInstalledAgentTools(session, priority: SshExecPriority.low);
+      await _refreshInstalledAgentTools(
+        session,
+        priority: SshExecPriority.low,
+        extraFlags: extraFlags,
+      );
     } on Object catch (error) {
       DiagnosticsLogService.instance.debug(
         'tmux.agent',
@@ -263,6 +274,7 @@ class TmuxService {
   Future<Set<AgentLaunchTool>> _refreshInstalledAgentTools(
     SshSession session, {
     SshExecPriority priority = SshExecPriority.normal,
+    String? extraFlags,
   }) {
     final existingRequest = _installedAgentToolRequests[session.connectionId];
     if (existingRequest != null) {
@@ -314,7 +326,10 @@ class TmuxService {
   }
 
   /// Lists all tmux sessions on the remote host.
-  Future<List<TmuxSession>> listSessions(SshSession session) async {
+  Future<List<TmuxSession>> listSessions(
+    SshSession session, {
+    String? extraFlags,
+  }) async {
     DiagnosticsLogService.instance.debug(
       'tmux.query',
       'list_sessions_start',
@@ -323,9 +338,9 @@ class TmuxService {
     try {
       final output = await _exec(
         session,
-        'tmux list-sessions -F '
+        "tmux ${extraFlags != null ? '$extraFlags ' : ''}list-sessions -F "
         "'#{session_name}|#{session_windows}|"
-        "#{session_attached}|#{session_activity}'",
+        "#{session_attached}'",
       );
       final sessions = _parseLines(output, TmuxSession.fromTmuxFormat);
       DiagnosticsLogService.instance.info(
@@ -358,7 +373,10 @@ class TmuxService {
   /// the first attached session from `tmux list-sessions` — this covers
   /// the common case where the interactive shell is inside tmux but the
   /// exec channel is not.
-  Future<String?> currentSessionName(SshSession session) async {
+  Future<String?> currentSessionName(
+    SshSession session, {
+    String? extraFlags,
+  }) async {
     DiagnosticsLogService.instance.debug(
       'tmux.query',
       'current_session_start',
@@ -368,7 +386,7 @@ class TmuxService {
       // Direct approach — works if the exec channel is inside tmux.
       final output = await _exec(
         session,
-        "tmux display-message -p '#{session_name}'",
+        "tmux ${extraFlags != null ? '$extraFlags ' : ''}display-message -p '#{session_name}'",
       );
       final name = output.trim();
       if (name.isNotEmpty) {
@@ -393,7 +411,7 @@ class TmuxService {
 
     // Fallback — find attached sessions.
     try {
-      final sessions = await listSessions(session);
+      final sessions = await listSessions(session, extraFlags: extraFlags);
       final attached = sessions.where((s) => s.isAttached).toList();
       if (attached.length == 1) {
         DiagnosticsLogService.instance.info(
@@ -429,9 +447,17 @@ class TmuxService {
   }
 
   /// Returns `true` if [sessionName] exists on the remote tmux server.
-  Future<bool> hasSession(SshSession session, String sessionName) async {
+  Future<bool> hasSession(
+    SshSession session,
+    String sessionName, {
+    String? extraFlags,
+  }) async {
     try {
-      return await hasSessionOrThrow(session, sessionName);
+      return await hasSessionOrThrow(
+        session,
+        sessionName,
+        extraFlags: extraFlags,
+      );
     } on Exception catch (error) {
       DiagnosticsLogService.instance.warning(
         'tmux.query',
@@ -450,7 +476,11 @@ class TmuxService {
   ///
   /// Unlike [hasSession], this distinguishes a missing tmux session from
   /// transient SSH exec/channel failures.
-  Future<bool> hasSessionOrThrow(SshSession session, String sessionName) async {
+  Future<bool> hasSessionOrThrow(
+    SshSession session,
+    String sessionName, {
+    String? extraFlags,
+  }) async {
     DiagnosticsLogService.instance.debug(
       'tmux.query',
       'has_session_start',
@@ -459,7 +489,7 @@ class TmuxService {
     await _cacheTmuxPath(session);
     final output = await _exec(
       session,
-      'tmux has-session -t ${_shellQuote(sessionName)} 2>/dev/null; '
+      'tmux ${extraFlags != null ? '$extraFlags ' : ''}has-session -t ${_shellQuote(sessionName)} 2>/dev/null; '
       r'status=$?; '
       r'if [ "$status" -eq 0 ]; then printf 1; '
       r'elif [ "$status" -eq 1 ]; then printf 0; '
@@ -479,11 +509,13 @@ class TmuxService {
   /// Lists all windows in the given tmux [sessionName].
   Future<List<TmuxWindow>> listWindows(
     SshSession session,
-    String sessionName,
-  ) async {
+    String sessionName, {
+    String? extraFlags,
+  }) async {
     final key = _TmuxWindowWatchKey(
       connectionId: session.connectionId,
       sessionName: sessionName,
+      extraFlags: extraFlags,
     );
     if (_isExecChannelCoolingDown(session)) {
       final cachedWindows = _windowSnapshotCache[key];
@@ -524,8 +556,9 @@ class TmuxService {
 
   Future<List<TmuxWindow>> _listWindows(
     SshSession session,
-    String sessionName,
-  ) async {
+    String sessionName, {
+    String? extraFlags,
+  }) async {
     DiagnosticsLogService.instance.debug(
       'tmux.query',
       'list_windows_start',
@@ -537,7 +570,7 @@ class TmuxService {
       final output = await _exec(
         session,
         r'SEP=$(printf "\037"); '
-        'tmux -u list-windows -t $quotedName -F '
+        "tmux ${extraFlags != null ? '$extraFlags ' : ''}-u list-windows -t $quotedName -F "
         '"#{window_index}$sep#{window_name}$sep#{window_active}$sep'
         '#{pane_current_command}$sep#{pane_current_path}$sep'
         '#{window_flags}$sep#{pane_title}$sep#{window_activity}$sep'
@@ -547,7 +580,12 @@ class TmuxService {
         _parseLines(output, TmuxWindow.fromTmuxFormat),
       );
       if (windows.isNotEmpty) {
-        _cacheWindowSnapshot(session, sessionName, windows);
+        _cacheWindowSnapshot(
+          session,
+          sessionName,
+          windows,
+          extraFlags: extraFlags,
+        );
       }
       DiagnosticsLogService.instance.info(
         'tmux.query',
@@ -567,6 +605,7 @@ class TmuxService {
           _windowSnapshotCache[_TmuxWindowWatchKey(
             connectionId: session.connectionId,
             sessionName: sessionName,
+            extraFlags: extraFlags,
           )];
       if (cachedWindows != null &&
           cachedWindows.isNotEmpty &&
@@ -590,8 +629,9 @@ class TmuxService {
   /// reports one.
   Future<String?> currentPanePath(
     SshSession session,
-    String sessionName,
-  ) async {
+    String sessionName, {
+    String? extraFlags,
+  }) async {
     DiagnosticsLogService.instance.debug(
       'tmux.query',
       'current_pane_path_start',
@@ -600,7 +640,7 @@ class TmuxService {
     try {
       final output = await _exec(
         session,
-        'tmux display-message -p -t ${_shellQuote('$sessionName:')} '
+        "tmux ${extraFlags != null ? '$extraFlags ' : ''}display-message -p -t ${_shellQuote('$sessionName:')} "
         "'#{pane_current_path}'",
       );
       final path = parseTmuxCurrentPanePath(output);
@@ -630,8 +670,9 @@ class TmuxService {
   /// window updates even after the visible interactive shell has left tmux.
   Future<bool> hasForegroundClient(
     SshSession session,
-    String sessionName,
-  ) async {
+    String sessionName, {
+    String? extraFlags,
+  }) async {
     DiagnosticsLogService.instance.debug(
       'tmux.query',
       'foreground_client_start',
@@ -640,7 +681,7 @@ class TmuxService {
     try {
       final output = await _exec(
         session,
-        'tmux list-clients -t ${_shellQuote(sessionName)} '
+        "tmux ${extraFlags != null ? '$extraFlags ' : ''}list-clients -t ${_shellQuote(sessionName)} "
         "-F '#{client_control_mode}' 2>/dev/null",
       );
       final hasClient = hasForegroundTmuxClient(output);
@@ -670,11 +711,13 @@ class TmuxService {
   /// has changed for [sessionName].
   Stream<TmuxWindowChangeEvent> watchWindowChanges(
     SshSession session,
-    String sessionName,
-  ) {
+    String sessionName, {
+    String? extraFlags,
+  }) {
     final key = _TmuxWindowWatchKey(
       connectionId: session.connectionId,
       sessionName: sessionName,
+      extraFlags: extraFlags,
     );
     final observer = _windowObservers.putIfAbsent(
       key,
@@ -682,6 +725,7 @@ class TmuxService {
         service: this,
         session: session,
         sessionName: sessionName,
+        extraFlags: extraFlags,
         onDispose: () => _windowObservers.remove(key),
       ),
     );
@@ -706,6 +750,7 @@ class TmuxService {
     String? command,
     String? name,
     String? workingDirectory,
+    String? extraFlags,
   }) async {
     DiagnosticsLogService.instance.info(
       'tmux.action',
@@ -721,7 +766,7 @@ class TmuxService {
     // (e.g. resuming an AI session in a specific project). Without -c,
     // tmux uses the session's default-directory — matching Ctrl+b,c.
     final parts = <String>[
-      "tmux new-window -P -F '#{window_index}' -t ${_shellQuote(sessionName)}",
+      "tmux ${extraFlags != null ? '$extraFlags ' : ''}new-window -P -F '#{window_index}' -t ${_shellQuote(sessionName)}",
       if (workingDirectory != null && workingDirectory.trim().isNotEmpty)
         '-c ${_shellQuote(workingDirectory.trim())}',
       if (name != null && name.trim().isNotEmpty)
@@ -737,7 +782,7 @@ class TmuxService {
     if (agentTool != null) {
       await _exec(
         session,
-        'tmux set-option -w -t ${_shellQuote(target)} '
+        "tmux ${extraFlags != null ? '$extraFlags ' : ''}set-option -w -t ${_shellQuote(target)} "
         '@flutty_agent_tool ${_shellQuote(agentTool.commandName)}',
       );
     }
@@ -756,7 +801,7 @@ class TmuxService {
     if (command != null && command.trim().isNotEmpty) {
       _execFireAndForget(
         session,
-        'tmux send-keys -t ${_shellQuote(target)} '
+        "tmux ${extraFlags != null ? '$extraFlags ' : ''}send-keys -t ${_shellQuote(target)} "
         '${_shellQuote(command.trim())} Enter',
       );
       DiagnosticsLogService.instance.info(
@@ -779,8 +824,9 @@ class TmuxService {
   Future<void> selectWindow(
     SshSession session,
     String sessionName,
-    int windowIndex,
-  ) async {
+    int windowIndex, {
+    String? extraFlags,
+  }) async {
     DiagnosticsLogService.instance.info(
       'tmux.action',
       'select_window_start',
@@ -791,7 +837,7 @@ class TmuxService {
     );
     await _exec(
       session,
-      'tmux select-window -t ${_shellQuote(sessionName)}:$windowIndex',
+      "tmux ${extraFlags != null ? '$extraFlags ' : ''}select-window -t ${_shellQuote(sessionName)}:$windowIndex",
     );
     DiagnosticsLogService.instance.info(
       'tmux.action',
@@ -807,8 +853,9 @@ class TmuxService {
   Future<void> killWindow(
     SshSession session,
     String sessionName,
-    int windowIndex,
-  ) async {
+    int windowIndex, {
+    String? extraFlags,
+  }) async {
     DiagnosticsLogService.instance.info(
       'tmux.action',
       'kill_window_start',
@@ -819,7 +866,7 @@ class TmuxService {
     );
     await _exec(
       session,
-      'tmux kill-window -t ${_shellQuote(sessionName)}:$windowIndex',
+      "tmux ${extraFlags != null ? '$extraFlags ' : ''}kill-window -t ${_shellQuote(sessionName)}:$windowIndex",
     );
     DiagnosticsLogService.instance.info(
       'tmux.action',
@@ -876,12 +923,14 @@ class TmuxService {
   void _cacheWindowSnapshot(
     SshSession session,
     String sessionName,
-    List<TmuxWindow> windows,
-  ) {
+    List<TmuxWindow> windows, {
+    String? extraFlags,
+  }) {
     if (windows.isEmpty) return;
     _windowSnapshotCache[_TmuxWindowWatchKey(
       connectionId: session.connectionId,
       sessionName: sessionName,
+      extraFlags: extraFlags,
     )] = List<TmuxWindow>.unmodifiable(
       windows,
     );
@@ -890,11 +939,13 @@ class TmuxService {
   void _applyCachedWindowEvent(
     SshSession session,
     String sessionName,
-    TmuxWindowChangeEvent event,
-  ) {
+    TmuxWindowChangeEvent event, {
+    String? extraFlags,
+  }) {
     final key = _TmuxWindowWatchKey(
       connectionId: session.connectionId,
       sessionName: sessionName,
+      extraFlags: extraFlags,
     );
     final cachedWindows = _windowSnapshotCache[key];
     if (cachedWindows == null || cachedWindows.isEmpty) return;
@@ -1370,8 +1421,11 @@ const _tmuxControlModeClientFlags = 'read-only,ignore-size,no-output,wait-exit';
 
 /// Builds the tmux control-mode attach command used for live window updates.
 @visibleForTesting
-String buildTmuxControlModeAttachCommand(String sessionName) =>
-    'tmux -CC attach-session -f $_tmuxControlModeClientFlags '
+String buildTmuxControlModeAttachCommand(
+  String sessionName, {
+  String? extraFlags,
+}) =>
+    'tmux ${extraFlags != null ? '$extraFlags ' : ''}-CC attach-session -f $_tmuxControlModeClientFlags '
     '-t ${TmuxService._shellQuote(sessionName)}';
 
 /// Builds the tmux control-mode subscription command for window snapshots.
@@ -1519,20 +1573,23 @@ class _TmuxWindowWatchKey {
   const _TmuxWindowWatchKey({
     required this.connectionId,
     required this.sessionName,
+    this.extraFlags,
   });
 
   final int connectionId;
   final String sessionName;
+  final String? extraFlags;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is _TmuxWindowWatchKey &&
           connectionId == other.connectionId &&
-          sessionName == other.sessionName;
+          sessionName == other.sessionName &&
+          extraFlags == other.extraFlags;
 
   @override
-  int get hashCode => Object.hash(connectionId, sessionName);
+  int get hashCode => Object.hash(connectionId, sessionName, extraFlags);
 }
 
 class _TmuxWindowChangeObserver {
@@ -1541,6 +1598,7 @@ class _TmuxWindowChangeObserver {
     required this.session,
     required this.sessionName,
     required this.onDispose,
+    this.extraFlags,
     DateTime Function()? now,
   }) : _now = now ?? DateTime.now,
        _controller = StreamController<TmuxWindowChangeEvent>.broadcast() {
@@ -1559,6 +1617,7 @@ class _TmuxWindowChangeObserver {
   final TmuxService service;
   final SshSession session;
   final String sessionName;
+  final String? extraFlags;
   final VoidCallback onDispose;
   final DateTime Function() _now;
   final StreamController<TmuxWindowChangeEvent> _controller;
@@ -1695,7 +1754,12 @@ class _TmuxWindowChangeObserver {
       if (!_preserveScheduledReloadThroughSnapshots) {
         _cancelScheduledReload();
       }
-      service._applyCachedWindowEvent(session, sessionName, event);
+      service._applyCachedWindowEvent(
+        session,
+        sessionName,
+        event,
+        extraFlags: extraFlags,
+      );
       DiagnosticsLogService.instance.debug(
         'tmux.watch',
         'snapshot_event',

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -232,9 +232,8 @@ class TmuxService {
   /// Stale cached results are returned immediately while a refresh runs in
   /// the background.
   Future<Set<AgentLaunchTool>> detectInstalledAgentTools(
-    SshSession session, {
-    String? extraFlags,
-  }) async {
+    SshSession session,
+  ) async {
     final cached = _installedAgentToolsCache[session.connectionId];
     if (cached != null) {
       final age = DateTime.now().difference(cached.cachedAt);
@@ -248,19 +247,16 @@ class TmuxService {
         },
       );
       if (age >= _installedAgentToolsFreshTtl) {
-        unawaited(_refreshInstalledAgentTools(session, extraFlags: extraFlags));
+        unawaited(_refreshInstalledAgentTools(session));
       }
       return cached.tools;
     }
 
-    return _refreshInstalledAgentTools(session, extraFlags: extraFlags);
+    return _refreshInstalledAgentTools(session);
   }
 
   /// Warms the installed agent CLI cache in the background.
-  Future<void> prefetchInstalledAgentTools(
-    SshSession session, {
-    String? extraFlags,
-  }) async {
+  Future<void> prefetchInstalledAgentTools(SshSession session) async {
     final cached = _installedAgentToolsCache[session.connectionId];
     if (cached != null &&
         DateTime.now().difference(cached.cachedAt) <
@@ -276,11 +272,7 @@ class TmuxService {
       return;
     }
     try {
-      await _refreshInstalledAgentTools(
-        session,
-        priority: SshExecPriority.low,
-        extraFlags: extraFlags,
-      );
+      await _refreshInstalledAgentTools(session, priority: SshExecPriority.low);
     } on Object catch (error) {
       DiagnosticsLogService.instance.debug(
         'tmux.agent',
@@ -296,7 +288,6 @@ class TmuxService {
   Future<Set<AgentLaunchTool>> _refreshInstalledAgentTools(
     SshSession session, {
     SshExecPriority priority = SshExecPriority.normal,
-    String? extraFlags,
   }) {
     final existingRequest = _installedAgentToolRequests[session.connectionId];
     if (existingRequest != null) {
@@ -1471,18 +1462,36 @@ String? resolveTmuxClientFlagsFromExtraFlags(String? extraFlags) {
       continue;
     }
     if (token.value.length > 2) {
-      clientFlags.add(token.raw);
+      clientFlags.add(_buildReusableTmuxClientFlag(token.value));
       continue;
     }
     if (index + 1 >= tokens.length ||
         _isTmuxCommandSeparatorToken(tokens[index + 1].value)) {
       continue;
     }
-    clientFlags.add('${token.raw} ${tokens[index + 1].raw}');
+    clientFlags.add(
+      '${token.value} ${_shellQuoteReusableTmuxClientFlagValue(tokens[index + 1].value)}',
+    );
     index++;
   }
 
   return clientFlags.isEmpty ? null : clientFlags.join(' ');
+}
+
+String _buildReusableTmuxClientFlag(String tokenValue) {
+  final flag = tokenValue.substring(0, 2);
+  final value = tokenValue.substring(2);
+  return '$flag ${_shellQuoteReusableTmuxClientFlagValue(value)}';
+}
+
+String _shellQuoteReusableTmuxClientFlagValue(String value) {
+  if (value == '~') {
+    return r'"$HOME"';
+  }
+  if (value.startsWith('~/')) {
+    return r'"$HOME"' + TmuxService._shellQuote(value.substring(1));
+  }
+  return TmuxService._shellQuote(value);
 }
 
 List<_ShellToken>? _tokenizeShellFragment(String? value) {
@@ -1859,7 +1868,10 @@ class _TmuxWindowChangeObserver {
         session,
         service._wrapCommand(
           session,
-          buildTmuxControlModeAttachCommand(sessionName),
+          buildTmuxControlModeAttachCommand(
+            sessionName,
+            extraFlags: extraFlags,
+          ),
         ),
         // tmux control mode stays silent over a plain exec channel on some SSH
         // servers. Request a dedicated PTY so `%subscription-changed` events

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -11,6 +11,17 @@ import 'diagnostics_log_service.dart';
 import 'ssh_exec_queue.dart';
 import 'ssh_service.dart';
 
+const _backslashCodeUnit = 0x5C;
+
+enum _ShellQuoteMode { none, single, double }
+
+class _ShellToken {
+  const _ShellToken({required this.value, required this.raw});
+
+  final String value;
+  final String raw;
+}
+
 /// Error thrown when a tmux command channel ends before confirming completion.
 class TmuxCommandException implements Exception {
   /// Creates a [TmuxCommandException].
@@ -66,6 +77,17 @@ class TmuxService {
   static final RegExp _execDoneMarkerLinePattern = RegExp(
     '(?:^|\\n)${RegExp.escape(_execDoneMarker)}:([0-9]+)\\n',
   );
+
+  static String _tmuxCommand(
+    String command, {
+    String? extraFlags,
+    bool forceUtf8 = false,
+  }) {
+    final clientFlags = resolveTmuxClientFlagsFromExtraFlags(extraFlags);
+    final options = <String>[if (forceUtf8) '-u', ?clientFlags];
+    final optionText = options.isEmpty ? '' : '${options.join(' ')} ';
+    return 'tmux $optionText$command';
+  }
 
   /// Clears the cached tmux path for a connection.
   void clearCache(int connectionId) {
@@ -141,7 +163,7 @@ class TmuxService {
     await _cacheTmuxPath(session);
     final output = await _exec(
       session,
-      "tmux ${extraFlags != null ? '$extraFlags ' : ''}list-sessions -F '#{session_name}' 2>/dev/null; "
+      '${_tmuxCommand("list-sessions -F '#{session_name}'", extraFlags: extraFlags)} 2>/dev/null; '
       r'status=$?; '
       r'if [ "$status" -eq 0 ] || [ "$status" -eq 1 ]; then true; '
       'else false; fi',
@@ -338,9 +360,10 @@ class TmuxService {
     try {
       final output = await _exec(
         session,
-        "tmux ${extraFlags != null ? '$extraFlags ' : ''}list-sessions -F "
-        "'#{session_name}|#{session_windows}|"
-        "#{session_attached}'",
+        _tmuxCommand(
+          "list-sessions -F '#{session_name}|#{session_windows}|#{session_attached}|#{session_activity}'",
+          extraFlags: extraFlags,
+        ),
       );
       final sessions = _parseLines(output, TmuxSession.fromTmuxFormat);
       DiagnosticsLogService.instance.info(
@@ -386,7 +409,10 @@ class TmuxService {
       // Direct approach — works if the exec channel is inside tmux.
       final output = await _exec(
         session,
-        "tmux ${extraFlags != null ? '$extraFlags ' : ''}display-message -p '#{session_name}'",
+        _tmuxCommand(
+          "display-message -p '#{session_name}'",
+          extraFlags: extraFlags,
+        ),
       );
       final name = output.trim();
       if (name.isNotEmpty) {
@@ -489,7 +515,7 @@ class TmuxService {
     await _cacheTmuxPath(session);
     final output = await _exec(
       session,
-      'tmux ${extraFlags != null ? '$extraFlags ' : ''}has-session -t ${_shellQuote(sessionName)} 2>/dev/null; '
+      '${_tmuxCommand('has-session -t ${_shellQuote(sessionName)}', extraFlags: extraFlags)} 2>/dev/null; '
       r'status=$?; '
       r'if [ "$status" -eq 0 ]; then printf 1; '
       r'elif [ "$status" -eq 1 ]; then printf 0; '
@@ -515,7 +541,7 @@ class TmuxService {
     final key = _TmuxWindowWatchKey(
       connectionId: session.connectionId,
       sessionName: sessionName,
-      extraFlags: extraFlags,
+      extraFlags: resolveTmuxClientFlagsFromExtraFlags(extraFlags),
     );
     if (_isExecChannelCoolingDown(session)) {
       final cachedWindows = _windowSnapshotCache[key];
@@ -544,7 +570,7 @@ class TmuxService {
       return existingRequest;
     }
 
-    final request = _listWindows(session, sessionName);
+    final request = _listWindows(session, sessionName, extraFlags: extraFlags);
     _windowListRequests[key] = request;
     request.whenComplete(() {
       if (identical(_windowListRequests[key], request)) {
@@ -570,7 +596,7 @@ class TmuxService {
       final output = await _exec(
         session,
         r'SEP=$(printf "\037"); '
-        "tmux ${extraFlags != null ? '$extraFlags ' : ''}-u list-windows -t $quotedName -F "
+        '${_tmuxCommand('list-windows -t $quotedName -F ', extraFlags: extraFlags, forceUtf8: true)}'
         '"#{window_index}$sep#{window_name}$sep#{window_active}$sep'
         '#{pane_current_command}$sep#{pane_current_path}$sep'
         '#{window_flags}$sep#{pane_title}$sep#{window_activity}$sep'
@@ -605,7 +631,7 @@ class TmuxService {
           _windowSnapshotCache[_TmuxWindowWatchKey(
             connectionId: session.connectionId,
             sessionName: sessionName,
-            extraFlags: extraFlags,
+            extraFlags: resolveTmuxClientFlagsFromExtraFlags(extraFlags),
           )];
       if (cachedWindows != null &&
           cachedWindows.isNotEmpty &&
@@ -640,8 +666,11 @@ class TmuxService {
     try {
       final output = await _exec(
         session,
-        "tmux ${extraFlags != null ? '$extraFlags ' : ''}display-message -p -t ${_shellQuote('$sessionName:')} "
-        "'#{pane_current_path}'",
+        _tmuxCommand(
+          "display-message -p -t ${_shellQuote('$sessionName:')} "
+          "'#{pane_current_path}'",
+          extraFlags: extraFlags,
+        ),
       );
       final path = parseTmuxCurrentPanePath(output);
       DiagnosticsLogService.instance.info(
@@ -681,8 +710,8 @@ class TmuxService {
     try {
       final output = await _exec(
         session,
-        "tmux ${extraFlags != null ? '$extraFlags ' : ''}list-clients -t ${_shellQuote(sessionName)} "
-        "-F '#{client_control_mode}' 2>/dev/null",
+        '${_tmuxCommand('list-clients -t ${_shellQuote(sessionName)} '
+        "-F '#{client_control_mode}'", extraFlags: extraFlags)} 2>/dev/null',
       );
       final hasClient = hasForegroundTmuxClient(output);
       DiagnosticsLogService.instance.info(
@@ -717,7 +746,7 @@ class TmuxService {
     final key = _TmuxWindowWatchKey(
       connectionId: session.connectionId,
       sessionName: sessionName,
-      extraFlags: extraFlags,
+      extraFlags: resolveTmuxClientFlagsFromExtraFlags(extraFlags),
     );
     final observer = _windowObservers.putIfAbsent(
       key,
@@ -766,7 +795,10 @@ class TmuxService {
     // (e.g. resuming an AI session in a specific project). Without -c,
     // tmux uses the session's default-directory — matching Ctrl+b,c.
     final parts = <String>[
-      "tmux ${extraFlags != null ? '$extraFlags ' : ''}new-window -P -F '#{window_index}' -t ${_shellQuote(sessionName)}",
+      _tmuxCommand(
+        "new-window -P -F '#{window_index}' -t ${_shellQuote(sessionName)}",
+        extraFlags: extraFlags,
+      ),
       if (workingDirectory != null && workingDirectory.trim().isNotEmpty)
         '-c ${_shellQuote(workingDirectory.trim())}',
       if (name != null && name.trim().isNotEmpty)
@@ -782,8 +814,11 @@ class TmuxService {
     if (agentTool != null) {
       await _exec(
         session,
-        "tmux ${extraFlags != null ? '$extraFlags ' : ''}set-option -w -t ${_shellQuote(target)} "
-        '@flutty_agent_tool ${_shellQuote(agentTool.commandName)}',
+        _tmuxCommand(
+          'set-option -w -t ${_shellQuote(target)} '
+          '@flutty_agent_tool ${_shellQuote(agentTool.commandName)}',
+          extraFlags: extraFlags,
+        ),
       );
     }
     DiagnosticsLogService.instance.info(
@@ -801,8 +836,11 @@ class TmuxService {
     if (command != null && command.trim().isNotEmpty) {
       _execFireAndForget(
         session,
-        "tmux ${extraFlags != null ? '$extraFlags ' : ''}send-keys -t ${_shellQuote(target)} "
-        '${_shellQuote(command.trim())} Enter',
+        _tmuxCommand(
+          'send-keys -t ${_shellQuote(target)} '
+          '${_shellQuote(command.trim())} Enter',
+          extraFlags: extraFlags,
+        ),
       );
       DiagnosticsLogService.instance.info(
         'tmux.action',
@@ -837,7 +875,10 @@ class TmuxService {
     );
     await _exec(
       session,
-      "tmux ${extraFlags != null ? '$extraFlags ' : ''}select-window -t ${_shellQuote(sessionName)}:$windowIndex",
+      _tmuxCommand(
+        'select-window -t ${_shellQuote(sessionName)}:$windowIndex',
+        extraFlags: extraFlags,
+      ),
     );
     DiagnosticsLogService.instance.info(
       'tmux.action',
@@ -866,7 +907,10 @@ class TmuxService {
     );
     await _exec(
       session,
-      "tmux ${extraFlags != null ? '$extraFlags ' : ''}kill-window -t ${_shellQuote(sessionName)}:$windowIndex",
+      _tmuxCommand(
+        'kill-window -t ${_shellQuote(sessionName)}:$windowIndex',
+        extraFlags: extraFlags,
+      ),
     );
     DiagnosticsLogService.instance.info(
       'tmux.action',
@@ -930,7 +974,7 @@ class TmuxService {
     _windowSnapshotCache[_TmuxWindowWatchKey(
       connectionId: session.connectionId,
       sessionName: sessionName,
-      extraFlags: extraFlags,
+      extraFlags: resolveTmuxClientFlagsFromExtraFlags(extraFlags),
     )] = List<TmuxWindow>.unmodifiable(
       windows,
     );
@@ -945,7 +989,7 @@ class TmuxService {
     final key = _TmuxWindowWatchKey(
       connectionId: session.connectionId,
       sessionName: sessionName,
-      extraFlags: extraFlags,
+      extraFlags: resolveTmuxClientFlagsFromExtraFlags(extraFlags),
     );
     final cachedWindows = _windowSnapshotCache[key];
     if (cachedWindows == null || cachedWindows.isEmpty) return;
@@ -987,6 +1031,9 @@ class TmuxService {
   String _forceUtf8TmuxCommand(String command) {
     final trimmed = command.trimLeft();
     if (!trimmed.startsWith('tmux ')) return command;
+    if (trimmed == 'tmux -u' || trimmed.startsWith('tmux -u ')) {
+      return command;
+    }
     return command.replaceFirst('tmux ', 'tmux -u ');
   }
 
@@ -1405,6 +1452,161 @@ bool hasForegroundTmuxClient(String output) {
   return false;
 }
 
+/// Extracts only tmux client/server flags that can be reused with commands
+/// other than `new-session`.
+@visibleForTesting
+String? resolveTmuxClientFlagsFromExtraFlags(String? extraFlags) {
+  final tokens = _tokenizeShellFragment(extraFlags);
+  if (tokens == null || tokens.isEmpty) {
+    return null;
+  }
+
+  final clientFlags = <String>[];
+  for (var index = 0; index < tokens.length; index++) {
+    final token = tokens[index];
+    if (_isTmuxCommandSeparatorToken(token.value)) {
+      break;
+    }
+    if (!_isReusableTmuxClientFlag(token.value)) {
+      continue;
+    }
+    if (token.value.length > 2) {
+      clientFlags.add(token.raw);
+      continue;
+    }
+    if (index + 1 >= tokens.length ||
+        _isTmuxCommandSeparatorToken(tokens[index + 1].value)) {
+      continue;
+    }
+    clientFlags.add('${token.raw} ${tokens[index + 1].raw}');
+    index++;
+  }
+
+  return clientFlags.isEmpty ? null : clientFlags.join(' ');
+}
+
+List<_ShellToken>? _tokenizeShellFragment(String? value) {
+  final normalized = value?.trim();
+  if (normalized == null || normalized.isEmpty) {
+    return const [];
+  }
+  if (normalized.contains('\n') || normalized.contains('\r')) {
+    return null;
+  }
+
+  final tokens = <_ShellToken>[];
+  var currentToken = StringBuffer();
+  var tokenStarted = false;
+  var tokenStart = 0;
+  var quoteMode = _ShellQuoteMode.none;
+
+  void startToken(int index) {
+    if (tokenStarted) {
+      return;
+    }
+    tokenStarted = true;
+    tokenStart = index;
+  }
+
+  void commitToken(int end) {
+    if (!tokenStarted) {
+      return;
+    }
+    tokens.add(
+      _ShellToken(
+        value: currentToken.toString(),
+        raw: normalized.substring(tokenStart, end),
+      ),
+    );
+    currentToken = StringBuffer();
+    tokenStarted = false;
+  }
+
+  for (var index = 0; index < normalized.length; index++) {
+    final character = normalized[index];
+
+    if (quoteMode == _ShellQuoteMode.single) {
+      if (character == "'") {
+        quoteMode = _ShellQuoteMode.none;
+      } else {
+        startToken(index);
+        currentToken.write(character);
+      }
+      continue;
+    }
+
+    if (quoteMode == _ShellQuoteMode.double) {
+      if (character == '"') {
+        quoteMode = _ShellQuoteMode.none;
+        continue;
+      }
+      if (character.codeUnitAt(0) == _backslashCodeUnit) {
+        if (index + 1 >= normalized.length) {
+          return null;
+        }
+        final nextCharacter = normalized[index + 1];
+        if (nextCharacter == '"' ||
+            nextCharacter.codeUnitAt(0) == _backslashCodeUnit ||
+            nextCharacter == r'$' ||
+            nextCharacter == '`') {
+          startToken(index);
+          currentToken.write(nextCharacter);
+          index++;
+          continue;
+        }
+      }
+      startToken(index);
+      currentToken.write(character);
+      continue;
+    }
+
+    if (character == ' ' || character == '\t') {
+      commitToken(index);
+      continue;
+    }
+    if (character == "'") {
+      startToken(index);
+      quoteMode = _ShellQuoteMode.single;
+      continue;
+    }
+    if (character == '"') {
+      startToken(index);
+      quoteMode = _ShellQuoteMode.double;
+      continue;
+    }
+    if (character.codeUnitAt(0) == _backslashCodeUnit) {
+      if (index + 1 >= normalized.length) {
+        return null;
+      }
+      startToken(index);
+      currentToken.write(normalized[index + 1]);
+      index++;
+      continue;
+    }
+    startToken(index);
+    currentToken.write(character);
+  }
+
+  if (quoteMode != _ShellQuoteMode.none) {
+    return null;
+  }
+
+  commitToken(normalized.length);
+  return tokens;
+}
+
+bool _isReusableTmuxClientFlag(String value) {
+  if (value == '-S' || value == '-L' || value == '-f') {
+    return true;
+  }
+  return value.length > 2 &&
+      (value.startsWith('-S') ||
+          value.startsWith('-L') ||
+          value.startsWith('-f'));
+}
+
+bool _isTmuxCommandSeparatorToken(String value) => value == ';';
+
 const _tmuxWindowSubscriptionFormat =
     '#{window_index}$tmuxWindowFieldSeparator'
     '#{window_name}$tmuxWindowFieldSeparator'
@@ -1425,7 +1627,7 @@ String buildTmuxControlModeAttachCommand(
   String sessionName, {
   String? extraFlags,
 }) =>
-    'tmux ${extraFlags != null ? '$extraFlags ' : ''}-CC attach-session -f $_tmuxControlModeClientFlags '
+    '${TmuxService._tmuxCommand('-CC attach-session -f $_tmuxControlModeClientFlags', extraFlags: extraFlags)} '
     '-t ${TmuxService._shellQuote(sessionName)}';
 
 /// Builds the tmux control-mode subscription command for window snapshots.

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2537,10 +2537,12 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     final connectionChanged = oldWidget.connectionId != widget.connectionId;
     final preferredSessionChanged =
         oldWidget.preferredSessionName != widget.preferredSessionName;
+    final tmuxExtraFlagsChanged =
+        oldWidget.tmuxExtraFlags != widget.tmuxExtraFlags;
     if (connectionChanged) {
       unawaited(_loadPreferredSessionToolName());
     }
-    if (connectionChanged || preferredSessionChanged) {
+    if (connectionChanged || preferredSessionChanged || tmuxExtraFlagsChanged) {
       _tmuxQueryGeneration++;
       _tmuxRetryTimer?.cancel();
       _tmuxRetryTimer = null;
@@ -2553,6 +2555,10 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         _queried = false;
         _loadingWindows = false;
         _pendingWindowReload = false;
+        if (tmuxExtraFlagsChanged) {
+          _showSessions = false;
+          _hasInitializedSessionProviders = false;
+        }
       });
       unawaited(_queryTmux());
     }

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1734,6 +1734,7 @@ class _ConnectionsPanel extends ConsumerWidget {
                             ),
                             connectionId: connection.connectionId,
                             preferredSessionName: preferredTmuxSessionName,
+                            tmuxExtraFlags: host?.tmuxExtraFlags,
                             onTap: () => unawaited(
                               context.push(
                                 '/terminal/${connection.hostId}'
@@ -2485,11 +2486,13 @@ class _TmuxConnectionBadge extends ConsumerStatefulWidget {
     required this.connectionId,
     required this.onTap,
     this.preferredSessionName,
+    this.tmuxExtraFlags,
     super.key,
   });
 
   final int connectionId;
   final String? preferredSessionName;
+  final String? tmuxExtraFlags;
 
   /// Called when the user taps a window chip — opens the terminal.
   final VoidCallback onTap;
@@ -2708,8 +2711,12 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     final preferredSessionName = widget.preferredSessionName?.trim();
     final active =
         preferredSessionName != null && preferredSessionName.isNotEmpty
-        ? await tmux.hasSession(session, preferredSessionName)
-        : await tmux.isTmuxActive(session);
+        ? await tmux.hasSession(
+            session,
+            preferredSessionName,
+            extraFlags: widget.tmuxExtraFlags,
+          )
+        : await tmux.isTmuxActive(session, extraFlags: widget.tmuxExtraFlags);
     if (!_isCurrentTmuxQuery(queryGeneration)) {
       return;
     }
@@ -2721,7 +2728,10 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     final sessionName =
         preferredSessionName != null && preferredSessionName.isNotEmpty
         ? preferredSessionName
-        : await tmux.currentSessionName(session);
+        : await tmux.currentSessionName(
+            session,
+            extraFlags: widget.tmuxExtraFlags,
+          );
     if (!_isCurrentTmuxQuery(queryGeneration)) {
       return;
     }
@@ -2733,7 +2743,11 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     await _windowChangeSubscription?.cancel();
     final generation = ++_windowEventGeneration;
     _windowChangeSubscription = tmux
-        .watchWindowChanges(session, sessionName)
+        .watchWindowChanges(
+          session,
+          sessionName,
+          extraFlags: widget.tmuxExtraFlags,
+        )
         .listen((event) {
           if (!_isCurrentTmuxQuery(queryGeneration)) return;
           _handleWindowChangeEvent(
@@ -2804,7 +2818,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     try {
       final windows = await ref
           .read(tmuxServiceProvider)
-          .listWindows(session, sessionName);
+          .listWindows(session, sessionName, extraFlags: widget.tmuxExtraFlags);
       if (!_isCurrentTmuxQuery(queryGeneration)) {
         return;
       }
@@ -3076,7 +3090,12 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     _runTmuxPreviewAction(
       ref
           .read(tmuxServiceProvider)
-          .killWindow(session, _sessionName!, windowIndex),
+          .killWindow(
+            session,
+            _sessionName!,
+            windowIndex,
+            extraFlags: widget.tmuxExtraFlags,
+          ),
     );
 
     // Optimistically remove from the list.
@@ -3094,7 +3113,12 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       _runTmuxPreviewAction(
         ref
             .read(tmuxServiceProvider)
-            .selectWindow(session, _sessionName!, windowIndex),
+            .selectWindow(
+              session,
+              _sessionName!,
+              windowIndex,
+              extraFlags: widget.tmuxExtraFlags,
+            ),
       );
     }
     widget.onTap();
@@ -3138,6 +3162,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
           command: command,
           name: info.toolName,
           workingDirectory: info.workingDirectory,
+          extraFlags: widget.tmuxExtraFlags,
         )
         .then((_) => widget.onTap())
         .ignore();

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -596,12 +596,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           CurvedAnimation(parent: _bounceController, curve: Curves.easeInOut),
         );
     unawaited(_loadPreferredLaunchTool());
-    unawaited(
-      _tmux.prefetchInstalledAgentTools(
-        widget.session,
-        extraFlags: widget.tmuxExtraFlags,
-      ),
-    );
+    unawaited(_tmux.prefetchInstalledAgentTools(widget.session));
     _loadWindows();
     _subscribeToWindowChanges();
   }
@@ -644,12 +639,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           }
         });
       }
-      unawaited(
-        _tmux.prefetchInstalledAgentTools(
-          widget.session,
-          extraFlags: widget.tmuxExtraFlags,
-        ),
-      );
+      unawaited(_tmux.prefetchInstalledAgentTools(widget.session));
     } else if (!(_windows?.isNotEmpty ?? false)) {
       setState(() => _isLoading = true);
     }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -485,6 +485,7 @@ class _TmuxExpandableBar extends StatefulWidget {
     required this.ref,
     required this.onAction,
     required this.onExpandedChanged,
+    this.tmuxExtraFlags,
     this.scopeWorkingDirectory,
     this.onWindowLoadStalled,
     super.key,
@@ -495,6 +496,9 @@ class _TmuxExpandableBar extends StatefulWidget {
 
   /// The tmux session name.
   final String tmuxSessionName;
+
+  /// Optional extra flags for tmux commands (e.g. custom socket path).
+  final String? tmuxExtraFlags;
 
   /// The available terminal height the bar can expand into.
   final double availableHeight;
@@ -592,7 +596,12 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           CurvedAnimation(parent: _bounceController, curve: Curves.easeInOut),
         );
     unawaited(_loadPreferredLaunchTool());
-    unawaited(_tmux.prefetchInstalledAgentTools(widget.session));
+    unawaited(
+      _tmux.prefetchInstalledAgentTools(
+        widget.session,
+        extraFlags: widget.tmuxExtraFlags,
+      ),
+    );
     _loadWindows();
     _subscribeToWindowChanges();
   }
@@ -602,7 +611,8 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     super.didUpdateWidget(oldWidget);
     final sessionChanged =
         oldWidget.session.connectionId != widget.session.connectionId ||
-        oldWidget.tmuxSessionName != widget.tmuxSessionName;
+        oldWidget.tmuxSessionName != widget.tmuxSessionName ||
+        oldWidget.tmuxExtraFlags != widget.tmuxExtraFlags;
     final recoveryChanged =
         oldWidget.recoveryGeneration != widget.recoveryGeneration;
     if (!sessionChanged && !recoveryChanged) {
@@ -634,7 +644,12 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           }
         });
       }
-      unawaited(_tmux.prefetchInstalledAgentTools(widget.session));
+      unawaited(
+        _tmux.prefetchInstalledAgentTools(
+          widget.session,
+          extraFlags: widget.tmuxExtraFlags,
+        ),
+      );
     } else if (!(_windows?.isNotEmpty ?? false)) {
       setState(() => _isLoading = true);
     }
@@ -679,7 +694,11 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       },
     );
     _windowChangeSubscription = _tmux
-        .watchWindowChanges(widget.session, widget.tmuxSessionName)
+        .watchWindowChanges(
+          widget.session,
+          widget.tmuxSessionName,
+          extraFlags: widget.tmuxExtraFlags,
+        )
         .listen((event) => _handleWindowChangeEvent(event, generation));
   }
 
@@ -915,6 +934,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       final reloadedWindows = await _tmux.listWindows(
         widget.session,
         widget.tmuxSessionName,
+        extraFlags: widget.tmuxExtraFlags,
       );
       if (!mounted) return;
       if (reloadGeneration < _windowReloadGeneration) return;
@@ -4482,8 +4502,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         final bool active;
         try {
           active = candidateSessionName != null
-              ? await tmux.hasSessionOrThrow(session, candidateSessionName)
-              : await tmux.isTmuxActiveOrThrow(session);
+              ? await tmux.hasSessionOrThrow(
+                  session,
+                  candidateSessionName,
+                  extraFlags: host?.tmuxExtraFlags,
+                )
+              : await tmux.isTmuxActiveOrThrow(
+                  session,
+                  extraFlags: host?.tmuxExtraFlags,
+                );
         } on Object catch (error) {
           hadDetectionFailure = true;
           DiagnosticsLogService.instance.warning(
@@ -4528,7 +4555,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
         var sessionName = candidateSessionName;
         try {
-          sessionName ??= await tmux.currentSessionName(session);
+          sessionName ??= await tmux.currentSessionName(
+            session,
+            extraFlags: host?.tmuxExtraFlags,
+          );
         } on Object catch (error) {
           hadDetectionFailure = true;
           DiagnosticsLogService.instance.warning(
@@ -4557,7 +4587,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
         final List<TmuxWindow> windows;
         try {
-          windows = await tmux.listWindows(session, sessionName);
+          windows = await tmux.listWindows(
+            session,
+            sessionName,
+            extraFlags: host?.tmuxExtraFlags,
+          );
         } on Object catch (error) {
           hadDetectionFailure = true;
           DiagnosticsLogService.instance.warning(
@@ -4853,6 +4887,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       key: _tmuxBarKey,
       session: session,
       tmuxSessionName: _tmuxSessionName!,
+      tmuxExtraFlags: _host?.tmuxExtraFlags,
       availableHeight: availableHeight,
       recoveryGeneration: _tmuxBarRecoveryGeneration,
       isProUser: isProUser,
@@ -4959,6 +4994,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       ref: ref,
       session: session,
       tmuxSessionName: _tmuxSessionName!,
+      tmuxExtraFlags: _host?.tmuxExtraFlags,
       isProUser: isProUser,
       startClisInYoloMode: _startClisInYoloMode,
       scopeWorkingDirectory: resolveTmuxAiSessionScopeWorkingDirectory(
@@ -5037,7 +5073,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     await ref
         .read(tmuxServiceProvider)
-        .selectWindow(session, sessionName, windowIndex);
+        .selectWindow(
+          session,
+          sessionName,
+          windowIndex,
+          extraFlags: _host?.tmuxExtraFlags,
+        );
 
     // Clear stale working directory — it will be refreshed from
     // OSC 7 or the next tmux query.
@@ -5070,6 +5111,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       currentPaneWorkingDirectory = await tmux.currentPanePath(
         session,
         sessionName,
+        extraFlags: _host?.tmuxExtraFlags,
       );
     }
     if (!mounted) return;
@@ -5086,6 +5128,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       command: command,
       name: name,
       workingDirectory: resolvedWorkingDirectory,
+      extraFlags: _host?.tmuxExtraFlags,
     );
     _tmuxWorkingDirectory = resolvedWorkingDirectory;
     await _reattachTmuxIfNeeded(session, sessionName);
@@ -5098,7 +5141,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     await ref
         .read(tmuxServiceProvider)
-        .killWindow(session, sessionName, windowIndex);
+        .killWindow(
+          session,
+          sessionName,
+          windowIndex,
+          extraFlags: _host?.tmuxExtraFlags,
+        );
   }
 
   Future<void> _reattachTmuxIfNeeded(
@@ -5110,6 +5158,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final hasForegroundClient = await tmux.hasForegroundClient(
       session,
       sessionName,
+      extraFlags: _host?.tmuxExtraFlags,
     );
     if (!mounted || hasForegroundClient) {
       DiagnosticsLogService.instance.info(

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -55,6 +55,7 @@ Future<TmuxNavigatorAction?> showTmuxNavigator({
   required String tmuxSessionName,
   required bool isProUser,
   required bool startClisInYoloMode,
+  String? tmuxExtraFlags,
   String? scopeWorkingDirectory,
 }) => showModalBottomSheet<TmuxNavigatorAction>(
   context: context,
@@ -62,6 +63,7 @@ Future<TmuxNavigatorAction?> showTmuxNavigator({
   builder: (context) => _TmuxNavigatorSheet(
     session: session,
     tmuxSessionName: tmuxSessionName,
+    tmuxExtraFlags: tmuxExtraFlags,
     isProUser: isProUser,
     startClisInYoloMode: startClisInYoloMode,
     ref: ref,
@@ -133,11 +135,13 @@ class _TmuxNavigatorSheet extends StatefulWidget {
     required this.isProUser,
     required this.startClisInYoloMode,
     required this.ref,
+    this.tmuxExtraFlags,
     this.scopeWorkingDirectory,
   });
 
   final SshSession session;
   final String tmuxSessionName;
+  final String? tmuxExtraFlags;
   final bool isProUser;
   final bool startClisInYoloMode;
   final WidgetRef ref;
@@ -211,7 +215,11 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       },
     );
     _windowChangeSubscription = _tmux
-        .watchWindowChanges(widget.session, widget.tmuxSessionName)
+        .watchWindowChanges(
+          widget.session,
+          widget.tmuxSessionName,
+          extraFlags: widget.tmuxExtraFlags,
+        )
         .listen((event) => _handleWindowChangeEvent(event, generation));
   }
 
@@ -274,6 +282,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
       final reloadedWindows = await _tmux.listWindows(
         widget.session,
         widget.tmuxSessionName,
+        extraFlags: widget.tmuxExtraFlags,
       );
       if (!mounted) return;
       if (reloadGeneration < _windowReloadGeneration) return;

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -33,7 +33,7 @@ void main() {
             'main',
             extraFlags: '-x 160 -S /tmp/tmux-socket -n editor',
           ),
-          'tmux -S /tmp/tmux-socket -CC attach-session -f '
+          "tmux -S '/tmp/tmux-socket' -CC attach-session -f "
           'read-only,ignore-size,no-output,wait-exit '
           "-t 'main'",
         );
@@ -45,13 +45,34 @@ void main() {
         resolveTmuxClientFlagsFromExtraFlags(
           r'-x 160 -S "/tmp/tmux socket" -y 48 \; set status off',
         ),
-        '-S "/tmp/tmux socket"',
+        "-S '/tmp/tmux socket'",
       );
       expect(
         resolveTmuxClientFlagsFromExtraFlags('-L alerts -f ~/.tmux.conf'),
-        '-L alerts -f ~/.tmux.conf',
+        r"""-L 'alerts' -f "$HOME"'/.tmux.conf'""",
       );
       expect(resolveTmuxClientFlagsFromExtraFlags('-x 200 -n editor'), isNull);
+    });
+
+    test('shell-quotes reusable client flag values', () {
+      expect(
+        resolveTmuxClientFlagsFromExtraFlags(r'-S "$(touch /tmp/pwn)"'),
+        r"-S '$(touch /tmp/pwn)'",
+      );
+      expect(
+        resolveTmuxClientFlagsFromExtraFlags('-L `id` -f /tmp/>out'),
+        "-L '`id`' -f '/tmp/>out'",
+      );
+      expect(
+        resolveTmuxClientFlagsFromExtraFlags(
+          '-S/tmp/sock;id -Lname&&id -f/tmp/sock|id',
+        ),
+        "-S '/tmp/sock;id' -L 'name&&id' -f '/tmp/sock|id'",
+      );
+      expect(
+        resolveTmuxClientFlagsFromExtraFlags('-S /tmp/socket ; set status off'),
+        "-S '/tmp/socket'",
+      );
     });
 
     test(
@@ -508,6 +529,38 @@ void main() {
       },
     );
 
+    test('listWindows uses only reusable client flags when provided', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client);
+      const service = TmuxService();
+      final execSession = _buildOpenExecSession(
+        stdout:
+            '1|editor|1|vim|/tmp|*|vim-title|1712930000\n'
+            '${_doneMarker()}',
+      );
+
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) async => execSession);
+
+      await service.listWindows(
+        session,
+        'main',
+        extraFlags: r'-S /tmp/socket -x 160 \; set status off',
+      );
+
+      final command =
+          verify(
+                () => client.execute(captureAny(), pty: any(named: 'pty')),
+              ).captured.single
+              as String;
+      expect(
+        command,
+        contains("tmux -u -S '/tmp/socket' list-windows -t 'main' -F "),
+      );
+      expect(command, isNot(contains('set status off')));
+    });
+
     test('listWindows coalesces duplicate in-flight reloads', () async {
       final client = _MockSshClient();
       final session = _buildSession(client);
@@ -623,6 +676,56 @@ void main() {
     );
 
     test(
+      'watchWindowChanges attaches with only reusable client flags',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client);
+        const service = TmuxService();
+        final execSessions = Queue<SSHSession>.from([
+          _buildOpenExecSession(stdout: 'zsh\n/usr/bin/tmux\n${_doneMarker()}'),
+          _buildOpenExecSession(),
+        ]);
+
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => execSessions.removeFirst());
+
+        final subscription = service
+            .watchWindowChanges(
+              session,
+              'main',
+              extraFlags: r'-S /tmp/socket -x 160 \; set status off',
+            )
+            .listen((_) {});
+        await untilCalled(
+          () => client.execute(
+            any(that: contains('attach-session')),
+            pty: any(named: 'pty'),
+          ),
+        );
+
+        final command =
+            verify(
+                  () => client.execute(
+                    captureAny(that: contains('attach-session')),
+                    pty: any(named: 'pty'),
+                  ),
+                ).captured.single
+                as String;
+        expect(
+          command,
+          contains(
+            "/usr/bin/tmux -u -S '/tmp/socket' -CC attach-session -f "
+            'read-only,ignore-size,no-output,wait-exit ',
+          ),
+        );
+        expect(command, isNot(contains('set status off')));
+
+        await subscription.cancel();
+      },
+    );
+
+    test(
       'selectWindow completes when stdout stays open after the done marker',
       () async {
         final client = _MockSshClient();
@@ -674,7 +777,7 @@ void main() {
           () => client.execute(
             any(
               that: contains(
-                "tmux -u -S /tmp/socket select-window -t 'main':2",
+                "tmux -u -S '/tmp/socket' select-window -t 'main':2",
               ),
             ),
             pty: any(named: 'pty'),
@@ -955,10 +1058,16 @@ Stream<Uint8List> _closedUtf8Stream(String value) =>
 
 void _ignoreInvocation(Invocation _) {}
 
-SSHSession _buildOpenExecSession({String stdout = '', String stderr = ''}) {
+SSHSession _buildOpenExecSession({
+  String stdout = '',
+  String stderr = '',
+  Future<void>? done,
+}) {
   final session = _MockExecSession();
+  final doneFuture = done ?? Completer<void>().future;
   when(() => session.stdout).thenAnswer((_) => _openUtf8Stream(stdout));
   when(() => session.stderr).thenAnswer((_) => _openUtf8Stream(stderr));
+  when(() => session.done).thenAnswer((_) => doneFuture);
   when(session.close).thenAnswer(_ignoreInvocation);
   return session;
 }
@@ -967,6 +1076,7 @@ SSHSession _buildClosedExecSession({String stdout = '', String stderr = ''}) {
   final session = _MockExecSession();
   when(() => session.stdout).thenAnswer((_) => _closedUtf8Stream(stdout));
   when(() => session.stderr).thenAnswer((_) => _closedUtf8Stream(stderr));
+  when(() => session.done).thenAnswer((_) => Future<void>.value());
   when(session.close).thenAnswer(_ignoreInvocation);
   return session;
 }

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -25,6 +25,18 @@ void main() {
       },
     );
 
+    test('attach command includes extraFlags when provided', () {
+      expect(
+        buildTmuxControlModeAttachCommand(
+          'main',
+          extraFlags: '-S /tmp/tmux-socket',
+        ),
+        'tmux -S /tmp/tmux-socket -CC attach-session -f '
+        'read-only,ignore-size,no-output,wait-exit '
+        "-t 'main'",
+      );
+    });
+
     test(
       'subscription command watches all windows in the attached session',
       () {
@@ -621,6 +633,33 @@ void main() {
         verify(execSession.close).called(1);
       },
     );
+
+    test('selectWindow uses extraFlags when provided', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client);
+      const service = TmuxService();
+      final execSession = _buildOpenExecSession(stdout: _doneMarker());
+
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) async => execSession);
+
+      await service.selectWindow(
+        session,
+        'main',
+        2,
+        extraFlags: '-S /tmp/socket',
+      );
+
+      verify(
+        () => client.execute(
+          any(
+            that: contains("tmux -u -S /tmp/socket select-window -t 'main':2"),
+          ),
+          pty: any(named: 'pty'),
+        ),
+      ).called(1);
+    });
 
     test(
       'killWindow waits for the done marker so failures can surface',

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -25,16 +25,33 @@ void main() {
       },
     );
 
-    test('attach command includes extraFlags when provided', () {
+    test(
+      'attach command includes reusable tmux client flags when provided',
+      () {
+        expect(
+          buildTmuxControlModeAttachCommand(
+            'main',
+            extraFlags: '-x 160 -S /tmp/tmux-socket -n editor',
+          ),
+          'tmux -S /tmp/tmux-socket -CC attach-session -f '
+          'read-only,ignore-size,no-output,wait-exit '
+          "-t 'main'",
+        );
+      },
+    );
+
+    test('extracts only reusable client flags from tmux extra flags', () {
       expect(
-        buildTmuxControlModeAttachCommand(
-          'main',
-          extraFlags: '-S /tmp/tmux-socket',
+        resolveTmuxClientFlagsFromExtraFlags(
+          r'-x 160 -S "/tmp/tmux socket" -y 48 \; set status off',
         ),
-        'tmux -S /tmp/tmux-socket -CC attach-session -f '
-        'read-only,ignore-size,no-output,wait-exit '
-        "-t 'main'",
+        '-S "/tmp/tmux socket"',
       );
+      expect(
+        resolveTmuxClientFlagsFromExtraFlags('-L alerts -f ~/.tmux.conf'),
+        '-L alerts -f ~/.tmux.conf',
+      );
+      expect(resolveTmuxClientFlagsFromExtraFlags('-x 200 -n editor'), isNull);
     });
 
     test(
@@ -634,32 +651,37 @@ void main() {
       },
     );
 
-    test('selectWindow uses extraFlags when provided', () async {
-      final client = _MockSshClient();
-      final session = _buildSession(client);
-      const service = TmuxService();
-      final execSession = _buildOpenExecSession(stdout: _doneMarker());
+    test(
+      'selectWindow uses only reusable client flags when provided',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client);
+        const service = TmuxService();
+        final execSession = _buildOpenExecSession(stdout: _doneMarker());
 
-      when(
-        () => client.execute(any(), pty: any(named: 'pty')),
-      ).thenAnswer((_) async => execSession);
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => execSession);
 
-      await service.selectWindow(
-        session,
-        'main',
-        2,
-        extraFlags: '-S /tmp/socket',
-      );
+        await service.selectWindow(
+          session,
+          'main',
+          2,
+          extraFlags: r'-S /tmp/socket -x 160 \; set status off',
+        );
 
-      verify(
-        () => client.execute(
-          any(
-            that: contains("tmux -u -S /tmp/socket select-window -t 'main':2"),
+        verify(
+          () => client.execute(
+            any(
+              that: contains(
+                "tmux -u -S /tmp/socket select-window -t 'main':2",
+              ),
+            ),
+            pty: any(named: 'pty'),
           ),
-          pty: any(named: 'pty'),
-        ),
-      ).called(1);
-    });
+        ).called(1);
+      },
+    );
 
     test(
       'killWindow waits for the done marker so failures can surface',

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -77,6 +77,7 @@ Host _buildHost({
   required int id,
   String? autoConnectCommand,
   String? tmuxSessionName,
+  String? tmuxExtraFlags,
 }) => Host(
   id: id,
   label: 'Terminal test host',
@@ -85,6 +86,7 @@ Host _buildHost({
   username: 'root',
   autoConnectCommand: autoConnectCommand,
   tmuxSessionName: tmuxSessionName,
+  tmuxExtraFlags: tmuxExtraFlags,
   isFavorite: false,
   createdAt: DateTime(2026),
   updatedAt: DateTime(2026),
@@ -812,6 +814,7 @@ void main() {
       (tester) async {
         final tmuxService = _MockTmuxService();
         const tmuxSessionName = 'alerts';
+        const tmuxExtraFlags = '-S /tmp/alerts.sock';
         const targetWindowIndex = 3;
         final windows = <TmuxWindow>[
           const TmuxWindow(index: 1, name: 'shell', isActive: true),
@@ -828,24 +831,46 @@ void main() {
           }
           return shellChannel;
         });
+        host = _buildHost(
+          id: host.id,
+          tmuxSessionName: tmuxSessionName,
+          tmuxExtraFlags: tmuxExtraFlags,
+        );
         when(
-          () => tmuxService.hasSessionOrThrow(session, tmuxSessionName),
+          () => tmuxService.hasSessionOrThrow(
+            session,
+            tmuxSessionName,
+            extraFlags: tmuxExtraFlags,
+          ),
         ).thenAnswer((_) async => true);
         when(
-          () => tmuxService.listWindows(session, tmuxSessionName),
+          () => tmuxService.listWindows(
+            session,
+            tmuxSessionName,
+            extraFlags: tmuxExtraFlags,
+          ),
         ).thenAnswer((_) async => windows);
         when(
           () => tmuxService.selectWindow(
             session,
             tmuxSessionName,
             targetWindowIndex,
+            extraFlags: tmuxExtraFlags,
           ),
         ).thenAnswer((_) async {});
         when(
-          () => tmuxService.hasForegroundClient(session, tmuxSessionName),
+          () => tmuxService.hasForegroundClient(
+            session,
+            tmuxSessionName,
+            extraFlags: tmuxExtraFlags,
+          ),
         ).thenAnswer((_) async => false);
         when(
-          () => tmuxService.watchWindowChanges(session, tmuxSessionName),
+          () => tmuxService.watchWindowChanges(
+            session,
+            tmuxSessionName,
+            extraFlags: tmuxExtraFlags,
+          ),
         ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
         when(
           () => tmuxService.prefetchInstalledAgentTools(session),
@@ -895,11 +920,30 @@ void main() {
             session,
             tmuxSessionName,
             targetWindowIndex,
+            extraFlags: tmuxExtraFlags,
           ),
         ).called(1);
         verify(
-          () => tmuxService.hasForegroundClient(session, tmuxSessionName),
+          () => tmuxService.hasForegroundClient(
+            session,
+            tmuxSessionName,
+            extraFlags: tmuxExtraFlags,
+          ),
         ).called(1);
+        verify(
+          () => tmuxService.hasSessionOrThrow(
+            session,
+            tmuxSessionName,
+            extraFlags: tmuxExtraFlags,
+          ),
+        ).called(1);
+        verify(
+          () => tmuxService.listWindows(
+            session,
+            tmuxSessionName,
+            extraFlags: tmuxExtraFlags,
+          ),
+        ).called(greaterThanOrEqualTo(1));
         expect(find.textContaining('tmux action failed'), findsNothing);
         expect(
           find.text(

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -145,6 +145,7 @@ Host _buildHost({
   required int sortOrder,
   String? autoConnectCommand,
   String? tmuxSessionName,
+  String? tmuxExtraFlags,
 }) => Host(
   id: id,
   label: label,
@@ -170,7 +171,7 @@ Host _buildHost({
   autoConnectRequiresConfirmation: false,
   tmuxSessionName: tmuxSessionName,
   tmuxWorkingDirectory: null,
-  tmuxExtraFlags: null,
+  tmuxExtraFlags: tmuxExtraFlags,
   sortOrder: sortOrder,
 );
 
@@ -732,6 +733,117 @@ void main() {
       expect(find.text('correct-session · 1 windows'), findsOneWidget);
     },
   );
+
+  testWidgets('refreshes tmux badge when host extra flags change', (
+    tester,
+  ) async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final tmuxService = _MockTmuxService();
+    final sshClient = _MockSshClient();
+    final hostsController = StreamController<List<Host>>.broadcast();
+    addTearDown(hostsController.close);
+
+    final session = SshSession(
+      connectionId: 7,
+      hostId: 1,
+      client: sshClient,
+      config: const SshConnectionConfig(
+        hostname: 'alpha.example.com',
+        port: 22,
+        username: 'root',
+      ),
+    );
+    final sessionsNotifier = _MutableActiveSessionsNotifier(
+      initialConnections: [_buildActiveConnection(connectionId: 7, hostId: 1)],
+      initialSessions: [session],
+    );
+
+    const oldFlags = '-S /tmp/old.sock';
+    const newFlags = '-S /tmp/new.sock';
+    when(
+      () => tmuxService.hasSession(session, 'work', extraFlags: oldFlags),
+    ).thenAnswer((_) async => true);
+    when(
+      () =>
+          tmuxService.watchWindowChanges(session, 'work', extraFlags: oldFlags),
+    ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+    when(
+      () => tmuxService.listWindows(session, 'work', extraFlags: oldFlags),
+    ).thenAnswer(
+      (_) async => const <TmuxWindow>[
+        TmuxWindow(index: 0, name: 'old-server', isActive: true),
+      ],
+    );
+    when(
+      () => tmuxService.hasSession(session, 'work', extraFlags: newFlags),
+    ).thenAnswer((_) async => true);
+    when(
+      () =>
+          tmuxService.watchWindowChanges(session, 'work', extraFlags: newFlags),
+    ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+    when(
+      () => tmuxService.listWindows(session, 'work', extraFlags: newFlags),
+    ).thenAnswer(
+      (_) async => const <TmuxWindow>[
+        TmuxWindow(index: 0, name: 'new-server', isActive: true),
+      ],
+    );
+
+    await tester.pumpWidget(
+      buildMobileHomeScreen(
+        db: db,
+        overrides: [
+          activeSessionsProvider.overrideWith(() => sessionsNotifier),
+          allHostsProvider.overrideWith((ref) => hostsController.stream),
+          tmuxServiceProvider.overrideWithValue(tmuxService),
+        ],
+      ),
+    );
+    await tester.pump();
+    hostsController.add([
+      _buildHost(
+        id: 1,
+        label: 'Alpha',
+        sortOrder: 0,
+        tmuxSessionName: 'work',
+        tmuxExtraFlags: oldFlags,
+      ),
+    ]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    await tester.tap(find.text('Connections').first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('work · 1 windows'), findsOneWidget);
+    await tester.tap(find.text('work · 1 windows'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(find.text('old-server'), findsOneWidget);
+
+    hostsController.add([
+      _buildHost(
+        id: 1,
+        label: 'Alpha',
+        sortOrder: 0,
+        tmuxSessionName: 'work',
+        tmuxExtraFlags: newFlags,
+      ),
+    ]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('new-server'), findsOneWidget);
+    expect(find.text('old-server'), findsNothing);
+    verify(
+      () => tmuxService.listWindows(session, 'work', extraFlags: oldFlags),
+    ).called(1);
+    verify(
+      () => tmuxService.listWindows(session, 'work', extraFlags: newFlags),
+    ).called(1);
+  });
 
   testWidgets('returns to Hosts when the last active connection disappears', (
     tester,


### PR DESCRIPTION
This PR fixes a bug where tmux alert notifications could open the terminal but select against the wrong tmux server/window when a host starts tmux with custom client/server flags such as `-S`, `-L`, or `-f`.

What changed:

- Thread the host tmux flags through tmux detection, window listing, control-mode watches, and window actions used by alert notification routing.
- Extract only reusable tmux client/server flags for follow-up commands, so new-session-only flags like `-x`, `-y`, `-n`, and `\; set status off` do not break `list-windows`, `select-window`, or control-mode attach.
- Keep tmux window caches/watchers separated by the effective client flags so custom socket sessions do not share stale state with default tmux sessions.

Validation:

- `flutter analyze`
- `flutter test test/domain/services/tmux_service_control_mode_test.dart test/domain/services/local_notification_service_test.dart`
- `flutter test test/presentation/screens/terminal_screen_test.dart`
- Full pre-commit checks, including analyzer and the repo test suite
