### PR TITLE
fix: keep terminal theme queries responsive

### DIFF
--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -82,8 +82,8 @@ typedef TerminalControlModeState = ({
 
     output.write(combinedInput.substring(cursor, startIndex));
     final payloadStart = startIndex + _terminalTmuxPassthroughStart.length;
-    final endIndex = combinedInput.indexOf(
-      _terminalStringTerminator,
+    final endIndex = _terminalTmuxPassthroughEndIndex(
+      combinedInput,
       payloadStart,
     );
     if (endIndex == -1) {
@@ -298,6 +298,27 @@ const _terminalTmuxPassthroughStart = '${_terminalEscape}Ptmux;';
 
 String _formatTerminalModeReport(int mode, int status) =>
     '\x1b[?$mode;$status\$y';
+
+int _terminalTmuxPassthroughEndIndex(String input, int payloadStart) {
+  var index = payloadStart;
+  while (index < input.length - 1) {
+    if (input[index] != _terminalEscape) {
+      index += 1;
+      continue;
+    }
+
+    final next = input[index + 1];
+    if (next == _terminalEscape) {
+      index += 2;
+      continue;
+    }
+    if (next == r'\') {
+      return index;
+    }
+    index += 1;
+  }
+  return -1;
+}
 
 String _terminalTmuxPassthroughPendingSuffix(String input) {
   final maxSuffixLength =

--- a/lib/domain/services/ssh_session_runtime.dart
+++ b/lib/domain/services/ssh_session_runtime.dart
@@ -213,6 +213,9 @@ class _SshSessionRuntime {
                 terminalData: terminalData,
                 stdoutData: data,
               );
+              if (_shouldFlushShellOutputImmediately(terminalData)) {
+                _flushPendingShellOutput(drainAll: true);
+              }
             }
           },
           onError: (Object error, StackTrace stackTrace) {
@@ -397,6 +400,9 @@ class _SshSessionRuntime {
       );
     }
   }
+
+  bool _shouldFlushShellOutputImmediately(String terminalData) =>
+      terminalData.contains('\x1b]') || terminalData.contains('\x1b[?');
 
   void _flushPendingShellOutput({bool drainAll = false}) {
     _terminalOutputFlushTimer?.cancel();

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -1742,6 +1742,11 @@ String buildTmuxRefreshTerminalThemeCommand(
     theme,
     extraFlags: extraFlags,
   );
+  final provideClientThemeReports = _buildTmuxProvideClientThemeReportsCommand(
+    sessionName,
+    theme,
+    extraFlags: extraFlags,
+  );
   // Make sure tmux forwards focus events to inner panes — without this,
   // theme-aware TUIs like Codex/Copilot CLI never receive the FocusGained
   // signal we use as the trigger to re-query OSC 10/11 after a theme switch
@@ -1761,6 +1766,7 @@ String buildTmuxRefreshTerminalThemeCommand(
       r'{ while IFS="$SEP" read -r pane active alternate pane_command pane_title; do '
       r'[ -n "$pane" ] || continue; '
       '$setPaneColours '
+      '$provideClientThemeReports '
       'injected=0; foreground_tui=0; '
       r'if [ "$active" = 1 ]; then '
       r'case "${pane_command##*/}" in '
@@ -1866,6 +1872,45 @@ String _buildTmuxSetPaneColourSubcommand(int index, TerminalThemeData theme) {
   final optionName = TmuxService._shellQuote('pane-colours[$index]');
   return r'set-option -p -t "$pane" '
       '$optionName ${TmuxService._shellQuote(hexColor)}';
+}
+
+String _buildTmuxProvideClientThemeReportsCommand(
+  String sessionName,
+  TerminalThemeData theme, {
+  String? extraFlags,
+}) {
+  final reports = [
+    buildTerminalThemeOscResponse(theme: theme, code: '10', args: const ['?']),
+    buildTerminalThemeOscResponse(theme: theme, code: '11', args: const ['?']),
+  ].whereType<String>().toList(growable: false);
+  if (reports.isEmpty) {
+    return '';
+  }
+
+  const sep = r'${SEP}';
+  final listClients = TmuxService._tmuxCommand(
+    'list-clients -t ${TmuxService._shellQuote(sessionName)} -F ',
+    extraFlags: extraFlags,
+    forceUtf8: true,
+  );
+  final refreshReports = reports
+      .map((report) {
+        final reportCommand = TmuxService._tmuxCommand(
+          '${r'refresh-client -t "$client" -r "$pane":'}'
+          '${TmuxService._shellQuote(report)}',
+          extraFlags: extraFlags,
+          forceUtf8: true,
+        );
+        return '$reportCommand 2>/dev/null || true;';
+      })
+      .join(' ');
+
+  return '$listClients"#{client_name}$sep#{client_control_mode}" '
+      '2>/dev/null | '
+      r'while IFS="$SEP" read -r client _control; do '
+      r'[ -n "$client" ] || continue; '
+      '$refreshReports '
+      'done;';
 }
 
 String _buildTmuxSendPaneTerminalThemeCommand(

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -17,6 +17,7 @@ import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/key_repository.dart';
 import 'package:monkeyssh/data/repositories/known_hosts_repository.dart';
 import 'package:monkeyssh/data/security/secret_encryption_service.dart';
+import 'package:monkeyssh/domain/models/terminal_theme.dart';
 import 'package:monkeyssh/domain/models/terminal_themes.dart' as monkey_themes;
 import 'package:monkeyssh/domain/services/background_ssh_service.dart';
 import 'package:monkeyssh/domain/services/host_key_verification.dart';
@@ -204,6 +205,7 @@ class _FakeActiveSessionsSshService extends SshService {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   registerFallbackValue(const SSHPtyConfig());
+  registerFallbackValue(Uint8List(0));
 
   group('SshConnectionState', () {
     test('has expected values', () {
@@ -922,9 +924,11 @@ void main() {
     Future<
       ({
         Completer<void> done,
+        _MockExecSession shell,
         SshSession session,
         StreamController<Uint8List> stderr,
         StreamController<Uint8List> stdout,
+        List<List<int>> shellWrites,
       })
     >
     openShell() async {
@@ -933,6 +937,7 @@ void main() {
       final stdout = StreamController<Uint8List>();
       final stderr = StreamController<Uint8List>();
       final done = Completer<void>();
+      final shellWrites = <List<int>>[];
       final session = SshSession(
         connectionId: 91,
         hostId: 2,
@@ -950,6 +955,10 @@ void main() {
       when(() => shell.stdout).thenAnswer((_) => stdout.stream);
       when(() => shell.stderr).thenAnswer((_) => stderr.stream);
       when(() => shell.done).thenAnswer((_) => done.future);
+      when(() => shell.write(any())).thenAnswer((invocation) {
+        final bytes = invocation.positionalArguments.single as List<int>;
+        shellWrites.add(List<int>.from(bytes));
+      });
 
       await session.getShell();
       addTearDown(() async {
@@ -960,7 +969,14 @@ void main() {
           done.complete();
         }
       });
-      return (done: done, session: session, stderr: stderr, stdout: stdout);
+      return (
+        done: done,
+        shell: shell,
+        session: session,
+        stderr: stderr,
+        stdout: stdout,
+        shellWrites: shellWrites,
+      );
     }
 
     String firstLineText(Terminal terminal) => terminal.buffer.lines[0]
@@ -995,6 +1011,26 @@ void main() {
       expect(terminalNotifications, 1);
     });
 
+    test('flushes terminal theme OSC queries without frame delay', () async {
+      final shell = await openShell();
+      final session = shell.session;
+      final terminal = session.terminal!;
+      session.terminalTheme = monkey_themes.TerminalThemes.defaultLightTheme;
+
+      shell.stdout.add(Uint8List.fromList(utf8.encode('\x1b]11;?\x1b\\')));
+      await pumpEventQueue();
+
+      expect(firstLineText(terminal), isEmpty);
+      expect(
+        utf8.decode(shell.shellWrites.expand((chunk) => chunk).toList()),
+        buildTerminalThemeOscResponse(
+          theme: monkey_themes.TerminalThemes.defaultLightTheme,
+          code: '11',
+          args: const ['?'],
+        ),
+      );
+    });
+
     test('flushes pending terminal output before shell done event', () async {
       final shell = await openShell();
       final done = shell.done;
@@ -1007,10 +1043,6 @@ void main() {
       addTearDown(doneSubscription.cancel);
 
       shell.stdout.add(Uint8List.fromList(utf8.encode('final prompt')));
-      await pumpEventQueue();
-
-      expect(firstLineText(terminal), isNot(contains('final prompt')));
-
       done.complete();
 
       expect(await lineWhenDone.future, 'final prompt');

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -314,6 +314,16 @@ void main() {
       expect(result.pendingInput, isEmpty);
     });
 
+    test('unwraps ST-terminated tmux passthrough OSC sequences', () {
+      final result = unwrapTerminalTmuxPassthroughSequences(
+        input: 'before\x1bPtmux;\x1b\x1b]11;?\x1b\x1b\\\x1b\\after',
+        pendingInput: '',
+      );
+
+      expect(result.output, 'before\x1b]11;?\x1b\\after');
+      expect(result.pendingInput, isEmpty);
+    });
+
     test('preserves split tmux passthrough sequences across chunks', () {
       final first = unwrapTerminalTmuxPassthroughSequences(
         input: 'before\x1bPtmux;\x1b',
@@ -1030,6 +1040,33 @@ void main() {
         ),
       );
     });
+
+    test(
+      'flushes tmux-wrapped terminal theme OSC queries without frame delay',
+      () async {
+        final shell = await openShell();
+        final session = shell.session;
+        final terminal = session.terminal!;
+        session.terminalTheme = monkey_themes.TerminalThemes.defaultLightTheme;
+
+        shell.stdout.add(
+          Uint8List.fromList(
+            utf8.encode('\x1bPtmux;\x1b\x1b]11;?\x1b\x1b\\\x1b\\'),
+          ),
+        );
+        await pumpEventQueue();
+
+        expect(firstLineText(terminal), isEmpty);
+        expect(
+          utf8.decode(shell.shellWrites.expand((chunk) => chunk).toList()),
+          buildTerminalThemeOscResponse(
+            theme: monkey_themes.TerminalThemes.defaultLightTheme,
+            code: '11',
+            args: const ['?'],
+          ),
+        );
+      },
+    );
 
     test('flushes pending terminal output before shell done event', () async {
       final shell = await openShell();

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -7,6 +7,7 @@ import 'package:dartssh2/dartssh2.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
+import 'package:monkeyssh/domain/models/terminal_theme.dart';
 import 'package:monkeyssh/domain/models/terminal_themes.dart';
 import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
@@ -168,6 +169,27 @@ void main() {
       expect(command, contains(r'case "$pane_title" in'));
       expect(command, contains('*OpenCode*|*opencode*)'));
       expect(command, contains(r'send-keys -t "$pane" -H'));
+      expect(command, contains(r'refresh-client -t "$client" -r "$pane":'));
+      expect(
+        command,
+        contains(
+          buildTerminalThemeOscResponse(
+            theme: TerminalThemes.dracula,
+            code: '10',
+            args: const ['?'],
+          ),
+        ),
+      );
+      expect(
+        command,
+        contains(
+          buildTerminalThemeOscResponse(
+            theme: TerminalThemes.dracula,
+            code: '11',
+            args: const ['?'],
+          ),
+        ),
+      );
       expect(command, contains('1b 5b 3f 39 39 37 3b 31 6e'));
       expect(command, contains('1b 5b 4f'));
       expect(command, contains('1b 5b 49'));
@@ -225,6 +247,14 @@ void main() {
           'tmux -u -S '
           "'/tmp/tmux-socket' -L 'alerts' "
           r"""set-option -p -t "$pane" 'pane-colours[0]'""",
+        ),
+      );
+      expect(
+        command,
+        contains(
+          'tmux -u -S '
+          "'/tmp/tmux-socket' -L 'alerts' "
+          r'refresh-client -t "$client" -r "$pane":',
         ),
       );
       expect(


### PR DESCRIPTION
## Summary

- Keeps terminal stdout batching for ordinary shell output, but immediately flushes terminal control/query chunks.
- Restores prompt handling for OSC/private CSI theme probes so xterm/TUI contents can fully re-query light/dark theme colors during theme transitions.
- Fixes tmux-wrapped OSC theme queries by treating doubled inner ESC bytes as payload, not as the tmux DCS terminator.
- Feeds updated OSC 10/11 theme reports directly into tmux's client report cache via `refresh-client -r` before waking pane TUIs, avoiding stale tmux per-pane color answers during theme switches.
- Adds regression coverage for immediate OSC 11 theme-query responses both directly and through tmux passthrough wrapping, plus tmux refresh command coverage for cached report updates.

## Validation

- `dart format lib/domain/services/ssh_service.dart lib/domain/services/ssh_session_runtime.dart lib/domain/services/tmux_service.dart test/domain/services/ssh_service_test.dart test/domain/services/tmux_service_control_mode_test.dart`
- `flutter test test/domain/services/ssh_service_test.dart --name "tmux|terminal output batching"`
- `flutter test test/domain/services/tmux_service_control_mode_test.dart --name "theme refresh command|refresh command"`
- `flutter analyze`
- `flutter test`
