### PR TITLE
test: avoid private key fixture markers

### DIFF
--- a/test/data/repositories/decrypt_cost_characterization_test.dart
+++ b/test/data/repositories/decrypt_cost_characterization_test.dart
@@ -80,7 +80,7 @@ Future<void> _insertKeysWithSecrets(KeyRepository repo, int count) async {
         name: 'key-$i',
         keyType: 'ed25519',
         publicKey: 'ssh-ed25519 AAAA$i',
-        privateKey: '-----BEGIN OPENSSH PRIVATE KEY----- $i -----END-----',
+        privateKey: 'encrypted-key-payload-$i',
         passphrase: Value('passphrase-$i'),
       ),
     );
@@ -368,7 +368,7 @@ void main() {
         final repo = KeyRepository(db, enc);
         addTearDown(db.close);
 
-        const privateKey = '-----BEGIN OPENSSH PRIVATE KEY----- DATA';
+        const privateKey = 'encrypted-key-payload';
         const passphrase = 'key-passphrase';
         await repo.insert(
           SshKeysCompanion.insert(
@@ -455,7 +455,7 @@ void main() {
           name: 'No-passphrase key',
           keyType: 'ed25519',
           publicKey: 'ssh-ed25519 AAAA',
-          privateKey: '-----BEGIN OPENSSH PRIVATE KEY-----',
+          privateKey: 'encrypted-key-payload',
         ),
       );
 


### PR DESCRIPTION
## Summary

- Replaces PEM-like private key fixture markers in decrypt-cost tests with generic encrypted payload placeholders.
- Keeps the tests exercising private-key/passphrase repository behavior without looking like real key material to secret scanners.

## Validation

- `dart format test/data/repositories/decrypt_cost_characterization_test.dart`
- `flutter analyze test/data/repositories/decrypt_cost_characterization_test.dart`
- `flutter test test/data/repositories/decrypt_cost_characterization_test.dart`
