### PR TITLE
ci: upload raw mobile package artifacts

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -405,7 +405,7 @@ jobs:
           AAB_PATH="${{ steps.preview-aab.outputs.path }}"
           APKS_PATH="$RUNNER_TEMP/app-${{ inputs.flavor }}-preview.apks"
           APK_DIR="$RUNNER_TEMP/app-${{ inputs.flavor }}-preview-apks"
-          APK_PATH="build/app/outputs/flutter-apk/app-${{ inputs.flavor }}-preview.apk"
+          APK_PATH="build/app/outputs/flutter-apk/android-apk-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}.apk"
           DEBUG_KEYSTORE="$HOME/.android/debug.keystore"
 
           curl \
@@ -493,8 +493,8 @@ jobs:
         if: inputs.build-android-apk && inputs.deploy-android-to == 'none'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: android-apk-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
-          path: build/app/outputs/flutter-apk/app-${{ inputs.flavor }}-preview.apk
+          path: build/app/outputs/flutter-apk/android-apk-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}.apk
+          archive: false
 
       - name: Fetch PR commits
         if: inputs.pr-number != ''
@@ -773,7 +773,7 @@ jobs:
             if [ -d SwiftSupport ]; then
               ZIP_INPUTS+=(SwiftSupport)
             fi
-            zip -qry ../ipa/Runner-unsigned.ipa "${ZIP_INPUTS[@]}"
+            zip -qry "../ipa/ios-unsigned-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}.ipa" "${ZIP_INPUTS[@]}"
           )
 
       - name: Download reusable IPA artifact
@@ -883,19 +883,39 @@ jobs:
             bundle exec fastlane build_ipa scheme:"$SCHEME"
           fi
 
+      - name: Prepare signed IPA artifact
+        id: signed-ipa-artifact
+        if: inputs.deploy-ios-to != 'none' && inputs.ios-reuse-ipa-artifact-name == ''
+        run: |
+          set -euo pipefail
+
+          IPA_PATH=$(find build/ios/ipa -maxdepth 1 -name '*.ipa' -print -quit)
+          if [ -z "$IPA_PATH" ]; then
+            echo 'Expected a signed IPA under build/ios/ipa, but none was found.'
+            find build/ios/ipa -maxdepth 2 -print || true
+            exit 1
+          fi
+
+          ARTIFACT_PATH="build/ios/ipa/ios-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}.ipa"
+          if [ "$IPA_PATH" != "$ARTIFACT_PATH" ]; then
+            cp "$IPA_PATH" "$ARTIFACT_PATH"
+          fi
+
+          echo "path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
+
       - name: Upload signed IPA artifact
         if: inputs.deploy-ios-to != 'none' && inputs.ios-reuse-ipa-artifact-name == ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ios-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
-          path: build/ios/ipa/*.ipa
+          path: ${{ steps.signed-ipa-artifact.outputs.path }}
+          archive: false
 
       - name: Upload unsigned IPA artifact
         if: inputs.build-ios-unsigned-ipa && inputs.ios-reuse-ipa-artifact-name == '' && inputs.deploy-ios-to == 'none'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ios-unsigned-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
-          path: build/ios/ipa/Runner-unsigned.ipa
+          path: build/ios/ipa/ios-unsigned-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}.ipa
+          archive: false
 
   deploy-status-summary:
     name: Summarize Deploy Status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,9 +214,8 @@ jobs:
       - name: Upload APK
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: android-apk
           path: build/app/outputs/flutter-apk/app-production-release.apk
-          compression-level: 0
+          archive: false
           retention-days: 5
 
       - name: Clean up CI signing config

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -199,7 +199,7 @@ jobs:
             const requestedBuildNumber = (process.env.INPUT_BUILD_NUMBER || '').trim();
             const workflowIds = ['deploy-testflight.yml', 'develop.yml'];
             const markerArtifactPattern = /^private-deploy-build-number-(\d+)$/;
-            const legacyArtifactPattern = /^(?:android|ios)-private-.+-(\d+)$/;
+            const legacyArtifactPattern = /^(?:android|ios)-private-.+-(\d+)(?:\.(?:aab|apk|ipa))?$/;
             const maxDiscoveredBuildNumbersPerWorkflow = 20;
             const maxWorkflowRunPages = 3;
 
@@ -357,7 +357,7 @@ jobs:
             const workflowId = 'preview.yml';
             const requiredArtifactNames = [
               `android-unsigned-private-${buildName}-${buildNumber}`,
-              `ios-unsigned-private-${buildName}-${buildNumber}`,
+              `ios-unsigned-private-${buildName}-${buildNumber}.ipa`,
             ];
             const waitStatuses = new Set(['queued', 'in_progress', 'requested', 'waiting']);
             const maxWaitAttempts = 40;
@@ -668,7 +668,7 @@ jobs:
       android-reuse-aab-is-unsigned: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' }}
       android-reuse-source-sha: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.validate-pr.outputs.deploy-sha || '' }}
       ios-reuse-run-id: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.resolve-preview-artifacts.outputs.preview-run-id || '' }}
-      ios-reuse-ipa-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('ios-unsigned-{0}-{1}-{2}', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
+      ios-reuse-ipa-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('ios-unsigned-{0}-{1}-{2}.ipa', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
       ios-reuse-ipa-is-unsigned: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' }}
       ios-reuse-source-sha: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.validate-pr.outputs.deploy-sha || '' }}
       update-pr-deploy-comment: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Download iOS artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: ios-production-${{ needs.compute-version.outputs.build-name }}-${{ needs.compute-version.outputs.build-number }}
+          name: ios-production-${{ needs.compute-version.outputs.build-name }}-${{ needs.compute-version.outputs.build-number }}.ipa
           path: artifacts/ios
 
       - name: Generate release checksums


### PR DESCRIPTION
## Summary

- Upload APK and IPA workflow artifacts with `archive: false` so they are available as raw package files instead of artifact ZIP archives.
- Rename generated APK/IPA files to stable artifact filenames because raw uploads use the file basename as the artifact name.
- Update preview deploy reuse and release download references for the new raw IPA artifact filename.

## Validation

- Parsed all workflow YAML files with Ruby YAML.
- Ran `git diff --check`.
- Ran pre-commit checks.
