### PR TITLE
fix: keep iOS backspace repeat fast

### DIFF
--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -40,8 +40,12 @@ const modifierChordFollowUpWindow = Duration(milliseconds: 500);
 const terminalKeyboardTapLongPressTimeout = kLongPressTimeout;
 
 /// How long iOS keeps the IME buffer intact after a trailing backspace.
+///
+/// Held iOS backspace can briefly pause between native repeat phases, so keep
+/// the buffer alive long enough that those pauses do not fall back to the slow
+/// marker-deletion path.
 @visibleForTesting
-const terminalIosBackspaceRepeatSettleDelay = Duration(milliseconds: 250);
+const terminalIosBackspaceRepeatSettleDelay = Duration(seconds: 2);
 
 /// Delay before iOS hardware keys begin app-controlled repeat.
 @visibleForTesting

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -6771,6 +6771,65 @@ void main() {
       },
     );
 
+    testWidgets(
+      'keeps the iOS backspace buffer through slow native repeat gaps',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        try {
+          final harness = await _pumpTerminalHarness(tester);
+
+          tester.testTextInput.updateEditingValue(
+            _editingValue('hello', selectionOffset: 5),
+          );
+          await tester.pump();
+          harness.terminalOutput.clear();
+          tester.testTextInput.log.clear();
+
+          tester.testTextInput.updateEditingValue(
+            _editingValue('hell', selectionOffset: 4),
+          );
+          await tester.pump();
+
+          await tester.pump(const Duration(milliseconds: 600));
+
+          expect(
+            tester.testTextInput.log.where(
+              (call) => call.method == 'TextInput.setEditingState',
+            ),
+            isEmpty,
+          );
+          expect(
+            _terminalTextInputClient(tester).currentTextEditingValue,
+            _editingValue('hell', selectionOffset: 4),
+          );
+
+          tester.testTextInput.updateEditingValue(
+            _editingValue('hel', selectionOffset: 3),
+          );
+          await tester.pump();
+
+          expect(
+            _terminalStateFromEvents(
+              harness.terminalOutput,
+              initialText: 'hello',
+              initialCursorOffset: 5,
+            ),
+            (text: 'hel', cursorOffset: 3),
+          );
+          expect(
+            tester.testTextInput.log.where(
+              (call) => call.method == 'TextInput.setEditingState',
+            ),
+            isEmpty,
+          );
+
+          await _disposeTerminalHarness(tester, harness);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
     testWidgets('typing cancels the deferred iOS trailing backspace clear', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- Keep the iOS trailing-backspace IME buffer alive across slower native repeat gaps so held delete does not fall back to the slow marker path mid-repeat.
- Add a regression test covering a slower repeat cadence between iOS backspace updates.

## Tests

- `flutter analyze`
- `flutter test test/widget/terminal_text_input_handler_test.dart`
- `flutter test`
