### PR TITLE
ci: upload PR Android builds to Internal App Sharing

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -346,6 +346,19 @@ jobs:
             --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE" \
             --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED"
 
+      - name: Build debug AAB for Internal App Sharing
+        if: inputs.upload-android-to-internal-app-sharing && inputs.deploy-android-to == 'none'
+        run: |
+          flutter build appbundle \
+            --flavor ${{ inputs.flavor }} \
+            --debug \
+            --no-tree-shake-icons \
+            --build-name=${{ inputs.build-name }} \
+            --build-number=${{ inputs.build-number }} \
+            --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
+            --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE" \
+            --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED"
+
       - name: Build debug APK
         if: inputs.deploy-android-to == 'none'
         run: |
@@ -499,8 +512,8 @@ jobs:
         run: |
           cd android
           PACKAGE_NAME="${{ inputs.flavor == 'private' && 'xyz.depollsoft.monkeyssh.private' || 'xyz.depollsoft.monkeyssh' }}"
-          APK_PATH="../build/app/outputs/flutter-apk/app-${{ inputs.flavor }}-debug.apk"
-          bundle exec fastlane internal_app_sharing package_name:"$PACKAGE_NAME" apk_path:"$APK_PATH"
+          AAB_PATH="../build/app/outputs/bundle/${{ inputs.flavor }}Debug/app-${{ inputs.flavor }}-debug.aab"
+          bundle exec fastlane internal_app_sharing package_name:"$PACKAGE_NAME" aab_path:"$AAB_PATH"
 
           INTERNAL_APP_SHARING_URL="$(tr -d '\r\n' < "$INTERNAL_APP_SHARING_URL_FILE")"
           if [ -z "$INTERNAL_APP_SHARING_URL" ]; then

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -70,11 +70,6 @@ on:
         type: boolean
         default: true
         description: 'Whether to derive and upload a universal Android APK artifact from the preview AAB when deploy-android-to == none'
-      upload-android-to-internal-app-sharing:
-        required: false
-        type: boolean
-        default: false
-        description: 'Whether to upload the Android preview APK to Play Internal App Sharing'
       build-ios-unsigned-ipa:
         required: false
         type: boolean
@@ -172,9 +167,6 @@ on:
       apk-artifact-id:
         description: 'Artifact ID of the uploaded APK'
         value: ${{ jobs.build-android.outputs.apk-artifact-id }}
-      android-internal-app-sharing-url:
-        description: 'Google Play Internal App Sharing URL for the uploaded Android preview'
-        value: ${{ jobs.build-android.outputs.internal-app-sharing-url }}
       android-source-sha:
         description: 'Git SHA used for Android build checkout'
         value: ${{ jobs.build-android.outputs.source-sha }}
@@ -204,7 +196,6 @@ jobs:
       FLUTTY_DIAGNOSTICS_ENABLED: ${{ inputs.enable-diagnostics || inputs.pr-number != '' }}
     outputs:
       apk-artifact-id: ${{ steps.upload-apk.outputs.artifact-id }}
-      internal-app-sharing-url: ${{ steps.upload-internal-app-sharing.outputs.url }}
       source-sha: ${{ steps.resolved-source-sha.outputs.value }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -352,7 +343,7 @@ jobs:
             --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED"
 
       - name: Build debug AAB for preview artifacts
-        if: (inputs.upload-android-to-internal-app-sharing || inputs.build-android-apk) && inputs.deploy-android-to == 'none' && !inputs.build-android-unsigned-aab
+        if: inputs.build-android-apk && inputs.deploy-android-to == 'none' && !inputs.build-android-unsigned-aab
         run: |
           flutter build appbundle \
             --flavor ${{ inputs.flavor }} \
@@ -366,7 +357,7 @@ jobs:
 
       - name: Prepare AAB for preview install artifacts
         id: preview-aab
-        if: (inputs.upload-android-to-internal-app-sharing || inputs.build-android-apk) && inputs.deploy-android-to == 'none'
+        if: inputs.build-android-apk && inputs.deploy-android-to == 'none'
         run: |
           set -euo pipefail
 
@@ -553,7 +544,7 @@ jobs:
           SCRIPT
 
       - name: Validate Play Store service account
-        if: (inputs.deploy-android-to != 'none' && inputs.run-android-deploy) || inputs.upload-android-to-internal-app-sharing
+        if: inputs.deploy-android-to != 'none' && inputs.run-android-deploy
         env:
           PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
         run: |
@@ -563,31 +554,11 @@ jobs:
           fi
 
       - name: Setup Ruby for Play deployment
-        if: (inputs.deploy-android-to != 'none' && inputs.run-android-deploy) || inputs.upload-android-to-internal-app-sharing
+        if: inputs.deploy-android-to != 'none' && inputs.run-android-deploy
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: '3.3'
           bundler-cache: true
-
-      - name: Upload Android Internal App Sharing artifact
-        id: upload-internal-app-sharing
-        if: inputs.upload-android-to-internal-app-sharing && inputs.deploy-android-to == 'none'
-        env:
-          PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
-          INTERNAL_APP_SHARING_URL_FILE: ${{ runner.temp }}/android-internal-app-sharing-url.txt
-          BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
-        run: |
-          cd android
-          PACKAGE_NAME="${{ inputs.flavor == 'private' && 'xyz.depollsoft.monkeyssh.private' || 'xyz.depollsoft.monkeyssh' }}"
-          AAB_PATH="${{ steps.preview-aab.outputs.path }}"
-          bundle exec fastlane internal_app_sharing package_name:"$PACKAGE_NAME" aab_path:"$AAB_PATH"
-
-          INTERNAL_APP_SHARING_URL="$(tr -d '\r\n' < "$INTERNAL_APP_SHARING_URL_FILE")"
-          if [ -z "$INTERNAL_APP_SHARING_URL" ]; then
-            echo "::error title=Missing Internal App Sharing URL::Fastlane completed without writing an Internal App Sharing URL."
-            exit 1
-          fi
-          echo "url=$INTERNAL_APP_SHARING_URL" >> "$GITHUB_OUTPUT"
 
       - name: Refresh Play Store icon metadata
         if: inputs.deploy-android-to != 'none' && inputs.run-android-deploy && inputs.sync-metadata

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -65,6 +65,11 @@ on:
         type: boolean
         default: false
         description: 'Whether to build an unsigned Android release bundle artifact'
+      upload-android-to-internal-app-sharing:
+        required: false
+        type: boolean
+        default: false
+        description: 'Whether to upload the Android preview APK to Play Internal App Sharing'
       build-ios-unsigned-ipa:
         required: false
         type: boolean
@@ -162,6 +167,9 @@ on:
       apk-artifact-id:
         description: 'Artifact ID of the uploaded APK'
         value: ${{ jobs.build-android.outputs.apk-artifact-id }}
+      android-internal-app-sharing-url:
+        description: 'Google Play Internal App Sharing URL for the uploaded Android preview'
+        value: ${{ jobs.build-android.outputs.internal-app-sharing-url }}
       android-source-sha:
         description: 'Git SHA used for Android build checkout'
         value: ${{ jobs.build-android.outputs.source-sha }}
@@ -191,6 +199,7 @@ jobs:
       FLUTTY_DIAGNOSTICS_ENABLED: ${{ inputs.enable-diagnostics || inputs.pr-number != '' }}
     outputs:
       apk-artifact-id: ${{ steps.upload-apk.outputs.artifact-id }}
+      internal-app-sharing-url: ${{ steps.upload-internal-app-sharing.outputs.url }}
       source-sha: ${{ steps.resolved-source-sha.outputs.value }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -463,12 +472,42 @@ jobs:
               print(f'Warning: failed to fetch PR commits: {e}', file=sys.stderr)
           SCRIPT
 
+      - name: Validate Play Store service account
+        if: (inputs.deploy-android-to != 'none' && inputs.run-android-deploy) || inputs.upload-android-to-internal-app-sharing
+        env:
+          PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -z "$PLAY_STORE_SERVICE_ACCOUNT_JSON" ]; then
+            echo "::error title=Missing Play Store service account::PLAY_STORE_SERVICE_ACCOUNT_JSON is required for Android Play uploads."
+            exit 1
+          fi
+
       - name: Setup Ruby for Play deployment
-        if: inputs.deploy-android-to != 'none' && inputs.run-android-deploy
+        if: (inputs.deploy-android-to != 'none' && inputs.run-android-deploy) || inputs.upload-android-to-internal-app-sharing
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: '3.3'
           bundler-cache: true
+
+      - name: Upload Android Internal App Sharing artifact
+        id: upload-internal-app-sharing
+        if: inputs.upload-android-to-internal-app-sharing && inputs.deploy-android-to == 'none'
+        env:
+          PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+          INTERNAL_APP_SHARING_URL_FILE: ${{ runner.temp }}/android-internal-app-sharing-url.txt
+          BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
+        run: |
+          cd android
+          PACKAGE_NAME="${{ inputs.flavor == 'private' && 'xyz.depollsoft.monkeyssh.private' || 'xyz.depollsoft.monkeyssh' }}"
+          APK_PATH="../build/app/outputs/flutter-apk/app-${{ inputs.flavor }}-debug.apk"
+          bundle exec fastlane internal_app_sharing package_name:"$PACKAGE_NAME" apk_path:"$APK_PATH"
+
+          INTERNAL_APP_SHARING_URL="$(tr -d '\r\n' < "$INTERNAL_APP_SHARING_URL_FILE")"
+          if [ -z "$INTERNAL_APP_SHARING_URL" ]; then
+            echo "::error title=Missing Internal App Sharing URL::Fastlane completed without writing an Internal App Sharing URL."
+            exit 1
+          fi
+          echo "url=$INTERNAL_APP_SHARING_URL" >> "$GITHUB_OUTPUT"
 
       - name: Refresh Play Store icon metadata
         if: inputs.deploy-android-to != 'none' && inputs.run-android-deploy && inputs.sync-metadata

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -69,7 +69,7 @@ on:
         required: false
         type: boolean
         default: true
-        description: 'Whether to derive and upload a debug Android APK artifact from the debug AAB when deploy-android-to == none'
+        description: 'Whether to derive and upload a universal Android APK artifact from the preview AAB when deploy-android-to == none'
       upload-android-to-internal-app-sharing:
         required: false
         type: boolean
@@ -352,7 +352,7 @@ jobs:
             --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED"
 
       - name: Build debug AAB for preview artifacts
-        if: (inputs.upload-android-to-internal-app-sharing || inputs.build-android-apk) && inputs.deploy-android-to == 'none'
+        if: (inputs.upload-android-to-internal-app-sharing || inputs.build-android-apk) && inputs.deploy-android-to == 'none' && !inputs.build-android-unsigned-aab
         run: |
           flutter build appbundle \
             --flavor ${{ inputs.flavor }} \
@@ -364,27 +364,13 @@ jobs:
             --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE" \
             --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED"
 
-      - name: Generate APK artifact from debug AAB
-        if: inputs.build-android-apk && inputs.deploy-android-to == 'none'
-        env:
-          BUNDLETOOL_VERSION: '1.18.3'
+      - name: Prepare AAB for preview install artifacts
+        id: preview-aab
+        if: (inputs.upload-android-to-internal-app-sharing || inputs.build-android-apk) && inputs.deploy-android-to == 'none'
         run: |
           set -euo pipefail
 
-          BUNDLETOOL_JAR="$RUNNER_TEMP/bundletool.jar"
-          AAB_PATH="build/app/outputs/bundle/${{ inputs.flavor }}Debug/app-${{ inputs.flavor }}-debug.aab"
-          APKS_PATH="$RUNNER_TEMP/app-${{ inputs.flavor }}-debug.apks"
-          APK_DIR="$RUNNER_TEMP/app-${{ inputs.flavor }}-debug-apks"
-          APK_PATH="build/app/outputs/flutter-apk/app-${{ inputs.flavor }}-debug.apk"
           DEBUG_KEYSTORE="$HOME/.android/debug.keystore"
-
-          curl \
-            --fail \
-            --location \
-            --retry 3 \
-            --output "$BUNDLETOOL_JAR" \
-            "https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar"
-
           if [ ! -f "$DEBUG_KEYSTORE" ]; then
             mkdir -p "$HOME/.android"
             keytool -genkeypair \
@@ -397,6 +383,46 @@ jobs:
               -validity 10000 \
               -dname "CN=Android Debug,O=Android,C=US"
           fi
+
+          if [ "${{ inputs.build-android-unsigned-aab }}" = "true" ]; then
+            UNSIGNED_AAB_PATH="build/app/outputs/bundle/${{ inputs.flavor }}Release/app-${{ inputs.flavor }}-release.aab"
+            PREVIEW_AAB_PATH="$RUNNER_TEMP/app-${{ inputs.flavor }}-release-preview-signed.aab"
+            jarsigner \
+              -sigalg SHA256withRSA \
+              -digestalg SHA-256 \
+              -keystore "$DEBUG_KEYSTORE" \
+              -storepass android \
+              -keypass android \
+              -signedjar "$PREVIEW_AAB_PATH" \
+              "$UNSIGNED_AAB_PATH" \
+              androiddebugkey
+            jarsigner -verify "$PREVIEW_AAB_PATH"
+          else
+            PREVIEW_AAB_PATH="$GITHUB_WORKSPACE/build/app/outputs/bundle/${{ inputs.flavor }}Debug/app-${{ inputs.flavor }}-debug.aab"
+          fi
+
+          echo "path=$PREVIEW_AAB_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Generate APK artifact from preview AAB
+        if: inputs.build-android-apk && inputs.deploy-android-to == 'none'
+        env:
+          BUNDLETOOL_VERSION: '1.18.3'
+        run: |
+          set -euo pipefail
+
+          BUNDLETOOL_JAR="$RUNNER_TEMP/bundletool.jar"
+          AAB_PATH="${{ steps.preview-aab.outputs.path }}"
+          APKS_PATH="$RUNNER_TEMP/app-${{ inputs.flavor }}-preview.apks"
+          APK_DIR="$RUNNER_TEMP/app-${{ inputs.flavor }}-preview-apks"
+          APK_PATH="build/app/outputs/flutter-apk/app-${{ inputs.flavor }}-preview.apk"
+          DEBUG_KEYSTORE="$HOME/.android/debug.keystore"
+
+          curl \
+            --fail \
+            --location \
+            --retry 3 \
+            --output "$BUNDLETOOL_JAR" \
+            "https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar"
 
           java -jar "$BUNDLETOOL_JAR" build-apks \
             --bundle="$AAB_PATH" \
@@ -477,7 +503,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: android-apk-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
-          path: build/app/outputs/flutter-apk/app-${{ inputs.flavor }}-debug.apk
+          path: build/app/outputs/flutter-apk/app-${{ inputs.flavor }}-preview.apk
 
       - name: Fetch PR commits
         if: inputs.pr-number != ''
@@ -553,7 +579,7 @@ jobs:
         run: |
           cd android
           PACKAGE_NAME="${{ inputs.flavor == 'private' && 'xyz.depollsoft.monkeyssh.private' || 'xyz.depollsoft.monkeyssh' }}"
-          AAB_PATH="../build/app/outputs/bundle/${{ inputs.flavor }}Debug/app-${{ inputs.flavor }}-debug.aab"
+          AAB_PATH="${{ steps.preview-aab.outputs.path }}"
           bundle exec fastlane internal_app_sharing package_name:"$PACKAGE_NAME" aab_path:"$AAB_PATH"
 
           INTERNAL_APP_SHARING_URL="$(tr -d '\r\n' < "$INTERNAL_APP_SHARING_URL_FILE")"

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -65,6 +65,11 @@ on:
         type: boolean
         default: false
         description: 'Whether to build an unsigned Android release bundle artifact'
+      build-android-apk:
+        required: false
+        type: boolean
+        default: true
+        description: 'Whether to derive and upload a debug Android APK artifact from the debug AAB when deploy-android-to == none'
       upload-android-to-internal-app-sharing:
         required: false
         type: boolean
@@ -346,8 +351,8 @@ jobs:
             --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE" \
             --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED"
 
-      - name: Build debug AAB for Internal App Sharing
-        if: inputs.upload-android-to-internal-app-sharing && inputs.deploy-android-to == 'none'
+      - name: Build debug AAB for preview artifacts
+        if: (inputs.upload-android-to-internal-app-sharing || inputs.build-android-apk) && inputs.deploy-android-to == 'none'
         run: |
           flutter build appbundle \
             --flavor ${{ inputs.flavor }} \
@@ -359,18 +364,54 @@ jobs:
             --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE" \
             --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED"
 
-      - name: Build debug APK
-        if: inputs.deploy-android-to == 'none'
+      - name: Generate APK artifact from debug AAB
+        if: inputs.build-android-apk && inputs.deploy-android-to == 'none'
+        env:
+          BUNDLETOOL_VERSION: '1.18.3'
         run: |
-          flutter build apk \
-            --flavor ${{ inputs.flavor }} \
-            --debug \
-            --no-tree-shake-icons \
-            --build-name=${{ inputs.build-name }} \
-            --build-number=${{ inputs.build-number }} \
-            --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
-            --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE" \
-            --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED"
+          set -euo pipefail
+
+          BUNDLETOOL_JAR="$RUNNER_TEMP/bundletool.jar"
+          AAB_PATH="build/app/outputs/bundle/${{ inputs.flavor }}Debug/app-${{ inputs.flavor }}-debug.aab"
+          APKS_PATH="$RUNNER_TEMP/app-${{ inputs.flavor }}-debug.apks"
+          APK_DIR="$RUNNER_TEMP/app-${{ inputs.flavor }}-debug-apks"
+          APK_PATH="build/app/outputs/flutter-apk/app-${{ inputs.flavor }}-debug.apk"
+          DEBUG_KEYSTORE="$HOME/.android/debug.keystore"
+
+          curl \
+            --fail \
+            --location \
+            --retry 3 \
+            --output "$BUNDLETOOL_JAR" \
+            "https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar"
+
+          if [ ! -f "$DEBUG_KEYSTORE" ]; then
+            mkdir -p "$HOME/.android"
+            keytool -genkeypair \
+              -keystore "$DEBUG_KEYSTORE" \
+              -storepass android \
+              -alias androiddebugkey \
+              -keypass android \
+              -keyalg RSA \
+              -keysize 2048 \
+              -validity 10000 \
+              -dname "CN=Android Debug,O=Android,C=US"
+          fi
+
+          java -jar "$BUNDLETOOL_JAR" build-apks \
+            --bundle="$AAB_PATH" \
+            --output="$APKS_PATH" \
+            --mode=universal \
+            --ks="$DEBUG_KEYSTORE" \
+            --ks-pass=pass:android \
+            --ks-key-alias=androiddebugkey \
+            --key-pass=pass:android \
+            --overwrite
+
+          rm -rf "$APK_DIR"
+          mkdir -p "$APK_DIR" "$(dirname "$APK_PATH")"
+          unzip -q "$APKS_PATH" universal.apk -d "$APK_DIR"
+          mv "$APK_DIR/universal.apk" "$APK_PATH"
 
       - name: Download reusable AAB artifact
         if: inputs.android-reuse-aab-artifact-name != ''
@@ -432,7 +473,7 @@ jobs:
 
       - name: Upload APK artifact
         id: upload-apk
-        if: inputs.deploy-android-to == 'none'
+        if: inputs.build-android-apk && inputs.deploy-android-to == 'none'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: android-apk-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}

--- a/.github/workflows/preview-internal-app-sharing.yml
+++ b/.github/workflows/preview-internal-app-sharing.yml
@@ -1,0 +1,246 @@
+name: PR Preview Internal App Sharing
+
+on:
+  workflow_run:
+    workflows: [PR Preview]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  upload-android:
+    name: Upload Android Internal App Sharing
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve preview artifacts
+        id: preview
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const workflowRun = context.payload.workflow_run;
+            const pullRequestSummary = workflowRun.pull_requests?.[0];
+
+            if (!pullRequestSummary) {
+              core.notice(`Workflow run ${workflowRun.id} is not associated with a pull request.`);
+              core.setOutput('should-upload', 'false');
+              return;
+            }
+
+            const {data: pullRequest} = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullRequestSummary.number,
+            });
+
+            if (pullRequest.head.repo?.full_name !== `${owner}/${repo}`) {
+              core.notice(
+                `Skipping Internal App Sharing upload for fork PR #${pullRequest.number}.`,
+              );
+              core.setOutput('should-upload', 'false');
+              return;
+            }
+
+            if (pullRequest.head.sha !== workflowRun.head_sha) {
+              core.notice(
+                `Skipping stale workflow run ${workflowRun.id}; PR #${pullRequest.number} now points at ${pullRequest.head.sha}.`,
+              );
+              core.setOutput('should-upload', 'false');
+              return;
+            }
+
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner,
+              repo,
+              run_id: workflowRun.id,
+              per_page: 100,
+            });
+            const aabArtifact = artifacts.find((artifact) =>
+              !artifact.expired && artifact.name.startsWith('android-unsigned-private-'),
+            );
+            const apkArtifact = artifacts.find((artifact) =>
+              !artifact.expired && artifact.name.startsWith('android-apk-private-'),
+            );
+
+            if (!aabArtifact) {
+              core.setFailed(
+                `No reusable Android AAB artifact was found on workflow run ${workflowRun.id}.`,
+              );
+              return;
+            }
+
+            core.setOutput('should-upload', 'true');
+            core.setOutput('pull-number', String(pullRequest.number));
+            core.setOutput('aab-artifact-name', aabArtifact.name);
+            core.setOutput('apk-artifact-id', apkArtifact ? String(apkArtifact.id) : '');
+            core.setOutput('preview-run-id', String(workflowRun.id));
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: steps.preview.outputs.should-upload == 'true'
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        if: steps.preview.outputs.should-upload == 'true'
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+        if: steps.preview.outputs.should-upload == 'true'
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Download preview AAB artifact
+        if: steps.preview.outputs.should-upload == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.preview.outputs.preview-run-id }}
+          name: ${{ steps.preview.outputs.aab-artifact-name }}
+          path: preview-aab
+
+      - name: Sign preview AAB for Internal App Sharing
+        id: signed-aab
+        if: steps.preview.outputs.should-upload == 'true'
+        run: |
+          set -euo pipefail
+
+          AAB_PATH="$(find preview-aab -maxdepth 1 -name '*.aab' -print -quit)"
+          if [ -z "$AAB_PATH" ]; then
+            echo "::error title=Missing preview AAB::The downloaded preview artifact did not contain an AAB."
+            exit 1
+          fi
+
+          DEBUG_KEYSTORE="$HOME/.android/debug.keystore"
+          if [ ! -f "$DEBUG_KEYSTORE" ]; then
+            mkdir -p "$HOME/.android"
+            keytool -genkeypair \
+              -keystore "$DEBUG_KEYSTORE" \
+              -storepass android \
+              -alias androiddebugkey \
+              -keypass android \
+              -keyalg RSA \
+              -keysize 2048 \
+              -validity 10000 \
+              -dname "CN=Android Debug,O=Android,C=US"
+          fi
+
+          SIGNED_AAB_PATH="$RUNNER_TEMP/$(basename "$AAB_PATH" .aab)-ias-signed.aab"
+          jarsigner \
+            -sigalg SHA256withRSA \
+            -digestalg SHA-256 \
+            -keystore "$DEBUG_KEYSTORE" \
+            -storepass android \
+            -keypass android \
+            -signedjar "$SIGNED_AAB_PATH" \
+            "$AAB_PATH" \
+            androiddebugkey
+          jarsigner -verify "$SIGNED_AAB_PATH"
+
+          echo "path=$SIGNED_AAB_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Android Internal App Sharing artifact
+        id: upload-internal-app-sharing
+        if: steps.preview.outputs.should-upload == 'true'
+        env:
+          PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+          INTERNAL_APP_SHARING_URL_FILE: ${{ runner.temp }}/android-internal-app-sharing-url.txt
+          BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
+        run: |
+          set -euo pipefail
+
+          if [ -z "$PLAY_STORE_SERVICE_ACCOUNT_JSON" ]; then
+            echo "::error title=Missing Play Store service account::PLAY_STORE_SERVICE_ACCOUNT_JSON is required for Android Play uploads."
+            exit 1
+          fi
+
+          cd android
+          bundle exec fastlane internal_app_sharing \
+            package_name:xyz.depollsoft.monkeyssh.private \
+            aab_path:"${{ steps.signed-aab.outputs.path }}"
+
+          if [ ! -f "$INTERNAL_APP_SHARING_URL_FILE" ]; then
+            echo "::error title=Missing Internal App Sharing URL file::Fastlane completed without creating the Internal App Sharing URL file."
+            exit 1
+          fi
+
+          INTERNAL_APP_SHARING_URL="$(tr -d '\r\n' < "$INTERNAL_APP_SHARING_URL_FILE")"
+          if [ -z "$INTERNAL_APP_SHARING_URL" ]; then
+            echo "::error title=Missing Internal App Sharing URL::Fastlane completed without writing an Internal App Sharing URL."
+            exit 1
+          fi
+
+          echo "url=$INTERNAL_APP_SHARING_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Add Internal App Sharing link to PR comment
+        if: steps.preview.outputs.should-upload == 'true' && steps.upload-internal-app-sharing.outputs.url != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INTERNAL_APP_SHARING_URL: ${{ steps.upload-internal-app-sharing.outputs.url }}
+          PREVIEW_RUN_ID: ${{ steps.preview.outputs.preview-run-id }}
+          PULL_NUMBER: ${{ steps.preview.outputs.pull-number }}
+          APK_ARTIFACT_ID: ${{ steps.preview.outputs.apk-artifact-id }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullNumber = Number(process.env.PULL_NUMBER);
+            const previewRunId = process.env.PREVIEW_RUN_ID;
+            const internalAppSharingUrl = process.env.INTERNAL_APP_SHARING_URL;
+            const apkArtifactId = process.env.APK_ARTIFACT_ID;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pullNumber,
+              per_page: 100,
+            });
+            const stickyMarker = '<!-- Sticky Pull Request Commentpreview-build -->';
+            const runMarker = `<!-- preview-build-run-id:${previewRunId} -->`;
+            const targets = comments.filter((comment) =>
+              comment.body?.includes(stickyMarker) && comment.body.includes(runMarker),
+            );
+
+            if (targets.length === 0) {
+              core.warning(
+                `No preview build comment for workflow run ${previewRunId} was found on PR #${pullNumber}.`,
+              );
+              return;
+            }
+
+            const links = [
+              `[Install via Internal App Sharing](${internalAppSharingUrl})`,
+            ];
+            if (apkArtifactId) {
+              links.push(
+                `[Download APK artifact](https://github.com/${owner}/${repo}/actions/runs/${previewRunId}/artifacts/${apkArtifactId})`,
+              );
+            }
+
+            const androidStatusRow = '| **Android Status** | ✅ Built |';
+            const androidInstallRow = `| 🤖 **Android** | ${links.join('<br>')} |`;
+
+            for (const comment of targets) {
+              let body = comment.body;
+              body = body.replace(/^\| \*\*Android Status\*\* \|.*\|$/m, androidStatusRow);
+              body = body.replace(/^\| 🤖 \*\*Android\*\* \|.*\|$/m, androidInstallRow);
+
+              if (body === comment.body) {
+                continue;
+              }
+
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: comment.id,
+                body,
+              });
+            }

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -147,9 +147,6 @@ jobs:
       build-ios: false
       build-android: true
       build-android-unsigned-aab: true
-      upload-android-to-internal-app-sharing: true
-    secrets:
-      PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
 
   build-ios:
     name: Build iOS Preview
@@ -188,20 +185,17 @@ jobs:
       - name: Resolve preview status
         id: preview-status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          ANDROID_INTERNAL_APP_SHARING_URL: ${{ needs.build-android.outputs.android-internal-app-sharing-url }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const runId = context.runId;
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
-            const androidInternalAppSharingUrl =
-              (process.env.ANDROID_INTERNAL_APP_SHARING_URL || '').trim();
             const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
               owner,
               repo,
               run_id: runId,
+              filter: 'latest',
               per_page: 100,
             });
             const statusFor = (job) => {
@@ -233,19 +227,15 @@ jobs:
               artifact.name.startsWith('android-apk-private-'),
             );
             let androidLink = `[View workflow run](${runUrl})`;
+            const androidLinks = [];
+            if (apkArtifact) {
+              androidLinks.push(`[Download APK artifact](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${apkArtifact.id})`);
+            }
+            if (androidLinks.length > 0) {
+              androidLink = androidLinks.join('<br>');
+            }
             if (androidJob && androidJob.status === 'completed') {
-              if (androidJob.conclusion === 'success') {
-                const androidLinks = [];
-                if (androidInternalAppSharingUrl) {
-                  androidLinks.push(`[Install via Internal App Sharing](${androidInternalAppSharingUrl})`);
-                }
-                if (apkArtifact) {
-                  androidLinks.push(`[Download APK artifact](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${apkArtifact.id})`);
-                }
-                if (androidLinks.length > 0) {
-                  androidLink = androidLinks.join('<br>');
-                }
-              } else if (androidJob.conclusion === 'skipped') {
+              if (androidJob.conclusion === 'skipped') {
                 androidLink = 'N/A (build skipped for fork PR)';
               }
             }
@@ -289,7 +279,7 @@ jobs:
   comment-ios:
     name: PR Comment (iOS)
     runs-on: ubuntu-latest
-    needs: [compute-version, build-android, build-ios]
+    needs: [compute-version, build-ios]
     if: always() && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       issues: write
@@ -299,20 +289,17 @@ jobs:
       - name: Resolve preview status
         id: preview-status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          ANDROID_INTERNAL_APP_SHARING_URL: ${{ needs.build-android.outputs.android-internal-app-sharing-url }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const runId = context.runId;
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
-            const androidInternalAppSharingUrl =
-              (process.env.ANDROID_INTERNAL_APP_SHARING_URL || '').trim();
             const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
               owner,
               repo,
               run_id: runId,
+              filter: 'latest',
               per_page: 100,
             });
             const statusFor = (job) => {
@@ -344,19 +331,15 @@ jobs:
               artifact.name.startsWith('android-apk-private-'),
             );
             let androidLink = `[View workflow run](${runUrl})`;
+            const androidLinks = [];
+            if (apkArtifact) {
+              androidLinks.push(`[Download APK artifact](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${apkArtifact.id})`);
+            }
+            if (androidLinks.length > 0) {
+              androidLink = androidLinks.join('<br>');
+            }
             if (androidJob && androidJob.status === 'completed') {
-              if (androidJob.conclusion === 'success') {
-                const androidLinks = [];
-                if (androidInternalAppSharingUrl) {
-                  androidLinks.push(`[Install via Internal App Sharing](${androidInternalAppSharingUrl})`);
-                }
-                if (apkArtifact) {
-                  androidLinks.push(`[Download APK artifact](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${apkArtifact.id})`);
-                }
-                if (androidLinks.length > 0) {
-                  androidLink = androidLinks.join('<br>');
-                }
-              } else if (androidJob.conclusion === 'skipped') {
+              if (androidJob.conclusion === 'skipped') {
                 androidLink = 'N/A (build skipped for fork PR)';
               }
             }

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -234,10 +234,17 @@ jobs:
             );
             let androidLink = `[View workflow run](${runUrl})`;
             if (androidJob && androidJob.status === 'completed') {
-              if (androidJob.conclusion === 'success' && androidInternalAppSharingUrl) {
-                androidLink = `[Install via Internal App Sharing](${androidInternalAppSharingUrl})`;
-              } else if (androidJob.conclusion === 'success' && apkArtifact) {
-                androidLink = `[Download APK artifact](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${apkArtifact.id})`;
+              if (androidJob.conclusion === 'success') {
+                const androidLinks = [];
+                if (androidInternalAppSharingUrl) {
+                  androidLinks.push(`[Install via Internal App Sharing](${androidInternalAppSharingUrl})`);
+                }
+                if (apkArtifact) {
+                  androidLinks.push(`[Download APK artifact](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${apkArtifact.id})`);
+                }
+                if (androidLinks.length > 0) {
+                  androidLink = androidLinks.join('<br>');
+                }
               } else if (androidJob.conclusion === 'skipped') {
                 androidLink = 'N/A (build skipped for fork PR)';
               }
@@ -338,10 +345,17 @@ jobs:
             );
             let androidLink = `[View workflow run](${runUrl})`;
             if (androidJob && androidJob.status === 'completed') {
-              if (androidJob.conclusion === 'success' && androidInternalAppSharingUrl) {
-                androidLink = `[Install via Internal App Sharing](${androidInternalAppSharingUrl})`;
-              } else if (androidJob.conclusion === 'success' && apkArtifact) {
-                androidLink = `[Download APK artifact](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${apkArtifact.id})`;
+              if (androidJob.conclusion === 'success') {
+                const androidLinks = [];
+                if (androidInternalAppSharingUrl) {
+                  androidLinks.push(`[Install via Internal App Sharing](${androidInternalAppSharingUrl})`);
+                }
+                if (apkArtifact) {
+                  androidLinks.push(`[Download APK artifact](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${apkArtifact.id})`);
+                }
+                if (androidLinks.length > 0) {
+                  androidLink = androidLinks.join('<br>');
+                }
               } else if (androidJob.conclusion === 'skipped') {
                 androidLink = 'N/A (build skipped for fork PR)';
               }

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -110,7 +110,7 @@ jobs:
             | Platform | Link |
             |----------|------|
             | 🍎 **iOS** | Available after a PR preview deploy |
-            | 🤖 **Android (APK)** | [View workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+            | 🤖 **Android** | [View workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
 
             ### Promote
             Comment `/deploy` on this PR to deploy the current PR head to TestFlight and the Play Store internal track. The deploy workflow reuses these unsigned preview intermediates when their build number is still deployable; otherwise it rebuilds with a newer build number before uploading.
@@ -147,6 +147,9 @@ jobs:
       build-ios: false
       build-android: true
       build-android-unsigned-aab: true
+      upload-android-to-internal-app-sharing: true
+    secrets:
+      PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
 
   build-ios:
     name: Build iOS Preview
@@ -185,12 +188,16 @@ jobs:
       - name: Resolve preview status
         id: preview-status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ANDROID_INTERNAL_APP_SHARING_URL: ${{ needs.build-android.outputs.android-internal-app-sharing-url }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const runId = context.runId;
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
+            const androidInternalAppSharingUrl =
+              (process.env.ANDROID_INTERNAL_APP_SHARING_URL || '').trim();
             const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
               owner,
               repo,
@@ -227,8 +234,10 @@ jobs:
             );
             let androidLink = `[View workflow run](${runUrl})`;
             if (androidJob && androidJob.status === 'completed') {
-              if (androidJob.conclusion === 'success' && apkArtifact) {
-                androidLink = `[Download APK](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${apkArtifact.id})`;
+              if (androidJob.conclusion === 'success' && androidInternalAppSharingUrl) {
+                androidLink = `[Install via Internal App Sharing](${androidInternalAppSharingUrl})`;
+              } else if (androidJob.conclusion === 'success' && apkArtifact) {
+                androidLink = `[Download APK artifact](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${apkArtifact.id})`;
               } else if (androidJob.conclusion === 'skipped') {
                 androidLink = 'N/A (build skipped for fork PR)';
               }
@@ -256,7 +265,7 @@ jobs:
             | Platform | Link |
             |----------|------|
             | 🍎 **iOS** | Available after a PR preview deploy |
-            | 🤖 **Android (APK)** | ${{ steps.preview-status.outputs.android-link }} |
+            | 🤖 **Android** | ${{ steps.preview-status.outputs.android-link }} |
 
             ### Promote
             Comment `/deploy` on this PR to deploy the current PR head to TestFlight and the Play Store internal track. The deploy workflow reuses these unsigned preview intermediates when their build number is still deployable; otherwise it rebuilds with a newer build number before uploading.
@@ -273,7 +282,7 @@ jobs:
   comment-ios:
     name: PR Comment (iOS)
     runs-on: ubuntu-latest
-    needs: [compute-version, build-ios]
+    needs: [compute-version, build-android, build-ios]
     if: always() && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       issues: write
@@ -283,12 +292,16 @@ jobs:
       - name: Resolve preview status
         id: preview-status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ANDROID_INTERNAL_APP_SHARING_URL: ${{ needs.build-android.outputs.android-internal-app-sharing-url }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const runId = context.runId;
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
+            const androidInternalAppSharingUrl =
+              (process.env.ANDROID_INTERNAL_APP_SHARING_URL || '').trim();
             const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
               owner,
               repo,
@@ -325,8 +338,10 @@ jobs:
             );
             let androidLink = `[View workflow run](${runUrl})`;
             if (androidJob && androidJob.status === 'completed') {
-              if (androidJob.conclusion === 'success' && apkArtifact) {
-                androidLink = `[Download APK](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${apkArtifact.id})`;
+              if (androidJob.conclusion === 'success' && androidInternalAppSharingUrl) {
+                androidLink = `[Install via Internal App Sharing](${androidInternalAppSharingUrl})`;
+              } else if (androidJob.conclusion === 'success' && apkArtifact) {
+                androidLink = `[Download APK artifact](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${apkArtifact.id})`;
               } else if (androidJob.conclusion === 'skipped') {
                 androidLink = 'N/A (build skipped for fork PR)';
               }
@@ -354,7 +369,7 @@ jobs:
             | Platform | Link |
             |----------|------|
             | 🍎 **iOS** | Available after a PR preview deploy |
-            | 🤖 **Android (APK)** | ${{ steps.preview-status.outputs.android-link }} |
+            | 🤖 **Android** | ${{ steps.preview-status.outputs.android-link }} |
 
             ### Promote
             Comment `/deploy` on this PR to deploy the current PR head to TestFlight and the Play Store internal track. The deploy workflow reuses these unsigned preview intermediates when their build number is still deployable; otherwise it rebuilds with a newer build number before uploading.

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -170,6 +170,11 @@ platform :android do
   desc 'Upload flavor APK/AAB to Play Store Internal App Sharing'
   lane :internal_app_sharing do |options|
     package = options[:package_name] || 'xyz.depollsoft.monkeyssh.private'
+    allowed_packages = METADATA_DIRS.keys.sort.join(', ')
+    unless METADATA_DIRS.key?(package)
+      UI.user_error!("Unsupported package_name '#{package}'. Expected one of: #{allowed_packages}")
+    end
+
     apk_path = options[:apk_path] || options[:apk]
     aab_path = options[:aab_path] || options[:aab]
     output_file = ENV['INTERNAL_APP_SHARING_URL_FILE']

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -167,6 +167,33 @@ platform :android do
     FileUtils.rm_rf(upload_metadata_path) if remove_metadata_path
   end
 
+  desc 'Upload flavor APK/AAB to Play Store Internal App Sharing'
+  lane :internal_app_sharing do |options|
+    package = options[:package_name] || 'xyz.depollsoft.monkeyssh.private'
+    apk_path = options[:apk_path] || options[:apk]
+    aab_path = options[:aab_path] || options[:aab]
+    output_file = ENV['INTERNAL_APP_SHARING_URL_FILE']
+    upload_options = {
+      package_name: package,
+      json_key_data: ENV['PLAY_STORE_SERVICE_ACCOUNT_JSON'],
+    }
+
+    if apk_path.to_s.empty? && aab_path.to_s.empty?
+      UI.user_error!('Provide apk_path/apk or aab_path/aab for Internal App Sharing upload')
+    elsif apk_path.to_s.empty?
+      upload_options[:aab] = aab_path
+    else
+      upload_options[:apk] = apk_path
+    end
+
+    urls = upload_to_play_store_internal_app_sharing(upload_options)
+    url = Array(urls).first.to_s
+    UI.user_error!('Internal App Sharing upload did not return a download URL') if url.empty?
+
+    File.write(output_file, "#{url}\n") unless output_file.to_s.empty?
+    UI.success("Internal App Sharing URL: #{url}")
+  end
+
   desc 'Upload production flavor AAB to Play Store production'
   lane :release do |options|
     skip_meta = options[:skip_metadata].to_s == 'true'


### PR DESCRIPTION
## Summary

- Upload PR preview Android APKs to Google Play Internal App Sharing
- Surface the returned install link in the sticky Preview Build PR comment
- Keep the GitHub APK artifact as a fallback link when no sharing URL is available

## Validation

- ruby -c android/fastlane/Fastfile
- ruby -e "require 'yaml'; %w[.github/workflows/preview.yml .github/workflows/build-deploy.yml].each { |p| YAML.load_file(p); puts \"#{p}: ok\" }"
- git diff --check