### PR TITLE
Render terminal path underlines inline

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1113,34 +1113,25 @@ List<CellOffset> resolveForgivingTerminalTapOffsets(CellOffset offset) {
   return (topRow: topRow, bottomRow: bottomRow);
 }
 
-/// Builds a visible underline rect that hugs the bottom of a terminal row.
+/// Builds a terminal cell range for inline path underline painting.
 @visibleForTesting
-Rect? resolveTerminalPathUnderlineRect({
-  required Offset lineTopLeft,
-  required Offset lineEndOffset,
-  required double lineHeight,
-  required double viewportHeight,
-  double? rowHeight,
-  double? textHeight,
+TerminalTextUnderline? resolveTerminalPathInlineUnderline({
+  required int row,
+  required int startColumn,
+  required int endColumn,
+  required int rowCount,
+  required int columnCount,
 }) {
-  final width = lineEndOffset.dx - lineTopLeft.dx;
-  if (width <= 0 || lineHeight <= 0 || viewportHeight <= 0) {
+  if (row < 0 || row >= rowCount || columnCount <= 0) {
     return null;
   }
 
-  final effectiveRowHeight = (rowHeight ?? lineHeight) < lineHeight
-      ? lineHeight
-      : (rowHeight ?? lineHeight);
-  final effectiveTextHeight = textHeight ?? effectiveRowHeight;
-  final thickness = (effectiveTextHeight * 0.08).clamp(0.75, 2.5);
-  final rowBottom = lineTopLeft.dy + effectiveRowHeight;
-  final preferredTop = lineTopLeft.dy + effectiveTextHeight + 0.25;
-  final maxTopWithinRow = rowBottom - thickness - 0.5;
-  final top = min(
-    preferredTop,
-    maxTopWithinRow,
-  ).clamp(0.0, viewportHeight - thickness);
-  return Rect.fromLTWH(lineTopLeft.dx, top, width, thickness);
+  final normalizedStart = startColumn.clamp(0, columnCount - 1);
+  final normalizedEnd = endColumn.clamp(0, columnCount - 1);
+  if (normalizedStart > normalizedEnd) {
+    return null;
+  }
+  return (row: row, startColumn: normalizedStart, endColumn: normalizedEnd);
 }
 
 /// Builds a forgiving touch target around a terminal path segment.
@@ -2166,10 +2157,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   Offset? _pendingTerminalMouseTapDownPosition;
   Duration? _pendingTerminalMouseTapDownTimestamp;
   final Set<int> _terminalOutputPauseTouchPointers = <int>{};
-  Rect? _hoveredTerminalPathUnderline;
-  List<({String path, Rect underlineRect, Rect touchRect})>
+  TerminalTextUnderline? _hoveredTerminalPathUnderline;
+  List<({String path, TerminalTextUnderline underline, Rect touchRect})>
   _visibleTerminalPathUnderlines =
-      const <({String path, Rect underlineRect, Rect touchRect})>[];
+      const <
+        ({String path, TerminalTextUnderline underline, Rect touchRect})
+      >[];
   bool _shouldScheduleVisibleTerminalPathUnderlineRefreshFromBuild = true;
   bool? _lastShowsTerminalPathUnderlines;
   CellOffset? _lastHoveredTerminalPathOffset;
@@ -6391,6 +6384,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final terminalPathLinkUnderlinesEnabled = ref.watch(
       terminalPathLinkUnderlinesNotifierProvider,
     );
+    final showsTerminalPathUnderlines =
+        terminalPathLinksEnabled && terminalPathLinkUnderlinesEnabled;
+    final inlineUnderlines = showsTerminalPathUnderlines
+        ? _isMobilePlatform
+              ? [
+                  for (final underline in _visibleTerminalPathUnderlines)
+                    underline.underline,
+                ]
+              : <TerminalTextUnderline>[?_hoveredTerminalPathUnderline]
+        : const <TerminalTextUnderline>[];
     final keyboardAppearance = resolveTerminalKeyboardAppearance(terminalTheme);
     Widget terminalView = MonkeyTerminalView(
       key: _terminalViewKey,
@@ -6409,6 +6412,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       focusNode: _terminalFocusNode,
       theme: terminalTheme.toXtermTheme(),
       textStyle: terminalTextStyle,
+      inlineUnderlines: inlineUnderlines,
       keyboardAppearance: keyboardAppearance,
       padding: terminalViewportPadding,
       deleteDetection: !isMobile,
@@ -6426,8 +6430,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       onPasteText: isMobile ? null : _pasteClipboard,
     );
 
-    final showsTerminalPathUnderlines =
-        terminalPathLinksEnabled && terminalPathLinkUnderlinesEnabled;
     if (_lastShowsTerminalPathUnderlines != showsTerminalPathUnderlines) {
       _lastShowsTerminalPathUnderlines = showsTerminalPathUnderlines;
       _shouldScheduleVisibleTerminalPathUnderlineRefreshFromBuild =
@@ -6450,7 +6452,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         }
         setState(
           () => _visibleTerminalPathUnderlines =
-              const <({String path, Rect underlineRect, Rect touchRect})>[],
+              const <
+                ({String path, TerminalTextUnderline underline, Rect touchRect})
+              >[],
         );
       });
     }
@@ -6470,59 +6474,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _shouldScheduleVisibleTerminalPathUnderlineRefreshFromBuild = false;
           _queueVisibleTerminalPathUnderlineRefresh();
         }
-        terminalView = Stack(
-          fit: StackFit.expand,
-          children: [
-            terminalView,
-            for (final entry in _visibleTerminalPathUnderlines.asMap().entries)
-              Positioned(
-                left: entry.value.underlineRect.left,
-                top: entry.value.underlineRect.top,
-                child: IgnorePointer(
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      color: terminalTheme.foreground.withValues(alpha: 0.92),
-                      borderRadius: BorderRadius.circular(999),
-                    ),
-                    child: SizedBox(
-                      key: ValueKey<String>(
-                        'terminal-path-underline:${entry.key}:${entry.value.path}',
-                      ),
-                      width: entry.value.underlineRect.width,
-                      height: entry.value.underlineRect.height,
-                    ),
-                  ),
-                ),
-              ),
-          ],
-        );
       } else {
         terminalView = MouseRegion(
           onHover: _handleTerminalPathHover,
           onExit: (_) => _clearHoveredTerminalPathUnderline(),
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              terminalView,
-              if (_hoveredTerminalPathUnderline != null)
-                Positioned(
-                  left: _hoveredTerminalPathUnderline!.left,
-                  top: _hoveredTerminalPathUnderline!.top,
-                  child: IgnorePointer(
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        color: terminalTheme.foreground.withValues(alpha: 0.92),
-                        borderRadius: BorderRadius.circular(999),
-                      ),
-                      child: SizedBox(
-                        width: _hoveredTerminalPathUnderline!.width,
-                        height: _hoveredTerminalPathUnderline!.height,
-                      ),
-                    ),
-                  ),
-                ),
-            ],
-          ),
+          child: terminalView,
         );
       }
     }
@@ -6751,37 +6707,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       fontSize: fontSize,
     );
     return TerminalStyle.fromTextStyle(textStyle);
-  }
-
-  Size? _measureTerminalPathUnderlineTextSize(String text) {
-    if (text.isEmpty) {
-      return null;
-    }
-    final globalFontSize = ref.read(fontSizeNotifierProvider);
-    final fontSize = resolveTerminalFontSize(
-      globalFontSize: globalFontSize,
-      sessionFontSize: _sessionFontSizeOverride,
-      pinchFontSize: _pinchFontSize,
-    );
-    final fontFamily =
-        _host?.terminalFontFamily ??
-        ref.read(fontFamilyNotifierProvider) ??
-        'monospace';
-    final textStyle = resolveMonospaceTextStyle(
-      fontFamily,
-      platform: Theme.of(context).platform,
-      fontSize: fontSize,
-    );
-    final painter = TextPainter(
-      text: TextSpan(text: text, style: textStyle),
-      textDirection: TextDirection.ltr,
-      textScaler: MediaQuery.textScalerOf(context),
-      maxLines: 1,
-    )..layout();
-    if (painter.width <= 0 || painter.height <= 0) {
-      return null;
-    }
-    return Size(painter.width, painter.height);
   }
 
   void _openConnectionFileBrowser() {
@@ -7483,12 +7408,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _clearHoveredTerminalPathUnderline();
       return;
     }
-    final underline = _buildTerminalPathUnderlineRect(
-      terminalViewState,
+    final underline = _buildTerminalPathInlineUnderline(
       row: offset.y,
       startColumn: hoveredSegment.startColumn,
       endColumn: hoveredSegment.endColumn,
-      text: hoveredSegment.text,
     );
     if (underline == null) {
       _clearHoveredTerminalPathUnderline();
@@ -7972,7 +7895,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       if (_visibleTerminalPathUnderlines.isNotEmpty) {
         setState(
           () => _visibleTerminalPathUnderlines =
-              const <({String path, Rect underlineRect, Rect touchRect})>[],
+              const <
+                ({String path, TerminalTextUnderline underline, Rect touchRect})
+              >[],
         );
       }
       return;
@@ -7991,7 +7916,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
-    final underlines = <({String path, Rect underlineRect, Rect touchRect})>[];
+    final underlines =
+        <({String path, TerminalTextUnderline underline, Rect touchRect})>[];
     final buffer = _terminal.buffer;
     var row = rowRange.topRow;
     while (row <= rowRange.bottomRow) {
@@ -8029,12 +7955,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           if (!_shouldShowTerminalPathBadge(segment.path)) {
             continue;
           }
-          final underlineRect = _buildTerminalPathUnderlineRect(
-            terminalViewState,
+          final underline = _buildTerminalPathInlineUnderline(
             row: snapshotRow,
             startColumn: segment.startColumn,
             endColumn: segment.endColumn,
-            text: segment.text,
           );
           final touchRect = _buildTerminalPathTouchTargetRect(
             terminalViewState,
@@ -8042,10 +7966,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             startColumn: segment.startColumn,
             endColumn: segment.endColumn,
           );
-          if (underlineRect != null && touchRect != null) {
+          if (underline != null && touchRect != null) {
             underlines.add((
               path: segment.path,
-              underlineRect: underlineRect,
+              underline: underline,
               touchRect: touchRect,
             ));
           }
@@ -8059,38 +7983,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
-  Rect? _buildTerminalPathUnderlineRect(
-    MonkeyTerminalViewState terminalViewState, {
+  TerminalTextUnderline? _buildTerminalPathInlineUnderline({
     required int row,
     required int startColumn,
     required int endColumn,
-    required String text,
-  }) {
-    final terminalViewObject = terminalViewState.context.findRenderObject();
-    if (terminalViewObject is! RenderBox) {
-      return null;
-    }
-    final renderTerminal = terminalViewState.renderTerminal;
-    final lineTopLeft = renderTerminal.localToGlobal(
-      renderTerminal.getOffset(CellOffset(startColumn, row)),
-      ancestor: terminalViewObject,
-    );
-    final measuredTextSize = _measureTerminalPathUnderlineTextSize(text);
-    final lineEndOffset = renderTerminal.localToGlobal(
-      renderTerminal.getOffset(
-        CellOffset((endColumn + 1).clamp(0, _terminal.buffer.viewWidth), row),
-      ),
-      ancestor: terminalViewObject,
-    );
-    return resolveTerminalPathUnderlineRect(
-      lineTopLeft: lineTopLeft,
-      lineEndOffset: lineEndOffset,
-      lineHeight: renderTerminal.lineHeight,
-      viewportHeight: terminalViewObject.size.height,
-      rowHeight: renderTerminal.cellSize.height,
-      textHeight: measuredTextSize?.height,
-    );
-  }
+  }) => resolveTerminalPathInlineUnderline(
+    row: row,
+    startColumn: startColumn,
+    endColumn: endColumn,
+    rowCount: _terminal.buffer.height,
+    columnCount: _terminal.buffer.viewWidth,
+  );
 
   Rect? _buildTerminalPathTouchTargetRect(
     MonkeyTerminalViewState terminalViewState, {

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1313,6 +1313,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
 
   List<Color> _palette;
   final _paragraphCache = ParagraphCache(10240);
+  final _inlineUnderlineParagraphCache = ParagraphCache(1024);
 
   @override
   set textStyle(TerminalStyle value) {
@@ -1321,6 +1322,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
     }
     super.textStyle = value;
     _paragraphCache.clear();
+    _inlineUnderlineParagraphCache.clear();
   }
 
   @override
@@ -1330,6 +1332,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
     }
     super.textScaler = value;
     _paragraphCache.clear();
+    _inlineUnderlineParagraphCache.clear();
   }
 
   @override
@@ -1340,15 +1343,17 @@ class MonkeyTerminalPainter extends TerminalPainter {
     super.theme = value;
     _palette = _buildMonkeyTerminalPalette(value);
     _paragraphCache.clear();
+    _inlineUnderlineParagraphCache.clear();
   }
 
   @override
   void clearFontCache() {
     super.clearFontCache();
     _paragraphCache.clear();
+    _inlineUnderlineParagraphCache.clear();
   }
 
-  void paintLineWithInlineUnderlines(
+  void paintLineInlineUnderlines(
     Canvas canvas,
     Offset offset,
     BufferLine line,
@@ -1363,10 +1368,8 @@ class MonkeyTerminalPainter extends TerminalPainter {
       final charWidth = cellData.content >> CellContent.widthShift;
       final cellOffset = offset.translate(i * cellWidth, 0);
       if (_shouldUnderlineCell(i, inlineUnderlines)) {
-        cellData.flags |= CellFlags.underline;
+        paintCellInlineUnderline(canvas, cellOffset, cellData);
       }
-
-      paintCell(canvas, cellOffset, cellData);
 
       if (charWidth == 2) {
         i++;
@@ -1386,6 +1389,46 @@ class MonkeyTerminalPainter extends TerminalPainter {
     return false;
   }
 
+  void paintCellInlineUnderline(
+    Canvas canvas,
+    Offset offset,
+    CellData cellData,
+  ) {
+    final charCode = cellData.content & CellContent.codepointMask;
+    if (charCode == 0) {
+      return;
+    }
+
+    final cacheKey = cellData.getHash() ^ textScaler.hashCode;
+    var paragraph = _inlineUnderlineParagraphCache.getLayoutFromCache(cacheKey);
+
+    if (paragraph == null) {
+      final cellFlags = cellData.flags;
+      final style = textStyle
+          .toTextStyle(
+            color: Colors.transparent,
+            bold: cellFlags & CellFlags.bold != 0,
+            italic: cellFlags & CellFlags.italic != 0,
+            underline: true,
+          )
+          .copyWith(decorationColor: _resolveCellForegroundColor(cellData));
+
+      var char = String.fromCharCode(charCode);
+      if (charCode == 0x20) {
+        char = String.fromCharCode(0xA0);
+      }
+
+      paragraph = _inlineUnderlineParagraphCache.performAndCacheLayout(
+        char,
+        style,
+        textScaler,
+        cacheKey,
+      );
+    }
+
+    canvas.drawParagraph(paragraph, offset);
+  }
+
   @override
   void paintCellForeground(Canvas canvas, Offset offset, CellData cellData) {
     final charCode = cellData.content & CellContent.codepointMask;
@@ -1398,20 +1441,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
 
     if (paragraph == null) {
       final cellFlags = cellData.flags;
-      final inverse = cellFlags & CellFlags.inverse != 0;
-      var color = inverse
-          ? resolveBackgroundColor(cellData.background)
-          : resolveForegroundColor(cellData.foreground);
-
-      if (cellFlags & CellFlags.faint != 0) {
-        final background = inverse
-            ? resolveForegroundColor(cellData.foreground)
-            : resolveBackgroundColor(cellData.background);
-        color = resolveMonkeyTerminalFaintForegroundColor(
-          foreground: color,
-          background: background,
-        );
-      }
+      final color = _resolveCellForegroundColor(cellData);
 
       final style = textStyle.toTextStyle(
         color: color,
@@ -1434,6 +1464,25 @@ class MonkeyTerminalPainter extends TerminalPainter {
     }
 
     canvas.drawParagraph(paragraph, offset);
+  }
+
+  Color _resolveCellForegroundColor(CellData cellData) {
+    final cellFlags = cellData.flags;
+    final inverse = cellFlags & CellFlags.inverse != 0;
+    var color = inverse
+        ? resolveBackgroundColor(cellData.background)
+        : resolveForegroundColor(cellData.foreground);
+
+    if (cellFlags & CellFlags.faint != 0) {
+      final background = inverse
+          ? resolveForegroundColor(cellData.foreground)
+          : resolveBackgroundColor(cellData.background);
+      color = resolveMonkeyTerminalFaintForegroundColor(
+        foreground: color,
+        background: background,
+      );
+    }
+    return color;
   }
 
   @override
@@ -2680,21 +2729,7 @@ class MonkeyRenderTerminal extends RenderBox
     final effectLastLine = lastLine.clamp(0, lines.length - 1);
 
     for (var i = effectFirstLine; i <= effectLastLine; i++) {
-      final lineOffset = offset.translate(
-        origin.dx,
-        (i * charHeight + _lineOffset).truncateToDouble(),
-      );
-      final lineUnderlines = _inlineUnderlinesForRow(i);
-      if (lineUnderlines.isEmpty) {
-        _painter.paintLine(canvas, lineOffset, lines[i]);
-      } else {
-        _painter.paintLineWithInlineUnderlines(
-          canvas,
-          lineOffset,
-          lines[i],
-          lineUnderlines,
-        );
-      }
+      _painter.paintLine(canvas, _linePaintOffset(offset, i), lines[i]);
     }
 
     if (_terminal.buffer.absoluteCursorY >= effectFirstLine &&
@@ -2725,7 +2760,42 @@ class MonkeyRenderTerminal extends RenderBox
       _paintSelection(canvas, selection, effectFirstLine, effectLastLine);
     }
 
+    // Keep link affordances visible over opaque selection/highlight fills while
+    // preserving each cell's own underline styling.
+    _paintInlineUnderlines(canvas, offset, effectFirstLine, effectLastLine);
+
     _paintSelectionHandleLayers(context, offset);
+  }
+
+  Offset _linePaintOffset(Offset offset, int row) => offset.translate(
+    _contentOrigin.dx,
+    (row * _painter.cellSize.height + _lineOffset).truncateToDouble(),
+  );
+
+  void _paintInlineUnderlines(
+    Canvas canvas,
+    Offset offset,
+    int firstLine,
+    int lastLine,
+  ) {
+    if (_inlineUnderlines.isEmpty) {
+      return;
+    }
+
+    final lines = _terminal.buffer.lines;
+    for (var i = firstLine; i <= lastLine; i++) {
+      final lineUnderlines = _inlineUnderlinesForRow(i);
+      if (lineUnderlines.isEmpty) {
+        continue;
+      }
+
+      _painter.paintLineInlineUnderlines(
+        canvas,
+        _linePaintOffset(offset, i),
+        lines[i],
+        lineUnderlines,
+      );
+    }
   }
 
   List<TerminalTextUnderline> _inlineUnderlinesForRow(int row) {

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -15,6 +16,7 @@ import 'package:flutter/services.dart';
 import 'package:monkeyssh/domain/models/terminal_theme.dart';
 import 'package:xterm/src/core/buffer/cell_offset.dart';
 import 'package:xterm/src/core/buffer/cell_flags.dart';
+import 'package:xterm/src/core/buffer/line.dart';
 import 'package:xterm/src/core/buffer/range.dart';
 import 'package:xterm/src/core/buffer/range_line.dart';
 import 'package:xterm/src/core/buffer/segment.dart';
@@ -284,6 +286,9 @@ const _terminalFocusInReport = '\x1b[I';
 const _terminalFocusOutReport = '\x1b[O';
 const _terminalFocusTransitionDelay = Duration(milliseconds: 50);
 
+/// A terminal cell range rendered with text underline decoration.
+typedef TerminalTextUnderline = ({int row, int startColumn, int endColumn});
+
 /// Adapted xterm terminal view with a trackpad scroll fix for alt-buffer apps.
 class MonkeyTerminalView extends StatefulWidget {
   const MonkeyTerminalView(
@@ -327,6 +332,7 @@ class MonkeyTerminalView extends StatefulWidget {
     this.onSystemSelectionChanged,
     this.onInsertText,
     this.onPasteText,
+    this.inlineUnderlines = const <TerminalTextUnderline>[],
   });
 
   /// The underlying terminal that this widget renders.
@@ -467,6 +473,9 @@ class MonkeyTerminalView extends StatefulWidget {
 
   /// Called to handle paste shortcuts before xterm pastes clipboard text.
   final Future<void> Function()? onPasteText;
+
+  /// Cell ranges that should be painted with inline text underlines.
+  final List<TerminalTextUnderline> inlineUnderlines;
 
   @override
   State<MonkeyTerminalView> createState() => MonkeyTerminalViewState();
@@ -692,6 +701,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
           textStyle: widget.textStyle,
           textScaler: widget.textScaler ?? MediaQuery.textScalerOf(context),
           theme: widget.theme,
+          inlineUnderlines: widget.inlineUnderlines,
           focusNode: _focusNode,
           cursorType: widget.cursorType,
           alwaysShowCursor: widget.alwaysShowCursor,
@@ -1198,6 +1208,7 @@ class _TerminalView extends LeafRenderObjectWidget {
     required this.textStyle,
     required this.textScaler,
     required this.theme,
+    required this.inlineUnderlines,
     required this.focusNode,
     required this.cursorType,
     required this.alwaysShowCursor,
@@ -1228,6 +1239,8 @@ class _TerminalView extends LeafRenderObjectWidget {
 
   final TerminalTheme theme;
 
+  final List<TerminalTextUnderline> inlineUnderlines;
+
   final FocusNode focusNode;
 
   final TerminalCursorType cursorType;
@@ -1254,6 +1267,7 @@ class _TerminalView extends LeafRenderObjectWidget {
       textStyle: textStyle,
       textScaler: textScaler,
       theme: theme,
+      inlineUnderlines: inlineUnderlines,
       focusNode: focusNode,
       cursorType: cursorType,
       alwaysShowCursor: alwaysShowCursor,
@@ -1280,6 +1294,7 @@ class _TerminalView extends LeafRenderObjectWidget {
       ..textStyle = textStyle
       ..textScaler = textScaler
       ..theme = theme
+      ..inlineUnderlines = inlineUnderlines
       ..focusNode = focusNode
       ..cursorType = cursorType
       ..alwaysShowCursor = alwaysShowCursor
@@ -1331,6 +1346,44 @@ class MonkeyTerminalPainter extends TerminalPainter {
   void clearFontCache() {
     super.clearFontCache();
     _paragraphCache.clear();
+  }
+
+  void paintLineWithInlineUnderlines(
+    Canvas canvas,
+    Offset offset,
+    BufferLine line,
+    List<TerminalTextUnderline> inlineUnderlines,
+  ) {
+    final cellData = CellData.empty();
+    final cellWidth = cellSize.width;
+
+    for (var i = 0; i < line.length; i++) {
+      line.getCellData(i, cellData);
+
+      final charWidth = cellData.content >> CellContent.widthShift;
+      final cellOffset = offset.translate(i * cellWidth, 0);
+      if (_shouldUnderlineCell(i, inlineUnderlines)) {
+        cellData.flags |= CellFlags.underline;
+      }
+
+      paintCell(canvas, cellOffset, cellData);
+
+      if (charWidth == 2) {
+        i++;
+      }
+    }
+  }
+
+  bool _shouldUnderlineCell(
+    int column,
+    List<TerminalTextUnderline> inlineUnderlines,
+  ) {
+    for (final underline in inlineUnderlines) {
+      if (column >= underline.startColumn && column <= underline.endColumn) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @override
@@ -1432,6 +1485,7 @@ class MonkeyRenderTerminal extends RenderBox
     required TerminalStyle textStyle,
     required TextScaler textScaler,
     required TerminalTheme theme,
+    required List<TerminalTextUnderline> inlineUnderlines,
     required FocusNode focusNode,
     required TerminalCursorType cursorType,
     required bool alwaysShowCursor,
@@ -1446,6 +1500,7 @@ class MonkeyRenderTerminal extends RenderBox
        _autoResize = autoResize,
        _resizeBottomInset = resizeBottomInset,
        _liveOutputAutoScroll = liveOutputAutoScroll,
+       _inlineUnderlines = inlineUnderlines,
        _focusNode = focusNode,
        _cursorType = cursorType,
        _alwaysShowCursor = alwaysShowCursor,
@@ -1560,6 +1615,13 @@ class MonkeyRenderTerminal extends RenderBox
     markNeedsPaint();
   }
 
+  List<TerminalTextUnderline> _inlineUnderlines;
+  set inlineUnderlines(List<TerminalTextUnderline> value) {
+    if (listEquals(value, _inlineUnderlines)) return;
+    _inlineUnderlines = value;
+    markNeedsPaint();
+  }
+
   FocusNode _focusNode;
   set focusNode(FocusNode value) {
     if (value == _focusNode) return;
@@ -1616,7 +1678,7 @@ class MonkeyRenderTerminal extends RenderBox
   })?
   _pendingTerminalResize;
 
-  final TerminalPainter _painter;
+  final MonkeyTerminalPainter _painter;
 
   var _stickToBottom = true;
 
@@ -2618,14 +2680,21 @@ class MonkeyRenderTerminal extends RenderBox
     final effectLastLine = lastLine.clamp(0, lines.length - 1);
 
     for (var i = effectFirstLine; i <= effectLastLine; i++) {
-      _painter.paintLine(
-        canvas,
-        offset.translate(
-          origin.dx,
-          (i * charHeight + _lineOffset).truncateToDouble(),
-        ),
-        lines[i],
+      final lineOffset = offset.translate(
+        origin.dx,
+        (i * charHeight + _lineOffset).truncateToDouble(),
       );
+      final lineUnderlines = _inlineUnderlinesForRow(i);
+      if (lineUnderlines.isEmpty) {
+        _painter.paintLine(canvas, lineOffset, lines[i]);
+      } else {
+        _painter.paintLineWithInlineUnderlines(
+          canvas,
+          lineOffset,
+          lines[i],
+          lineUnderlines,
+        );
+      }
     }
 
     if (_terminal.buffer.absoluteCursorY >= effectFirstLine &&
@@ -2657,6 +2726,35 @@ class MonkeyRenderTerminal extends RenderBox
     }
 
     _paintSelectionHandleLayers(context, offset);
+  }
+
+  List<TerminalTextUnderline> _inlineUnderlinesForRow(int row) {
+    if (_inlineUnderlines.isEmpty) {
+      return const <TerminalTextUnderline>[];
+    }
+
+    final columnCount = _terminal.viewWidth;
+    if (columnCount <= 0) {
+      return const <TerminalTextUnderline>[];
+    }
+
+    final lineUnderlines = <TerminalTextUnderline>[];
+    for (final underline in _inlineUnderlines) {
+      if (underline.row != row) {
+        continue;
+      }
+
+      final startColumn = underline.startColumn.clamp(0, columnCount - 1);
+      final endColumn = underline.endColumn.clamp(0, columnCount - 1);
+      if (startColumn <= endColumn) {
+        lineUnderlines.add((
+          row: row,
+          startColumn: startColumn,
+          endColumn: endColumn,
+        ));
+      }
+    }
+    return lineUnderlines;
   }
 
   BufferRange? get _selectionRangeForPaint {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -2763,7 +2763,7 @@ void main() {
     );
 
     testWidgets(
-      'prompt path underline tracks scroll without dropping a frame',
+      'prompt path underline stays inline while scrolling',
       (tester) async {
         await pumpScreen(tester);
 
@@ -2775,17 +2775,11 @@ void main() {
         session.terminal!.write(output);
         await tester.pumpAndSettle();
 
-        final underlineFinder = find.byWidgetPredicate((widget) {
-          final key = widget.key;
-          return key is ValueKey<String> &&
-              key.value.startsWith('terminal-path-underline:');
-        });
-
-        expect(underlineFinder, findsOneWidget);
-        final initialTop = tester.getTopLeft(underlineFinder).dy;
         final terminalView = tester.widget<MonkeyTerminalView>(
           find.byType(MonkeyTerminalView),
         );
+        expect(terminalView.inlineUnderlines, hasLength(1));
+        final initialUnderline = terminalView.inlineUnderlines.single;
         final scrollController = terminalView.scrollController;
         final lineHeight = tester
             .state<MonkeyTerminalViewState>(find.byType(MonkeyTerminalView))
@@ -2801,8 +2795,10 @@ void main() {
         );
         await tester.pump();
 
-        expect(underlineFinder, findsOneWidget);
-        expect(tester.getTopLeft(underlineFinder).dy, isNot(initialTop));
+        final scrolledTerminalView = tester.widget<MonkeyTerminalView>(
+          find.byType(MonkeyTerminalView),
+        );
+        expect(scrolledTerminalView.inlineUnderlines, [initialUnderline]);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );
@@ -2833,21 +2829,24 @@ void main() {
         session.terminal!.write('git add $relativePath');
         await tester.pump();
 
-        final underlineFinder = find.byWidgetPredicate((widget) {
-          final key = widget.key;
-          return key is ValueKey<String> &&
-              key.value.contains('terminal-path-underline:') &&
-              key.value.contains(relativePath);
-        });
-
-        expect(underlineFinder, findsNothing);
+        expect(
+          tester
+              .widget<MonkeyTerminalView>(find.byType(MonkeyTerminalView))
+              .inlineUnderlines,
+          isEmpty,
+        );
 
         statCompleter.complete(
           SftpFileAttrs(mode: const SftpFileMode.value(1 << 14)),
         );
         await tester.pumpAndSettle();
 
-        expect(underlineFinder, findsOneWidget);
+        expect(
+          tester
+              .widget<MonkeyTerminalView>(find.byType(MonkeyTerminalView))
+              .inlineUnderlines,
+          hasLength(1),
+        );
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );
@@ -2913,16 +2912,24 @@ void main() {
         session.terminal!.write('open $remotePath');
         await tester.pumpAndSettle();
 
-        final underlineFinder = find.byWidgetPredicate((widget) {
-          final key = widget.key;
-          return key is ValueKey<String> &&
-              key.value.contains('terminal-path-underline:') &&
-              key.value.contains(remotePath);
-        });
-        expect(underlineFinder, findsOneWidget);
+        final terminalView = tester.widget<MonkeyTerminalView>(
+          find.byType(MonkeyTerminalView),
+        );
+        expect(terminalView.inlineUnderlines, hasLength(1));
         expect(find.byType(SelectionArea), findsOneWidget);
 
-        await tester.tapAt(tester.getCenter(underlineFinder));
+        final terminalState = tester.state<MonkeyTerminalViewState>(
+          find.byType(MonkeyTerminalView),
+        );
+        final underline = terminalView.inlineUnderlines.single;
+        final tapPosition = terminalState.renderTerminal.localToGlobal(
+          terminalState.renderTerminal.getOffset(
+                CellOffset(underline.startColumn, underline.row),
+              ) +
+              terminalState.renderTerminal.cellSize.center(Offset.zero),
+        );
+
+        await tester.tapAt(tapPosition);
         await tester.pumpAndSettle();
 
         expect(openedPaths, [remotePath]);

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -1024,80 +1024,74 @@ void main() {
     });
   });
 
-  group('resolveTerminalPathUnderlineRect', () {
-    test('places the underline at the bottom of the rendered row', () {
+  group('resolveTerminalPathInlineUnderline', () {
+    test('returns the requested cell range', () {
       expect(
-        resolveTerminalPathUnderlineRect(
-          lineTopLeft: const Offset(24, 18),
-          lineEndOffset: const Offset(104, 18),
-          lineHeight: 20,
-          viewportHeight: 300,
+        resolveTerminalPathInlineUnderline(
+          row: 12,
+          startColumn: 4,
+          endColumn: 18,
+          rowCount: 100,
+          columnCount: 80,
         ),
-        const Rect.fromLTWH(24, 35.9, 80, 1.6),
+        (row: 12, startColumn: 4, endColumn: 18),
       );
     });
 
-    test(
-      'uses the rendered row height when it is taller than the line height',
-      () {
-        expect(
-          resolveTerminalPathUnderlineRect(
-            lineTopLeft: const Offset(24, 18),
-            lineEndOffset: const Offset(104, 18),
-            lineHeight: 20,
-            rowHeight: 24,
-            viewportHeight: 300,
-          ),
-          const Rect.fromLTWH(24, 39.58, 80, 1.92),
-        );
-      },
-    );
-
-    test('prefers measured text height when available', () {
+    test('clamps columns to the terminal width', () {
       expect(
-        resolveTerminalPathUnderlineRect(
-          lineTopLeft: const Offset(24, 18),
-          lineEndOffset: const Offset(98, 18),
-          lineHeight: 20,
-          rowHeight: 24,
-          textHeight: 16,
-          viewportHeight: 300,
+        resolveTerminalPathInlineUnderline(
+          row: 2,
+          startColumn: -4,
+          endColumn: 100,
+          rowCount: 20,
+          columnCount: 80,
         ),
-        const Rect.fromLTWH(24, 34.25, 74, 1.28),
+        (row: 2, startColumn: 0, endColumn: 79),
       );
     });
 
-    test('scales underline thickness down for smaller terminal text', () {
+    test('returns null for invalid rows or empty terminal width', () {
       expect(
-        resolveTerminalPathUnderlineRect(
-          lineTopLeft: const Offset(24, 18),
-          lineEndOffset: const Offset(104, 18),
-          lineHeight: 12,
-          viewportHeight: 300,
+        resolveTerminalPathInlineUnderline(
+          row: -1,
+          startColumn: 0,
+          endColumn: 4,
+          rowCount: 20,
+          columnCount: 80,
         ),
-        const Rect.fromLTWH(24, 28.54, 80, 0.96),
+        isNull,
+      );
+      expect(
+        resolveTerminalPathInlineUnderline(
+          row: 20,
+          startColumn: 0,
+          endColumn: 4,
+          rowCount: 20,
+          columnCount: 80,
+        ),
+        isNull,
+      );
+      expect(
+        resolveTerminalPathInlineUnderline(
+          row: 0,
+          startColumn: 0,
+          endColumn: 4,
+          rowCount: 20,
+          columnCount: 0,
+        ),
+        isNull,
       );
     });
 
-    test('scales underline thickness up for larger terminal text', () {
+    test('returns null when the normalized range is empty', () {
       expect(
-        resolveTerminalPathUnderlineRect(
-          lineTopLeft: const Offset(24, 18),
-          lineEndOffset: const Offset(104, 18),
-          lineHeight: 32,
-          viewportHeight: 300,
-        ),
-        const Rect.fromLTWH(24, 47, 80, 2.5),
-      );
-    });
-
-    test('returns null when the underline would have no visible width', () {
-      expect(
-        resolveTerminalPathUnderlineRect(
-          lineTopLeft: const Offset(24, 18),
-          lineEndOffset: const Offset(24, 18),
-          lineHeight: 20,
-          viewportHeight: 300,
+        resolveTerminalPathInlineUnderline(
+          row: 0,
+          startColumn: 8,
+          endColumn: 4,
+          rowCount: 20,
+          columnCount: 80,
         ),
         isNull,
       );


### PR DESCRIPTION
## Summary

- Render terminal path underlines inline through `MonkeyTerminalView` text painting instead of overlay widgets.
- Keep mobile path hit targets separate so SFTP taps still work with system selection enabled.
- Update path underline tests to assert inline underline ranges.

## Tests

- `flutter analyze`
- `flutter test test/widget/terminal_screen_selection_test.dart test/presentation/screens/terminal_screen_test.dart`
- `flutter test`

Note: Flutter/pub repeatedly printed `Failed to decode advisories ... advisoriesUpdated must be a String`, but dependency resolution and checks completed successfully.
