### PR TITLE
fix: reassert terminal theme on session restore

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2625,6 +2625,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final plainTuiRefreshAllowed = _shouldRefreshPlainTerminalTui(
       targetSession,
     );
+    final terminalViewReady = _isTerminalThemeRefreshViewReady;
     final shouldRefreshFirstTheme =
         previousTheme == null && (_isTmuxActive || plainTuiRefreshAllowed);
     final willRefresh =
@@ -2649,7 +2650,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           'altBuffer': _terminal.isUsingAltBuffer,
           'mouseMode': _terminal.mouseMode != MouseMode.none,
           'shellReady': _shell != null,
-          'terminalViewReady': _terminalViewKey.currentState != null,
+          'terminalViewReady': terminalViewReady,
         },
       );
     }
@@ -2667,6 +2668,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _cancelTerminalThemeRefreshTimers();
     final refreshGeneration = ++_terminalThemeRefreshGeneration;
     final plainTuiRefreshAllowed = _shouldRefreshPlainTerminalTui(session);
+    final terminalViewReady = _isTerminalThemeRefreshViewReady;
     final tmuxStateBelongsToSession =
         _tmuxStateConnectionId == session.connectionId;
     DiagnosticsLogService.instance.info(
@@ -2683,9 +2685,25 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         'altBuffer': _terminal.isUsingAltBuffer,
         'mouseMode': _terminal.mouseMode != MouseMode.none,
         'shellReady': _shell != null,
-        'terminalViewReady': _terminalViewKey.currentState != null,
+        'terminalViewReady': terminalViewReady,
       },
     );
+    if (!terminalViewReady) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!_isCurrentTerminalThemeRefresh(
+          theme: theme,
+          session: session,
+          refreshGeneration: refreshGeneration,
+        )) {
+          return;
+        }
+        _refreshTerminalThemeForTui(
+          theme,
+          session,
+          reason: '${reason}_view_ready',
+        );
+      });
+    }
     if (_isTmuxActive && tmuxStateBelongsToSession) {
       // Push fresh OSC 10/11/4 reports to tmux itself. tmux caches the outer
       // terminal's default colors and ANSI palette and answers inner-pane OSC
@@ -2719,7 +2737,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           'altBuffer': _terminal.isUsingAltBuffer,
           'mouseMode': _terminal.mouseMode != MouseMode.none,
           'shellReady': _shell != null,
-          'terminalViewReady': _terminalViewKey.currentState != null,
+          'terminalViewReady': _isTerminalThemeRefreshViewReady,
         },
       );
       return;
@@ -2793,7 +2811,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     String reason = 'unspecified',
   }) {
     final terminalView = _terminalViewKey.currentState;
-    if (terminalView == null) {
+    if (terminalView == null || !_isTerminalThemeRefreshViewReady) {
       DiagnosticsLogService.instance.info(
         'terminal.theme',
         'reports_unavailable',
@@ -2841,6 +2859,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _terminal.reportFocusMode ||
       _terminal.isUsingAltBuffer ||
       _terminal.mouseMode != MouseMode.none;
+
+  bool get _isTerminalThemeRefreshViewReady {
+    final terminalViewWidget = _terminalViewKey.currentWidget;
+    return _terminalViewKey.currentState != null &&
+        terminalViewWidget is MonkeyTerminalView &&
+        identical(terminalViewWidget.terminal, _terminal);
+  }
 
   /// Proactively pushes the active terminal theme into tmux's per-pane color
   /// cache.
@@ -3868,6 +3893,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         );
         await _restoreSessionThemeOverride(
           session,
+          forceRemoteRefresh: true,
           reason: 'open_existing_restore_override',
         );
         setState(() {
@@ -3941,6 +3967,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
       await _restoreSessionThemeOverride(
         session,
+        forceRemoteRefresh: true,
         reason: 'open_new_restore_override',
       );
       setState(() {
@@ -5581,6 +5608,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _connectionLostWhileBackgrounded = false;
         _terminal.write('\r\n[reconnecting...]\r\n');
         _reconnect();
+      } else if (session != null) {
+        unawaited(
+          _reloadTerminalThemeForDependencies(
+            forceRemoteRefresh: true,
+            reason: 'app_resumed',
+          ),
+        );
       }
     }
   }

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -915,6 +915,55 @@ void main() {
     );
 
     testWidgets(
+      'reasserts the current theme when reopening an existing active TUI',
+      (tester) async {
+        session.terminalTheme = monkey_themes.TerminalThemes.defaultLightTheme;
+        enablePlainTuiSignals();
+        shellWrites.clear();
+
+        await pumpScreen(tester);
+        await tester.pump(const Duration(milliseconds: 500));
+
+        final writtenShellText = utf8.decode(
+          shellWrites.expand((chunk) => chunk).toList(growable: false),
+        );
+        expect(writtenShellText, contains('\x1b[O\x1b[I'));
+        expect(
+          session.terminalTheme?.id,
+          monkey_themes.TerminalThemes.defaultLightThemeId,
+        );
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
+      'reasserts the current theme when an active TUI resumes from background',
+      (tester) async {
+        await pumpScreen(tester);
+        enablePlainTuiSignals();
+        shellWrites.clear();
+
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+        await tester.pump();
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
+
+        final writtenShellText = utf8.decode(
+          shellWrites.expand((chunk) => chunk).toList(growable: false),
+        );
+        expect(writtenShellText, contains('\x1b[O\x1b[I'));
+        expect(
+          session.terminalTheme?.id,
+          monkey_themes.TerminalThemes.defaultLightThemeId,
+        );
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
       'build-path sets session.terminalTheme on initial build',
       (tester) async {
         await pumpScreen(tester);


### PR DESCRIPTION
## Summary

- Reassert terminal theme colors when reopening/restoring an existing SSH session.
- Reassert the current terminal theme after app resume when no reconnect is needed.
- Retry theme refresh after the terminal view is mounted so active TUIs receive the focus/theme nudge instead of dropping it during rebuild.
- Add widget coverage for session reopen and app resume theme reassertion paths.

## Validation

- `dart format lib/presentation/screens/terminal_screen.dart test/presentation/screens/terminal_screen_test.dart`
- `flutter analyze --no-pub`
- `flutter test --no-pub test/presentation/screens/terminal_screen_test.dart --name "reasserts the current theme"`
- `flutter test --no-pub test/presentation/screens/terminal_screen_test.dart`
- pre-commit hook: `dart format`, `flutter analyze`, `flutter test`

Note: local Flutter/pub emitted hosted advisory decode warnings while resolving dependencies, but dependency resolution continued and the hook completed successfully.
