### PR TITLE
Create snippets from terminal selection

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -158,12 +158,18 @@ final routerProvider = Provider<GoRouter>((ref) {
       ),
       GoRoute(
         path: '/snippets/add',
-        name: 'snippet-add',
-        builder: (context, state) => const SnippetEditScreen(),
+        name: Routes.snippetAdd,
+        builder: (context, state) {
+          final extra = state.extra;
+          final prefill = extra is SnippetEditPrefill
+              ? extra
+              : const SnippetEditPrefill();
+          return SnippetEditScreen(prefill: prefill);
+        },
       ),
       GoRoute(
         path: '/snippets/edit/:snippetId',
-        name: 'snippet-edit',
+        name: Routes.snippetEdit,
         builder: (context, state) {
           final snippetId = int.tryParse(
             state.pathParameters['snippetId'] ?? '',

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -21,6 +21,12 @@ abstract final class Routes {
   /// Snippets route.
   static const snippets = 'snippets';
 
+  /// Add snippet route.
+  static const snippetAdd = 'snippet-add';
+
+  /// Edit snippet route.
+  static const snippetEdit = 'snippet-edit';
+
   /// Port forwards route.
   static const portForwards = 'port-forwards';
 

--- a/lib/data/repositories/snippet_repository.dart
+++ b/lib/data/repositories/snippet_repository.dart
@@ -139,9 +139,15 @@ class SnippetRepository {
   Future<bool> updateFolder(SnippetFolder folder) =>
       _db.update(_db.snippetFolders).replace(folder);
 
-  /// Delete a folder.
-  Future<int> deleteFolder(int id) =>
-      (_db.delete(_db.snippetFolders)..where((f) => f.id.equals(id))).go();
+  /// Delete a folder, moving its snippets back to No folder.
+  Future<int> deleteFolder(int id) => _db.transaction(() async {
+    await (_db.update(_db.snippets)..where((s) => s.folderId.equals(id))).write(
+      const SnippetsCompanion(folderId: Value<int?>(null)),
+    );
+    await (_db.update(_db.snippetFolders)..where((f) => f.parentId.equals(id)))
+        .write(const SnippetFoldersCompanion(parentId: Value<int?>(null)));
+    return (_db.delete(_db.snippetFolders)..where((f) => f.id.equals(id))).go();
+  });
 
   SimpleSelectStatement<$SnippetsTable, Snippet> _orderedSnippetsQuery() =>
       _db.select(_db.snippets)..orderBy([

--- a/lib/presentation/providers/entity_list_providers.dart
+++ b/lib/presentation/providers/entity_list_providers.dart
@@ -34,6 +34,12 @@ final allSnippetsProvider = StreamProvider<List<Snippet>>((ref) {
   return repo.watchAll();
 });
 
+/// Shared stream of all snippet folders for presentation screens.
+final allSnippetFoldersProvider = StreamProvider<List<SnippetFolder>>((ref) {
+  final repo = ref.watch(snippetRepositoryProvider);
+  return repo.watchAllFolders();
+});
+
 /// Shared stream of all port forwards for presentation screens.
 final allPortForwardsProvider = StreamProvider<List<PortForward>>((ref) {
   final repo = ref.watch(portForwardRepositoryProvider);
@@ -50,6 +56,7 @@ void invalidateImportedEntityProviders(ProviderInvalidator invalidate) {
   invalidate(allKeysProvider);
   invalidate(allGroupsProvider);
   invalidate(allSnippetsProvider);
+  invalidate(allSnippetFoldersProvider);
   invalidate(allPortForwardsProvider);
 }
 

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2338,6 +2338,43 @@ class _SnippetsPanelState extends ConsumerState<SnippetsPanel> {
     }
   }
 
+  Future<void> _showFolderContextMenu(
+    BuildContext context,
+    LongPressStartDetails details,
+    SnippetFolder folder,
+    int snippetCount,
+  ) async {
+    final overlay = Overlay.of(context).context.findRenderObject();
+    if (overlay is! RenderBox) {
+      return;
+    }
+
+    final menuPosition = overlay.globalToLocal(details.globalPosition);
+    final action = await showMenu<_SnippetFolderAction>(
+      context: context,
+      position: RelativeRect.fromRect(
+        Rect.fromLTWH(menuPosition.dx, menuPosition.dy, 0, 0),
+        Offset.zero & overlay.size,
+      ),
+      items: [
+        const PopupMenuItem<_SnippetFolderAction>(
+          value: _SnippetFolderAction.delete,
+          child: Row(
+            children: [
+              Icon(Icons.delete_outline),
+              SizedBox(width: 12),
+              Text('Delete folder'),
+            ],
+          ),
+        ),
+      ],
+    );
+
+    if (action == _SnippetFolderAction.delete && context.mounted) {
+      await _deleteFolder(context, folder, snippetCount);
+    }
+  }
+
   Future<void> _deleteFolder(
     BuildContext context,
     SnippetFolder folder,
@@ -2518,11 +2555,16 @@ class _SnippetsPanelState extends ConsumerState<SnippetsPanel> {
           for (final folder in folders) ...[
             const SizedBox(width: 8),
             Tooltip(
-              message: 'Long press to delete folder',
+              message: 'Long press for folder actions',
               child: GestureDetector(
                 behavior: HitTestBehavior.opaque,
-                onLongPress: () => unawaited(
-                  _deleteFolder(context, folder, folderCounts[folder.id] ?? 0),
+                onLongPressStart: (details) => unawaited(
+                  _showFolderContextMenu(
+                    context,
+                    details,
+                    folder,
+                    folderCounts[folder.id] ?? 0,
+                  ),
                 ),
                 child: FilterChip(
                   label: Text(
@@ -2606,6 +2648,8 @@ class _SnippetsPanelState extends ConsumerState<SnippetsPanel> {
     await ref.read(snippetRepositoryProvider).reorderByIds(reorderedIds);
   }
 }
+
+enum _SnippetFolderAction { delete }
 
 class _SnippetRow extends ConsumerWidget {
   const _SnippetRow({

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2338,6 +2338,78 @@ class _SnippetsPanelState extends ConsumerState<SnippetsPanel> {
     }
   }
 
+  Future<void> _deleteFolder(
+    BuildContext context,
+    SnippetFolder folder,
+    int snippetCount,
+  ) async {
+    final snippetLabel = snippetCount == 1
+        ? '1 snippet'
+        : '$snippetCount snippets';
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Delete "${folder.name}"?'),
+        content: Text(
+          snippetCount == 0
+              ? 'This folder will be removed.'
+              : '$snippetLabel will move to No folder.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if ((confirmed ?? false) == false || !context.mounted) {
+      return;
+    }
+
+    try {
+      final deleted = await ref
+          .read(snippetRepositoryProvider)
+          .deleteFolder(folder.id);
+      if (!context.mounted) {
+        return;
+      }
+      setState(() {
+        if (_selectedFolderId == folder.id) {
+          _selectedFolderId = null;
+          _showsUnfiledSnippets = snippetCount > 0;
+        }
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            deleted == 0
+                ? 'Folder "${folder.name}" was already deleted.'
+                : 'Deleted folder "${folder.name}"',
+          ),
+        ),
+      );
+    } on Exception catch (e, stackTrace) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: e,
+          stack: stackTrace,
+          library: 'snippets',
+          context: ErrorDescription('while deleting a snippet folder'),
+        ),
+      );
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not delete folder. Try again.')),
+        );
+      }
+    }
+  }
+
   Widget _buildSnippetsBody(
     BuildContext context,
     List<Snippet> snippets,
@@ -2445,13 +2517,25 @@ class _SnippetsPanelState extends ConsumerState<SnippetsPanel> {
           ],
           for (final folder in folders) ...[
             const SizedBox(width: 8),
-            FilterChip(
-              label: Text('${folder.name} (${folderCounts[folder.id] ?? 0})'),
-              selected: !_showsUnfiledSnippets && selectedFolderId == folder.id,
-              onSelected: (_) => setState(() {
-                _selectedFolderId = folder.id;
-                _showsUnfiledSnippets = false;
-              }),
+            Tooltip(
+              message: 'Long press to delete folder',
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onLongPress: () => unawaited(
+                  _deleteFolder(context, folder, folderCounts[folder.id] ?? 0),
+                ),
+                child: FilterChip(
+                  label: Text(
+                    '${folder.name} (${folderCounts[folder.id] ?? 0})',
+                  ),
+                  selected:
+                      !_showsUnfiledSnippets && selectedFolderId == folder.id,
+                  onSelected: (_) => setState(() {
+                    _selectedFolderId = folder.id;
+                    _showsUnfiledSnippets = false;
+                  }),
+                ),
+              ),
             ),
           ],
         ],

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -37,7 +37,9 @@ import '../widgets/connection_preview_snippet.dart';
 import '../widgets/file_picker_helpers.dart';
 import '../widgets/premium_access.dart';
 import '../widgets/reorder_helpers.dart';
+import '../widgets/snippet_folder_dialog.dart';
 import '../widgets/tmux_window_status_badge.dart';
+import 'snippet_edit_screen.dart';
 import 'transfer_screen.dart';
 
 const _redactStoreScreenshotIdentities = bool.fromEnvironment(
@@ -2214,15 +2216,27 @@ class _KeyRow extends ConsumerWidget {
 }
 
 /// Panel for displaying and managing snippets inline.
-class SnippetsPanel extends ConsumerWidget {
+class SnippetsPanel extends ConsumerStatefulWidget {
   /// Creates a [SnippetsPanel].
   const SnippetsPanel({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<SnippetsPanel> createState() => _SnippetsPanelState();
+}
+
+class _SnippetsPanelState extends ConsumerState<SnippetsPanel> {
+  int? _selectedFolderId;
+  bool _showsUnfiledSnippets = false;
+
+  bool get _showsAllSnippets =>
+      !_showsUnfiledSnippets && _selectedFolderId == null;
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final snippetsAsync = ref.watch(allSnippetsProvider);
+    final foldersAsync = ref.watch(allSnippetFoldersProvider);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -2245,9 +2259,15 @@ class SnippetsPanel extends ConsumerWidget {
               ),
               const Spacer(),
               _ActionButton(
+                icon: Icons.create_new_folder_outlined,
+                label: 'New Folder',
+                onTap: () => unawaited(_createFolder(context)),
+              ),
+              const SizedBox(width: 8),
+              _ActionButton(
                 icon: Icons.add,
                 label: 'Add Snippet',
-                onTap: () => context.push('/snippets/add'),
+                onTap: () => _addSnippet(context),
                 primary: true,
               ),
             ],
@@ -2261,63 +2281,241 @@ class SnippetsPanel extends ConsumerWidget {
                 const Center(child: CircularProgressIndicator(strokeWidth: 2)),
             error: (_, _) =>
                 const Center(child: Text('Could not load snippets.')),
-            data: (snippets) => snippets.isEmpty
-                ? _buildEmptyState(context, ref)
-                : _buildSnippetsList(context, ref, snippets),
+            data: (snippets) => foldersAsync.when(
+              loading: () => const Center(
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+              error: (_, _) =>
+                  const Center(child: Text('Could not load snippet folders.')),
+              data: (folders) => _buildSnippetsBody(context, snippets, folders),
+            ),
           ),
         ),
       ],
     );
   }
 
-  Widget _buildEmptyState(BuildContext context, WidgetRef ref) =>
+  void _addSnippet(BuildContext context) {
+    context.push(
+      '/snippets/add',
+      extra: SnippetEditPrefill(folderId: _selectedFolderId),
+    );
+  }
+
+  Future<void> _createFolder(BuildContext context) async {
+    final name = await showCreateSnippetFolderDialog(context);
+    if (name == null || !context.mounted) {
+      return;
+    }
+
+    try {
+      final folderId = await ref
+          .read(snippetRepositoryProvider)
+          .insertFolder(SnippetFoldersCompanion.insert(name: name));
+      if (!context.mounted) {
+        return;
+      }
+      setState(() {
+        _selectedFolderId = folderId;
+        _showsUnfiledSnippets = false;
+      });
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Created folder "$name"')));
+    } on Exception catch (e) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: e,
+          library: 'snippets',
+          context: ErrorDescription('while creating a snippet folder'),
+        ),
+      );
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not create folder. Try again.')),
+        );
+      }
+    }
+  }
+
+  Widget _buildSnippetsBody(
+    BuildContext context,
+    List<Snippet> snippets,
+    List<SnippetFolder> folders,
+  ) {
+    final folderIds = folders.map((folder) => folder.id).toSet();
+    final selectedFolderId = folderIds.contains(_selectedFolderId)
+        ? _selectedFolderId
+        : null;
+    SnippetFolder? selectedFolder;
+    for (final folder in folders) {
+      if (folder.id == selectedFolderId) {
+        selectedFolder = folder;
+        break;
+      }
+    }
+    final visibleSnippets = _visibleSnippets(
+      snippets,
+      selectedFolderId: selectedFolderId,
+    );
+    final folderNames = {for (final folder in folders) folder.id: folder.name};
+    final showsFolderFilters =
+        folders.isNotEmpty ||
+        snippets.any((snippet) => snippet.folderId == null);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (showsFolderFilters)
+          _buildFolderFilters(
+            snippets: snippets,
+            folders: folders,
+            selectedFolderId: selectedFolderId,
+          ),
+        Expanded(
+          child: visibleSnippets.isEmpty
+              ? _buildEmptyState(context, selectedFolder?.name)
+              : _buildSnippetsList(
+                  context,
+                  snippets,
+                  visibleSnippets,
+                  folderNames,
+                ),
+        ),
+      ],
+    );
+  }
+
+  List<Snippet> _visibleSnippets(
+    List<Snippet> snippets, {
+    required int? selectedFolderId,
+  }) {
+    if (_showsUnfiledSnippets) {
+      return snippets
+          .where((snippet) => snippet.folderId == null)
+          .toList(growable: false);
+    }
+    if (selectedFolderId == null) {
+      return snippets;
+    }
+    return snippets
+        .where((snippet) => snippet.folderId == selectedFolderId)
+        .toList(growable: false);
+  }
+
+  Widget _buildFolderFilters({
+    required List<Snippet> snippets,
+    required List<SnippetFolder> folders,
+    required int? selectedFolderId,
+  }) {
+    final unfiledCount = snippets
+        .where((snippet) => snippet.folderId == null)
+        .length;
+    final folderCounts = <int, int>{};
+    for (final snippet in snippets) {
+      final folderId = snippet.folderId;
+      if (folderId != null) {
+        folderCounts[folderId] = (folderCounts[folderId] ?? 0) + 1;
+      }
+    }
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Row(
+        children: [
+          FilterChip(
+            label: Text('All (${snippets.length})'),
+            selected: _showsAllSnippets,
+            onSelected: (_) => setState(() {
+              _selectedFolderId = null;
+              _showsUnfiledSnippets = false;
+            }),
+          ),
+          if (unfiledCount > 0 || _showsUnfiledSnippets) ...[
+            const SizedBox(width: 8),
+            FilterChip(
+              label: Text('No folder ($unfiledCount)'),
+              selected: _showsUnfiledSnippets,
+              onSelected: (_) => setState(() {
+                _selectedFolderId = null;
+                _showsUnfiledSnippets = true;
+              }),
+            ),
+          ],
+          for (final folder in folders) ...[
+            const SizedBox(width: 8),
+            FilterChip(
+              label: Text('${folder.name} (${folderCounts[folder.id] ?? 0})'),
+              selected: !_showsUnfiledSnippets && selectedFolderId == folder.id,
+              onSelected: (_) => setState(() {
+                _selectedFolderId = folder.id;
+                _showsUnfiledSnippets = false;
+              }),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context, String? selectedFolderName) =>
       FluttyTheme.buildEmptyState(
         context: context,
         icon: Icons.code_outlined,
-        title: 'No snippets yet',
-        subtitle:
-            'Save commands you run often. Try templates such as '
-            '`tail -f {{log_file}}`, `docker restart {{container}}`, or '
-            '`git pull && {{restart_command}}`.',
-        onAction: () => context.push('/snippets/add'),
+        title: selectedFolderName == null
+            ? 'No snippets yet'
+            : 'No snippets in $selectedFolderName',
+        subtitle: selectedFolderName == null
+            ? 'Save commands you run often. Try templates such as '
+                  '`tail -f {{log_file}}`, `docker restart {{container}}`, or '
+                  '`git pull && {{restart_command}}`.'
+            : 'Add a snippet to this folder or pick another folder above.',
+        onAction: () => _addSnippet(context),
         actionLabel: 'Add Snippet',
       );
 
   Widget _buildSnippetsList(
     BuildContext context,
-    WidgetRef ref,
-    List<Snippet> snippets,
+    List<Snippet> allSnippets,
+    List<Snippet> visibleSnippets,
+    Map<int, String> folderNames,
   ) => ReorderableListView.builder(
     padding: const EdgeInsets.symmetric(vertical: 4),
     buildDefaultDragHandles: false,
-    itemCount: snippets.length,
+    itemCount: visibleSnippets.length,
     onReorder: (oldIndex, newIndex) => unawaited(
       _reorderSnippets(
-        ref: ref,
-        snippets: snippets,
+        allSnippets: allSnippets,
+        visibleSnippets: visibleSnippets,
         oldIndex: oldIndex,
         newIndex: newIndex,
       ),
     ),
     itemBuilder: (context, index) {
-      final snippet = snippets[index];
+      final snippet = visibleSnippets[index];
       return _SnippetRow(
         key: ValueKey('home-snippet-${snippet.id}'),
         snippet: snippet,
+        folderName: _showsAllSnippets && snippet.folderId != null
+            ? folderNames[snippet.folderId]
+            : null,
         reorderHandle: ReorderGrip(index: index),
       );
     },
   );
 
   Future<void> _reorderSnippets({
-    required WidgetRef ref,
-    required List<Snippet> snippets,
+    required List<Snippet> allSnippets,
+    required List<Snippet> visibleSnippets,
     required int oldIndex,
     required int newIndex,
   }) async {
     final reorderedIds = reorderVisibleIdsInFullOrder(
-      allIds: snippets.map((snippet) => snippet.id).toList(growable: false),
-      visibleIds: snippets.map((snippet) => snippet.id).toList(growable: false),
+      allIds: allSnippets.map((snippet) => snippet.id).toList(growable: false),
+      visibleIds: visibleSnippets
+          .map((snippet) => snippet.id)
+          .toList(growable: false),
       oldIndex: oldIndex,
       newIndex: newIndex,
     );
@@ -2329,10 +2527,12 @@ class _SnippetRow extends ConsumerWidget {
   const _SnippetRow({
     required this.snippet,
     required this.reorderHandle,
+    this.folderName,
     super.key,
   });
 
   final Snippet snippet;
+  final String? folderName;
   final Widget reorderHandle;
 
   @override
@@ -2386,6 +2586,29 @@ class _SnippetRow extends ConsumerWidget {
                         color: colorScheme.onSurface.withAlpha(100),
                       ),
                     ),
+                    if (folderName case final folderName?) ...[
+                      const SizedBox(height: 4),
+                      Row(
+                        children: [
+                          Icon(
+                            Icons.folder_outlined,
+                            size: 12,
+                            color: colorScheme.onSurface.withAlpha(110),
+                          ),
+                          const SizedBox(width: 4),
+                          Flexible(
+                            child: Text(
+                              folderName,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.labelSmall?.copyWith(
+                                color: colorScheme.onSurface.withAlpha(120),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
                   ],
                 ),
               ),

--- a/lib/presentation/screens/snippet_edit_screen.dart
+++ b/lib/presentation/screens/snippet_edit_screen.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import '../../app/theme.dart';
 import '../../data/database/database.dart';
 import '../../data/repositories/snippet_repository.dart';
+import '../widgets/snippet_folder_dialog.dart';
 import '../widgets/unsaved_changes_guard.dart';
 
 typedef _SnippetEditDraft = ({
@@ -17,11 +18,18 @@ typedef _SnippetEditDraft = ({
   int? selectedFolderId,
 });
 
+const _createFolderDropdownValue = -1;
+
 /// Initial values used when creating a new snippet draft.
 @immutable
 class SnippetEditPrefill {
   /// Creates initial snippet editor values.
-  const SnippetEditPrefill({this.name, this.command, this.description});
+  const SnippetEditPrefill({
+    this.name,
+    this.command,
+    this.description,
+    this.folderId,
+  });
 
   /// Initial snippet name.
   final String? name;
@@ -31,6 +39,9 @@ class SnippetEditPrefill {
 
   /// Initial snippet description.
   final String? description;
+
+  /// Initial folder selection.
+  final int? folderId;
 }
 
 /// Screen for adding or editing a snippet.
@@ -61,6 +72,7 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
   bool _isLoading = false;
   Snippet? _existingSnippet;
   int? _selectedFolderId;
+  int _folderDropdownRevision = 0;
   List<SnippetFolder> _folders = [];
   _SnippetEditDraft? _initialDraft;
 
@@ -80,12 +92,16 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
     _nameController.text = prefill.name ?? '';
     _contentController.text = prefill.command ?? '';
     _descriptionController.text = prefill.description ?? '';
+    _selectedFolderId = prefill.folderId;
   }
 
   Future<void> _loadFolders() async {
     final folders = await ref.read(snippetRepositoryProvider).getAllFolders();
     if (mounted) {
-      setState(() => _folders = folders);
+      setState(() {
+        _folders = folders;
+        _folderDropdownRevision += 1;
+      });
     }
   }
 
@@ -171,6 +187,10 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
                     const SizedBox(height: 16),
 
                     DropdownButtonFormField<int?>(
+                      key: ValueKey(
+                        'snippet-folder-$_selectedFolderId-'
+                        '$_folderDropdownRevision-${_folders.length}',
+                      ),
                       initialValue:
                           _folders.any(
                             (folder) => folder.id == _selectedFolderId,
@@ -189,9 +209,12 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
                             child: Text(folder.name),
                           ),
                         ),
+                        const DropdownMenuItem<int?>(
+                          value: _createFolderDropdownValue,
+                          child: Text('Create folder...'),
+                        ),
                       ],
-                      onChanged: (value) =>
-                          setState(() => _selectedFolderId = value),
+                      onChanged: _handleFolderChanged,
                     ),
                     const SizedBox(height: 16),
 
@@ -250,6 +273,58 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
     description: _descriptionController.text,
     selectedFolderId: _selectedFolderId,
   );
+
+  void _handleFolderChanged(int? value) {
+    if (value == _createFolderDropdownValue) {
+      unawaited(_createFolderFromDropdown());
+      return;
+    }
+    setState(() => _selectedFolderId = value);
+  }
+
+  Future<void> _createFolderFromDropdown() async {
+    setState(() => _folderDropdownRevision += 1);
+    final name = await showCreateSnippetFolderDialog(context);
+    if (name == null || !mounted) {
+      if (mounted) {
+        setState(() => _folderDropdownRevision += 1);
+      }
+      return;
+    }
+
+    try {
+      final repo = ref.read(snippetRepositoryProvider);
+      final folderId = await repo.insertFolder(
+        SnippetFoldersCompanion.insert(name: name),
+      );
+      final folders = await repo.getAllFolders();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _folders = folders;
+        _selectedFolderId = folderId;
+        _folderDropdownRevision += 1;
+      });
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Created folder "$name"')));
+    } on Exception catch (e) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: e,
+          library: 'snippets',
+          context: ErrorDescription('while creating a snippet folder'),
+        ),
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not create folder. Try again.')),
+        );
+        setState(() => _folderDropdownRevision += 1);
+      }
+    }
+  }
 
   void _closeWithoutUnsavedPrompt(SnackBar snackBar) {
     final messenger = ScaffoldMessenger.of(context);

--- a/lib/presentation/screens/snippet_edit_screen.dart
+++ b/lib/presentation/screens/snippet_edit_screen.dart
@@ -17,13 +17,36 @@ typedef _SnippetEditDraft = ({
   int? selectedFolderId,
 });
 
+/// Initial values used when creating a new snippet draft.
+@immutable
+class SnippetEditPrefill {
+  /// Creates initial snippet editor values.
+  const SnippetEditPrefill({this.name, this.command, this.description});
+
+  /// Initial snippet name.
+  final String? name;
+
+  /// Initial command content.
+  final String? command;
+
+  /// Initial snippet description.
+  final String? description;
+}
+
 /// Screen for adding or editing a snippet.
 class SnippetEditScreen extends ConsumerStatefulWidget {
   /// Creates a new [SnippetEditScreen].
-  const SnippetEditScreen({this.snippetId, super.key});
+  const SnippetEditScreen({
+    this.snippetId,
+    this.prefill = const SnippetEditPrefill(),
+    super.key,
+  });
 
   /// The snippet ID to edit, or null for a new snippet.
   final int? snippetId;
+
+  /// Initial values for a new snippet draft.
+  final SnippetEditPrefill prefill;
 
   @override
   ConsumerState<SnippetEditScreen> createState() => _SnippetEditScreenState();
@@ -48,8 +71,15 @@ class _SnippetEditScreenState extends ConsumerState<SnippetEditScreen> {
     if (widget.snippetId != null) {
       unawaited(_loadSnippet());
     } else {
+      _applyPrefill(widget.prefill);
       _initialDraft = _currentDraft();
     }
+  }
+
+  void _applyPrefill(SnippetEditPrefill prefill) {
+    _nameController.text = prefill.name ?? '';
+    _contentController.text = prefill.command ?? '';
+    _descriptionController.text = prefill.description ?? '';
   }
 
   Future<void> _loadFolders() async {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -58,6 +58,7 @@ import '../widgets/terminal_text_style.dart';
 import '../widgets/terminal_theme_picker.dart';
 import '../widgets/tmux_window_navigator.dart';
 import '../widgets/tmux_window_status_badge.dart';
+import 'snippet_edit_screen.dart';
 
 part '../widgets/tmux_expandable_bar.dart';
 
@@ -489,6 +490,7 @@ const _terminalPathTouchVerticalPadding = 8.0;
 const _terminalSelectionNearbySearchColumns = 4;
 const _recentLocalClipboardProtection = Duration(seconds: 5);
 const _maxTerminalFilePathVerificationCandidates = 12;
+const _terminalSelectionSnippetNameMaxLength = 60;
 const _terminalFilePathVerificationExtensions = <String>[
   'properties',
   'gradle',
@@ -1878,6 +1880,87 @@ List<ContextMenuButtonItem> buildNativeSelectionContextMenuButtonItems({
   return buttonItems;
 }
 
+/// Builds terminal selection context menu items with terminal-aware callbacks.
+@visibleForTesting
+List<ContextMenuButtonItem> buildTerminalSelectionContextMenuButtonItems({
+  required List<ContextMenuButtonItem> defaultItems,
+  required VoidCallback onCopy,
+  required VoidCallback onLookUp,
+  required VoidCallback onSearchWeb,
+  required VoidCallback onShare,
+  required VoidCallback? onCreateSnippet,
+  required VoidCallback onPaste,
+}) {
+  var hasCopy = false;
+  var addedCreateSnippet = false;
+  final buttonItems = <ContextMenuButtonItem>[];
+
+  void addCreateSnippet() {
+    if (onCreateSnippet == null || addedCreateSnippet) {
+      return;
+    }
+    addedCreateSnippet = true;
+    buttonItems.add(
+      ContextMenuButtonItem(
+        label: 'Create Snippet',
+        onPressed: onCreateSnippet,
+      ),
+    );
+  }
+
+  for (final item in defaultItems) {
+    switch (item.type) {
+      case ContextMenuButtonType.copy:
+        hasCopy = true;
+        buttonItems.add(item.copyWith(onPressed: onCopy));
+        addCreateSnippet();
+      case ContextMenuButtonType.lookUp:
+        buttonItems.add(item.copyWith(onPressed: onLookUp));
+      case ContextMenuButtonType.searchWeb:
+        buttonItems.add(item.copyWith(onPressed: onSearchWeb));
+      case ContextMenuButtonType.share:
+        buttonItems.add(item.copyWith(onPressed: onShare));
+      case ContextMenuButtonType.selectAll:
+      case ContextMenuButtonType.cut:
+      case ContextMenuButtonType.delete:
+        continue;
+      case ContextMenuButtonType.paste:
+        continue;
+      default:
+        buttonItems.add(item);
+    }
+  }
+  if (!hasCopy) {
+    buttonItems.insert(
+      0,
+      ContextMenuButtonItem(
+        onPressed: onCopy,
+        type: ContextMenuButtonType.copy,
+      ),
+    );
+    if (onCreateSnippet != null) {
+      buttonItems.insert(
+        1,
+        ContextMenuButtonItem(
+          label: 'Create Snippet',
+          onPressed: onCreateSnippet,
+        ),
+      );
+      addedCreateSnippet = true;
+    }
+  }
+  if (!addedCreateSnippet) {
+    addCreateSnippet();
+  }
+  buttonItems.add(
+    ContextMenuButtonItem(
+      onPressed: onPaste,
+      type: ContextMenuButtonType.paste,
+    ),
+  );
+  return buttonItems;
+}
+
 /// Builds a menu callback that lets the action read selection before hiding.
 @visibleForTesting
 VoidCallback buildTerminalSelectionContextMenuAction({
@@ -1890,6 +1973,22 @@ VoidCallback buildTerminalSelectionContextMenuAction({
     hideToolbar();
   }
 };
+
+/// Builds an editable snippet name from selected terminal text.
+@visibleForTesting
+String buildSnippetNameFromTerminalSelection(String text) {
+  for (final line in text.split('\n')) {
+    final candidate = line.trim();
+    if (candidate.isEmpty) {
+      continue;
+    }
+    if (candidate.length <= _terminalSelectionSnippetNameMaxLength) {
+      return candidate;
+    }
+    return '${candidate.substring(0, _terminalSelectionSnippetNameMaxLength - 3)}...';
+  }
+  return 'Terminal selection';
+}
 
 /// Whether a polled remote clipboard value should replace the local clipboard.
 @visibleForTesting
@@ -5949,6 +6048,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                     ],
                   ),
                 ),
+                if (_currentTerminalSelectionText() != null)
+                  const PopupMenuItem(
+                    value: 'create_snippet',
+                    child: Row(
+                      children: [
+                        Icon(Icons.code_rounded, size: 20),
+                        SizedBox(width: 12),
+                        Text('Create Snippet'),
+                      ],
+                    ),
+                  ),
                 const PopupMenuItem(
                   value: 'paste',
                   child: Row(
@@ -6630,122 +6740,48 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     SelectableRegionState selectableRegionState,
   ) {
     final selectionText = _currentTerminalSelectionText();
-    var hasCopy = false;
-    final buttonItems = <ContextMenuButtonItem>[];
-    for (final item in selectableRegionState.contextMenuButtonItems) {
-      switch (item.type) {
-        case ContextMenuButtonType.copy:
-          hasCopy = true;
-          buttonItems.add(
-            item.copyWith(
-              onPressed: buildTerminalSelectionContextMenuAction(
-                action: () {
-                  final text = selectionText;
-                  if (text == null) {
-                    return;
-                  }
-                  unawaited(
-                    _copySelectionText(
-                      text,
-                      clearTerminalSelection: true,
-                      restoreFocus: true,
-                    ),
-                  );
-                },
-                hideToolbar: selectableRegionState.hideToolbar,
-              ),
-            ),
-          );
-        case ContextMenuButtonType.lookUp:
-          buttonItems.add(
-            item.copyWith(
-              onPressed: buildTerminalSelectionContextMenuAction(
-                action: () {
-                  final text = selectionText;
-                  if (text == null) {
-                    return;
-                  }
-                  unawaited(_lookUpTerminalSelectionText(text));
-                },
-                hideToolbar: selectableRegionState.hideToolbar,
-              ),
-            ),
-          );
-        case ContextMenuButtonType.searchWeb:
-          buttonItems.add(
-            item.copyWith(
-              onPressed: buildTerminalSelectionContextMenuAction(
-                action: () {
-                  final text = selectionText;
-                  if (text == null) {
-                    return;
-                  }
-                  unawaited(_searchWebForTerminalSelectionText(text));
-                },
-                hideToolbar: selectableRegionState.hideToolbar,
-              ),
-            ),
-          );
-        case ContextMenuButtonType.share:
-          buttonItems.add(
-            item.copyWith(
-              onPressed: buildTerminalSelectionContextMenuAction(
-                action: () {
-                  final text = selectionText;
-                  if (text == null) {
-                    return;
-                  }
-                  unawaited(_shareTerminalSelectionText(text));
-                },
-                hideToolbar: selectableRegionState.hideToolbar,
-              ),
-            ),
-          );
-        case ContextMenuButtonType.selectAll:
-        case ContextMenuButtonType.cut:
-        case ContextMenuButtonType.delete:
-          // Drop items that have no meaningful action against the
-          // terminal's xterm-managed selection.
-          continue;
-        case ContextMenuButtonType.paste:
-          // Replaced below with our terminal-aware paste handler.
-          continue;
-        default:
-          buttonItems.add(item);
-      }
-    }
-    if (!hasCopy) {
-      buttonItems.insert(
-        0,
-        ContextMenuButtonItem(
-          onPressed: buildTerminalSelectionContextMenuAction(
-            action: () {
-              final text = selectionText;
-              if (text == null) {
-                return;
-              }
-              unawaited(
-                _copySelectionText(
-                  text,
-                  clearTerminalSelection: true,
-                  restoreFocus: true,
-                ),
-              );
-            },
-            hideToolbar: selectableRegionState.hideToolbar,
+    VoidCallback selectionAction(void Function(String text) action) =>
+        buildTerminalSelectionContextMenuAction(
+          action: () {
+            final text = selectionText;
+            if (text == null) {
+              return;
+            }
+            action(text);
+          },
+          hideToolbar: selectableRegionState.hideToolbar,
+        );
+
+    final buttonItems = buildTerminalSelectionContextMenuButtonItems(
+      defaultItems: selectableRegionState.contextMenuButtonItems,
+      onCopy: selectionAction(
+        (text) => unawaited(
+          _copySelectionText(
+            text,
+            clearTerminalSelection: true,
+            restoreFocus: true,
           ),
-          type: ContextMenuButtonType.copy,
         ),
-      );
-    }
-    buttonItems.add(
-      ContextMenuButtonItem(
-        onPressed: () {
-          selectableRegionState.hideToolbar();
-          unawaited(_pasteClipboard());
-        },
-        type: ContextMenuButtonType.paste,
       ),
+      onLookUp: selectionAction(
+        (text) => unawaited(_lookUpTerminalSelectionText(text)),
+      ),
+      onSearchWeb: selectionAction(
+        (text) => unawaited(_searchWebForTerminalSelectionText(text)),
+      ),
+      onShare: selectionAction(
+        (text) => unawaited(_shareTerminalSelectionText(text)),
+      ),
+      onCreateSnippet: selectionText == null
+          ? null
+          : selectionAction(
+              (text) =>
+                  unawaited(_createSnippetFromTerminalSelectionText(text)),
+            ),
+      onPaste: () {
+        selectableRegionState.hideToolbar();
+        unawaited(_pasteClipboard());
+      },
     );
     return AdaptiveTextSelectionToolbar.buttonItems(
       anchors: selectableRegionState.contextMenuAnchors,
@@ -6845,6 +6881,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         break;
       case 'copy':
         await _copySelection();
+        break;
+      case 'create_snippet':
+        await _createSnippetFromSelection();
         break;
       case 'paste':
         await _pasteClipboard();
@@ -8387,6 +8426,45 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       clearTerminalSelection: !_isNativeSelectionMode,
       restoreFocus: !_isNativeSelectionMode,
     );
+  }
+
+  Future<void> _createSnippetFromSelection() async {
+    final text = _currentTerminalSelectionText();
+    if (text == null) {
+      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+      return;
+    }
+
+    await _createSnippetFromTerminalSelectionText(text);
+  }
+
+  Future<void> _createSnippetFromTerminalSelectionText(String text) async {
+    final command = text.trimRight();
+    if (command.isEmpty) {
+      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+      return;
+    }
+
+    if (_isNativeSelectionMode) {
+      if (_isMobilePlatform) {
+        _dismissNativeSelectionOverlayForEditing();
+      } else {
+        _exitNativeSelectionMode();
+      }
+    } else {
+      _terminalController.clearSelection();
+    }
+
+    await context.pushNamed<void>(
+      Routes.snippetAdd,
+      extra: SnippetEditPrefill(
+        name: buildSnippetNameFromTerminalSelection(command),
+        command: command,
+      ),
+    );
+    if (mounted) {
+      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+    }
   }
 
   Future<void> _copySelectionText(

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2213,6 +2213,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _showKeyboardToolbar = !_hideStoreScreenshotKeyboardToolbar;
   bool _isUsingAltBuffer = false;
   bool _terminalReportsMouseWheel = false;
+  List<KeyboardToolbarSnippet> _keyboardToolbarSnippets =
+      const <KeyboardToolbarSnippet>[];
+  List<KeyboardToolbarSnippetFolder> _keyboardToolbarSnippetFolders =
+      const <KeyboardToolbarSnippetFolder>[];
   bool _isNativeSelectionMode = false;
   bool _revealsNativeSelectionOverlayInTouchScrollMode = false;
   bool _isSyncingNativeScroll = false;
@@ -2586,6 +2590,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _terminal.addListener(_onTerminalStateChanged);
     _terminalController.addListener(_onSelectionChanged);
     _terminalFocusNode = FocusNode();
+    unawaited(_refreshKeyboardToolbarSnippetMenu());
     // Defer connection to avoid modifying provider state during widget build
     Future.microtask(_loadHostAndConnect);
   }
@@ -6129,8 +6134,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                     terminal: _terminal,
                     onKeyPressed: _handleKeyboardToolbarKeyPressed,
                     onPasteRequested: _pasteClipboard,
+                    onPasteMenuOpened: _refreshKeyboardToolbarSnippetMenu,
+                    onSnippetPasteRequested: _pasteKeyboardToolbarSnippet,
                     onPasteImageRequested: _pastePickedImage,
                     onPasteFilesRequested: _pastePickedFiles,
+                    snippets: _keyboardToolbarSnippets,
+                    snippetFolders: _keyboardToolbarSnippetFolders,
                     terminalFocusNode: _terminalFocusNode,
                   ),
               ],
@@ -9337,6 +9346,74 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           'This text inserted from your keyboard could execute multiple or reshaped commands.',
       confirmLabel: 'Insert anyway',
     );
+  }
+
+  Future<void> _refreshKeyboardToolbarSnippetMenu() async {
+    final snippetRepo = ref.read(snippetRepositoryProvider);
+    final snippets = await snippetRepo.getAll();
+    final folders = await snippetRepo.getAllFolders();
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _keyboardToolbarSnippets = [
+        for (final snippet in snippets)
+          KeyboardToolbarSnippet(
+            id: snippet.id,
+            name: snippet.name,
+            command: snippet.command,
+            folderId: snippet.folderId,
+          ),
+      ];
+      _keyboardToolbarSnippetFolders = [
+        for (final folder in folders)
+          KeyboardToolbarSnippetFolder(id: folder.id, name: folder.name),
+      ];
+    });
+  }
+
+  Future<void> _pasteKeyboardToolbarSnippet(
+    KeyboardToolbarSnippet selectedSnippet,
+  ) async {
+    final snippetRepo = ref.read(snippetRepositoryProvider);
+    final snippet = await snippetRepo.getById(selectedSnippet.id);
+    if (!mounted) {
+      return;
+    }
+    if (snippet == null) {
+      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+      _showClipboardMessage('Snippet is no longer available.');
+      return;
+    }
+
+    final substitution = await _substituteVariables(context, snippet);
+    _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+    if (substitution == null || substitution.command.isEmpty) {
+      return;
+    }
+
+    final shouldInsert = await _confirmTerminalInsertionIfNeeded(
+      insertedText: substitution.command,
+      buildReview: (commandText) => assessSnippetCommandInsertion(
+        commandText,
+        hadVariableSubstitution: substitution.hadVariableSubstitution,
+      ),
+      title: 'Review snippet command',
+      messageBuilder: (_) =>
+          'Confirm the rendered command before inserting it.',
+      confirmLabel: 'Insert command',
+    );
+    if (!shouldInsert) {
+      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+      return;
+    }
+
+    _followLiveOutput();
+    _terminal.paste(substitution.command);
+    _terminalController.clearSelection();
+    _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+    unawaited(snippetRepo.incrementUsage(snippet.id));
   }
 
   /// Shows snippet picker and inserts selected snippet into terminal.

--- a/lib/presentation/widgets/keyboard_toolbar.dart
+++ b/lib/presentation/widgets/keyboard_toolbar.dart
@@ -179,6 +179,43 @@ class KeyboardToolbarController extends ChangeNotifier {
   }
 }
 
+/// Snippet option shown in the keyboard toolbar paste menu.
+@immutable
+class KeyboardToolbarSnippet {
+  /// Creates a [KeyboardToolbarSnippet].
+  const KeyboardToolbarSnippet({
+    required this.id,
+    required this.name,
+    required this.command,
+    this.folderId,
+  });
+
+  /// Persistent snippet ID.
+  final int id;
+
+  /// User-visible snippet name.
+  final String name;
+
+  /// Command text inserted when the snippet is selected.
+  final String command;
+
+  /// Folder containing this snippet, or null for a top-level snippet.
+  final int? folderId;
+}
+
+/// Snippet folder option shown in the keyboard toolbar paste menu.
+@immutable
+class KeyboardToolbarSnippetFolder {
+  /// Creates a [KeyboardToolbarSnippetFolder].
+  const KeyboardToolbarSnippetFolder({required this.id, required this.name});
+
+  /// Persistent folder ID.
+  final int id;
+
+  /// User-visible folder name.
+  final String name;
+}
+
 /// Compact keyboard toolbar for terminal input.
 ///
 /// Features:
@@ -193,8 +230,12 @@ class KeyboardToolbar extends StatefulWidget {
     this.controller,
     this.onKeyPressed,
     this.onPasteRequested,
+    this.onPasteMenuOpened,
+    this.onSnippetPasteRequested,
     this.onPasteImageRequested,
     this.onPasteFilesRequested,
+    this.snippets = const <KeyboardToolbarSnippet>[],
+    this.snippetFolders = const <KeyboardToolbarSnippetFolder>[],
     this.terminalFocusNode,
     super.key,
   });
@@ -211,11 +252,24 @@ class KeyboardToolbar extends StatefulWidget {
   /// Optional callback when the Paste key is tapped.
   final FutureOr<void> Function()? onPasteRequested;
 
+  /// Optional callback when the Paste key's long-press menu opens.
+  final FutureOr<void> Function()? onPasteMenuOpened;
+
+  /// Optional callback when a snippet is selected from the Paste menu.
+  final FutureOr<void> Function(KeyboardToolbarSnippet snippet)?
+  onSnippetPasteRequested;
+
   /// Optional callback when the Paste key's long-press image option is tapped.
   final FutureOr<void> Function()? onPasteImageRequested;
 
   /// Optional callback when the Paste key's long-press file option is tapped.
   final FutureOr<void> Function()? onPasteFilesRequested;
+
+  /// Snippets available in the Paste menu.
+  final List<KeyboardToolbarSnippet> snippets;
+
+  /// Snippet folders available in the Paste menu.
+  final List<KeyboardToolbarSnippetFolder> snippetFolders;
 
   /// Optional focus node for the terminal. When provided, the toolbar
   /// re-requests focus after interactions so the soft keyboard stays visible.
@@ -227,8 +281,10 @@ class KeyboardToolbar extends StatefulWidget {
 
 /// State for [KeyboardToolbar].
 class KeyboardToolbarState extends State<KeyboardToolbar> {
-  static const _pasteOptionsWidth = 220.0;
+  static const _pasteOptionsWidth = 200.0;
+  static const _pasteSnippetMenuWidth = 180.0;
   static const _pasteOptionHeight = 44.0;
+  static const _pasteOptionsDividerHeight = 1.0;
   static const _pasteOptionsGap = 8.0;
   static const _pasteOptionsScreenMargin = 8.0;
 
@@ -236,6 +292,8 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
   final _pasteButtonKey = GlobalKey();
   OverlayEntry? _pasteOptionsOverlay;
   _PasteToolbarAction? _highlightedPasteAction;
+  KeyboardToolbarSnippetFolder? _highlightedSnippetFolder;
+  KeyboardToolbarSnippet? _highlightedSnippet;
 
   KeyboardToolbarController get _controller =>
       widget.controller ?? _fallbackController;
@@ -255,6 +313,10 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
     if (!identical(previousController, nextController)) {
       previousController.removeListener(_handleControllerChanged);
       nextController.addListener(_handleControllerChanged);
+    }
+    if (!identical(oldWidget.snippets, widget.snippets) ||
+        !identical(oldWidget.snippetFolders, widget.snippetFolders)) {
+      _pasteOptionsOverlay?.markNeedsBuild();
     }
   }
 
@@ -511,6 +573,10 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
     widget.onKeyPressed?.call();
     _consumeOneShot();
     _showPasteOptionsMenu(details.globalPosition);
+    final onPasteMenuOpened = widget.onPasteMenuOpened;
+    if (onPasteMenuOpened != null) {
+      unawaited(Future<void>.sync(onPasteMenuOpened));
+    }
   }
 
   void _showPasteOptionsMenu(Offset globalPosition) {
@@ -528,7 +594,7 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
     final topLeft = overlayBox.globalToLocal(buttonRect.topLeft);
     final bottomRight = overlayBox.globalToLocal(buttonRect.bottomRight);
     final targetRect = Rect.fromPoints(topLeft, bottomRight);
-    final menuHeight = _PasteToolbarAction.values.length * _pasteOptionHeight;
+    final menuHeight = _pasteOptionsMenuHeight;
     final left = _clampDouble(
       targetRect.right - _pasteOptionsWidth,
       _pasteOptionsScreenMargin,
@@ -540,23 +606,69 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
       overlaySize.height - menuHeight - _pasteOptionsScreenMargin,
     );
     _hidePasteOptionsMenu();
-    _highlightedPasteAction = _pasteActionAtGlobalPosition(
+    final hit = _pasteMenuHitAtGlobalPosition(
       globalPosition,
       menuOrigin: overlayBox.localToGlobal(Offset(left, top)),
     );
-    _pasteOptionsOverlay = OverlayEntry(
-      builder: (context) => Positioned(
-        left: left,
-        top: top,
-        width: _pasteOptionsWidth,
-        child: _PasteOptionsMenu(
-          highlightedAction: _highlightedPasteAction,
-          imageEnabled: widget.onPasteImageRequested != null,
-          filesEnabled: widget.onPasteFilesRequested != null,
-        ),
-      ),
-    );
+    _applyPasteMenuHit(hit);
+    _pasteOptionsOverlay = OverlayEntry(builder: _buildPasteOptionsOverlay);
     overlay.insert(_pasteOptionsOverlay!);
+  }
+
+  Widget _buildPasteOptionsOverlay(BuildContext context) {
+    final overlayBox = Overlay.of(context).context.findRenderObject();
+    if (overlayBox is! RenderBox) {
+      return const SizedBox.shrink();
+    }
+    final layout = _pasteMenuLayout(overlayBox.size);
+    if (layout == null) {
+      return const SizedBox.shrink();
+    }
+
+    final snippetEntries = _snippetMenuEntries;
+    final highlightedFolder = _highlightedSnippetFolder;
+    final folderSnippets = highlightedFolder == null
+        ? const <KeyboardToolbarSnippet>[]
+        : _snippetsInFolder(highlightedFolder.id);
+    final showSnippetMenu =
+        _highlightedPasteAction == _PasteToolbarAction.snippets &&
+        snippetEntries.isNotEmpty;
+    final showFolderMenu =
+        showSnippetMenu &&
+        highlightedFolder != null &&
+        folderSnippets.isNotEmpty &&
+        layout.folderMenuRect != null;
+
+    return Stack(
+      children: [
+        Positioned.fromRect(
+          rect: layout.mainMenuRect,
+          child: _PasteOptionsMenu(
+            highlightedAction: _highlightedPasteAction,
+            snippetsEnabled: _areSnippetsEnabled,
+            imageEnabled: widget.onPasteImageRequested != null,
+            filesEnabled: widget.onPasteFilesRequested != null,
+          ),
+        ),
+        if (showSnippetMenu && layout.snippetMenuRect != null)
+          Positioned.fromRect(
+            rect: layout.snippetMenuRect!,
+            child: _SnippetCascadeMenu(
+              entries: snippetEntries,
+              highlightedFolder: _highlightedSnippetFolder,
+              highlightedSnippet: _highlightedSnippet,
+            ),
+          ),
+        if (showFolderMenu)
+          Positioned.fromRect(
+            rect: layout.folderMenuRect!,
+            child: _SnippetFolderCascadeMenu(
+              snippets: folderSnippets,
+              highlightedSnippet: _highlightedSnippet,
+            ),
+          ),
+      ],
+    );
   }
 
   Rect? _pasteButtonGlobalRect() {
@@ -568,15 +680,32 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
   }
 
   void _updatePasteOptionsHighlight(LongPressMoveUpdateDetails details) {
-    final action = _pasteActionAtGlobalPosition(details.globalPosition);
-    if (action == _highlightedPasteAction) {
+    final hit = _pasteMenuHitAtGlobalPosition(details.globalPosition);
+    if (hit == null &&
+        _highlightedPasteAction == _PasteToolbarAction.snippets) {
+      if (_highlightedSnippet == null) {
+        return;
+      }
+      _highlightedSnippet = null;
+      _pasteOptionsOverlay?.markNeedsBuild();
       return;
     }
-    _highlightedPasteAction = action;
+    if (_isSamePasteMenuHit(hit, _currentPasteMenuHit)) {
+      return;
+    }
+    _applyPasteMenuHit(hit);
     _pasteOptionsOverlay?.markNeedsBuild();
   }
 
-  _PasteToolbarAction? _pasteActionAtGlobalPosition(
+  _PasteMenuHit? get _currentPasteMenuHit => _highlightedPasteAction == null
+      ? null
+      : _PasteMenuHit(
+          action: _highlightedPasteAction!,
+          folder: _highlightedSnippetFolder,
+          snippet: _highlightedSnippet,
+        );
+
+  _PasteMenuHit? _pasteMenuHitAtGlobalPosition(
     Offset globalPosition, {
     Offset? menuOrigin,
   }) {
@@ -588,26 +717,73 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
     if (overlayBox is! RenderBox) {
       return null;
     }
-    final offset = menuOrigin == null
-        ? _pasteOptionsOverlayOffset(overlayBox.size)
-        : null;
-    if (menuOrigin == null && offset == null) {
+    final layout = _pasteMenuLayout(
+      overlayBox.size,
+      mainMenuOrigin: menuOrigin == null
+          ? null
+          : overlayBox.globalToLocal(menuOrigin),
+    );
+    if (layout == null) {
       return null;
     }
-    final origin = menuOrigin ?? overlayBox.localToGlobal(offset!);
-    final local = globalPosition - origin;
-    if (local.dx < 0 || local.dx > _pasteOptionsWidth || local.dy < 0) {
+
+    final globalMainRect = _localRectToGlobal(overlayBox, layout.mainMenuRect);
+    final globalSnippetRect = layout.snippetMenuRect == null
+        ? null
+        : _localRectToGlobal(overlayBox, layout.snippetMenuRect!);
+    final globalFolderRect = layout.folderMenuRect == null
+        ? null
+        : _localRectToGlobal(overlayBox, layout.folderMenuRect!);
+
+    if (globalFolderRect != null && globalFolderRect.contains(globalPosition)) {
+      final folder = _highlightedSnippetFolder;
+      if (folder == null) {
+        return null;
+      }
+      final snippets = _snippetsInFolder(folder.id);
+      final index =
+          (globalPosition.dy - globalFolderRect.top) ~/ _pasteOptionHeight;
+      if (index >= 0 && index < snippets.length) {
+        return _PasteMenuHit(
+          action: _PasteToolbarAction.snippets,
+          folder: folder,
+          snippet: snippets[index],
+        );
+      }
+    }
+
+    if (globalSnippetRect != null &&
+        globalSnippetRect.contains(globalPosition)) {
+      final entries = _snippetMenuEntries;
+      final index =
+          (globalPosition.dy - globalSnippetRect.top) ~/ _pasteOptionHeight;
+      if (index >= 0 && index < entries.length) {
+        final entry = entries[index];
+        return _PasteMenuHit(
+          action: _PasteToolbarAction.snippets,
+          folder: entry.folder,
+          snippet: entry.snippet,
+        );
+      }
+    }
+
+    if (!globalMainRect.contains(globalPosition)) {
       return null;
     }
-    final index = local.dy ~/ _pasteOptionHeight;
+    final index = _pasteMainActionIndexAt(
+      globalPosition.dy - globalMainRect.top,
+    );
     if (index < 0 || index >= _PasteToolbarAction.values.length) {
       return null;
     }
     final action = _PasteToolbarAction.values[index];
-    return _isPasteActionEnabled(action) ? action : null;
+    return _isPasteActionEnabled(action) ? _PasteMenuHit(action: action) : null;
   }
 
-  Offset? _pasteOptionsOverlayOffset(Size overlaySize) {
+  _PasteMenuLayout? _pasteMenuLayout(
+    Size overlaySize, {
+    Offset? mainMenuOrigin,
+  }) {
     final buttonRect = _pasteButtonGlobalRect();
     if (buttonRect == null) {
       return null;
@@ -619,32 +795,178 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
     final topLeft = overlayBox.globalToLocal(buttonRect.topLeft);
     final bottomRight = overlayBox.globalToLocal(buttonRect.bottomRight);
     final targetRect = Rect.fromPoints(topLeft, bottomRight);
-    final menuHeight = _PasteToolbarAction.values.length * _pasteOptionHeight;
-    return Offset(
-      _clampDouble(
-        targetRect.right - _pasteOptionsWidth,
-        _pasteOptionsScreenMargin,
-        overlaySize.width - _pasteOptionsWidth - _pasteOptionsScreenMargin,
-      ),
-      _clampDouble(
-        targetRect.top - menuHeight - _pasteOptionsGap,
-        _pasteOptionsScreenMargin,
-        overlaySize.height - menuHeight - _pasteOptionsScreenMargin,
-      ),
+    final mainLeft =
+        mainMenuOrigin?.dx ??
+        _clampDouble(
+          targetRect.right - _pasteOptionsWidth,
+          _pasteOptionsScreenMargin,
+          overlaySize.width - _pasteOptionsWidth - _pasteOptionsScreenMargin,
+        );
+    final mainTop =
+        mainMenuOrigin?.dy ??
+        _clampDouble(
+          targetRect.top - _pasteOptionsMenuHeight - _pasteOptionsGap,
+          _pasteOptionsScreenMargin,
+          overlaySize.height -
+              _pasteOptionsMenuHeight -
+              _pasteOptionsScreenMargin,
+        );
+    final mainRect = Rect.fromLTWH(
+      mainLeft,
+      mainTop,
+      _pasteOptionsWidth,
+      _pasteOptionsMenuHeight,
+    );
+    final entries = _snippetMenuEntries;
+    Rect? snippetMenuRect;
+    Rect? folderMenuRect;
+    var snippetMenuOpensLeft = true;
+    if (entries.isNotEmpty) {
+      final snippetMenuHeight = entries.length * _pasteOptionHeight;
+      final canOpenLeft =
+          mainRect.left -
+              _pasteOptionsGap -
+              _pasteSnippetMenuWidth -
+              _pasteOptionsScreenMargin >=
+          0;
+      snippetMenuOpensLeft =
+          canOpenLeft ||
+          mainRect.right + _pasteOptionsGap + _pasteSnippetMenuWidth >
+              overlaySize.width - _pasteOptionsScreenMargin;
+      final snippetLeft = snippetMenuOpensLeft
+          ? mainRect.left - _pasteOptionsGap - _pasteSnippetMenuWidth
+          : mainRect.right + _pasteOptionsGap;
+      snippetMenuRect = Rect.fromLTWH(
+        _clampDouble(
+          snippetLeft,
+          _pasteOptionsScreenMargin,
+          overlaySize.width -
+              _pasteSnippetMenuWidth -
+              _pasteOptionsScreenMargin,
+        ),
+        _clampDouble(
+          mainRect.top,
+          _pasteOptionsScreenMargin,
+          overlaySize.height - snippetMenuHeight - _pasteOptionsScreenMargin,
+        ),
+        _pasteSnippetMenuWidth,
+        snippetMenuHeight,
+      );
+
+      final folder = _highlightedSnippetFolder;
+      if (folder != null) {
+        final folderSnippets = _snippetsInFolder(folder.id);
+        final folderIndex = entries.indexWhere(
+          (entry) => entry.folder?.id == folder.id,
+        );
+        if (folderIndex >= 0 && folderSnippets.isNotEmpty) {
+          final folderMenuHeight = folderSnippets.length * _pasteOptionHeight;
+          final folderTop =
+              snippetMenuRect.top + folderIndex * _pasteOptionHeight;
+          final folderLeft = snippetMenuOpensLeft
+              ? snippetMenuRect.right + _pasteOptionsGap
+              : snippetMenuRect.left -
+                    _pasteOptionsGap -
+                    _pasteSnippetMenuWidth;
+          folderMenuRect = Rect.fromLTWH(
+            _clampDouble(
+              folderLeft,
+              _pasteOptionsScreenMargin,
+              overlaySize.width -
+                  _pasteSnippetMenuWidth -
+                  _pasteOptionsScreenMargin,
+            ),
+            _clampDouble(
+              folderTop,
+              _pasteOptionsScreenMargin,
+              overlaySize.height - folderMenuHeight - _pasteOptionsScreenMargin,
+            ),
+            _pasteSnippetMenuWidth,
+            folderMenuHeight,
+          );
+        }
+      }
+    }
+
+    return _PasteMenuLayout(
+      mainMenuRect: mainRect,
+      snippetMenuRect: snippetMenuRect,
+      folderMenuRect: folderMenuRect,
     );
   }
 
   bool _isPasteActionEnabled(_PasteToolbarAction action) => switch (action) {
+    _PasteToolbarAction.snippets => _areSnippetsEnabled,
     _PasteToolbarAction.images => widget.onPasteImageRequested != null,
     _PasteToolbarAction.files => widget.onPasteFilesRequested != null,
   };
 
+  bool get _areSnippetsEnabled =>
+      widget.onSnippetPasteRequested != null && _snippetMenuEntries.isNotEmpty;
+
+  double get _pasteOptionsMenuHeight =>
+      _PasteToolbarAction.values.length * _pasteOptionHeight +
+      (_PasteToolbarAction.values.length - 1) * _pasteOptionsDividerHeight;
+
+  int _pasteMainActionIndexAt(double localDy) {
+    if (localDy < 0) {
+      return -1;
+    }
+    for (var index = 0; index < _PasteToolbarAction.values.length; index += 1) {
+      final top = index * (_pasteOptionHeight + _pasteOptionsDividerHeight);
+      if (localDy >= top && localDy < top + _pasteOptionHeight) {
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  List<_SnippetMenuEntry> get _snippetMenuEntries {
+    final folderIds = widget.snippetFolders.map((folder) => folder.id).toSet();
+    final entries = <_SnippetMenuEntry>[
+      for (final folder in widget.snippetFolders)
+        if (_snippetsInFolder(folder.id).isNotEmpty)
+          _SnippetMenuEntry.folder(folder),
+      for (final snippet in widget.snippets)
+        if (snippet.folderId == null || !folderIds.contains(snippet.folderId))
+          _SnippetMenuEntry.snippet(snippet),
+    ];
+    return entries;
+  }
+
+  List<KeyboardToolbarSnippet> _snippetsInFolder(int folderId) => widget
+      .snippets
+      .where((snippet) => snippet.folderId == folderId)
+      .toList(growable: false);
+
+  Rect _localRectToGlobal(RenderBox overlayBox, Rect rect) {
+    final topLeft = overlayBox.localToGlobal(rect.topLeft);
+    return topLeft & rect.size;
+  }
+
+  void _applyPasteMenuHit(_PasteMenuHit? hit) {
+    _highlightedPasteAction = hit?.action;
+    _highlightedSnippetFolder = hit?.folder;
+    _highlightedSnippet = hit?.snippet;
+  }
+
+  bool _isSamePasteMenuHit(_PasteMenuHit? a, _PasteMenuHit? b) =>
+      a?.action == b?.action &&
+      a?.folder?.id == b?.folder?.id &&
+      a?.snippet?.id == b?.snippet?.id;
+
   void _chooseHighlightedPasteOption(LongPressEndDetails details) {
-    final action =
-        _pasteActionAtGlobalPosition(details.globalPosition) ??
-        _highlightedPasteAction;
+    final hit = _pasteMenuHitAtGlobalPosition(details.globalPosition);
+    final action = hit?.action ?? _highlightedPasteAction;
+    final snippet = hit?.snippet;
     _hidePasteOptionsMenu();
+    if (snippet != null) {
+      unawaited(_runSnippetPasteAction(snippet));
+      return;
+    }
     switch (action) {
+      case _PasteToolbarAction.snippets:
+        _refocusTerminal();
       case _PasteToolbarAction.images:
         unawaited(_runToolbarAction(widget.onPasteImageRequested));
       case _PasteToolbarAction.files:
@@ -658,6 +980,8 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
     _pasteOptionsOverlay?.remove();
     _pasteOptionsOverlay = null;
     _highlightedPasteAction = null;
+    _highlightedSnippetFolder = null;
+    _highlightedSnippet = null;
   }
 
   Future<void> _runToolbarAction(FutureOr<void> Function()? action) async {
@@ -666,6 +990,15 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
       return;
     }
     await action();
+  }
+
+  Future<void> _runSnippetPasteAction(KeyboardToolbarSnippet snippet) async {
+    final action = widget.onSnippetPasteRequested;
+    if (action == null) {
+      _refocusTerminal();
+      return;
+    }
+    await action(snippet);
   }
 
   void _consumeOneShot() {
@@ -788,7 +1121,38 @@ enum _Modifier { ctrl, alt, shift }
 
 enum _Arrow { up, down, left, right }
 
-enum _PasteToolbarAction { images, files }
+enum _PasteToolbarAction { snippets, images, files }
+
+class _PasteMenuHit {
+  const _PasteMenuHit({required this.action, this.folder, this.snippet});
+
+  final _PasteToolbarAction action;
+  final KeyboardToolbarSnippetFolder? folder;
+  final KeyboardToolbarSnippet? snippet;
+}
+
+class _PasteMenuLayout {
+  const _PasteMenuLayout({
+    required this.mainMenuRect,
+    required this.snippetMenuRect,
+    required this.folderMenuRect,
+  });
+
+  final Rect mainMenuRect;
+  final Rect? snippetMenuRect;
+  final Rect? folderMenuRect;
+}
+
+class _SnippetMenuEntry {
+  const _SnippetMenuEntry.folder(KeyboardToolbarSnippetFolder this.folder)
+    : snippet = null;
+
+  const _SnippetMenuEntry.snippet(KeyboardToolbarSnippet this.snippet)
+    : folder = null;
+
+  final KeyboardToolbarSnippetFolder? folder;
+  final KeyboardToolbarSnippet? snippet;
+}
 
 double _clampDouble(double value, double min, double max) {
   final effectiveMax = max < min ? min : max;
@@ -798,11 +1162,13 @@ double _clampDouble(double value, double min, double max) {
 class _PasteOptionsMenu extends StatelessWidget {
   const _PasteOptionsMenu({
     required this.highlightedAction,
+    required this.snippetsEnabled,
     required this.imageEnabled,
     required this.filesEnabled,
   });
 
   final _PasteToolbarAction? highlightedAction;
+  final bool snippetsEnabled;
   final bool imageEnabled;
   final bool filesEnabled;
 
@@ -817,6 +1183,14 @@ class _PasteOptionsMenu extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
+          _PasteOptionsMenuItem(
+            icon: Icons.code_rounded,
+            label: 'Snippets',
+            enabled: snippetsEnabled,
+            highlighted: highlightedAction == _PasteToolbarAction.snippets,
+            trailingIcon: Icons.chevron_right_rounded,
+          ),
+          Divider(height: 1, color: colorScheme.outlineVariant),
           _PasteOptionsMenuItem(
             icon: Icons.image_outlined,
             label: 'Paste Images',
@@ -836,18 +1210,95 @@ class _PasteOptionsMenu extends StatelessWidget {
   }
 }
 
+class _SnippetCascadeMenu extends StatelessWidget {
+  const _SnippetCascadeMenu({
+    required this.entries,
+    required this.highlightedFolder,
+    required this.highlightedSnippet,
+  });
+
+  final List<_SnippetMenuEntry> entries;
+  final KeyboardToolbarSnippetFolder? highlightedFolder;
+  final KeyboardToolbarSnippet? highlightedSnippet;
+
+  @override
+  Widget build(BuildContext context) => _CascadeMenuFrame(
+    children: [
+      for (final entry in entries)
+        if (entry.folder case final folder?)
+          _PasteOptionsMenuItem(
+            icon: Icons.folder_outlined,
+            label: folder.name,
+            enabled: true,
+            highlighted: highlightedFolder?.id == folder.id,
+            trailingIcon: Icons.chevron_right_rounded,
+          )
+        else if (entry.snippet case final snippet?)
+          _PasteOptionsMenuItem(
+            icon: Icons.code_rounded,
+            label: snippet.name,
+            enabled: true,
+            highlighted: highlightedSnippet?.id == snippet.id,
+          ),
+    ],
+  );
+}
+
+class _SnippetFolderCascadeMenu extends StatelessWidget {
+  const _SnippetFolderCascadeMenu({
+    required this.snippets,
+    required this.highlightedSnippet,
+  });
+
+  final List<KeyboardToolbarSnippet> snippets;
+  final KeyboardToolbarSnippet? highlightedSnippet;
+
+  @override
+  Widget build(BuildContext context) => _CascadeMenuFrame(
+    children: [
+      for (final snippet in snippets)
+        _PasteOptionsMenuItem(
+          icon: Icons.code_rounded,
+          label: snippet.name,
+          enabled: true,
+          highlighted: highlightedSnippet?.id == snippet.id,
+        ),
+    ],
+  );
+}
+
+class _CascadeMenuFrame extends StatelessWidget {
+  const _CascadeMenuFrame({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Material(
+      color: colorScheme.surfaceContainerHighest,
+      elevation: 8,
+      borderRadius: BorderRadius.circular(12),
+      clipBehavior: Clip.antiAlias,
+      child: Column(mainAxisSize: MainAxisSize.min, children: children),
+    );
+  }
+}
+
 class _PasteOptionsMenuItem extends StatelessWidget {
   const _PasteOptionsMenuItem({
     required this.icon,
     required this.label,
     required this.enabled,
     required this.highlighted,
+    this.trailingIcon,
   });
 
   final IconData icon;
   final String label;
   final bool enabled;
   final bool highlighted;
+  final IconData? trailingIcon;
 
   @override
   Widget build(BuildContext context) {
@@ -885,6 +1336,10 @@ class _PasteOptionsMenuItem extends StatelessWidget {
                 ),
               ),
             ),
+            if (trailingIcon case final trailingIcon?) ...[
+              const SizedBox(width: 8),
+              Icon(trailingIcon, size: 20, color: foregroundColor),
+            ],
           ],
         ),
       ),

--- a/lib/presentation/widgets/keyboard_toolbar.dart
+++ b/lib/presentation/widgets/keyboard_toolbar.dart
@@ -625,19 +625,10 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
       return const SizedBox.shrink();
     }
 
-    final snippetEntries = _snippetMenuEntries;
-    final highlightedFolder = _highlightedSnippetFolder;
-    final folderSnippets = highlightedFolder == null
-        ? const <KeyboardToolbarSnippet>[]
-        : _snippetsInFolder(highlightedFolder.id);
+    final snippetEntries = _expandedSnippetMenuEntries;
     final showSnippetMenu =
         _highlightedPasteAction == _PasteToolbarAction.snippets &&
-        snippetEntries.isNotEmpty;
-    final showFolderMenu =
-        showSnippetMenu &&
-        highlightedFolder != null &&
-        folderSnippets.isNotEmpty &&
-        layout.folderMenuRect != null;
+        _snippetMenuEntries.isNotEmpty;
 
     return Stack(
       children: [
@@ -648,6 +639,9 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
             snippetsEnabled: _areSnippetsEnabled,
             imageEnabled: widget.onPasteImageRequested != null,
             filesEnabled: widget.onPasteFilesRequested != null,
+            snippetsTrailingIcon: layout.snippetMenuOpensLeft
+                ? Icons.chevron_left_rounded
+                : Icons.chevron_right_rounded,
           ),
         ),
         if (showSnippetMenu && layout.snippetMenuRect != null)
@@ -656,14 +650,6 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
             child: _SnippetCascadeMenu(
               entries: snippetEntries,
               highlightedFolder: _highlightedSnippetFolder,
-              highlightedSnippet: _highlightedSnippet,
-            ),
-          ),
-        if (showFolderMenu)
-          Positioned.fromRect(
-            rect: layout.folderMenuRect!,
-            child: _SnippetFolderCascadeMenu(
-              snippets: folderSnippets,
               highlightedSnippet: _highlightedSnippet,
             ),
           ),
@@ -731,37 +717,17 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
     final globalSnippetRect = layout.snippetMenuRect == null
         ? null
         : _localRectToGlobal(overlayBox, layout.snippetMenuRect!);
-    final globalFolderRect = layout.folderMenuRect == null
-        ? null
-        : _localRectToGlobal(overlayBox, layout.folderMenuRect!);
-
-    if (globalFolderRect != null && globalFolderRect.contains(globalPosition)) {
-      final folder = _highlightedSnippetFolder;
-      if (folder == null) {
-        return null;
-      }
-      final snippets = _snippetsInFolder(folder.id);
-      final index =
-          (globalPosition.dy - globalFolderRect.top) ~/ _pasteOptionHeight;
-      if (index >= 0 && index < snippets.length) {
-        return _PasteMenuHit(
-          action: _PasteToolbarAction.snippets,
-          folder: folder,
-          snippet: snippets[index],
-        );
-      }
-    }
 
     if (globalSnippetRect != null &&
         globalSnippetRect.contains(globalPosition)) {
-      final entries = _snippetMenuEntries;
+      final entries = _expandedSnippetMenuEntries;
       final index =
           (globalPosition.dy - globalSnippetRect.top) ~/ _pasteOptionHeight;
       if (index >= 0 && index < entries.length) {
         final entry = entries[index];
         return _PasteMenuHit(
           action: _PasteToolbarAction.snippets,
-          folder: entry.folder,
+          folder: entry.folder ?? entry.parentFolder,
           snippet: entry.snippet,
         );
       }
@@ -817,9 +783,8 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
       _pasteOptionsWidth,
       _pasteOptionsMenuHeight,
     );
-    final entries = _snippetMenuEntries;
+    final entries = _expandedSnippetMenuEntries;
     Rect? snippetMenuRect;
-    Rect? folderMenuRect;
     var snippetMenuOpensLeft = true;
     if (entries.isNotEmpty) {
       final snippetMenuHeight = entries.length * _pasteOptionHeight;
@@ -852,46 +817,12 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
         _pasteSnippetMenuWidth,
         snippetMenuHeight,
       );
-
-      final folder = _highlightedSnippetFolder;
-      if (folder != null) {
-        final folderSnippets = _snippetsInFolder(folder.id);
-        final folderIndex = entries.indexWhere(
-          (entry) => entry.folder?.id == folder.id,
-        );
-        if (folderIndex >= 0 && folderSnippets.isNotEmpty) {
-          final folderMenuHeight = folderSnippets.length * _pasteOptionHeight;
-          final folderTop =
-              snippetMenuRect.top + folderIndex * _pasteOptionHeight;
-          final folderLeft = snippetMenuOpensLeft
-              ? snippetMenuRect.right + _pasteOptionsGap
-              : snippetMenuRect.left -
-                    _pasteOptionsGap -
-                    _pasteSnippetMenuWidth;
-          folderMenuRect = Rect.fromLTWH(
-            _clampDouble(
-              folderLeft,
-              _pasteOptionsScreenMargin,
-              overlaySize.width -
-                  _pasteSnippetMenuWidth -
-                  _pasteOptionsScreenMargin,
-            ),
-            _clampDouble(
-              folderTop,
-              _pasteOptionsScreenMargin,
-              overlaySize.height - folderMenuHeight - _pasteOptionsScreenMargin,
-            ),
-            _pasteSnippetMenuWidth,
-            folderMenuHeight,
-          );
-        }
-      }
     }
 
     return _PasteMenuLayout(
       mainMenuRect: mainRect,
       snippetMenuRect: snippetMenuRect,
-      folderMenuRect: folderMenuRect,
+      snippetMenuOpensLeft: snippetMenuOpensLeft,
     );
   }
 
@@ -932,6 +863,27 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
           _SnippetMenuEntry.snippet(snippet),
     ];
     return entries;
+  }
+
+  List<_SnippetMenuEntry> get _expandedSnippetMenuEntries {
+    final entries = _snippetMenuEntries;
+    final folder = _highlightedSnippetFolder;
+    if (folder == null) {
+      return entries;
+    }
+
+    final expandedEntries = <_SnippetMenuEntry>[];
+    for (final entry in entries) {
+      expandedEntries.add(entry);
+      if (entry.folder?.id == folder.id) {
+        expandedEntries.addAll(
+          _snippetsInFolder(
+            folder.id,
+          ).map((snippet) => _SnippetMenuEntry.snippet(snippet, folder)),
+        );
+      }
+    }
+    return expandedEntries;
   }
 
   List<KeyboardToolbarSnippet> _snippetsInFolder(int folderId) => widget
@@ -1135,23 +1087,25 @@ class _PasteMenuLayout {
   const _PasteMenuLayout({
     required this.mainMenuRect,
     required this.snippetMenuRect,
-    required this.folderMenuRect,
+    required this.snippetMenuOpensLeft,
   });
 
   final Rect mainMenuRect;
   final Rect? snippetMenuRect;
-  final Rect? folderMenuRect;
+  final bool snippetMenuOpensLeft;
 }
 
 class _SnippetMenuEntry {
   const _SnippetMenuEntry.folder(KeyboardToolbarSnippetFolder this.folder)
-    : snippet = null;
+    : snippet = null,
+      parentFolder = null;
 
-  const _SnippetMenuEntry.snippet(KeyboardToolbarSnippet this.snippet)
+  const _SnippetMenuEntry.snippet(this.snippet, [this.parentFolder])
     : folder = null;
 
   final KeyboardToolbarSnippetFolder? folder;
   final KeyboardToolbarSnippet? snippet;
+  final KeyboardToolbarSnippetFolder? parentFolder;
 }
 
 double _clampDouble(double value, double min, double max) {
@@ -1165,12 +1119,14 @@ class _PasteOptionsMenu extends StatelessWidget {
     required this.snippetsEnabled,
     required this.imageEnabled,
     required this.filesEnabled,
+    required this.snippetsTrailingIcon,
   });
 
   final _PasteToolbarAction? highlightedAction;
   final bool snippetsEnabled;
   final bool imageEnabled;
   final bool filesEnabled;
+  final IconData snippetsTrailingIcon;
 
   @override
   Widget build(BuildContext context) {
@@ -1188,7 +1144,7 @@ class _PasteOptionsMenu extends StatelessWidget {
             label: 'Snippets',
             enabled: snippetsEnabled,
             highlighted: highlightedAction == _PasteToolbarAction.snippets,
-            trailingIcon: Icons.chevron_right_rounded,
+            trailingIcon: snippetsTrailingIcon,
           ),
           Divider(height: 1, color: colorScheme.outlineVariant),
           _PasteOptionsMenuItem(
@@ -1231,7 +1187,7 @@ class _SnippetCascadeMenu extends StatelessWidget {
             label: folder.name,
             enabled: true,
             highlighted: highlightedFolder?.id == folder.id,
-            trailingIcon: Icons.chevron_right_rounded,
+            trailingIcon: Icons.expand_more_rounded,
           )
         else if (entry.snippet case final snippet?)
           _PasteOptionsMenuItem(
@@ -1239,30 +1195,8 @@ class _SnippetCascadeMenu extends StatelessWidget {
             label: snippet.name,
             enabled: true,
             highlighted: highlightedSnippet?.id == snippet.id,
+            leadingIndent: entry.parentFolder == null ? 0 : 18,
           ),
-    ],
-  );
-}
-
-class _SnippetFolderCascadeMenu extends StatelessWidget {
-  const _SnippetFolderCascadeMenu({
-    required this.snippets,
-    required this.highlightedSnippet,
-  });
-
-  final List<KeyboardToolbarSnippet> snippets;
-  final KeyboardToolbarSnippet? highlightedSnippet;
-
-  @override
-  Widget build(BuildContext context) => _CascadeMenuFrame(
-    children: [
-      for (final snippet in snippets)
-        _PasteOptionsMenuItem(
-          icon: Icons.code_rounded,
-          label: snippet.name,
-          enabled: true,
-          highlighted: highlightedSnippet?.id == snippet.id,
-        ),
     ],
   );
 }
@@ -1291,6 +1225,7 @@ class _PasteOptionsMenuItem extends StatelessWidget {
     required this.label,
     required this.enabled,
     required this.highlighted,
+    this.leadingIndent = 0,
     this.trailingIcon,
   });
 
@@ -1298,6 +1233,7 @@ class _PasteOptionsMenuItem extends StatelessWidget {
   final String label;
   final bool enabled;
   final bool highlighted;
+  final double leadingIndent;
   final IconData? trailingIcon;
 
   @override
@@ -1324,6 +1260,7 @@ class _PasteOptionsMenuItem extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 14),
         child: Row(
           children: [
+            if (leadingIndent > 0) SizedBox(width: leadingIndent),
             Icon(icon, size: 20, color: foregroundColor),
             const SizedBox(width: 12),
             Expanded(

--- a/lib/presentation/widgets/snippet_folder_dialog.dart
+++ b/lib/presentation/widgets/snippet_folder_dialog.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+/// Shows a dialog that prompts for a new snippet folder name.
+Future<String?> showCreateSnippetFolderDialog(BuildContext context) =>
+    showDialog<String>(
+      context: context,
+      builder: (context) => const _CreateSnippetFolderDialog(),
+    );
+
+class _CreateSnippetFolderDialog extends StatefulWidget {
+  const _CreateSnippetFolderDialog();
+
+  @override
+  State<_CreateSnippetFolderDialog> createState() =>
+      _CreateSnippetFolderDialogState();
+}
+
+class _CreateSnippetFolderDialogState
+    extends State<_CreateSnippetFolderDialog> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => AlertDialog(
+    title: const Text('New Folder'),
+    content: Form(
+      key: _formKey,
+      child: TextFormField(
+        controller: _nameController,
+        autofocus: true,
+        decoration: const InputDecoration(
+          labelText: 'Folder name',
+          hintText: 'Deployment',
+        ),
+        textInputAction: TextInputAction.done,
+        onFieldSubmitted: (_) => _submit(),
+        validator: (value) {
+          if (value == null || value.trim().isEmpty) {
+            return 'Please enter a folder name';
+          }
+          return null;
+        },
+      ),
+    ),
+    actions: [
+      TextButton(
+        onPressed: () => Navigator.pop(context),
+        child: const Text('Cancel'),
+      ),
+      FilledButton(onPressed: _submit, child: const Text('Create')),
+    ],
+  );
+
+  void _submit() {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    Navigator.pop(context, _nameController.text.trim());
+  }
+}

--- a/test/data/repositories/snippet_repository_test.dart
+++ b/test/data/repositories/snippet_repository_test.dart
@@ -367,6 +367,44 @@ void main() {
       expect(folders, isEmpty);
     });
 
+    test('deleteFolder moves snippets to no folder', () async {
+      final folderId = await repository.insertFolder(
+        SnippetFoldersCompanion.insert(name: 'Deploy'),
+      );
+      await repository.insert(
+        SnippetsCompanion.insert(
+          name: 'Restart API',
+          command: 'systemctl restart api',
+          folderId: Value(folderId),
+        ),
+      );
+
+      final deleted = await repository.deleteFolder(folderId);
+      expect(deleted, 1);
+
+      final snippets = await repository.getAll();
+      expect(snippets.single.folderId, isNull);
+      expect(await repository.getByFolder(null), hasLength(1));
+    });
+
+    test('deleteFolder clears child folder parents', () async {
+      final parentId = await repository.insertFolder(
+        SnippetFoldersCompanion.insert(name: 'Parent'),
+      );
+      await repository.insertFolder(
+        SnippetFoldersCompanion.insert(
+          name: 'Child',
+          parentId: Value(parentId),
+        ),
+      );
+
+      final deleted = await repository.deleteFolder(parentId);
+      expect(deleted, 1);
+
+      final child = (await repository.getAllFolders()).single;
+      expect(child.parentId, isNull);
+    });
+
     test('deleteFolder returns 0 when folder not exists', () async {
       final deleted = await repository.deleteFolder(999);
       expect(deleted, 0);

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -245,6 +245,77 @@ void main() {
       expect(selectedText, isNull);
     });
 
+    test('adds create snippet action after copy in terminal menu', () {
+      var didCreateSnippet = false;
+
+      final items = buildTerminalSelectionContextMenuButtonItems(
+        defaultItems: const [
+          ContextMenuButtonItem(
+            type: ContextMenuButtonType.copy,
+            onPressed: null,
+          ),
+          ContextMenuButtonItem(
+            type: ContextMenuButtonType.paste,
+            onPressed: null,
+          ),
+        ],
+        onCopy: () {},
+        onLookUp: () {},
+        onSearchWeb: () {},
+        onShare: () {},
+        onCreateSnippet: () => didCreateSnippet = true,
+        onPaste: () {},
+      );
+
+      final copyIndex = items.indexWhere(
+        (item) => item.type == ContextMenuButtonType.copy,
+      );
+      final snippetIndex = items.indexWhere(
+        (item) => item.label == 'Create Snippet',
+      );
+
+      expect(snippetIndex, copyIndex + 1);
+      items[snippetIndex].onPressed!();
+      expect(didCreateSnippet, isTrue);
+    });
+
+    test('omits create snippet action without selected text', () {
+      final items = buildTerminalSelectionContextMenuButtonItems(
+        defaultItems: const [
+          ContextMenuButtonItem(
+            type: ContextMenuButtonType.copy,
+            onPressed: null,
+          ),
+        ],
+        onCopy: () {},
+        onLookUp: () {},
+        onSearchWeb: () {},
+        onShare: () {},
+        onCreateSnippet: null,
+        onPaste: () {},
+      );
+
+      expect(items.where((item) => item.label == 'Create Snippet'), isEmpty);
+    });
+
+    test('builds snippet name from selected terminal text', () {
+      final longLine = List.filled(80, 'a').join();
+      final truncatedLine = '${List.filled(57, 'a').join()}...';
+
+      expect(
+        buildSnippetNameFromTerminalSelection('\n  git status\n'),
+        'git status',
+      );
+      expect(
+        buildSnippetNameFromTerminalSelection('   \n'),
+        'Terminal selection',
+      );
+      expect(
+        buildSnippetNameFromTerminalSelection('$longLine\nsecond'),
+        truncatedLine,
+      );
+    });
+
     test('hides terminal selection toolbar when action throws', () {
       var didHideToolbar = false;
 

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -443,6 +443,9 @@ void main() {
         ]),
       );
       when(
+        snippetRepository.watchAllFolders,
+      ).thenAnswer((_) => Stream.value(const <SnippetFolder>[]));
+      when(
         () => snippetRepository.reorderByIds(any()),
       ).thenAnswer((_) async {});
 

--- a/test/widget/keyboard_toolbar_test.dart
+++ b/test/widget/keyboard_toolbar_test.dart
@@ -414,6 +414,8 @@ void main() {
       await tester.pump(kLongPressTimeout + const Duration(milliseconds: 1));
       await tester.pump();
 
+      expect(find.byIcon(Icons.chevron_left_rounded), findsOneWidget);
+
       await gesture.moveTo(tester.getCenter(find.text('Snippets')));
       await tester.pump();
 
@@ -472,11 +474,23 @@ void main() {
       await tester.pump();
 
       expect(find.text('Deploy'), findsOneWidget);
+      expect(
+        tester.getTopLeft(find.text('Deploy')).dx,
+        lessThan(tester.getTopLeft(find.text('Snippets')).dx),
+      );
 
       await gesture.moveTo(tester.getCenter(find.text('Deploy')));
       await tester.pump();
 
       expect(find.text('Restart API'), findsOneWidget);
+      expect(
+        tester.getTopLeft(find.text('Restart API')).dx,
+        lessThan(tester.getTopLeft(find.text('Snippets')).dx),
+      );
+      expect(
+        tester.getTopLeft(find.text('Restart API')).dy,
+        greaterThan(tester.getTopLeft(find.text('Deploy')).dy),
+      );
 
       await gesture.moveTo(tester.getCenter(find.text('Restart API')));
       await tester.pump();

--- a/test/widget/keyboard_toolbar_test.dart
+++ b/test/widget/keyboard_toolbar_test.dart
@@ -379,6 +379,115 @@ void main() {
       expect(find.text('Paste Files'), findsNothing);
     });
 
+    testWidgets('Paste long press releases over a top-level snippet', (
+      tester,
+    ) async {
+      KeyboardToolbarSnippet? selectedSnippet;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                const Spacer(),
+                KeyboardToolbar(
+                  terminal: terminal,
+                  snippets: const [
+                    KeyboardToolbarSnippet(
+                      id: 1,
+                      name: 'Top level',
+                      command: 'git status',
+                    ),
+                  ],
+                  onSnippetPasteRequested: (snippet) async {
+                    selectedSnippet = snippet;
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final pasteCenter = tester.getCenter(find.byTooltip('Paste'));
+      final gesture = await tester.startGesture(pasteCenter);
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 1));
+      await tester.pump();
+
+      await gesture.moveTo(tester.getCenter(find.text('Snippets')));
+      await tester.pump();
+
+      expect(find.text('Top level'), findsOneWidget);
+
+      await gesture.moveTo(tester.getCenter(find.text('Top level')));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(selectedSnippet?.id, 1);
+      expect(selectedSnippet?.command, 'git status');
+      expect(find.text('Top level'), findsNothing);
+    });
+
+    testWidgets('Paste long press releases over a folder snippet', (
+      tester,
+    ) async {
+      KeyboardToolbarSnippet? selectedSnippet;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                const Spacer(),
+                KeyboardToolbar(
+                  terminal: terminal,
+                  snippetFolders: const [
+                    KeyboardToolbarSnippetFolder(id: 7, name: 'Deploy'),
+                  ],
+                  snippets: const [
+                    KeyboardToolbarSnippet(
+                      id: 2,
+                      name: 'Restart API',
+                      command: 'systemctl restart api',
+                      folderId: 7,
+                    ),
+                  ],
+                  onSnippetPasteRequested: (snippet) async {
+                    selectedSnippet = snippet;
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final pasteCenter = tester.getCenter(find.byTooltip('Paste'));
+      final gesture = await tester.startGesture(pasteCenter);
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 1));
+      await tester.pump();
+
+      await gesture.moveTo(tester.getCenter(find.text('Snippets')));
+      await tester.pump();
+
+      expect(find.text('Deploy'), findsOneWidget);
+
+      await gesture.moveTo(tester.getCenter(find.text('Deploy')));
+      await tester.pump();
+
+      expect(find.text('Restart API'), findsOneWidget);
+
+      await gesture.moveTo(tester.getCenter(find.text('Restart API')));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(selectedSnippet?.id, 2);
+      expect(selectedSnippet?.command, 'systemctl restart api');
+      expect(find.text('Restart API'), findsNothing);
+    });
+
     testWidgets('Enter button renders and triggers callback', (tester) async {
       var callCount = 0;
       final output = <String>[];

--- a/test/widget/snippets_screen_test.dart
+++ b/test/widget/snippets_screen_test.dart
@@ -140,6 +140,45 @@ void main() {
       expect(find.text('branch'), findsOneWidget);
     });
 
+    testWidgets('full editor uses snippet prefill values', (tester) async {
+      final snippetRepository = _MockSnippetRepository();
+      when(
+        snippetRepository.getAllFolders,
+      ).thenAnswer((_) async => const <SnippetFolder>[]);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            snippetRepositoryProvider.overrideWithValue(snippetRepository),
+          ],
+          child: const MaterialApp(
+            home: SnippetEditScreen(
+              prefill: SnippetEditPrefill(
+                name: 'git status',
+                command: 'git status --short',
+                description: 'Selected from terminal',
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final nameField = tester.widget<TextFormField>(
+        find.widgetWithText(TextFormField, 'Name'),
+      );
+      final commandField = tester.widget<TextFormField>(
+        find.widgetWithText(TextFormField, 'Command'),
+      );
+      final descriptionField = tester.widget<TextFormField>(
+        find.widgetWithText(TextFormField, 'Description (optional)'),
+      );
+
+      expect(nameField.controller!.text, 'git status');
+      expect(commandField.controller!.text, 'git status --short');
+      expect(descriptionField.controller!.text, 'Selected from terminal');
+    });
+
     testWidgets('reordering snippets persists the new order', (tester) async {
       final snippetRepository = _MockSnippetRepository();
       when(snippetRepository.watchAll).thenAnswer(

--- a/test/widget/snippets_screen_test.dart
+++ b/test/widget/snippets_screen_test.dart
@@ -19,19 +19,33 @@ Snippet _buildSnippet({
   required int id,
   required String name,
   required int sortOrder,
+  int? folderId,
 }) => Snippet(
   id: id,
   name: name,
   command: 'echo $name',
+  folderId: folderId,
   autoExecute: false,
   createdAt: DateTime(2026),
   usageCount: 0,
   sortOrder: sortOrder,
 );
 
+SnippetFolder _buildFolder({
+  required int id,
+  required String name,
+  int sortOrder = 0,
+}) => SnippetFolder(
+  id: id,
+  name: name,
+  sortOrder: sortOrder,
+  createdAt: DateTime(2026),
+);
+
 void main() {
   setUpAll(() {
     registerFallbackValue(<int>[]);
+    registerFallbackValue(SnippetFoldersCompanion.insert(name: 'fallback'));
   });
 
   group('SnippetsScreen', () {
@@ -45,6 +59,9 @@ void main() {
       when(
         snippetRepository.watchAll,
       ).thenAnswer((_) => snippetsController.stream);
+      when(
+        snippetRepository.watchAllFolders,
+      ).thenAnswer((_) => Stream.value(const <SnippetFolder>[]));
 
       await tester.pumpWidget(
         ProviderScope(
@@ -76,6 +93,9 @@ void main() {
       when(
         snippetRepository.watchAll,
       ).thenAnswer((_) => Stream.value(const <Snippet>[]));
+      when(
+        snippetRepository.watchAllFolders,
+      ).thenAnswer((_) => Stream.value(const <SnippetFolder>[]));
 
       await tester.pumpWidget(
         ProviderScope(
@@ -109,6 +129,50 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Full snippet editor'), findsOneWidget);
+    });
+
+    testWidgets('creates folders from the snippets screen header', (
+      tester,
+    ) async {
+      final snippetRepository = _MockSnippetRepository();
+      final snippetsController = StreamController<List<Snippet>>();
+      final foldersController = StreamController<List<SnippetFolder>>();
+      addTearDown(snippetsController.close);
+      addTearDown(foldersController.close);
+      when(
+        snippetRepository.watchAll,
+      ).thenAnswer((_) => snippetsController.stream);
+      when(
+        snippetRepository.watchAllFolders,
+      ).thenAnswer((_) => foldersController.stream);
+      when(() => snippetRepository.insertFolder(any())).thenAnswer((_) async {
+        foldersController.add([_buildFolder(id: 7, name: 'Deploy')]);
+        return 7;
+      });
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            snippetRepositoryProvider.overrideWithValue(snippetRepository),
+          ],
+          child: const MaterialApp(home: SnippetsScreen()),
+        ),
+      );
+      snippetsController.add(const <Snippet>[]);
+      foldersController.add(const <SnippetFolder>[]);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('New Folder'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Folder name'),
+        'Deploy',
+      );
+      await tester.tap(find.text('Create'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Deploy (0)'), findsOneWidget);
+      verify(() => snippetRepository.insertFolder(any())).called(1);
     });
 
     testWidgets('full editor updates variable preview as command changes', (
@@ -179,6 +243,47 @@ void main() {
       expect(descriptionField.controller!.text, 'Selected from terminal');
     });
 
+    testWidgets('full editor creates and selects a folder from the picker', (
+      tester,
+    ) async {
+      final snippetRepository = _MockSnippetRepository();
+      var getFoldersCallCount = 0;
+      when(snippetRepository.getAllFolders).thenAnswer((_) async {
+        getFoldersCallCount += 1;
+        if (getFoldersCallCount == 1) {
+          return const <SnippetFolder>[];
+        }
+        return [_buildFolder(id: 9, name: 'Deploy')];
+      });
+      when(
+        () => snippetRepository.insertFolder(any()),
+      ).thenAnswer((_) async => 9);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            snippetRepositoryProvider.overrideWithValue(snippetRepository),
+          ],
+          child: const MaterialApp(home: SnippetEditScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(DropdownButtonFormField<int?>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Create folder...').last);
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Folder name'),
+        'Deploy',
+      );
+      await tester.tap(find.text('Create'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Deploy'), findsOneWidget);
+      verify(() => snippetRepository.insertFolder(any())).called(1);
+    });
+
     testWidgets('reordering snippets persists the new order', (tester) async {
       final snippetRepository = _MockSnippetRepository();
       when(snippetRepository.watchAll).thenAnswer(
@@ -187,6 +292,9 @@ void main() {
           _buildSnippet(id: 2, name: 'Second', sortOrder: 1),
         ]),
       );
+      when(
+        snippetRepository.watchAllFolders,
+      ).thenAnswer((_) => Stream.value(const <SnippetFolder>[]));
       when(
         () => snippetRepository.reorderByIds(any()),
       ).thenAnswer((_) async {});
@@ -210,6 +318,64 @@ void main() {
       await tester.pumpAndSettle();
 
       verify(() => snippetRepository.reorderByIds([2, 1])).called(1);
+    });
+
+    testWidgets('folder filter shows and reorders snippets in that folder', (
+      tester,
+    ) async {
+      final snippetRepository = _MockSnippetRepository();
+      when(snippetRepository.watchAll).thenAnswer(
+        (_) => Stream.value([
+          _buildSnippet(id: 1, name: 'Unfiled', sortOrder: 0),
+          _buildSnippet(
+            id: 2,
+            name: 'Deploy first',
+            sortOrder: 1,
+            folderId: 10,
+          ),
+          _buildSnippet(
+            id: 3,
+            name: 'Deploy second',
+            sortOrder: 2,
+            folderId: 10,
+          ),
+          _buildSnippet(id: 4, name: 'Cleanup', sortOrder: 3),
+        ]),
+      );
+      when(
+        snippetRepository.watchAllFolders,
+      ).thenAnswer((_) => Stream.value([_buildFolder(id: 10, name: 'Deploy')]));
+      when(
+        () => snippetRepository.reorderByIds(any()),
+      ).thenAnswer((_) async {});
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            snippetRepositoryProvider.overrideWithValue(snippetRepository),
+          ],
+          child: const MaterialApp(home: SnippetsScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Deploy (2)'), findsOneWidget);
+      expect(find.text('Deploy'), findsNWidgets(2));
+
+      await tester.tap(find.text('Deploy (2)'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Deploy first'), findsOneWidget);
+      expect(find.text('Deploy second'), findsOneWidget);
+      expect(find.text('Unfiled'), findsNothing);
+
+      final list = tester.widget<ReorderableListView>(
+        find.byType(ReorderableListView),
+      );
+      list.onReorder(0, 2);
+      await tester.pumpAndSettle();
+
+      verify(() => snippetRepository.reorderByIds([1, 3, 2, 4])).called(1);
     });
   });
 }

--- a/test/widget/snippets_screen_test.dart
+++ b/test/widget/snippets_screen_test.dart
@@ -175,7 +175,7 @@ void main() {
       verify(() => snippetRepository.insertFolder(any())).called(1);
     });
 
-    testWidgets('long-pressing a folder chip deletes the folder', (
+    testWidgets('long-pressing a folder chip opens delete action', (
       tester,
     ) async {
       final snippetRepository = _MockSnippetRepository();
@@ -212,6 +212,13 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.longPress(find.text('Deploy (1)'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Delete folder'), findsOneWidget);
+      expect(find.text('Delete "Deploy"?'), findsNothing);
+      verifyNever(() => snippetRepository.deleteFolder(10));
+
+      await tester.tap(find.text('Delete folder'));
       await tester.pumpAndSettle();
 
       expect(find.text('Delete "Deploy"?'), findsOneWidget);

--- a/test/widget/snippets_screen_test.dart
+++ b/test/widget/snippets_screen_test.dart
@@ -175,6 +175,57 @@ void main() {
       verify(() => snippetRepository.insertFolder(any())).called(1);
     });
 
+    testWidgets('long-pressing a folder chip deletes the folder', (
+      tester,
+    ) async {
+      final snippetRepository = _MockSnippetRepository();
+      final snippetsController = StreamController<List<Snippet>>();
+      final foldersController = StreamController<List<SnippetFolder>>();
+      addTearDown(snippetsController.close);
+      addTearDown(foldersController.close);
+      when(
+        snippetRepository.watchAll,
+      ).thenAnswer((_) => snippetsController.stream);
+      when(
+        snippetRepository.watchAllFolders,
+      ).thenAnswer((_) => foldersController.stream);
+      when(() => snippetRepository.deleteFolder(10)).thenAnswer((_) async {
+        foldersController.add(const <SnippetFolder>[]);
+        snippetsController.add([
+          _buildSnippet(id: 1, name: 'Restart API', sortOrder: 0),
+        ]);
+        return 1;
+      });
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            snippetRepositoryProvider.overrideWithValue(snippetRepository),
+          ],
+          child: const MaterialApp(home: SnippetsScreen()),
+        ),
+      );
+      snippetsController.add([
+        _buildSnippet(id: 1, name: 'Restart API', sortOrder: 0, folderId: 10),
+      ]);
+      foldersController.add([_buildFolder(id: 10, name: 'Deploy')]);
+      await tester.pumpAndSettle();
+
+      await tester.longPress(find.text('Deploy (1)'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Delete "Deploy"?'), findsOneWidget);
+      expect(find.text('1 snippet will move to No folder.'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+      await tester.pumpAndSettle();
+
+      verify(() => snippetRepository.deleteFolder(10)).called(1);
+      expect(find.text('Deploy (1)'), findsNothing);
+      expect(find.text('No folder (1)'), findsOneWidget);
+      expect(find.text('Deleted folder "Deploy"'), findsOneWidget);
+    });
+
     testWidgets('full editor updates variable preview as command changes', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- Add a **Create Snippet** action next to Copy in the terminal text selection menu.
- Open the full snippet editor with the selected terminal text prefilled as the command and an editable name derived from the selection.
- Add tests for terminal menu item ordering, empty-selection behavior, generated snippet names, and snippet editor prefill values.

## Validation

- `flutter analyze`
- `flutter test test/presentation/screens/terminal_screen_test.dart test/widget/snippets_screen_test.dart --name 'terminal native selection helpers|SnippetsScreen'`
- `flutter test`
