### PR TITLE
fix: keep iOS backspace repeat fast after buffer drains

### DIFF
--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -47,6 +47,14 @@ const terminalKeyboardTapLongPressTimeout = kLongPressTimeout;
 @visibleForTesting
 const terminalIosBackspaceRepeatSettleDelay = Duration(seconds: 2);
 
+/// Hidden backspace sentinels to preload after iOS exhausts visible IME text.
+@visibleForTesting
+const terminalIosBackspaceRepeatRunwayLength = 96;
+
+/// Runway length at which the hidden iOS backspace sentinels are replenished.
+@visibleForTesting
+const terminalIosBackspaceRepeatRunwayRefillThreshold = 12;
+
 /// Delay before iOS hardware keys begin app-controlled repeat.
 @visibleForTesting
 const terminalIosHardwareKeyRepeatStartDelay = Duration(milliseconds: 250);
@@ -54,6 +62,8 @@ const terminalIosHardwareKeyRepeatStartDelay = Duration(milliseconds: 250);
 /// Repeat interval for iOS hardware terminal navigation/editing keys.
 @visibleForTesting
 const terminalIosHardwareKeyRepeatInterval = Duration(milliseconds: 35);
+
+const _iosBackspaceRepeatRunwayCodeUnit = 0x200B;
 
 DateTime Function()? _modifierChordClockOverride;
 
@@ -311,6 +321,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   String? _pendingDeleteResetDeletedSuffixText;
   String _lastSentText = '';
   int _lastSentCursorOffset = 0;
+  int _iosBackspaceRunwayLength = 0;
   String? _pendingPerformedEnterText;
   int _pendingEnterActionSuppressions = 0;
   int _latestEditingValueRevision = 0;
@@ -531,6 +542,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
 
   bool get _shouldUseCustomHardwareKeyRepeat =>
       !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS;
+
+  bool get _shouldUseIosBackspaceRunway =>
+      widget.deleteDetection && _shouldDeferTrailingBackspaceImeClear;
 
   bool _isRepeatableHardwareTerminalKey(TerminalKey key) => switch (key) {
     TerminalKey.backspace ||
@@ -803,6 +817,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     int? deleteResetBaselineCursorOffset,
     String? deleteResetDeletedSuffixText,
     bool flushPlatformContext = false,
+    bool armIosBackspaceRunway = false,
   }) {
     _cancelDeferredTrailingBackspaceImeClear();
     if (flushPlatformContext && hasInputConnection) {
@@ -813,7 +828,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       _connection!.setEditingState(_currentEditingState);
     }
     _invalidatePendingEditingUpdates();
-    _resetCommittedInputState(clearPendingDeleteResetBaseline: false);
+    _resetCommittedInputState(
+      clearPendingDeleteResetBaseline: false,
+      armIosBackspaceRunway: armIosBackspaceRunway,
+    );
     _sawImeComposition = false;
     _hasPendingPromptOutputImeReset = false;
     if (deleteResetBaselineText != null &&
@@ -909,6 +927,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       _clearPendingDeleteResetBaseline();
       _lastSentText = '';
       _lastSentCursorOffset = 0;
+      _iosBackspaceRunwayLength = 0;
       _pendingPerformedEnterText = null;
       _pendingEnterActionSuppressions = 0;
       _currentEditingState = _initEditingState.copyWith();
@@ -950,6 +969,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _clearPendingDeleteResetBaseline();
     _lastSentText = '';
     _lastSentCursorOffset = 0;
+    _iosBackspaceRunwayLength = 0;
     _pendingPerformedEnterText = null;
     _pendingEnterActionSuppressions = 0;
     _currentEditingState = _initEditingState.copyWith();
@@ -1222,6 +1242,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     int pendingEnterSuppressions = 0,
     bool clearPendingPerformedEnterText = true,
     bool clearPendingDeleteResetBaseline = true,
+    bool armIosBackspaceRunway = false,
   }) {
     _cancelDeferredTrailingBackspaceImeClear();
     _lastSentText = '';
@@ -1238,7 +1259,11 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (clearPendingDeleteResetBaseline) {
       _clearPendingDeleteResetBaseline();
     }
-    _syncEditingStateWithUserText('');
+    if (armIosBackspaceRunway && _shouldUseIosBackspaceRunway) {
+      _syncEditingStateWithIosBackspaceRunway();
+    } else {
+      _syncEditingStateWithUserText('');
+    }
   }
 
   void _clearPendingDeleteResetBaseline() {
@@ -2006,11 +2031,192 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     );
   }
 
+  String _iosBackspaceRunwayPayload(int length) =>
+      String.fromCharCodes(List<int>.filled(length, 0x200B));
+
+  TextEditingValue _editingStateForIosBackspaceRunway() {
+    final text =
+        '$_deleteDetectionMarker'
+        '${_iosBackspaceRunwayPayload(terminalIosBackspaceRepeatRunwayLength)}';
+    return TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+  }
+
+  void _syncEditingStateWithIosBackspaceRunway() {
+    if (!_shouldUseIosBackspaceRunway) {
+      _syncEditingStateWithUserText('');
+      return;
+    }
+
+    _iosBackspaceRunwayLength = terminalIosBackspaceRepeatRunwayLength;
+    _currentEditingState = _editingStateForIosBackspaceRunway();
+    if (hasInputConnection) {
+      _connection!.setEditingState(_currentEditingState);
+    }
+  }
+
+  int _leadingIosBackspaceRunwayLength(String rawUserText) {
+    final limit = rawUserText.length < _iosBackspaceRunwayLength
+        ? rawUserText.length
+        : _iosBackspaceRunwayLength;
+    var length = 0;
+    while (length < limit &&
+        rawUserText.codeUnitAt(length) == _iosBackspaceRepeatRunwayCodeUnit) {
+      length++;
+    }
+    return length;
+  }
+
+  int _offsetAfterRemovedRange({
+    required int offset,
+    required int start,
+    required int length,
+  }) {
+    if (offset < 0 || offset <= start) {
+      return offset;
+    }
+    final end = start + length;
+    if (offset <= end) {
+      return start;
+    }
+    return offset - length;
+  }
+
+  TextSelection _selectionAfterRemovedRange(
+    TextSelection selection, {
+    required int start,
+    required int length,
+  }) => TextSelection(
+    baseOffset: _offsetAfterRemovedRange(
+      offset: selection.baseOffset,
+      start: start,
+      length: length,
+    ),
+    extentOffset: _offsetAfterRemovedRange(
+      offset: selection.extentOffset,
+      start: start,
+      length: length,
+    ),
+    affinity: selection.affinity,
+    isDirectional: selection.isDirectional,
+  );
+
+  TextRange _rangeAfterRemovedRange(
+    TextRange range, {
+    required int start,
+    required int length,
+  }) {
+    if (!range.isValid || range.isCollapsed) {
+      return range;
+    }
+    final shiftedStart = _offsetAfterRemovedRange(
+      offset: range.start,
+      start: start,
+      length: length,
+    );
+    final shiftedEnd = _offsetAfterRemovedRange(
+      offset: range.end,
+      start: start,
+      length: length,
+    );
+    if (shiftedStart >= shiftedEnd) {
+      return TextRange.empty;
+    }
+    return TextRange(start: shiftedStart, end: shiftedEnd);
+  }
+
+  TextEditingValue _editingValueWithoutIosBackspaceRunway(
+    TextEditingValue value,
+    int runwayPrefixLength,
+  ) {
+    final markerLength = _initEditingState.text.length;
+    final text = value.text.replaceRange(
+      markerLength,
+      markerLength + runwayPrefixLength,
+      '',
+    );
+    return TextEditingValue(
+      text: text,
+      selection: _selectionAfterRemovedRange(
+        value.selection,
+        start: markerLength,
+        length: runwayPrefixLength,
+      ),
+      composing: _rangeAfterRemovedRange(
+        value.composing,
+        start: markerLength,
+        length: runwayPrefixLength,
+      ),
+    );
+  }
+
+  bool _handleIosBackspaceRunwayDeletion(TextEditingValue value) {
+    if (!_shouldUseIosBackspaceRunway || _iosBackspaceRunwayLength == 0) {
+      return false;
+    }
+    if (_editingPrefixLength(value.text) != _initEditingState.text.length) {
+      _iosBackspaceRunwayLength = 0;
+      return false;
+    }
+
+    final rawUserText = _extractRawInputText(value.text);
+    final runwayPrefixLength = _leadingIosBackspaceRunwayLength(rawUserText);
+    if (runwayPrefixLength == 0) {
+      _iosBackspaceRunwayLength = 0;
+      return false;
+    }
+    if (runwayPrefixLength < rawUserText.length) {
+      return false;
+    }
+
+    final deletedCount = _iosBackspaceRunwayLength - runwayPrefixLength;
+    if (deletedCount > 0) {
+      _notifyUserInput();
+      for (var index = 0; index < deletedCount; index++) {
+        widget.terminal.keyInput(TerminalKey.backspace);
+      }
+    }
+    _lastSentText = '';
+    _lastSentCursorOffset = 0;
+    _iosBackspaceRunwayLength = runwayPrefixLength;
+    _currentEditingState = value;
+
+    if (_iosBackspaceRunwayLength <=
+        terminalIosBackspaceRepeatRunwayRefillThreshold) {
+      _syncEditingStateWithIosBackspaceRunway();
+    }
+    return true;
+  }
+
+  TextEditingValue _stripIosBackspaceRunway(TextEditingValue value) {
+    if (!_shouldUseIosBackspaceRunway || _iosBackspaceRunwayLength == 0) {
+      return value;
+    }
+    if (_editingPrefixLength(value.text) != _initEditingState.text.length) {
+      _iosBackspaceRunwayLength = 0;
+      return value;
+    }
+
+    final runwayPrefixLength = _leadingIosBackspaceRunwayLength(
+      _extractRawInputText(value.text),
+    );
+    if (runwayPrefixLength == 0) {
+      _iosBackspaceRunwayLength = 0;
+      return value;
+    }
+
+    _iosBackspaceRunwayLength = 0;
+    return _editingValueWithoutIosBackspaceRunway(value, runwayPrefixLength);
+  }
+
   void _syncEditingStateWithUserText(
     String userText, {
     TextEditingValue? sourceValue,
     bool forceResyncState = false,
   }) {
+    _iosBackspaceRunwayLength = 0;
     final rawPrefixLength = sourceValue == null
         ? _initEditingState.text.length
         : _editingPrefixLength(sourceValue.text);
@@ -2106,7 +2312,11 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
   }
 
-  Future<void> _updateEditingValue(TextEditingValue value, int revision) async {
+  Future<void> _updateEditingValue(
+    TextEditingValue incomingValue,
+    int revision,
+  ) async {
+    var value = incomingValue;
     _currentEditingState = value;
     var processedUserSelectionWasValid = false;
     var processedUserSelection = const TextSelection.collapsed(offset: 0);
@@ -2123,9 +2333,17 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       // Handle composing (IME input in progress).
       if (!value.composing.isCollapsed) {
         _cancelDeferredTrailingBackspaceImeClear();
+        _iosBackspaceRunwayLength = 0;
         _sawImeComposition = true;
         return;
       }
+
+      if (_handleIosBackspaceRunwayDeletion(value)) {
+        _sawImeComposition = false;
+        return;
+      }
+      value = _stripIosBackspaceRunway(value);
+      _currentEditingState = value;
 
       if (_editingPrefixLength(value.text) < _initEditingState.text.length) {
         final deletedCount = _textLengthInGraphemes(_lastSentText);
@@ -2140,7 +2358,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
           widget.terminal.keyInput(TerminalKey.backspace);
         }
         _sawImeComposition = false;
-        _resetCommittedInputState();
+        _resetCommittedInputState(
+          armIosBackspaceRunway: _shouldUseIosBackspaceRunway,
+        );
         _trimLeadingSwipeSpaceAfterBufferClear = clearedBufferedInput;
         return;
       }
@@ -2359,11 +2579,20 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
             .join();
         if (_shouldDeferTrailingBackspaceImeClear) {
           _trimLeadingSuggestionSpaceAfterDelete = true;
-          _scheduleDeferredTrailingBackspaceImeClear(
-            baselineText: effectiveCurrentText,
-            baselineCursorOffset: _lastSentCursorOffset,
-            deletedSuffixText: deletedSuffixText,
-          );
+          if (effectiveCurrentText.isEmpty) {
+            _clearImeBufferForFreshInput(
+              deleteResetBaselineText: effectiveCurrentText,
+              deleteResetBaselineCursorOffset: _lastSentCursorOffset,
+              deleteResetDeletedSuffixText: deletedSuffixText,
+              armIosBackspaceRunway: true,
+            );
+          } else {
+            _scheduleDeferredTrailingBackspaceImeClear(
+              baselineText: effectiveCurrentText,
+              baselineCursorOffset: _lastSentCursorOffset,
+              deletedSuffixText: deletedSuffixText,
+            );
+          }
         } else {
           _clearImeBufferForFreshInput(
             deleteResetBaselineText: effectiveCurrentText,
@@ -2452,6 +2681,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _hasPendingPromptOutputImeReset = false;
     _lastSentText = '';
     _lastSentCursorOffset = 0;
+    _iosBackspaceRunwayLength = 0;
     _pendingPerformedEnterText = null;
     _lastProcessedUserSelectionWasValid = false;
     _lastProcessedSelectionWasCollapsed = true;

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -959,6 +959,19 @@ TextEditingValue _editingValue(
         ),
 );
 
+String _iosBackspaceRunwayPayload(int length) =>
+    String.fromCharCodes(List<int>.filled(length, 0x200B));
+
+TextEditingValue _iosBackspaceRunwayValue(int length, {String suffix = ''}) {
+  final text =
+      '$_deleteDetectionMarker${_iosBackspaceRunwayPayload(length)}'
+      '$suffix';
+  return TextEditingValue(
+    text: text,
+    selection: TextSelection.collapsed(offset: text.length),
+  );
+}
+
 String _terminalKeyOutput(
   TerminalKey key, {
   bool shift = false,
@@ -6821,6 +6834,84 @@ void main() {
               (call) => call.method == 'TextInput.setEditingState',
             ),
             isEmpty,
+          );
+
+          await _disposeTerminalHarness(tester, harness);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testWidgets(
+      'keeps iOS held backspace fast after visible text is exhausted',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        try {
+          final harness = await _pumpTerminalHarness(tester);
+          final backspaceOutput = _terminalKeyOutput(TerminalKey.backspace);
+
+          tester.testTextInput.updateEditingValue(
+            _editingValue('ab', selectionOffset: 2),
+          );
+          await tester.pump();
+          harness.terminalOutput.clear();
+          tester.testTextInput.log.clear();
+
+          tester.testTextInput.updateEditingValue(
+            _editingValue('a', selectionOffset: 1),
+          );
+          await tester.pump();
+          tester.testTextInput.updateEditingValue(
+            _editingValue('', selectionOffset: 0),
+          );
+          await tester.pump();
+
+          expect(
+            _terminalStateFromEvents(
+              harness.terminalOutput,
+              initialText: 'ab',
+              initialCursorOffset: 2,
+            ),
+            (text: '', cursorOffset: 0),
+          );
+          expect(
+            _terminalTextInputClient(tester).currentTextEditingValue,
+            _iosBackspaceRunwayValue(terminalIosBackspaceRepeatRunwayLength),
+          );
+
+          harness.terminalOutput.clear();
+          tester.testTextInput.log.clear();
+
+          tester.testTextInput.updateEditingValue(
+            _iosBackspaceRunwayValue(
+              terminalIosBackspaceRepeatRunwayLength - 1,
+            ),
+          );
+          await tester.pump();
+
+          expect(harness.terminalOutput, [backspaceOutput]);
+          expect(
+            tester.testTextInput.log.where(
+              (call) => call.method == 'TextInput.setEditingState',
+            ),
+            isEmpty,
+          );
+
+          harness.terminalOutput.clear();
+
+          tester.testTextInput.updateEditingValue(
+            _iosBackspaceRunwayValue(
+              terminalIosBackspaceRepeatRunwayLength - 1,
+              suffix: 'x',
+            ),
+          );
+          await tester.pump();
+
+          expect(harness.terminalOutput, ['x']);
+          expect(
+            _terminalTextInputClient(tester).currentTextEditingValue,
+            _editingValue('x', selectionOffset: 1),
           );
 
           await _disposeTerminalHarness(tester, harness);


### PR DESCRIPTION
## Summary

- Add an iOS-only hidden backspace runway after visible IME text drains, so a held soft-keyboard Backspace can keep repeating without deleting and resetting the marker on every tick.
- Strip the hidden runway before resumed typing, preserving normal terminal text input once the user stops backspacing.
- Add a widget regression for the exhausted-buffer held-backspace case.

## Tests

- `dart format . --output=none --set-exit-if-changed`
- `flutter analyze`
- `flutter test test/widget/terminal_text_input_handler_test.dart`
- `flutter test test/presentation/widgets/terminal_text_input_handler_test.dart test/widget/terminal_text_input_handler_unicode_test.dart test/presentation/screens/terminal_screen_test.dart test/widget/terminal_screen_selection_test.dart`

## Notes

- Full `flutter test` was attempted twice but hung early after starting `test/unit/syntax_highlight_language_test.dart`; that file passes when run alone.
