### PR TITLE
Warn before discarding unsaved edits

### DIFF
--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -28,6 +28,7 @@ import '../widgets/premium_access.dart';
 import '../widgets/premium_badge.dart';
 import '../widgets/terminal_text_style.dart';
 import '../widgets/terminal_theme_picker.dart';
+import '../widgets/unsaved_changes_guard.dart';
 import 'transfer_screen.dart';
 
 enum _HostStartupMode { none, tmux, agent, customCommand, snippet }
@@ -81,6 +82,37 @@ String? _resolveTmuxExtraFlags({
   }
   return '$normalized $tmuxDisableStatusBarCommand';
 }
+
+typedef _HostEditDraft = ({
+  String label,
+  String hostname,
+  String port,
+  String username,
+  String password,
+  String tags,
+  String autoConnectCommand,
+  String tmuxSession,
+  String tmuxWorkingDirectory,
+  String tmuxExtraFlags,
+  String agentWorkingDirectory,
+  String agentTmuxSession,
+  String agentTmuxExtraFlags,
+  String agentArguments,
+  int? selectedKeyId,
+  int? selectedGroupId,
+  int? selectedJumpHostId,
+  int? selectedAutoConnectSnippetId,
+  String? selectedLightThemeId,
+  String? selectedDarkThemeId,
+  String? selectedFontFamily,
+  _HostStartupMode selectedStartupMode,
+  AutoConnectCommandMode selectedAutoConnectMode,
+  AgentLaunchTool selectedAgentLaunchTool,
+  bool isFavorite,
+  bool disableTmuxStatusBar,
+  bool disableAgentTmuxStatusBar,
+  bool startClisInYoloMode,
+});
 
 /// Screen for adding or editing a host.
 class HostEditScreen extends ConsumerStatefulWidget {
@@ -151,6 +183,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
 
   Host? _existingHost;
   List<PortForward> _portForwards = [];
+  _HostEditDraft? _initialDraft;
 
   @override
   void initState() {
@@ -180,8 +213,11 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
 
     if (widget.hostId != null) {
       _loadHost();
-    } else if (widget.initialSshUrl?.trim().isNotEmpty ?? false) {
-      _applySshUrl(widget.initialSshUrl!.trim());
+    } else {
+      if (widget.initialSshUrl?.trim().isNotEmpty ?? false) {
+        _applySshUrl(widget.initialSshUrl!.trim());
+      }
+      _initialDraft = _currentDraft();
     }
   }
 
@@ -207,7 +243,10 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     final host = await ref.read(hostRepositoryProvider).getById(widget.hostId!);
     if (!mounted) return;
     if (host == null) {
-      setState(() => _isLoading = false);
+      setState(() {
+        _isLoading = false;
+        _initialDraft = _currentDraft();
+      });
       return;
     }
     final portForwards = await ref
@@ -273,6 +312,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       _isFavorite = host.isFavorite;
       _portForwards = portForwards;
       _isLoading = false;
+      _initialDraft = _currentDraft();
     });
   }
 
@@ -304,6 +344,62 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     super.dispose();
   }
 
+  bool get _hasUnsavedChanges {
+    final initialDraft = _initialDraft;
+    return initialDraft != null && _currentDraft() != initialDraft;
+  }
+
+  _HostEditDraft _currentDraft() => (
+    label: _labelController.text,
+    hostname: _hostnameController.text,
+    port: _portController.text,
+    username: _usernameController.text,
+    password: _passwordController.text,
+    tags: _tagsController.text,
+    autoConnectCommand: _autoConnectCommandController.text,
+    tmuxSession: _tmuxSessionController.text,
+    tmuxWorkingDirectory: _tmuxWorkingDirectoryController.text,
+    tmuxExtraFlags: _tmuxExtraFlagsController.text,
+    agentWorkingDirectory: _agentWorkingDirectoryController.text,
+    agentTmuxSession: _agentTmuxSessionController.text,
+    agentTmuxExtraFlags: _agentTmuxExtraFlagsController.text,
+    agentArguments: _agentArgumentsController.text,
+    selectedKeyId: _selectedKeyId,
+    selectedGroupId: _selectedGroupId,
+    selectedJumpHostId: _selectedJumpHostId,
+    selectedAutoConnectSnippetId: _selectedAutoConnectSnippetId,
+    selectedLightThemeId: _selectedLightThemeId,
+    selectedDarkThemeId: _selectedDarkThemeId,
+    selectedFontFamily: _selectedFontFamily,
+    selectedStartupMode: _selectedStartupMode,
+    selectedAutoConnectMode: _selectedAutoConnectMode,
+    selectedAgentLaunchTool: _selectedAgentLaunchTool,
+    isFavorite: _isFavorite,
+    disableTmuxStatusBar: _disableTmuxStatusBar,
+    disableAgentTmuxStatusBar: _disableAgentTmuxStatusBar,
+    startClisInYoloMode: _startClisInYoloMode,
+  );
+
+  void _closeWithoutUnsavedPrompt(
+    SnackBar snackBar, {
+    bool clearLoading = false,
+  }) {
+    final messenger = ScaffoldMessenger.of(context);
+    setState(() {
+      _initialDraft = _currentDraft();
+      if (clearLoading) {
+        _isLoading = false;
+      }
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      context.pop();
+      messenger.showSnackBar(snackBar);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final isEditing = widget.hostId != null;
@@ -323,356 +419,368 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       MonetizationFeature.hostSpecificThemes,
     );
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(isEditing ? 'Edit Host' : 'Add Host'),
-        actions: [
-          if (!isEditing)
+    return UnsavedChangesGuard(
+      hasUnsavedChanges: _hasUnsavedChanges,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(isEditing ? 'Edit Host' : 'Add Host'),
+          actions: [
+            if (!isEditing)
+              IconButton(
+                icon: const Icon(Icons.download_for_offline_outlined),
+                tooltip: 'Import transfer payload',
+                onPressed: () => unawaited(_handleImportTransferTap()),
+              ),
             IconButton(
-              icon: const Icon(Icons.download_for_offline_outlined),
-              tooltip: 'Import transfer payload',
-              onPressed: () => unawaited(_handleImportTransferTap()),
+              icon: Icon(_isFavorite ? Icons.star : Icons.star_border),
+              onPressed: () => setState(() => _isFavorite = !_isFavorite),
+              tooltip: _isFavorite
+                  ? 'Remove from favorites'
+                  : 'Add to favorites',
             ),
-          IconButton(
-            icon: Icon(_isFavorite ? Icons.star : Icons.star_border),
-            onPressed: () => setState(() => _isFavorite = !_isFavorite),
-            tooltip: _isFavorite ? 'Remove from favorites' : 'Add to favorites',
-          ),
-        ],
-      ),
-      body: _isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : Form(
-              key: _formKey,
-              child: SingleChildScrollView(
-                controller: _scrollController,
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    // Label
-                    KeyedSubtree(
-                      key: _labelFieldLocationKey,
-                      child: TextFormField(
-                        key: const Key('host-label-field'),
-                        controller: _labelController,
-                        focusNode: _labelFocusNode,
-                        decoration: const InputDecoration(
-                          labelText: 'Label',
-                          hintText: 'My Server',
-                          prefixIcon: Icon(Icons.label),
-                        ),
-                        textInputAction: TextInputAction.next,
-                        validator: (value) {
-                          if (value == null || value.isEmpty) {
-                            return 'Please enter a label';
-                          }
-                          return null;
-                        },
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-
-                    // Hostname
-                    KeyedSubtree(
-                      key: _hostnameFieldLocationKey,
-                      child: TextFormField(
-                        key: const Key('host-hostname-field'),
-                        controller: _hostnameController,
-                        focusNode: _hostnameFocusNode,
-                        decoration: const InputDecoration(
-                          labelText: 'Hostname',
-                          hintText: 'example.com or 192.168.1.1',
-                          prefixIcon: Icon(Icons.dns),
-                        ),
-                        keyboardType: TextInputType.url,
-                        textInputAction: TextInputAction.next,
-                        autocorrect: false,
-                        validator: (value) {
-                          if (value == null || value.isEmpty) {
-                            return 'Please enter a hostname';
-                          }
-                          return null;
-                        },
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-
-                    // Port
-                    KeyedSubtree(
-                      key: _portFieldLocationKey,
-                      child: TextFormField(
-                        key: const Key('host-port-field'),
-                        controller: _portController,
-                        focusNode: _portFocusNode,
-                        decoration: const InputDecoration(
-                          labelText: 'Port',
-                          hintText: '22',
-                          prefixIcon: Icon(Icons.numbers),
-                        ),
-                        keyboardType: TextInputType.number,
-                        textInputAction: TextInputAction.next,
-                        validator: (value) {
-                          if (value == null || value.isEmpty) {
-                            return 'Please enter a port';
-                          }
-                          final port = int.tryParse(value);
-                          if (port == null || port < 1 || port > 65535) {
-                            return 'Port must be between 1 and 65535';
-                          }
-                          return null;
-                        },
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-
-                    // Username
-                    KeyedSubtree(
-                      key: _usernameFieldLocationKey,
-                      child: TextFormField(
-                        key: const Key('host-username-field'),
-                        controller: _usernameController,
-                        focusNode: _usernameFocusNode,
-                        decoration: const InputDecoration(
-                          labelText: 'Username',
-                          hintText: 'root',
-                          prefixIcon: Icon(Icons.person),
-                        ),
-                        textInputAction: TextInputAction.next,
-                        autocorrect: false,
-                        validator: (value) {
-                          if (value == null || value.isEmpty) {
-                            return 'Please enter a username';
-                          }
-                          return null;
-                        },
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-
-                    TextFormField(
-                      controller: _tagsController,
-                      decoration: const InputDecoration(
-                        labelText: 'Tags (optional)',
-                        hintText: 'prod, db, eu-west',
-                        prefixIcon: Icon(Icons.sell_outlined),
-                        helperText:
-                            'Comma-separated tags for search/organization',
-                      ),
-                      textInputAction: TextInputAction.next,
-                      autocorrect: false,
-                    ),
-                    const SizedBox(height: 24),
-
-                    // Authentication section
-                    Text(
-                      'Authentication',
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                    const SizedBox(height: 12),
-
-                    // Password
-                    TextFormField(
-                      controller: _passwordController,
-                      decoration: InputDecoration(
-                        labelText: 'Password (optional)',
-                        hintText: 'Leave empty for key-only auth',
-                        prefixIcon: const Icon(Icons.lock),
-                        suffixIcon: IconButton(
-                          icon: Icon(
-                            _showPassword
-                                ? Icons.visibility_off
-                                : Icons.visibility,
-                          ),
-                          onPressed: () =>
-                              setState(() => _showPassword = !_showPassword),
-                        ),
-                      ),
-                      obscureText: !_showPassword,
-                      textInputAction: TextInputAction.done,
-                    ),
-                    const SizedBox(height: 16),
-
-                    // SSH Key dropdown
-                    keysAsync.when(
-                      loading: () => const LinearProgressIndicator(),
-                      error: (_, _) => const Text('Error loading keys'),
-                      data: (keys) {
-                        // Validate selected key still exists
-                        final validKeyId =
-                            _selectedKeyId != null &&
-                                keys.any((k) => k.id == _selectedKeyId)
-                            ? _selectedKeyId
-                            : null;
-                        if (validKeyId != _selectedKeyId) {
-                          // Schedule state update for next frame
-                          WidgetsBinding.instance.addPostFrameCallback((_) {
-                            if (mounted) setState(() => _selectedKeyId = null);
-                          });
-                        }
-                        return DropdownButtonFormField<int?>(
-                          // ignore: deprecated_member_use
-                          value: validKeyId,
+          ],
+        ),
+        body: _isLoading
+            ? const Center(child: CircularProgressIndicator())
+            : Form(
+                key: _formKey,
+                onChanged: () => setState(() {}),
+                child: SingleChildScrollView(
+                  controller: _scrollController,
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      // Label
+                      KeyedSubtree(
+                        key: _labelFieldLocationKey,
+                        child: TextFormField(
+                          key: const Key('host-label-field'),
+                          controller: _labelController,
+                          focusNode: _labelFocusNode,
                           decoration: const InputDecoration(
-                            labelText: 'SSH Key (optional)',
-                            prefixIcon: Icon(Icons.key),
-                            helperText:
-                                'Auto tries up to 5 installed keys when password is empty',
+                            labelText: 'Label',
+                            hintText: 'My Server',
+                            prefixIcon: Icon(Icons.label),
                           ),
-                          items: [
-                            const DropdownMenuItem<int?>(child: Text('Auto')),
-                            ...keys.map(
-                              (key) => DropdownMenuItem(
-                                value: key.id,
-                                child: Text(key.name),
-                              ),
-                            ),
-                          ],
-                          onChanged: (value) =>
-                              setState(() => _selectedKeyId = value),
-                        );
-                      },
-                    ),
-                    const SizedBox(height: 24),
-
-                    _buildStartupSection(
-                      context: context,
-                      hasAutomationAccess: hasAutomationAccess,
-                      hasAgentPresetAccess: hasAgentPresetAccess,
-                      snippetsAsync: snippetsAsync,
-                    ),
-                    const SizedBox(height: 24),
-
-                    // Advanced section
-                    ExpansionTile(
-                      key: const Key('host-advanced-tile'),
-                      title: const Text('Advanced'),
-                      initiallyExpanded: _selectedJumpHostId != null,
-                      children: [
-                        const SizedBox(height: 8),
-                        // Jump host dropdown
-                        hostsAsync.when(
-                          loading: () => const LinearProgressIndicator(),
-                          error: (_, _) => const Text('Error loading hosts'),
-                          data: (hosts) {
-                            // Filter out current host from jump host options
-                            final availableHosts = hosts
-                                .where((h) => h.id != widget.hostId)
-                                .toList();
-                            // Validate selected jump host still exists
-                            final validJumpHostId =
-                                _selectedJumpHostId != null &&
-                                    availableHosts.any(
-                                      (h) => h.id == _selectedJumpHostId,
-                                    )
-                                ? _selectedJumpHostId
-                                : null;
-                            if (validJumpHostId != _selectedJumpHostId) {
-                              WidgetsBinding.instance.addPostFrameCallback((_) {
-                                if (mounted) {
-                                  setState(() => _selectedJumpHostId = null);
-                                }
-                              });
+                          textInputAction: TextInputAction.next,
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Please enter a label';
                             }
-                            return DropdownButtonFormField<int?>(
-                              // ignore: deprecated_member_use
-                              value: validJumpHostId,
-                              decoration: const InputDecoration(
-                                labelText: 'Jump Host (optional)',
-                                prefixIcon: Icon(Icons.hub),
-                                helperText:
-                                    'Connect through another host (bastion)',
-                              ),
-                              items: [
-                                const DropdownMenuItem(child: Text('None')),
-                                ...availableHosts.map(
-                                  (host) => DropdownMenuItem(
-                                    value: host.id,
-                                    child: Text(host.label),
-                                  ),
-                                ),
-                              ],
-                              onChanged: (value) =>
-                                  setState(() => _selectedJumpHostId = value),
-                            );
+                            return null;
                           },
                         ),
-                        const SizedBox(height: 24),
-                        // Terminal theme section
-                        Row(
-                          children: [
-                            Text(
-                              'Terminal Theme',
-                              style: Theme.of(context).textTheme.titleSmall
-                                  ?.copyWith(
-                                    color: Theme.of(
-                                      context,
-                                    ).colorScheme.primary,
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                            ),
-                            const SizedBox(width: 8),
-                            const PremiumBadge(),
-                          ],
+                      ),
+                      const SizedBox(height: 16),
+
+                      // Hostname
+                      KeyedSubtree(
+                        key: _hostnameFieldLocationKey,
+                        child: TextFormField(
+                          key: const Key('host-hostname-field'),
+                          controller: _hostnameController,
+                          focusNode: _hostnameFocusNode,
+                          decoration: const InputDecoration(
+                            labelText: 'Hostname',
+                            hintText: 'example.com or 192.168.1.1',
+                            prefixIcon: Icon(Icons.dns),
+                          ),
+                          keyboardType: TextInputType.url,
+                          textInputAction: TextInputAction.next,
+                          autocorrect: false,
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Please enter a hostname';
+                            }
+                            return null;
+                          },
                         ),
-                        const SizedBox(height: 12),
-                        if (!hasHostThemeAccess) ...[
-                          Text(
-                            'MonkeySSH Pro unlocks per-host theme overrides. App-wide default themes stay free in Settings.',
-                            style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                      const SizedBox(height: 16),
+
+                      // Port
+                      KeyedSubtree(
+                        key: _portFieldLocationKey,
+                        child: TextFormField(
+                          key: const Key('host-port-field'),
+                          controller: _portController,
+                          focusNode: _portFocusNode,
+                          decoration: const InputDecoration(
+                            labelText: 'Port',
+                            hintText: '22',
+                            prefixIcon: Icon(Icons.numbers),
+                          ),
+                          keyboardType: TextInputType.number,
+                          textInputAction: TextInputAction.next,
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Please enter a port';
+                            }
+                            final port = int.tryParse(value);
+                            if (port == null || port < 1 || port > 65535) {
+                              return 'Port must be between 1 and 65535';
+                            }
+                            return null;
+                          },
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+
+                      // Username
+                      KeyedSubtree(
+                        key: _usernameFieldLocationKey,
+                        child: TextFormField(
+                          key: const Key('host-username-field'),
+                          controller: _usernameController,
+                          focusNode: _usernameFocusNode,
+                          decoration: const InputDecoration(
+                            labelText: 'Username',
+                            hintText: 'root',
+                            prefixIcon: Icon(Icons.person),
+                          ),
+                          textInputAction: TextInputAction.next,
+                          autocorrect: false,
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Please enter a username';
+                            }
+                            return null;
+                          },
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+
+                      TextFormField(
+                        controller: _tagsController,
+                        decoration: const InputDecoration(
+                          labelText: 'Tags (optional)',
+                          hintText: 'prod, db, eu-west',
+                          prefixIcon: Icon(Icons.sell_outlined),
+                          helperText:
+                              'Comma-separated tags for search/organization',
+                        ),
+                        textInputAction: TextInputAction.next,
+                        autocorrect: false,
+                      ),
+                      const SizedBox(height: 24),
+
+                      // Authentication section
+                      Text(
+                        'Authentication',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 12),
+
+                      // Password
+                      TextFormField(
+                        controller: _passwordController,
+                        decoration: InputDecoration(
+                          labelText: 'Password (optional)',
+                          hintText: 'Leave empty for key-only auth',
+                          prefixIcon: const Icon(Icons.lock),
+                          suffixIcon: IconButton(
+                            icon: Icon(
+                              _showPassword
+                                  ? Icons.visibility_off
+                                  : Icons.visibility,
+                            ),
+                            onPressed: () =>
+                                setState(() => _showPassword = !_showPassword),
+                          ),
+                        ),
+                        obscureText: !_showPassword,
+                        textInputAction: TextInputAction.done,
+                      ),
+                      const SizedBox(height: 16),
+
+                      // SSH Key dropdown
+                      keysAsync.when(
+                        loading: () => const LinearProgressIndicator(),
+                        error: (_, _) => const Text('Error loading keys'),
+                        data: (keys) {
+                          // Validate selected key still exists
+                          final validKeyId =
+                              _selectedKeyId != null &&
+                                  keys.any((k) => k.id == _selectedKeyId)
+                              ? _selectedKeyId
+                              : null;
+                          if (validKeyId != _selectedKeyId) {
+                            // Schedule state update for next frame
+                            WidgetsBinding.instance.addPostFrameCallback((_) {
+                              if (mounted) {
+                                setState(() => _selectedKeyId = null);
+                              }
+                            });
+                          }
+                          return DropdownButtonFormField<int?>(
+                            // ignore: deprecated_member_use
+                            value: validKeyId,
+                            decoration: const InputDecoration(
+                              labelText: 'SSH Key (optional)',
+                              prefixIcon: Icon(Icons.key),
+                              helperText:
+                                  'Auto tries up to 5 installed keys when password is empty',
+                            ),
+                            items: [
+                              const DropdownMenuItem<int?>(child: Text('Auto')),
+                              ...keys.map(
+                                (key) => DropdownMenuItem(
+                                  value: key.id,
+                                  child: Text(key.name),
+                                ),
+                              ),
+                            ],
+                            onChanged: (value) =>
+                                setState(() => _selectedKeyId = value),
+                          );
+                        },
+                      ),
+                      const SizedBox(height: 24),
+
+                      _buildStartupSection(
+                        context: context,
+                        hasAutomationAccess: hasAutomationAccess,
+                        hasAgentPresetAccess: hasAgentPresetAccess,
+                        snippetsAsync: snippetsAsync,
+                      ),
+                      const SizedBox(height: 24),
+
+                      // Advanced section
+                      ExpansionTile(
+                        key: const Key('host-advanced-tile'),
+                        title: const Text('Advanced'),
+                        initiallyExpanded: _selectedJumpHostId != null,
+                        children: [
+                          const SizedBox(height: 8),
+                          // Jump host dropdown
+                          hostsAsync.when(
+                            loading: () => const LinearProgressIndicator(),
+                            error: (_, _) => const Text('Error loading hosts'),
+                            data: (hosts) {
+                              // Filter out current host from jump host options
+                              final availableHosts = hosts
+                                  .where((h) => h.id != widget.hostId)
+                                  .toList();
+                              // Validate selected jump host still exists
+                              final validJumpHostId =
+                                  _selectedJumpHostId != null &&
+                                      availableHosts.any(
+                                        (h) => h.id == _selectedJumpHostId,
+                                      )
+                                  ? _selectedJumpHostId
+                                  : null;
+                              if (validJumpHostId != _selectedJumpHostId) {
+                                WidgetsBinding.instance.addPostFrameCallback((
+                                  _,
+                                ) {
+                                  if (mounted) {
+                                    setState(() => _selectedJumpHostId = null);
+                                  }
+                                });
+                              }
+                              return DropdownButtonFormField<int?>(
+                                // ignore: deprecated_member_use
+                                value: validJumpHostId,
+                                decoration: const InputDecoration(
+                                  labelText: 'Jump Host (optional)',
+                                  prefixIcon: Icon(Icons.hub),
+                                  helperText:
+                                      'Connect through another host (bastion)',
+                                ),
+                                items: [
+                                  const DropdownMenuItem(child: Text('None')),
+                                  ...availableHosts.map(
+                                    (host) => DropdownMenuItem(
+                                      value: host.id,
+                                      child: Text(host.label),
+                                    ),
+                                  ),
+                                ],
+                                onChanged: (value) =>
+                                    setState(() => _selectedJumpHostId = value),
+                              );
+                            },
+                          ),
+                          const SizedBox(height: 24),
+                          // Terminal theme section
+                          Row(
+                            children: [
+                              Text(
+                                'Terminal Theme',
+                                style: Theme.of(context).textTheme.titleSmall
+                                    ?.copyWith(
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.primary,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                              ),
+                              const SizedBox(width: 8),
+                              const PremiumBadge(),
+                            ],
                           ),
                           const SizedBox(height: 12),
+                          if (!hasHostThemeAccess) ...[
+                            Text(
+                              'MonkeySSH Pro unlocks per-host theme overrides. App-wide default themes stay free in Settings.',
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                            const SizedBox(height: 12),
+                          ],
+                          // Light mode theme
+                          _ThemeSelectionTile(
+                            label: 'Light Mode Theme',
+                            themeId: _selectedLightThemeId,
+                            defaultLabel: 'Use default',
+                            onTap: () =>
+                                _handleThemeSelectionTap(isLight: true),
+                          ),
+                          const SizedBox(height: 8),
+                          // Dark mode theme
+                          _ThemeSelectionTile(
+                            label: 'Dark Mode Theme',
+                            themeId: _selectedDarkThemeId,
+                            defaultLabel: 'Use default',
+                            onTap: () =>
+                                _handleThemeSelectionTap(isLight: false),
+                          ),
+                          const SizedBox(height: 16),
+                          // Terminal font section
+                          _FontSelectionTile(
+                            fontFamily: _selectedFontFamily,
+                            defaultLabel: 'Use default',
+                            onTap: _selectFont,
+                          ),
+                          const SizedBox(height: 16),
                         ],
-                        // Light mode theme
-                        _ThemeSelectionTile(
-                          label: 'Light Mode Theme',
-                          themeId: _selectedLightThemeId,
-                          defaultLabel: 'Use default',
-                          onTap: () => _handleThemeSelectionTap(isLight: true),
-                        ),
-                        const SizedBox(height: 8),
-                        // Dark mode theme
-                        _ThemeSelectionTile(
-                          label: 'Dark Mode Theme',
-                          themeId: _selectedDarkThemeId,
-                          defaultLabel: 'Use default',
-                          onTap: () => _handleThemeSelectionTap(isLight: false),
-                        ),
-                        const SizedBox(height: 16),
-                        // Terminal font section
-                        _FontSelectionTile(
-                          fontFamily: _selectedFontFamily,
-                          defaultLabel: 'Use default',
-                          onTap: _selectFont,
-                        ),
-                        const SizedBox(height: 16),
-                      ],
-                    ),
-                    const SizedBox(height: 32),
+                      ),
+                      const SizedBox(height: 32),
 
-                    // Port Forwards section
-                    _buildPortForwardsSection(context, isEditing),
-                    const SizedBox(height: 32),
+                      // Port Forwards section
+                      _buildPortForwardsSection(context, isEditing),
+                      const SizedBox(height: 32),
 
-                    // Save button
-                    FilledButton.icon(
-                      key: const Key('host-save-button'),
-                      onPressed: _saveHost,
-                      icon: const Icon(Icons.save),
-                      label: Text(isEditing ? 'Save Changes' : 'Add Host'),
-                    ),
-                    const SizedBox(height: 16),
+                      // Save button
+                      FilledButton.icon(
+                        key: const Key('host-save-button'),
+                        onPressed: _saveHost,
+                        icon: const Icon(Icons.save),
+                        label: Text(isEditing ? 'Save Changes' : 'Add Host'),
+                      ),
+                      const SizedBox(height: 16),
 
-                    // Test connection button
-                    OutlinedButton.icon(
-                      onPressed: _testConnection,
-                      icon: const Icon(Icons.network_check),
-                      label: const Text('Test Connection'),
-                    ),
-                  ],
+                      // Test connection button
+                      OutlinedButton.icon(
+                        onPressed: _testConnection,
+                        icon: const Icon(Icons.network_check),
+                        label: const Text('Test Connection'),
+                      ),
+                    ],
+                  ),
                 ),
               ),
-            ),
+      ),
     );
   }
 
@@ -1220,6 +1328,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     }
 
     setState(() => _isLoading = true);
+    var didScheduleClose = false;
 
     try {
       final monetizationState =
@@ -1434,13 +1543,14 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       ref.invalidate(allHostsProvider);
 
       if (mounted) {
-        context.pop();
-        ScaffoldMessenger.of(context).showSnackBar(
+        didScheduleClose = true;
+        _closeWithoutUnsavedPrompt(
           SnackBar(
             content: Text(
               widget.hostId != null ? 'Host updated' : 'Host added',
             ),
           ),
+          clearLoading: true,
         );
       }
     } on Exception catch (e) {
@@ -1457,7 +1567,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         );
       }
     } finally {
-      if (mounted) setState(() => _isLoading = false);
+      if (mounted && !didScheduleClose) setState(() => _isLoading = false);
     }
   }
 
@@ -1782,8 +1892,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       if (!mounted) {
         return;
       }
-      context.pop();
-      ScaffoldMessenger.of(context).showSnackBar(
+      _closeWithoutUnsavedPrompt(
         SnackBar(content: Text('Imported host: ${importedHost.label}')),
       );
     } on FormatException catch (error) {

--- a/lib/presentation/screens/key_add_screen.dart
+++ b/lib/presentation/screens/key_add_screen.dart
@@ -11,7 +11,17 @@ import '../../domain/services/key_service.dart';
 import '../../domain/services/secure_transfer_service.dart';
 import '../widgets/premium_access.dart';
 import '../widgets/premium_badge.dart';
+import '../widgets/unsaved_changes_guard.dart';
 import 'transfer_screen.dart';
+
+typedef _GenerateKeyDraft = ({
+  String name,
+  String passphrase,
+  String keyType,
+  int rsaBits,
+});
+
+typedef _ImportKeyDraft = ({String name, String privateKey, String passphrase});
 
 /// Screen for adding or importing SSH keys.
 class KeyAddScreen extends ConsumerStatefulWidget {
@@ -28,6 +38,9 @@ class KeyAddScreen extends ConsumerStatefulWidget {
 class _KeyAddScreenState extends ConsumerState<KeyAddScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
+  bool _generateHasUnsavedChanges = false;
+  bool _importHasUnsavedChanges = false;
+  bool _isLeavingWithoutPrompt = false;
 
   @override
   void initState() {
@@ -50,26 +63,78 @@ class _KeyAddScreenState extends ConsumerState<KeyAddScreen>
   }
 
   @override
-  Widget build(BuildContext context) => Scaffold(
-    appBar: AppBar(
-      title: const Text('Add SSH Key'),
-      bottom: TabBar(
+  Widget build(BuildContext context) => UnsavedChangesGuard(
+    hasUnsavedChanges: _hasUnsavedChanges,
+    child: Scaffold(
+      appBar: AppBar(
+        title: const Text('Add SSH Key'),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Generate'),
+            Tab(text: 'Import'),
+          ],
+        ),
+      ),
+      body: TabBarView(
         controller: _tabController,
-        tabs: const [
-          Tab(text: 'Generate'),
-          Tab(text: 'Import'),
+        children: [
+          _GenerateKeyTab(
+            onSaved: _closeWithoutUnsavedPrompt,
+            onUnsavedChangesChanged: _handleGenerateUnsavedChangesChanged,
+          ),
+          _ImportKeyTab(
+            onSaved: _closeWithoutUnsavedPrompt,
+            onUnsavedChangesChanged: _handleImportUnsavedChangesChanged,
+          ),
         ],
       ),
     ),
-    body: TabBarView(
-      controller: _tabController,
-      children: const [_GenerateKeyTab(), _ImportKeyTab()],
-    ),
   );
+
+  bool get _hasUnsavedChanges =>
+      !_isLeavingWithoutPrompt &&
+      (_generateHasUnsavedChanges || _importHasUnsavedChanges);
+
+  void _handleGenerateUnsavedChangesChanged(bool hasUnsavedChanges) {
+    if (_generateHasUnsavedChanges == hasUnsavedChanges) {
+      return;
+    }
+    setState(() => _generateHasUnsavedChanges = hasUnsavedChanges);
+  }
+
+  void _handleImportUnsavedChangesChanged(bool hasUnsavedChanges) {
+    if (_importHasUnsavedChanges == hasUnsavedChanges) {
+      return;
+    }
+    setState(() => _importHasUnsavedChanges = hasUnsavedChanges);
+  }
+
+  void _closeWithoutUnsavedPrompt(SnackBar snackBar) {
+    final messenger = ScaffoldMessenger.of(context);
+    setState(() {
+      _isLeavingWithoutPrompt = true;
+      _generateHasUnsavedChanges = false;
+      _importHasUnsavedChanges = false;
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      context.pop();
+      messenger.showSnackBar(snackBar);
+    });
+  }
 }
 
 class _GenerateKeyTab extends ConsumerStatefulWidget {
-  const _GenerateKeyTab();
+  const _GenerateKeyTab({
+    required this.onSaved,
+    required this.onUnsavedChangesChanged,
+  });
+
+  final ValueChanged<SnackBar> onSaved;
+  final ValueChanged<bool> onUnsavedChangesChanged;
 
   @override
   ConsumerState<_GenerateKeyTab> createState() => _GenerateKeyTabState();
@@ -84,6 +149,13 @@ class _GenerateKeyTabState extends ConsumerState<_GenerateKeyTab> {
   int _rsaBits = 4096;
   bool _isGenerating = false;
   bool _showPassphrase = false;
+  late final _GenerateKeyDraft _initialDraft;
+
+  @override
+  void initState() {
+    super.initState();
+    _initialDraft = _currentDraft();
+  }
 
   @override
   void dispose() {
@@ -95,6 +167,7 @@ class _GenerateKeyTabState extends ConsumerState<_GenerateKeyTab> {
   @override
   Widget build(BuildContext context) => Form(
     key: _formKey,
+    onChanged: _notifyUnsavedChangesChanged,
     child: ListView(
       padding: const EdgeInsets.all(16),
       children: [
@@ -135,6 +208,7 @@ class _GenerateKeyTabState extends ConsumerState<_GenerateKeyTab> {
           selected: {_keyType},
           onSelectionChanged: (value) {
             setState(() => _keyType = value.first);
+            _notifyUnsavedChangesChanged();
           },
         ),
         const SizedBox(height: 16),
@@ -151,6 +225,7 @@ class _GenerateKeyTabState extends ConsumerState<_GenerateKeyTab> {
             selected: {_rsaBits},
             onSelectionChanged: (value) {
               setState(() => _rsaBits = value.first);
+              _notifyUnsavedChangesChanged();
             },
           ),
           const SizedBox(height: 16),
@@ -252,8 +327,7 @@ class _GenerateKeyTabState extends ConsumerState<_GenerateKeyTab> {
             const SnackBar(content: Text('Failed to generate key')),
           );
         } else {
-          context.pop();
-          messenger.showSnackBar(
+          widget.onSaved(
             const SnackBar(content: Text('Key generated successfully')),
           );
         }
@@ -273,13 +347,34 @@ class _GenerateKeyTabState extends ConsumerState<_GenerateKeyTab> {
       }
     } finally {
       _passphraseController.clear();
-      if (mounted) setState(() => _isGenerating = false);
+      if (mounted) {
+        _notifyUnsavedChangesChanged();
+        setState(() => _isGenerating = false);
+      }
     }
   }
+
+  bool get _hasUnsavedChanges => _currentDraft() != _initialDraft;
+
+  _GenerateKeyDraft _currentDraft() => (
+    name: _nameController.text,
+    passphrase: _passphraseController.text,
+    keyType: _keyType,
+    rsaBits: _rsaBits,
+  );
+
+  void _notifyUnsavedChangesChanged() =>
+      widget.onUnsavedChangesChanged(_hasUnsavedChanges);
 }
 
 class _ImportKeyTab extends ConsumerStatefulWidget {
-  const _ImportKeyTab();
+  const _ImportKeyTab({
+    required this.onSaved,
+    required this.onUnsavedChangesChanged,
+  });
+
+  final ValueChanged<SnackBar> onSaved;
+  final ValueChanged<bool> onUnsavedChangesChanged;
 
   @override
   ConsumerState<_ImportKeyTab> createState() => _ImportKeyTabState();
@@ -293,6 +388,13 @@ class _ImportKeyTabState extends ConsumerState<_ImportKeyTab> {
 
   bool _isImporting = false;
   bool _showPassphrase = false;
+  late final _ImportKeyDraft _initialDraft;
+
+  @override
+  void initState() {
+    super.initState();
+    _initialDraft = _currentDraft();
+  }
 
   @override
   void dispose() {
@@ -305,6 +407,7 @@ class _ImportKeyTabState extends ConsumerState<_ImportKeyTab> {
   @override
   Widget build(BuildContext context) => Form(
     key: _formKey,
+    onChanged: _notifyUnsavedChangesChanged,
     child: ListView(
       padding: const EdgeInsets.all(16),
       children: [
@@ -453,8 +556,7 @@ class _ImportKeyTabState extends ConsumerState<_ImportKeyTab> {
 
       if (mounted) {
         _privateKeyController.clear();
-        context.pop();
-        ScaffoldMessenger.of(context).showSnackBar(
+        widget.onSaved(
           const SnackBar(content: Text('Key imported successfully')),
         );
       }
@@ -473,7 +575,10 @@ class _ImportKeyTabState extends ConsumerState<_ImportKeyTab> {
       }
     } finally {
       _passphraseController.clear();
-      if (mounted) setState(() => _isImporting = false);
+      if (mounted) {
+        _notifyUnsavedChangesChanged();
+        setState(() => _isImporting = false);
+      }
     }
   }
 
@@ -503,6 +608,7 @@ class _ImportKeyTabState extends ConsumerState<_ImportKeyTab> {
           ? file.name.substring(0, dotIndex)
           : file.name;
     }
+    _notifyUnsavedChangesChanged();
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text('Loaded "${file.name}"')));
@@ -570,8 +676,7 @@ class _ImportKeyTabState extends ConsumerState<_ImportKeyTab> {
       if (!mounted) {
         return;
       }
-      context.pop();
-      ScaffoldMessenger.of(context).showSnackBar(
+      widget.onSaved(
         SnackBar(content: Text('Imported key: ${importedKey.name}')),
       );
     } on FormatException catch (error) {
@@ -605,4 +710,15 @@ class _ImportKeyTabState extends ConsumerState<_ImportKeyTab> {
       }
     }
   }
+
+  bool get _hasUnsavedChanges => _currentDraft() != _initialDraft;
+
+  _ImportKeyDraft _currentDraft() => (
+    name: _nameController.text,
+    privateKey: _privateKeyController.text,
+    passphrase: _passphraseController.text,
+  );
+
+  void _notifyUnsavedChangesChanged() =>
+      widget.onUnsavedChangesChanged(_hasUnsavedChanges);
 }

--- a/lib/presentation/screens/port_forward_edit_screen.dart
+++ b/lib/presentation/screens/port_forward_edit_screen.dart
@@ -7,6 +7,18 @@ import 'package:go_router/go_router.dart';
 import '../../data/database/database.dart';
 import '../../data/repositories/host_repository.dart';
 import '../../data/repositories/port_forward_repository.dart';
+import '../widgets/unsaved_changes_guard.dart';
+
+typedef _PortForwardEditDraft = ({
+  String name,
+  String localHost,
+  String localPort,
+  String remoteHost,
+  String remotePort,
+  bool autoStart,
+  String forwardType,
+  int? selectedHostId,
+});
 
 /// Screen for adding or editing a port forward rule.
 class PortForwardEditScreen extends ConsumerStatefulWidget {
@@ -35,6 +47,7 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
   int? _selectedHostId;
   PortForward? _existingPortForward;
   List<Host> _hosts = [];
+  _PortForwardEditDraft? _initialDraft;
 
   @override
   void initState() {
@@ -42,6 +55,8 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
     _loadHosts();
     if (widget.portForwardId != null) {
       _loadPortForward();
+    } else {
+      _initialDraft = _currentDraft();
     }
   }
 
@@ -69,6 +84,7 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
         _remotePortController.text = portForward.remotePort.toString();
         _autoStart = portForward.autoStart;
         _isLoading = false;
+        _initialDraft = _currentDraft();
       });
     }
   }
@@ -130,205 +146,246 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
   Widget build(BuildContext context) {
     final isEditing = widget.portForwardId != null;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(isEditing ? 'Edit Port Forward' : 'Add Port Forward'),
-      ),
-      body: _isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : Form(
-              key: _formKey,
-              child: ListView(
-                padding: const EdgeInsets.all(16),
-                children: [
-                  // Name
-                  TextFormField(
-                    controller: _nameController,
-                    decoration: const InputDecoration(
-                      labelText: 'Name',
-                      hintText: 'Web Server',
-                      prefixIcon: Icon(Icons.label),
-                    ),
-                    textInputAction: TextInputAction.next,
-                    validator: (value) {
-                      if (value == null || value.isEmpty) {
-                        return 'Please enter a name';
-                      }
-                      return null;
-                    },
-                  ),
-                  const SizedBox(height: 16),
-
-                  // Host selection
-                  DropdownButtonFormField<int>(
-                    initialValue: _selectedHostId,
-                    decoration: const InputDecoration(
-                      labelText: 'Host',
-                      prefixIcon: Icon(Icons.computer),
-                    ),
-                    items: _hosts
-                        .map(
-                          (host) => DropdownMenuItem(
-                            value: host.id,
-                            child: Text(host.label),
-                          ),
-                        )
-                        .toList(),
-                    onChanged: (value) =>
-                        setState(() => _selectedHostId = value),
-                    validator: (value) {
-                      if (value == null) {
-                        return 'Please select a host';
-                      }
-                      return null;
-                    },
-                  ),
-                  const SizedBox(height: 16),
-
-                  // Forward type
-                  Text(
-                    'Forward Type',
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  SegmentedButton<String>(
-                    segments: const [
-                      ButtonSegment(
-                        value: 'local',
-                        label: Text('Local'),
-                        icon: Icon(Icons.arrow_forward),
+    return UnsavedChangesGuard(
+      hasUnsavedChanges: _hasUnsavedChanges,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(isEditing ? 'Edit Port Forward' : 'Add Port Forward'),
+        ),
+        body: _isLoading
+            ? const Center(child: CircularProgressIndicator())
+            : Form(
+                key: _formKey,
+                onChanged: () => setState(() {}),
+                child: ListView(
+                  padding: const EdgeInsets.all(16),
+                  children: [
+                    // Name
+                    TextFormField(
+                      controller: _nameController,
+                      decoration: const InputDecoration(
+                        labelText: 'Name',
+                        hintText: 'Web Server',
+                        prefixIcon: Icon(Icons.label),
                       ),
-                      ButtonSegment(
-                        value: 'remote',
-                        label: Text('Remote'),
-                        icon: Icon(Icons.arrow_back),
-                      ),
-                    ],
-                    selected: {_forwardType},
-                    onSelectionChanged: (selected) {
-                      setState(() => _forwardType = selected.first);
-                    },
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    _forwardType == 'local'
-                        ? 'Forward local port to remote host'
-                        : 'Forward remote port to local host',
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.outline,
+                      textInputAction: TextInputAction.next,
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'Please enter a name';
+                        }
+                        return null;
+                      },
                     ),
-                  ),
-                  const SizedBox(height: 24),
+                    const SizedBox(height: 16),
 
-                  // Local host/port
-                  Text('Local', style: Theme.of(context).textTheme.titleSmall),
-                  const SizedBox(height: 8),
-                  Row(
-                    children: [
-                      Expanded(
-                        flex: 2,
-                        child: TextFormField(
-                          controller: _localHostController,
-                          decoration: const InputDecoration(
-                            labelText: 'Host',
-                            hintText: '127.0.0.1',
-                          ),
-                          textInputAction: TextInputAction.next,
-                          validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return 'Required';
-                            }
-                            return null;
-                          },
+                    // Host selection
+                    DropdownButtonFormField<int>(
+                      initialValue: _selectedHostId,
+                      decoration: const InputDecoration(
+                        labelText: 'Host',
+                        prefixIcon: Icon(Icons.computer),
+                      ),
+                      items: _hosts
+                          .map(
+                            (host) => DropdownMenuItem(
+                              value: host.id,
+                              child: Text(host.label),
+                            ),
+                          )
+                          .toList(),
+                      onChanged: (value) =>
+                          setState(() => _selectedHostId = value),
+                      validator: (value) {
+                        if (value == null) {
+                          return 'Please select a host';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Forward type
+                    Text(
+                      'Forward Type',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    SegmentedButton<String>(
+                      segments: const [
+                        ButtonSegment(
+                          value: 'local',
+                          label: Text('Local'),
+                          icon: Icon(Icons.arrow_forward),
                         ),
-                      ),
-                      const SizedBox(width: 16),
-                      Expanded(
-                        child: TextFormField(
-                          controller: _localPortController,
-                          decoration: const InputDecoration(
-                            labelText: 'Port',
-                            hintText: '8080',
-                          ),
-                          keyboardType: TextInputType.number,
-                          inputFormatters: [
-                            FilteringTextInputFormatter.digitsOnly,
-                          ],
-                          textInputAction: TextInputAction.next,
-                          validator: _validatePort,
+                        ButtonSegment(
+                          value: 'remote',
+                          label: Text('Remote'),
+                          icon: Icon(Icons.arrow_back),
                         ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 24),
-
-                  // Remote host/port
-                  Text('Remote', style: Theme.of(context).textTheme.titleSmall),
-                  const SizedBox(height: 8),
-                  Row(
-                    children: [
-                      Expanded(
-                        flex: 2,
-                        child: TextFormField(
-                          controller: _remoteHostController,
-                          decoration: const InputDecoration(
-                            labelText: 'Host',
-                            hintText: 'localhost',
-                          ),
-                          textInputAction: TextInputAction.next,
-                          validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return 'Required';
-                            }
-                            return null;
-                          },
-                        ),
-                      ),
-                      const SizedBox(width: 16),
-                      Expanded(
-                        child: TextFormField(
-                          controller: _remotePortController,
-                          decoration: const InputDecoration(
-                            labelText: 'Port',
-                            hintText: '80',
-                          ),
-                          keyboardType: TextInputType.number,
-                          inputFormatters: [
-                            FilteringTextInputFormatter.digitsOnly,
-                          ],
-                          textInputAction: TextInputAction.done,
-                          validator: _validatePort,
-                        ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 24),
-
-                  // Auto-start toggle
-                  SwitchListTile(
-                    title: const Text('Auto-start'),
-                    subtitle: const Text(
-                      'Start forwarding when connecting to host',
+                      ],
+                      selected: {_forwardType},
+                      onSelectionChanged: (selected) {
+                        setState(() => _forwardType = selected.first);
+                      },
                     ),
-                    value: _autoStart,
-                    onChanged: (value) => setState(() => _autoStart = value),
-                  ),
-                  const SizedBox(height: 32),
-
-                  // Save button
-                  FilledButton.icon(
-                    onPressed: _savePortForward,
-                    icon: const Icon(Icons.save),
-                    label: Text(
-                      isEditing ? 'Save Changes' : 'Add Port Forward',
+                    const SizedBox(height: 8),
+                    Text(
+                      _forwardType == 'local'
+                          ? 'Forward local port to remote host'
+                          : 'Forward remote port to local host',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.outline,
+                      ),
                     ),
-                  ),
-                ],
+                    const SizedBox(height: 24),
+
+                    // Local host/port
+                    Text(
+                      'Local',
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Expanded(
+                          flex: 2,
+                          child: TextFormField(
+                            controller: _localHostController,
+                            decoration: const InputDecoration(
+                              labelText: 'Host',
+                              hintText: '127.0.0.1',
+                            ),
+                            textInputAction: TextInputAction.next,
+                            validator: (value) {
+                              if (value == null || value.isEmpty) {
+                                return 'Required';
+                              }
+                              return null;
+                            },
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: TextFormField(
+                            controller: _localPortController,
+                            decoration: const InputDecoration(
+                              labelText: 'Port',
+                              hintText: '8080',
+                            ),
+                            keyboardType: TextInputType.number,
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
+                            textInputAction: TextInputAction.next,
+                            validator: _validatePort,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 24),
+
+                    // Remote host/port
+                    Text(
+                      'Remote',
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Expanded(
+                          flex: 2,
+                          child: TextFormField(
+                            controller: _remoteHostController,
+                            decoration: const InputDecoration(
+                              labelText: 'Host',
+                              hintText: 'localhost',
+                            ),
+                            textInputAction: TextInputAction.next,
+                            validator: (value) {
+                              if (value == null || value.isEmpty) {
+                                return 'Required';
+                              }
+                              return null;
+                            },
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: TextFormField(
+                            controller: _remotePortController,
+                            decoration: const InputDecoration(
+                              labelText: 'Port',
+                              hintText: '80',
+                            ),
+                            keyboardType: TextInputType.number,
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
+                            textInputAction: TextInputAction.done,
+                            validator: _validatePort,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 24),
+
+                    // Auto-start toggle
+                    SwitchListTile(
+                      title: const Text('Auto-start'),
+                      subtitle: const Text(
+                        'Start forwarding when connecting to host',
+                      ),
+                      value: _autoStart,
+                      onChanged: (value) => setState(() => _autoStart = value),
+                    ),
+                    const SizedBox(height: 32),
+
+                    // Save button
+                    FilledButton.icon(
+                      onPressed: _savePortForward,
+                      icon: const Icon(Icons.save),
+                      label: Text(
+                        isEditing ? 'Save Changes' : 'Add Port Forward',
+                      ),
+                    ),
+                  ],
+                ),
               ),
-            ),
+      ),
     );
+  }
+
+  bool get _hasUnsavedChanges {
+    final initialDraft = _initialDraft;
+    return initialDraft != null && _currentDraft() != initialDraft;
+  }
+
+  _PortForwardEditDraft _currentDraft() => (
+    name: _nameController.text,
+    localHost: _localHostController.text,
+    localPort: _localPortController.text,
+    remoteHost: _remoteHostController.text,
+    remotePort: _remotePortController.text,
+    autoStart: _autoStart,
+    forwardType: _forwardType,
+    selectedHostId: _selectedHostId,
+  );
+
+  void _closeWithoutUnsavedPrompt(SnackBar snackBar) {
+    final messenger = ScaffoldMessenger.of(context);
+    setState(() {
+      _initialDraft = _currentDraft();
+      _isLoading = false;
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      context.pop();
+      messenger.showSnackBar(snackBar);
+    });
   }
 
   Future<void> _savePortForward() async {
@@ -340,6 +397,7 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
     }
 
     setState(() => _isLoading = true);
+    var didScheduleClose = false;
 
     try {
       final repo = ref.read(portForwardRepositoryProvider);
@@ -375,8 +433,8 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
       }
 
       if (mounted) {
-        context.pop();
-        ScaffoldMessenger.of(context).showSnackBar(
+        didScheduleClose = true;
+        _closeWithoutUnsavedPrompt(
           SnackBar(
             content: Text(
               widget.portForwardId != null
@@ -402,7 +460,7 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
         );
       }
     } finally {
-      if (mounted) setState(() => _isLoading = false);
+      if (mounted && !didScheduleClose) setState(() => _isLoading = false);
     }
   }
 }

--- a/lib/presentation/screens/remote_text_editor_screen.dart
+++ b/lib/presentation/screens/remote_text_editor_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import '../../domain/models/terminal_theme.dart';
 import '../widgets/terminal_pinch_zoom_gesture_handler.dart';
 import '../widgets/terminal_text_style.dart';
+import '../widgets/unsaved_changes_guard.dart';
 
 const _unwrappedEditorTrailingSlack = 24.0;
 const _minRemoteEditorFontSize = 8.0;
@@ -286,6 +287,7 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
   double? _cachedMeasuredWidthTextScale;
   String? _cachedMeasuredWidthFontFamily;
   double? _cachedMeasuredWidthFontSize;
+  late String _initialText;
 
   @override
   void initState() {
@@ -296,6 +298,7 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
         widget.horizontalScrollController ?? ScrollController();
     _ownsHorizontalScrollController = widget.horizontalScrollController == null;
     _ensureInitialSelectionIsVisibleFromStart(widget.controller);
+    _initialText = widget.controller.text;
     widget.controller.addListener(_handleControllerChanged);
     _editorScrollController.addListener(_syncLineNumberScrollOffset);
     _refreshCachedMetrics();
@@ -313,6 +316,7 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
     if (oldWidget.controller != widget.controller) {
       oldWidget.controller.removeListener(_handleControllerChanged);
       _ensureInitialSelectionIsVisibleFromStart(widget.controller);
+      _initialText = widget.controller.text;
       widget.controller.addListener(_handleControllerChanged);
       _cachedText = null;
       _cachedSelection = null;
@@ -365,6 +369,8 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
 
   ({int line, int column}) get _caretPosition => _cachedCaretPosition;
 
+  bool get _hasUnsavedChanges => widget.controller.text != _initialText;
+
   void _refreshCachedMetrics() {
     final text = widget.controller.text;
     final selection = widget.controller.selection;
@@ -401,6 +407,17 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
     _refreshCachedMetrics();
     setState(() {});
     _scheduleSelectionVisibilityUpdate();
+  }
+
+  void _closeWithSavedText() {
+    final savedText = widget.controller.text;
+    setState(() => _initialText = savedText);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      Navigator.of(context).pop(savedText);
+    });
   }
 
   void _syncLineNumberScrollOffset() {
@@ -619,199 +636,201 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
           foregroundColor: colors.foreground,
         ),
       ),
-      child: Scaffold(
-        backgroundColor: colors.background,
-        appBar: AppBar(
-          leading: IconButton(
-            icon: const Icon(Icons.close),
-            tooltip: 'Close editor',
-            onPressed: () => Navigator.pop(context),
+      child: UnsavedChangesGuard(
+        hasUnsavedChanges: _hasUnsavedChanges,
+        child: Scaffold(
+          backgroundColor: colors.background,
+          appBar: AppBar(
+            leading: IconButton(
+              icon: const Icon(Icons.close),
+              tooltip: 'Close editor',
+              onPressed: () => Navigator.pop(context),
+            ),
+            title: Text('Edit ${widget.fileName}'),
+            actions: [
+              if (_showDesktopZoomButtons(theme.platform))
+                IconButton(
+                  onPressed: _fontSize <= _minRemoteEditorFontSize
+                      ? null
+                      : () => _changeFontSize(-_remoteEditorFontStep),
+                  icon: const Icon(Icons.zoom_out),
+                  tooltip: 'Zoom out',
+                ),
+              IconButton(
+                onPressed: () {
+                  setState(() {
+                    _wrapLines = !_wrapLines;
+                  });
+                  if (!_wrapLines) {
+                    _scheduleSelectionVisibilityUpdate();
+                  }
+                },
+                icon: Icon(_wrapLines ? Icons.wrap_text : Icons.segment),
+                tooltip: _wrapLines ? 'Disable line wrap' : 'Enable line wrap',
+              ),
+              if (_showDesktopZoomButtons(theme.platform))
+                IconButton(
+                  onPressed: _fontSize >= _maxRemoteEditorFontSize
+                      ? null
+                      : () => _changeFontSize(_remoteEditorFontStep),
+                  icon: const Icon(Icons.zoom_in),
+                  tooltip: 'Zoom in',
+                ),
+              TextButton(
+                onPressed: _closeWithSavedText,
+                child: const Text('Save'),
+              ),
+            ],
           ),
-          title: Text('Edit ${widget.fileName}'),
-          actions: [
-            if (_showDesktopZoomButtons(theme.platform))
-              IconButton(
-                onPressed: _fontSize <= _minRemoteEditorFontSize
-                    ? null
-                    : () => _changeFontSize(-_remoteEditorFontStep),
-                icon: const Icon(Icons.zoom_out),
-                tooltip: 'Zoom out',
-              ),
-            IconButton(
-              onPressed: () {
-                setState(() {
-                  _wrapLines = !_wrapLines;
-                });
-                if (!_wrapLines) {
-                  _scheduleSelectionVisibilityUpdate();
-                }
-              },
-              icon: Icon(_wrapLines ? Icons.wrap_text : Icons.segment),
-              tooltip: _wrapLines ? 'Disable line wrap' : 'Enable line wrap',
-            ),
-            if (_showDesktopZoomButtons(theme.platform))
-              IconButton(
-                onPressed: _fontSize >= _maxRemoteEditorFontSize
-                    ? null
-                    : () => _changeFontSize(_remoteEditorFontStep),
-                icon: const Icon(Icons.zoom_in),
-                tooltip: 'Zoom in',
-              ),
-            TextButton(
-              onPressed: () => Navigator.pop(context, widget.controller.text),
-              child: const Text('Save'),
-            ),
-          ],
-        ),
-        body: Padding(
-          padding: const EdgeInsets.all(12),
-          child: SizedBox.expand(
-            child: ClipRect(
-              key: _remoteTextEditorSurfaceKey,
-              child: ColoredBox(
-                color: colors.background,
-                child: Column(
-                  children: [
-                    Expanded(
-                      child: LayoutBuilder(
-                        builder: (context, constraints) {
-                          final gutterWidth = _wrapLines
-                              ? 0.0
-                              : _resolveGutterWidth(context, editorTextStyle);
-                          final viewportWidth =
-                              constraints.maxWidth > gutterWidth
-                              ? constraints.maxWidth - gutterWidth
-                              : 0.0;
-                          _updateEditorViewportWidth(viewportWidth);
+          body: Padding(
+            padding: const EdgeInsets.all(12),
+            child: SizedBox.expand(
+              child: ClipRect(
+                key: _remoteTextEditorSurfaceKey,
+                child: ColoredBox(
+                  color: colors.background,
+                  child: Column(
+                    children: [
+                      Expanded(
+                        child: LayoutBuilder(
+                          builder: (context, constraints) {
+                            final gutterWidth = _wrapLines
+                                ? 0.0
+                                : _resolveGutterWidth(context, editorTextStyle);
+                            final viewportWidth =
+                                constraints.maxWidth > gutterWidth
+                                ? constraints.maxWidth - gutterWidth
+                                : 0.0;
+                            _updateEditorViewportWidth(viewportWidth);
 
-                          final editor = TextField(
-                            controller: widget.controller,
-                            focusNode: _editorFocusNode,
-                            expands: true,
-                            maxLines: null,
-                            keyboardType: TextInputType.multiline,
-                            textAlignVertical: TextAlignVertical.top,
-                            style: editorTextStyle,
-                            scrollController: _editorScrollController,
-                            scrollPhysics: const ClampingScrollPhysics(),
-                            strutStyle: StrutStyle.fromTextStyle(
-                              editorTextStyle,
-                              forceStrutHeight: true,
-                            ),
-                            decoration: null,
-                          );
+                            final editor = TextField(
+                              controller: widget.controller,
+                              focusNode: _editorFocusNode,
+                              expands: true,
+                              maxLines: null,
+                              keyboardType: TextInputType.multiline,
+                              textAlignVertical: TextAlignVertical.top,
+                              style: editorTextStyle,
+                              scrollController: _editorScrollController,
+                              scrollPhysics: const ClampingScrollPhysics(),
+                              strutStyle: StrutStyle.fromTextStyle(
+                                editorTextStyle,
+                                forceStrutHeight: true,
+                              ),
+                              decoration: null,
+                            );
 
-                          final editorPane = _wrapLines
-                              ? SizedBox(
-                                  width: viewportWidth,
-                                  height: constraints.maxHeight,
-                                  child: editor,
-                                )
-                              : _buildNowrapEditorPane(
-                                  context,
-                                  constraints.maxHeight,
-                                  viewportWidth,
-                                  editorTextStyle,
-                                  editor,
-                                );
+                            final editorPane = _wrapLines
+                                ? SizedBox(
+                                    width: viewportWidth,
+                                    height: constraints.maxHeight,
+                                    child: editor,
+                                  )
+                                : _buildNowrapEditorPane(
+                                    context,
+                                    constraints.maxHeight,
+                                    viewportWidth,
+                                    editorTextStyle,
+                                    editor,
+                                  );
 
-                          return Padding(
-                            padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
-                            child: TerminalPinchZoomGestureHandler(
-                              onPinchStart: _handleEditorScaleStart,
-                              onPinchUpdate: _handleEditorScaleUpdate,
-                              onPinchEnd: _handleEditorScaleEnd,
-                              child: Transform.scale(
-                                key: _remoteTextEditorContentTransformKey,
-                                alignment: Alignment.topLeft,
-                                scale: editorVisualScale,
-                                child: Row(
-                                  children: [
-                                    if (!_wrapLines)
-                                      Container(
-                                        width: gutterWidth,
-                                        height: constraints.maxHeight,
-                                        padding: const EdgeInsets.only(
-                                          left: _remoteEditorGutterLeftPadding,
-                                          right:
-                                              _remoteEditorGutterRightPadding,
-                                        ),
-                                        color: colors.gutterBackground,
-                                        child: IgnorePointer(
-                                          child: ListView.builder(
-                                            controller:
-                                                _lineNumberScrollController,
-                                            physics:
-                                                const NeverScrollableScrollPhysics(),
-                                            itemCount: _lineCount,
-                                            itemExtent: lineHeight,
-                                            itemBuilder: (context, index) =>
-                                                Align(
-                                                  alignment:
-                                                      Alignment.centerRight,
-                                                  child: Text(
-                                                    '${index + 1}',
-                                                    style: editorTextStyle
-                                                        .copyWith(
-                                                          color: colors
-                                                              .gutterForeground,
-                                                        ),
-                                                    strutStyle:
-                                                        StrutStyle.fromTextStyle(
-                                                          editorTextStyle,
-                                                          forceStrutHeight:
-                                                              true,
-                                                        ),
-                                                  ),
+                            return Padding(
+                              padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+                              child: TerminalPinchZoomGestureHandler(
+                                onPinchStart: _handleEditorScaleStart,
+                                onPinchUpdate: _handleEditorScaleUpdate,
+                                onPinchEnd: _handleEditorScaleEnd,
+                                child: Transform.scale(
+                                  key: _remoteTextEditorContentTransformKey,
+                                  alignment: Alignment.topLeft,
+                                  scale: editorVisualScale,
+                                  child: Row(
+                                    children: [
+                                      if (!_wrapLines)
+                                        Container(
+                                          width: gutterWidth,
+                                          height: constraints.maxHeight,
+                                          padding: const EdgeInsets.only(
+                                            left:
+                                                _remoteEditorGutterLeftPadding,
+                                            right:
+                                                _remoteEditorGutterRightPadding,
+                                          ),
+                                          color: colors.gutterBackground,
+                                          child: IgnorePointer(
+                                            child: ListView.builder(
+                                              controller:
+                                                  _lineNumberScrollController,
+                                              physics:
+                                                  const NeverScrollableScrollPhysics(),
+                                              itemCount: _lineCount,
+                                              itemExtent: lineHeight,
+                                              itemBuilder: (context, index) => Align(
+                                                alignment:
+                                                    Alignment.centerRight,
+                                                child: Text(
+                                                  '${index + 1}',
+                                                  style: editorTextStyle
+                                                      .copyWith(
+                                                        color: colors
+                                                            .gutterForeground,
+                                                      ),
+                                                  strutStyle:
+                                                      StrutStyle.fromTextStyle(
+                                                        editorTextStyle,
+                                                        forceStrutHeight: true,
+                                                      ),
                                                 ),
+                                              ),
+                                            ),
                                           ),
                                         ),
-                                      ),
-                                    Expanded(child: editorPane),
-                                  ],
+                                      Expanded(child: editorPane),
+                                    ],
+                                  ),
                                 ),
                               ),
-                            ),
-                          );
-                        },
+                            );
+                          },
+                        ),
                       ),
-                    ),
-                    Container(
-                      key: _remoteTextEditorStatusKey,
-                      width: double.infinity,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 12,
+                      Container(
+                        key: _remoteTextEditorStatusKey,
+                        width: double.infinity,
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 12,
+                        ),
+                        color: colors.statusBackground,
+                        child: Wrap(
+                          alignment: WrapAlignment.spaceBetween,
+                          runSpacing: 8,
+                          spacing: 16,
+                          children: [
+                            Text(
+                              'Line ${caretPosition.line}, Column ${caretPosition.column}',
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: colors.statusForeground,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            Text(
+                              _wrapLines ? 'Wrap on' : 'Wrap off',
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: colors.statusForeground,
+                              ),
+                            ),
+                            Text(
+                              '${displayedFontSize.toStringAsFixed(0)} pt',
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: colors.statusForeground,
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
-                      color: colors.statusBackground,
-                      child: Wrap(
-                        alignment: WrapAlignment.spaceBetween,
-                        runSpacing: 8,
-                        spacing: 16,
-                        children: [
-                          Text(
-                            'Line ${caretPosition.line}, Column ${caretPosition.column}',
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: colors.statusForeground,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                          Text(
-                            _wrapLines ? 'Wrap on' : 'Wrap off',
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: colors.statusForeground,
-                            ),
-                          ),
-                          Text(
-                            '${displayedFontSize.toStringAsFixed(0)} pt',
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: colors.statusForeground,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/presentation/screens/remote_text_editor_screen.dart
+++ b/lib/presentation/screens/remote_text_editor_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -644,7 +645,7 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
             leading: IconButton(
               icon: const Icon(Icons.close),
               tooltip: 'Close editor',
-              onPressed: () => Navigator.pop(context),
+              onPressed: () => unawaited(Navigator.of(context).maybePop()),
             ),
             title: Text('Edit ${widget.fileName}'),
             actions: [

--- a/lib/presentation/screens/snippet_edit_screen.dart
+++ b/lib/presentation/screens/snippet_edit_screen.dart
@@ -44,18 +44,11 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
   @override
   void initState() {
     super.initState();
-    _contentController.addListener(_handleCommandChanged);
     unawaited(_loadFolders());
     if (widget.snippetId != null) {
       unawaited(_loadSnippet());
     } else {
       _initialDraft = _currentDraft();
-    }
-  }
-
-  void _handleCommandChanged() {
-    if (mounted) {
-      setState(() {});
     }
   }
 
@@ -86,7 +79,6 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
 
   @override
   void dispose() {
-    _contentController.removeListener(_handleCommandChanged);
     _nameController.dispose();
     _contentController.dispose();
     _descriptionController.dispose();

--- a/lib/presentation/screens/snippet_edit_screen.dart
+++ b/lib/presentation/screens/snippet_edit_screen.dart
@@ -8,6 +8,14 @@ import 'package:go_router/go_router.dart';
 import '../../app/theme.dart';
 import '../../data/database/database.dart';
 import '../../data/repositories/snippet_repository.dart';
+import '../widgets/unsaved_changes_guard.dart';
+
+typedef _SnippetEditDraft = ({
+  String name,
+  String command,
+  String description,
+  int? selectedFolderId,
+});
 
 /// Screen for adding or editing a snippet.
 class SnippetEditScreen extends ConsumerStatefulWidget {
@@ -31,6 +39,7 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
   Snippet? _existingSnippet;
   int? _selectedFolderId;
   List<SnippetFolder> _folders = [];
+  _SnippetEditDraft? _initialDraft;
 
   @override
   void initState() {
@@ -39,6 +48,8 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
     unawaited(_loadFolders());
     if (widget.snippetId != null) {
       unawaited(_loadSnippet());
+    } else {
+      _initialDraft = _currentDraft();
     }
   }
 
@@ -68,6 +79,7 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
         _descriptionController.text = snippet.description ?? '';
         _selectedFolderId = snippet.folderId;
         _isLoading = false;
+        _initialDraft = _currentDraft();
       });
     }
   }
@@ -85,118 +97,151 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
   Widget build(BuildContext context) {
     final isEditing = widget.snippetId != null;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(isEditing ? 'Edit Snippet' : 'Add Snippet'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.help_outline),
-            onPressed: _showVariablesHelp,
-            tooltip: 'Variable syntax',
-          ),
-        ],
-      ),
-      body: _isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : Form(
-              key: _formKey,
-              child: ListView(
-                padding: const EdgeInsets.all(16),
-                children: [
-                  // Name
-                  TextFormField(
-                    controller: _nameController,
-                    decoration: const InputDecoration(
-                      labelText: 'Name',
-                      hintText: 'Restart Docker',
-                      prefixIcon: Icon(Icons.label),
-                    ),
-                    textInputAction: TextInputAction.next,
-                    validator: (value) {
-                      if (value == null || value.isEmpty) {
-                        return 'Please enter a name';
-                      }
-                      return null;
-                    },
-                  ),
-                  const SizedBox(height: 16),
-
-                  // Description (optional)
-                  TextFormField(
-                    controller: _descriptionController,
-                    decoration: const InputDecoration(
-                      labelText: 'Description (optional)',
-                      hintText: 'What this snippet does',
-                      prefixIcon: Icon(Icons.description),
-                    ),
-                    textInputAction: TextInputAction.next,
-                  ),
-                  const SizedBox(height: 16),
-
-                  DropdownButtonFormField<int?>(
-                    initialValue:
-                        _folders.any((folder) => folder.id == _selectedFolderId)
-                        ? _selectedFolderId
-                        : null,
-                    decoration: const InputDecoration(
-                      labelText: 'Folder (optional)',
-                      prefixIcon: Icon(Icons.folder_outlined),
-                    ),
-                    items: [
-                      const DropdownMenuItem<int?>(child: Text('No folder')),
-                      ..._folders.map(
-                        (folder) => DropdownMenuItem<int?>(
-                          value: folder.id,
-                          child: Text(folder.name),
-                        ),
-                      ),
-                    ],
-                    onChanged: (value) =>
-                        setState(() => _selectedFolderId = value),
-                  ),
-                  const SizedBox(height: 16),
-
-                  // Content
-                  TextFormField(
-                    controller: _contentController,
-                    decoration: const InputDecoration(
-                      labelText: 'Command',
-                      hintText: 'docker restart {{container}}',
-                      alignLabelWithHint: true,
-                    ),
-                    maxLines: 6,
-                    style: FluttyTheme.monoStyle.copyWith(fontSize: 14),
-                    validator: (value) {
-                      if (value == null || value.isEmpty) {
-                        return 'Please enter a command';
-                      }
-                      return null;
-                    },
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    'Use {{variable}} placeholders. Examples: '
-                    '{{container}}, {{branch}}, {{log_file}}.',
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.outline,
-                    ),
-                  ),
-                  const SizedBox(height: 24),
-
-                  // Variable preview
-                  _buildVariablePreview(),
-                  const SizedBox(height: 32),
-
-                  // Save button
-                  FilledButton.icon(
-                    onPressed: _saveSnippet,
-                    icon: const Icon(Icons.save),
-                    label: Text(isEditing ? 'Save Changes' : 'Add Snippet'),
-                  ),
-                ],
-              ),
+    return UnsavedChangesGuard(
+      hasUnsavedChanges: _hasUnsavedChanges,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(isEditing ? 'Edit Snippet' : 'Add Snippet'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.help_outline),
+              onPressed: _showVariablesHelp,
+              tooltip: 'Variable syntax',
             ),
+          ],
+        ),
+        body: _isLoading
+            ? const Center(child: CircularProgressIndicator())
+            : Form(
+                key: _formKey,
+                onChanged: () => setState(() {}),
+                child: ListView(
+                  padding: const EdgeInsets.all(16),
+                  children: [
+                    // Name
+                    TextFormField(
+                      controller: _nameController,
+                      decoration: const InputDecoration(
+                        labelText: 'Name',
+                        hintText: 'Restart Docker',
+                        prefixIcon: Icon(Icons.label),
+                      ),
+                      textInputAction: TextInputAction.next,
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'Please enter a name';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Description (optional)
+                    TextFormField(
+                      controller: _descriptionController,
+                      decoration: const InputDecoration(
+                        labelText: 'Description (optional)',
+                        hintText: 'What this snippet does',
+                        prefixIcon: Icon(Icons.description),
+                      ),
+                      textInputAction: TextInputAction.next,
+                    ),
+                    const SizedBox(height: 16),
+
+                    DropdownButtonFormField<int?>(
+                      initialValue:
+                          _folders.any(
+                            (folder) => folder.id == _selectedFolderId,
+                          )
+                          ? _selectedFolderId
+                          : null,
+                      decoration: const InputDecoration(
+                        labelText: 'Folder (optional)',
+                        prefixIcon: Icon(Icons.folder_outlined),
+                      ),
+                      items: [
+                        const DropdownMenuItem<int?>(child: Text('No folder')),
+                        ..._folders.map(
+                          (folder) => DropdownMenuItem<int?>(
+                            value: folder.id,
+                            child: Text(folder.name),
+                          ),
+                        ),
+                      ],
+                      onChanged: (value) =>
+                          setState(() => _selectedFolderId = value),
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Content
+                    TextFormField(
+                      controller: _contentController,
+                      decoration: const InputDecoration(
+                        labelText: 'Command',
+                        hintText: 'docker restart {{container}}',
+                        alignLabelWithHint: true,
+                      ),
+                      maxLines: 6,
+                      style: FluttyTheme.monoStyle.copyWith(fontSize: 14),
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'Please enter a command';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Use {{variable}} placeholders. Examples: '
+                      '{{container}}, {{branch}}, {{log_file}}.',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.outline,
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+
+                    // Variable preview
+                    _buildVariablePreview(),
+                    const SizedBox(height: 32),
+
+                    // Save button
+                    FilledButton.icon(
+                      onPressed: _saveSnippet,
+                      icon: const Icon(Icons.save),
+                      label: Text(isEditing ? 'Save Changes' : 'Add Snippet'),
+                    ),
+                  ],
+                ),
+              ),
+      ),
     );
+  }
+
+  bool get _hasUnsavedChanges {
+    final initialDraft = _initialDraft;
+    return initialDraft != null && _currentDraft() != initialDraft;
+  }
+
+  _SnippetEditDraft _currentDraft() => (
+    name: _nameController.text,
+    command: _contentController.text,
+    description: _descriptionController.text,
+    selectedFolderId: _selectedFolderId,
+  );
+
+  void _closeWithoutUnsavedPrompt(SnackBar snackBar) {
+    final messenger = ScaffoldMessenger.of(context);
+    setState(() {
+      _initialDraft = _currentDraft();
+      _isLoading = false;
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      context.pop();
+      messenger.showSnackBar(snackBar);
+    });
   }
 
   Widget _buildVariablePreview() {
@@ -243,6 +288,7 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
     if (!_formKey.currentState!.validate()) return;
 
     setState(() => _isLoading = true);
+    var didScheduleClose = false;
 
     try {
       final repo = ref.read(snippetRepositoryProvider);
@@ -273,8 +319,8 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
       }
 
       if (mounted) {
-        context.pop();
-        ScaffoldMessenger.of(context).showSnackBar(
+        didScheduleClose = true;
+        _closeWithoutUnsavedPrompt(
           SnackBar(
             content: Text(
               widget.snippetId != null ? 'Snippet updated' : 'Snippet added',
@@ -296,7 +342,7 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
         );
       }
     } finally {
-      if (mounted) setState(() => _isLoading = false);
+      if (mounted && !didScheduleClose) setState(() => _isLoading = false);
     }
   }
 

--- a/lib/presentation/screens/theme_editor_screen.dart
+++ b/lib/presentation/screens/theme_editor_screen.dart
@@ -7,6 +7,32 @@ import 'package:uuid/uuid.dart';
 import '../../domain/models/terminal_theme.dart';
 import '../../domain/models/terminal_themes.dart';
 import '../../domain/services/terminal_theme_service.dart';
+import '../widgets/unsaved_changes_guard.dart';
+
+typedef _ThemeEditDraft = ({
+  String name,
+  bool isDark,
+  Color foreground,
+  Color background,
+  Color cursor,
+  Color selection,
+  Color black,
+  Color red,
+  Color green,
+  Color yellow,
+  Color blue,
+  Color magenta,
+  Color cyan,
+  Color white,
+  Color brightBlack,
+  Color brightRed,
+  Color brightGreen,
+  Color brightYellow,
+  Color brightBlue,
+  Color brightMagenta,
+  Color brightCyan,
+  Color brightWhite,
+});
 
 /// Screen for creating or editing custom terminal themes.
 class ThemeEditorScreen extends ConsumerStatefulWidget {
@@ -50,6 +76,7 @@ class _ThemeEditorScreenState extends ConsumerState<ThemeEditorScreen> {
   bool _isDark = true;
   bool _isLoading = false;
   TerminalThemeData? _existingTheme;
+  _ThemeEditDraft? _initialDraft;
 
   @override
   void initState() {
@@ -59,6 +86,8 @@ class _ThemeEditorScreenState extends ConsumerState<ThemeEditorScreen> {
 
     if (widget.themeId != null) {
       _loadTheme();
+    } else {
+      _initialDraft = _currentDraft();
     }
   }
 
@@ -118,6 +147,7 @@ class _ThemeEditorScreenState extends ConsumerState<ThemeEditorScreen> {
         _brightCyan = theme.brightCyan;
         _brightWhite = theme.brightWhite;
         _isLoading = false;
+        _initialDraft = _currentDraft();
       });
     }
   }
@@ -159,180 +189,232 @@ class _ThemeEditorScreenState extends ConsumerState<ThemeEditorScreen> {
   Widget build(BuildContext context) {
     final isEditing = widget.themeId != null;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(isEditing ? 'Edit Theme' : 'Create Theme'),
-        actions: [TextButton(onPressed: _saveTheme, child: const Text('Save'))],
-      ),
-      body: _isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : Row(
-              children: [
-                // Editor panel
-                Expanded(
-                  flex: 2,
-                  child: Form(
-                    key: _formKey,
-                    child: ListView(
-                      padding: const EdgeInsets.all(16),
-                      children: [
-                        // Theme name
-                        TextFormField(
-                          controller: _nameController,
-                          decoration: const InputDecoration(
-                            labelText: 'Theme Name',
-                            hintText: 'My Custom Theme',
+    return UnsavedChangesGuard(
+      hasUnsavedChanges: _hasUnsavedChanges,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(isEditing ? 'Edit Theme' : 'Create Theme'),
+          actions: [
+            TextButton(onPressed: _saveTheme, child: const Text('Save')),
+          ],
+        ),
+        body: _isLoading
+            ? const Center(child: CircularProgressIndicator())
+            : Row(
+                children: [
+                  // Editor panel
+                  Expanded(
+                    flex: 2,
+                    child: Form(
+                      key: _formKey,
+                      onChanged: () => setState(() {}),
+                      child: ListView(
+                        padding: const EdgeInsets.all(16),
+                        children: [
+                          // Theme name
+                          TextFormField(
+                            controller: _nameController,
+                            decoration: const InputDecoration(
+                              labelText: 'Theme Name',
+                              hintText: 'My Custom Theme',
+                            ),
+                            validator: (v) =>
+                                v?.isEmpty ?? true ? 'Name is required' : null,
                           ),
-                          validator: (v) =>
-                              v?.isEmpty ?? true ? 'Name is required' : null,
-                        ),
-                        const SizedBox(height: 16),
+                          const SizedBox(height: 16),
 
-                        // Dark/Light toggle
-                        SwitchListTile(
-                          title: const Text('Dark Theme'),
-                          subtitle: Text(
-                            _isDark ? 'Dark background' : 'Light background',
+                          // Dark/Light toggle
+                          SwitchListTile(
+                            title: const Text('Dark Theme'),
+                            subtitle: Text(
+                              _isDark ? 'Dark background' : 'Light background',
+                            ),
+                            value: _isDark,
+                            onChanged: (v) => setState(() => _isDark = v),
                           ),
-                          value: _isDark,
-                          onChanged: (v) => setState(() => _isDark = v),
-                        ),
-                        const Divider(height: 32),
+                          const Divider(height: 32),
 
-                        // Special colors section
-                        const _SectionHeader(title: 'Special Colors'),
-                        _ColorRow(
-                          label: 'Background',
-                          color: _background,
-                          onChanged: (c) => setState(() => _background = c),
-                        ),
-                        _ColorRow(
-                          label: 'Foreground',
-                          color: _foreground,
-                          onChanged: (c) => setState(() => _foreground = c),
-                        ),
-                        _ColorRow(
-                          label: 'Cursor',
-                          color: _cursor,
-                          onChanged: (c) => setState(() => _cursor = c),
-                        ),
-                        _ColorRow(
-                          label: 'Selection',
-                          color: _selection,
-                          onChanged: (c) => setState(() => _selection = c),
-                        ),
-                        const Divider(height: 32),
+                          // Special colors section
+                          const _SectionHeader(title: 'Special Colors'),
+                          _ColorRow(
+                            label: 'Background',
+                            color: _background,
+                            onChanged: (c) => setState(() => _background = c),
+                          ),
+                          _ColorRow(
+                            label: 'Foreground',
+                            color: _foreground,
+                            onChanged: (c) => setState(() => _foreground = c),
+                          ),
+                          _ColorRow(
+                            label: 'Cursor',
+                            color: _cursor,
+                            onChanged: (c) => setState(() => _cursor = c),
+                          ),
+                          _ColorRow(
+                            label: 'Selection',
+                            color: _selection,
+                            onChanged: (c) => setState(() => _selection = c),
+                          ),
+                          const Divider(height: 32),
 
-                        // Standard ANSI colors
-                        const _SectionHeader(title: 'Standard Colors'),
-                        _ColorRow(
-                          label: 'Black',
-                          color: _black,
-                          onChanged: (c) => setState(() => _black = c),
-                        ),
-                        _ColorRow(
-                          label: 'Red',
-                          color: _red,
-                          onChanged: (c) => setState(() => _red = c),
-                        ),
-                        _ColorRow(
-                          label: 'Green',
-                          color: _green,
-                          onChanged: (c) => setState(() => _green = c),
-                        ),
-                        _ColorRow(
-                          label: 'Yellow',
-                          color: _yellow,
-                          onChanged: (c) => setState(() => _yellow = c),
-                        ),
-                        _ColorRow(
-                          label: 'Blue',
-                          color: _blue,
-                          onChanged: (c) => setState(() => _blue = c),
-                        ),
-                        _ColorRow(
-                          label: 'Magenta',
-                          color: _magenta,
-                          onChanged: (c) => setState(() => _magenta = c),
-                        ),
-                        _ColorRow(
-                          label: 'Cyan',
-                          color: _cyan,
-                          onChanged: (c) => setState(() => _cyan = c),
-                        ),
-                        _ColorRow(
-                          label: 'White',
-                          color: _white,
-                          onChanged: (c) => setState(() => _white = c),
-                        ),
-                        const Divider(height: 32),
+                          // Standard ANSI colors
+                          const _SectionHeader(title: 'Standard Colors'),
+                          _ColorRow(
+                            label: 'Black',
+                            color: _black,
+                            onChanged: (c) => setState(() => _black = c),
+                          ),
+                          _ColorRow(
+                            label: 'Red',
+                            color: _red,
+                            onChanged: (c) => setState(() => _red = c),
+                          ),
+                          _ColorRow(
+                            label: 'Green',
+                            color: _green,
+                            onChanged: (c) => setState(() => _green = c),
+                          ),
+                          _ColorRow(
+                            label: 'Yellow',
+                            color: _yellow,
+                            onChanged: (c) => setState(() => _yellow = c),
+                          ),
+                          _ColorRow(
+                            label: 'Blue',
+                            color: _blue,
+                            onChanged: (c) => setState(() => _blue = c),
+                          ),
+                          _ColorRow(
+                            label: 'Magenta',
+                            color: _magenta,
+                            onChanged: (c) => setState(() => _magenta = c),
+                          ),
+                          _ColorRow(
+                            label: 'Cyan',
+                            color: _cyan,
+                            onChanged: (c) => setState(() => _cyan = c),
+                          ),
+                          _ColorRow(
+                            label: 'White',
+                            color: _white,
+                            onChanged: (c) => setState(() => _white = c),
+                          ),
+                          const Divider(height: 32),
 
-                        // Bright ANSI colors
-                        const _SectionHeader(title: 'Bright Colors'),
-                        _ColorRow(
-                          label: 'Bright Black',
-                          color: _brightBlack,
-                          onChanged: (c) => setState(() => _brightBlack = c),
-                        ),
-                        _ColorRow(
-                          label: 'Bright Red',
-                          color: _brightRed,
-                          onChanged: (c) => setState(() => _brightRed = c),
-                        ),
-                        _ColorRow(
-                          label: 'Bright Green',
-                          color: _brightGreen,
-                          onChanged: (c) => setState(() => _brightGreen = c),
-                        ),
-                        _ColorRow(
-                          label: 'Bright Yellow',
-                          color: _brightYellow,
-                          onChanged: (c) => setState(() => _brightYellow = c),
-                        ),
-                        _ColorRow(
-                          label: 'Bright Blue',
-                          color: _brightBlue,
-                          onChanged: (c) => setState(() => _brightBlue = c),
-                        ),
-                        _ColorRow(
-                          label: 'Bright Magenta',
-                          color: _brightMagenta,
-                          onChanged: (c) => setState(() => _brightMagenta = c),
-                        ),
-                        _ColorRow(
-                          label: 'Bright Cyan',
-                          color: _brightCyan,
-                          onChanged: (c) => setState(() => _brightCyan = c),
-                        ),
-                        _ColorRow(
-                          label: 'Bright White',
-                          color: _brightWhite,
-                          onChanged: (c) => setState(() => _brightWhite = c),
-                        ),
-                        const SizedBox(height: 32),
-                      ],
-                    ),
-                  ),
-                ),
-                // Preview panel
-                Expanded(
-                  child: Container(
-                    margin: const EdgeInsets.all(16),
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(12),
-                      border: Border.all(
-                        color: Theme.of(context).colorScheme.outline,
+                          // Bright ANSI colors
+                          const _SectionHeader(title: 'Bright Colors'),
+                          _ColorRow(
+                            label: 'Bright Black',
+                            color: _brightBlack,
+                            onChanged: (c) => setState(() => _brightBlack = c),
+                          ),
+                          _ColorRow(
+                            label: 'Bright Red',
+                            color: _brightRed,
+                            onChanged: (c) => setState(() => _brightRed = c),
+                          ),
+                          _ColorRow(
+                            label: 'Bright Green',
+                            color: _brightGreen,
+                            onChanged: (c) => setState(() => _brightGreen = c),
+                          ),
+                          _ColorRow(
+                            label: 'Bright Yellow',
+                            color: _brightYellow,
+                            onChanged: (c) => setState(() => _brightYellow = c),
+                          ),
+                          _ColorRow(
+                            label: 'Bright Blue',
+                            color: _brightBlue,
+                            onChanged: (c) => setState(() => _brightBlue = c),
+                          ),
+                          _ColorRow(
+                            label: 'Bright Magenta',
+                            color: _brightMagenta,
+                            onChanged: (c) =>
+                                setState(() => _brightMagenta = c),
+                          ),
+                          _ColorRow(
+                            label: 'Bright Cyan',
+                            color: _brightCyan,
+                            onChanged: (c) => setState(() => _brightCyan = c),
+                          ),
+                          _ColorRow(
+                            label: 'Bright White',
+                            color: _brightWhite,
+                            onChanged: (c) => setState(() => _brightWhite = c),
+                          ),
+                          const SizedBox(height: 32),
+                        ],
                       ),
                     ),
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(11),
-                      child: _buildPreview(),
+                  ),
+                  // Preview panel
+                  Expanded(
+                    child: Container(
+                      margin: const EdgeInsets.all(16),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(
+                          color: Theme.of(context).colorScheme.outline,
+                        ),
+                      ),
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(11),
+                        child: _buildPreview(),
+                      ),
                     ),
                   ),
-                ),
-              ],
-            ),
+                ],
+              ),
+      ),
     );
+  }
+
+  bool get _hasUnsavedChanges {
+    final initialDraft = _initialDraft;
+    return initialDraft != null && _currentDraft() != initialDraft;
+  }
+
+  _ThemeEditDraft _currentDraft() => (
+    name: _nameController.text,
+    isDark: _isDark,
+    foreground: _foreground,
+    background: _background,
+    cursor: _cursor,
+    selection: _selection,
+    black: _black,
+    red: _red,
+    green: _green,
+    yellow: _yellow,
+    blue: _blue,
+    magenta: _magenta,
+    cyan: _cyan,
+    white: _white,
+    brightBlack: _brightBlack,
+    brightRed: _brightRed,
+    brightGreen: _brightGreen,
+    brightYellow: _brightYellow,
+    brightBlue: _brightBlue,
+    brightMagenta: _brightMagenta,
+    brightCyan: _brightCyan,
+    brightWhite: _brightWhite,
+  );
+
+  void _closeWithoutUnsavedPrompt(SnackBar snackBar) {
+    final messenger = ScaffoldMessenger.of(context);
+    setState(() {
+      _initialDraft = _currentDraft();
+      _isLoading = false;
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      context.pop();
+      messenger.showSnackBar(snackBar);
+    });
   }
 
   Widget _buildPreview() => Container(
@@ -448,6 +530,7 @@ class _ThemeEditorScreenState extends ConsumerState<ThemeEditorScreen> {
     if (!_formKey.currentState!.validate()) return;
 
     setState(() => _isLoading = true);
+    var didScheduleClose = false;
 
     try {
       final service = ref.read(terminalThemeServiceProvider);
@@ -459,10 +542,10 @@ class _ThemeEditorScreenState extends ConsumerState<ThemeEditorScreen> {
         ..invalidate(customTerminalThemesProvider);
 
       if (mounted) {
-        context.pop();
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Theme "${theme.name}" saved')));
+        didScheduleClose = true;
+        _closeWithoutUnsavedPrompt(
+          SnackBar(content: Text('Theme "${theme.name}" saved')),
+        );
       }
     } on Exception catch (e) {
       FlutterError.reportError(
@@ -478,7 +561,7 @@ class _ThemeEditorScreenState extends ConsumerState<ThemeEditorScreen> {
         );
       }
     } finally {
-      if (mounted) setState(() => _isLoading = false);
+      if (mounted && !didScheduleClose) setState(() => _isLoading = false);
     }
   }
 }

--- a/lib/presentation/widgets/unsaved_changes_guard.dart
+++ b/lib/presentation/widgets/unsaved_changes_guard.dart
@@ -1,0 +1,123 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// Blocks route pops while a page has unsaved changes.
+class UnsavedChangesGuard extends StatefulWidget {
+  /// Creates a guard that asks for confirmation before discarding changes.
+  const UnsavedChangesGuard({
+    required this.hasUnsavedChanges,
+    required this.child,
+    this.title = 'Discard changes?',
+    this.message =
+        'You have unsaved changes. If you leave now, those changes will be lost.',
+    this.keepEditingLabel = 'Keep editing',
+    this.discardLabel = 'Discard',
+    super.key,
+  });
+
+  /// Whether leaving the current route would discard unsaved user changes.
+  final bool hasUnsavedChanges;
+
+  /// The guarded page content.
+  final Widget child;
+
+  /// Dialog title shown when the user tries to leave.
+  final String title;
+
+  /// Dialog body shown when the user tries to leave.
+  final String message;
+
+  /// Label for the action that keeps the user on the page.
+  final String keepEditingLabel;
+
+  /// Label for the destructive action that discards changes.
+  final String discardLabel;
+
+  @override
+  State<UnsavedChangesGuard> createState() => _UnsavedChangesGuardState();
+}
+
+class _UnsavedChangesGuardState extends State<UnsavedChangesGuard> {
+  bool _allowNextPop = false;
+  bool _isShowingPrompt = false;
+
+  bool get _canPop => _allowNextPop || !widget.hasUnsavedChanges;
+
+  @override
+  void didUpdateWidget(covariant UnsavedChangesGuard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!widget.hasUnsavedChanges && _allowNextPop) {
+      _allowNextPop = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => PopScope<Object?>(
+    canPop: _canPop,
+    onPopInvokedWithResult: (didPop, _) {
+      if (didPop || _canPop || _isShowingPrompt) {
+        return;
+      }
+      unawaited(_confirmDiscardAndPop());
+    },
+    child: widget.child,
+  );
+
+  Future<void> _confirmDiscardAndPop() async {
+    _isShowingPrompt = true;
+    final shouldDiscard = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(widget.title),
+        content: Text(widget.message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(widget.keepEditingLabel),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(dialogContext).colorScheme.error,
+            ),
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(widget.discardLabel),
+          ),
+        ],
+      ),
+    );
+    _isShowingPrompt = false;
+
+    if (!mounted || shouldDiscard != true) {
+      return;
+    }
+
+    setState(() => _allowNextPop = true);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) {
+          return;
+        }
+        unawaited(_popGuardedRoute());
+      });
+    });
+  }
+
+  Future<void> _popGuardedRoute() async {
+    final navigator = Navigator.of(context);
+    if (navigator.canPop()) {
+      navigator.pop();
+      return;
+    }
+    final router = GoRouter.maybeOf(context);
+    if (router != null && router.canPop()) {
+      router.pop();
+      return;
+    }
+    await navigator.maybePop();
+  }
+}

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -328,6 +328,41 @@ void main() {
       },
     );
 
+    testWidgets('warns before leaving with unsaved host changes', (
+      tester,
+    ) async {
+      await _pumpHostCreateScreen(tester);
+
+      await tester.enterText(
+        find.byKey(const Key('host-label-field')),
+        'Unsaved Host',
+      );
+      await tester.pump();
+      await tester.pageBack();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('Discard changes?'), findsOneWidget);
+
+      await tester.tap(find.text('Keep editing'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.byType(HostEditScreen), findsOneWidget);
+
+      await tester.pageBack();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text('Discard'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(seconds: 2));
+
+      expect(find.byType(HostEditScreen), findsNothing);
+    });
+
     testWidgets('scrolls to missing tmux session when saving tmux startup', (
       tester,
     ) async {

--- a/test/widget/sftp_screen_test.dart
+++ b/test/widget/sftp_screen_test.dart
@@ -152,6 +152,44 @@ void main() {
       expect(find.byIcon(Icons.close), findsOneWidget);
     });
 
+    testWidgets('close affordance warns before discarding unsaved edits', (
+      tester,
+    ) async {
+      final controller = TextEditingController(text: 'alpha');
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => FilledButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<String>(
+                    builder: (_) => buildRemoteTextEditorScreenForTesting(
+                      fileName: 'notes.txt',
+                      controller: controller,
+                    ),
+                  ),
+                );
+              },
+              child: const Text('Open editor'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open editor'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), 'beta');
+      await tester.pump();
+      await tester.tap(find.byTooltip('Close editor'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('Discard changes?'), findsOneWidget);
+      expect(find.text('Edit notes.txt'), findsOneWidget);
+    });
+
     testWidgets(
       'starts at line 1 when the incoming controller selection is invalid',
       (tester) async {

--- a/test/widget/unsaved_changes_guard_test.dart
+++ b/test/widget/unsaved_changes_guard_test.dart
@@ -1,0 +1,79 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/presentation/widgets/unsaved_changes_guard.dart';
+
+void main() {
+  group('UnsavedChangesGuard', () {
+    testWidgets('pops without a prompt when there are no changes', (
+      tester,
+    ) async {
+      await _pumpGuardHost(tester, hasUnsavedChanges: false);
+
+      await tester.tap(find.text('Open editor'));
+      await tester.pumpAndSettle();
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Discard changes?'), findsNothing);
+      expect(find.text('Open editor'), findsOneWidget);
+    });
+
+    testWidgets('asks before discarding unsaved changes', (tester) async {
+      await _pumpGuardHost(tester, hasUnsavedChanges: true);
+
+      await tester.tap(find.text('Open editor'));
+      await tester.pumpAndSettle();
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Discard changes?'), findsOneWidget);
+
+      await tester.tap(find.text('Keep editing'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Editor body'), findsOneWidget);
+
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Discard'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Editor body'), findsNothing);
+      expect(find.text('Open editor'), findsOneWidget);
+    });
+  });
+}
+
+Future<void> _pumpGuardHost(
+  WidgetTester tester, {
+  required bool hasUnsavedChanges,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (context) => Scaffold(
+          body: Center(
+            child: FilledButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => UnsavedChangesGuard(
+                      hasUnsavedChanges: hasUnsavedChanges,
+                      child: Scaffold(
+                        appBar: AppBar(title: const Text('Editor')),
+                        body: const Text('Editor body'),
+                      ),
+                    ),
+                  ),
+                );
+              },
+              child: const Text('Open editor'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

- Add a reusable `UnsavedChangesGuard` that prompts before discarding dirty edit pages.
- Track dirty draft state for host, snippet, port forward, theme, SSH key, and remote text editor flows.
- Add widget coverage for the shared guard and host edit unsaved-change warning.

## Validation

- `flutter analyze`
- `flutter test`
