### PR TITLE
chore: relax commit hook test gate

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,7 +33,8 @@ flutter test integration_test
 
 ## Pre-Commit Checklist
 
-**IMPORTANT**: Before committing any code changes, always run these checks:
+**IMPORTANT**: Before committing code changes, run the checks that match the
+scope of your change:
 
 ```bash
 # 1. Analyze for ALL issues (not just warnings - CI fails on info too)
@@ -42,11 +43,14 @@ flutter analyze
 # 2. Format all code
 dart format .
 
-# 3. Run tests
-flutter test
+# 3. Run tests relevant to the changed behavior
+flutter test test/path/to/relevant_test.dart
 ```
 
-CI will fail if there are ANY analyzer issues (including `info` level). Common issues to watch for:
+Run the full `flutter test` suite locally when the touched area is broad,
+high-risk, or lacks narrower coverage. Otherwise, CI runs the full suite with
+coverage after the PR is opened. CI will fail if there are ANY analyzer issues
+(including `info` level). Common issues to watch for:
 
 - **`public_member_api_docs`**: Add `///` documentation to all public members
 - **`prefer_const_constructors`**: Use `const` for widget constructors when possible

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,17 +64,20 @@ Be respectful and constructive in all interactions.
 
 3. Write tests for new functionality
 
-4. Ensure all checks pass:
+4. Ensure local checks cover your change:
    ```bash
    # Format code
    dart format .
-   
+
    # Analyze code
    flutter analyze
-   
-   # Run tests
-   flutter test
+
+   # Run tests relevant to the changed behavior
+   flutter test test/path/to/relevant_test.dart
    ```
+
+   Run the full `flutter test` suite locally for broad or high-risk changes.
+   CI runs the full suite with coverage for every pull request.
 
 5. Commit your changes:
    ```bash

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -27,5 +27,5 @@ dart format --output=none --set-exit-if-changed -- "${staged_dart_files[@]}"
 echo 'Running analyzer on staged Dart files...'
 flutter analyze --fatal-warnings --fatal-infos --no-pub -- "${staged_dart_files[@]}"
 
-echo 'Skipping tests in pre-commit; full checks run in pre-push.'
+echo 'Skipping tests in pre-commit; run targeted tests for changed behavior before pushing.'
 echo 'Pre-commit checks passed!'

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -13,7 +13,7 @@ echo 'Running pre-push checks...'
 echo 'Running analyzer...'
 flutter analyze --fatal-warnings --fatal-infos --no-pub
 
-echo 'Running tests...'
-flutter test --no-pub
+echo 'Skipping full test suite in pre-push; run targeted tests for changed behavior locally.'
+echo 'CI runs the full test suite with coverage.'
 
 echo 'Pre-push checks passed!'


### PR DESCRIPTION
## Summary

- Remove the full `flutter test --no-pub` run from the pre-push hook.
- Keep analyzer enforcement in pre-push and make both hooks tell contributors to run targeted tests locally.
- Update Copilot/contributor guidance so agents run tests relevant to their changes while CI remains the full-suite gate.

## Validation

- `bash -n scripts/pre-commit scripts/pre-push scripts/setup.sh`
- `scripts/pre-commit`
- `scripts/pre-push`
