### PR TITLE
Remove terminal copy menu item

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -5940,16 +5940,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                     ),
                   ),
                 const PopupMenuItem(
-                  value: 'copy',
-                  child: Row(
-                    children: [
-                      Icon(Icons.copy_rounded, size: 20),
-                      SizedBox(width: 12),
-                      Text('Copy'),
-                    ],
-                  ),
-                ),
-                const PopupMenuItem(
                   value: 'paste',
                   child: Row(
                     children: [
@@ -6842,9 +6832,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         break;
       case 'copy_working_directory':
         await _copyWorkingDirectory();
-        break;
-      case 'copy':
-        await _copySelection();
         break;
       case 'paste':
         await _pasteClipboard();
@@ -8374,19 +8361,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
 
     _showTerminalLinkMessage(result);
-  }
-
-  Future<void> _copySelection() async {
-    final text = _currentTerminalSelectionText();
-    if (text == null) {
-      return;
-    }
-
-    await _copySelectionText(
-      text,
-      clearTerminalSelection: !_isNativeSelectionMode,
-      restoreFocus: !_isNativeSelectionMode,
-    );
   }
 
   Future<void> _copySelectionText(

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -703,6 +703,19 @@ void main() {
       expect(wakelockPlatform.toggleCalls.last, false);
     });
 
+    testWidgets('terminal overflow menu omits standalone copy action', (
+      tester,
+    ) async {
+      await pumpScreen(tester);
+
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Copy'), findsNothing);
+      expect(find.text('Paste'), findsOneWidget);
+      expect(find.text('Paste Files'), findsOneWidget);
+    });
+
     testWidgets(
       'does not send synthetic terminal reports to an idle shell prompt',
       (tester) async {


### PR DESCRIPTION
## Summary

- Remove the standalone terminal overflow menu Copy item now that copying is handled through selection.
- Keep selection-context-menu copy behavior intact and leave paste/file actions in the overflow menu.
- Add a widget regression test for the terminal overflow menu contents.

## Validation

- dart format .
- flutter analyze
- flutter test
