### PR TITLE
Fix light theme detection for terminal TUIs

### DIFF
--- a/lib/domain/models/terminal_theme.dart
+++ b/lib/domain/models/terminal_theme.dart
@@ -3,6 +3,142 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:xterm/xterm.dart';
 
+/// Builds an xterm-compatible response for terminal theme OSC color queries.
+///
+/// Modern TUIs use these queries (notably `OSC 11;?`) to detect whether the
+/// terminal background is light or dark. Returning `null` means the OSC
+/// sequence is not a color query and should be handled by other OSC handlers.
+String? buildTerminalThemeOscResponse({
+  required TerminalThemeData theme,
+  required String code,
+  required List<String> args,
+}) {
+  switch (code) {
+    case '4':
+      return _buildAnsiPaletteOscResponse(theme, args);
+    case '10':
+      return _buildSingleColorOscResponse(code, theme.foreground, args);
+    case '11':
+      return _buildSingleColorOscResponse(code, theme.background, args);
+    case '12':
+      return _buildSingleColorOscResponse(code, theme.cursor, args);
+    default:
+      return null;
+  }
+}
+
+String? _buildSingleColorOscResponse(
+  String code,
+  Color color,
+  List<String> args,
+) {
+  if (args.isEmpty || args.first.trim() != '?') {
+    return null;
+  }
+  return _formatOscColorResponse(code, color);
+}
+
+String? _buildAnsiPaletteOscResponse(
+  TerminalThemeData theme,
+  List<String> args,
+) {
+  final responses = <String>[];
+  for (var index = 0; index + 1 < args.length; index += 2) {
+    final colorIndex = int.tryParse(args[index].trim());
+    if (colorIndex == null || args[index + 1].trim() != '?') {
+      continue;
+    }
+    final color = _terminalPaletteColor(theme, colorIndex);
+    if (color == null) {
+      continue;
+    }
+    responses.add(
+      _formatOscColorResponse('4', color, paletteIndex: colorIndex),
+    );
+  }
+  if (responses.isEmpty) {
+    return null;
+  }
+  return responses.join();
+}
+
+Color? _terminalPaletteColor(TerminalThemeData theme, int index) {
+  switch (index) {
+    case 0:
+      return theme.black;
+    case 1:
+      return theme.red;
+    case 2:
+      return theme.green;
+    case 3:
+      return theme.yellow;
+    case 4:
+      return theme.blue;
+    case 5:
+      return theme.magenta;
+    case 6:
+      return theme.cyan;
+    case 7:
+      return theme.white;
+    case 8:
+      return theme.brightBlack;
+    case 9:
+      return theme.brightRed;
+    case 10:
+      return theme.brightGreen;
+    case 11:
+      return theme.brightYellow;
+    case 12:
+      return theme.brightBlue;
+    case 13:
+      return theme.brightMagenta;
+    case 14:
+      return theme.brightCyan;
+    case 15:
+      return theme.brightWhite;
+  }
+
+  if (index >= 16 && index < 232) {
+    final colorIndex = index - 16;
+    final red = _xtermColorCubeComponent(colorIndex ~/ 36);
+    final green = _xtermColorCubeComponent((colorIndex ~/ 6) % 6);
+    final blue = _xtermColorCubeComponent(colorIndex % 6);
+    return Color.fromARGB(0xFF, red, green, blue);
+  }
+
+  if (index >= 232 && index <= 255) {
+    final level = 8 + ((index - 232) * 10);
+    return Color.fromARGB(0xFF, level, level, level);
+  }
+
+  return null;
+}
+
+int _xtermColorCubeComponent(int value) => value == 0 ? 0 : 55 + (value * 40);
+
+String _formatOscColorResponse(String code, Color color, {int? paletteIndex}) {
+  final colorSpec = _formatOscRgbColor(color);
+  final payload = paletteIndex == null
+      ? '$code;$colorSpec'
+      : '$code;$paletteIndex;$colorSpec';
+  return '\x1b]$payload\x1b\\';
+}
+
+String _formatOscRgbColor(Color color) {
+  final value = color.toARGB32();
+  final red = (value >> 16) & 0xFF;
+  final green = (value >> 8) & 0xFF;
+  final blue = value & 0xFF;
+  return 'rgb:${_formatOscRgbComponent(red)}/'
+      '${_formatOscRgbComponent(green)}/'
+      '${_formatOscRgbComponent(blue)}';
+}
+
+String _formatOscRgbComponent(int value) {
+  final hex = value.toRadixString(16).padLeft(2, '0');
+  return '$hex$hex';
+}
+
 /// Data model for a terminal color theme.
 ///
 /// Contains all 16 ANSI colors plus special colors for cursor, selection,

--- a/lib/domain/models/terminal_theme.dart
+++ b/lib/domain/models/terminal_theme.dart
@@ -22,6 +22,10 @@ String? buildTerminalThemeOscResponse({
       return _buildSingleColorOscResponse(code, theme.background, args);
     case '12':
       return _buildSingleColorOscResponse(code, theme.cursor, args);
+    case '17':
+      return _buildSingleColorOscResponse(code, theme.selection, args);
+    case '19':
+      return _buildSingleColorOscResponse(code, theme.foreground, args);
     default:
       return null;
   }

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -12,6 +12,7 @@ import '../../data/database/database.dart';
 import '../../data/repositories/host_repository.dart';
 import '../../data/repositories/key_repository.dart';
 import '../../data/repositories/known_hosts_repository.dart';
+import '../models/terminal_theme.dart';
 import 'background_ssh_service.dart';
 import 'clipboard_sharing_service.dart';
 import 'diagnostics_log_service.dart';
@@ -1591,6 +1592,9 @@ class SshSession {
   /// Persistent terminal that survives screen rebuilds.
   Terminal? _terminal;
 
+  /// The active terminal theme used to answer remote OSC color queries.
+  TerminalThemeData? terminalTheme;
+
   /// Tracks OSC 8 hyperlinks rendered in the persistent terminal.
   final terminalHyperlinkTracker = TerminalHyperlinkTracker();
 
@@ -2032,6 +2036,18 @@ class SshSession {
   }
 
   void _handlePrivateOsc(String code, List<String> args) {
+    final themeOscResponse = terminalTheme == null
+        ? null
+        : buildTerminalThemeOscResponse(
+            theme: terminalTheme!,
+            code: code,
+            args: args,
+          );
+    if (themeOscResponse != null) {
+      _shell?.write(utf8.encode(themeOscResponse));
+      return;
+    }
+
     terminalHyperlinkTracker.handlePrivateOsc(code, args);
 
     if (code == '7') {

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -22,6 +22,89 @@ import 'ssh_exec_queue.dart';
 import 'terminal_hyperlink_tracker.dart';
 import 'wifi_network_service.dart';
 
+/// Current terminal dimensions used to answer terminal size queries.
+typedef TerminalWindowMetrics = ({
+  int columns,
+  int rows,
+  int pixelWidth,
+  int pixelHeight,
+});
+
+/// Builds responses for terminal window/cell size reports in shell output.
+///
+/// [pendingInput] should be the pending suffix returned by the previous call,
+/// so split CSI sequences can be recognized across UTF-8 stream chunks.
+({String? response, String pendingInput})
+buildTerminalWindowControlQueryResponses({
+  required String input,
+  required String pendingInput,
+  required TerminalWindowMetrics? metrics,
+}) {
+  final combinedInput = pendingInput + input;
+  final responses = StringBuffer();
+
+  for (final match in _terminalWindowQueryPattern.allMatches(combinedInput)) {
+    final params = match.group(1) ?? '';
+    final primaryParam = params.split(';').first;
+    final response = _buildTerminalWindowQueryResponse(primaryParam, metrics);
+    if (response != null) {
+      responses.write(response);
+    }
+  }
+
+  final response = responses.isEmpty ? null : responses.toString();
+  return (
+    response: response,
+    pendingInput: _terminalWindowQueryPendingSuffix(combinedInput),
+  );
+}
+
+final _terminalWindowQueryPattern = RegExp(r'\x1b\[([0-9;?]*)t');
+final _terminalWindowQueryPrefixPattern = RegExp(r'^\x1b(?:$|\[[0-9;?]*)$');
+
+String? _buildTerminalWindowQueryResponse(
+  String primaryParam,
+  TerminalWindowMetrics? metrics,
+) {
+  if (!_hasValidTerminalWindowMetrics(metrics)) {
+    return null;
+  }
+
+  final validMetrics = metrics!;
+  switch (primaryParam) {
+    case '14':
+      return '\x1b[4;${validMetrics.pixelHeight};${validMetrics.pixelWidth}t';
+    case '16':
+      final cellWidth = (validMetrics.pixelWidth / validMetrics.columns)
+          .round();
+      final cellHeight = (validMetrics.pixelHeight / validMetrics.rows).round();
+      if (cellWidth < 1 || cellHeight < 1) {
+        return null;
+      }
+      return '\x1b[6;$cellHeight;${cellWidth}t';
+    default:
+      return null;
+  }
+}
+
+bool _hasValidTerminalWindowMetrics(TerminalWindowMetrics? metrics) =>
+    metrics != null &&
+    metrics.columns > 0 &&
+    metrics.rows > 0 &&
+    metrics.pixelWidth > 0 &&
+    metrics.pixelHeight > 0;
+
+String _terminalWindowQueryPendingSuffix(String input) {
+  final start = input.length > 16 ? input.length - 16 : 0;
+  for (var index = start; index < input.length; index += 1) {
+    final suffix = input.substring(index);
+    if (_terminalWindowQueryPrefixPattern.hasMatch(suffix)) {
+      return suffix;
+    }
+  }
+  return '';
+}
+
 /// Connection state for an SSH session.
 enum SshConnectionState {
   /// Not connected.
@@ -1588,6 +1671,8 @@ class SshSession {
   int _shellStderrCharCount = 0;
   int _shellStdinWriteCount = 0;
   int _shellStdinCharCount = 0;
+  TerminalWindowMetrics? _terminalWindowMetrics;
+  String _terminalWindowQueryPendingInput = '';
 
   /// Persistent terminal that survives screen rebuilds.
   Terminal? _terminal;
@@ -1627,6 +1712,21 @@ class SshSession {
 
   /// The latest command exit code emitted through shell integration.
   int? get lastExitCode => _lastExitCode;
+
+  /// Records visible terminal dimensions used to answer size report queries.
+  void updateTerminalWindowMetrics({
+    required int columns,
+    required int rows,
+    required int pixelWidth,
+    required int pixelHeight,
+  }) {
+    _terminalWindowMetrics = (
+      columns: columns,
+      rows: rows,
+      pixelWidth: pixelWidth,
+      pixelHeight: pixelHeight,
+    );
+  }
 
   /// Adds a listener for terminal preview and preview-adjacent metadata changes.
   void addPreviewListener(VoidCallback listener) {
@@ -1789,6 +1889,8 @@ class SshSession {
     _workingDirectory = null;
     _shellStatus = null;
     _lastExitCode = null;
+    _terminalWindowMetrics = null;
+    _terminalWindowQueryPendingInput = '';
     _terminal = null;
     _terminalPreview = null;
     _windowTitle = null;
@@ -1816,6 +1918,7 @@ class SshSession {
         .listen(
           (data) {
             _recordShellIo(stdoutChars: data.length);
+            _respondToTerminalWindowControlQueries(data);
             terminal.write(data);
             _scheduleTerminalPreviewRefresh();
             final stdoutController = _shellStdoutController;
@@ -1971,6 +2074,22 @@ class SshSession {
     _shellStdinCharCount = 0;
   }
 
+  void _respondToTerminalWindowControlQueries(String data) {
+    final result = buildTerminalWindowControlQueryResponses(
+      input: data,
+      pendingInput: _terminalWindowQueryPendingInput,
+      metrics: _terminalWindowMetrics,
+    );
+    _terminalWindowQueryPendingInput = result.pendingInput;
+
+    final response = result.response;
+    if (response == null) {
+      return;
+    }
+
+    _shell?.write(utf8.encode(response));
+  }
+
   void _scheduleTerminalPreviewRefresh() {
     if (_previewRefreshTimer?.isActive ?? false) {
       return;
@@ -2049,6 +2168,9 @@ class SshSession {
     }
 
     terminalHyperlinkTracker.handlePrivateOsc(code, args);
+    if (code == '8') {
+      return;
+    }
 
     if (code == '7') {
       final nextWorkingDirectory = parseTerminalWorkingDirectoryUri(args);
@@ -2095,7 +2217,22 @@ class SshSession {
         },
       );
       _notifyMetadataChanged();
+      return;
     }
+
+    _logUnhandledPrivateOsc(code, args);
+  }
+
+  void _logUnhandledPrivateOsc(String code, List<String> args) {
+    DiagnosticsLogService.instance.debug(
+      'terminal.osc',
+      'unhandled',
+      fields: {
+        'connectionId': connectionId,
+        'oscCode': int.tryParse(code) ?? -1,
+        'argCount': args.length,
+      },
+    );
   }
 
   void _handleOsc52(List<String> args) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3554,6 +3554,26 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     unawaited(_startSharedClipboardSync(targetSession));
   }
 
+  void _applyTerminalThemeToSession(
+    TerminalThemeData theme, {
+    SshSession? session,
+  }) {
+    final targetSession =
+        session ??
+        _observedSession ??
+        (_connectionId == null
+            ? null
+            : _sessionsNotifier?.getSession(_connectionId!));
+    targetSession?.terminalTheme = theme;
+  }
+
+  TerminalThemeData _resolveEffectiveTerminalTheme() {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return _sessionThemeOverride ??
+        _currentTheme ??
+        (isDark ? TerminalThemes.midnightPurple : TerminalThemes.cleanWhite);
+  }
+
   Future<void> _startSharedClipboardSync(SshSession session) async {
     _stopSharedClipboardSync();
     _remoteClipboardUnsupported = false;
@@ -3865,6 +3885,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     if (mounted) {
       setState(() => _currentTheme = theme);
+      _applyTerminalThemeToSession(theme);
     }
   }
 
@@ -3877,6 +3898,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (themeId == null) {
       if (mounted) {
         setState(() => _sessionThemeOverride = null);
+        _applyTerminalThemeToSession(
+          _resolveEffectiveTerminalTheme(),
+          session: session,
+        );
       }
       return false;
     }
@@ -3887,6 +3912,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return false;
     }
     setState(() => _sessionThemeOverride = resolvedTheme);
+    if (resolvedTheme != null) {
+      _applyTerminalThemeToSession(resolvedTheme, session: session);
+    }
     return resolvedTheme != null;
   }
 
@@ -3987,6 +4015,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _isUsingAltBuffer = _terminal.isUsingAltBuffer;
         _terminalReportsMouseWheel = _terminal.mouseMode.reportScroll;
         _terminal.addListener(_onTerminalStateChanged);
+        _applyTerminalThemeToSession(
+          _resolveEffectiveTerminalTheme(),
+          session: session,
+        );
         _shell = await session.getShell();
         _wireTerminalCallbacks(session);
         await _applySharedClipboardSetting(
@@ -4029,6 +4061,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _isUsingAltBuffer = _terminal.isUsingAltBuffer;
       _terminalReportsMouseWheel = _terminal.mouseMode.reportScroll;
       _terminal.addListener(_onTerminalStateChanged);
+      _applyTerminalThemeToSession(
+        _resolveEffectiveTerminalTheme(),
+        session: session,
+      );
 
       _shell = await session.getShell(
         pty: SSHPtyConfig(
@@ -5274,6 +5310,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         return null;
       }
 
+      _applyTerminalThemeToSession(
+        _resolveEffectiveTerminalTheme(),
+        session: session,
+      );
       shell = await session.getShell(pty: pty);
       if (!stillOwnsSession()) {
         restorePreviousTerminalState(restoreShell: false);
@@ -5607,7 +5647,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
     final theme = Theme.of(context);
     final connectionStates = ref.watch(activeSessionsProvider);
-    final isDark = theme.brightness == Brightness.dark;
     final isMobile =
         defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS;
@@ -5620,11 +5659,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         !_isConnecting &&
         connectionState == SshConnectionState.disconnected;
 
-    // Use session override, or loaded theme, or fallback
-    final terminalTheme =
-        _sessionThemeOverride ??
-        _currentTheme ??
-        (isDark ? TerminalThemes.midnightPurple : TerminalThemes.cleanWhite);
+    // Use session override, or loaded theme, or fallback.
+    final terminalTheme = _resolveEffectiveTerminalTheme();
+    _applyTerminalThemeToSession(terminalTheme);
     final connectionLabel = describeTerminalConnectionState(
       connectionState,
       isConnecting: _isConnecting,
@@ -6090,6 +6127,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             .updateSessionTheme(_connectionId!, theme.id, isDark: isDark);
       }
       setState(() => _sessionThemeOverride = theme);
+      _applyTerminalThemeToSession(theme);
 
       // Show option to save to host
       if (_host != null) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -4164,6 +4164,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     };
 
     _terminal.onResize = (width, height, pixelWidth, pixelHeight) {
+      session.updateTerminalWindowMetrics(
+        columns: width,
+        rows: height,
+        pixelWidth: pixelWidth,
+        pixelHeight: pixelHeight,
+      );
       _shell?.resizeTerminal(width, height, pixelWidth, pixelHeight);
     };
   }

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -148,6 +148,8 @@ double resolveTerminalHorizontalFillScale({
 /// How long to wait for keyboard inset animations to settle before resizing.
 @visibleForTesting
 const terminalKeyboardResizeDebounceDuration = Duration(milliseconds: 180);
+const _terminalFocusInReport = '\x1b[I';
+const _terminalFocusOutReport = '\x1b[O';
 
 /// Adapted xterm terminal view with a trackpad scroll fix for alt-buffer apps.
 class MonkeyTerminalView extends StatefulWidget {
@@ -1303,6 +1305,11 @@ class MonkeyRenderTerminal extends RenderBox
   }
 
   void _onFocusChange() {
+    if (_terminal.reportFocusMode) {
+      _terminal.onOutput?.call(
+        _focusNode.hasFocus ? _terminalFocusInReport : _terminalFocusOutReport,
+      );
+    }
     markNeedsPaint();
   }
 

--- a/test/domain/models/terminal_theme_test.dart
+++ b/test/domain/models/terminal_theme_test.dart
@@ -255,6 +255,22 @@ void main() {
         ),
         '\x1b]12;rgb:0404/4242/8989\x1b\\',
       );
+      expect(
+        buildTerminalThemeOscResponse(
+          theme: theme,
+          code: '17',
+          args: const ['?'],
+        ),
+        '\x1b]17;rgb:b4b4/d5d5/fefe\x1b\\',
+      );
+      expect(
+        buildTerminalThemeOscResponse(
+          theme: theme,
+          code: '19',
+          args: const ['?'],
+        ),
+        '\x1b]19;rgb:7272/7676/7979\x1b\\',
+      );
     });
 
     test('buildTerminalThemeOscResponse answers ANSI palette queries', () {

--- a/test/domain/models/terminal_theme_test.dart
+++ b/test/domain/models/terminal_theme_test.dart
@@ -227,6 +227,79 @@ void main() {
 
       expect(xtermTheme, isNotNull);
     });
+
+    test('buildTerminalThemeOscResponse answers special color queries', () {
+      const theme = TerminalThemes.cleanWhite;
+
+      expect(
+        buildTerminalThemeOscResponse(
+          theme: theme,
+          code: '10',
+          args: const ['?'],
+        ),
+        '\x1b]10;rgb:7272/7676/7979\x1b\\',
+      );
+      expect(
+        buildTerminalThemeOscResponse(
+          theme: theme,
+          code: '11',
+          args: const ['?'],
+        ),
+        '\x1b]11;rgb:ffff/ffff/ffff\x1b\\',
+      );
+      expect(
+        buildTerminalThemeOscResponse(
+          theme: theme,
+          code: '12',
+          args: const ['?'],
+        ),
+        '\x1b]12;rgb:0404/4242/8989\x1b\\',
+      );
+    });
+
+    test('buildTerminalThemeOscResponse answers ANSI palette queries', () {
+      const theme = TerminalThemes.cleanWhite;
+
+      expect(
+        buildTerminalThemeOscResponse(
+          theme: theme,
+          code: '4',
+          args: const ['0', '?', '4', '?', '232', '?'],
+        ),
+        '\x1b]4;0;rgb:0000/0000/0000\x1b\\'
+        '\x1b]4;4;rgb:0909/6969/dada\x1b\\'
+        '\x1b]4;232;rgb:0808/0808/0808\x1b\\',
+      );
+    });
+
+    test('buildTerminalThemeOscResponse ignores unsupported OSC values', () {
+      const theme = TerminalThemes.cleanWhite;
+
+      expect(
+        buildTerminalThemeOscResponse(
+          theme: theme,
+          code: '11',
+          args: const ['#000000'],
+        ),
+        isNull,
+      );
+      expect(
+        buildTerminalThemeOscResponse(
+          theme: theme,
+          code: '4',
+          args: const ['999', '?'],
+        ),
+        isNull,
+      );
+      expect(
+        buildTerminalThemeOscResponse(
+          theme: theme,
+          code: '8',
+          args: const ['id=1', 'https://example.com'],
+        ),
+        isNull,
+      );
+    });
   });
 
   group('TerminalThemes', () {

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -289,6 +289,52 @@ void main() {
         expect(exitState.lastExitCode, 17);
       },
     );
+
+    test('answers terminal window and cell size reports', () {
+      final result = buildTerminalWindowControlQueryResponses(
+        input: 'before\x1b[14tmiddle\x1b[16tafter',
+        pendingInput: '',
+        metrics: const (
+          columns: 80,
+          rows: 24,
+          pixelWidth: 960,
+          pixelHeight: 480,
+        ),
+      );
+
+      expect(result.response, '\x1b[4;480;960t\x1b[6;20;12t');
+      expect(result.pendingInput, isEmpty);
+    });
+
+    test('preserves split terminal size report queries across chunks', () {
+      final first = buildTerminalWindowControlQueryResponses(
+        input: 'before\x1b[1',
+        pendingInput: '',
+        metrics: const (
+          columns: 80,
+          rows: 24,
+          pixelWidth: 960,
+          pixelHeight: 480,
+        ),
+      );
+
+      expect(first.response, isNull);
+      expect(first.pendingInput, '\x1b[1');
+
+      final second = buildTerminalWindowControlQueryResponses(
+        input: '6tafter',
+        pendingInput: first.pendingInput,
+        metrics: const (
+          columns: 80,
+          rows: 24,
+          pixelWidth: 960,
+          pixelHeight: 480,
+        ),
+      );
+
+      expect(second.response, '\x1b[6;20;12t');
+      expect(second.pendingInput, isEmpty);
+    });
   });
 
   group('host key capture', () {

--- a/test/widget/monkey_terminal_view_resize_test.dart
+++ b/test/widget/monkey_terminal_view_resize_test.dart
@@ -10,6 +10,8 @@ void main() {
     required Terminal terminal,
     required Size size,
     double keyboardInset = 0,
+    FocusNode? focusNode,
+    bool readOnly = true,
   }) => MaterialApp(
     home: MediaQuery(
       data: MediaQueryData(
@@ -22,8 +24,9 @@ void main() {
           height: size.height,
           child: MonkeyTerminalView(
             terminal,
+            focusNode: focusNode,
             hardwareKeyboardOnly: true,
-            readOnly: true,
+            readOnly: readOnly,
           ),
         ),
       ),
@@ -113,5 +116,35 @@ void main() {
     expect(resizeEvents.last.height, initialEvent.height);
     expect(resizeEvents.last.pixelWidth, initialEvent.pixelWidth);
     expect(resizeEvents.last.pixelHeight, initialEvent.pixelHeight);
+  });
+
+  testWidgets('emits focus reports when focus reporting mode is enabled', (
+    tester,
+  ) async {
+    final output = <String>[];
+    final terminal = Terminal()
+      ..write('\x1b[?1004h')
+      ..onOutput = output.add;
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      buildTerminal(
+        terminal: terminal,
+        size: const Size(320, 240),
+        focusNode: focusNode,
+        readOnly: false,
+      ),
+    );
+
+    focusNode.requestFocus();
+    await tester.pump();
+
+    expect(output, contains('\x1b[I'));
+
+    focusNode.unfocus();
+    await tester.pump();
+
+    expect(output, contains('\x1b[O'));
   });
 }


### PR DESCRIPTION
## Summary

- Answer terminal OSC color queries (`OSC 10`, `11`, `12`, and `4`) from the active MonkeySSH terminal theme so remote TUIs can infer light backgrounds.
- Propagate the effective terminal theme into each SSH session before shells/reopened shells start and when terminal theme overrides change.
- Add unit coverage for OSC color-query response formatting and unsupported OSC handling.

## Why

Claude Code and Codex query terminal colors, especially background color via `OSC 11;?`, to decide whether to render light or dark UI surfaces. MonkeySSH already rendered the selected light palette locally, but it did not answer those OSC queries, so the tools fell back to dark/black surfaces inside an otherwise light terminal.

## Validation

- `dart format .`
- `flutter analyze`
- `flutter test --reporter compact`
- `git diff --check`
- `flutter test test/domain/models/terminal_theme_test.dart --reporter compact`
- Real-device harness using a temporary local SSH daemon and running installed local Claude/Codex CLIs:
  - iOS Simulator + Claude Code: reached Claude trust screen, black ratio `0.0`, light ratio `0.8971`.
  - iOS Simulator + Codex: reached Codex trust screen, black ratio `0.0`, light ratio `0.9623`.
  - Android Emulator + Claude Code: reached Claude trust screen, black ratio `0.0`, light ratio `0.8939`.
  - Android Emulator + Codex: reached Codex trust screen, black ratio `0.0`, light ratio `0.9729`.
