### PR TITLE
Enable keyboard voice input

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ MonkeySSH is not just an SSH pipe with a keyboard attached. It is designed aroun
 - **Saved launch presets** for tools like Claude Code, Copilot CLI, Codex, Gemini CLI, OpenCode, and Aider
 - **Per-host startup flows** with working-directory changes, tmux session names, extra arguments, and optional one-tap automation
 - **Tmux integration** for discovering sessions and windows, tracking the active pane path, and launching agents into persistent workspaces
-- **IME keyboard support** so autocorrect, suggestions, swipe typing, and keyboard dictation behave more like a normal mobile text field, even in a terminal
+- **IME keyboard support** so autocorrect, suggestions, swipe typing, keyboard dictation, and password-friendly prompt input behave more like a normal mobile text field, even in a terminal
 - **Safer command handling** with review prompts for suspicious pasted or auto-run shell text before it is inserted or executed
 - **Remote clipboard sync** so it is easier to move code and commands between your device and the remote machine
 
@@ -33,7 +33,7 @@ MonkeySSH is not just an SSH pipe with a keyboard attached. It is designed aroun
 | Area | What you get |
 | --- | --- |
 | **SSH connections** | Password and key auth, jump hosts, multiple concurrent sessions, host organization, search, favorites |
-| **Terminal** | xterm-256color, customizable themes, adjustable fonts, modifier keys, function keys, gestures, macros, bell, tap-to-show keyboard, and IME-friendly typing with autocorrect, swipe, and keyboard dictation input |
+| **Terminal** | xterm-256color, customizable themes, adjustable fonts, modifier keys, function keys, gestures, macros, bell, tap-to-show keyboard, and IME-friendly typing with autocorrect, swipe, keyboard dictation, and password-friendly prompt input |
 | **Coding workflow** | AI session picker, recent session resume, tmux-aware launch flows, clickable file paths, shared clipboard, safer paste review |
 | **Files** | SFTP browser, upload/download, remote file creation, direct remote text editing, syntax highlighting, path-aware navigation from terminal output |
 | **Automation** | Snippets, variable-aware snippet insertion, host auto-connect commands, saved agent launch presets |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ MonkeySSH is not just an SSH pipe with a keyboard attached. It is designed aroun
 - **Saved launch presets** for tools like Claude Code, Copilot CLI, Codex, Gemini CLI, OpenCode, and Aider
 - **Per-host startup flows** with working-directory changes, tmux session names, extra arguments, and optional one-tap automation
 - **Tmux integration** for discovering sessions and windows, tracking the active pane path, and launching agents into persistent workspaces
-- **IME keyboard support** so autocorrect, suggestions, and swipe typing behave more like a normal mobile text field, even in a terminal
+- **IME keyboard support** so autocorrect, suggestions, swipe typing, and keyboard dictation behave more like a normal mobile text field, even in a terminal
 - **Safer command handling** with review prompts for suspicious pasted or auto-run shell text before it is inserted or executed
 - **Remote clipboard sync** so it is easier to move code and commands between your device and the remote machine
 
@@ -33,7 +33,7 @@ MonkeySSH is not just an SSH pipe with a keyboard attached. It is designed aroun
 | Area | What you get |
 | --- | --- |
 | **SSH connections** | Password and key auth, jump hosts, multiple concurrent sessions, host organization, search, favorites |
-| **Terminal** | xterm-256color, customizable themes, adjustable fonts, modifier keys, function keys, gestures, macros, bell, tap-to-show keyboard, and IME-friendly typing with autocorrect and swipe input |
+| **Terminal** | xterm-256color, customizable themes, adjustable fonts, modifier keys, function keys, gestures, macros, bell, tap-to-show keyboard, and IME-friendly typing with autocorrect, swipe, and keyboard dictation input |
 | **Coding workflow** | AI session picker, recent session resume, tmux-aware launch flows, clickable file paths, shared clipboard, safer paste review |
 | **Files** | SFTP browser, upload/download, remote file creation, direct remote text editing, syntax highlighting, path-aware navigation from terminal output |
 | **Automation** | Snippets, variable-aware snippet insertion, host auto-connect commands, saved agent launch presets |

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -480,6 +480,41 @@ String _stripTerminalPromptEscapeSequences(String text) => text
     .replaceAll(_csiEscapeSequencePattern, '')
     .replaceAll(_singleCharEscapeSequencePattern, '');
 
+final _terminalSensitivePromptPattern = RegExp(
+  r'\b(?:password|passphrase|pin|otp|one[- ]time(?:\s+password)?|verification(?:\s+code)?|authentication(?:\s+code)?|auth(?:\s+code)?|security(?:\s+code)?)\b[^\r\n]{0,160}[:：]\s*$',
+  caseSensitive: false,
+);
+
+final _terminalPasswordPolicyPromptPattern = RegExp(
+  r'\b(?:password|passphrase)\s+(?:requirements?|policy|rules?|hint|incorrect|invalid|failed|failure|reset|changed|updated)\b',
+  caseSensitive: false,
+);
+
+/// Returns whether the visible terminal text appears to be requesting a secret.
+@visibleForTesting
+bool terminalTextLooksLikeSensitiveInputPrompt(String? textBeforeCursor) {
+  if (textBeforeCursor == null) {
+    return false;
+  }
+
+  final sanitizedText = _stripTerminalPromptEscapeSequences(textBeforeCursor);
+  if (sanitizedText.trimRight().isEmpty) {
+    return false;
+  }
+
+  final lastLine = sanitizedText.split(RegExp(r'[\r\n]')).last.trimRight();
+  if (lastLine.isEmpty || lastLine.length > 220) {
+    return false;
+  }
+
+  final normalizedLine = lastLine.replaceAll(RegExp(r'\s+'), ' ').trim();
+  if (_terminalPasswordPolicyPromptPattern.hasMatch(normalizedLine)) {
+    return false;
+  }
+
+  return _terminalSensitivePromptPattern.hasMatch(normalizedLine);
+}
+
 const _minTerminalFontSize = 8.0;
 const _maxTerminalFontSize = 32.0;
 const _terminalFollowOutputTolerance = 1.0;
@@ -2112,6 +2147,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _isConnecting = true;
   String? _error;
   bool _showKeyboardToolbar = !_hideStoreScreenshotKeyboardToolbar;
+  bool _manualSensitiveKeyboardMode = false;
+  bool _detectedSensitiveKeyboardPrompt = false;
   bool _isUsingAltBuffer = false;
   bool _terminalReportsMouseWheel = false;
   bool _isNativeSelectionMode = false;
@@ -2223,6 +2260,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   DateTime? _recentLocalClipboardAt;
   bool _isTerminalSizeRefreshQueued = false;
   bool _terminalWakeLockSetting = false;
+
+  bool get _usesSensitiveKeyboardMode =>
+      _manualSensitiveKeyboardMode || _detectedSensitiveKeyboardPrompt;
 
   // Theme state
   Host? _host;
@@ -2526,21 +2566,35 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _queueTerminalScrollToBottom();
     }
 
+    if (!mounted) {
+      return;
+    }
+
     final isUsingAltBuffer = _terminal.isUsingAltBuffer;
     final terminalReportsMouseWheel = _terminal.mouseMode.reportScroll;
-    if (!mounted ||
-        !didTerminalScrollPolicyChange(
-          previousIsUsingAltBuffer: _isUsingAltBuffer,
-          nextIsUsingAltBuffer: isUsingAltBuffer,
-          previousReportsMouseWheel: _terminalReportsMouseWheel,
-          nextReportsMouseWheel: terminalReportsMouseWheel,
-        )) {
+    final scrollPolicyChanged = didTerminalScrollPolicyChange(
+      previousIsUsingAltBuffer: _isUsingAltBuffer,
+      nextIsUsingAltBuffer: isUsingAltBuffer,
+      previousReportsMouseWheel: _terminalReportsMouseWheel,
+      nextReportsMouseWheel: terminalReportsMouseWheel,
+    );
+    final detectedSensitiveKeyboardPrompt =
+        _isMobilePlatform &&
+        terminalTextLooksLikeSensitiveInputPrompt(_terminalTextBeforeCursor());
+    final sensitiveKeyboardPromptChanged =
+        detectedSensitiveKeyboardPrompt != _detectedSensitiveKeyboardPrompt;
+    if (!scrollPolicyChanged && !sensitiveKeyboardPromptChanged) {
       return;
     }
 
     setState(() {
-      _isUsingAltBuffer = isUsingAltBuffer;
-      _terminalReportsMouseWheel = terminalReportsMouseWheel;
+      if (scrollPolicyChanged) {
+        _isUsingAltBuffer = isUsingAltBuffer;
+        _terminalReportsMouseWheel = terminalReportsMouseWheel;
+      }
+      if (sensitiveKeyboardPromptChanged) {
+        _detectedSensitiveKeyboardPrompt = detectedSensitiveKeyboardPrompt;
+      }
     });
   }
 
@@ -4017,6 +4071,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         data == '\n' ? '\r' : data,
       );
 
+      _clearDetectedSensitiveKeyboardPromptAfterInput(output);
       _shell?.write(utf8.encode(output));
     };
 
@@ -4057,6 +4112,20 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   void _syncTerminalWakeLock([SshConnectionState? connectionState]) {
     _sessionController.syncWakeLock(connectionState);
+  }
+
+  void _clearDetectedSensitiveKeyboardPromptAfterInput(String output) {
+    if (!_detectedSensitiveKeyboardPrompt ||
+        (!output.contains('\r') && !output.contains('\n'))) {
+      return;
+    }
+
+    if (!mounted) {
+      _detectedSensitiveKeyboardPrompt = false;
+      return;
+    }
+
+    setState(() => _detectedSensitiveKeyboardPrompt = false);
   }
 
   void _schedulePromptOutputImeResetCheck(String data) {
@@ -5447,6 +5516,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     } else {
       setState(() {
         _clearTmuxState();
+        _detectedSensitiveKeyboardPrompt = false;
         _isConnecting = false;
         _error = 'Connection closed';
       });
@@ -5909,6 +5979,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                     value: 'toggle_tap_keyboard',
                     checked: ref.read(tapToShowKeyboardNotifierProvider),
                     child: const Text('Tap to Show Keyboard'),
+                  ),
+                if (isMobile)
+                  CheckedPopupMenuItem(
+                    value: 'toggle_sensitive_keyboard',
+                    checked: _manualSensitiveKeyboardMode,
+                    child: const Text('Sensitive Keyboard'),
                   ),
                 const PopupMenuDivider(),
                 if (!isMobile)
@@ -6593,6 +6669,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _toolbarController.applySystemKeyboardModifiers,
       hasActiveToolbarModifier: () =>
           _toolbarController.isCtrlActive || _toolbarController.isAltActive,
+      sensitiveInput: _usesSensitiveKeyboardMode,
       readOnly: _showsNativeSelectionOverlay || overlayMessage != null,
       tapToShowKeyboard:
           ref.watch(tapToShowKeyboardNotifierProvider) &&
@@ -6720,6 +6797,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         final notifier = ref.read(tapToShowKeyboardNotifierProvider.notifier);
         await notifier.setEnabled(
           enabled: !ref.read(tapToShowKeyboardNotifierProvider),
+        );
+        break;
+      case 'toggle_sensitive_keyboard':
+        setState(
+          () => _manualSensitiveKeyboardMode = !_manualSensitiveKeyboardMode,
         );
         break;
       case 'native_select':

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -328,6 +328,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   String? _pendingDeleteResetBaselineText;
   int? _pendingDeleteResetBaselineCursorOffset;
   String? _pendingDeleteResetDeletedSuffixText;
+  bool _isInputConnectionShown = false;
   String _lastSentText = '';
   int _lastSentCursorOffset = 0;
   int _iosBackspaceRunwayLength = 0;
@@ -365,8 +366,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       }
     }
     if (hasInputConnection &&
-        (widget.keyboardAppearance != oldWidget.keyboardAppearance ||
-            widget.sensitiveInput != oldWidget.sensitiveInput)) {
+        widget.sensitiveInput != oldWidget.sensitiveInput) {
+      _restartInputConnection();
+    } else if (hasInputConnection &&
+        widget.keyboardAppearance != oldWidget.keyboardAppearance) {
       _connection!.updateConfig(_buildTextInputConfiguration());
     }
     if (!_shouldCreateInputConnection) {
@@ -814,6 +817,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (hasInputConnection) {
       _connection?.close();
     }
+    _isInputConnectionShown = false;
   }
 
   void _suppressNextTouchKeyboardRequest() {
@@ -921,10 +925,17 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (!_shouldCreateInputConnection) return;
 
     if (hasInputConnection) {
-      if (show) _connection!.show();
+      if (show) {
+        _connection!.show();
+        _isInputConnectionShown = true;
+      }
     } else {
       _connection = TextInput.attach(this, _buildTextInputConfiguration());
-      if (show) _connection!.show();
+      _isInputConnectionShown = false;
+      if (show) {
+        _connection!.show();
+        _isInputConnectionShown = true;
+      }
       _invalidatePendingEditingUpdates();
       _sawImeComposition = false;
       _lastProcessedUserSelectionWasValid = false;
@@ -949,9 +960,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       TextInputConfiguration(
         // Keep these explicit because terminal IME behavior is central here.
         // ignore: avoid_redundant_argument_values
-        inputType: widget.sensitiveInput
-            ? TextInputType.visiblePassword
-            : TextInputType.text,
+        inputType: TextInputType.text,
         // ignore: avoid_redundant_argument_values
         autocorrect: !widget.sensitiveInput,
         // ignore: avoid_redundant_argument_values
@@ -977,6 +986,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       _connection!.close();
       _connection = null;
     }
+    _isInputConnectionShown = false;
     _invalidatePendingEditingUpdates();
     _sawImeComposition = false;
     _lastProcessedUserSelectionWasValid = false;
@@ -993,6 +1003,12 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _pendingPerformedEnterText = null;
     _pendingEnterActionSuppressions = 0;
     _currentEditingState = _initEditingState.copyWith();
+  }
+
+  void _restartInputConnection() {
+    final shouldShow = _isInputConnectionShown;
+    _closeInputConnectionIfNeeded();
+    _openInputConnection(show: shouldShow);
   }
 
   // -- Editing state --

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -189,6 +189,7 @@ class TerminalTextInputHandler extends StatefulWidget {
     this.consumeTerminalKeyModifiers,
     this.applyTerminalTextInputModifiers,
     this.hasActiveToolbarModifier,
+    this.sensitiveInput = false,
     this.readOnly = false,
     this.tapToShowKeyboard = true,
     this.showKeyboardOnFocus,
@@ -244,6 +245,13 @@ class TerminalTextInputHandler extends StatefulWidget {
   /// than visible text. In that case the IME buffer is cleared after sending
   /// the input so that stale suggestions don't accumulate from non-text input.
   final ValueGetter<bool>? hasActiveToolbarModifier;
+
+  /// Whether the terminal appears to be accepting sensitive text.
+  ///
+  /// When true, the platform keyboard is configured like a password field so
+  /// autocorrect, suggestions, dictation, and IME learning stay disabled while
+  /// a remote password/passphrase prompt is active.
+  final bool sensitiveInput;
 
   /// Whether input should be suppressed.
   final bool readOnly;
@@ -346,7 +354,8 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       }
     }
     if (hasInputConnection &&
-        widget.keyboardAppearance != oldWidget.keyboardAppearance) {
+        (widget.keyboardAppearance != oldWidget.keyboardAppearance ||
+            widget.sensitiveInput != oldWidget.sensitiveInput)) {
       _connection!.updateConfig(_buildTextInputConfiguration());
     }
     if (!_shouldCreateInputConnection) {
@@ -921,22 +930,25 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       TextInputConfiguration(
         // Keep these explicit because terminal IME behavior is central here.
         // ignore: avoid_redundant_argument_values
-        inputType: TextInputType.text,
+        inputType: widget.sensitiveInput
+            ? TextInputType.visiblePassword
+            : TextInputType.text,
         // ignore: avoid_redundant_argument_values
-        autocorrect: true,
+        autocorrect: !widget.sensitiveInput,
         // ignore: avoid_redundant_argument_values
         inputAction: TextInputAction.newline,
         keyboardAppearance: widget.keyboardAppearance,
         // Enable suggestions so the IME offers dictation and adds spaces
         // between swiped words.
         // ignore: avoid_redundant_argument_values
-        enableSuggestions: true,
+        enableSuggestions: !widget.sensitiveInput,
+        obscureText: widget.sensitiveInput,
         smartDashesType: SmartDashesType.disabled,
         smartQuotesType: SmartQuotesType.disabled,
         // Let the keyboard behave like a normal text field; voice input can
         // depend on this on third-party IMEs.
         // ignore: avoid_redundant_argument_values
-        enableIMEPersonalizedLearning: true,
+        enableIMEPersonalizedLearning: !widget.sensitiveInput,
       );
 
   void _closeInputConnectionIfNeeded() {

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -165,10 +165,11 @@ class TerminalTextInputHandlerController {
 /// proper IME configuration for swipe typing.
 ///
 /// The xterm package's built-in [CustomTextEdit] hard-codes
-/// `autocorrect: false` and `enableSuggestions: false`, which causes
-/// most IMEs to drop spaces between swiped words. This widget replaces
-/// that text input handling with `enableSuggestions: true` so swipe
-/// typing works correctly.
+/// `autocorrect: false` and `enableSuggestions: false`, which hides voice
+/// input on some system keyboards and causes most IMEs to drop spaces between
+/// swiped words. This widget replaces that text input handling with a normal
+/// text keyboard configuration so dictation, suggestions, and swipe typing work
+/// correctly.
 ///
 /// The child [TerminalView] should use `hardwareKeyboardOnly: true`.
 class TerminalTextInputHandler extends StatefulWidget {
@@ -920,15 +921,22 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       TextInputConfiguration(
         // Keep these explicit because terminal IME behavior is central here.
         // ignore: avoid_redundant_argument_values
-        autocorrect: false,
+        inputType: TextInputType.text,
+        // ignore: avoid_redundant_argument_values
+        autocorrect: true,
+        // ignore: avoid_redundant_argument_values
         inputAction: TextInputAction.newline,
         keyboardAppearance: widget.keyboardAppearance,
-        // Enable suggestions so the IME adds spaces between swiped words.
+        // Enable suggestions so the IME offers dictation and adds spaces
+        // between swiped words.
         // ignore: avoid_redundant_argument_values
         enableSuggestions: true,
         smartDashesType: SmartDashesType.disabled,
         smartQuotesType: SmartQuotesType.disabled,
-        enableIMEPersonalizedLearning: false,
+        // Let the keyboard behave like a normal text field; voice input can
+        // depend on this on third-party IMEs.
+        // ignore: avoid_redundant_argument_values
+        enableIMEPersonalizedLearning: true,
       );
 
   void _closeInputConnectionIfNeeded() {

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -1248,13 +1248,6 @@ Map<dynamic, dynamic> _latestTextInputSetClientConfiguration(
   return _textInputConfigurationFromCall(call);
 }
 
-Map<dynamic, dynamic> _latestTextInputUpdateConfiguration(WidgetTester tester) {
-  final call = tester.testTextInput.log.lastWhere(
-    (call) => call.method == 'TextInput.updateConfig',
-  );
-  return _textInputConfigurationFromCall(call);
-}
-
 void main() {
   group('terminalTextLooksLikeSensitiveInputPrompt', () {
     test('detects common password-like prompts', () {
@@ -1337,7 +1330,7 @@ void main() {
       final configuration = _latestTextInputSetClientConfiguration(tester);
       final inputType = configuration['inputType']! as Map<dynamic, dynamic>;
 
-      expect(inputType['name'], 'TextInputType.visiblePassword');
+      expect(inputType['name'], 'TextInputType.text');
       expect(configuration['obscureText'], isTrue);
       expect(configuration['autocorrect'], isFalse);
       expect(configuration['enableSuggestions'], isFalse);
@@ -1346,7 +1339,7 @@ void main() {
       await _disposeTerminalHarness(tester, harness);
     });
 
-    testWidgets('updates the active IME configuration for sensitive input', (
+    testWidgets('restarts the active IME connection for sensitive input', (
       tester,
     ) async {
       final terminal = Terminal();
@@ -1372,10 +1365,22 @@ void main() {
       await tester.pumpWidget(buildHarness(sensitiveInput: true));
       await tester.pump();
 
-      final configuration = _latestTextInputUpdateConfiguration(tester);
+      final configuration = _latestTextInputSetClientConfiguration(tester);
       final inputType = configuration['inputType']! as Map<dynamic, dynamic>;
 
-      expect(inputType['name'], 'TextInputType.visiblePassword');
+      expect(
+        tester.testTextInput.log.where(
+          (call) => call.method == 'TextInput.clearClient',
+        ),
+        hasLength(1),
+      );
+      expect(
+        tester.testTextInput.log.where(
+          (call) => call.method == 'TextInput.updateConfig',
+        ),
+        isEmpty,
+      );
+      expect(inputType['name'], 'TextInputType.text');
       expect(configuration['obscureText'], isTrue);
       expect(configuration['enableSuggestions'], isFalse);
 

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -738,6 +738,7 @@ Future<_TerminalHarness> _pumpTerminalHarness(
   bool readOnly = false,
   bool deleteDetection = true,
   bool tapToShowKeyboard = true,
+  bool sensitiveInput = false,
   String Function()? resolveTextBeforeCursor,
   TerminalKeyModifierResolver? resolveTerminalKeyModifiers,
   VoidCallback? consumeTerminalKeyModifiers,
@@ -761,6 +762,7 @@ Future<_TerminalHarness> _pumpTerminalHarness(
           deleteDetection: deleteDetection,
           readOnly: readOnly,
           tapToShowKeyboard: tapToShowKeyboard,
+          sensitiveInput: sensitiveInput,
           resolveTextBeforeCursor: resolveTextBeforeCursor,
           resolveTerminalKeyModifiers: resolveTerminalKeyModifiers,
           consumeTerminalKeyModifiers: consumeTerminalKeyModifiers,
@@ -1216,17 +1218,88 @@ Future<void> _expectTextFieldComparisonScenario(
 TextInputClient _terminalTextInputClient(WidgetTester tester) =>
     tester.state(find.byType(TerminalTextInputHandler)) as TextInputClient;
 
+Map<dynamic, dynamic> _textInputConfigurationFromCall(MethodCall call) {
+  final arguments = call.arguments;
+  if (call.method == 'TextInput.setClient') {
+    return (arguments as List<dynamic>)[1]! as Map<dynamic, dynamic>;
+  }
+  return arguments as Map<dynamic, dynamic>;
+}
+
 Map<dynamic, dynamic> _latestTextInputSetClientConfiguration(
   WidgetTester tester,
 ) {
   final call = tester.testTextInput.log.lastWhere(
     (call) => call.method == 'TextInput.setClient',
   );
-  final arguments = call.arguments! as List<dynamic>;
-  return arguments[1]! as Map<dynamic, dynamic>;
+  return _textInputConfigurationFromCall(call);
+}
+
+Map<dynamic, dynamic> _latestTextInputUpdateConfiguration(WidgetTester tester) {
+  final call = tester.testTextInput.log.lastWhere(
+    (call) => call.method == 'TextInput.updateConfig',
+  );
+  return _textInputConfigurationFromCall(call);
 }
 
 void main() {
+  group('terminalTextLooksLikeSensitiveInputPrompt', () {
+    test('detects common password-like prompts', () {
+      const prompts = [
+        'Password:',
+        '[sudo] password for depoll:',
+        'root@example.com\'s password: ',
+        'Enter passphrase for key \'/Users/depoll/.ssh/id_ed25519\':',
+        'PIN:',
+        'Verification code:',
+        'One-time password:',
+        'Authentication code:',
+      ];
+
+      for (final prompt in prompts) {
+        expect(
+          terminalTextLooksLikeSensitiveInputPrompt(prompt),
+          isTrue,
+          reason: prompt,
+        );
+      }
+    });
+
+    test('only checks the prompt-like text before the cursor', () {
+      expect(
+        terminalTextLooksLikeSensitiveInputPrompt(
+          'Last login: Sun May 3\n\x1B[31mPassword:\x1B[0m ',
+        ),
+        isTrue,
+      );
+      expect(
+        terminalTextLooksLikeSensitiveInputPrompt('Password:\n\$ '),
+        isFalse,
+      );
+    });
+
+    test('ignores non-secret password-related output', () {
+      const lines = [
+        'Password requirements:',
+        'Password policy:',
+        'Password incorrect:',
+        'Password reset:',
+        'passwordless login enabled:',
+        'Last login:',
+        'Enter a username:',
+        null,
+      ];
+
+      for (final line in lines) {
+        expect(
+          terminalTextLooksLikeSensitiveInputPrompt(line),
+          isFalse,
+          reason: '$line',
+        );
+      }
+    });
+  });
+
   group('TerminalTextInputHandler', () {
     testWidgets(
       'uses a normal text IME configuration for keyboard voice input',
@@ -1243,6 +1316,60 @@ void main() {
         await _disposeTerminalHarness(tester, harness);
       },
     );
+
+    testWidgets('uses a password-friendly IME configuration for secrets', (
+      tester,
+    ) async {
+      final harness = await _pumpTerminalHarness(tester, sensitiveInput: true);
+      final configuration = _latestTextInputSetClientConfiguration(tester);
+      final inputType = configuration['inputType']! as Map<dynamic, dynamic>;
+
+      expect(inputType['name'], 'TextInputType.visiblePassword');
+      expect(configuration['obscureText'], isTrue);
+      expect(configuration['autocorrect'], isFalse);
+      expect(configuration['enableSuggestions'], isFalse);
+      expect(configuration['enableIMEPersonalizedLearning'], isFalse);
+
+      await _disposeTerminalHarness(tester, harness);
+    });
+
+    testWidgets('updates the active IME configuration for sensitive input', (
+      tester,
+    ) async {
+      final terminal = Terminal();
+      final focusNode = FocusNode();
+
+      Widget buildHarness({required bool sensitiveInput}) => MaterialApp(
+        home: Scaffold(
+          body: TerminalTextInputHandler(
+            terminal: terminal,
+            focusNode: focusNode,
+            deleteDetection: true,
+            sensitiveInput: sensitiveInput,
+            child: const SizedBox.expand(),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(buildHarness(sensitiveInput: false));
+      focusNode.requestFocus();
+      await tester.pump();
+
+      tester.testTextInput.log.clear();
+      await tester.pumpWidget(buildHarness(sensitiveInput: true));
+      await tester.pump();
+
+      final configuration = _latestTextInputUpdateConfiguration(tester);
+      final inputType = configuration['inputType']! as Map<dynamic, dynamic>;
+
+      expect(inputType['name'], 'TextInputType.visiblePassword');
+      expect(configuration['obscureText'], isTrue);
+      expect(configuration['enableSuggestions'], isFalse);
+
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+      await tester.pump();
+      focusNode.dispose();
+    });
 
     testWidgets('preserves swipe typing context across short pauses', (
       tester,

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -1216,8 +1216,34 @@ Future<void> _expectTextFieldComparisonScenario(
 TextInputClient _terminalTextInputClient(WidgetTester tester) =>
     tester.state(find.byType(TerminalTextInputHandler)) as TextInputClient;
 
+Map<dynamic, dynamic> _latestTextInputSetClientConfiguration(
+  WidgetTester tester,
+) {
+  final call = tester.testTextInput.log.lastWhere(
+    (call) => call.method == 'TextInput.setClient',
+  );
+  final arguments = call.arguments! as List<dynamic>;
+  return arguments[1]! as Map<dynamic, dynamic>;
+}
+
 void main() {
   group('TerminalTextInputHandler', () {
+    testWidgets(
+      'uses a normal text IME configuration for keyboard voice input',
+      (tester) async {
+        final harness = await _pumpTerminalHarness(tester);
+        final configuration = _latestTextInputSetClientConfiguration(tester);
+        final inputType = configuration['inputType']! as Map<dynamic, dynamic>;
+
+        expect(inputType['name'], 'TextInputType.text');
+        expect(configuration['autocorrect'], isTrue);
+        expect(configuration['enableSuggestions'], isTrue);
+        expect(configuration['enableIMEPersonalizedLearning'], isTrue);
+
+        await _disposeTerminalHarness(tester, harness);
+      },
+    );
+
     testWidgets('preserves swipe typing context across short pauses', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- Enable the terminal text input client to use a normal text keyboard configuration so OS keyboard dictation/voice input stays available.
- Detect password-like terminal prompts and switch to a password-friendly keyboard mode that disables autocorrect, suggestions, dictation, and IME learning while secrets are being entered.
- Restart the platform text input connection when sensitive mode changes so Android/iOS keyboards actually drop suggestions and microphone affordances.
- Add a manual **Sensitive Keyboard** mobile menu toggle for prompts the heuristic misses.
- Add widget coverage for normal and sensitive terminal text input configurations and update README feature text.

## Tests

- `flutter analyze --no-pub`
- `flutter test --no-pub test/widget/terminal_text_input_handler_test.dart --name "password-friendly|restarts the active IME|normal text IME|terminalTextLooksLikeSensitiveInputPrompt"`
- `flutter test --no-pub test/widget/terminal_text_input_handler_test.dart`
