### PR TITLE
feat: add terminal wake lock setting

### DIFF
--- a/lib/domain/services/settings_service.dart
+++ b/lib/domain/services/settings_service.dart
@@ -34,6 +34,9 @@ abstract final class SettingKeys {
   /// Terminal bell sound enabled.
   static const bellSound = 'bell_sound';
 
+  /// Keep the device awake while a terminal is active.
+  static const terminalWakeLock = 'terminal_wake_lock';
+
   /// Enable tapping terminal file paths to open SFTP.
   static const terminalPathLinks = 'terminal_path_links';
 
@@ -473,6 +476,39 @@ class BellSoundNotifier extends Notifier<bool> {
 final bellSoundNotifierProvider = NotifierProvider<BellSoundNotifier, bool>(
   BellSoundNotifier.new,
 );
+
+/// Notifier for terminal wake lock with write capability.
+class TerminalWakeLockNotifier extends Notifier<bool> {
+  late SettingsService _settings;
+  bool _disposed = false;
+
+  @override
+  bool build() {
+    _settings = ref.watch(settingsServiceProvider);
+    _disposed = false;
+    ref.onDispose(() => _disposed = true);
+    Future.microtask(_init);
+    return false;
+  }
+
+  Future<void> _init() async {
+    final value = await _settings.getBool(SettingKeys.terminalWakeLock);
+    if (_disposed) return;
+    state = value;
+  }
+
+  /// Set terminal wake lock enabled.
+  Future<void> setEnabled({required bool enabled}) async {
+    await _settings.setBool(SettingKeys.terminalWakeLock, value: enabled);
+    state = enabled;
+  }
+}
+
+/// Provider for terminal wake lock with write capability.
+final terminalWakeLockNotifierProvider =
+    NotifierProvider<TerminalWakeLockNotifier, bool>(
+      TerminalWakeLockNotifier.new,
+    );
 
 /// Notifier for terminal file path links with write capability.
 class TerminalPathLinksNotifier extends Notifier<bool> {

--- a/lib/domain/services/terminal_wake_lock_service.dart
+++ b/lib/domain/services/terminal_wake_lock_service.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
+
+import 'diagnostics_log_service.dart';
+
+/// Coordinates process-wide terminal wake-lock ownership.
+class TerminalWakeLockService {
+  final Set<int> _activeOwnerIds = <int>{};
+  int _nextOwnerId = 0;
+  bool _targetEnabled = false;
+  bool _isEnabled = false;
+  Future<void> _writeChain = Future<void>.value();
+
+  /// Creates a unique owner ID for a terminal screen instance.
+  int createOwner() => _nextOwnerId++;
+
+  /// Marks whether [ownerId] currently needs the terminal wake lock.
+  Future<void> setOwnerActive(int ownerId, {required bool active}) {
+    final didChange = active
+        ? _activeOwnerIds.add(ownerId)
+        : _activeOwnerIds.remove(ownerId);
+    if (!didChange) {
+      return _writeChain;
+    }
+    return _sync();
+  }
+
+  /// Releases all wake-lock ownership for [ownerId].
+  Future<void> releaseOwner(int ownerId) =>
+      setOwnerActive(ownerId, active: false);
+
+  /// Releases all owners and disables the wake lock.
+  Future<void> dispose() {
+    if (_activeOwnerIds.isEmpty) {
+      return _writeChain;
+    }
+    _activeOwnerIds.clear();
+    return _sync();
+  }
+
+  Future<void> _sync() => _setEnabled(enabled: _activeOwnerIds.isNotEmpty);
+
+  Future<void> _setEnabled({required bool enabled}) async {
+    if (_targetEnabled == enabled && _isEnabled == enabled) {
+      return;
+    }
+    _targetEnabled = enabled;
+    final nextWrite = _writeChain
+        .catchError((Object error, StackTrace stackTrace) {
+          _reportWakeLockError(error, stackTrace, enabled: _targetEnabled);
+        })
+        .then((_) async {
+          final target = _targetEnabled;
+          if (_isEnabled == target) {
+            return;
+          }
+
+          try {
+            await WakelockPlus.toggle(enable: target);
+            _isEnabled = target;
+          } on MissingPluginException catch (error, stackTrace) {
+            _reportWakeLockError(error, stackTrace, enabled: target);
+          } on PlatformException catch (error, stackTrace) {
+            _reportWakeLockError(error, stackTrace, enabled: target);
+          } on Object catch (error, stackTrace) {
+            _reportWakeLockError(error, stackTrace, enabled: target);
+          }
+        });
+    _writeChain = nextWrite;
+    await nextWrite;
+  }
+
+  void _reportWakeLockError(
+    Object error,
+    StackTrace stackTrace, {
+    required bool enabled,
+  }) {
+    DiagnosticsLogService.instance.error(
+      'terminal',
+      'wake_lock_failed',
+      fields: {'enabled': enabled, 'errorType': error.runtimeType},
+    );
+    FlutterError.reportError(
+      FlutterErrorDetails(
+        exception: error,
+        stack: stackTrace,
+        library: 'terminal',
+        context: ErrorDescription(
+          'while ${enabled ? 'enabling' : 'disabling'} the terminal wake lock',
+        ),
+      ),
+    );
+  }
+}
+
+/// Provider for [TerminalWakeLockService].
+final terminalWakeLockServiceProvider = Provider<TerminalWakeLockService>((
+  ref,
+) {
+  final service = TerminalWakeLockService();
+  ref.onDispose(() => unawaited(service.dispose()));
+  return service;
+});

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -596,6 +596,7 @@ class _TerminalSection extends ConsumerWidget {
     final fontFamily = ref.watch(fontFamilyNotifierProvider);
     final cursorStyle = ref.watch(cursorStyleNotifierProvider);
     final bellSound = ref.watch(bellSoundNotifierProvider);
+    final terminalWakeLock = ref.watch(terminalWakeLockNotifierProvider);
     final terminalPathLinks = ref.watch(terminalPathLinksNotifierProvider);
     final terminalPathLinkUnderlines = ref.watch(
       terminalPathLinkUnderlinesNotifierProvider,
@@ -656,6 +657,19 @@ class _TerminalSection extends ConsumerWidget {
             ref
                 .read(bellSoundNotifierProvider.notifier)
                 .setEnabled(enabled: value);
+          },
+        ),
+        SwitchListTile(
+          secondary: const Icon(Icons.screen_lock_portrait_outlined),
+          title: const Text('Keep screen awake'),
+          subtitle: const Text('Hold a wake lock while a terminal is active'),
+          value: terminalWakeLock,
+          onChanged: (value) {
+            unawaited(
+              ref
+                  .read(terminalWakeLockNotifierProvider.notifier)
+                  .setEnabled(enabled: value),
+            );
           },
         ),
         SwitchListTile(

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -16,7 +16,6 @@ import 'package:go_router/go_router.dart';
 import 'package:pasteboard/pasteboard.dart';
 import 'package:path/path.dart' as path;
 import 'package:url_launcher/url_launcher.dart';
-import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:xterm/xterm.dart' hide TerminalThemes;
 
 import '../../app/routes.dart';
@@ -43,6 +42,7 @@ import '../../domain/services/ssh_exec_queue.dart';
 import '../../domain/services/ssh_service.dart';
 import '../../domain/services/terminal_hyperlink_tracker.dart';
 import '../../domain/services/terminal_theme_service.dart';
+import '../../domain/services/terminal_wake_lock_service.dart';
 import '../../domain/services/tmux_service.dart';
 import '../widgets/agent_tool_icon.dart';
 import '../widgets/ai_session_picker.dart';
@@ -3297,6 +3297,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   late final ProviderSubscription<bool> _sharedClipboardSubscription;
   late final ProviderSubscription<bool> _sharedClipboardLocalReadSubscription;
   late final ProviderSubscription<bool> _terminalWakeLockSubscription;
+  late final TerminalWakeLockService _terminalWakeLockService;
+  late final int _terminalWakeLockOwnerId;
   Timer? _localClipboardSyncTimer;
   Timer? _remoteClipboardSyncTimer;
   Timer? _promptOutputImeResetTimer;
@@ -3311,9 +3313,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   DateTime? _recentLocalClipboardAt;
   bool _isTerminalSizeRefreshQueued = false;
   bool _terminalWakeLockSetting = false;
-  bool _terminalWakeLockTarget = false;
-  bool _isTerminalWakeLockHeld = false;
-  Future<void> _terminalWakeLockWriteChain = Future<void>.value();
 
   // Theme state
   Host? _host;
@@ -3488,6 +3487,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         ),
       ),
     );
+    _terminalWakeLockService = ref.read(terminalWakeLockServiceProvider);
+    _terminalWakeLockOwnerId = _terminalWakeLockService.createOwner();
     _terminalWakeLockSetting = ref.read(terminalWakeLockNotifierProvider);
     _terminalWakeLockSubscription = ref.listenManual<bool>(
       terminalWakeLockNotifierProvider,
@@ -4314,51 +4315,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _error == null &&
         (connectionState ?? _readCurrentConnectionState()) ==
             SshConnectionState.connected;
-    unawaited(_setTerminalWakeLockHeld(held: shouldHold));
-  }
-
-  Future<void> _setTerminalWakeLockHeld({required bool held}) async {
-    if (_terminalWakeLockTarget == held && _isTerminalWakeLockHeld == held) {
-      return;
-    }
-    _terminalWakeLockTarget = held;
-    final nextWrite = _terminalWakeLockWriteChain.then((_) async {
-      final target = _terminalWakeLockTarget;
-      if (_isTerminalWakeLockHeld == target) {
-        return;
-      }
-
-      try {
-        await WakelockPlus.toggle(enable: target);
-        _isTerminalWakeLockHeld = target;
-      } on MissingPluginException catch (error, stackTrace) {
-        _reportTerminalWakeLockError(error, stackTrace, held: target);
-      } on PlatformException catch (error, stackTrace) {
-        _reportTerminalWakeLockError(error, stackTrace, held: target);
-      }
-    });
-    _terminalWakeLockWriteChain = nextWrite;
-    await nextWrite;
-  }
-
-  void _reportTerminalWakeLockError(
-    Object error,
-    StackTrace stackTrace, {
-    required bool held,
-  }) {
-    DiagnosticsLogService.instance.error(
-      'terminal',
-      'wake_lock_failed',
-      fields: {'enabled': held, 'errorType': error.runtimeType},
-    );
-    FlutterError.reportError(
-      FlutterErrorDetails(
-        exception: error,
-        stack: stackTrace,
-        library: 'terminal',
-        context: ErrorDescription(
-          'while ${held ? 'enabling' : 'disabling'} the terminal wake lock',
-        ),
+    unawaited(
+      _terminalWakeLockService.setOwnerActive(
+        _terminalWakeLockOwnerId,
+        active: shouldHold,
       ),
     );
   }
@@ -5711,7 +5671,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _sharedClipboardSubscription.close();
     _sharedClipboardLocalReadSubscription.close();
     _terminalWakeLockSubscription.close();
-    unawaited(_setTerminalWakeLockHeld(held: false));
+    unawaited(_terminalWakeLockService.releaseOwner(_terminalWakeLockOwnerId));
     _stopSharedClipboardSync();
     _promptOutputImeResetTimer?.cancel();
     _disposeTerminalPathVerificationSftp();

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -16,6 +16,7 @@ import 'package:go_router/go_router.dart';
 import 'package:pasteboard/pasteboard.dart';
 import 'package:path/path.dart' as path;
 import 'package:url_launcher/url_launcher.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:xterm/xterm.dart' hide TerminalThemes;
 
 import '../../app/routes.dart';
@@ -3295,6 +3296,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   String? _terminalPathVerificationHomeDirectory;
   late final ProviderSubscription<bool> _sharedClipboardSubscription;
   late final ProviderSubscription<bool> _sharedClipboardLocalReadSubscription;
+  late final ProviderSubscription<bool> _terminalWakeLockSubscription;
   Timer? _localClipboardSyncTimer;
   Timer? _remoteClipboardSyncTimer;
   Timer? _promptOutputImeResetTimer;
@@ -3308,6 +3310,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   String? _recentLocalClipboardText;
   DateTime? _recentLocalClipboardAt;
   bool _isTerminalSizeRefreshQueued = false;
+  bool _terminalWakeLockSetting = false;
+  bool _terminalWakeLockTarget = false;
+  bool _isTerminalWakeLockHeld = false;
+  Future<void> _terminalWakeLockWriteChain = Future<void>.value();
 
   // Theme state
   Host? _host;
@@ -3481,6 +3487,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           allowLocalClipboardRead: next,
         ),
       ),
+    );
+    _terminalWakeLockSetting = ref.read(terminalWakeLockNotifierProvider);
+    _terminalWakeLockSubscription = ref.listenManual<bool>(
+      terminalWakeLockNotifierProvider,
+      (previous, next) {
+        _terminalWakeLockSetting = next;
+        _syncTerminalWakeLock();
+      },
     );
     _terminal = Terminal(maxLines: 10000);
     _terminalController = TerminalController();
@@ -4070,6 +4084,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _isConnecting = false;
         _error = 'Session not found';
       });
+      _syncTerminalWakeLock(SshConnectionState.disconnected);
       return;
     }
 
@@ -4120,6 +4135,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _sessionFontSizeOverride = session.terminalFontSize;
           _isConnecting = false;
         });
+        _syncTerminalWakeLock(SshConnectionState.connected);
         _scheduleTerminalSizeRefresh();
         _restoreTerminalFocus();
 
@@ -4182,6 +4198,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _sessionFontSizeOverride = session.terminalFontSize;
         _isConnecting = false;
       });
+      _syncTerminalWakeLock(SshConnectionState.connected);
       _scheduleTerminalSizeRefresh();
       _restoreTerminalFocus();
       _primeTmuxStateFromHost();
@@ -4277,6 +4294,73 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _terminalViewKey.currentState?.refreshTerminalSize();
     });
     WidgetsBinding.instance.ensureVisualUpdate();
+  }
+
+  SshConnectionState _readCurrentConnectionState() {
+    final connectionId = _connectionId;
+    if (connectionId == null) {
+      return SshConnectionState.disconnected;
+    }
+    return ref.read(activeSessionsProvider)[connectionId] ??
+        SshConnectionState.disconnected;
+  }
+
+  void _syncTerminalWakeLock([SshConnectionState? connectionState]) {
+    final shouldHold =
+        _terminalWakeLockSetting &&
+        !_wasBackgrounded &&
+        _connectionId != null &&
+        _shell != null &&
+        _error == null &&
+        (connectionState ?? _readCurrentConnectionState()) ==
+            SshConnectionState.connected;
+    unawaited(_setTerminalWakeLockHeld(held: shouldHold));
+  }
+
+  Future<void> _setTerminalWakeLockHeld({required bool held}) async {
+    if (_terminalWakeLockTarget == held && _isTerminalWakeLockHeld == held) {
+      return;
+    }
+    _terminalWakeLockTarget = held;
+    final nextWrite = _terminalWakeLockWriteChain.then((_) async {
+      final target = _terminalWakeLockTarget;
+      if (_isTerminalWakeLockHeld == target) {
+        return;
+      }
+
+      try {
+        await WakelockPlus.toggle(enable: target);
+        _isTerminalWakeLockHeld = target;
+      } on MissingPluginException catch (error, stackTrace) {
+        _reportTerminalWakeLockError(error, stackTrace, held: target);
+      } on PlatformException catch (error, stackTrace) {
+        _reportTerminalWakeLockError(error, stackTrace, held: target);
+      }
+    });
+    _terminalWakeLockWriteChain = nextWrite;
+    await nextWrite;
+  }
+
+  void _reportTerminalWakeLockError(
+    Object error,
+    StackTrace stackTrace, {
+    required bool held,
+  }) {
+    DiagnosticsLogService.instance.error(
+      'terminal',
+      'wake_lock_failed',
+      fields: {'enabled': held, 'errorType': error.runtimeType},
+    );
+    FlutterError.reportError(
+      FlutterErrorDetails(
+        exception: error,
+        stack: stackTrace,
+        library: 'terminal',
+        context: ErrorDescription(
+          'while ${held ? 'enabling' : 'disabling'} the terminal wake lock',
+        ),
+      ),
+    );
   }
 
   void _schedulePromptOutputImeResetCheck(String data) {
@@ -5491,12 +5575,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   ) {
     final connectionId = _connectionId;
     if (connectionId == null) {
+      _syncTerminalWakeLock(SshConnectionState.disconnected);
       return;
     }
 
     final previousState =
         previous?[connectionId] ?? SshConnectionState.disconnected;
     final nextState = next[connectionId] ?? SshConnectionState.disconnected;
+    _syncTerminalWakeLock(nextState);
     if (previousState == nextState ||
         nextState != SshConnectionState.disconnected) {
       return;
@@ -5527,6 +5613,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _shell = null;
     unawaited(_doneSubscription?.cancel());
     _doneSubscription = null;
+    _syncTerminalWakeLock(SshConnectionState.disconnected);
     if (!mounted) {
       if (connectionId != null) {
         unawaited(
@@ -5566,6 +5653,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   Future<void> _disconnect() async {
     final connectionId = _connectionId;
     _connectionId = null;
+    _syncTerminalWakeLock(SshConnectionState.disconnected);
     await _doneSubscription?.cancel();
     _doneSubscription = null;
     _shell = null;
@@ -5596,6 +5684,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     final previousConnectionId = _connectionId;
     _connectionId = null;
+    _syncTerminalWakeLock(SshConnectionState.disconnected);
     _connectionLostWhileBackgrounded = false;
     try {
       await _doneSubscription?.cancel();
@@ -5621,6 +5710,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     WidgetsBinding.instance.removeObserver(this);
     _sharedClipboardSubscription.close();
     _sharedClipboardLocalReadSubscription.close();
+    _terminalWakeLockSubscription.close();
+    unawaited(_setTerminalWakeLockHeld(held: false));
     _stopSharedClipboardSync();
     _promptOutputImeResetTimer?.cancel();
     _disposeTerminalPathVerificationSftp();
@@ -5653,8 +5744,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         state == AppLifecycleState.inactive) {
       _wasBackgrounded = true;
       _stopSharedClipboardSync();
+      _syncTerminalWakeLock();
     } else if (state == AppLifecycleState.resumed && _wasBackgrounded) {
       _wasBackgrounded = false;
+      _syncTerminalWakeLock();
       _scheduleTerminalSizeRefresh();
       final session = _observedSession;
       if (session != null && session.clipboardSharingEnabled) {

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -16,6 +16,7 @@ import pasteboard
 import share_plus
 import url_launcher_macos
 import video_player_avfoundation
+import wakelock_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
@@ -29,4 +30,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
+  WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1524,6 +1524,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.1.0"
+  wakelock_plus:
+    dependency: "direct main"
+    description:
+      name: wakelock_plus
+      sha256: "9296d40c9adbedaba95d1e704f4e0b434be446e2792948d0e4aa977048104228"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
+  wakelock_plus_platform_interface:
+    dependency: "direct dev"
+    description:
+      name: wakelock_plus_platform_interface
+      sha256: "24b84143787220a403491c2e5de0877fbbb87baf3f0b18a2a988973863db4b03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,7 +73,7 @@ dependencies:
   # Network / connectivity
   network_info_plus: ^6.1.4
   permission_handler: ^11.3.1
-  wakelock_plus: 1.4.0
+  wakelock_plus: '>=1.4.0 <1.5.0'
 
 dev_dependencies:
   flutter_test:
@@ -89,7 +89,7 @@ dev_dependencies:
   
   # Testing
   mocktail: ^1.0.4
-  wakelock_plus_platform_interface: 1.4.0
+  wakelock_plus_platform_interface: '>=1.4.0 <1.5.0'
   integration_test:
     sdk: flutter
   

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,6 +73,7 @@ dependencies:
   # Network / connectivity
   network_info_plus: ^6.1.4
   permission_handler: ^11.3.1
+  wakelock_plus: 1.4.0
 
 dev_dependencies:
   flutter_test:
@@ -88,6 +89,7 @@ dev_dependencies:
   
   # Testing
   mocktail: ^1.0.4
+  wakelock_plus_platform_interface: 1.4.0
   integration_test:
     sdk: flutter
   

--- a/test/domain/services/terminal_wake_lock_service_test.dart
+++ b/test/domain/services/terminal_wake_lock_service_test.dart
@@ -1,0 +1,52 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/services/terminal_wake_lock_service.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
+import 'package:wakelock_plus_platform_interface/wakelock_plus_platform_interface.dart';
+
+class _FakeWakelockPlusPlatform extends WakelockPlusPlatformInterface {
+  final toggleCalls = <bool>[];
+  bool _enabled = false;
+
+  @override
+  Future<void> toggle({required bool enable}) async {
+    _enabled = enable;
+    toggleCalls.add(enable);
+  }
+
+  @override
+  Future<bool> get enabled async => _enabled;
+}
+
+void main() {
+  late WakelockPlusPlatformInterface originalWakelockPlatform;
+  late _FakeWakelockPlusPlatform wakelockPlatform;
+  late TerminalWakeLockService service;
+
+  setUp(() {
+    originalWakelockPlatform = wakelockPlusPlatformInstance;
+    wakelockPlatform = _FakeWakelockPlusPlatform();
+    wakelockPlusPlatformInstance = wakelockPlatform;
+    service = TerminalWakeLockService();
+  });
+
+  tearDown(() {
+    wakelockPlusPlatformInstance = originalWakelockPlatform;
+  });
+
+  test('keeps wake lock enabled while any owner remains active', () async {
+    final firstOwnerId = service.createOwner();
+    final secondOwnerId = service.createOwner();
+
+    await service.setOwnerActive(firstOwnerId, active: true);
+    await service.setOwnerActive(secondOwnerId, active: true);
+    await service.releaseOwner(firstOwnerId);
+
+    expect(wakelockPlatform.toggleCalls, [true]);
+
+    await service.releaseOwner(secondOwnerId);
+
+    expect(wakelockPlatform.toggleCalls, [true, false]);
+  });
+}

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
-
 import 'package:monkeyssh/app/routes.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
@@ -29,6 +28,8 @@ import 'package:monkeyssh/domain/services/tmux_service.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
+import 'package:wakelock_plus_platform_interface/wakelock_plus_platform_interface.dart';
 import 'package:xterm/xterm.dart';
 
 const _deleteDetectionMarker = '\u200B\u200B';
@@ -44,6 +45,20 @@ class _MockMonetizationService extends Mock implements MonetizationService {}
 class _MockSftpClient extends Mock implements SftpClient {}
 
 class _MockTmuxService extends Mock implements TmuxService {}
+
+class _FakeWakelockPlusPlatform extends WakelockPlusPlatformInterface {
+  final toggleCalls = <bool>[];
+  bool _enabled = false;
+
+  @override
+  Future<void> toggle({required bool enable}) async {
+    _enabled = enable;
+    toggleCalls.add(enable);
+  }
+
+  @override
+  Future<bool> get enabled async => _enabled;
+}
 
 class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
   _TestActiveSessionsNotifier(this.session);
@@ -510,6 +525,8 @@ void main() {
     late Completer<void> shellDoneCompleter;
     late StreamController<Uint8List> shellStdoutController;
     late List<List<int>> shellWrites;
+    late WakelockPlusPlatformInterface originalWakelockPlatform;
+    late _FakeWakelockPlusPlatform wakelockPlatform;
 
     setUp(() {
       db = AppDatabase.forTesting(NativeDatabase.memory());
@@ -521,6 +538,9 @@ void main() {
       shellDoneCompleter = Completer<void>();
       shellStdoutController = StreamController<Uint8List>.broadcast();
       shellWrites = <List<int>>[];
+      originalWakelockPlatform = wakelockPlusPlatformInstance;
+      wakelockPlatform = _FakeWakelockPlusPlatform();
+      wakelockPlusPlatformInstance = wakelockPlatform;
 
       when(
         () => monetizationService.currentState,
@@ -566,6 +586,7 @@ void main() {
     });
 
     tearDown(() async {
+      wakelockPlusPlatformInstance = originalWakelockPlatform;
       await shellStdoutController.close();
       await db.close();
     });
@@ -597,6 +618,24 @@ void main() {
       await tester.pump();
       await tester.pump();
     }
+
+    testWidgets('holds wake lock while an opted-in terminal is active', (
+      tester,
+    ) async {
+      await SettingsService(
+        db,
+      ).setBool(SettingKeys.terminalWakeLock, value: true);
+
+      await pumpScreen(tester);
+      await tester.pump();
+
+      expect(wakelockPlatform.toggleCalls, contains(true));
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      expect(wakelockPlatform.toggleCalls.last, false);
+    });
 
     Future<void> pumpTmuxScreen(
       WidgetTester tester,

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -315,6 +315,26 @@ void main() {
       expect(find.byType(SwitchListTile), findsWidgets);
     });
 
+    testWidgets('displays terminal wake lock toggle', (tester) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      await _pumpSettingsScreen(tester, db: db);
+
+      await tester.scrollUntilVisible(
+        find.text('Keep screen awake'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Keep screen awake'), findsOneWidget);
+      expect(
+        find.text('Hold a wake lock while a terminal is active'),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('displays terminal path link toggles', (tester) async {
       final db = AppDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);


### PR DESCRIPTION
## Summary

- Add a persisted Terminal setting to keep the screen awake while a terminal is active
- Wire TerminalScreen to acquire/release wakelock on active connection, background/resume, disconnect, and dispose
- Add settings UI and widget coverage for the wake-lock option

## Validation

- `flutter analyze`
- `flutter test`
