### PR TITLE
fix: keep terminal selection actions working

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3020,14 +3020,17 @@ List<ContextMenuButtonItem> buildNativeSelectionContextMenuButtonItems({
   return buttonItems;
 }
 
-/// Builds a selection menu action that reads terminal selection before hiding.
+/// Builds a menu callback that lets the action read selection before hiding.
 @visibleForTesting
 VoidCallback buildTerminalSelectionContextMenuAction({
   required VoidCallback action,
   required VoidCallback hideToolbar,
 }) => () {
-  action();
-  hideToolbar();
+  try {
+    action();
+  } finally {
+    hideToolbar();
+  }
 };
 
 /// Whether terminal tap links should be resolved for the current overlay state.

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3020,6 +3020,16 @@ List<ContextMenuButtonItem> buildNativeSelectionContextMenuButtonItems({
   return buttonItems;
 }
 
+/// Builds a selection menu action that reads terminal selection before hiding.
+@visibleForTesting
+VoidCallback buildTerminalSelectionContextMenuAction({
+  required VoidCallback action,
+  required VoidCallback hideToolbar,
+}) => () {
+  action();
+  hideToolbar();
+};
+
 /// Whether terminal tap links should be resolved for the current overlay state.
 @visibleForTesting
 bool shouldResolveTerminalTapLinks({
@@ -6603,37 +6613,37 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           hasCopy = true;
           buttonItems.add(
             item.copyWith(
-              onPressed: () {
-                selectableRegionState.hideToolbar();
-                unawaited(_copySelection());
-              },
+              onPressed: buildTerminalSelectionContextMenuAction(
+                action: () => unawaited(_copySelection()),
+                hideToolbar: selectableRegionState.hideToolbar,
+              ),
             ),
           );
         case ContextMenuButtonType.lookUp:
           buttonItems.add(
             item.copyWith(
-              onPressed: () {
-                selectableRegionState.hideToolbar();
-                unawaited(_lookUpTerminalSelection());
-              },
+              onPressed: buildTerminalSelectionContextMenuAction(
+                action: () => unawaited(_lookUpTerminalSelection()),
+                hideToolbar: selectableRegionState.hideToolbar,
+              ),
             ),
           );
         case ContextMenuButtonType.searchWeb:
           buttonItems.add(
             item.copyWith(
-              onPressed: () {
-                selectableRegionState.hideToolbar();
-                unawaited(_searchWebForTerminalSelection());
-              },
+              onPressed: buildTerminalSelectionContextMenuAction(
+                action: () => unawaited(_searchWebForTerminalSelection()),
+                hideToolbar: selectableRegionState.hideToolbar,
+              ),
             ),
           );
         case ContextMenuButtonType.share:
           buttonItems.add(
             item.copyWith(
-              onPressed: () {
-                selectableRegionState.hideToolbar();
-                unawaited(_shareTerminalSelection());
-              },
+              onPressed: buildTerminalSelectionContextMenuAction(
+                action: () => unawaited(_shareTerminalSelection()),
+                hideToolbar: selectableRegionState.hideToolbar,
+              ),
             ),
           );
         case ContextMenuButtonType.selectAll:
@@ -6653,10 +6663,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       buttonItems.insert(
         0,
         ContextMenuButtonItem(
-          onPressed: () {
-            selectableRegionState.hideToolbar();
-            unawaited(_copySelection());
-          },
+          onPressed: buildTerminalSelectionContextMenuAction(
+            action: () => unawaited(_copySelection()),
+            hideToolbar: selectableRegionState.hideToolbar,
+          ),
           type: ContextMenuButtonType.copy,
         ),
       );

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -452,6 +452,7 @@ const _maxVerifiedTerminalPathCacheEntries = 128;
 const _terminalPathTouchHorizontalPadding = 10.0;
 const _terminalPathTouchVerticalPadding = 8.0;
 const _terminalSelectionNearbySearchColumns = 4;
+const _recentLocalClipboardProtection = Duration(seconds: 5);
 const _maxTerminalFilePathVerificationCandidates = 12;
 const _terminalFilePathVerificationExtensions = <String>[
   'properties',
@@ -3033,6 +3034,36 @@ VoidCallback buildTerminalSelectionContextMenuAction({
   }
 };
 
+/// Whether a polled remote clipboard value should replace the local clipboard.
+@visibleForTesting
+bool shouldApplyRemoteClipboardTextToLocal({
+  required String? remoteText,
+  required String? lastObservedRemoteText,
+  required String? lastObservedLocalText,
+  required String? lastAppliedRemoteText,
+  required String? recentLocalClipboardText,
+  required DateTime? recentLocalClipboardAt,
+  required DateTime now,
+  Duration recentLocalClipboardProtection = _recentLocalClipboardProtection,
+}) {
+  if (remoteText == null || remoteText.isEmpty) {
+    return false;
+  }
+  if (remoteText == lastObservedRemoteText ||
+      remoteText == lastObservedLocalText ||
+      remoteText == lastAppliedRemoteText) {
+    return false;
+  }
+  if (recentLocalClipboardText != null && recentLocalClipboardAt != null) {
+    final isProtectedRecentLocalWrite =
+        now.difference(recentLocalClipboardAt) < recentLocalClipboardProtection;
+    if (remoteText == recentLocalClipboardText || isProtectedRecentLocalWrite) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /// Whether terminal tap links should be resolved for the current overlay state.
 @visibleForTesting
 bool shouldResolveTerminalTapLinks({
@@ -3274,6 +3305,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   String? _lastObservedRemoteClipboardText;
   String? _lastAppliedLocalClipboardText;
   String? _lastAppliedRemoteClipboardText;
+  String? _recentLocalClipboardText;
+  DateTime? _recentLocalClipboardAt;
   bool _isTerminalSizeRefreshQueued = false;
 
   // Theme state
@@ -3700,20 +3733,29 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _isPollingRemoteClipboard = true;
     try {
       final remoteText = await _readRemoteClipboardText(session);
-      if (remoteText == null ||
-          remoteText == _lastObservedRemoteClipboardText ||
-          remoteText == _lastObservedLocalClipboardText ||
-          remoteText == _lastAppliedRemoteClipboardText) {
+      if (!shouldApplyRemoteClipboardTextToLocal(
+        remoteText: remoteText,
+        lastObservedRemoteText: _lastObservedRemoteClipboardText,
+        lastObservedLocalText: _lastObservedLocalClipboardText,
+        lastAppliedRemoteText: _lastAppliedRemoteClipboardText,
+        recentLocalClipboardText: _recentLocalClipboardText,
+        recentLocalClipboardAt: _recentLocalClipboardAt,
+        now: DateTime.now(),
+      )) {
         if (remoteText != null) {
           _lastObservedRemoteClipboardText = remoteText;
         }
         return;
       }
 
-      await Clipboard.setData(ClipboardData(text: remoteText));
-      _lastObservedRemoteClipboardText = remoteText;
-      _lastObservedLocalClipboardText = remoteText;
-      _lastAppliedLocalClipboardText = remoteText;
+      final remoteClipboardText = remoteText;
+      if (remoteClipboardText == null) {
+        return;
+      }
+      await Clipboard.setData(ClipboardData(text: remoteClipboardText));
+      _lastObservedRemoteClipboardText = remoteClipboardText;
+      _lastObservedLocalClipboardText = remoteClipboardText;
+      _lastAppliedLocalClipboardText = remoteClipboardText;
     } on PlatformException {
       return;
     } finally {
@@ -6608,6 +6650,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     BuildContext _,
     SelectableRegionState selectableRegionState,
   ) {
+    final selectionText = _currentTerminalSelectionText();
     var hasCopy = false;
     final buttonItems = <ContextMenuButtonItem>[];
     for (final item in selectableRegionState.contextMenuButtonItems) {
@@ -6617,7 +6660,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           buttonItems.add(
             item.copyWith(
               onPressed: buildTerminalSelectionContextMenuAction(
-                action: () => unawaited(_copySelection()),
+                action: () {
+                  final text = selectionText;
+                  if (text == null) {
+                    return;
+                  }
+                  unawaited(
+                    _copySelectionText(
+                      text,
+                      clearTerminalSelection: true,
+                      restoreFocus: true,
+                    ),
+                  );
+                },
                 hideToolbar: selectableRegionState.hideToolbar,
               ),
             ),
@@ -6626,7 +6681,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           buttonItems.add(
             item.copyWith(
               onPressed: buildTerminalSelectionContextMenuAction(
-                action: () => unawaited(_lookUpTerminalSelection()),
+                action: () {
+                  final text = selectionText;
+                  if (text == null) {
+                    return;
+                  }
+                  unawaited(_lookUpTerminalSelectionText(text));
+                },
                 hideToolbar: selectableRegionState.hideToolbar,
               ),
             ),
@@ -6635,7 +6696,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           buttonItems.add(
             item.copyWith(
               onPressed: buildTerminalSelectionContextMenuAction(
-                action: () => unawaited(_searchWebForTerminalSelection()),
+                action: () {
+                  final text = selectionText;
+                  if (text == null) {
+                    return;
+                  }
+                  unawaited(_searchWebForTerminalSelectionText(text));
+                },
                 hideToolbar: selectableRegionState.hideToolbar,
               ),
             ),
@@ -6644,7 +6711,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           buttonItems.add(
             item.copyWith(
               onPressed: buildTerminalSelectionContextMenuAction(
-                action: () => unawaited(_shareTerminalSelection()),
+                action: () {
+                  final text = selectionText;
+                  if (text == null) {
+                    return;
+                  }
+                  unawaited(_shareTerminalSelectionText(text));
+                },
                 hideToolbar: selectableRegionState.hideToolbar,
               ),
             ),
@@ -6667,7 +6740,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         0,
         ContextMenuButtonItem(
           onPressed: buildTerminalSelectionContextMenuAction(
-            action: () => unawaited(_copySelection()),
+            action: () {
+              final text = selectionText;
+              if (text == null) {
+                return;
+              }
+              unawaited(
+                _copySelectionText(
+                  text,
+                  clearTerminalSelection: true,
+                  restoreFocus: true,
+                ),
+              );
+            },
             hideToolbar: selectableRegionState.hideToolbar,
           ),
           type: ContextMenuButtonType.copy,
@@ -8279,35 +8364,37 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   Future<void> _copySelection() async {
-    if (_isNativeSelectionMode) {
-      final text = selectedNativeOverlayText(_nativeSelectionController.value);
-      if (text.isEmpty) {
-        return;
-      }
-
-      await Clipboard.setData(ClipboardData(text: text));
-      if (!mounted) {
-        return;
-      }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Copied')));
+    final text = _currentTerminalSelectionText();
+    if (text == null) {
       return;
     }
 
-    final selection = _terminalController.selection;
-    if (selection == null) {
-      return;
-    }
-    final text = trimTerminalSelectionText(_terminal.buffer.getText(selection));
+    await _copySelectionText(
+      text,
+      clearTerminalSelection: !_isNativeSelectionMode,
+      restoreFocus: !_isNativeSelectionMode,
+    );
+  }
+
+  Future<void> _copySelectionText(
+    String text, {
+    required bool clearTerminalSelection,
+    required bool restoreFocus,
+  }) async {
     if (text.isEmpty) {
-      _restoreTerminalFocus();
+      if (restoreFocus) {
+        _restoreTerminalFocus();
+      }
       return;
     }
 
-    await Clipboard.setData(ClipboardData(text: text));
-    _terminalController.clearSelection();
-    _restoreTerminalFocus();
+    await _writeLocalClipboardText(text);
+    if (clearTerminalSelection) {
+      _terminalController.clearSelection();
+    }
+    if (restoreFocus) {
+      _restoreTerminalFocus();
+    }
 
     if (!mounted) {
       return;
@@ -8330,11 +8417,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     return text.isEmpty ? null : text;
   }
 
-  Future<void> _lookUpTerminalSelection() async {
-    final text = _currentTerminalSelectionText();
-    if (text == null) {
-      return;
-    }
+  Future<void> _lookUpTerminalSelectionText(String text) async {
     try {
       await SystemChannels.platform.invokeMethod<void>('LookUp.invoke', text);
     } on PlatformException {
@@ -8342,11 +8425,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
-  Future<void> _searchWebForTerminalSelection() async {
-    final text = _currentTerminalSelectionText();
-    if (text == null) {
-      return;
-    }
+  Future<void> _searchWebForTerminalSelectionText(String text) async {
     try {
       await SystemChannels.platform.invokeMethod<void>(
         'SearchWeb.invoke',
@@ -8357,16 +8436,18 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
-  Future<void> _shareTerminalSelection() async {
-    final text = _currentTerminalSelectionText();
-    if (text == null) {
-      return;
-    }
+  Future<void> _shareTerminalSelectionText(String text) async {
     try {
       await SystemChannels.platform.invokeMethod<void>('Share.invoke', text);
     } on PlatformException {
       // Platform doesn't support Share; ignore.
     }
+  }
+
+  Future<void> _writeLocalClipboardText(String text) async {
+    _recentLocalClipboardText = text;
+    _recentLocalClipboardAt = DateTime.now();
+    await Clipboard.setData(ClipboardData(text: text));
   }
 
   void _showClipboardMessage(String message) {
@@ -8385,7 +8466,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
-    await Clipboard.setData(ClipboardData(text: path));
+    await _writeLocalClipboardText(path);
     _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
 
     if (!mounted) {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -191,6 +191,18 @@ void main() {
       expect(copiedText, 'alpha');
       expect(selectedText, isNull);
     });
+
+    test('hides terminal selection toolbar when action throws', () {
+      var didHideToolbar = false;
+
+      final onPressed = buildTerminalSelectionContextMenuAction(
+        action: () => throw StateError('copy failed'),
+        hideToolbar: () => didHideToolbar = true,
+      );
+
+      expect(onPressed, throwsStateError);
+      expect(didHideToolbar, isTrue);
+    });
   });
 
   group('MonkeyTerminalView system selection geometry', () {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -176,6 +176,21 @@ void main() {
 
       expect(didPaste, isTrue);
     });
+
+    test('runs terminal selection menu action before hiding toolbar', () {
+      String? selectedText = 'alpha';
+      String? copiedText;
+
+      final onPressed = buildTerminalSelectionContextMenuAction(
+        action: () => copiedText = selectedText,
+        hideToolbar: () => selectedText = null,
+      );
+
+      onPressed();
+
+      expect(copiedText, 'alpha');
+      expect(selectedText, isNull);
+    });
   });
 
   group('MonkeyTerminalView system selection geometry', () {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -203,6 +203,58 @@ void main() {
       expect(onPressed, throwsStateError);
       expect(didHideToolbar, isTrue);
     });
+
+    test('does not apply empty remote clipboard text locally', () {
+      expect(
+        shouldApplyRemoteClipboardTextToLocal(
+          remoteText: '',
+          lastObservedRemoteText: null,
+          lastObservedLocalText: 'alpha',
+          lastAppliedRemoteText: null,
+          recentLocalClipboardText: null,
+          recentLocalClipboardAt: null,
+          now: DateTime(2026),
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not overwrite a recent local clipboard write', () {
+      final now = DateTime(2026);
+
+      expect(
+        shouldApplyRemoteClipboardTextToLocal(
+          remoteText: 'stale remote',
+          lastObservedRemoteText: 'older remote',
+          lastObservedLocalText: 'older local',
+          lastAppliedRemoteText: null,
+          recentLocalClipboardText: 'fresh local',
+          recentLocalClipboardAt: now.subtract(const Duration(seconds: 1)),
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+      'applies changed non-empty remote clipboard after local protection',
+      () {
+        final now = DateTime(2026);
+
+        expect(
+          shouldApplyRemoteClipboardTextToLocal(
+            remoteText: 'fresh remote',
+            lastObservedRemoteText: 'older remote',
+            lastObservedLocalText: 'older local',
+            lastAppliedRemoteText: null,
+            recentLocalClipboardText: 'local',
+            recentLocalClipboardAt: now.subtract(const Duration(seconds: 10)),
+            now: now,
+          ),
+          isTrue,
+        );
+      },
+    );
   });
 
   group('MonkeyTerminalView system selection geometry', () {


### PR DESCRIPTION
## Summary

- Run terminal selection toolbar actions before hiding the toolbar so selection text remains available
- Add a regression test for the terminal selection action ordering

## Validation

- `flutter analyze`
- `flutter test test/presentation/screens/terminal_screen_test.dart`
- `flutter test`
