### PR TITLE
fix: refresh tmux colors on theme change

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3628,6 +3628,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final refreshGeneration = ++_terminalThemeRefreshGeneration;
     final terminalViewState = _terminalViewKey.currentState;
     if (_isTmuxActive) {
+      terminalViewState?.refreshThemeColorReports(theme);
       terminalViewState?.refreshThemeModeReport(isDark: theme.isDark);
       unawaited(
         Future<void>.delayed(const Duration(milliseconds: 150), () {
@@ -3637,13 +3638,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
               session.terminalTheme?.id != theme.id) {
             return;
           }
-          _terminalViewKey.currentState?.refreshFocusReport();
+          _terminalViewKey.currentState?.refreshFocusReport(
+            forceTransition: true,
+          );
         }),
       );
       return;
     }
 
-    terminalViewState?.refreshFocusReport();
+    terminalViewState?.refreshFocusReport(forceTransition: true);
   }
 
   TerminalThemeData _resolveEffectiveTerminalTheme() {

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -545,16 +545,20 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
     }
   }
 
-  /// Re-sends a focus-gained report after terminal state changes.
+  /// Re-sends focus reports after terminal state changes.
   ///
   /// TUIs such as Codex re-query terminal colors after focus-gained events. The
   /// app can use this after a theme change so those TUIs refresh cached
   /// foreground/background colors without waiting for a real focus transition.
-  void refreshFocusReport() {
+  void refreshFocusReport({bool forceTransition = false}) {
     if (!widget.terminal.reportFocusMode) {
       return;
     }
-    widget.terminal.onOutput?.call(_terminalFocusInReport);
+    widget.terminal.onOutput?.call(
+      forceTransition
+          ? '$_terminalFocusOutReport$_terminalFocusInReport'
+          : _terminalFocusInReport,
+    );
   }
 
   /// Reports the current terminal theme mode to focus-aware terminal muxers.
@@ -562,6 +566,26 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
     widget.terminal.onOutput?.call(
       buildTerminalThemeModeReport(isDark: isDark),
     );
+  }
+
+  /// Reports the current terminal foreground/background colors to tmux.
+  void refreshThemeColorReports(TerminalThemeData theme) {
+    final reports = [
+      buildTerminalThemeOscResponse(
+        theme: theme,
+        code: '10',
+        args: const ['?'],
+      ),
+      buildTerminalThemeOscResponse(
+        theme: theme,
+        code: '11',
+        args: const ['?'],
+      ),
+    ].whereType<String>().join();
+    if (reports.isEmpty) {
+      return;
+    }
+    widget.terminal.onOutput?.call(reports);
   }
 
   /// Re-sends the current viewport dimensions to the attached terminal.

--- a/test/widget/monkey_terminal_view_resize_test.dart
+++ b/test/widget/monkey_terminal_view_resize_test.dart
@@ -310,6 +310,13 @@ void main() {
 
     expect(output, ['\x1b[I']);
 
+    output.clear();
+    tester
+        .state<MonkeyTerminalViewState>(find.byType(MonkeyTerminalView))
+        .refreshFocusReport(forceTransition: true);
+
+    expect(output, ['\x1b[O\x1b[I']);
+
     terminal.write('\x1b[?1004l');
     output.clear();
     tester
@@ -338,6 +345,27 @@ void main() {
     }
 
     expect(output, ['\x1b[?997;1n', '\x1b[?997;2n']);
+  });
+
+  testWidgets('refreshThemeColorReports sends foreground and background', (
+    tester,
+  ) async {
+    final output = <String>[];
+    final terminal = Terminal()..onOutput = output.add;
+
+    await tester.pumpWidget(
+      buildTerminal(terminal: terminal, size: const Size(320, 240)),
+    );
+
+    tester
+        .state<MonkeyTerminalViewState>(find.byType(MonkeyTerminalView))
+        .refreshThemeColorReports(
+          monkey_themes.TerminalThemes.defaultLightTheme,
+        );
+
+    expect(output, [
+      '\x1b]10;rgb:1f1f/2323/2828\x1b\\\x1b]11;rgb:ffff/ffff/ffff\x1b\\',
+    ]);
   });
 
   test('grayscale palette backgrounds follow the active theme surface', () {


### PR DESCRIPTION
## Summary

- Send refreshed OSC 10/11 foreground/background reports into tmux when a terminal theme changes, so existing tmux clients update cached default colors even when the new theme has the same dark/light mode.
- Force a focus-out/focus-in transition after theme changes so focus-aware TUIs re-query terminal colors instead of keeping stale text colors.
- Add widget tests for the new color report and focus transition behavior.

## Validation

- flutter analyze
- flutter test --reporter compact
