### PR TITLE
Apply terminal themes app-wide

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../data/database/database.dart';
 import '../data/repositories/host_repository.dart';
+import '../domain/models/terminal_theme.dart';
 import '../domain/models/terminal_themes.dart';
 import '../domain/services/auth_service.dart';
 import '../domain/services/background_ssh_service.dart';
@@ -37,26 +38,23 @@ class FluttyApp extends ConsumerWidget {
 
     if (terminalThemesApplyToApp) {
       final terminalThemeSettings = ref.watch(terminalThemeSettingsProvider);
+      final terminalAppThemeOverride = ref.watch(
+        terminalAppThemeOverrideProvider,
+      );
       final terminalThemes =
           ref.watch(allTerminalThemesProvider).asData?.value ??
           TerminalThemes.all;
-      final lightTerminalTheme = TerminalThemes.resolveById(
+      lightTheme = buildTerminalAppTheme(
         brightness: Brightness.light,
-        themeId: terminalThemeSettings.lightThemeId,
-        additionalThemes: terminalThemes,
+        terminalThemeSettings: terminalThemeSettings,
+        terminalThemes: terminalThemes,
+        terminalAppThemeOverride: terminalAppThemeOverride,
       );
-      final darkTerminalTheme = TerminalThemes.resolveById(
+      darkTheme = buildTerminalAppTheme(
         brightness: Brightness.dark,
-        themeId: terminalThemeSettings.darkThemeId,
-        additionalThemes: terminalThemes,
-      );
-      lightTheme = FluttyTheme.fromTerminalTheme(
-        lightTerminalTheme,
-        brightness: Brightness.light,
-      );
-      darkTheme = FluttyTheme.fromTerminalTheme(
-        darkTerminalTheme,
-        brightness: Brightness.dark,
+        terminalThemeSettings: terminalThemeSettings,
+        terminalThemes: terminalThemes,
+        terminalAppThemeOverride: terminalAppThemeOverride,
       );
     } else {
       lightTheme = FluttyTheme.light;
@@ -75,6 +73,30 @@ class FluttyApp extends ConsumerWidget {
       ),
     );
   }
+}
+
+/// Builds an app [ThemeData] from global settings plus active terminal overrides.
+@visibleForTesting
+ThemeData buildTerminalAppTheme({
+  required Brightness brightness,
+  required TerminalThemeSettings terminalThemeSettings,
+  required List<TerminalThemeData> terminalThemes,
+  TerminalAppThemeOverride? terminalAppThemeOverride,
+}) {
+  final themeId = switch (brightness) {
+    Brightness.light =>
+      terminalAppThemeOverride?.lightThemeId ??
+          terminalThemeSettings.lightThemeId,
+    Brightness.dark =>
+      terminalAppThemeOverride?.darkThemeId ??
+          terminalThemeSettings.darkThemeId,
+  };
+  final terminalTheme = TerminalThemes.resolveById(
+    brightness: brightness,
+    themeId: themeId,
+    additionalThemes: terminalThemes,
+  );
+  return FluttyTheme.fromTerminalTheme(terminalTheme, brightness: brightness);
 }
 
 class _BackgroundLifecycleBridge extends ConsumerStatefulWidget {

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -30,14 +30,13 @@ class FluttyApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(routerProvider);
     final themeMode = ref.watch(themeModeNotifierProvider);
-    final terminalThemesApplyToApp = ref
-        .watch(terminalThemesApplyToAppProvider)
-        .asData
-        ?.value;
+    final terminalThemesApplyToApp = ref.watch(
+      terminalThemesApplyToAppNotifierProvider,
+    );
     late final ThemeData lightTheme;
     late final ThemeData darkTheme;
 
-    if (terminalThemesApplyToApp ?? false) {
+    if (terminalThemesApplyToApp) {
       final terminalThemeSettings = ref.watch(terminalThemeSettingsProvider);
       final terminalAppThemeOverride = ref.watch(
         terminalAppThemeOverrideProvider,

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../data/database/database.dart';
 import '../data/repositories/host_repository.dart';
+import '../domain/models/terminal_themes.dart';
 import '../domain/services/auth_service.dart';
 import '../domain/services/background_ssh_service.dart';
 import '../domain/services/home_screen_shortcut_service.dart';
@@ -12,6 +13,7 @@ import '../domain/services/local_notification_service.dart';
 import '../domain/services/monetization_service.dart';
 import '../domain/services/settings_service.dart';
 import '../domain/services/ssh_service.dart';
+import '../domain/services/terminal_theme_service.dart';
 import 'app_lifecycle_coordinator.dart';
 import 'app_metadata.dart';
 import 'auth_lifecycle_controller.dart';
@@ -27,14 +29,34 @@ class FluttyApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(routerProvider);
     final themeMode = ref.watch(themeModeNotifierProvider);
+    final terminalThemeSettings = ref.watch(terminalThemeSettingsProvider);
+    final terminalThemes =
+        ref.watch(allTerminalThemesProvider).asData?.value ??
+        TerminalThemes.all;
+    final lightTerminalTheme = TerminalThemes.resolveById(
+      brightness: Brightness.light,
+      themeId: terminalThemeSettings.lightThemeId,
+      additionalThemes: terminalThemes,
+    );
+    final darkTerminalTheme = TerminalThemes.resolveById(
+      brightness: Brightness.dark,
+      themeId: terminalThemeSettings.darkThemeId,
+      additionalThemes: terminalThemes,
+    );
     final appName = ref.watch(appDisplayNameProvider);
 
     return _BackgroundLifecycleBridge(
       child: MaterialApp.router(
         title: appName,
         debugShowCheckedModeBanner: false,
-        theme: FluttyTheme.light,
-        darkTheme: FluttyTheme.dark,
+        theme: FluttyTheme.fromTerminalTheme(
+          lightTerminalTheme,
+          brightness: Brightness.light,
+        ),
+        darkTheme: FluttyTheme.fromTerminalTheme(
+          darkTerminalTheme,
+          brightness: Brightness.dark,
+        ),
         themeMode: themeMode,
         routerConfig: router,
       ),

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -30,13 +30,14 @@ class FluttyApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(routerProvider);
     final themeMode = ref.watch(themeModeNotifierProvider);
-    final terminalThemesApplyToApp = ref.watch(
-      terminalThemesApplyToAppNotifierProvider,
-    );
+    final terminalThemesApplyToApp = ref
+        .watch(terminalThemesApplyToAppProvider)
+        .asData
+        ?.value;
     late final ThemeData lightTheme;
     late final ThemeData darkTheme;
 
-    if (terminalThemesApplyToApp) {
+    if (terminalThemesApplyToApp ?? false) {
       final terminalThemeSettings = ref.watch(terminalThemeSettingsProvider);
       final terminalAppThemeOverride = ref.watch(
         terminalAppThemeOverrideProvider,

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -29,34 +29,47 @@ class FluttyApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(routerProvider);
     final themeMode = ref.watch(themeModeNotifierProvider);
-    final terminalThemeSettings = ref.watch(terminalThemeSettingsProvider);
-    final terminalThemes =
-        ref.watch(allTerminalThemesProvider).asData?.value ??
-        TerminalThemes.all;
-    final lightTerminalTheme = TerminalThemes.resolveById(
-      brightness: Brightness.light,
-      themeId: terminalThemeSettings.lightThemeId,
-      additionalThemes: terminalThemes,
+    final terminalThemesApplyToApp = ref.watch(
+      terminalThemesApplyToAppNotifierProvider,
     );
-    final darkTerminalTheme = TerminalThemes.resolveById(
-      brightness: Brightness.dark,
-      themeId: terminalThemeSettings.darkThemeId,
-      additionalThemes: terminalThemes,
-    );
+    late final ThemeData lightTheme;
+    late final ThemeData darkTheme;
+
+    if (terminalThemesApplyToApp) {
+      final terminalThemeSettings = ref.watch(terminalThemeSettingsProvider);
+      final terminalThemes =
+          ref.watch(allTerminalThemesProvider).asData?.value ??
+          TerminalThemes.all;
+      final lightTerminalTheme = TerminalThemes.resolveById(
+        brightness: Brightness.light,
+        themeId: terminalThemeSettings.lightThemeId,
+        additionalThemes: terminalThemes,
+      );
+      final darkTerminalTheme = TerminalThemes.resolveById(
+        brightness: Brightness.dark,
+        themeId: terminalThemeSettings.darkThemeId,
+        additionalThemes: terminalThemes,
+      );
+      lightTheme = FluttyTheme.fromTerminalTheme(
+        lightTerminalTheme,
+        brightness: Brightness.light,
+      );
+      darkTheme = FluttyTheme.fromTerminalTheme(
+        darkTerminalTheme,
+        brightness: Brightness.dark,
+      );
+    } else {
+      lightTheme = FluttyTheme.light;
+      darkTheme = FluttyTheme.dark;
+    }
     final appName = ref.watch(appDisplayNameProvider);
 
     return _BackgroundLifecycleBridge(
       child: MaterialApp.router(
         title: appName,
         debugShowCheckedModeBanner: false,
-        theme: FluttyTheme.fromTerminalTheme(
-          lightTerminalTheme,
-          brightness: Brightness.light,
-        ),
-        darkTheme: FluttyTheme.fromTerminalTheme(
-          darkTerminalTheme,
-          brightness: Brightness.dark,
-        ),
+        theme: lightTheme,
+        darkTheme: darkTheme,
         themeMode: themeMode,
         routerConfig: router,
       ),

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+import '../domain/models/terminal_theme.dart';
+
 /// Theme configuration for the Flutty app.
 /// Inspired by Termius with a modern hacker aesthetic.
 abstract final class FluttyTheme {
@@ -55,24 +57,84 @@ abstract final class FluttyTheme {
   /// Dark theme.
   static ThemeData get dark => _buildTheme(Brightness.dark);
 
-  static ThemeData _buildTheme(Brightness brightness) {
+  /// Uses system text styles instead of Google Fonts when true.
+  ///
+  /// This is intended for tests that instantiate theme data without a bundled
+  /// font asset bundle.
+  @visibleForTesting
+  static bool debugUseSystemFonts = false;
+
+  /// Builds an app theme using colors from a terminal theme palette.
+  static ThemeData fromTerminalTheme(
+    TerminalThemeData terminalTheme, {
+    required Brightness brightness,
+  }) => _buildTheme(brightness, terminalTheme: terminalTheme);
+
+  static ThemeData _buildTheme(
+    Brightness brightness, {
+    TerminalThemeData? terminalTheme,
+  }) {
     final isDark = brightness == Brightness.dark;
+    final background =
+        terminalTheme?.background ??
+        (isDark ? _backgroundDark : _backgroundLight);
+    final textPrimary =
+        terminalTheme?.foreground ?? (isDark ? _textPrimary : Colors.black87);
+    final textSecondary = terminalTheme == null
+        ? (isDark ? _textSecondary : Colors.black54)
+        : _blend(background, textPrimary, isDark ? 0.62 : 0.84);
+    final surface =
+        terminalTheme?.background ?? (isDark ? _surfaceDark : _surfaceLight);
+    final card = terminalTheme == null
+        ? (isDark ? _cardDark : _cardLight)
+        : _blend(background, textPrimary, isDark ? 0.07 : 0.025);
+    final border = terminalTheme == null
+        ? (isDark ? _borderDark : _borderLight)
+        : _blend(background, textPrimary, isDark ? 0.18 : 0.16);
+    final primary = terminalTheme == null
+        ? _accentTeal
+        : _resolveTerminalAccent(terminalTheme);
+    final primarySoft = terminalTheme == null
+        ? _accentTealSoft
+        : _blend(background, primary, isDark ? 0.55 : 0.28);
+    final error = terminalTheme?.red ?? _errorColor;
+    final warning = terminalTheme?.yellow ?? _warningColor;
+    final inputFill = terminalTheme == null
+        ? (isDark ? _cardDark : Colors.grey.shade50)
+        : _blend(background, textPrimary, isDark ? 0.08 : 0.018);
+    final inputHover = terminalTheme == null
+        ? (isDark ? _borderDark : Colors.grey.shade100)
+        : _blend(background, textPrimary, isDark ? 0.12 : 0.045);
+    final overlayBackground = terminalTheme?.black ?? Colors.grey.shade900;
+    final snackBarBackground = isDark ? card : overlayBackground;
+    final snackBarForeground = _readableTextColor(snackBarBackground);
+    final tooltipBackground = isDark ? card : overlayBackground;
+    final tooltipForeground = _readableTextColor(tooltipBackground);
+    final onPrimary = terminalTheme == null
+        ? Colors.white
+        : _readableTextColor(primary);
+    final onTertiary = terminalTheme == null
+        ? Colors.black
+        : _readableTextColor(warning);
+    final onError = terminalTheme == null
+        ? Colors.white
+        : _readableTextColor(error);
 
     final colorScheme = ColorScheme(
       brightness: brightness,
-      primary: _accentTeal,
-      onPrimary: Colors.white,
-      secondary: isDark ? _cardDark : _surfaceLight,
-      onSecondary: isDark ? _textPrimary : Colors.black87,
-      tertiary: _warningColor,
-      onTertiary: Colors.black,
-      error: _errorColor,
-      onError: Colors.white,
-      surface: isDark ? _surfaceDark : _surfaceLight,
-      onSurface: isDark ? _textPrimary : Colors.black87,
-      surfaceContainerHighest: isDark ? _cardDark : _cardLight,
-      outline: isDark ? _borderDark : _borderLight,
-      outlineVariant: isDark ? _borderDark.withAlpha(128) : _borderLight,
+      primary: primary,
+      onPrimary: onPrimary,
+      secondary: card,
+      onSecondary: textPrimary,
+      tertiary: warning,
+      onTertiary: onTertiary,
+      error: error,
+      onError: onError,
+      surface: surface,
+      onSurface: textPrimary,
+      surfaceContainerHighest: card,
+      outline: border,
+      outlineVariant: border.withAlpha(isDark ? 128 : 180),
     );
 
     // Use JetBrains Mono for that terminal feel, Inter for UI
@@ -80,54 +142,54 @@ abstract final class FluttyTheme {
         ? ThemeData.dark().textTheme
         : ThemeData.light().textTheme;
 
-    final textTheme = GoogleFonts.interTextTheme(baseTextTheme).copyWith(
+    final textTheme = _interTextTheme(baseTextTheme).copyWith(
       // Headings with more weight
-      headlineLarge: GoogleFonts.inter(
+      headlineLarge: _inter(
         fontSize: 32,
         fontWeight: FontWeight.w700,
-        color: isDark ? _textPrimary : Colors.black87,
+        color: textPrimary,
         letterSpacing: -0.5,
       ),
-      headlineMedium: GoogleFonts.inter(
+      headlineMedium: _inter(
         fontSize: 24,
         fontWeight: FontWeight.w600,
-        color: isDark ? _textPrimary : Colors.black87,
+        color: textPrimary,
         letterSpacing: -0.3,
       ),
-      headlineSmall: GoogleFonts.inter(
+      headlineSmall: _inter(
         fontSize: 20,
         fontWeight: FontWeight.w600,
-        color: isDark ? _textPrimary : Colors.black87,
+        color: textPrimary,
       ),
-      titleLarge: GoogleFonts.inter(
+      titleLarge: _inter(
         fontSize: 18,
         fontWeight: FontWeight.w600,
-        color: isDark ? _textPrimary : Colors.black87,
+        color: textPrimary,
       ),
-      titleMedium: GoogleFonts.inter(
+      titleMedium: _inter(
         fontSize: 16,
         fontWeight: FontWeight.w500,
-        color: isDark ? _textPrimary : Colors.black87,
+        color: textPrimary,
       ),
-      bodyLarge: GoogleFonts.inter(
+      bodyLarge: _inter(
         fontSize: 16,
         fontWeight: FontWeight.w400,
-        color: isDark ? _textPrimary : Colors.black87,
+        color: textPrimary,
       ),
-      bodyMedium: GoogleFonts.inter(
+      bodyMedium: _inter(
         fontSize: 14,
         fontWeight: FontWeight.w400,
-        color: isDark ? _textSecondary : Colors.black54,
+        color: textSecondary,
       ),
-      bodySmall: GoogleFonts.inter(
+      bodySmall: _inter(
         fontSize: 12,
         fontWeight: FontWeight.w400,
-        color: isDark ? _textSecondary : Colors.black54,
+        color: textSecondary,
       ),
-      labelLarge: GoogleFonts.inter(
+      labelLarge: _inter(
         fontSize: 14,
         fontWeight: FontWeight.w600,
-        color: isDark ? _textPrimary : Colors.black87,
+        color: textPrimary,
       ),
     );
 
@@ -136,30 +198,30 @@ abstract final class FluttyTheme {
       brightness: brightness,
       colorScheme: colorScheme,
       textTheme: textTheme,
-      scaffoldBackgroundColor: isDark ? _backgroundDark : _backgroundLight,
+      scaffoldBackgroundColor: background,
 
       // App bar with subtle blur effect vibe
       appBarTheme: AppBarTheme(
-        backgroundColor: isDark ? _backgroundDark : _backgroundLight,
-        foregroundColor: isDark ? _textPrimary : Colors.black87,
+        backgroundColor: background,
+        foregroundColor: textPrimary,
         elevation: 0,
         scrolledUnderElevation: 0,
         centerTitle: false,
-        titleTextStyle: GoogleFonts.inter(
+        titleTextStyle: _inter(
           fontSize: 20,
           fontWeight: FontWeight.w600,
-          color: isDark ? _textPrimary : Colors.black87,
+          color: textPrimary,
         ),
       ),
 
       // Cards with subtle glow on dark theme
       cardTheme: CardThemeData(
-        color: isDark ? _cardDark : _cardLight,
+        color: card,
         elevation: isDark ? 0 : 1,
-        shadowColor: isDark ? _accentTeal.withAlpha(20) : Colors.black12,
+        shadowColor: isDark ? primary.withAlpha(20) : Colors.black12,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(16),
-          side: BorderSide(color: isDark ? _borderDark : _borderLight),
+          side: BorderSide(color: border),
         ),
         margin: EdgeInsets.zero,
       ),
@@ -175,33 +237,31 @@ abstract final class FluttyTheme {
       // Modern input fields
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: isDark ? _cardDark : Colors.grey.shade50,
-        hoverColor: isDark ? _borderDark : Colors.grey.shade100,
+        fillColor: inputFill,
+        hoverColor: inputHover,
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: BorderSide(color: isDark ? _borderDark : _borderLight),
+          borderSide: BorderSide(color: border),
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: BorderSide(color: isDark ? _borderDark : _borderLight),
+          borderSide: BorderSide(color: border),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: _accentTeal, width: 2),
+          borderSide: BorderSide(color: primary, width: 2),
         ),
         errorBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: _errorColor),
+          borderSide: BorderSide(color: error),
         ),
         contentPadding: const EdgeInsets.symmetric(
           horizontal: 16,
           vertical: 16,
         ),
-        labelStyle: TextStyle(color: isDark ? _textSecondary : Colors.black54),
-        hintStyle: TextStyle(
-          color: isDark ? _textSecondary.withAlpha(150) : Colors.black38,
-        ),
-        prefixIconColor: isDark ? _textSecondary : Colors.black45,
+        labelStyle: TextStyle(color: textSecondary),
+        hintStyle: TextStyle(color: textSecondary.withAlpha(150)),
+        prefixIconColor: textSecondary,
       ),
 
       // Buttons with glow
@@ -214,10 +274,7 @@ abstract final class FluttyTheme {
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
           ),
-          textStyle: GoogleFonts.inter(
-            fontSize: 15,
-            fontWeight: FontWeight.w600,
-          ),
+          textStyle: _inter(fontSize: 15, fontWeight: FontWeight.w600),
         ),
       ),
 
@@ -226,33 +283,24 @@ abstract final class FluttyTheme {
           backgroundColor: colorScheme.primary,
           foregroundColor: colorScheme.onPrimary,
           elevation: isDark ? 4 : 2,
-          shadowColor: isDark ? _accentTeal.withAlpha(80) : Colors.black26,
+          shadowColor: isDark ? primary.withAlpha(80) : Colors.black26,
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
           ),
-          textStyle: GoogleFonts.inter(
-            fontSize: 15,
-            fontWeight: FontWeight.w600,
-          ),
+          textStyle: _inter(fontSize: 15, fontWeight: FontWeight.w600),
         ),
       ),
 
       outlinedButtonTheme: OutlinedButtonThemeData(
         style: OutlinedButton.styleFrom(
-          foregroundColor: isDark ? _textPrimary : Colors.black87,
+          foregroundColor: textPrimary,
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
           ),
-          side: BorderSide(
-            color: isDark ? _borderDark : _borderLight,
-            width: 1.5,
-          ),
-          textStyle: GoogleFonts.inter(
-            fontSize: 15,
-            fontWeight: FontWeight.w500,
-          ),
+          side: BorderSide(color: border, width: 1.5),
+          textStyle: _inter(fontSize: 15, fontWeight: FontWeight.w500),
         ),
       ),
 
@@ -260,10 +308,7 @@ abstract final class FluttyTheme {
         style: TextButton.styleFrom(
           foregroundColor: colorScheme.primary,
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          textStyle: GoogleFonts.inter(
-            fontSize: 14,
-            fontWeight: FontWeight.w600,
-          ),
+          textStyle: _inter(fontSize: 14, fontWeight: FontWeight.w600),
         ),
       ),
 
@@ -274,56 +319,48 @@ abstract final class FluttyTheme {
             if (states.contains(WidgetState.selected)) {
               return colorScheme.primary;
             }
-            return isDark ? _cardDark : _cardLight;
+            return card;
           }),
           foregroundColor: WidgetStateProperty.resolveWith((states) {
             if (states.contains(WidgetState.selected)) {
               return colorScheme.onPrimary;
             }
-            return isDark ? _textPrimary : Colors.black87;
+            return textPrimary;
           }),
-          side: WidgetStateProperty.all(
-            BorderSide(color: isDark ? _borderDark : _borderLight),
-          ),
+          side: WidgetStateProperty.all(BorderSide(color: border)),
         ),
       ),
 
       // Chips
       chipTheme: ChipThemeData(
-        backgroundColor: isDark ? _cardDark : _cardLight,
-        selectedColor: _accentTealSoft,
-        labelStyle: GoogleFonts.inter(
+        backgroundColor: card,
+        selectedColor: primarySoft,
+        labelStyle: _inter(
           fontSize: 13,
           fontWeight: FontWeight.w500,
           // Material 3 InputChip leaves the label transparent if labelStyle
           // is supplied without a color, so pin one here.
-          color: isDark ? _textPrimary : Colors.black87,
+          color: textPrimary,
         ),
-        side: BorderSide(color: isDark ? _borderDark : _borderLight),
+        side: BorderSide(color: border),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
       ),
 
       // Dividers
-      dividerTheme: DividerThemeData(
-        color: isDark ? _borderDark : _borderLight,
-        thickness: 1,
-        space: 1,
-      ),
+      dividerTheme: DividerThemeData(color: border, thickness: 1, space: 1),
 
       // List tiles
       listTileTheme: ListTileThemeData(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         tileColor: Colors.transparent,
-        selectedTileColor: isDark
-            ? _accentTeal.withAlpha(20)
-            : _accentTeal.withAlpha(30),
-        iconColor: isDark ? _textSecondary : Colors.black54,
+        selectedTileColor: primary.withAlpha(isDark ? 20 : 30),
+        iconColor: textSecondary,
       ),
 
       // Bottom sheet
       bottomSheetTheme: BottomSheetThemeData(
-        backgroundColor: isDark ? _surfaceDark : _surfaceLight,
+        backgroundColor: surface,
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
         ),
@@ -331,19 +368,19 @@ abstract final class FluttyTheme {
 
       // Dialog
       dialogTheme: DialogThemeData(
-        backgroundColor: isDark ? _surfaceDark : _surfaceLight,
+        backgroundColor: surface,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-        titleTextStyle: GoogleFonts.inter(
+        titleTextStyle: _inter(
           fontSize: 20,
           fontWeight: FontWeight.w600,
-          color: isDark ? _textPrimary : Colors.black87,
+          color: textPrimary,
         ),
       ),
 
       // Snackbar
       snackBarTheme: SnackBarThemeData(
-        backgroundColor: isDark ? _cardDark : Colors.grey.shade900,
-        contentTextStyle: GoogleFonts.inter(color: Colors.white),
+        backgroundColor: snackBarBackground,
+        contentTextStyle: _inter(color: snackBarForeground),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         behavior: SnackBarBehavior.floating,
       ),
@@ -351,51 +388,39 @@ abstract final class FluttyTheme {
       // Tab bar
       tabBarTheme: TabBarThemeData(
         labelColor: colorScheme.primary,
-        unselectedLabelColor: isDark ? _textSecondary : Colors.black54,
+        unselectedLabelColor: textSecondary,
         indicatorColor: colorScheme.primary,
         indicatorSize: TabBarIndicatorSize.label,
-        labelStyle: GoogleFonts.inter(
-          fontSize: 14,
-          fontWeight: FontWeight.w600,
-        ),
-        unselectedLabelStyle: GoogleFonts.inter(
-          fontSize: 14,
-          fontWeight: FontWeight.w500,
-        ),
+        labelStyle: _inter(fontSize: 14, fontWeight: FontWeight.w600),
+        unselectedLabelStyle: _inter(fontSize: 14, fontWeight: FontWeight.w500),
       ),
 
       // Progress indicators
       progressIndicatorTheme: ProgressIndicatorThemeData(
         color: colorScheme.primary,
-        linearTrackColor: isDark ? _borderDark : _borderLight,
-        circularTrackColor: isDark ? _borderDark : _borderLight,
+        linearTrackColor: border,
+        circularTrackColor: border,
       ),
 
       // Icons
-      iconTheme: IconThemeData(
-        color: isDark ? _textSecondary : Colors.black54,
-        size: 24,
-      ),
+      iconTheme: IconThemeData(color: textSecondary, size: 24),
 
       // Popup menu
       popupMenuTheme: PopupMenuThemeData(
-        color: isDark ? _cardDark : _cardLight,
+        color: card,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: isDark ? _borderDark : _borderLight),
+          side: BorderSide(color: border),
         ),
-        textStyle: GoogleFonts.inter(
-          fontSize: 14,
-          color: isDark ? _textPrimary : Colors.black87,
-        ),
+        textStyle: _inter(fontSize: 14, color: textPrimary),
       ),
 
       // Expansion tile
       expansionTileTheme: ExpansionTileThemeData(
-        iconColor: isDark ? _textSecondary : Colors.black54,
-        collapsedIconColor: isDark ? _textSecondary : Colors.black54,
-        textColor: isDark ? _textPrimary : Colors.black87,
-        collapsedTextColor: isDark ? _textPrimary : Colors.black87,
+        iconColor: textSecondary,
+        collapsedIconColor: textSecondary,
+        textColor: textPrimary,
+        collapsedTextColor: textPrimary,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         collapsedShape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
@@ -404,25 +429,21 @@ abstract final class FluttyTheme {
 
       // Navigation bar (mobile bottom nav)
       navigationBarTheme: NavigationBarThemeData(
-        backgroundColor: isDark ? _surfaceDark : _surfaceLight,
+        backgroundColor: surface,
         indicatorColor: colorScheme.primary.withAlpha(isDark ? 35 : 30),
         labelTextStyle: WidgetStateProperty.resolveWith((states) {
           final selected = states.contains(WidgetState.selected);
-          return GoogleFonts.inter(
+          return _inter(
             fontSize: 12,
             fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
-            color: selected
-                ? colorScheme.primary
-                : (isDark ? _textSecondary : Colors.black54),
+            color: selected ? colorScheme.primary : textSecondary,
           );
         }),
         iconTheme: WidgetStateProperty.resolveWith((states) {
           final selected = states.contains(WidgetState.selected);
           return IconThemeData(
             size: 22,
-            color: selected
-                ? colorScheme.primary
-                : (isDark ? _textSecondary : Colors.black54),
+            color: selected ? colorScheme.primary : textSecondary,
           );
         }),
         elevation: isDark ? 0 : 1,
@@ -432,14 +453,16 @@ abstract final class FluttyTheme {
       // Tooltips
       tooltipTheme: TooltipThemeData(
         decoration: BoxDecoration(
-          color: isDark ? _cardDark : Colors.grey.shade800,
+          color: tooltipBackground,
           borderRadius: BorderRadius.circular(8),
-          border: isDark ? Border.all(color: _borderDark) : null,
+          border: terminalTheme == null && !isDark
+              ? null
+              : Border.all(color: border),
         ),
-        textStyle: GoogleFonts.inter(
+        textStyle: _inter(
           fontSize: 12,
           fontWeight: FontWeight.w500,
-          color: isDark ? _textPrimary : Colors.white,
+          color: tooltipForeground,
         ),
         waitDuration: const Duration(milliseconds: 500),
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
@@ -449,29 +472,109 @@ abstract final class FluttyTheme {
       switchTheme: SwitchThemeData(
         thumbColor: WidgetStateProperty.resolveWith((states) {
           if (states.contains(WidgetState.selected)) {
-            return Colors.white;
+            return colorScheme.onPrimary;
           }
-          return isDark ? _textSecondary : Colors.grey.shade400;
+          return textSecondary;
         }),
         trackColor: WidgetStateProperty.resolveWith((states) {
           if (states.contains(WidgetState.selected)) {
             return colorScheme.primary;
           }
-          return isDark ? _borderDark : Colors.grey.shade300;
+          return border;
         }),
         trackOutlineColor: WidgetStateProperty.resolveWith((states) {
           if (states.contains(WidgetState.selected)) {
             return Colors.transparent;
           }
-          return isDark ? _borderDark.withAlpha(100) : Colors.grey.shade400;
+          return border.withAlpha(isDark ? 100 : 180);
         }),
       ),
     );
   }
 
+  static TextTheme _interTextTheme(TextTheme textTheme) =>
+      debugUseSystemFonts ? textTheme : GoogleFonts.interTextTheme(textTheme);
+
+  static TextStyle _inter({
+    double? fontSize,
+    FontWeight? fontWeight,
+    Color? color,
+    double? letterSpacing,
+  }) {
+    if (debugUseSystemFonts) {
+      return TextStyle(
+        fontSize: fontSize,
+        fontWeight: fontWeight,
+        color: color,
+        letterSpacing: letterSpacing,
+      );
+    }
+
+    return GoogleFonts.inter(
+      fontSize: fontSize,
+      fontWeight: fontWeight,
+      color: color,
+      letterSpacing: letterSpacing,
+    );
+  }
+
+  static Color _blend(Color background, Color foreground, double amount) =>
+      Color.lerp(background, foreground, amount)!;
+
+  static Color _resolveTerminalAccent(TerminalThemeData theme) {
+    final candidates = [
+      theme.blue,
+      theme.cyan,
+      theme.magenta,
+      theme.green,
+      theme.brightBlue,
+      theme.brightCyan,
+      theme.brightMagenta,
+      theme.cursor,
+      theme.yellow,
+      theme.red,
+    ];
+    var bestColor = candidates.first;
+    var bestScore = double.negativeInfinity;
+
+    for (final candidate in candidates) {
+      final hsl = HSLColor.fromColor(candidate);
+      final balance = 1 - (hsl.lightness - 0.5).abs();
+      final score =
+          _contrastRatio(candidate, theme.background) +
+          (hsl.saturation * 2) +
+          balance;
+      if (score > bestScore) {
+        bestColor = candidate;
+        bestScore = score;
+      }
+    }
+
+    return bestColor;
+  }
+
+  static Color _readableTextColor(Color background) =>
+      _contrastRatio(Colors.white, background) >
+          _contrastRatio(Colors.black, background)
+      ? Colors.white
+      : Colors.black;
+
+  static double _contrastRatio(Color a, Color b) {
+    final luminanceA = a.computeLuminance();
+    final luminanceB = b.computeLuminance();
+    final lighter = luminanceA > luminanceB ? luminanceA : luminanceB;
+    final darker = luminanceA > luminanceB ? luminanceB : luminanceA;
+    return (lighter + 0.05) / (darker + 0.05);
+  }
+
   /// Monospace text style for terminal/code content.
-  static TextStyle get monoStyle =>
-      GoogleFonts.jetBrainsMono(fontSize: 13, fontWeight: FontWeight.w400);
+  static TextStyle get monoStyle => debugUseSystemFonts
+      ? const TextStyle(
+          fontFamily: 'monospace',
+          fontSize: 13,
+          fontWeight: FontWeight.w400,
+        )
+      : GoogleFonts.jetBrainsMono(fontSize: 13, fontWeight: FontWeight.w400);
 
   /// Accent gradient for special elements.
   static LinearGradient get accentGradient => const LinearGradient(

--- a/lib/domain/models/terminal_theme.dart
+++ b/lib/domain/models/terminal_theme.dart
@@ -151,6 +151,35 @@ String _formatOscRgbComponent(int value) {
   return '$hex$hex';
 }
 
+const _terminalThemeRequiredColorKeys = <String>[
+  'foreground',
+  'background',
+  'cursor',
+  'selection',
+  'black',
+  'red',
+  'green',
+  'yellow',
+  'blue',
+  'magenta',
+  'cyan',
+  'white',
+  'brightBlack',
+  'brightRed',
+  'brightGreen',
+  'brightYellow',
+  'brightBlue',
+  'brightMagenta',
+  'brightCyan',
+  'brightWhite',
+];
+
+const _terminalThemeOptionalColorKeys = <String>[
+  'searchHitBackground',
+  'searchHitBackgroundCurrent',
+  'searchHitForeground',
+];
+
 /// Data model for a terminal color theme.
 ///
 /// Contains all 16 ANSI colors plus special colors for cursor, selection,
@@ -231,6 +260,39 @@ class TerminalThemeData {
       TerminalThemeData.fromJson(
         jsonDecode(jsonString) as Map<String, dynamic>,
       );
+
+  /// Safely creates a theme from decoded JSON, or null when invalid.
+  static TerminalThemeData? tryFromJson(Object? json) {
+    if (json is! Map || json.keys.any((key) => key is! String)) {
+      return null;
+    }
+
+    final id = json['id'];
+    if (id is! String || id.isEmpty || json['name'] is! String) {
+      return null;
+    }
+    if (json['isDark'] is! bool) {
+      return null;
+    }
+    final isCustom = json['isCustom'];
+    if (isCustom != null && isCustom is! bool) {
+      return null;
+    }
+
+    for (final key in _terminalThemeRequiredColorKeys) {
+      if (json[key] is! int) {
+        return null;
+      }
+    }
+    for (final key in _terminalThemeOptionalColorKeys) {
+      final value = json[key];
+      if (value != null && value is! int) {
+        return null;
+      }
+    }
+
+    return TerminalThemeData.fromJson(Map<String, dynamic>.from(json));
+  }
 
   /// Unique identifier for the theme.
   final String id;

--- a/lib/domain/models/terminal_themes.dart
+++ b/lib/domain/models/terminal_themes.dart
@@ -49,11 +49,43 @@ abstract final class TerminalThemes {
   ];
 
   /// Gets a theme by ID, returns null if not found.
-  static TerminalThemeData? getById(String id) {
-    for (final theme in all) {
+  ///
+  /// [additionalThemes] can include user-created themes loaded from settings.
+  static TerminalThemeData? getById(
+    String id, {
+    Iterable<TerminalThemeData> additionalThemes = const [],
+  }) {
+    for (final theme in [...all, ...additionalThemes]) {
       if (theme.id == id) return theme;
     }
     return null;
+  }
+
+  /// Returns the built-in default theme ID for [brightness].
+  static String defaultThemeIdForBrightness(Brightness brightness) =>
+      brightness == Brightness.dark ? defaultDarkThemeId : defaultLightThemeId;
+
+  /// Returns the built-in default theme for [brightness].
+  static TerminalThemeData defaultThemeForBrightness(Brightness brightness) =>
+      brightness == Brightness.dark ? midnightPurple : cleanWhite;
+
+  /// Resolves [themeId] against built-in and [additionalThemes].
+  ///
+  /// Falls back to the built-in default for [brightness] when the ID is null or
+  /// unavailable.
+  static TerminalThemeData resolveById({
+    required Brightness brightness,
+    required String? themeId,
+    Iterable<TerminalThemeData> additionalThemes = const [],
+  }) {
+    if (themeId != null) {
+      final theme = getById(themeId, additionalThemes: additionalThemes);
+      if (theme != null) {
+        return theme;
+      }
+    }
+
+    return defaultThemeForBrightness(brightness);
   }
 
   // ============================================

--- a/lib/domain/models/terminal_themes.dart
+++ b/lib/domain/models/terminal_themes.dart
@@ -50,12 +50,16 @@ abstract final class TerminalThemes {
 
   /// Gets a theme by ID, returns null if not found.
   ///
-  /// [additionalThemes] can include user-created themes loaded from settings.
+  /// [additionalThemes] should contain non-built-in themes, such as
+  /// user-created themes loaded from settings.
   static TerminalThemeData? getById(
     String id, {
     Iterable<TerminalThemeData> additionalThemes = const [],
   }) {
-    for (final theme in [...all, ...additionalThemes]) {
+    for (final theme in all) {
+      if (theme.id == id) return theme;
+    }
+    for (final theme in additionalThemes) {
       if (theme.id == id) return theme;
     }
     return null;

--- a/lib/domain/models/terminal_themes.dart
+++ b/lib/domain/models/terminal_themes.dart
@@ -50,8 +50,8 @@ abstract final class TerminalThemes {
 
   /// Gets a theme by ID, returns null if not found.
   ///
-  /// [additionalThemes] should contain non-built-in themes, such as
-  /// user-created themes loaded from settings.
+  /// [additionalThemes] may include custom themes or a combined built-in/custom
+  /// list; built-ins are checked first so duplicate built-in IDs are ignored.
   static TerminalThemeData? getById(
     String id, {
     Iterable<TerminalThemeData> additionalThemes = const [],

--- a/lib/domain/services/settings_service.dart
+++ b/lib/domain/services/settings_service.dart
@@ -304,6 +304,7 @@ class TerminalThemesApplyToAppNotifier extends Notifier<bool> {
       value: enabled,
     );
     state = enabled;
+    ref.invalidate(terminalThemesApplyToAppProvider);
   }
 }
 

--- a/lib/domain/services/settings_service.dart
+++ b/lib/domain/services/settings_service.dart
@@ -260,7 +260,7 @@ class TerminalThemesApplyToAppNotifier extends Notifier<bool> {
     _disposed = false;
     ref.onDispose(() => _disposed = true);
     Future.microtask(_init);
-    return false;
+    return true;
   }
 
   Future<void> _init() async {
@@ -749,14 +749,15 @@ class TerminalThemeSettingsNotifier extends Notifier<TerminalThemeSettings> {
     final defaultThemeId = TerminalThemes.defaultThemeIdForBrightness(
       brightness,
     );
-    if (themeId == null ||
-        themeId.isEmpty ||
-        _legacyDefaultTerminalThemeIds.contains(themeId)) {
+    if (themeId == null || themeId.isEmpty) {
       return defaultThemeId;
     }
     if (TerminalThemes.getById(themeId) != null ||
         customThemeIds.contains(themeId)) {
       return themeId;
+    }
+    if (_legacyDefaultTerminalThemeIds.contains(themeId)) {
+      return defaultThemeId;
     }
     return defaultThemeId;
   }

--- a/lib/domain/services/settings_service.dart
+++ b/lib/domain/services/settings_service.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/database/database.dart';
+import '../models/terminal_themes.dart';
 
 /// Keys for app settings.
 abstract final class SettingKeys {
@@ -583,8 +584,8 @@ class TerminalThemeSettingsNotifier extends Notifier<TerminalThemeSettings> {
     ref.onDispose(() => _disposed = true);
     Future.microtask(_init);
     return const TerminalThemeSettings(
-      lightThemeId: 'github-light',
-      darkThemeId: 'dracula',
+      lightThemeId: TerminalThemes.defaultLightThemeId,
+      darkThemeId: TerminalThemes.defaultDarkThemeId,
     );
   }
 
@@ -597,8 +598,8 @@ class TerminalThemeSettingsNotifier extends Notifier<TerminalThemeSettings> {
     );
     if (_disposed) return;
     state = TerminalThemeSettings(
-      lightThemeId: light ?? 'github-light',
-      darkThemeId: dark ?? 'dracula',
+      lightThemeId: light ?? TerminalThemes.defaultLightThemeId,
+      darkThemeId: dark ?? TerminalThemes.defaultDarkThemeId,
     );
   }
 

--- a/lib/domain/services/settings_service.dart
+++ b/lib/domain/services/settings_service.dart
@@ -12,6 +12,9 @@ abstract final class SettingKeys {
   /// Theme mode: 'system', 'light', 'dark'.
   static const themeMode = 'theme_mode';
 
+  /// Whether terminal themes also style app chrome.
+  static const terminalThemesApplyToApp = 'terminal_themes_apply_to_app';
+
   /// Terminal font family.
   static const terminalFont = 'terminal_font';
 
@@ -233,6 +236,54 @@ class ThemeModeNotifier extends Notifier<ThemeMode> {
 /// Provider for theme mode with write capability.
 final themeModeNotifierProvider =
     NotifierProvider<ThemeModeNotifier, ThemeMode>(ThemeModeNotifier.new);
+
+/// Provider for terminal themes applying to app chrome.
+final terminalThemesApplyToAppProvider = FutureProvider<bool>((ref) async {
+  final settings = ref.watch(settingsServiceProvider);
+  return settings.getBool(
+    SettingKeys.terminalThemesApplyToApp,
+    defaultValue: true,
+  );
+});
+
+/// Notifier for terminal themes applying to app chrome.
+class TerminalThemesApplyToAppNotifier extends Notifier<bool> {
+  late SettingsService _settings;
+  bool _disposed = false;
+
+  @override
+  bool build() {
+    _settings = ref.watch(settingsServiceProvider);
+    _disposed = false;
+    ref.onDispose(() => _disposed = true);
+    Future.microtask(_init);
+    return true;
+  }
+
+  Future<void> _init() async {
+    final value = await _settings.getBool(
+      SettingKeys.terminalThemesApplyToApp,
+      defaultValue: true,
+    );
+    if (_disposed) return;
+    state = value;
+  }
+
+  /// Set whether terminal themes also style app chrome.
+  Future<void> setEnabled({required bool enabled}) async {
+    await _settings.setBool(
+      SettingKeys.terminalThemesApplyToApp,
+      value: enabled,
+    );
+    state = enabled;
+  }
+}
+
+/// Provider for terminal themes applying to app chrome with write capability.
+final terminalThemesApplyToAppNotifierProvider =
+    NotifierProvider<TerminalThemesApplyToAppNotifier, bool>(
+      TerminalThemesApplyToAppNotifier.new,
+    );
 
 /// Provider for font size setting.
 final fontSizeProvider = FutureProvider<double>((ref) async {

--- a/lib/domain/services/settings_service.dart
+++ b/lib/domain/services/settings_service.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/database/database.dart';
+import '../models/terminal_theme.dart';
 import '../models/terminal_themes.dart';
 
 /// Keys for app settings.
@@ -574,6 +575,8 @@ class TerminalThemeSettings {
 
 /// Notifier for terminal theme settings.
 class TerminalThemeSettingsNotifier extends Notifier<TerminalThemeSettings> {
+  static const _legacyDefaultTerminalThemeIds = {'github-light', 'dracula'};
+
   late SettingsService _settings;
   bool _disposed = false;
 
@@ -596,11 +599,82 @@ class TerminalThemeSettingsNotifier extends Notifier<TerminalThemeSettings> {
     final dark = await _settings.getString(
       SettingKeys.defaultTerminalThemeDark,
     );
+    final customThemeIds = await _getCustomTerminalThemeIds();
+    final lightThemeId = _normalizeThemeId(
+      light,
+      brightness: Brightness.light,
+      customThemeIds: customThemeIds,
+    );
+    final darkThemeId = _normalizeThemeId(
+      dark,
+      brightness: Brightness.dark,
+      customThemeIds: customThemeIds,
+    );
+    if (_disposed) return;
+    await _persistNormalizedThemeId(
+      key: SettingKeys.defaultTerminalThemeLight,
+      storedThemeId: light,
+      normalizedThemeId: lightThemeId,
+    );
+    await _persistNormalizedThemeId(
+      key: SettingKeys.defaultTerminalThemeDark,
+      storedThemeId: dark,
+      normalizedThemeId: darkThemeId,
+    );
     if (_disposed) return;
     state = TerminalThemeSettings(
-      lightThemeId: light ?? TerminalThemes.defaultLightThemeId,
-      darkThemeId: dark ?? TerminalThemes.defaultDarkThemeId,
+      lightThemeId: lightThemeId,
+      darkThemeId: darkThemeId,
     );
+  }
+
+  Future<Set<String>> _getCustomTerminalThemeIds() async {
+    final json = await _settings.getString(SettingKeys.customTerminalThemes);
+    if (json == null || json.isEmpty) {
+      return const {};
+    }
+
+    try {
+      final list = jsonDecode(json) as List<dynamic>;
+      return list
+          .map(
+            (item) =>
+                TerminalThemeData.fromJson(item as Map<String, dynamic>).id,
+          )
+          .toSet();
+    } on FormatException {
+      return const {};
+    }
+  }
+
+  String _normalizeThemeId(
+    String? themeId, {
+    required Brightness brightness,
+    required Set<String> customThemeIds,
+  }) {
+    final defaultThemeId = TerminalThemes.defaultThemeIdForBrightness(
+      brightness,
+    );
+    if (themeId == null ||
+        themeId.isEmpty ||
+        _legacyDefaultTerminalThemeIds.contains(themeId)) {
+      return defaultThemeId;
+    }
+    if (TerminalThemes.getById(themeId) != null ||
+        customThemeIds.contains(themeId)) {
+      return themeId;
+    }
+    return defaultThemeId;
+  }
+
+  Future<void> _persistNormalizedThemeId({
+    required String key,
+    required String? storedThemeId,
+    required String normalizedThemeId,
+  }) async {
+    if (storedThemeId != null && storedThemeId != normalizedThemeId) {
+      await _settings.setString(key, normalizedThemeId);
+    }
   }
 
   /// Set the light mode theme.

--- a/lib/domain/services/settings_service.dart
+++ b/lib/domain/services/settings_service.dart
@@ -4,8 +4,36 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/database/database.dart';
-import '../models/terminal_theme.dart';
 import '../models/terminal_themes.dart';
+
+const _customTerminalThemeRequiredColorKeys = <String>[
+  'foreground',
+  'background',
+  'cursor',
+  'selection',
+  'black',
+  'red',
+  'green',
+  'yellow',
+  'blue',
+  'magenta',
+  'cyan',
+  'white',
+  'brightBlack',
+  'brightRed',
+  'brightGreen',
+  'brightYellow',
+  'brightBlue',
+  'brightMagenta',
+  'brightCyan',
+  'brightWhite',
+];
+
+const _customTerminalThemeOptionalColorKeys = <String>[
+  'searchHitBackground',
+  'searchHitBackgroundCurrent',
+  'searchHitForeground',
+];
 
 /// Keys for app settings.
 abstract final class SettingKeys {
@@ -686,16 +714,54 @@ class TerminalThemeSettingsNotifier extends Notifier<TerminalThemeSettings> {
     }
 
     try {
-      final list = jsonDecode(json) as List<dynamic>;
-      return list
-          .map(
-            (item) =>
-                TerminalThemeData.fromJson(item as Map<String, dynamic>).id,
-          )
-          .toSet();
+      final decoded = jsonDecode(json);
+      if (decoded is! List) {
+        return const {};
+      }
+
+      final themeIds = <String>{};
+      for (final item in decoded) {
+        final themeId = _customTerminalThemeIdFromJson(item);
+        if (themeId != null) {
+          themeIds.add(themeId);
+        }
+      }
+      return themeIds;
     } on FormatException {
       return const {};
     }
+  }
+
+  String? _customTerminalThemeIdFromJson(Object? item) {
+    if (item is! Map) {
+      return null;
+    }
+
+    final id = item['id'];
+    if (id is! String || id.isEmpty || item['name'] is! String) {
+      return null;
+    }
+    if (item['isDark'] is! bool) {
+      return null;
+    }
+    final isCustom = item['isCustom'];
+    if (isCustom != null && isCustom is! bool) {
+      return null;
+    }
+
+    for (final key in _customTerminalThemeRequiredColorKeys) {
+      if (item[key] is! int) {
+        return null;
+      }
+    }
+    for (final key in _customTerminalThemeOptionalColorKeys) {
+      final value = item[key];
+      if (value != null && value is! int) {
+        return null;
+      }
+    }
+
+    return id;
   }
 
   String _normalizeThemeId(

--- a/lib/domain/services/settings_service.dart
+++ b/lib/domain/services/settings_service.dart
@@ -4,36 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/database/database.dart';
+import '../models/terminal_theme.dart';
 import '../models/terminal_themes.dart';
-
-const _customTerminalThemeRequiredColorKeys = <String>[
-  'foreground',
-  'background',
-  'cursor',
-  'selection',
-  'black',
-  'red',
-  'green',
-  'yellow',
-  'blue',
-  'magenta',
-  'cyan',
-  'white',
-  'brightBlack',
-  'brightRed',
-  'brightGreen',
-  'brightYellow',
-  'brightBlue',
-  'brightMagenta',
-  'brightCyan',
-  'brightWhite',
-];
-
-const _customTerminalThemeOptionalColorKeys = <String>[
-  'searchHitBackground',
-  'searchHitBackgroundCurrent',
-  'searchHitForeground',
-];
 
 /// Keys for app settings.
 abstract final class SettingKeys {
@@ -285,7 +257,7 @@ class TerminalThemesApplyToAppNotifier extends Notifier<bool> {
     _disposed = false;
     ref.onDispose(() => _disposed = true);
     Future.microtask(_init);
-    return true;
+    return false;
   }
 
   Future<void> _init() async {
@@ -722,47 +694,15 @@ class TerminalThemeSettingsNotifier extends Notifier<TerminalThemeSettings> {
 
       final themeIds = <String>{};
       for (final item in decoded) {
-        final themeId = _customTerminalThemeIdFromJson(item);
-        if (themeId != null) {
-          themeIds.add(themeId);
+        final theme = TerminalThemeData.tryFromJson(item);
+        if (theme != null) {
+          themeIds.add(theme.id);
         }
       }
       return themeIds;
     } on FormatException {
       return const {};
     }
-  }
-
-  String? _customTerminalThemeIdFromJson(Object? item) {
-    if (item is! Map) {
-      return null;
-    }
-
-    final id = item['id'];
-    if (id is! String || id.isEmpty || item['name'] is! String) {
-      return null;
-    }
-    if (item['isDark'] is! bool) {
-      return null;
-    }
-    final isCustom = item['isCustom'];
-    if (isCustom != null && isCustom is! bool) {
-      return null;
-    }
-
-    for (final key in _customTerminalThemeRequiredColorKeys) {
-      if (item[key] is! int) {
-        return null;
-      }
-    }
-    for (final key in _customTerminalThemeOptionalColorKeys) {
-      final value = item[key];
-      if (value != null && value is! int) {
-        return null;
-      }
-    }
-
-    return id;
   }
 
   String _normalizeThemeId(

--- a/lib/domain/services/terminal_theme_service.dart
+++ b/lib/domain/services/terminal_theme_service.dart
@@ -139,12 +139,12 @@ class TerminalThemeService {
     }
 
     try {
-      final list = jsonDecode(json) as List<dynamic>;
-      return list
-          .map(
-            (item) => TerminalThemeData.fromJson(item as Map<String, dynamic>),
-          )
-          .toList();
+      final decoded = jsonDecode(json);
+      if (decoded is! List) {
+        return [];
+      }
+
+      return [for (final item in decoded) ?TerminalThemeData.tryFromJson(item)];
     } on FormatException {
       return [];
     }

--- a/lib/domain/services/terminal_theme_service.dart
+++ b/lib/domain/services/terminal_theme_service.dart
@@ -8,6 +8,46 @@ import '../models/terminal_theme.dart';
 import '../models/terminal_themes.dart';
 import 'settings_service.dart';
 
+/// Theme IDs from the foreground terminal connection that should drive app UI.
+class TerminalAppThemeOverride {
+  /// Creates a new [TerminalAppThemeOverride].
+  const TerminalAppThemeOverride({
+    required this.owner,
+    this.lightThemeId,
+    this.darkThemeId,
+  });
+
+  /// Identity token used so screens only clear overrides they created.
+  final Object owner;
+
+  /// Light terminal theme ID for the foreground terminal connection.
+  final String? lightThemeId;
+
+  /// Dark terminal theme ID for the foreground terminal connection.
+  final String? darkThemeId;
+}
+
+/// Notifier for the active terminal connection app-theme override.
+class TerminalAppThemeOverrideNotifier
+    extends Notifier<TerminalAppThemeOverride?> {
+  /// Starts without an active terminal app-theme override.
+  @override
+  TerminalAppThemeOverride? build() => null;
+
+  /// Current active terminal app-theme override.
+  TerminalAppThemeOverride? get activeOverride => state;
+
+  /// Updates the active terminal app-theme override.
+  set activeOverride(TerminalAppThemeOverride override) => state = override;
+
+  /// Clears the active terminal app-theme override if [owner] created it.
+  void clearForOwner(Object owner) {
+    if (identical(state?.owner, owner)) {
+      state = null;
+    }
+  }
+}
+
 /// Service for managing terminal themes.
 ///
 /// Provides methods for resolving the appropriate theme for a host,
@@ -158,3 +198,10 @@ final customTerminalThemesProvider = FutureProvider<List<TerminalThemeData>>((
   final service = ref.watch(terminalThemeServiceProvider);
   return service.getCustomThemes();
 });
+
+/// Active terminal connection theme override for app-wide UI theming.
+final terminalAppThemeOverrideProvider =
+    NotifierProvider<
+      TerminalAppThemeOverrideNotifier,
+      TerminalAppThemeOverride?
+    >(TerminalAppThemeOverrideNotifier.new);

--- a/lib/domain/services/terminal_theme_service.dart
+++ b/lib/domain/services/terminal_theme_service.dart
@@ -54,7 +54,7 @@ class TerminalThemeService {
       }
     }
 
-    return isDark ? TerminalThemes.midnightPurple : TerminalThemes.cleanWhite;
+    return TerminalThemes.defaultThemeForBrightness(brightness);
   }
 
   /// Gets a theme by ID (checks built-in themes first, then custom).

--- a/lib/presentation/providers/entity_list_providers.dart
+++ b/lib/presentation/providers/entity_list_providers.dart
@@ -40,6 +40,8 @@ void invalidateImportedEntityProviders(ProviderInvalidator invalidate) {
 /// Refreshes presentation providers that depend on synced settings and data.
 void invalidateSyncedDataProviders(ProviderInvalidator invalidate) {
   invalidate(themeModeNotifierProvider);
+  invalidate(terminalThemesApplyToAppNotifierProvider);
+  invalidate(terminalThemesApplyToAppProvider);
   invalidate(fontSizeNotifierProvider);
   invalidate(fontFamilyNotifierProvider);
   invalidate(cursorStyleNotifierProvider);

--- a/lib/presentation/providers/entity_list_providers.dart
+++ b/lib/presentation/providers/entity_list_providers.dart
@@ -6,6 +6,7 @@ import '../../data/repositories/group_repository.dart';
 import '../../data/repositories/host_repository.dart';
 import '../../data/repositories/key_repository.dart';
 import '../../domain/services/settings_service.dart';
+import '../../domain/services/terminal_theme_service.dart';
 
 /// Shared stream of all saved hosts for presentation screens.
 final allHostsProvider = StreamProvider<List<Host>>((ref) {
@@ -44,5 +45,7 @@ void invalidateSyncedDataProviders(ProviderInvalidator invalidate) {
   invalidate(cursorStyleNotifierProvider);
   invalidate(bellSoundNotifierProvider);
   invalidate(terminalThemeSettingsProvider);
+  invalidate(allTerminalThemesProvider);
+  invalidate(customTerminalThemesProvider);
   invalidateImportedEntityProviders(invalidate);
 }

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -254,7 +254,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
             ..invalidate(fontFamilyNotifierProvider)
             ..invalidate(cursorStyleNotifierProvider)
             ..invalidate(bellSoundNotifierProvider)
-            ..invalidate(terminalThemeSettingsProvider);
+            ..invalidate(terminalThemeSettingsProvider)
+            ..invalidate(allTerminalThemesProvider)
+            ..invalidate(customTerminalThemesProvider);
           invalidateImportedEntityProviders(ref.invalidate);
           if (!mounted) {
             return;

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -250,6 +250,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           }
           ref
             ..invalidate(themeModeNotifierProvider)
+            ..invalidate(terminalThemesApplyToAppNotifierProvider)
+            ..invalidate(terminalThemesApplyToAppProvider)
             ..invalidate(fontSizeNotifierProvider)
             ..invalidate(fontFamilyNotifierProvider)
             ..invalidate(cursorStyleNotifierProvider)

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -169,6 +169,9 @@ class _AppearanceSection extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final themeMode = ref.watch(themeModeNotifierProvider);
+    final terminalThemesApplyToApp = ref.watch(
+      terminalThemesApplyToAppNotifierProvider,
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -182,6 +185,21 @@ class _AppearanceSection extends ConsumerWidget {
           title: const Text('Theme'),
           subtitle: Text(_themeModeLabel(themeMode)),
           onTap: () => _showThemeDialog(context, ref, themeMode),
+        ),
+        SwitchListTile(
+          secondary: const Icon(Icons.color_lens_outlined),
+          title: const Text('Use terminal themes for app'),
+          subtitle: const Text(
+            'Apply the selected terminal light and dark themes to app colors',
+          ),
+          value: terminalThemesApplyToApp,
+          onChanged: (value) {
+            unawaited(
+              ref
+                  .read(terminalThemesApplyToAppNotifierProvider.notifier)
+                  .setEnabled(enabled: value),
+            );
+          },
         ),
       ],
     );
@@ -1488,6 +1506,8 @@ class _ImportExportSection extends ConsumerWidget {
       }
       ref
         ..invalidate(themeModeNotifierProvider)
+        ..invalidate(terminalThemesApplyToAppNotifierProvider)
+        ..invalidate(terminalThemesApplyToAppProvider)
         ..invalidate(fontSizeNotifierProvider)
         ..invalidate(fontFamilyNotifierProvider)
         ..invalidate(cursorStyleNotifierProvider)

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -17,6 +17,7 @@ import '../../domain/services/monetization_service.dart';
 import '../../domain/services/secure_transfer_service.dart';
 import '../../domain/services/settings_service.dart';
 import '../../domain/services/ssh_service.dart';
+import '../../domain/services/terminal_theme_service.dart';
 import '../providers/entity_list_providers.dart';
 import '../widgets/premium_access.dart';
 import '../widgets/premium_badge.dart';
@@ -606,9 +607,20 @@ class _TerminalSection extends ConsumerWidget {
     );
     final tapToShowKeyboard = ref.watch(tapToShowKeyboardNotifierProvider);
     final themeSettings = ref.watch(terminalThemeSettingsProvider);
+    final availableThemes =
+        ref.watch(allTerminalThemesProvider).asData?.value ??
+        TerminalThemes.all;
 
-    final lightTheme = TerminalThemes.getById(themeSettings.lightThemeId);
-    final darkTheme = TerminalThemes.getById(themeSettings.darkThemeId);
+    final lightTheme = TerminalThemes.resolveById(
+      brightness: Brightness.light,
+      themeId: themeSettings.lightThemeId,
+      additionalThemes: availableThemes,
+    );
+    final darkTheme = TerminalThemes.resolveById(
+      brightness: Brightness.dark,
+      themeId: themeSettings.darkThemeId,
+      additionalThemes: availableThemes,
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -620,13 +632,13 @@ class _TerminalSection extends ConsumerWidget {
         ListTile(
           leading: const Icon(Icons.palette_outlined),
           title: const Text('Light Mode Theme'),
-          subtitle: Text(lightTheme?.name ?? 'Default'),
+          subtitle: Text(lightTheme.name),
           onTap: () => _showThemePicker(context, ref, isLight: true),
         ),
         ListTile(
           leading: const Icon(Icons.palette),
           title: const Text('Dark Mode Theme'),
-          subtitle: Text(darkTheme?.name ?? 'Default'),
+          subtitle: Text(darkTheme.name),
           onTap: () => _showThemePicker(context, ref, isLight: false),
         ),
         ListTile(
@@ -1482,7 +1494,9 @@ class _ImportExportSection extends ConsumerWidget {
         ..invalidate(bellSoundNotifierProvider)
         ..invalidate(sharedClipboardNotifierProvider)
         ..invalidate(sharedClipboardProvider)
-        ..invalidate(terminalThemeSettingsProvider);
+        ..invalidate(terminalThemeSettingsProvider)
+        ..invalidate(allTerminalThemesProvider)
+        ..invalidate(customTerminalThemesProvider);
       invalidateImportedEntityProviders(ref.invalidate);
 
       if (!context.mounted) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3269,6 +3269,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _startClisInYoloMode = false;
   TerminalThemeData? _currentTheme;
   TerminalThemeData? _sessionThemeOverride;
+  final Object _terminalAppThemeOverrideOwner = Object();
+  late final TerminalAppThemeOverrideNotifier _terminalAppThemeOverrideNotifier;
 
   // Cache the notifier for use in dispose
   ActiveSessionsNotifier? _sessionsNotifier;
@@ -3435,6 +3437,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         ),
       ),
     );
+    _terminalAppThemeOverrideNotifier = ref.read(
+      terminalAppThemeOverrideProvider.notifier,
+    );
     _terminal = Terminal(maxLines: 10000);
     _terminalController = TerminalController();
     _terminalScrollController = ScrollController()
@@ -3567,6 +3572,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             : _sessionsNotifier?.getSession(_connectionId!));
     targetSession?.terminalTheme = theme;
   }
+
+  void _syncAppThemeOverrideFromSession(SshSession session) {
+    _terminalAppThemeOverrideNotifier.activeOverride = TerminalAppThemeOverride(
+      owner: _terminalAppThemeOverrideOwner,
+      lightThemeId: session.terminalThemeLightId,
+      darkThemeId: session.terminalThemeDarkId,
+    );
+  }
+
+  void _clearAppThemeOverride() => _terminalAppThemeOverrideNotifier
+      .clearForOwner(_terminalAppThemeOverrideOwner);
 
   TerminalThemeData _resolveEffectiveTerminalTheme() {
     final isDark = Theme.of(context).brightness == Brightness.dark;
@@ -3903,6 +3919,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _resolveEffectiveTerminalTheme(),
           session: session,
         );
+        _syncAppThemeOverrideFromSession(session);
       }
       return false;
     }
@@ -3916,6 +3933,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (resolvedTheme != null) {
       _applyTerminalThemeToSession(resolvedTheme, session: session);
     }
+    _syncAppThemeOverrideFromSession(session);
     return resolvedTheme != null;
   }
 
@@ -5479,6 +5497,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   Future<void> _disconnect() async {
     final connectionId = _connectionId;
     _connectionId = null;
+    _clearAppThemeOverride();
     await _doneSubscription?.cancel();
     _doneSubscription = null;
     _shell = null;
@@ -5509,6 +5528,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     final previousConnectionId = _connectionId;
     _connectionId = null;
+    _clearAppThemeOverride();
     _connectionLostWhileBackgrounded = false;
     try {
       await _doneSubscription?.cancel();
@@ -5532,6 +5552,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    _clearAppThemeOverride();
     _sharedClipboardSubscription.close();
     _sharedClipboardLocalReadSubscription.close();
     _stopSharedClipboardSync();
@@ -6156,10 +6177,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       final hasHostThemeAccess = monetizationState.allowsFeature(
         MonetizationFeature.hostSpecificThemes,
       );
-      if (_connectionId != null) {
-        ref
-            .read(activeSessionsProvider.notifier)
-            .updateSessionTheme(_connectionId!, theme.id, isDark: isDark);
+      final connectionId = _connectionId;
+      if (connectionId != null) {
+        final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
+        final session =
+            (sessionsNotifier
+                  ..updateSessionTheme(connectionId, theme.id, isDark: isDark))
+                .getSession(connectionId);
+        if (session != null) {
+          _syncAppThemeOverrideFromSession(session);
+        }
       }
       setState(() => _sessionThemeOverride = theme);
       _applyTerminalThemeToSession(theme);

--- a/lib/presentation/widgets/connection_preview_snippet.dart
+++ b/lib/presentation/widgets/connection_preview_snippet.dart
@@ -15,14 +15,15 @@ TerminalThemeData resolveConnectionPreviewTheme({
   String? darkThemeId,
 }) {
   final isDark = brightness == Brightness.dark;
-  final themeLookup = {for (final theme in availableThemes) theme.id: theme};
   final preferredThemeId = isDark
       ? darkThemeId ?? themeSettings.darkThemeId
       : lightThemeId ?? themeSettings.lightThemeId;
 
-  return themeLookup[preferredThemeId] ??
-      TerminalThemes.getById(preferredThemeId) ??
-      (isDark ? TerminalThemes.midnightPurple : TerminalThemes.cleanWhite);
+  return TerminalThemes.resolveById(
+    brightness: brightness,
+    themeId: preferredThemeId,
+    additionalThemes: availableThemes,
+  );
 }
 
 /// Fallback status text for a connection preview with no terminal output yet.

--- a/lib/presentation/widgets/terminal_theme_picker.dart
+++ b/lib/presentation/widgets/terminal_theme_picker.dart
@@ -57,10 +57,14 @@ class _TerminalThemePickerState extends ConsumerState<TerminalThemePicker> {
   Widget build(BuildContext context) {
     final themesAsync = ref.watch(allTerminalThemesProvider);
     final colorScheme = Theme.of(context).colorScheme;
+    final availableThemes = themesAsync.asData?.value ?? TerminalThemes.all;
 
     // Get the currently selected theme for the preview
     final currentTheme = widget.selectedThemeId != null
-        ? TerminalThemes.getById(widget.selectedThemeId!)
+        ? TerminalThemes.getById(
+            widget.selectedThemeId!,
+            additionalThemes: availableThemes,
+          )
         : null;
 
     return NestedScrollView(

--- a/test/app/theme_test.dart
+++ b/test/app/theme_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/app/theme.dart';
+import 'package:monkeyssh/domain/models/terminal_theme.dart';
+import 'package:monkeyssh/domain/models/terminal_themes.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    FluttyTheme.debugUseSystemFonts = true;
+  });
+
+  tearDownAll(() {
+    FluttyTheme.debugUseSystemFonts = false;
+  });
+
+  group('FluttyTheme', () {
+    test('builds app colors from a terminal palette', () {
+      const terminalTheme = TerminalThemes.cityLights;
+
+      final theme = FluttyTheme.fromTerminalTheme(
+        terminalTheme,
+        brightness: Brightness.dark,
+      );
+
+      expect(theme.scaffoldBackgroundColor, terminalTheme.background);
+      expect(theme.appBarTheme.backgroundColor, terminalTheme.background);
+      expect(theme.colorScheme.surface, terminalTheme.background);
+      expect(theme.colorScheme.onSurface, terminalTheme.foreground);
+      expect(theme.textTheme.titleLarge?.color, terminalTheme.foreground);
+      expect(
+        _terminalAccentCandidates(terminalTheme),
+        contains(theme.colorScheme.primary),
+      );
+    });
+
+    test('keeps the requested brightness for the Material theme slot', () {
+      const terminalTheme = TerminalThemes.slate;
+
+      final theme = FluttyTheme.fromTerminalTheme(
+        terminalTheme,
+        brightness: Brightness.light,
+      );
+
+      expect(theme.brightness, Brightness.light);
+      expect(theme.colorScheme.brightness, Brightness.light);
+      expect(theme.scaffoldBackgroundColor, terminalTheme.background);
+    });
+  });
+}
+
+Set<Color> _terminalAccentCandidates(TerminalThemeData theme) => {
+  theme.blue,
+  theme.cyan,
+  theme.magenta,
+  theme.green,
+  theme.brightBlue,
+  theme.brightCyan,
+  theme.brightMagenta,
+  theme.cursor,
+  theme.yellow,
+  theme.red,
+};

--- a/test/app/theme_test.dart
+++ b/test/app/theme_test.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/app/app.dart';
 import 'package:monkeyssh/app/theme.dart';
 import 'package:monkeyssh/domain/models/terminal_theme.dart';
 import 'package:monkeyssh/domain/models/terminal_themes.dart';
+import 'package:monkeyssh/domain/services/settings_service.dart';
+import 'package:monkeyssh/domain/services/terminal_theme_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -46,6 +49,48 @@ void main() {
       expect(theme.brightness, Brightness.light);
       expect(theme.colorScheme.brightness, Brightness.light);
       expect(theme.scaffoldBackgroundColor, terminalTheme.background);
+    });
+
+    test('builds app theme from active terminal connection override', () {
+      const terminalThemeSettings = TerminalThemeSettings(
+        lightThemeId: TerminalThemes.defaultLightThemeId,
+        darkThemeId: TerminalThemes.defaultDarkThemeId,
+      );
+      const overrideTheme = TerminalThemes.cityLights;
+
+      final theme = buildTerminalAppTheme(
+        brightness: Brightness.dark,
+        terminalThemeSettings: terminalThemeSettings,
+        terminalThemes: TerminalThemes.all,
+        terminalAppThemeOverride: TerminalAppThemeOverride(
+          owner: const Object(),
+          darkThemeId: overrideTheme.id,
+        ),
+      );
+
+      expect(theme.scaffoldBackgroundColor, overrideTheme.background);
+      expect(theme.colorScheme.onSurface, overrideTheme.foreground);
+    });
+
+    test('falls back to global theme when override omits brightness', () {
+      const terminalThemeSettings = TerminalThemeSettings(
+        lightThemeId: TerminalThemes.defaultLightThemeId,
+        darkThemeId: TerminalThemes.defaultDarkThemeId,
+      );
+      const globalTheme = TerminalThemes.midnightPurple;
+
+      final theme = buildTerminalAppTheme(
+        brightness: Brightness.dark,
+        terminalThemeSettings: terminalThemeSettings,
+        terminalThemes: TerminalThemes.all,
+        terminalAppThemeOverride: TerminalAppThemeOverride(
+          owner: const Object(),
+          lightThemeId: TerminalThemes.cleanWhite.id,
+        ),
+      );
+
+      expect(theme.scaffoldBackgroundColor, globalTheme.background);
+      expect(theme.colorScheme.onSurface, globalTheme.foreground);
     });
   });
 }

--- a/test/domain/models/terminal_theme_test.dart
+++ b/test/domain/models/terminal_theme_test.dart
@@ -347,6 +347,21 @@ void main() {
       expect(theme.name, 'Midnight Purple');
     });
 
+    test('getById returns additional themes', () {
+      final customTheme = TerminalThemes.midnightPurple.copyWith(
+        id: 'custom-theme',
+        name: 'Custom Theme',
+        isCustom: true,
+      );
+
+      final theme = TerminalThemes.getById(
+        'custom-theme',
+        additionalThemes: [customTheme],
+      );
+
+      expect(theme, customTheme);
+    });
+
     test('getById returns null when not exists', () {
       final theme = TerminalThemes.getById('nonexistent-theme');
       expect(theme, isNull);
@@ -363,6 +378,31 @@ void main() {
       expect(TerminalThemes.getById('clean-white'), isNotNull);
       expect(TerminalThemes.getById('vivid'), isNotNull);
       expect(TerminalThemes.getById('ocean-dark'), isNotNull);
+    });
+
+    test('defaultThemeForBrightness returns built-in defaults', () {
+      expect(
+        TerminalThemes.defaultThemeForBrightness(Brightness.dark),
+        TerminalThemes.midnightPurple,
+      );
+      expect(
+        TerminalThemes.defaultThemeForBrightness(Brightness.light),
+        TerminalThemes.cleanWhite,
+      );
+    });
+
+    test('resolveById falls back by brightness when the id is unavailable', () {
+      expect(
+        TerminalThemes.resolveById(
+          brightness: Brightness.dark,
+          themeId: 'missing-theme',
+        ),
+        TerminalThemes.midnightPurple,
+      );
+      expect(
+        TerminalThemes.resolveById(brightness: Brightness.light, themeId: null),
+        TerminalThemes.cleanWhite,
+      );
     });
 
     test('dark built-in themes keep default text readable', () {

--- a/test/domain/services/settings_service_test.dart
+++ b/test/domain/services/settings_service_test.dart
@@ -249,6 +249,13 @@ void main() {
     });
 
     group('terminalThemesApplyToAppNotifierProvider', () {
+      test('starts enabled by default', () {
+        expect(
+          container.read(terminalThemesApplyToAppNotifierProvider),
+          isTrue,
+        );
+      });
+
       test('persists disabled state', () async {
         final notifier = container.read(
           terminalThemesApplyToAppNotifierProvider.notifier,
@@ -432,6 +439,51 @@ void main() {
         expect(
           await settings.getString(SettingKeys.defaultTerminalThemeLight),
           customTheme.id,
+        );
+      });
+
+      test('keeps custom theme ids that match legacy defaults', () async {
+        final settings = container.read(settingsServiceProvider);
+        final customLightTheme = TerminalThemes.cleanWhite.copyWith(
+          id: 'github-light',
+          name: 'Custom GitHub Light',
+          isCustom: true,
+        );
+        final customDarkTheme = TerminalThemes.midnightPurple.copyWith(
+          id: 'dracula',
+          name: 'Custom Dracula',
+          isCustom: true,
+        );
+        await settings.setString(
+          SettingKeys.customTerminalThemes,
+          jsonEncode([customLightTheme.toJson(), customDarkTheme.toJson()]),
+        );
+        await settings.setString(
+          SettingKeys.defaultTerminalThemeLight,
+          customLightTheme.id,
+        );
+        await settings.setString(
+          SettingKeys.defaultTerminalThemeDark,
+          customDarkTheme.id,
+        );
+
+        container.read(terminalThemeSettingsProvider);
+        final state = await _waitForTerminalThemeSettings(
+          container,
+          (settings) =>
+              settings.lightThemeId == customLightTheme.id &&
+              settings.darkThemeId == customDarkTheme.id,
+        );
+
+        expect(state.lightThemeId, customLightTheme.id);
+        expect(state.darkThemeId, customDarkTheme.id);
+        expect(
+          await settings.getString(SettingKeys.defaultTerminalThemeLight),
+          customLightTheme.id,
+        );
+        expect(
+          await settings.getString(SettingKeys.defaultTerminalThemeDark),
+          customDarkTheme.id,
         );
       });
 

--- a/test/domain/services/settings_service_test.dart
+++ b/test/domain/services/settings_service_test.dart
@@ -1,10 +1,13 @@
 // ignore_for_file: public_member_api_docs
 
+import 'dart:convert';
+
 import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/domain/models/terminal_themes.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
 
 void main() {
@@ -287,9 +290,126 @@ void main() {
       });
     });
 
-    // Note: NotifierProvider tests (themeModeNotifierProvider, fontSizeNotifierProvider,
-    // terminalThemeSettingsProvider, etc.) are skipped because they have async _init()
-    // methods that can race with test teardown and cause "database closed" errors.
+    group('terminalThemeSettingsProvider', () {
+      test('normalizes legacy default theme ids', () async {
+        final settings = container.read(settingsServiceProvider);
+        await settings.setString(
+          SettingKeys.defaultTerminalThemeLight,
+          'github-light',
+        );
+        await settings.setString(
+          SettingKeys.defaultTerminalThemeDark,
+          'dracula',
+        );
+
+        container.read(terminalThemeSettingsProvider);
+        await _waitForStoredTerminalThemeIds(
+          settings,
+          lightThemeId: TerminalThemes.defaultLightThemeId,
+          darkThemeId: TerminalThemes.defaultDarkThemeId,
+        );
+        final state = container.read(terminalThemeSettingsProvider);
+
+        expect(state.lightThemeId, TerminalThemes.defaultLightThemeId);
+        expect(state.darkThemeId, TerminalThemes.defaultDarkThemeId);
+        expect(
+          await settings.getString(SettingKeys.defaultTerminalThemeLight),
+          TerminalThemes.defaultLightThemeId,
+        );
+        expect(
+          await settings.getString(SettingKeys.defaultTerminalThemeDark),
+          TerminalThemes.defaultDarkThemeId,
+        );
+      });
+
+      test('normalizes unknown saved theme ids', () async {
+        final settings = container.read(settingsServiceProvider);
+        await settings.setString(
+          SettingKeys.defaultTerminalThemeLight,
+          'missing-light-theme',
+        );
+        await settings.setString(
+          SettingKeys.defaultTerminalThemeDark,
+          'missing-dark-theme',
+        );
+
+        container.read(terminalThemeSettingsProvider);
+        await _waitForStoredTerminalThemeIds(
+          settings,
+          lightThemeId: TerminalThemes.defaultLightThemeId,
+          darkThemeId: TerminalThemes.defaultDarkThemeId,
+        );
+        final state = container.read(terminalThemeSettingsProvider);
+
+        expect(state.lightThemeId, TerminalThemes.defaultLightThemeId);
+        expect(state.darkThemeId, TerminalThemes.defaultDarkThemeId);
+      });
+
+      test('keeps saved custom theme ids', () async {
+        final settings = container.read(settingsServiceProvider);
+        final customTheme = TerminalThemes.cleanWhite.copyWith(
+          id: 'custom-light-theme',
+          name: 'Custom Light Theme',
+          isCustom: true,
+        );
+        await settings.setString(
+          SettingKeys.customTerminalThemes,
+          jsonEncode([customTheme.toJson()]),
+        );
+        await settings.setString(
+          SettingKeys.defaultTerminalThemeLight,
+          customTheme.id,
+        );
+
+        container.read(terminalThemeSettingsProvider);
+        final state = await _waitForTerminalThemeSettings(
+          container,
+          (settings) => settings.lightThemeId == customTheme.id,
+        );
+
+        expect(state.lightThemeId, customTheme.id);
+        expect(
+          await settings.getString(SettingKeys.defaultTerminalThemeLight),
+          customTheme.id,
+        );
+      });
+    });
+
+    // Note: most NotifierProvider tests (themeModeNotifierProvider,
+    // fontSizeNotifierProvider, etc.) are skipped because they have async _init()
+    // methods that can race with test teardown and cause "database closed"
+    // errors.
     // The FutureProvider tests above provide coverage for the provider initialization.
   });
+}
+
+Future<TerminalThemeSettings> _waitForTerminalThemeSettings(
+  ProviderContainer container,
+  bool Function(TerminalThemeSettings settings) matches,
+) async {
+  for (var attempt = 0; attempt < 20; attempt += 1) {
+    final settings = container.read(terminalThemeSettingsProvider);
+    if (matches(settings)) {
+      return settings;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  return container.read(terminalThemeSettingsProvider);
+}
+
+Future<void> _waitForStoredTerminalThemeIds(
+  SettingsService settings, {
+  required String lightThemeId,
+  required String darkThemeId,
+}) async {
+  for (var attempt = 0; attempt < 20; attempt += 1) {
+    final light = await settings.getString(
+      SettingKeys.defaultTerminalThemeLight,
+    );
+    final dark = await settings.getString(SettingKeys.defaultTerminalThemeDark);
+    if (light == lightThemeId && dark == darkThemeId) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
 }

--- a/test/domain/services/settings_service_test.dart
+++ b/test/domain/services/settings_service_test.dart
@@ -266,6 +266,10 @@ void main() {
               .getBool(SettingKeys.terminalThemesApplyToApp),
           isFalse,
         );
+        expect(
+          await container.read(terminalThemesApplyToAppProvider.future),
+          isFalse,
+        );
       });
     });
 
@@ -392,6 +396,14 @@ void main() {
 
         expect(state.lightThemeId, TerminalThemes.defaultLightThemeId);
         expect(state.darkThemeId, TerminalThemes.defaultDarkThemeId);
+        expect(
+          await settings.getString(SettingKeys.defaultTerminalThemeLight),
+          TerminalThemes.defaultLightThemeId,
+        );
+        expect(
+          await settings.getString(SettingKeys.defaultTerminalThemeDark),
+          TerminalThemes.defaultDarkThemeId,
+        );
       });
 
       test('keeps saved custom theme ids', () async {

--- a/test/domain/services/settings_service_test.dart
+++ b/test/domain/services/settings_service_test.dart
@@ -174,6 +174,10 @@ void main() {
   group('SettingKeys', () {
     test('has expected constants', () {
       expect(SettingKeys.themeMode, 'theme_mode');
+      expect(
+        SettingKeys.terminalThemesApplyToApp,
+        'terminal_themes_apply_to_app',
+      );
       expect(SettingKeys.terminalFont, 'terminal_font');
       expect(SettingKeys.terminalFontSize, 'terminal_font_size');
       expect(SettingKeys.terminalColorScheme, 'terminal_color_scheme');
@@ -217,6 +221,51 @@ void main() {
         container.invalidate(themeModeProvider);
         final result = await container.read(themeModeProvider.future);
         expect(result, 'dark');
+      });
+    });
+
+    group('terminalThemesApplyToAppProvider', () {
+      test('returns true by default', () async {
+        final result = await container.read(
+          terminalThemesApplyToAppProvider.future,
+        );
+        expect(result, isTrue);
+      });
+
+      test('returns stored false when disabled', () async {
+        final settings = container.read(settingsServiceProvider);
+        await settings.setBool(
+          SettingKeys.terminalThemesApplyToApp,
+          value: false,
+        );
+        container.invalidate(terminalThemesApplyToAppProvider);
+
+        final result = await container.read(
+          terminalThemesApplyToAppProvider.future,
+        );
+
+        expect(result, isFalse);
+      });
+    });
+
+    group('terminalThemesApplyToAppNotifierProvider', () {
+      test('persists disabled state', () async {
+        final notifier = container.read(
+          terminalThemesApplyToAppNotifierProvider.notifier,
+        );
+
+        await notifier.setEnabled(enabled: false);
+
+        expect(
+          container.read(terminalThemesApplyToAppNotifierProvider),
+          isFalse,
+        );
+        expect(
+          await container
+              .read(settingsServiceProvider)
+              .getBool(SettingKeys.terminalThemesApplyToApp),
+          isFalse,
+        );
       });
     });
 

--- a/test/domain/services/settings_service_test.dart
+++ b/test/domain/services/settings_service_test.dart
@@ -422,6 +422,68 @@ void main() {
           customTheme.id,
         );
       });
+
+      test(
+        'normalizes unknown ids when custom theme JSON is not a list',
+        () async {
+          final settings = container.read(settingsServiceProvider);
+          await settings.setString(
+            SettingKeys.customTerminalThemes,
+            jsonEncode({'themes': <String>[]}),
+          );
+          await settings.setString(
+            SettingKeys.defaultTerminalThemeLight,
+            'missing-light-theme',
+          );
+          await settings.setString(
+            SettingKeys.defaultTerminalThemeDark,
+            'missing-dark-theme',
+          );
+
+          container.read(terminalThemeSettingsProvider);
+          await _waitForStoredTerminalThemeIds(
+            settings,
+            lightThemeId: TerminalThemes.defaultLightThemeId,
+            darkThemeId: TerminalThemes.defaultDarkThemeId,
+          );
+          final state = container.read(terminalThemeSettingsProvider);
+
+          expect(state.lightThemeId, TerminalThemes.defaultLightThemeId);
+          expect(state.darkThemeId, TerminalThemes.defaultDarkThemeId);
+        },
+      );
+
+      test(
+        'keeps valid custom themes while skipping malformed entries',
+        () async {
+          final settings = container.read(settingsServiceProvider);
+          final customTheme = TerminalThemes.cleanWhite.copyWith(
+            id: 'custom-theme-with-malformed-neighbors',
+            name: 'Custom Theme With Malformed Neighbors',
+            isCustom: true,
+          );
+          await settings.setString(
+            SettingKeys.customTerminalThemes,
+            jsonEncode([
+              42,
+              {'id': 'incomplete-theme'},
+              customTheme.toJson(),
+            ]),
+          );
+          await settings.setString(
+            SettingKeys.defaultTerminalThemeLight,
+            customTheme.id,
+          );
+
+          container.read(terminalThemeSettingsProvider);
+          final state = await _waitForTerminalThemeSettings(
+            container,
+            (settings) => settings.lightThemeId == customTheme.id,
+          );
+
+          expect(state.lightThemeId, customTheme.id);
+        },
+      );
     });
 
     // Note: most NotifierProvider tests (themeModeNotifierProvider,
@@ -451,14 +513,25 @@ Future<void> _waitForStoredTerminalThemeIds(
   required String lightThemeId,
   required String darkThemeId,
 }) async {
+  String? lastLight;
+  String? lastDark;
+
   for (var attempt = 0; attempt < 20; attempt += 1) {
     final light = await settings.getString(
       SettingKeys.defaultTerminalThemeLight,
     );
     final dark = await settings.getString(SettingKeys.defaultTerminalThemeDark);
+    lastLight = light;
+    lastDark = dark;
     if (light == lightThemeId && dark == darkThemeId) {
       return;
     }
     await Future<void>.delayed(const Duration(milliseconds: 10));
   }
+
+  throw TestFailure(
+    'Timed out waiting for stored terminal theme IDs. '
+    'Expected light="$lightThemeId", dark="$darkThemeId", '
+    'but last observed light="$lastLight", dark="$lastDark".',
+  );
 }

--- a/test/domain/services/terminal_theme_service_test.dart
+++ b/test/domain/services/terminal_theme_service_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: public_member_api_docs
 
+import 'dart:convert';
+
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -109,6 +111,41 @@ void main() {
       test('returns empty list initially', () async {
         final themes = await themeService.getCustomThemes();
         expect(themes, isEmpty);
+      });
+
+      test(
+        'returns empty list when stored custom themes are not a list',
+        () async {
+          await settingsService.setString(
+            SettingKeys.customTerminalThemes,
+            jsonEncode({'themes': <String>[]}),
+          );
+
+          final themes = await themeService.getCustomThemes();
+
+          expect(themes, isEmpty);
+        },
+      );
+
+      test('skips malformed custom theme entries', () async {
+        final theme = TerminalThemes.midnightPurple.copyWith(
+          id: 'custom-with-malformed-neighbors',
+          name: 'Custom With Malformed Neighbors',
+          isCustom: true,
+        );
+        await settingsService.setString(
+          SettingKeys.customTerminalThemes,
+          jsonEncode([
+            42,
+            {'id': 'incomplete-theme'},
+            theme.toJson(),
+          ]),
+        );
+
+        final themes = await themeService.getCustomThemes();
+
+        expect(themes, hasLength(1));
+        expect(themes.single.id, theme.id);
       });
     });
 

--- a/test/support/settings_import_test_helpers.dart
+++ b/test/support/settings_import_test_helpers.dart
@@ -164,6 +164,12 @@ class StaticThemeModeNotifier extends ThemeModeNotifier {
   ThemeMode build() => ThemeMode.system;
 }
 
+class StaticTerminalThemesApplyToAppNotifier
+    extends TerminalThemesApplyToAppNotifier {
+  @override
+  bool build() => true;
+}
+
 class StaticFontSizeNotifier extends FontSizeNotifier {
   @override
   double build() => 14;

--- a/test/support/settings_import_test_helpers.dart
+++ b/test/support/settings_import_test_helpers.dart
@@ -11,6 +11,7 @@ import 'package:local_auth/local_auth.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/key_repository.dart';
+import 'package:monkeyssh/domain/models/terminal_themes.dart';
 import 'package:monkeyssh/domain/services/auth_service.dart';
 import 'package:monkeyssh/domain/services/secure_transfer_service.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
@@ -187,7 +188,7 @@ class StaticTerminalThemeSettingsNotifier
     extends TerminalThemeSettingsNotifier {
   @override
   TerminalThemeSettings build() => const TerminalThemeSettings(
-    lightThemeId: 'github-light',
-    darkThemeId: 'dracula',
+    lightThemeId: TerminalThemes.defaultLightThemeId,
+    darkThemeId: TerminalThemes.defaultDarkThemeId,
   );
 }

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -244,6 +244,7 @@ void main() {
 
       expect(find.text('Theme'), findsOneWidget);
       expect(find.text('System default'), findsOneWidget);
+      expect(find.text('Use terminal themes for app'), findsOneWidget);
     });
 
     testWidgets('displays font size option', (tester) async {
@@ -873,6 +874,9 @@ void main() {
             authServiceProvider.overrideWithValue(FakeAuthService()),
             authStateProvider.overrideWith(MockAuthStateNotifier.new),
             themeModeNotifierProvider.overrideWith(StaticThemeModeNotifier.new),
+            terminalThemesApplyToAppNotifierProvider.overrideWith(
+              StaticTerminalThemesApplyToAppNotifier.new,
+            ),
             fontSizeNotifierProvider.overrideWith(StaticFontSizeNotifier.new),
             fontFamilyNotifierProvider.overrideWith(
               StaticFontFamilyNotifier.new,


### PR DESCRIPTION
## Summary

- Apply selected light/dark terminal themes to the whole app chrome via `FluttyTheme.fromTerminalTheme`
- Centralize terminal theme resolution/default fallbacks and use current built-in defaults
- Refresh app-wide palettes when synced/imported custom themes change
- Add tests for app theme derivation and terminal theme resolution

## Validation

- `flutter analyze`
- `flutter test test/app/theme_test.dart test/domain/models/terminal_theme_test.dart test/domain/services/terminal_theme_service_test.dart test/widget/settings_screen_test.dart`
- `flutter test`

## Review

- Opus code-review: no substantive findings
- Gemini CLI review: no substantive findings
