### PR TITLE
fix: guard swipe backspace after cursor touch

### DIFF
--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -1661,8 +1661,6 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   bool _sendSingleBackspaceForPendingTouchDeletion({
     required ({int deletedCount, String appendedText, int deleteCursorOffset})
     delta,
-    required int? cursorOffsetHint,
-    required String previousText,
   }) {
     if (!_clearImeAfterNextTouchCursorMove ||
         delta.deletedCount == 0 ||
@@ -1670,12 +1668,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       return false;
     }
 
-    final previousTextLength = _textLengthInGraphemes(previousText);
-    final targetCursorOffset = cursorOffsetHint == null
-        ? delta.deleteCursorOffset
-        : _clampTextOffset(cursorOffsetHint + 1, previousTextLength);
     _notifyUserInput();
-    _moveTerminalCursorTo(targetCursorOffset);
     widget.terminal.keyInput(TerminalKey.backspace);
     _clearImeAfterNextTouchCursorMove = false;
     _clearImeBufferForFreshInput();
@@ -2251,11 +2244,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         previousTextOverride: deleteResetContinuation?.previousText,
         lastCursorOffsetOverride: deleteResetContinuation?.previousCursorOffset,
       );
-      if (_sendSingleBackspaceForPendingTouchDeletion(
-        delta: delta,
-        cursorOffsetHint: effectiveTargetCursorOffset,
-        previousText: deltaPreviousText,
-      )) {
+      if (_sendSingleBackspaceForPendingTouchDeletion(delta: delta)) {
         _sawImeComposition = false;
         return;
       }

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -1634,6 +1634,54 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
 
   int _textLengthInGraphemes(String text) => text.characters.length;
 
+  bool _clearImeForPendingTouchCursorMove(
+    TextEditingValue value,
+    String currentText,
+  ) {
+    if (!_clearImeAfterNextTouchCursorMove || currentText != _lastSentText) {
+      return false;
+    }
+
+    final targetCursorOffset = _collapsedSelectionCursorOffset(
+      currentText,
+      value,
+    );
+    if (targetCursorOffset == null ||
+        targetCursorOffset == _lastSentCursorOffset) {
+      return false;
+    }
+
+    _notifyUserInput();
+    _moveTerminalCursorTo(targetCursorOffset);
+    _clearImeAfterNextTouchCursorMove = false;
+    _clearImeBufferForFreshInput();
+    return true;
+  }
+
+  bool _sendSingleBackspaceForPendingTouchDeletion({
+    required ({int deletedCount, String appendedText, int deleteCursorOffset})
+    delta,
+    required int? cursorOffsetHint,
+    required String previousText,
+  }) {
+    if (!_clearImeAfterNextTouchCursorMove ||
+        delta.deletedCount == 0 ||
+        delta.appendedText.isNotEmpty) {
+      return false;
+    }
+
+    final previousTextLength = _textLengthInGraphemes(previousText);
+    final targetCursorOffset = cursorOffsetHint == null
+        ? delta.deleteCursorOffset
+        : _clampTextOffset(cursorOffsetHint + 1, previousTextLength);
+    _notifyUserInput();
+    _moveTerminalCursorTo(targetCursorOffset);
+    widget.terminal.keyInput(TerminalKey.backspace);
+    _clearImeAfterNextTouchCursorMove = false;
+    _clearImeBufferForFreshInput();
+    return true;
+  }
+
   int _graphemeOffsetForCodeUnitOffset(String text, int codeUnitOffset) => text
       .substring(0, _clampTextOffset(codeUnitOffset, text.length))
       .characters
@@ -2070,6 +2118,15 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     var processedUserSelectionWasValid = false;
     var processedUserSelection = const TextSelection.collapsed(offset: 0);
     try {
+      final pendingTouchCursorCurrentText = _extractInputText(value.text);
+      if (_clearImeForPendingTouchCursorMove(
+        value,
+        pendingTouchCursorCurrentText,
+      )) {
+        _sawImeComposition = false;
+        return;
+      }
+
       // Handle composing (IME input in progress).
       if (!value.composing.isCollapsed) {
         _cancelDeferredTrailingBackspaceImeClear();
@@ -2175,7 +2232,6 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         return;
       }
 
-      _clearImeAfterNextTouchCursorMove = false;
       final deleteResetContinuation = _resolveDeleteResetContinuation(
         normalizedCurrentText,
         cursorOffsetHint: normalizedTargetCursorOffset,
@@ -2195,6 +2251,15 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         previousTextOverride: deleteResetContinuation?.previousText,
         lastCursorOffsetOverride: deleteResetContinuation?.previousCursorOffset,
       );
+      if (_sendSingleBackspaceForPendingTouchDeletion(
+        delta: delta,
+        cursorOffsetHint: effectiveTargetCursorOffset,
+        previousText: deltaPreviousText,
+      )) {
+        _sawImeComposition = false;
+        return;
+      }
+      _clearImeAfterNextTouchCursorMove = false;
       final pendingInputIsTrailingPureDeletion =
           deltaPreviousText.isNotEmpty &&
           delta.deletedCount > 0 &&

--- a/test/presentation/widgets/terminal_text_input_handler_test.dart
+++ b/test/presentation/widgets/terminal_text_input_handler_test.dart
@@ -1,0 +1,205 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show TextInputClient;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
+import 'package:xterm/xterm.dart';
+
+const _deleteDetectionMarker = '\u200B\u200B';
+
+({String text, int cursorOffset}) _terminalStateFromEvents(
+  Iterable<String> events, {
+  required String initialText,
+  required int initialCursorOffset,
+}) {
+  final visibleCharacters = initialText.characters.toList(growable: true);
+  var cursorOffset = initialCursorOffset;
+
+  for (final event in events) {
+    var offset = 0;
+    while (offset < event.length) {
+      if (event.startsWith('\u001b[D', offset)) {
+        if (cursorOffset > 0) {
+          cursorOffset--;
+        }
+        offset += 3;
+        continue;
+      }
+      if (event.startsWith('\u001b[C', offset)) {
+        if (cursorOffset < visibleCharacters.length) {
+          cursorOffset++;
+        }
+        offset += 3;
+        continue;
+      }
+
+      final character = event.substring(offset).characters.first;
+      offset += character.length;
+      if (character == '\x7f') {
+        if (cursorOffset > 0) {
+          visibleCharacters.removeAt(cursorOffset - 1);
+          cursorOffset--;
+        }
+        continue;
+      }
+
+      visibleCharacters.insert(cursorOffset, character);
+      cursorOffset++;
+    }
+  }
+
+  return (text: visibleCharacters.join(), cursorOffset: cursorOffset);
+}
+
+void main() {
+  group('TerminalTextInputHandler', () {
+    testWidgets('clears composing IME state after a touch-driven caret move', (
+      tester,
+    ) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalTextInputHandler(
+              terminal: terminal,
+              focusNode: focusNode,
+              deleteDetection: true,
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      tester.testTextInput.updateEditingValue(
+        const TextEditingValue(
+          text: '${_deleteDetectionMarker}hello world',
+          selection: TextSelection.collapsed(offset: 13),
+        ),
+      );
+      await tester.pump();
+
+      terminalOutput.clear();
+
+      await tester.tap(find.byType(TerminalTextInputHandler));
+      await tester.pump();
+
+      tester.testTextInput.updateEditingValue(
+        const TextEditingValue(
+          text: '${_deleteDetectionMarker}hello world',
+          selection: TextSelection.collapsed(offset: 8),
+          composing: TextRange(start: 8, end: 13),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        _terminalStateFromEvents(
+          terminalOutput,
+          initialText: 'hello world',
+          initialCursorOffset: 'hello world'.length,
+        ),
+        (text: 'hello world', cursorOffset: 'hello '.length),
+      );
+
+      final client =
+          tester.state(find.byType(TerminalTextInputHandler))
+              as TextInputClient;
+      expect(
+        client.currentTextEditingValue,
+        const TextEditingValue(
+          text: _deleteDetectionMarker,
+          selection: TextSelection.collapsed(offset: 2),
+        ),
+      );
+
+      terminalOutput.clear();
+
+      tester.testTextInput.updateEditingValue(
+        const TextEditingValue(
+          text: '\u200B',
+          selection: TextSelection.collapsed(offset: 1),
+        ),
+      );
+      await tester.pump();
+
+      expect(terminalOutput, ['\x7f']);
+
+      focusNode.dispose();
+    });
+
+    testWidgets(
+      'sends one backspace when stale IME selection deletes a chunk after touch',
+      (tester) async {
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add);
+        final focusNode = FocusNode();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TerminalTextInputHandler(
+                terminal: terminal,
+                focusNode: focusNode,
+                deleteDetection: true,
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        tester.testTextInput.updateEditingValue(
+          const TextEditingValue(
+            text: '${_deleteDetectionMarker}hello world',
+            selection: TextSelection.collapsed(offset: 13),
+          ),
+        );
+        await tester.pump();
+
+        terminalOutput.clear();
+
+        await tester.tap(find.byType(TerminalTextInputHandler));
+        await tester.pump();
+
+        tester.testTextInput.updateEditingValue(
+          const TextEditingValue(
+            text: '${_deleteDetectionMarker}hello ',
+            selection: TextSelection.collapsed(offset: 8),
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          _terminalStateFromEvents(
+            terminalOutput,
+            initialText: 'hello world',
+            initialCursorOffset: 'hello world'.length,
+          ),
+          (text: 'hello orld', cursorOffset: 'hello '.length),
+        );
+
+        final client =
+            tester.state(find.byType(TerminalTextInputHandler))
+                as TextInputClient;
+        expect(
+          client.currentTextEditingValue,
+          const TextEditingValue(
+            text: _deleteDetectionMarker,
+            selection: TextSelection.collapsed(offset: 2),
+          ),
+        );
+
+        focusNode.dispose();
+      },
+    );
+  });
+}

--- a/test/presentation/widgets/terminal_text_input_handler_test.dart
+++ b/test/presentation/widgets/terminal_text_input_handler_test.dart
@@ -184,7 +184,7 @@ void main() {
             initialText: 'hello world',
             initialCursorOffset: 'hello world'.length,
           ),
-          (text: 'hello orld', cursorOffset: 'hello '.length),
+          (text: 'hello worl', cursorOffset: 'hello worl'.length),
         );
 
         final client =
@@ -196,6 +196,72 @@ void main() {
             text: _deleteDetectionMarker,
             selection: TextSelection.collapsed(offset: 2),
           ),
+        );
+
+        focusNode.dispose();
+      },
+    );
+
+    testWidgets(
+      'does not move before backspacing a stale chunk deletion after touch',
+      (tester) async {
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add);
+        final focusNode = FocusNode();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TerminalTextInputHandler(
+                terminal: terminal,
+                focusNode: focusNode,
+                deleteDetection: true,
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        tester.testTextInput.updateEditingValue(
+          const TextEditingValue(
+            text: '${_deleteDetectionMarker}hello world',
+            selection: TextSelection.collapsed(offset: 13),
+          ),
+        );
+        await tester.pump();
+
+        tester.testTextInput.updateEditingValue(
+          const TextEditingValue(
+            text: '${_deleteDetectionMarker}hello world',
+            selection: TextSelection.collapsed(offset: 8),
+          ),
+        );
+        await tester.pump();
+
+        terminalOutput.clear();
+
+        await tester.tap(find.byType(TerminalTextInputHandler));
+        await tester.pump();
+
+        tester.testTextInput.updateEditingValue(
+          const TextEditingValue(
+            text: '${_deleteDetectionMarker}hello ',
+            selection: TextSelection.collapsed(offset: 8),
+          ),
+        );
+        await tester.pump();
+
+        expect(terminalOutput, ['\x7f']);
+        expect(
+          _terminalStateFromEvents(
+            terminalOutput,
+            initialText: 'hello world',
+            initialCursorOffset: 'hello '.length,
+          ),
+          (text: 'helloworld', cursorOffset: 'hello'.length),
         );
 
         focusNode.dispose();


### PR DESCRIPTION
## Summary

- Reset stale IME composing/deletion state when a touch-driven caret move is detected.
- Treat the first stale chunk delete after a touch caret move as a single terminal Backspace.
- Add focused widget regressions for composing-state reset and single-backspace behavior.

## Validation

- `flutter test test/presentation/widgets/terminal_text_input_handler_test.dart`
- `flutter test test/presentation/screens/terminal_screen_test.dart --plain-name "toolbar navigation keys clear the screen IME buffer"`
- `flutter test test/presentation/screens/terminal_screen_test.dart --plain-name "toolbar Ctrl state flows into the screen IME handler"`
- `flutter analyze`
- `flutter test --no-pub`
