### PR TITLE
fix: reduce SSH channel pressure for tmux windows

### DIFF
--- a/lib/domain/services/ssh_exec_queue.dart
+++ b/lib/domain/services/ssh_exec_queue.dart
@@ -5,7 +5,7 @@ import 'package:flutter/foundation.dart';
 
 import 'diagnostics_log_service.dart';
 
-const _maxExecJobsPerConnection = 2;
+const _maxExecJobsPerConnection = 1;
 const _maxLowPriorityExecJobsPerConnection = 1;
 
 final _execQueues = <int, _SshExecQueue>{};
@@ -22,8 +22,8 @@ enum SshExecPriority {
 /// Runs [operation] through a bounded per-connection SSH exec queue.
 ///
 /// SSH exec channels are single-use, so this does not reuse a channel. Instead,
-/// it limits how many short-lived exec channels MonkeySSH opens concurrently on
-/// each connection, preserving room for the terminal and tmux watcher channels.
+/// it serializes short-lived exec channels per connection, preserving room for
+/// the terminal, tmux watcher, SFTP, and other long-lived channels.
 Future<T> runQueuedSshExec<T>(
   int connectionId,
   Future<T> Function() operation, {

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -337,7 +337,17 @@ class TmuxService {
         },
       );
       if (age >= _installedAgentToolsFreshTtl) {
-        unawaited(_refreshInstalledAgentTools(session));
+        if (_isExecChannelCoolingDown(session)) {
+          DiagnosticsLogService.instance.debug(
+            'tmux.agent',
+            'tool_detection_refresh_deferred',
+            fields: {'connectionId': session.connectionId},
+          );
+        } else {
+          unawaited(
+            _refreshInstalledAgentTools(session, priority: SshExecPriority.low),
+          );
+        }
       }
       return cached.tools;
     }
@@ -641,7 +651,13 @@ class TmuxService {
       sessionName: sessionName,
       extraFlags: resolveTmuxClientFlagsFromExtraFlags(extraFlags),
     );
-    if (_isExecChannelCoolingDown(session)) {
+    if (_isExecChannelCoolingDown(session) &&
+        _controlCommandObserver(
+              session,
+              sessionName,
+              extraFlags: extraFlags,
+            )?.canRunCommands !=
+            true) {
       final cachedWindows = _windowSnapshotCache[key];
       if (cachedWindows != null && cachedWindows.isNotEmpty) {
         DiagnosticsLogService.instance.warning(
@@ -689,16 +705,14 @@ class TmuxService {
       fields: {'connectionId': session.connectionId},
     );
     final quotedName = _shellQuote(sessionName);
-    const sep = r'${SEP}';
     try {
-      final output = await _exec(
+      final output = await _execTmuxCommand(
         session,
-        r'SEP=$(printf "\037"); '
-        '${_tmuxCommand('list-windows -t $quotedName -F ', extraFlags: extraFlags, forceUtf8: true)}'
-        '"#{window_index}$sep#{window_name}$sep#{window_active}$sep'
-        '#{pane_current_command}$sep#{pane_current_path}$sep'
-        '#{window_flags}$sep#{pane_title}$sep#{window_activity}$sep'
-        '#{pane_start_command}$sep#{@flutty_agent_tool}$sep#{window_id}"',
+        sessionName,
+        'list-windows -t $quotedName -F '
+        '${_shellQuote(_tmuxWindowSubscriptionFormat)}',
+        extraFlags: extraFlags,
+        forceUtf8: true,
       );
       final windows = List<TmuxWindow>.unmodifiable(
         _parseLines(output, TmuxWindow.fromTmuxFormat),
@@ -1139,6 +1153,10 @@ class TmuxService {
     _execChannelBackoffs.remove(session.connectionId);
     return false;
   }
+
+  /// Returns whether optional SSH exec-channel work should be deferred.
+  bool isExecChannelCoolingDown(SshSession session) =>
+      _isExecChannelCoolingDown(session);
 
   void _recordExecChannelFailure(int connectionId, Object error) {
     final failureCount =
@@ -2565,6 +2583,8 @@ class _TmuxWindowChangeObserver {
       'flutty-${session.connectionId}-${sessionName.hashCode.abs()}';
 
   Stream<TmuxWindowChangeEvent> get stream => _controller.stream;
+
+  bool get canRunCommands => !_disposed && _controlSession != null;
 
   Future<String> runCommand(
     String command, {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -607,6 +607,8 @@ final _terminalStandalonePathMetadataPattern = RegExp(
 );
 const _terminalSftpPathPrefix = 'monkeyssh-sftp-path:';
 const _terminalPathVerificationTimeout = Duration(seconds: 5);
+const _terminalPathVerificationChannelBackoff = Duration(seconds: 10);
+const _terminalPathVerificationBatchDelay = Duration(milliseconds: 50);
 
 typedef _TerminalPathMatch = ({
   String path,
@@ -2196,6 +2198,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   Future<SftpClient?>? _terminalPathVerificationSftpFuture;
   SftpClient? _terminalPathVerificationSftp;
   String? _terminalPathVerificationHomeDirectory;
+  DateTime? _terminalPathVerificationBackoffUntil;
+  final Map<String, String> _pendingTerminalPathVerifications = {};
+  bool _isTerminalPathVerificationBatchScheduled = false;
   late final ProviderSubscription<bool> _sharedClipboardSubscription;
   late final ProviderSubscription<bool> _sharedClipboardLocalReadSubscription;
   late final ProviderSubscription<bool> _terminalWakeLockSubscription;
@@ -5208,6 +5213,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     bool forceVisibleTmux = false,
   }) async {
     final tmux = ref.read(tmuxServiceProvider);
+    if (!forceVisibleTmux && tmux.isExecChannelCoolingDown(session)) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.ui',
+        'reattach_foreground_check_deferred',
+        fields: {'connectionId': session.connectionId},
+      );
+      return;
+    }
     var hasForegroundClient = false;
     try {
       hasForegroundClient = await tmux.hasForegroundClientOrThrow(
@@ -8256,6 +8269,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _verifiedTerminalPathCache.clear();
     _verifiedTerminalPathCacheOrder.clear();
     _verifyingTerminalPathCacheKeys.clear();
+    _pendingTerminalPathVerifications.clear();
   }
 
   void _cacheVerifiedTerminalPath(
@@ -8284,11 +8298,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _terminalPathVerificationSftpFuture = null;
     _terminalPathVerificationSession = null;
     _terminalPathVerificationHomeDirectory = null;
+    _terminalPathVerificationBackoffUntil = null;
+    _pendingTerminalPathVerifications.clear();
+    _verifyingTerminalPathCacheKeys.clear();
   }
 
   Future<SftpClient?> _resolveTerminalPathVerificationSftp(
-    SshSession session,
-  ) async {
+    SshSession session, {
+    required bool allowBackoff,
+  }) async {
     if (!identical(_terminalPathVerificationSession, session)) {
       _disposeTerminalPathVerificationSftp();
       _terminalPathVerificationSession = session;
@@ -8304,6 +8322,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return inFlight;
     }
 
+    if (allowBackoff && _isTerminalPathVerificationBackedOff()) {
+      DiagnosticsLogService.instance.debug(
+        'terminal',
+        'sftp_path_resolution_deferred',
+        fields: {'connectionId': session.connectionId},
+      );
+      return null;
+    }
+
     final future = session
         .sftp()
         .timeout(_terminalPathVerificationTimeout)
@@ -8312,17 +8339,58 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             sftp.close();
             return null;
           }
+          _terminalPathVerificationBackoffUntil = null;
           _terminalPathVerificationSftp = sftp;
           return sftp;
         });
     _terminalPathVerificationSftpFuture = future;
     try {
       return await future;
+    } on Object catch (error) {
+      _recordTerminalPathVerificationBackoff(session, error);
+      rethrow;
     } finally {
       if (identical(_terminalPathVerificationSftpFuture, future)) {
         _terminalPathVerificationSftpFuture = null;
       }
     }
+  }
+
+  bool _isTerminalPathVerificationBackedOff() =>
+      _terminalPathVerificationBackoffRemaining() != null;
+
+  Duration? _terminalPathVerificationBackoffRemaining() {
+    final backoffUntil = _terminalPathVerificationBackoffUntil;
+    if (backoffUntil == null) {
+      return null;
+    }
+    final remaining = backoffUntil.difference(DateTime.now());
+    if (remaining > Duration.zero) {
+      return remaining;
+    }
+    _terminalPathVerificationBackoffUntil = null;
+    return null;
+  }
+
+  void _recordTerminalPathVerificationBackoff(
+    SshSession session,
+    Object error,
+  ) {
+    if (error is! SSHChannelOpenError && error is! TimeoutException) {
+      return;
+    }
+    _terminalPathVerificationBackoffUntil = DateTime.now().add(
+      _terminalPathVerificationChannelBackoff,
+    );
+    DiagnosticsLogService.instance.debug(
+      'terminal',
+      'sftp_path_resolution_backoff',
+      fields: {
+        'connectionId': session.connectionId,
+        'delayMs': _terminalPathVerificationChannelBackoff.inMilliseconds,
+        'errorType': error.runtimeType.toString(),
+      },
+    );
   }
 
   Future<String?> _resolveTerminalPathVerificationHomeDirectory(
@@ -8378,23 +8446,186 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
+    _pendingTerminalPathVerifications[cacheKey] = terminalPath;
     _verifyingTerminalPathCacheKeys.add(cacheKey);
+    _scheduleTerminalPathVerificationBatch();
+  }
+
+  void _scheduleTerminalPathVerificationBatch([
+    Duration delay = _terminalPathVerificationBatchDelay,
+  ]) {
+    if (_isTerminalPathVerificationBatchScheduled) {
+      return;
+    }
+    _isTerminalPathVerificationBatchScheduled = true;
     unawaited(() async {
+      Duration? nextDelay;
       try {
-        final verifiedPath = await _resolveVerifiedTerminalFilePath(
-          terminalPath,
-          showErrors: false,
-        );
-        if (!mounted || verifiedPath == null) {
+        await Future<void>.delayed(delay);
+        if (!mounted) {
+          _pendingTerminalPathVerifications.clear();
+          _verifyingTerminalPathCacheKeys.clear();
           return;
         }
-        setState(() {
-          _shouldScheduleVisibleTerminalPathUnderlineRefreshFromBuild = true;
-        });
+        nextDelay = await _verifyPendingTerminalFilePaths();
       } finally {
-        _verifyingTerminalPathCacheKeys.remove(cacheKey);
+        _isTerminalPathVerificationBatchScheduled = false;
+        if (mounted && _pendingTerminalPathVerifications.isNotEmpty) {
+          _scheduleTerminalPathVerificationBatch(
+            nextDelay ?? _terminalPathVerificationBatchDelay,
+          );
+        }
       }
     }());
+  }
+
+  Future<Duration?> _verifyPendingTerminalFilePaths() async {
+    _syncVerifiedTerminalPathCacheScope();
+    if (_pendingTerminalPathVerifications.isEmpty) {
+      return null;
+    }
+
+    final backoffRemaining = _terminalPathVerificationBackoffRemaining();
+    if (backoffRemaining != null) {
+      DiagnosticsLogService.instance.debug(
+        'terminal',
+        'sftp_path_resolution_batch_deferred',
+        fields: {'pendingCount': _pendingTerminalPathVerifications.length},
+      );
+      return backoffRemaining;
+    }
+
+    final session = _activeSession();
+    if (session == null) {
+      _pendingTerminalPathVerifications.clear();
+      _verifyingTerminalPathCacheKeys.clear();
+      return null;
+    }
+
+    final batch = Map<String, String>.from(_pendingTerminalPathVerifications);
+    _pendingTerminalPathVerifications.clear();
+    var verifiedAny = false;
+    try {
+      final sftp = await _resolveTerminalPathVerificationSftp(
+        session,
+        allowBackoff: true,
+      );
+      if (sftp == null) {
+        return null;
+      }
+
+      for (final entry in batch.entries) {
+        if (_verifiedTerminalPathCache.containsKey(entry.key)) {
+          continue;
+        }
+        try {
+          final verifiedPath = await _resolveVerifiedTerminalFilePathWithSftp(
+            sftp,
+            entry.value,
+            showErrors: false,
+          );
+          verifiedAny = verifiedAny || verifiedPath != null;
+        } on TimeoutException {
+          // Background path verification is opportunistic.
+        } on SftpStatusError {
+          // Background path verification is opportunistic.
+        } on Object catch (error, stackTrace) {
+          DiagnosticsLogService.instance.warning(
+            'terminal',
+            'sftp_path_resolution_failed',
+            fields: {'errorType': error.runtimeType.toString()},
+          );
+          if (kDebugMode) {
+            debugPrint('Failed to resolve terminal file path: $error');
+            debugPrint('$stackTrace');
+          }
+        }
+      }
+    } on Object catch (error, stackTrace) {
+      final backoffRemaining = _terminalPathVerificationBackoffRemaining();
+      if (backoffRemaining != null) {
+        _pendingTerminalPathVerifications.addAll(batch);
+        return backoffRemaining;
+      }
+      DiagnosticsLogService.instance.warning(
+        'terminal',
+        'sftp_path_resolution_failed',
+        fields: {'errorType': error.runtimeType.toString()},
+      );
+      if (kDebugMode) {
+        debugPrint('Failed to resolve terminal file paths: $error');
+        debugPrint('$stackTrace');
+      }
+    } finally {
+      for (final cacheKey in batch.keys) {
+        if (!_pendingTerminalPathVerifications.containsKey(cacheKey)) {
+          _verifyingTerminalPathCacheKeys.remove(cacheKey);
+        }
+      }
+    }
+
+    if (verifiedAny && mounted) {
+      setState(() {
+        _shouldScheduleVisibleTerminalPathUnderlineRefreshFromBuild = true;
+      });
+    }
+    return null;
+  }
+
+  Future<String?> _resolveVerifiedTerminalFilePathWithSftp(
+    SftpClient sftp,
+    String terminalPath, {
+    required bool showErrors,
+  }) async {
+    _syncVerifiedTerminalPathCacheScope();
+    final cacheKey = _terminalPathCacheKey(terminalPath);
+    final cachedPath = _verifiedTerminalPathCache[cacheKey];
+    if (cachedPath != null) {
+      return cachedPath.resolvedPath;
+    }
+
+    final isExplicitPath = isExplicitTerminalFilePath(terminalPath);
+    final verificationCandidates =
+        requiresTerminalFilePathVerification(terminalPath)
+        ? resolveTerminalFilePathVerificationCandidates(terminalPath)
+        : <String>[terminalPath];
+    for (final candidate in verificationCandidates) {
+      final homeDirectory = await _resolveTerminalPathVerificationHomeDirectory(
+        sftp,
+        candidate,
+      );
+      final resolvedPath = resolveRequestedSftpPath(
+        candidate,
+        workingDirectory: _workingDirectoryPath,
+        homeDirectory: homeDirectory,
+      );
+      if (resolvedPath == null) {
+        continue;
+      }
+
+      try {
+        await sftp.stat(resolvedPath).timeout(_terminalPathVerificationTimeout);
+      } on SftpStatusError catch (error) {
+        if (error.code == SftpStatusCode.noSuchFile) {
+          continue;
+        }
+        rethrow;
+      }
+
+      _cacheVerifiedTerminalPath(
+        cacheKey,
+        terminalPath: candidate,
+        resolvedPath: resolvedPath,
+      );
+      return resolvedPath;
+    }
+
+    if (showErrors && isExplicitPath) {
+      _showTerminalLinkMessage(
+        'Could not open "$terminalPath" in SFTP: path does not exist',
+      );
+    }
+    return null;
   }
 
   Future<String?> _resolveVerifiedTerminalFilePath(
@@ -8418,54 +8649,18 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
 
     try {
-      final sftp = await _resolveTerminalPathVerificationSftp(session);
+      final sftp = await _resolveTerminalPathVerificationSftp(
+        session,
+        allowBackoff: !showErrors,
+      );
       if (sftp == null) {
         return null;
       }
-      final verificationCandidates =
-          requiresTerminalFilePathVerification(terminalPath)
-          ? resolveTerminalFilePathVerificationCandidates(terminalPath)
-          : <String>[terminalPath];
-      for (final candidate in verificationCandidates) {
-        final homeDirectory =
-            await _resolveTerminalPathVerificationHomeDirectory(
-              sftp,
-              candidate,
-            );
-        final resolvedPath = resolveRequestedSftpPath(
-          candidate,
-          workingDirectory: _workingDirectoryPath,
-          homeDirectory: homeDirectory,
-        );
-        if (resolvedPath == null) {
-          continue;
-        }
-
-        try {
-          await sftp
-              .stat(resolvedPath)
-              .timeout(_terminalPathVerificationTimeout);
-        } on SftpStatusError catch (error) {
-          if (error.code == SftpStatusCode.noSuchFile) {
-            continue;
-          }
-          rethrow;
-        }
-
-        _cacheVerifiedTerminalPath(
-          cacheKey,
-          terminalPath: candidate,
-          resolvedPath: resolvedPath,
-        );
-        return resolvedPath;
-      }
-
-      if (showErrors && isExplicitPath) {
-        _showTerminalLinkMessage(
-          'Could not open "$terminalPath" in SFTP: path does not exist',
-        );
-      }
-      return null;
+      return await _resolveVerifiedTerminalFilePathWithSftp(
+        sftp,
+        terminalPath,
+        showErrors: showErrors,
+      );
     } on TimeoutException {
       if (showErrors && isExplicitPath) {
         _showTerminalLinkMessage('Timed out opening "$terminalPath" in SFTP');

--- a/test/domain/services/ssh_exec_queue_test.dart
+++ b/test/domain/services/ssh_exec_queue_test.dart
@@ -19,18 +19,24 @@ void main() {
 
     await pumpEventQueue();
 
-    expect(startedJobs, [0, 1]);
-    expect(activeQueuedSshExecCountForTesting(1), 2);
-    expect(pendingQueuedSshExecCountForTesting(1), 1);
+    expect(startedJobs, [0]);
+    expect(activeQueuedSshExecCountForTesting(1), 1);
+    expect(pendingQueuedSshExecCountForTesting(1), 2);
 
     completers[0].complete(0);
     await pumpEventQueue();
 
-    expect(startedJobs, [0, 1, 2]);
-    expect(activeQueuedSshExecCountForTesting(1), 2);
-    expect(pendingQueuedSshExecCountForTesting(1), 0);
+    expect(startedJobs, [0, 1]);
+    expect(activeQueuedSshExecCountForTesting(1), 1);
+    expect(pendingQueuedSshExecCountForTesting(1), 1);
 
     completers[1].complete(1);
+    await pumpEventQueue();
+
+    expect(startedJobs, [0, 1, 2]);
+    expect(activeQueuedSshExecCountForTesting(1), 1);
+    expect(pendingQueuedSshExecCountForTesting(1), 0);
+
     completers[2].complete(2);
 
     expect(await Future.wait(futures), [0, 1, 2]);
@@ -64,16 +70,16 @@ void main() {
 
     await pumpEventQueue();
 
-    expect(startedJobs, ['low-1', 'normal']);
-    expect(activeQueuedSshExecCountForTesting(2), 2);
-    expect(pendingQueuedSshExecCountForTesting(2), 1);
+    expect(startedJobs, ['low-1']);
+    expect(activeQueuedSshExecCountForTesting(2), 1);
+    expect(pendingQueuedSshExecCountForTesting(2), 2);
 
-    normal.complete('normal');
+    firstLow.complete('low-1');
     await pumpEventQueue();
 
     expect(startedJobs, ['low-1', 'normal']);
 
-    firstLow.complete('low-1');
+    normal.complete('normal');
     await pumpEventQueue();
 
     expect(startedJobs, ['low-1', 'normal', 'low-2']);
@@ -87,7 +93,7 @@ void main() {
     ]);
   });
 
-  test('keeps a spare slot while normal work is active', () async {
+  test('prioritizes normal work ahead of queued low-priority work', () async {
     final startedJobs = <String>[];
     final firstNormal = Completer<String>();
     final low = Completer<String>();
@@ -121,18 +127,17 @@ void main() {
 
     await pumpEventQueue();
 
-    expect(startedJobs, ['normal-1', 'normal-2']);
-    expect(activeQueuedSshExecCountForTesting(3), 2);
-    expect(pendingQueuedSshExecCountForTesting(3), 1);
+    expect(activeQueuedSshExecCountForTesting(3), 1);
+    expect(pendingQueuedSshExecCountForTesting(3), 2);
 
-    secondNormal.complete('normal-2');
+    firstNormal.complete('normal-1');
     await pumpEventQueue();
 
     expect(startedJobs, ['normal-1', 'normal-2']);
     expect(activeQueuedSshExecCountForTesting(3), 1);
     expect(pendingQueuedSshExecCountForTesting(3), 1);
 
-    firstNormal.complete('normal-1');
+    secondNormal.complete('normal-2');
     await pumpEventQueue();
 
     expect(startedJobs, ['normal-1', 'normal-2', 'low']);

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -882,16 +882,20 @@ void main() {
 
       await pumpEventQueue();
 
-      expect(started, [0, 1]);
-      expect(activeQueuedSshExecCountForTesting(9), 2);
-      expect(pendingQueuedSshExecCountForTesting(9), 1);
+      expect(started, [0]);
+      expect(activeQueuedSshExecCountForTesting(9), 1);
+      expect(pendingQueuedSshExecCountForTesting(9), 2);
 
       completers[0].complete(0);
       await pumpEventQueue();
 
-      expect(started, [0, 1, 2]);
+      expect(started, [0, 1]);
 
       completers[1].complete(1);
+      await pumpEventQueue();
+
+      expect(started, [0, 1, 2]);
+
       completers[2].complete(2);
 
       expect(await Future.wait(futures), [0, 1, 2]);

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -1179,6 +1179,101 @@ void main() {
     });
 
     test(
+      'listWindows uses an active control-mode watcher during exec backoff',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client, connectionId: 72);
+        const service = TmuxService();
+        const sep = tmuxWindowFieldSeparator;
+        final stdoutController = StreamController<Uint8List>();
+        final writes = <String>[];
+        final windowLine = [
+          '1',
+          'fresh',
+          '1',
+          'nvim',
+          '/tmp/project',
+          '*',
+          'fresh-title',
+          '200',
+          'nvim',
+          '',
+          '@9',
+        ].join(sep);
+        final controlSession = _buildInteractiveExecSession(
+          stdoutController: stdoutController,
+          onWrite: (value) {
+            writes.add(value);
+            if (value.startsWith('refresh-client ')) {
+              scheduleMicrotask(
+                () => stdoutController.add(
+                  _utf8Bytes('%begin 1 1 0\n%end 1 1 0\n'),
+                ),
+              );
+            } else if (value.startsWith('list-windows ')) {
+              scheduleMicrotask(
+                () => stdoutController.add(
+                  _utf8Bytes('%begin 2 1 0\n$windowLine\n%end 2 1 0\n'),
+                ),
+              );
+            }
+          },
+        );
+        var executeCalls = 0;
+
+        when(() => client.execute(any(), pty: any(named: 'pty'))).thenAnswer((
+          _,
+        ) async {
+          executeCalls += 1;
+          if (executeCalls == 1) {
+            return _buildOpenExecSession(
+              stdout: 'zsh\n/usr/bin/tmux\n${_doneMarker()}',
+            );
+          }
+          if (executeCalls == 2) {
+            return controlSession;
+          }
+          if (executeCalls == 3) {
+            return Future<SSHSession>.error(
+              SSHChannelOpenError(2, 'open failed'),
+            );
+          }
+          throw StateError('Unexpected SSH exec call $executeCalls');
+        });
+
+        final subscription = service
+            .watchWindowChanges(session, 'main')
+            .listen((_) {});
+        addTearDown(() async {
+          service.clearCache(72);
+          await subscription.cancel();
+          await stdoutController.close();
+        });
+        await untilCalled(() => controlSession.write(any()));
+        await Future<void>.delayed(Duration.zero);
+
+        await expectLater(
+          service.hasSessionOrThrow(session, 'main'),
+          throwsA(isA<SSHChannelOpenError>()),
+        );
+        expect(TmuxService.hasExecChannelBackoffEntry(72), isTrue);
+
+        final windows = await service.listWindows(session, 'main');
+
+        expect(windows, hasLength(1));
+        expect(windows.single.name, 'fresh');
+        expect(windows.single.id, '@9');
+        expect(
+          writes,
+          contains(
+            predicate<String>((value) => value.startsWith('list-windows ')),
+          ),
+        );
+        expect(executeCalls, 3);
+      },
+    );
+
+    test(
       'selectWindow completes when stdout stays open after the done marker',
       () async {
         final client = _MockSshClient();

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -46,7 +46,10 @@ class _MockMonetizationService extends Mock implements MonetizationService {}
 
 class _MockSftpClient extends Mock implements SftpClient {}
 
-class _MockTmuxService extends Mock implements TmuxService {}
+class _MockTmuxService extends Mock implements TmuxService {
+  @override
+  bool isExecChannelCoolingDown(SshSession session) => false;
+}
 
 class _FakeWakelockPlusPlatform extends WakelockPlusPlatformInterface {
   final toggleCalls = <bool>[];
@@ -2937,6 +2940,57 @@ void main() {
               .inlineUnderlines,
           hasLength(1),
         );
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'background path verification batches relative path stats',
+      (tester) async {
+        const firstPath = 'lib/presentation/screens/terminal_screen.dart';
+        const secondPath = 'lib/domain/services/tmux_service.dart';
+        const workingDirectory = '/Users/tester/project';
+        final sftp = _MockSftpClient();
+        final firstStatStarted = Completer<void>();
+        final firstStatCompleter = Completer<SftpFileAttrs>();
+        var secondStatCalls = 0;
+
+        when(() => sshClient.sftp()).thenAnswer((_) async => sftp);
+        when(() => sftp.stat('$workingDirectory/$firstPath')).thenAnswer((_) {
+          if (!firstStatStarted.isCompleted) {
+            firstStatStarted.complete();
+          }
+          return firstStatCompleter.future;
+        });
+        when(() => sftp.stat('$workingDirectory/$secondPath')).thenAnswer((_) {
+          secondStatCalls++;
+          return Future.value(SftpFileAttrs());
+        });
+
+        await pumpScreen(tester);
+        shellStdoutController.add(
+          Uint8List.fromList(
+            utf8.encode(
+              '\u001b]7;file://remote.example.com$workingDirectory\u0007',
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        session.terminal!.write('git add $firstPath $secondPath');
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 75));
+        await firstStatStarted.future.timeout(const Duration(seconds: 1));
+
+        expect(secondStatCalls, 0);
+
+        firstStatCompleter.complete(SftpFileAttrs());
+        await tester.pumpAndSettle();
+
+        expect(secondStatCalls, 1);
+        verify(() => sshClient.sftp()).called(1);
+        verify(() => sftp.stat('$workingDirectory/$firstPath')).called(1);
+        verify(() => sftp.stat('$workingDirectory/$secondPath')).called(1);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );


### PR DESCRIPTION
## Summary

- Route tmux `list-windows` reloads through the active control-mode watcher when available, avoiding SSH exec backoff stale-cache behavior.
- Serialize short-lived SSH exec work per connection and defer optional tmux probes/agent refreshes during exec-channel cooldown.
- Batch passive terminal path verification through one delayed SFTP pass, while keeping explicit path opens immediate.

## Validation

- `flutter analyze`
- `flutter test`
