### PR TITLE
perf: stop relaying out terminal on every scroll tick / idle redraw

### DIFF
--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1289,11 +1289,17 @@ class MonkeyRenderTerminal extends RenderBox
   bool _selectionGeometryNotificationScheduled = false;
   final Set<VoidCallback> _selectionListeners = <VoidCallback>{};
 
+  int _lastKnownLineCount = -1;
+
   void _onScroll() {
     _stickToBottom = _scrollOffset >= _maxScrollExtent;
-    markNeedsLayout();
-    _updateSelectionGeometry(deferNotification: true);
-    _notifyEditableRect();
+    markNeedsPaint();
+    if (_hasSelectableTextSelection) {
+      _updateSelectionGeometry(deferNotification: true);
+    }
+    if (_onEditableRect != null) {
+      _notifyEditableRect();
+    }
   }
 
   void _onFocusChange() {
@@ -1306,8 +1312,16 @@ class MonkeyRenderTerminal extends RenderBox
     } else {
       _syncSelectableSelectionFromController();
     }
-    markNeedsLayout();
-    _notifyEditableRect();
+    final lineCount = _terminal.buffer.lines.length;
+    if (lineCount != _lastKnownLineCount) {
+      _lastKnownLineCount = lineCount;
+      markNeedsLayout();
+    } else {
+      markNeedsPaint();
+    }
+    if (_onEditableRect != null) {
+      _notifyEditableRect();
+    }
   }
 
   void _onControllerUpdate() {


### PR DESCRIPTION
## Summary

- Stop marking the terminal render object as needing layout on every scroll callback — scroll position changes don't move the viewport, content dimensions, or cell metrics, so a paint pass is sufficient.
- Stop relaying out on every `Terminal` listener notification when the line count hasn't changed. Idle in-place rewrites (status lines, spinners) now mark paint only; layout still runs when new lines are appended (which is what `_maxScrollExtent` and stick-to-bottom actually depend on).
- Skip the per-scroll selection-geometry recompute and editable-rect notification when there is no active selection / IME consumer.

## Why

With quiet CLIs (plain shell, Codex, Gemini, Copilot, vim, less, tmux), the in-app terminal scrolls smoothly. With Claude Code, finger-scrolling through scrollback feels noticeably laggy. The differentiator is that Claude Code's UI repaints its status line / spinner several times a second even while "idle." That made every spinner tick fire `Terminal.notifyListeners()` → `_onTerminalChange()` → `markNeedsLayout()`, which then contended with scroll-driven repaints in the same frame budget. Combined with the heavy per-cell paint cost of Claude Code's truecolor styling, frames started dropping.

## Test plan

- [x] `flutter analyze` clean on the changed file
- [x] Existing terminal widget tests pass (`monkey_terminal_view_*`, `monkey_terminal_*_gesture_handler`, `terminal_screen_*`)
- [x] Full pre-commit test suite (1630+ tests) green
- [ ] Manual: launch Claude Code in a tmux session, generate ~screenfuls of styled output, finger-scroll up through history while the spinner is animating — should feel as smooth as plain shell scroll
- [ ] Manual sanity: stick-to-bottom still works when new output arrives at the bottom; resize still rewraps; selection drag still tracks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
