### PR TITLE
fix: target tmux alert notifications by window id

### DIFF
--- a/integration_test/tmux_notification_navigation_validation_test.dart
+++ b/integration_test/tmux_notification_navigation_validation_test.dart
@@ -1,0 +1,230 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
+import 'package:monkeyssh/domain/models/monetization.dart';
+import 'package:monkeyssh/domain/models/tmux_state.dart';
+import 'package:monkeyssh/domain/services/monetization_service.dart';
+import 'package:monkeyssh/domain/services/settings_service.dart';
+import 'package:monkeyssh/domain/services/ssh_service.dart';
+import 'package:monkeyssh/domain/services/tmux_service.dart';
+import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
+
+class _MockHostRepository extends Mock implements HostRepository {}
+
+class _MockSshClient extends Mock implements SSHClient {}
+
+class _MockShellChannel extends Mock implements SSHSession {}
+
+class _MockMonetizationService extends Mock implements MonetizationService {}
+
+class _MockTmuxService extends Mock implements TmuxService {}
+
+class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
+  _TestActiveSessionsNotifier(this.session);
+
+  final SshSession session;
+
+  @override
+  Map<int, SshConnectionState> build() => <int, SshConnectionState>{
+    session.connectionId: SshConnectionState.connected,
+  };
+
+  @override
+  ConnectionAttemptStatus? getConnectionAttempt(int hostId) => null;
+
+  @override
+  List<int> getConnectionsForHost(int hostId) =>
+      hostId == session.hostId ? <int>[session.connectionId] : const <int>[];
+
+  @override
+  ActiveConnection? getActiveConnection(int connectionId) => null;
+
+  @override
+  SshSession? getSession(int connectionId) =>
+      connectionId == session.connectionId ? session : null;
+
+  @override
+  Future<void> syncBackgroundStatus() async {}
+}
+
+Host _buildHost({required int id, required String tmuxSessionName}) => Host(
+  id: id,
+  label: 'Notification navigation validation',
+  hostname: 'terminal.example.com',
+  port: 22,
+  username: 'root',
+  tmuxSessionName: tmuxSessionName,
+  isFavorite: false,
+  createdAt: DateTime(2026),
+  updatedAt: DateTime(2026),
+  autoConnectRequiresConfirmation: false,
+  sortOrder: 0,
+);
+
+const _proMonetizationState = MonetizationState(
+  billingAvailability: MonetizationBillingAvailability.available,
+  entitlements: MonetizationEntitlements.pro(),
+  offers: [],
+  debugUnlockAvailable: false,
+  debugUnlocked: false,
+);
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(const SSHPtyConfig());
+    registerFallbackValue(<int>[]);
+    registerFallbackValue(Uint8List(0));
+    registerFallbackValue(MonetizationFeature.autoConnectAutomation);
+  });
+
+  testWidgets(
+    'notification tmux target selects the stable window ID on device',
+    (tester) async {
+      const tmuxSessionName = 'alerts';
+      const stalePayloadWindowIndex = 2;
+      const currentTargetWindowIndex = 3;
+      const targetWindowId = '@9';
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      final hostRepository = _MockHostRepository();
+      final sshClient = _MockSshClient();
+      final shellChannel = _MockShellChannel();
+      final tmuxService = _MockTmuxService();
+      final monetizationService = _MockMonetizationService();
+      final host = _buildHost(id: 1, tmuxSessionName: tmuxSessionName);
+      final shellDoneCompleter = Completer<void>();
+      final shellStdoutController = StreamController<Uint8List>.broadcast();
+
+      addTearDown(() async {
+        await shellStdoutController.close();
+        await db.close();
+      });
+
+      final session = SshSession(
+        connectionId: 7,
+        hostId: host.id,
+        client: sshClient,
+        config: const SshConnectionConfig(
+          hostname: 'terminal.example.com',
+          port: 22,
+          username: 'root',
+        ),
+      )..getOrCreateTerminal();
+
+      when(() => hostRepository.getById(host.id)).thenAnswer((_) async => host);
+      when(
+        () => sshClient.shell(pty: any(named: 'pty')),
+      ).thenAnswer((_) async => shellChannel);
+      when(
+        () => shellChannel.stdout,
+      ).thenAnswer((_) => shellStdoutController.stream);
+      when(
+        () => shellChannel.stderr,
+      ).thenAnswer((_) => const Stream<Uint8List>.empty());
+      when(
+        () => shellChannel.done,
+      ).thenAnswer((_) => shellDoneCompleter.future);
+      when(() => shellChannel.write(any())).thenReturn(null);
+      when(
+        () => monetizationService.currentState,
+      ).thenReturn(_proMonetizationState);
+      when(
+        () => monetizationService.states,
+      ).thenAnswer((_) => Stream.value(_proMonetizationState));
+      when(
+        monetizationService.initialize,
+      ).thenAnswer((_) => Future<void>.value());
+      when(
+        () => monetizationService.canUseFeature(any()),
+      ).thenAnswer((_) async => true);
+      when(
+        () => tmuxService.hasSessionOrThrow(session, tmuxSessionName),
+      ).thenAnswer((_) async => true);
+      when(() => tmuxService.listWindows(session, tmuxSessionName)).thenAnswer(
+        (_) async => const <TmuxWindow>[
+          TmuxWindow(index: 1, id: '@8', name: 'shell', isActive: true),
+          TmuxWindow(
+            index: currentTargetWindowIndex,
+            id: targetWindowId,
+            name: 'agent',
+            isActive: false,
+          ),
+        ],
+      );
+      when(
+        () => tmuxService.selectWindow(
+          session,
+          tmuxSessionName,
+          currentTargetWindowIndex,
+          windowId: targetWindowId,
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => tmuxService.hasForegroundClient(session, tmuxSessionName),
+      ).thenAnswer((_) async => true);
+      when(
+        () => tmuxService.watchWindowChanges(session, tmuxSessionName),
+      ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+      when(
+        () => tmuxService.prefetchInstalledAgentTools(session),
+      ).thenAnswer((_) async {});
+      when(
+        () => tmuxService.detectInstalledAgentTools(session),
+      ).thenAnswer((_) async => const <AgentLaunchTool>{});
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            hostRepositoryProvider.overrideWithValue(hostRepository),
+            monetizationServiceProvider.overrideWithValue(monetizationService),
+            monetizationStateProvider.overrideWith(
+              (ref) => Stream.value(_proMonetizationState),
+            ),
+            sharedClipboardProvider.overrideWith((ref) async => false),
+            activeSessionsProvider.overrideWith(
+              () => _TestActiveSessionsNotifier(session),
+            ),
+            tmuxServiceProvider.overrideWithValue(tmuxService),
+          ],
+          child: MaterialApp(
+            home: TerminalScreen(
+              hostId: host.id,
+              connectionId: session.connectionId,
+              initialTmuxSessionName: tmuxSessionName,
+              initialTmuxWindowIndex: stalePayloadWindowIndex,
+              initialTmuxWindowId: targetWindowId,
+              initialTmuxWindowRequiresVisibleSession: true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+
+      verify(
+        () => tmuxService.selectWindow(
+          session,
+          tmuxSessionName,
+          currentTargetWindowIndex,
+          windowId: targetWindowId,
+        ),
+      ).called(1);
+    },
+  );
+}

--- a/integration_test/tmux_notification_navigation_validation_test.dart
+++ b/integration_test/tmux_notification_navigation_validation_test.dart
@@ -8,13 +8,16 @@ import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:monkeyssh/app/notification_navigation.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
 import 'package:monkeyssh/domain/models/monetization.dart';
 import 'package:monkeyssh/domain/models/tmux_state.dart';
+import 'package:monkeyssh/domain/services/local_notification_service.dart';
 import 'package:monkeyssh/domain/services/monetization_service.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
@@ -227,4 +230,64 @@ void main() {
       ).called(1);
     },
   );
+
+  testWidgets('notification route keeps the connections back stack on device', (
+    tester,
+  ) async {
+    final terminalLocations = <String>[];
+    final router = GoRouter(
+      initialLocation: '/settings',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => Scaffold(
+            body: Text('home:${state.uri.queryParameters['tab'] ?? 'hosts'}'),
+          ),
+        ),
+        GoRoute(
+          path: '/settings',
+          builder: (context, state) => const Scaffold(body: Text('settings')),
+        ),
+        GoRoute(
+          path: '/terminal/:hostId',
+          builder: (context, state) {
+            terminalLocations.add(state.uri.toString());
+            return Scaffold(
+              body: Text('terminal:${state.pathParameters['hostId']}'),
+            );
+          },
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    openTmuxAlertNotificationStack(
+      router: router,
+      payload: const TmuxAlertNotificationPayload(
+        hostId: 12,
+        connectionId: 34,
+        tmuxSessionName: 'work',
+        windowIndex: 5,
+        windowId: '@9',
+      ),
+      notificationTapId: 'tap-1',
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('terminal:12'), findsOneWidget);
+    expect(router.canPop(), isTrue);
+    expect(
+      terminalLocations.single,
+      '/terminal/12?connectionId=34&tmuxSession=work&tmuxWindow=5&tmuxWindowId=%409&notificationTap=tap-1',
+    );
+
+    router.pop();
+    await tester.pumpAndSettle();
+
+    expect(find.text('home:connections'), findsOneWidget);
+    expect(find.text('settings'), findsNothing);
+  });
 }

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -15,6 +15,7 @@ import '../domain/services/ssh_service.dart';
 import 'app_lifecycle_coordinator.dart';
 import 'app_metadata.dart';
 import 'auth_lifecycle_controller.dart';
+import 'notification_navigation.dart';
 import 'router.dart';
 import 'theme.dart';
 
@@ -163,13 +164,11 @@ class _BackgroundLifecycleBridgeState
         return;
       }
       _pendingTmuxAlertNavigation = null;
-      final targetUri = Uri.parse(buildTmuxAlertTerminalLocation(payload));
-      final queryParameters = Map<String, String>.from(
-        targetUri.queryParameters,
-      )..['notificationTap'] = '${DateTime.now().microsecondsSinceEpoch}';
-      ref
-          .read(routerProvider)
-          .go(targetUri.replace(queryParameters: queryParameters).toString());
+      openTmuxAlertNotificationStack(
+        router: ref.read(routerProvider),
+        payload: payload,
+        notificationTapId: '${DateTime.now().microsecondsSinceEpoch}',
+      );
     });
     WidgetsBinding.instance.ensureVisualUpdate();
   }

--- a/lib/app/notification_navigation.dart
+++ b/lib/app/notification_navigation.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import 'package:go_router/go_router.dart';
+
+import '../domain/services/local_notification_service.dart';
+
+const _homeTabQueryKey = 'tab';
+const _connectionsTabQueryValue = 'connections';
+
+/// Builds the home route that should sit underneath a tmux alert terminal.
+String buildTmuxAlertHomeLocation() => Uri(
+  path: '/',
+  queryParameters: const <String, String>{
+    _homeTabQueryKey: _connectionsTabQueryValue,
+  },
+).toString();
+
+/// Builds the terminal route for a tmux alert notification navigation.
+String buildTmuxAlertNotificationTerminalLocation(
+  TmuxAlertNotificationPayload payload, {
+  required String notificationTapId,
+}) {
+  final targetUri = Uri.parse(buildTmuxAlertTerminalLocation(payload));
+  final queryParameters = Map<String, String>.from(targetUri.queryParameters)
+    ..['notificationTap'] = notificationTapId;
+  return targetUri.replace(queryParameters: queryParameters).toString();
+}
+
+/// Opens a tmux alert notification with the same stack as manual navigation.
+void openTmuxAlertNotificationStack({
+  required GoRouter router,
+  required TmuxAlertNotificationPayload payload,
+  required String notificationTapId,
+}) {
+  router.go(buildTmuxAlertHomeLocation());
+  unawaited(
+    router.push<void>(
+      buildTmuxAlertNotificationTerminalLocation(
+        payload,
+        notificationTapId: notificationTapId,
+      ),
+    ),
+  );
+}

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -41,7 +41,9 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/',
         name: Routes.home,
-        builder: (context, state) => const HomeScreen(),
+        builder: (context, state) => HomeScreen(
+          initialTab: _homeScreenTabFromRoute(state.uri.queryParameters['tab']),
+        ),
       ),
       GoRoute(
         path: '/lock',
@@ -219,6 +221,11 @@ final routerProvider = Provider<GoRouter>((ref) {
     ],
   );
 });
+
+HomeScreenTab _homeScreenTabFromRoute(String? tab) => switch (tab) {
+  'connections' => HomeScreenTab.connections,
+  _ => HomeScreenTab.hosts,
+};
 
 /// Computes the route redirect for the given authentication state.
 String? redirectForAuthState({

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -66,6 +66,7 @@ final routerProvider = Provider<GoRouter>((ref) {
           final initialTmuxWindowIndex = int.tryParse(
             state.uri.queryParameters['tmuxWindow'] ?? '',
           );
+          final initialTmuxWindowId = state.uri.queryParameters['tmuxWindowId'];
           if (hostId == null) {
             return const Scaffold(body: Center(child: Text('Invalid host ID')));
           }
@@ -76,6 +77,7 @@ final routerProvider = Provider<GoRouter>((ref) {
                 connectionId,
                 initialTmuxSessionName,
                 initialTmuxWindowIndex,
+                initialTmuxWindowId,
                 state.uri.queryParameters['notificationTap'],
               ),
             ),
@@ -83,6 +85,7 @@ final routerProvider = Provider<GoRouter>((ref) {
             connectionId: connectionId,
             initialTmuxSessionName: initialTmuxSessionName,
             initialTmuxWindowIndex: initialTmuxWindowIndex,
+            initialTmuxWindowId: initialTmuxWindowId,
             initialTmuxWindowRequiresVisibleSession:
                 state.uri.queryParameters['notificationTap'] != null,
             initiallyExpandTmuxWindows:

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -79,6 +79,7 @@ class TmuxWindow {
     required this.index,
     required this.name,
     required this.isActive,
+    this.id,
     this.currentCommand,
     this.currentPath,
     this.flags,
@@ -94,7 +95,8 @@ class TmuxWindow {
   /// Expected primary format (from `tmux list-windows -F`) is Unit
   /// Separator-delimited:
   /// `index<US>name<US>active_flag<US>command<US>path<US>flags<US>`
-  /// `pane_title<US>activity_epoch<US>pane_start_command<US>agent_tool`
+  /// `pane_title<US>activity_epoch<US>pane_start_command<US>agent_tool<US>`
+  /// `window_id`
   ///
   /// Legacy pipe-delimited snapshots are still accepted for older tests and
   /// stale control-mode messages.
@@ -111,6 +113,9 @@ class TmuxWindow {
       index: int.tryParse(fields[0]) ?? 0,
       name: fields[1],
       isActive: fields[2] == '1',
+      id: fields.length > 10 && isValidTmuxWindowId(fields[10])
+          ? fields[10]
+          : null,
       currentCommand: fields.length > 3 ? _nonEmpty(fields[3]) : null,
       currentPath: fields.length > 4 ? _nonEmpty(fields[4]) : null,
       flags: fields.length > 5 ? _nonEmpty(fields[5]) : null,
@@ -125,6 +130,9 @@ class TmuxWindow {
 
   /// The tmux-reported window index within the session.
   final int index;
+
+  /// The stable tmux window ID (for example `@7`), when reported.
+  final String? id;
 
   /// The window name (often set by the running program or user).
   final String name;
@@ -190,6 +198,7 @@ class TmuxWindow {
 
   /// Returns a copy of this window with selectively overridden fields.
   TmuxWindow copyWith({
+    String? id,
     bool? isActive,
     String? name,
     String? currentCommand,
@@ -201,6 +210,7 @@ class TmuxWindow {
     int? lastActivityEpochSeconds,
   }) => TmuxWindow(
     index: index,
+    id: id ?? this.id,
     name: name ?? this.name,
     isActive: isActive ?? this.isActive,
     currentCommand: currentCommand ?? this.currentCommand,
@@ -384,7 +394,7 @@ class TmuxWindow {
 
   @override
   String toString() =>
-      'TmuxWindow(index: $index, name: $name, active: $isActive, '
+      'TmuxWindow(index: $index, id: $id, name: $name, active: $isActive, '
       'command: $currentCommand, title: $paneTitle)';
 
   @override
@@ -392,6 +402,7 @@ class TmuxWindow {
       identical(this, other) ||
       other is TmuxWindow &&
           index == other.index &&
+          id == other.id &&
           name == other.name &&
           isActive == other.isActive &&
           currentCommand == other.currentCommand &&
@@ -406,6 +417,7 @@ class TmuxWindow {
   @override
   int get hashCode => Object.hash(
     index,
+    id,
     name,
     isActive,
     currentCommand,
@@ -451,13 +463,14 @@ List<TmuxWindow> applyTmuxWindowChangeEvent(
     case TmuxWindowSnapshotEvent(window: final window):
       final updated = windows
           .map(
-            (existing) => window.isActive && existing.index != window.index
+            (existing) =>
+                window.isActive && !_isSameTmuxWindow(existing, window)
                 ? existing.copyWith(isActive: false)
                 : existing,
           )
           .toList(growable: true);
       final existingIndex = updated.indexWhere(
-        (existing) => existing.index == window.index,
+        (existing) => _isSameTmuxWindow(existing, window),
       );
       if (existingIndex == -1) {
         updated.add(window);
@@ -467,6 +480,14 @@ List<TmuxWindow> applyTmuxWindowChangeEvent(
       updated.sort((a, b) => a.index.compareTo(b.index));
       return updated;
   }
+}
+
+bool _isSameTmuxWindow(TmuxWindow existing, TmuxWindow updated) {
+  final updatedId = updated.id;
+  if (updatedId != null) {
+    return existing.id == updatedId;
+  }
+  return existing.index == updated.index;
 }
 
 /// Resolves the tmux window list after a full reload query.
@@ -609,6 +630,9 @@ const _monthAbbreviations = <String>[
   'Nov',
   'Dec',
 ];
+
+/// Returns whether [value] is a stable tmux window ID such as `@7`.
+bool isValidTmuxWindowId(String value) => RegExp(r'^@\d+$').hasMatch(value);
 
 String? _nonEmpty(String value) {
   final trimmed = value.trim();

--- a/lib/domain/services/local_notification_service.dart
+++ b/lib/domain/services/local_notification_service.dart
@@ -6,6 +6,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../models/tmux_state.dart';
+
 /// Local notification channel used for tmux activity alerts.
 const tmuxAlertNotificationChannelId = 'tmux-alerts';
 const _androidNotificationIcon = 'ic_notification_monkey';
@@ -22,6 +24,7 @@ class TmuxAlertNotificationPayload {
     required this.connectionId,
     required this.tmuxSessionName,
     required this.windowIndex,
+    this.windowId,
   });
 
   static const _type = 'tmux-alert';
@@ -39,6 +42,9 @@ class TmuxAlertNotificationPayload {
   /// tmux window index that needs attention.
   final int windowIndex;
 
+  /// Stable tmux window ID that needs attention, when available.
+  final String? windowId;
+
   /// Encodes this payload for the notification plugin.
   String encode() => jsonEncode(<String, Object>{
     'type': _type,
@@ -47,6 +53,7 @@ class TmuxAlertNotificationPayload {
     'connectionId': connectionId,
     'tmuxSessionName': tmuxSessionName,
     'windowIndex': windowIndex,
+    'windowId': ?windowId,
   });
 
   /// Decodes a notification payload, returning `null` for other payload types.
@@ -65,11 +72,16 @@ class TmuxAlertNotificationPayload {
       final connectionId = decoded['connectionId'];
       final tmuxSessionName = decoded['tmuxSessionName'];
       final windowIndex = decoded['windowIndex'];
+      final windowId = decoded['windowId'];
+      final stableWindowId = windowId is String && isValidTmuxWindowId(windowId)
+          ? windowId
+          : null;
       if (hostId is! int ||
           connectionId is! int ||
           tmuxSessionName is! String ||
           tmuxSessionName.trim().isEmpty ||
-          windowIndex is! int) {
+          windowIndex is! int ||
+          (windowId != null && stableWindowId == null)) {
         return null;
       }
       return TmuxAlertNotificationPayload(
@@ -77,6 +89,7 @@ class TmuxAlertNotificationPayload {
         connectionId: connectionId,
         tmuxSessionName: tmuxSessionName,
         windowIndex: windowIndex,
+        windowId: stableWindowId,
       );
     } on FormatException {
       return null;
@@ -90,11 +103,12 @@ class TmuxAlertNotificationPayload {
           hostId == other.hostId &&
           connectionId == other.connectionId &&
           tmuxSessionName == other.tmuxSessionName &&
-          windowIndex == other.windowIndex;
+          windowIndex == other.windowIndex &&
+          windowId == other.windowId;
 
   @override
   int get hashCode =>
-      Object.hash(hostId, connectionId, tmuxSessionName, windowIndex);
+      Object.hash(hostId, connectionId, tmuxSessionName, windowIndex, windowId);
 }
 
 /// Builds the terminal route location for a tmux alert notification tap.
@@ -105,6 +119,7 @@ String buildTmuxAlertTerminalLocation(TmuxAlertNotificationPayload payload) =>
         'connectionId': '${payload.connectionId}',
         'tmuxSession': payload.tmuxSessionName,
         'tmuxWindow': '${payload.windowIndex}',
+        if (payload.windowId != null) 'tmuxWindowId': payload.windowId!,
       },
     ).toString();
 

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -591,7 +591,7 @@ class TmuxService {
         '"#{window_index}$sep#{window_name}$sep#{window_active}$sep'
         '#{pane_current_command}$sep#{pane_current_path}$sep'
         '#{window_flags}$sep#{pane_title}$sep#{window_activity}$sep'
-        '#{pane_start_command}$sep#{@flutty_agent_tool}"',
+        '#{pane_start_command}$sep#{@flutty_agent_tool}$sep#{window_id}"',
       );
       final windows = List<TmuxWindow>.unmodifiable(
         _parseLines(output, TmuxWindow.fromTmuxFormat),
@@ -854,22 +854,30 @@ class TmuxService {
     SshSession session,
     String sessionName,
     int windowIndex, {
+    String? windowId,
     String? extraFlags,
   }) async {
+    final targetWindowId = windowId?.trim();
+    final safeWindowId =
+        targetWindowId != null && isValidTmuxWindowId(targetWindowId)
+        ? targetWindowId
+        : null;
+    final hasTargetWindowId = safeWindowId != null;
+    final target = safeWindowId == null
+        ? '${_shellQuote(sessionName)}:$windowIndex'
+        : _shellQuote(safeWindowId);
     DiagnosticsLogService.instance.info(
       'tmux.action',
       'select_window_start',
       fields: {
         'connectionId': session.connectionId,
         'windowIndex': windowIndex,
+        'hasWindowId': hasTargetWindowId,
       },
     );
     await _exec(
       session,
-      _tmuxCommand(
-        'select-window -t ${_shellQuote(sessionName)}:$windowIndex',
-        extraFlags: extraFlags,
-      ),
+      _tmuxCommand('select-window -t $target', extraFlags: extraFlags),
     );
     DiagnosticsLogService.instance.info(
       'tmux.action',
@@ -877,6 +885,7 @@ class TmuxService {
       fields: {
         'connectionId': session.connectionId,
         'windowIndex': windowIndex,
+        'hasWindowId': hasTargetWindowId,
       },
     );
   }
@@ -1626,7 +1635,8 @@ const _tmuxWindowSubscriptionFormat =
     '#{pane_title}$tmuxWindowFieldSeparator'
     '#{window_activity}$tmuxWindowFieldSeparator'
     '#{pane_start_command}$tmuxWindowFieldSeparator'
-    '#{@flutty_agent_tool}';
+    '#{@flutty_agent_tool}$tmuxWindowFieldSeparator'
+    '#{window_id}';
 
 const _tmuxControlModeClientFlags = 'read-only,ignore-size,no-output,wait-exit';
 

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -43,10 +43,28 @@ const _redactStoreScreenshotIdentities = bool.fromEnvironment(
   'STORE_SCREENSHOT_REDACT_IDENTITIES',
 );
 
+/// Top-level sections available on the home screen.
+enum HomeScreenTab {
+  /// Saved host definitions.
+  hosts,
+
+  /// Active SSH connections.
+  connections,
+
+  /// SSH key management.
+  keys,
+
+  /// Snippet management.
+  snippets,
+}
+
 /// The main home screen - Termius-style sidebar layout.
 class HomeScreen extends ConsumerStatefulWidget {
   /// Creates a new [HomeScreen].
-  const HomeScreen({super.key});
+  const HomeScreen({super.key, this.initialTab = HomeScreenTab.hosts});
+
+  /// The tab selected when the home screen route is opened.
+  final HomeScreenTab initialTab;
 
   @override
   ConsumerState<HomeScreen> createState() => _HomeScreenState();
@@ -54,7 +72,7 @@ class HomeScreen extends ConsumerStatefulWidget {
 
 class _HomeScreenState extends ConsumerState<HomeScreen>
     with WidgetsBindingObserver {
-  int _selectedIndex = 0;
+  late int _selectedIndex;
 
   /// Switches to the Connections tab so the user lands there when
   /// returning from the terminal.
@@ -82,6 +100,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   @override
   void initState() {
     super.initState();
+    _selectedIndex = widget.initialTab.index;
     WidgetsBinding.instance.addObserver(this);
     final transferIntentService = ref.read(transferIntentServiceProvider);
     _incomingTransferSubscription = transferIntentService.incomingPayloads
@@ -103,6 +122,14 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         unawaited(_checkIncomingTransferPayload());
       }
     });
+  }
+
+  @override
+  void didUpdateWidget(covariant HomeScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.initialTab != widget.initialTab) {
+      _selectedIndex = widget.initialTab.index;
+    }
   }
 
   @override

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -588,6 +588,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   List<TmuxWindow>? _windows;
   AgentLaunchTool? _preferredLaunchTool;
   final Set<String> _seenAlertWindowKeys = <String>{};
+  final Map<String, int> _seenAlertWindowIndexesByKey = <String, int>{};
   late bool _expanded;
   bool _isLoading = true;
   bool _showSessions = false;
@@ -606,6 +607,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   int _windowRetryAttempts = 0;
   int _consecutiveEmptyWindowReloads = 0;
   bool _windowReloadRecoveryRequested = false;
+  late LocalNotificationService _localNotifications;
 
   TmuxService get _tmux => widget.ref.read(tmuxServiceProvider);
 
@@ -620,6 +622,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   @override
   void initState() {
     super.initState();
+    _localNotifications = widget.ref.read(localNotificationServiceProvider);
     _expanded = widget.initiallyExpanded;
     _bounceController = AnimationController(
       vsync: this,
@@ -784,7 +787,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     if (newAlerts.isNotEmpty) {
       unawaited(_bounceController.forward(from: 0));
       for (final w in newAlerts) {
-        _seenAlertWindowKeys.add(_tmuxAlertWindowKey(w));
+        final windowKey = _tmuxAlertWindowKey(w);
+        _seenAlertWindowKeys.add(windowKey);
+        _seenAlertWindowIndexesByKey[windowKey] = w.index;
         _sendAlertNotification(w, windows);
       }
     }
@@ -807,8 +812,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         )
         .toList(growable: false);
     for (final windowKey in clearedAlerts) {
-      _seenAlertWindowKeys.remove(windowKey);
       _clearAlertNotification(windowKey);
+      _seenAlertWindowKeys.remove(windowKey);
+      _seenAlertWindowIndexesByKey.remove(windowKey);
     }
 
     final nextPendingSelectedWindowIndex =
@@ -1119,8 +1125,70 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       ) &
       0x7fffffff;
 
+  int _legacyTmuxAlertNotificationId(
+    SshSession session,
+    String tmuxSessionName,
+    int windowIndex,
+  ) =>
+      Object.hash(
+        session.hostId,
+        session.connectionId,
+        tmuxSessionName,
+        windowIndex,
+      ) &
+      0x7fffffff;
+
+  Set<int> _tmuxAlertIndexNotificationIds(
+    SshSession session,
+    String tmuxSessionName,
+    int windowIndex,
+  ) => {
+    _legacyTmuxAlertNotificationId(session, tmuxSessionName, windowIndex),
+    _tmuxAlertNotificationId(
+      session,
+      tmuxSessionName,
+      _tmuxAlertIndexWindowKey(windowIndex),
+    ),
+  };
+
+  Set<int> _tmuxAlertNotificationIdsForWindowKey(
+    SshSession session,
+    String tmuxSessionName,
+    String windowKey,
+  ) {
+    final notificationIds = <int>{};
+    if (isValidTmuxWindowId(windowKey)) {
+      notificationIds.add(
+        _tmuxAlertNotificationId(session, tmuxSessionName, windowKey),
+      );
+    }
+    final legacyWindowIndex = _tmuxAlertLegacyWindowIndex(windowKey);
+    if (legacyWindowIndex != null) {
+      notificationIds.addAll(
+        _tmuxAlertIndexNotificationIds(
+          session,
+          tmuxSessionName,
+          legacyWindowIndex,
+        ),
+      );
+    }
+    return notificationIds;
+  }
+
+  int? _tmuxAlertLegacyWindowIndex(String windowKey) {
+    const legacyPrefix = 'index:';
+    if (windowKey.startsWith(legacyPrefix)) {
+      return int.tryParse(windowKey.substring(legacyPrefix.length));
+    }
+    return _seenAlertWindowIndexesByKey[windowKey];
+  }
+
+  String _tmuxAlertIndexWindowKey(int windowIndex) => 'index:$windowIndex';
+
   String _tmuxAlertWindowKey(TmuxWindow window) =>
-      window.id ?? 'index:${window.index}';
+      window.id != null && isValidTmuxWindowId(window.id!)
+      ? window.id!
+      : _tmuxAlertIndexWindowKey(window.index);
 
   void _sendAlertNotification(TmuxWindow window, List<TmuxWindow> windows) {
     final content = resolveTmuxAlertNotificationContent(
@@ -1128,41 +1196,50 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       window: window,
       windows: windows,
     );
-    unawaited(HapticFeedback.mediumImpact());
-    unawaited(
-      widget.ref
-          .read(localNotificationServiceProvider)
-          .showTmuxAlert(
-            notificationId: _tmuxAlertNotificationId(
-              widget.session,
-              widget.tmuxSessionName,
-              _tmuxAlertWindowKey(window),
-            ),
-            title: content.title,
-            body: content.body,
-            payload: TmuxAlertNotificationPayload(
-              hostId: widget.session.hostId,
-              connectionId: widget.session.connectionId,
-              tmuxSessionName: widget.tmuxSessionName,
-              windowIndex: window.index,
-              windowId: window.id,
-            ),
-          ),
+    final windowId = window.id;
+    final stableWindowId = windowId != null && isValidTmuxWindowId(windowId)
+        ? windowId
+        : null;
+    final session = widget.session;
+    final tmuxSessionName = widget.tmuxSessionName;
+    final windowIndex = window.index;
+    final notificationId = stableWindowId != null
+        ? _tmuxAlertNotificationId(session, tmuxSessionName, stableWindowId)
+        : _legacyTmuxAlertNotificationId(session, tmuxSessionName, windowIndex);
+    final obsoleteNotificationIds = _tmuxAlertIndexNotificationIds(
+      session,
+      tmuxSessionName,
+      windowIndex,
+    )..remove(notificationId);
+    final payload = TmuxAlertNotificationPayload(
+      hostId: session.hostId,
+      connectionId: session.connectionId,
+      tmuxSessionName: tmuxSessionName,
+      windowIndex: windowIndex,
+      windowId: stableWindowId,
     );
+    unawaited(HapticFeedback.mediumImpact());
+    unawaited(() async {
+      for (final obsoleteNotificationId in obsoleteNotificationIds) {
+        await _localNotifications.clearTmuxAlert(obsoleteNotificationId);
+      }
+      await _localNotifications.showTmuxAlert(
+        notificationId: notificationId,
+        title: content.title,
+        body: content.body,
+        payload: payload,
+      );
+    }());
   }
 
   void _clearAlertNotification(String windowKey) {
-    unawaited(
-      widget.ref
-          .read(localNotificationServiceProvider)
-          .clearTmuxAlert(
-            _tmuxAlertNotificationId(
-              widget.session,
-              widget.tmuxSessionName,
-              windowKey,
-            ),
-          ),
-    );
+    for (final notificationId in _tmuxAlertNotificationIdsForWindowKey(
+      widget.session,
+      widget.tmuxSessionName,
+      windowKey,
+    )) {
+      unawaited(_localNotifications.clearTmuxAlert(notificationId));
+    }
   }
 
   void _clearAlertNotificationFor(
@@ -1170,13 +1247,13 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     String tmuxSessionName,
     String windowKey,
   ) {
-    unawaited(
-      widget.ref
-          .read(localNotificationServiceProvider)
-          .clearTmuxAlert(
-            _tmuxAlertNotificationId(session, tmuxSessionName, windowKey),
-          ),
-    );
+    for (final notificationId in _tmuxAlertNotificationIdsForWindowKey(
+      session,
+      tmuxSessionName,
+      windowKey,
+    )) {
+      unawaited(_localNotifications.clearTmuxAlert(notificationId));
+    }
   }
 
   void _clearSeenAlertNotifications(
@@ -1187,6 +1264,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       _clearAlertNotificationFor(session, tmuxSessionName, windowKey);
     }
     _seenAlertWindowKeys.clear();
+    _seenAlertWindowIndexesByKey.clear();
   }
 
   void _onVerticalDragUpdate(DragUpdateDetails details) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -586,7 +586,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
 
   List<TmuxWindow>? _windows;
   AgentLaunchTool? _preferredLaunchTool;
-  final Set<int> _seenAlertWindows = <int>{};
+  final Set<String> _seenAlertWindowKeys = <String>{};
   late bool _expanded;
   bool _isLoading = true;
   bool _showSessions = false;
@@ -775,32 +775,39 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   void _applyWindows(List<TmuxWindow> windows) {
     // Detect new alerts that weren't in the previous window list.
     final newAlerts = windows.where(
-      (w) => w.hasAlert && !w.isActive && !_seenAlertWindows.contains(w.index),
+      (w) =>
+          w.hasAlert &&
+          !w.isActive &&
+          !_seenAlertWindowKeys.contains(_tmuxAlertWindowKey(w)),
     );
     if (newAlerts.isNotEmpty) {
       unawaited(_bounceController.forward(from: 0));
       for (final w in newAlerts) {
-        _seenAlertWindows.add(w.index);
+        _seenAlertWindowKeys.add(_tmuxAlertWindowKey(w));
         _sendAlertNotification(w, windows);
       }
     }
 
-    final activeAlerts = _seenAlertWindows
+    final activeAlerts = _seenAlertWindowKeys
         .where(
-          (idx) =>
-              windows.any((w) => w.index == idx && w.hasAlert && w.isActive),
+          (key) => windows.any(
+            (w) => _tmuxAlertWindowKey(w) == key && w.hasAlert && w.isActive,
+          ),
         )
         .toList(growable: false);
-    for (final windowIndex in activeAlerts) {
-      _clearAlertNotification(windowIndex);
+    for (final windowKey in activeAlerts) {
+      _clearAlertNotification(windowKey);
     }
 
-    final clearedAlerts = _seenAlertWindows
-        .where((idx) => !windows.any((w) => w.index == idx && w.hasAlert))
+    final clearedAlerts = _seenAlertWindowKeys
+        .where(
+          (key) =>
+              !windows.any((w) => _tmuxAlertWindowKey(w) == key && w.hasAlert),
+        )
         .toList(growable: false);
-    for (final windowIndex in clearedAlerts) {
-      _seenAlertWindows.remove(windowIndex);
-      _clearAlertNotification(windowIndex);
+    for (final windowKey in clearedAlerts) {
+      _seenAlertWindowKeys.remove(windowKey);
+      _clearAlertNotification(windowKey);
     }
 
     final nextPendingSelectedWindowIndex =
@@ -1101,15 +1108,18 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   int _tmuxAlertNotificationId(
     SshSession session,
     String tmuxSessionName,
-    int windowIndex,
+    String windowKey,
   ) =>
       Object.hash(
         session.hostId,
         session.connectionId,
         tmuxSessionName,
-        windowIndex,
+        windowKey,
       ) &
       0x7fffffff;
+
+  String _tmuxAlertWindowKey(TmuxWindow window) =>
+      window.id ?? 'index:${window.index}';
 
   void _sendAlertNotification(TmuxWindow window, List<TmuxWindow> windows) {
     final content = resolveTmuxAlertNotificationContent(
@@ -1125,7 +1135,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
             notificationId: _tmuxAlertNotificationId(
               widget.session,
               widget.tmuxSessionName,
-              window.index,
+              _tmuxAlertWindowKey(window),
             ),
             title: content.title,
             body: content.body,
@@ -1134,12 +1144,13 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
               connectionId: widget.session.connectionId,
               tmuxSessionName: widget.tmuxSessionName,
               windowIndex: window.index,
+              windowId: window.id,
             ),
           ),
     );
   }
 
-  void _clearAlertNotification(int windowIndex) {
+  void _clearAlertNotification(String windowKey) {
     unawaited(
       widget.ref
           .read(localNotificationServiceProvider)
@@ -1147,7 +1158,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
             _tmuxAlertNotificationId(
               widget.session,
               widget.tmuxSessionName,
-              windowIndex,
+              windowKey,
             ),
           ),
     );
@@ -1156,13 +1167,13 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   void _clearAlertNotificationFor(
     SshSession session,
     String tmuxSessionName,
-    int windowIndex,
+    String windowKey,
   ) {
     unawaited(
       widget.ref
           .read(localNotificationServiceProvider)
           .clearTmuxAlert(
-            _tmuxAlertNotificationId(session, tmuxSessionName, windowIndex),
+            _tmuxAlertNotificationId(session, tmuxSessionName, windowKey),
           ),
     );
   }
@@ -1171,10 +1182,10 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     SshSession session,
     String tmuxSessionName,
   ) {
-    for (final windowIndex in _seenAlertWindows) {
-      _clearAlertNotificationFor(session, tmuxSessionName, windowIndex);
+    for (final windowKey in _seenAlertWindowKeys) {
+      _clearAlertNotificationFor(session, tmuxSessionName, windowKey);
     }
-    _seenAlertWindows.clear();
+    _seenAlertWindowKeys.clear();
   }
 
   void _onVerticalDragUpdate(DragUpdateDetails details) {
@@ -3165,6 +3176,7 @@ class TerminalScreen extends ConsumerStatefulWidget {
     this.connectionId,
     this.initialTmuxSessionName,
     this.initialTmuxWindowIndex,
+    this.initialTmuxWindowId,
     this.initialTmuxWindowRequiresVisibleSession = false,
     this.initiallyExpandTmuxWindows = false,
     super.key,
@@ -3182,6 +3194,9 @@ class TerminalScreen extends ConsumerStatefulWidget {
   /// Optional tmux window to focus after opening the terminal.
   final int? initialTmuxWindowIndex;
 
+  /// Optional stable tmux window ID to focus after opening the terminal.
+  final String? initialTmuxWindowId;
+
   /// Whether focusing the initial tmux window must also make tmux visible.
   final bool initialTmuxWindowRequiresVisibleSession;
 
@@ -3197,10 +3212,12 @@ class _InitialTmuxWindowTarget {
     required this.sessionName,
     required this.windowIndex,
     required this.requiresVisibleSession,
+    this.windowId,
   });
 
   final String sessionName;
   final int windowIndex;
+  final String? windowId;
   final bool requiresVisibleSession;
 }
 
@@ -3505,6 +3522,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   ) {
     final sessionName = widget.initialTmuxSessionName?.trim();
     final windowIndex = widget.initialTmuxWindowIndex;
+    final windowId = widget.initialTmuxWindowId?.trim();
     if (sessionName == null ||
         sessionName.isEmpty ||
         windowIndex == null ||
@@ -3514,6 +3532,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     return _InitialTmuxWindowTarget(
       sessionName: sessionName,
       windowIndex: windowIndex,
+      windowId: windowId != null && isValidTmuxWindowId(windowId)
+          ? windowId
+          : null,
       requiresVisibleSession: widget.initialTmuxWindowRequiresVisibleSession,
     );
   }
@@ -4886,16 +4907,23 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     List<TmuxWindow> windows,
   ) async {
     final target = _pendingInitialTmuxWindowTarget;
-    if (target == null ||
-        target.sessionName != sessionName ||
-        !windows.any((window) => window.index == target.windowIndex)) {
+    if (target == null || target.sessionName != sessionName) {
+      return;
+    }
+    final targetWindow = target.windowId == null
+        ? windows
+              .where((window) => window.index == target.windowIndex)
+              .firstOrNull
+        : windows.where((window) => window.id == target.windowId).firstOrNull;
+    if (targetWindow == null) {
       return;
     }
     _pendingInitialTmuxWindowTarget = null;
     try {
       await _switchTmuxWindow(
         session,
-        target.windowIndex,
+        targetWindow.index,
+        windowId: target.windowId,
         forceVisibleTmux: target.requiresVisibleSession,
       );
     } on Exception catch (error) {
@@ -5213,19 +5241,32 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   Future<void> _switchTmuxWindow(
     SshSession session,
     int windowIndex, {
+    String? windowId,
     bool forceVisibleTmux = false,
   }) async {
     final sessionName = _tmuxSessionName;
     if (sessionName == null) return;
 
-    await ref
-        .read(tmuxServiceProvider)
-        .selectWindow(
-          session,
-          sessionName,
-          windowIndex,
-          extraFlags: _host?.tmuxExtraFlags,
-        );
+    final tmux = ref.read(tmuxServiceProvider);
+    final targetWindowId = windowId != null && isValidTmuxWindowId(windowId)
+        ? windowId
+        : null;
+    if (targetWindowId == null) {
+      await tmux.selectWindow(
+        session,
+        sessionName,
+        windowIndex,
+        extraFlags: _host?.tmuxExtraFlags,
+      );
+    } else {
+      await tmux.selectWindow(
+        session,
+        sessionName,
+        windowIndex,
+        windowId: targetWindowId,
+        extraFlags: _host?.tmuxExtraFlags,
+      );
+    }
 
     // Clear stale working directory — it will be refreshed from
     // OSC 7 or the next tmux query.

--- a/test/app/notification_navigation_test.dart
+++ b/test/app/notification_navigation_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:monkeyssh/app/notification_navigation.dart';
+import 'package:monkeyssh/domain/services/local_notification_service.dart';
+
+void main() {
+  testWidgets('tmux alert opens terminal above the connections screen', (
+    tester,
+  ) async {
+    final terminalLocations = <String>[];
+    final router = GoRouter(
+      initialLocation: '/settings',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => Scaffold(
+            body: Text('home:${state.uri.queryParameters['tab'] ?? 'hosts'}'),
+          ),
+        ),
+        GoRoute(
+          path: '/settings',
+          builder: (context, state) => const Scaffold(body: Text('settings')),
+        ),
+        GoRoute(
+          path: '/terminal/:hostId',
+          builder: (context, state) {
+            terminalLocations.add(state.uri.toString());
+            return Scaffold(
+              body: Text('terminal:${state.pathParameters['hostId']}'),
+            );
+          },
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    expect(find.text('settings'), findsOneWidget);
+
+    openTmuxAlertNotificationStack(
+      router: router,
+      payload: const TmuxAlertNotificationPayload(
+        hostId: 12,
+        connectionId: 34,
+        tmuxSessionName: 'work',
+        windowIndex: 5,
+        windowId: '@9',
+      ),
+      notificationTapId: 'tap-1',
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('terminal:12'), findsOneWidget);
+    expect(router.canPop(), isTrue);
+    expect(
+      terminalLocations.single,
+      '/terminal/12?connectionId=34&tmuxSession=work&tmuxWindow=5&tmuxWindowId=%409&notificationTap=tap-1',
+    );
+
+    router.pop();
+    await tester.pumpAndSettle();
+
+    expect(find.text('home:connections'), findsOneWidget);
+    expect(find.text('settings'), findsNothing);
+  });
+}

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -62,10 +62,13 @@ void main() {
         'Editing main.dart',
         '1712930000',
         'vim main.dart',
+        '',
+        '@8',
       ].join(sep);
       final window = TmuxWindow.fromTmuxFormat(line);
 
       expect(window.index, 0);
+      expect(window.id, '@8');
       expect(window.name, 'vim');
       expect(window.isActive, true);
       expect(window.currentCommand, 'vim');
@@ -82,6 +85,7 @@ void main() {
       final window = TmuxWindow.fromTmuxFormat(line);
 
       expect(window.index, 0);
+      expect(window.id, isNull);
       expect(window.name, 'vim');
       expect(window.displayTitle, 'Editing main.dart');
     });
@@ -411,8 +415,8 @@ void main() {
       'replaces an existing window snapshot and clears prior active state',
       () {
         const windows = <TmuxWindow>[
-          TmuxWindow(index: 0, name: 'first', isActive: true),
-          TmuxWindow(index: 1, name: 'second', isActive: false),
+          TmuxWindow(index: 0, id: '@1', name: 'first', isActive: true),
+          TmuxWindow(index: 1, id: '@2', name: 'second', isActive: false),
         ];
 
         final updated = applyTmuxWindowChangeEvent(
@@ -420,6 +424,7 @@ void main() {
           const TmuxWindowSnapshotEvent(
             TmuxWindow(
               index: 1,
+              id: '@2',
               name: 'second-renamed',
               isActive: true,
               paneTitle: 'editing',
@@ -433,6 +438,24 @@ void main() {
         expect(updated[1].paneTitle, 'editing');
       },
     );
+
+    test('matches snapshots by stable window ID when indexes changed', () {
+      const windows = <TmuxWindow>[
+        TmuxWindow(index: 1, id: '@7', name: 'agent', isActive: false),
+        TmuxWindow(index: 2, id: '@8', name: 'shell', isActive: true),
+      ];
+
+      final updated = applyTmuxWindowChangeEvent(
+        windows,
+        const TmuxWindowSnapshotEvent(
+          TmuxWindow(index: 3, id: '@7', name: 'agent', isActive: true),
+        ),
+      );
+
+      expect(updated, hasLength(2));
+      expect(updated.firstWhere((window) => window.id == '@7').index, 3);
+      expect(updated.firstWhere((window) => window.id == '@8').isActive, false);
+    });
 
     test('adds a new window snapshot in index order', () {
       const windows = <TmuxWindow>[

--- a/test/domain/services/local_notification_service_test.dart
+++ b/test/domain/services/local_notification_service_test.dart
@@ -10,6 +10,7 @@ void main() {
         connectionId: 34,
         tmuxSessionName: 'work',
         windowIndex: 5,
+        windowId: '@9',
       );
 
       expect(TmuxAlertNotificationPayload.decode(payload.encode()), payload);
@@ -25,25 +26,31 @@ void main() {
         ),
         isNull,
       );
+      expect(
+        TmuxAlertNotificationPayload.decode(
+          '{"type":"tmux-alert","version":1,"hostId":12,'
+          '"connectionId":34,"tmuxSessionName":"work","windowIndex":5,'
+          '"windowId":"not-a-window-id"}',
+        ),
+        isNull,
+      );
     });
   });
 
-  test(
-    'buildTmuxAlertTerminalLocation targets the source connection window',
-    () {
-      final location = buildTmuxAlertTerminalLocation(
-        const TmuxAlertNotificationPayload(
-          hostId: 12,
-          connectionId: 34,
-          tmuxSessionName: 'project main',
-          windowIndex: 5,
-        ),
-      );
+  test('buildTmuxAlertTerminalLocation targets the source connection window', () {
+    final location = buildTmuxAlertTerminalLocation(
+      const TmuxAlertNotificationPayload(
+        hostId: 12,
+        connectionId: 34,
+        tmuxSessionName: 'project main',
+        windowIndex: 5,
+        windowId: '@9',
+      ),
+    );
 
-      expect(
-        location,
-        '/terminal/12?connectionId=34&tmuxSession=project+main&tmuxWindow=5',
-      );
-    },
-  );
+    expect(
+      location,
+      '/terminal/12?connectionId=34&tmuxSession=project+main&tmuxWindow=5&tmuxWindowId=%409',
+    );
+  });
 }

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -87,7 +87,8 @@ void main() {
           '#{pane_current_command}$sep#{pane_current_path}$sep'
           '#{window_flags}$sep#{pane_title}$sep#{window_activity}$sep'
           '#{pane_start_command}$sep'
-          "#{@flutty_agent_tool}'",
+          '#{@flutty_agent_tool}$sep'
+          "#{window_id}'",
         );
       },
     );
@@ -201,6 +202,7 @@ void main() {
           '100',
           'bash',
           '',
+          '@4',
         ].join(sep);
         final execSession = _buildOpenExecSession(
           stdout: '$windowLine\n${_doneMarker()}',
@@ -224,6 +226,7 @@ void main() {
         expect(initial, hasLength(1));
         expect(cached, initial);
         expect(cached.single.name, 'shell');
+        expect(cached.single.id, '@4');
         verify(() => client.execute(any(), pty: any(named: 'pty'))).called(2);
       },
     );
@@ -245,6 +248,7 @@ void main() {
         '1712930000',
         'sleep 30',
         'gemini',
+        '@12',
       ].join(sep);
       final event = parseTmuxWindowChangeEventFromControlLine(
         '${r'%subscription-changed flutty-1-42 $1 @1 1 %1 : '}$snapshotValue',
@@ -259,6 +263,7 @@ void main() {
       expect(snapshot.window.paneTitle, 'custom-title');
       expect(snapshot.window.paneStartCommand, 'sleep 30');
       expect(snapshot.window.agentTool, AgentLaunchTool.geminiCli);
+      expect(snapshot.window.id, '@12');
     });
 
     test('normalizes the wrapped first control-mode line', () {
@@ -273,6 +278,7 @@ void main() {
         '1712930000',
         'sleep 30',
         '',
+        '@3',
       ].join(sep);
       final event = parseTmuxWindowChangeEventFromControlLine(
         '\u001bP1000p'
@@ -284,6 +290,7 @@ void main() {
       expect(event, isA<TmuxWindowSnapshotEvent>());
       final snapshot = event! as TmuxWindowSnapshotEvent;
       expect(snapshot.window.displayTitle, 'wrapped-title');
+      expect(snapshot.window.id, '@3');
     });
 
     test('returns null for other subscriptions', () {
@@ -785,6 +792,26 @@ void main() {
         ).called(1);
       },
     );
+
+    test('selectWindow targets stable window IDs when provided', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client);
+      const service = TmuxService();
+      final execSession = _buildOpenExecSession(stdout: _doneMarker());
+
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) async => execSession);
+
+      await service.selectWindow(session, 'main', 2, windowId: '@12');
+
+      verify(
+        () => client.execute(
+          any(that: contains("tmux -u select-window -t '@12'")),
+          pty: any(named: 'pty'),
+        ),
+      ).called(1);
+    });
 
     test(
       'killWindow waits for the done marker so failures can surface',

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -728,7 +728,10 @@ void main() {
         expect(find.textContaining(tmuxSessionName), findsOneWidget);
         expect(hasSessionCalls, greaterThanOrEqualTo(2));
       },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+      variant: const TargetPlatformVariant({
+        TargetPlatform.android,
+        TargetPlatform.iOS,
+      }),
     );
 
     testWidgets(
@@ -806,18 +809,28 @@ void main() {
         expect(find.byKey(const ValueKey('tmux-handle-bar')), findsNothing);
         expect(hasSessionCalls, greaterThanOrEqualTo(2));
       },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+      variant: const TargetPlatformVariant({
+        TargetPlatform.android,
+        TargetPlatform.iOS,
+      }),
     );
 
     testWidgets(
-      'initial tmux target selects the alerted window and can start expanded',
+      'initial tmux target selects stable window ID and can start expanded',
       (tester) async {
         final tmuxService = _MockTmuxService();
         const tmuxSessionName = 'alerts';
+        const staleTargetWindowIndex = 2;
         const targetWindowIndex = 3;
+        const targetWindowId = '@9';
         final windows = <TmuxWindow>[
-          const TmuxWindow(index: 1, name: 'shell', isActive: true),
-          const TmuxWindow(index: 3, name: 'agent', isActive: false),
+          const TmuxWindow(index: 1, id: '@8', name: 'shell', isActive: true),
+          const TmuxWindow(
+            index: targetWindowIndex,
+            id: targetWindowId,
+            name: 'agent',
+            isActive: false,
+          ),
         ];
         when(
           () => tmuxService.hasSessionOrThrow(session, tmuxSessionName),
@@ -830,6 +843,7 @@ void main() {
             session,
             tmuxSessionName,
             targetWindowIndex,
+            windowId: targetWindowId,
           ),
         ).thenAnswer((_) async {});
         when(
@@ -864,7 +878,8 @@ void main() {
                 hostId: host.id,
                 connectionId: session.connectionId,
                 initialTmuxSessionName: tmuxSessionName,
-                initialTmuxWindowIndex: targetWindowIndex,
+                initialTmuxWindowIndex: staleTargetWindowIndex,
+                initialTmuxWindowId: targetWindowId,
                 initiallyExpandTmuxWindows: true,
               ),
             ),
@@ -880,12 +895,16 @@ void main() {
             session,
             tmuxSessionName,
             targetWindowIndex,
+            windowId: targetWindowId,
           ),
         ).called(1);
         expect(find.text('shell'), findsOneWidget);
         expect(find.text('agent'), findsOneWidget);
       },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+      variant: const TargetPlatformVariant({
+        TargetPlatform.android,
+        TargetPlatform.iOS,
+      }),
     );
 
     testWidgets(
@@ -895,9 +914,15 @@ void main() {
         const tmuxSessionName = 'alerts';
         const tmuxExtraFlags = '-S /tmp/alerts.sock';
         const targetWindowIndex = 3;
+        const targetWindowId = '@9';
         final windows = <TmuxWindow>[
-          const TmuxWindow(index: 1, name: 'shell', isActive: true),
-          const TmuxWindow(index: 3, name: 'agent', isActive: false),
+          const TmuxWindow(index: 1, id: '@8', name: 'shell', isActive: true),
+          const TmuxWindow(
+            index: targetWindowIndex,
+            id: targetWindowId,
+            name: 'agent',
+            isActive: false,
+          ),
         ];
         final secondShellOpen = Completer<void>();
         var shellOpenCount = 0;
@@ -934,6 +959,7 @@ void main() {
             session,
             tmuxSessionName,
             targetWindowIndex,
+            windowId: targetWindowId,
             extraFlags: tmuxExtraFlags,
           ),
         ).thenAnswer((_) async {});
@@ -980,6 +1006,7 @@ void main() {
                 connectionId: session.connectionId,
                 initialTmuxSessionName: tmuxSessionName,
                 initialTmuxWindowIndex: targetWindowIndex,
+                initialTmuxWindowId: targetWindowId,
                 initialTmuxWindowRequiresVisibleSession: true,
               ),
             ),
@@ -999,6 +1026,7 @@ void main() {
             session,
             tmuxSessionName,
             targetWindowIndex,
+            windowId: targetWindowId,
             extraFlags: tmuxExtraFlags,
           ),
         ).called(1);
@@ -1033,7 +1061,10 @@ void main() {
         expect(shellWrites.map(utf8.decode).join(), contains(tmuxSessionName));
         expect(shellOpenCount, greaterThanOrEqualTo(2));
       },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+      variant: const TargetPlatformVariant({
+        TargetPlatform.android,
+        TargetPlatform.iOS,
+      }),
     );
 
     testWidgets(

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -21,6 +21,7 @@ import 'package:monkeyssh/domain/models/monetization.dart';
 import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/domain/services/agent_launch_preset_service.dart';
 import 'package:monkeyssh/domain/services/host_cli_launch_preferences_service.dart';
+import 'package:monkeyssh/domain/services/local_notification_service.dart';
 import 'package:monkeyssh/domain/services/monetization_service.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
@@ -58,6 +59,26 @@ class _FakeWakelockPlusPlatform extends WakelockPlusPlatformInterface {
 
   @override
   Future<bool> get enabled async => _enabled;
+}
+
+class _RecordingLocalNotificationService extends LocalNotificationService {
+  final shownNotificationIds = <int>[];
+  final clearedNotificationIds = <int>[];
+
+  @override
+  Future<void> showTmuxAlert({
+    required int notificationId,
+    required String title,
+    required String body,
+    required TmuxAlertNotificationPayload payload,
+  }) async {
+    shownNotificationIds.add(notificationId);
+  }
+
+  @override
+  Future<void> clearTmuxAlert(int notificationId) async {
+    clearedNotificationIds.add(notificationId);
+  }
 }
 
 class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
@@ -692,6 +713,206 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
     }
+
+    testWidgets(
+      'tmux alert notifications clear legacy index IDs when stable IDs exist',
+      (tester) async {
+        final tmuxService = _MockTmuxService();
+        final notificationService = _RecordingLocalNotificationService();
+        final windowEvents = StreamController<TmuxWindowChangeEvent>();
+        const tmuxSessionName = 'work';
+        const windowIndex = 1;
+        const windowId = '@9';
+        const indexOnlyWindowIndex = 2;
+        const initialWindows = <TmuxWindow>[
+          TmuxWindow(index: 0, id: '@8', name: 'shell', isActive: true),
+          TmuxWindow(
+            index: windowIndex,
+            id: windowId,
+            name: 'agent',
+            isActive: false,
+          ),
+          TmuxWindow(
+            index: indexOnlyWindowIndex,
+            name: 'logs',
+            isActive: false,
+          ),
+        ];
+        final legacyNotificationId =
+            Object.hash(
+              session.hostId,
+              session.connectionId,
+              tmuxSessionName,
+              windowIndex,
+            ) &
+            0x7fffffff;
+        final stableNotificationId =
+            Object.hash(
+              session.hostId,
+              session.connectionId,
+              tmuxSessionName,
+              windowId,
+            ) &
+            0x7fffffff;
+        final stringFallbackNotificationId =
+            Object.hash(
+              session.hostId,
+              session.connectionId,
+              tmuxSessionName,
+              'index:$windowIndex',
+            ) &
+            0x7fffffff;
+        final indexOnlyNotificationId =
+            Object.hash(
+              session.hostId,
+              session.connectionId,
+              tmuxSessionName,
+              indexOnlyWindowIndex,
+            ) &
+            0x7fffffff;
+        final indexOnlyStringFallbackNotificationId =
+            Object.hash(
+              session.hostId,
+              session.connectionId,
+              tmuxSessionName,
+              'index:$indexOnlyWindowIndex',
+            ) &
+            0x7fffffff;
+
+        addTearDown(windowEvents.close);
+        host = _buildHost(id: host.id, tmuxSessionName: tmuxSessionName);
+        when(
+          () => tmuxService.hasSessionOrThrow(session, tmuxSessionName),
+        ).thenAnswer((_) async => true);
+        when(
+          () => tmuxService.listWindows(session, tmuxSessionName),
+        ).thenAnswer((_) async => initialWindows);
+        when(
+          () => tmuxService.watchWindowChanges(session, tmuxSessionName),
+        ).thenAnswer((_) => windowEvents.stream);
+        when(
+          () => tmuxService.detectInstalledAgentTools(session),
+        ).thenAnswer((_) async => const <AgentLaunchTool>{});
+        when(
+          () => tmuxService.prefetchInstalledAgentTools(session),
+        ).thenAnswer((_) async {});
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+              tmuxServiceProvider.overrideWithValue(tmuxService),
+              localNotificationServiceProvider.overrideWithValue(
+                notificationService,
+              ),
+            ],
+            child: MaterialApp(
+              home: TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+                initialTmuxSessionName: tmuxSessionName,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(notificationService.shownNotificationIds, isEmpty);
+
+        windowEvents.add(
+          const TmuxWindowSnapshotEvent(
+            TmuxWindow(
+              index: windowIndex,
+              id: windowId,
+              name: 'agent',
+              isActive: false,
+              flags: '!',
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(notificationService.shownNotificationIds, [
+          stableNotificationId,
+        ]);
+        expect(notificationService.clearedNotificationIds, [
+          legacyNotificationId,
+          stringFallbackNotificationId,
+        ]);
+
+        windowEvents.add(
+          const TmuxWindowSnapshotEvent(
+            TmuxWindow(
+              index: indexOnlyWindowIndex,
+              name: 'logs',
+              isActive: false,
+              flags: '!',
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(notificationService.shownNotificationIds, [
+          stableNotificationId,
+          indexOnlyNotificationId,
+        ]);
+        expect(notificationService.clearedNotificationIds, [
+          legacyNotificationId,
+          stringFallbackNotificationId,
+          indexOnlyStringFallbackNotificationId,
+        ]);
+
+        windowEvents.add(
+          const TmuxWindowSnapshotEvent(
+            TmuxWindow(
+              index: windowIndex,
+              id: windowId,
+              name: 'agent',
+              isActive: true,
+              flags: '!',
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(
+          notificationService.clearedNotificationIds
+              .where((id) => id == stableNotificationId)
+              .length,
+          1,
+        );
+        expect(
+          notificationService.clearedNotificationIds
+              .where((id) => id == legacyNotificationId)
+              .length,
+          2,
+        );
+        expect(
+          notificationService.clearedNotificationIds
+              .where((id) => id == stringFallbackNotificationId)
+              .length,
+          2,
+        );
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
 
     testWidgets(
       'keeps a primed tmux bar visible after transient detection failure',


### PR DESCRIPTION
## Summary

- Use stable tmux `#{window_id}` values in window snapshots, alert notification payloads, terminal routes, and `select-window` targeting.
- Preserve window-index fallback compatibility for older notifications/routes while validating `@<digits>` IDs before using them.
- Open tmux alert notification taps with a real navigation stack: Home on the Connections tab, then the targeted terminal route, so Back returns to Connections.
- Add regression coverage for payload routing, tmux parsing/reconciliation, window selection, terminal initial target activation, notification back-stack behavior, and device-backed notification navigation.

## Validation

- `flutter analyze`
- `flutter test`
- `flutter test test/app/notification_navigation_test.dart test/presentation/screens/terminal_screen_test.dart --plain-name "tmux target"`
- `flutter drive --driver=test_driver/integration_test.dart --target=integration_test/tmux_notification_navigation_validation_test.dart -d emulator-5554 --flavor private`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer flutter drive --driver=test_driver/integration_test.dart --target=integration_test/tmux_notification_navigation_validation_test.dart -d 64373A13-11D3-4298-B8CA-00AC1C1F7344 --flavor production`
