### PR TITLE
ci: add regenerate iOS provisioning profiles workflow

### DIFF
--- a/.github/workflows/regenerate-ios-profiles.yml
+++ b/.github/workflows/regenerate-ios-profiles.yml
@@ -1,0 +1,54 @@
+name: Regenerate iOS Provisioning Profiles
+
+# Run this workflow manually after changing App ID capabilities in Apple
+# Developer (e.g. enabling "Access WiFi Information"). It force-regenerates
+# the provisioning profiles via fastlane match so that the new entitlements
+# are baked into the profile stored in the match git repo. Subsequent
+# normal builds will then pick up the refreshed profile via setup_signing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      scheme:
+        description: 'Which scheme to regenerate (default: both)'
+        required: false
+        type: choice
+        default: 'both'
+        options:
+          - both
+          - Private
+          - Production
+
+permissions:
+  contents: read
+
+jobs:
+  regenerate:
+    name: Regenerate provisioning profiles
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Regenerate provisioning profiles
+        env:
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
+        run: |
+          cd ios
+          if [ "${{ inputs.scheme }}" = "both" ]; then
+            bundle exec fastlane regenerate_profiles
+          else
+            bundle exec fastlane regenerate_profiles scheme:${{ inputs.scheme }}
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,20 @@
 - Use JDK 17 for Android/Gradle builds in this repo. JDK 25 fails in the Android/Kotlin toolchain with `IllegalArgumentException: 25.0.1`.
 - On macOS, set `JAVA_HOME="$(/usr/libexec/java_home -v 17)"` before running `flutter build ...` or `./gradlew ...` for Android.
 
+## iOS provisioning profiles after capability changes
+
+After enabling a new App ID capability in the Apple Developer portal (e.g. Access WiFi Information, Push Notifications, App Groups), the existing provisioning profiles in the match git repo are stale — they don't include the new entitlement, so signing with the new entitlements file in `ios/Runner/Runner.entitlements` will fail.
+
+Refresh once via the **Regenerate iOS Provisioning Profiles** GitHub Actions workflow (`workflow_dispatch`), or run locally:
+
+```bash
+cd ios
+bundle exec fastlane regenerate_profiles            # both Private + Production
+bundle exec fastlane regenerate_profiles scheme:Private
+```
+
+Local Xcode builds with automatic signing pick up the new entitlement on next build without any extra step (Xcode regenerates dev profiles via the developer portal automatically).
+
 ## Manual testing: tmux navigation
 
 The tmux navigator feature requires a real SSH connection to a host running tmux. Use the setup script to create a local test environment:

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -43,6 +43,7 @@ platform :ios do
     app_id = options[:app_identifier]
     match_type = options[:type] || 'appstore'
     readonly = options.key?(:readonly) ? options[:readonly] : true
+    force = options[:force] == true
 
     api_key = get_api_key
 
@@ -51,6 +52,7 @@ platform :ios do
       app_identifier: app_id,
       api_key: api_key,
       readonly: readonly,
+      force: force,
     )
   end
 
@@ -244,6 +246,26 @@ platform :ios do
   lane :setup_signing do |options|
     app_id = options[:app_identifier] || 'xyz.depollsoft.monkeyssh.private'
     sync_certs(app_identifier: app_id, type: 'appstore')
+  end
+
+  desc 'Force-regenerate provisioning profiles for both bundle IDs and their ' \
+       'live activity extensions. Run this after enabling a new App ID ' \
+       'capability (e.g. Access WiFi Information) so the new entitlement is ' \
+       'baked into the profile stored in the match git repo.'
+  lane :regenerate_profiles do |options|
+    schemes = options[:scheme] ? [options[:scheme]] : APP_IDS.keys
+    schemes.each do |scheme|
+      app_id = APP_IDS[scheme]
+      live_activity_app_id = LIVE_ACTIVITY_APP_IDS[scheme]
+      UI.user_error!("Unknown scheme '#{scheme}'") unless app_id && live_activity_app_id
+
+      sync_certs(
+        app_identifier: [app_id, live_activity_app_id],
+        type: 'appstore',
+        readonly: false,
+        force: true,
+      )
+    end
   end
 
   desc 'Build and sign an IPA without uploading it'


### PR DESCRIPTION
Cherry-picks the CI-only commit from #381 onto main so the workflow file lands on the default branch — required before \`workflow_dispatch\` can trigger it. This is a prerequisite for refreshing the match-managed profiles after the new \"Access WiFi Information\" capability was enabled in Apple Developer portal.

## What's in here
- \`regenerate_profiles\` lane in \`ios/fastlane/Fastfile\` (force-regen via match)
- \`force\` option threaded through the existing \`sync_certs\` private lane
- New \`Regenerate iOS Provisioning Profiles\` workflow_dispatch GitHub Actions workflow
- AGENTS.md note documenting when to run it

No application code changes — pure CI tooling. The full feature work lives in #381.

## After merging
Trigger \"Regenerate iOS Provisioning Profiles\" from the Actions tab (default scheme: both). Subsequent normal builds will pick up the refreshed profiles via the existing setup_signing step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)