### PR TITLE
fix: refresh terminal size after window changes

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3261,6 +3261,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   String? _lastObservedRemoteClipboardText;
   String? _lastAppliedLocalClipboardText;
   String? _lastAppliedRemoteClipboardText;
+  bool _isTerminalSizeRefreshQueued = false;
 
   // Theme state
   Host? _host;
@@ -4032,6 +4033,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _sessionFontSizeOverride = session.terminalFontSize;
           _isConnecting = false;
         });
+        _scheduleTerminalSizeRefresh();
         _restoreTerminalFocus();
 
         // Detect tmux on existing sessions too (may not have been detected
@@ -4093,6 +4095,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _sessionFontSizeOverride = session.terminalFontSize;
         _isConnecting = false;
       });
+      _scheduleTerminalSizeRefresh();
       _restoreTerminalFocus();
       _primeTmuxStateFromHost();
 
@@ -4172,6 +4175,20 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       );
       _shell?.resizeTerminal(width, height, pixelWidth, pixelHeight);
     };
+  }
+
+  void _scheduleTerminalSizeRefresh() {
+    if (_isTerminalSizeRefreshQueued) {
+      return;
+    }
+    _isTerminalSizeRefreshQueued = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _isTerminalSizeRefreshQueued = false;
+      if (!mounted) {
+        return;
+      }
+      _terminalViewKey.currentState?.refreshTerminalSize();
+    });
   }
 
   void _schedulePromptOutputImeResetCheck(String data) {
@@ -5130,6 +5147,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       sessionName,
       forceVisibleTmux: forceVisibleTmux,
     );
+    _scheduleTerminalSizeRefresh();
   }
 
   /// Creates a new tmux window via exec channel, then reattaches the visible
@@ -5174,6 +5192,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
     _tmuxWorkingDirectory = resolvedWorkingDirectory;
     await _reattachTmuxIfNeeded(session, sessionName);
+    _scheduleTerminalSizeRefresh();
   }
 
   /// Closes a tmux window via exec channel.
@@ -5189,6 +5208,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           windowIndex,
           extraFlags: _host?.tmuxExtraFlags,
         );
+    _scheduleTerminalSizeRefresh();
   }
 
   Future<void> _reattachTmuxIfNeeded(
@@ -5372,6 +5392,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _isUsingAltBuffer = _terminal.isUsingAltBuffer;
         _terminalReportsMouseWheel = _terminal.mouseMode.reportScroll;
       });
+      _scheduleTerminalSizeRefresh();
     }
     return shell;
   }
@@ -5546,6 +5567,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _stopSharedClipboardSync();
     } else if (state == AppLifecycleState.resumed && _wasBackgrounded) {
       _wasBackgrounded = false;
+      _scheduleTerminalSizeRefresh();
       final session = _observedSession;
       if (session != null && session.clipboardSharingEnabled) {
         unawaited(_startSharedClipboardSync(session));
@@ -5556,6 +5578,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _reconnect();
       }
     }
+  }
+
+  @override
+  void didChangeMetrics() {
+    _scheduleTerminalSizeRefresh();
   }
 
   @override

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -4189,6 +4189,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       }
       _terminalViewKey.currentState?.refreshTerminalSize();
     });
+    WidgetsBinding.instance.ensureVisualUpdate();
   }
 
   void _schedulePromptOutputImeResetCheck(String data) {
@@ -5582,6 +5583,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   @override
   void didChangeMetrics() {
+    super.didChangeMetrics();
     _scheduleTerminalSizeRefresh();
   }
 

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -450,6 +450,14 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
     }
   }
 
+  /// Re-sends the current viewport dimensions to the attached terminal.
+  void refreshTerminalSize() {
+    final renderObject = _viewportKey.currentContext?.findRenderObject();
+    if (renderObject is MonkeyRenderTerminal) {
+      renderObject._refreshTerminalSize();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final mediaQuery = MediaQuery.of(context);
@@ -2084,7 +2092,7 @@ class MonkeyRenderTerminal extends RenderBox
     _onEditableRect?.call(rect, caretRect);
   }
 
-  void _updateViewportSize() {
+  void _updateViewportSize({bool force = false}) {
     final availableWidth = size.width - _padding.horizontal;
     final availableHeight = _viewportHeight;
     if (availableWidth <= _painter.cellSize.width ||
@@ -2101,9 +2109,19 @@ class MonkeyRenderTerminal extends RenderBox
       padding: _padding,
     );
 
-    if (_viewportSize != viewportSize || _viewportPixelSize != pixelSize) {
+    if (force ||
+        _viewportSize != viewportSize ||
+        _viewportPixelSize != pixelSize) {
       _resizeTerminalIfNeeded(viewportSize: viewportSize, pixelSize: pixelSize);
     }
+  }
+
+  void _refreshTerminalSize() {
+    if (!hasSize) {
+      markNeedsLayout();
+      return;
+    }
+    _updateViewportSize(force: true);
   }
 
   void _resizeTerminalIfNeeded({

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1283,7 +1283,11 @@ class MonkeyRenderTerminal extends RenderBox
 
   bool _isDebouncingKeyboardResize = false;
 
-  ({TerminalSize viewportSize, ({int width, int height}) pixelSize})?
+  ({
+    TerminalSize viewportSize,
+    ({int width, int height}) pixelSize,
+    bool resizeTerminal,
+  })?
   _pendingTerminalResize;
 
   final TerminalPainter _painter;
@@ -2092,7 +2096,7 @@ class MonkeyRenderTerminal extends RenderBox
     _onEditableRect?.call(rect, caretRect);
   }
 
-  void _updateViewportSize({bool force = false}) {
+  void _updateViewportSize({bool notifyIfUnchanged = false}) {
     final availableWidth = size.width - _padding.horizontal;
     final availableHeight = _viewportHeight;
     if (availableWidth <= _painter.cellSize.width ||
@@ -2109,10 +2113,13 @@ class MonkeyRenderTerminal extends RenderBox
       padding: _padding,
     );
 
-    if (force ||
-        _viewportSize != viewportSize ||
-        _viewportPixelSize != pixelSize) {
+    if (_viewportSize != viewportSize) {
       _resizeTerminalIfNeeded(viewportSize: viewportSize, pixelSize: pixelSize);
+    } else if (_viewportPixelSize != pixelSize || notifyIfUnchanged) {
+      _notifyTerminalResizeIfNeeded(
+        viewportSize: viewportSize,
+        pixelSize: pixelSize,
+      );
     }
   }
 
@@ -2121,7 +2128,7 @@ class MonkeyRenderTerminal extends RenderBox
       markNeedsLayout();
       return;
     }
-    _updateViewportSize(force: true);
+    _updateViewportSize(notifyIfUnchanged: true);
   }
 
   void _resizeTerminalIfNeeded({
@@ -2146,11 +2153,36 @@ class MonkeyRenderTerminal extends RenderBox
       _pendingTerminalResize = (
         viewportSize: nextViewportSize,
         pixelSize: nextPixelSize,
+        resizeTerminal: true,
       );
       return;
     }
 
     _applyTerminalResize(nextViewportSize, nextPixelSize);
+  }
+
+  void _notifyTerminalResizeIfNeeded({
+    required TerminalSize viewportSize,
+    required ({int width, int height}) pixelSize,
+  }) {
+    if (!_autoResize) {
+      return;
+    }
+
+    if (_isDebouncingKeyboardResize) {
+      final pendingResize = _pendingTerminalResize;
+      if (pendingResize != null && pendingResize.resizeTerminal) {
+        return;
+      }
+      _pendingTerminalResize = (
+        viewportSize: viewportSize,
+        pixelSize: pixelSize,
+        resizeTerminal: false,
+      );
+      return;
+    }
+
+    _notifyTerminalResize(viewportSize, pixelSize);
   }
 
   void _applyTerminalResize(
@@ -2160,6 +2192,20 @@ class MonkeyRenderTerminal extends RenderBox
     _viewportSize = viewportSize;
     _viewportPixelSize = pixelSize;
     _terminal.resize(
+      viewportSize.width,
+      viewportSize.height,
+      pixelSize.width,
+      pixelSize.height,
+    );
+  }
+
+  void _notifyTerminalResize(
+    TerminalSize viewportSize,
+    ({int width, int height}) pixelSize,
+  ) {
+    _viewportSize = viewportSize;
+    _viewportPixelSize = pixelSize;
+    _terminal.onResize?.call(
       viewportSize.width,
       viewportSize.height,
       pixelSize.width,
@@ -2180,10 +2226,17 @@ class MonkeyRenderTerminal extends RenderBox
         if (pendingResize == null || !_autoResize) {
           return;
         }
-        _applyTerminalResize(
-          pendingResize.viewportSize,
-          pendingResize.pixelSize,
-        );
+        if (pendingResize.resizeTerminal) {
+          _applyTerminalResize(
+            pendingResize.viewportSize,
+            pendingResize.pixelSize,
+          );
+        } else {
+          _notifyTerminalResize(
+            pendingResize.viewportSize,
+            pendingResize.pixelSize,
+          );
+        }
       },
     );
   }

--- a/test/widget/monkey_terminal_view_resize_test.dart
+++ b/test/widget/monkey_terminal_view_resize_test.dart
@@ -94,6 +94,98 @@ void main() {
     expect(resizeEvents.last, initialEvent);
   });
 
+  testWidgets('same-size refresh preserves terminal scroll margins', (
+    tester,
+  ) async {
+    final terminal = Terminal();
+    final terminalKey = GlobalKey<MonkeyTerminalViewState>();
+    final resizeEvents =
+        <({int width, int height, int pixelWidth, int pixelHeight})>[];
+    terminal.onResize = (width, height, pixelWidth, pixelHeight) {
+      resizeEvents.add((
+        width: width,
+        height: height,
+        pixelWidth: pixelWidth,
+        pixelHeight: pixelHeight,
+      ));
+    };
+
+    await tester.pumpWidget(
+      buildTerminal(
+        terminal: terminal,
+        terminalKey: terminalKey,
+        size: const Size(320, 240),
+      ),
+    );
+
+    expect(resizeEvents, isNotEmpty);
+    final initialCount = resizeEvents.length;
+    terminal.setMargins(1, 2);
+    expect(terminal.buffer.marginTop, 1);
+    expect(terminal.buffer.marginBottom, 2);
+
+    terminalKey.currentState!.refreshTerminalSize();
+
+    expect(resizeEvents, hasLength(initialCount + 1));
+    expect(terminal.buffer.marginTop, 1);
+    expect(terminal.buffer.marginBottom, 2);
+  });
+
+  testWidgets('pixel-only resize preserves terminal scroll margins', (
+    tester,
+  ) async {
+    final terminal = Terminal();
+    final terminalKey = GlobalKey<MonkeyTerminalViewState>();
+    final resizeEvents =
+        <({int width, int height, int pixelWidth, int pixelHeight})>[];
+    terminal.onResize = (width, height, pixelWidth, pixelHeight) {
+      resizeEvents.add((
+        width: width,
+        height: height,
+        pixelWidth: pixelWidth,
+        pixelHeight: pixelHeight,
+      ));
+    };
+
+    await tester.pumpWidget(
+      buildTerminal(
+        terminal: terminal,
+        terminalKey: terminalKey,
+        size: const Size(320, 240),
+      ),
+    );
+
+    final renderTerminal = terminalKey.currentState!.renderTerminal;
+    final cellSize = renderTerminal.cellSize;
+    final columns = terminal.viewWidth;
+    final rows = terminal.viewHeight;
+    final nextSize = Size(
+      (columns * cellSize.width) + (cellSize.width * 0.5),
+      (rows * cellSize.height) + (cellSize.height * 0.5),
+    );
+    final initialCount = resizeEvents.length;
+
+    terminal.setMargins(1, 2);
+    expect(terminal.buffer.marginTop, 1);
+    expect(terminal.buffer.marginBottom, 2);
+
+    await tester.pumpWidget(
+      buildTerminal(
+        terminal: terminal,
+        terminalKey: terminalKey,
+        size: nextSize,
+      ),
+    );
+
+    expect(resizeEvents, hasLength(initialCount + 1));
+    expect(resizeEvents.last.width, columns);
+    expect(resizeEvents.last.height, rows);
+    expect(resizeEvents.last.pixelWidth, nextSize.width.round());
+    expect(resizeEvents.last.pixelHeight, nextSize.height.round());
+    expect(terminal.buffer.marginTop, 1);
+    expect(terminal.buffer.marginBottom, 2);
+  });
+
   testWidgets('keyboard inset changes debounce before the final resize', (
     tester,
   ) async {

--- a/test/widget/monkey_terminal_view_resize_test.dart
+++ b/test/widget/monkey_terminal_view_resize_test.dart
@@ -9,6 +9,7 @@ void main() {
   Widget buildTerminal({
     required Terminal terminal,
     required Size size,
+    Key? terminalKey,
     double keyboardInset = 0,
     FocusNode? focusNode,
     bool readOnly = true,
@@ -23,6 +24,7 @@ void main() {
           width: size.width,
           height: size.height,
           child: MonkeyTerminalView(
+            key: terminalKey,
             terminal,
             focusNode: focusNode,
             hardwareKeyboardOnly: true,
@@ -56,6 +58,40 @@ void main() {
     expect(event.height, greaterThan(0));
     expect(event.pixelWidth, 320);
     expect(event.pixelHeight, 240);
+  });
+
+  testWidgets('size refresh re-sends the current viewport dimensions', (
+    tester,
+  ) async {
+    final terminal = Terminal();
+    final terminalKey = GlobalKey<MonkeyTerminalViewState>();
+    final resizeEvents =
+        <({int width, int height, int pixelWidth, int pixelHeight})>[];
+    terminal.onResize = (width, height, pixelWidth, pixelHeight) {
+      resizeEvents.add((
+        width: width,
+        height: height,
+        pixelWidth: pixelWidth,
+        pixelHeight: pixelHeight,
+      ));
+    };
+
+    await tester.pumpWidget(
+      buildTerminal(
+        terminal: terminal,
+        terminalKey: terminalKey,
+        size: const Size(320, 240),
+      ),
+    );
+
+    expect(resizeEvents, isNotEmpty);
+    final initialEvent = resizeEvents.last;
+    final initialCount = resizeEvents.length;
+
+    terminalKey.currentState!.refreshTerminalSize();
+
+    expect(resizeEvents, hasLength(initialCount + 1));
+    expect(resizeEvents.last, initialEvent);
   });
 
   testWidgets('keyboard inset changes debounce before the final resize', (


### PR DESCRIPTION
## Summary

- Refresh the terminal's current viewport size after the terminal screen first becomes visible, app/window metrics change, app resume, and tmux window actions.
- Add an explicit `MonkeyTerminalViewState.refreshTerminalSize()` path that re-sends the current grid and pixel dimensions even when Flutter layout size did not change.
- Cover forced size refresh behavior with a widget test.

## Tests

- `flutter analyze`
- `flutter test test/widget/monkey_terminal_view_resize_test.dart`
- `flutter test test/presentation/screens/terminal_screen_test.dart`
- `flutter test`
