### PR TITLE
Fix Wi-Fi jump host bypass permission prompt

### DIFF
--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -795,16 +795,34 @@ class SshService {
       var skipJumpHost = false;
       if (host.skipJumpHostOnSsids != null &&
           host.skipJumpHostOnSsids!.isNotEmpty) {
-        final currentSsid = await wifiNetworkService.getCurrentSsid();
-        skipJumpHost = shouldSkipJumpHostForSsid(
-          currentSsid: currentSsid,
-          skipJumpHostOnSsids: host.skipJumpHostOnSsids,
+        onProgress?.call(
+          const ConnectionProgressUpdate(
+            state: SshConnectionState.connecting,
+            message: 'Checking Wi-Fi network for jump host bypass…',
+          ),
         );
+        final permission = await wifiNetworkService.requestPermission();
+        String? currentSsid;
+        if (permission == WifiPermissionStatus.granted) {
+          currentSsid = await wifiNetworkService.getCurrentSsid();
+          skipJumpHost = shouldSkipJumpHostForSsid(
+            currentSsid: currentSsid,
+            skipJumpHostOnSsids: host.skipJumpHostOnSsids,
+          );
+        } else {
+          onProgress?.call(
+            const ConnectionProgressUpdate(
+              state: SshConnectionState.connecting,
+              message: 'Wi-Fi permission denied. Using jump host…',
+            ),
+          );
+        }
         DiagnosticsLogService.instance.info(
           'ssh.connect',
           'jump_host_ssid_check',
           fields: {
             'hostId': hostId,
+            'permissionStatus': permission.name,
             'hasCurrentSsid': currentSsid != null,
             'skipJumpHost': skipJumpHost,
           },

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -5740,6 +5740,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       connectionState,
       isConnecting: _isConnecting,
     );
+    final isConnectedThroughJumpHost =
+        connectionState == SshConnectionState.connected &&
+        _connectionId != null &&
+        ref
+                .read(activeSessionsProvider.notifier)
+                .getSession(_connectionId!)
+                ?.config
+                .jumpHost !=
+            null;
     final connectionIdentity = formatTerminalConnectionIdentity(
       username: _redactStoreScreenshotIdentities ? 'store' : _host?.username,
       hostname: _redactStoreScreenshotIdentities
@@ -5791,6 +5800,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                     state: connectionState,
                     isConnecting: _isConnecting,
                   ),
+                  if (isConnectedThroughJumpHost) ...[
+                    const SizedBox(width: 4),
+                    const _TerminalJumpHostIndicator(),
+                  ],
                 ],
               ),
               if (titleSubtitle.isNotEmpty)
@@ -9399,6 +9412,24 @@ class _TerminalConnectionStatusIcon extends StatelessWidget {
         message: label,
         excludeFromSemantics: true,
         child: Icon(_icon, size: 20, color: statusColor),
+      ),
+    );
+  }
+}
+
+class _TerminalJumpHostIndicator extends StatelessWidget {
+  const _TerminalJumpHostIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Semantics(
+      label: 'Connected through jump host',
+      child: Tooltip(
+        message: 'Connected through jump host',
+        excludeFromSemantics: true,
+        child: Icon(Icons.alt_route, size: 18, color: colorScheme.secondary),
       ),
     );
   }

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -51,12 +51,27 @@ class _CapturingSshService extends SshService {
 }
 
 class _StubWifiNetworkService extends WifiNetworkService {
-  _StubWifiNetworkService(this.ssid);
+  _StubWifiNetworkService(
+    this.ssid, {
+    this.permissionStatus = WifiPermissionStatus.granted,
+  });
 
   final String? ssid;
+  final WifiPermissionStatus permissionStatus;
+  int requestPermissionCallCount = 0;
+  int getCurrentSsidCallCount = 0;
 
   @override
-  Future<String?> getCurrentSsid() async => ssid;
+  Future<WifiPermissionStatus> requestPermission() async {
+    requestPermissionCallCount++;
+    return permissionStatus;
+  }
+
+  @override
+  Future<String?> getCurrentSsid() async {
+    getCurrentSsidCallCount++;
+    return ssid;
+  }
 }
 
 class _CountingKeyRepository extends KeyRepository {
@@ -2470,16 +2485,19 @@ void main() {
       final encryption = SecretEncryptionService.forTesting();
       final hostRepo = HostRepository(db, encryption);
       final keyRepo = KeyRepository(db, encryption);
+      final wifiNetworkService = _StubWifiNetworkService('home');
       final service = _CapturingSshService(
         hostRepository: hostRepo,
         keyRepository: keyRepo,
-        wifiNetworkService: _StubWifiNetworkService('home'),
+        wifiNetworkService: wifiNetworkService,
       );
 
       final hostId = await seedHostWithJump(db);
       await service.connectToHost(hostId);
 
       expect(service.capturedConfig?.jumpHost, isNotNull);
+      expect(wifiNetworkService.requestPermissionCallCount, 0);
+      expect(wifiNetworkService.getCurrentSsidCallCount, 0);
     });
 
     test('uses jump host when current SSID is not in skip list', () async {
@@ -2488,10 +2506,11 @@ void main() {
       final encryption = SecretEncryptionService.forTesting();
       final hostRepo = HostRepository(db, encryption);
       final keyRepo = KeyRepository(db, encryption);
+      final wifiNetworkService = _StubWifiNetworkService('cafe');
       final service = _CapturingSshService(
         hostRepository: hostRepo,
         keyRepository: keyRepo,
-        wifiNetworkService: _StubWifiNetworkService('cafe'),
+        wifiNetworkService: wifiNetworkService,
       );
 
       final hostId = await seedHostWithJump(
@@ -2502,6 +2521,8 @@ void main() {
 
       expect(service.capturedConfig?.jumpHost, isNotNull);
       expect(service.capturedConfig?.hostname, 'target.example.com');
+      expect(wifiNetworkService.requestPermissionCallCount, 1);
+      expect(wifiNetworkService.getCurrentSsidCallCount, 1);
     });
 
     test('skips jump host when current SSID is in skip list', () async {
@@ -2510,10 +2531,11 @@ void main() {
       final encryption = SecretEncryptionService.forTesting();
       final hostRepo = HostRepository(db, encryption);
       final keyRepo = KeyRepository(db, encryption);
+      final wifiNetworkService = _StubWifiNetworkService('home');
       final service = _CapturingSshService(
         hostRepository: hostRepo,
         keyRepository: keyRepo,
-        wifiNetworkService: _StubWifiNetworkService('home'),
+        wifiNetworkService: wifiNetworkService,
       );
 
       final hostId = await seedHostWithJump(
@@ -2525,6 +2547,32 @@ void main() {
       expect(service.capturedConfig, isNotNull);
       expect(service.capturedConfig!.jumpHost, isNull);
       expect(service.capturedConfig!.hostname, 'target.example.com');
+      expect(wifiNetworkService.requestPermissionCallCount, 1);
+      expect(wifiNetworkService.getCurrentSsidCallCount, 1);
+    });
+
+    test('uses jump host when Wi-Fi permission is denied', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final encryption = SecretEncryptionService.forTesting();
+      final hostRepo = HostRepository(db, encryption);
+      final keyRepo = KeyRepository(db, encryption);
+      final wifiNetworkService = _StubWifiNetworkService(
+        'home',
+        permissionStatus: WifiPermissionStatus.denied,
+      );
+      final service = _CapturingSshService(
+        hostRepository: hostRepo,
+        keyRepository: keyRepo,
+        wifiNetworkService: wifiNetworkService,
+      );
+
+      final hostId = await seedHostWithJump(db, skipJumpHostOnSsids: 'home');
+      await service.connectToHost(hostId);
+
+      expect(service.capturedConfig?.jumpHost, isNotNull);
+      expect(wifiNetworkService.requestPermissionCallCount, 1);
+      expect(wifiNetworkService.getCurrentSsidCallCount, 0);
     });
 
     test('uses jump host when SSID detection returns null', () async {
@@ -2533,16 +2581,19 @@ void main() {
       final encryption = SecretEncryptionService.forTesting();
       final hostRepo = HostRepository(db, encryption);
       final keyRepo = KeyRepository(db, encryption);
+      final wifiNetworkService = _StubWifiNetworkService(null);
       final service = _CapturingSshService(
         hostRepository: hostRepo,
         keyRepository: keyRepo,
-        wifiNetworkService: _StubWifiNetworkService(null),
+        wifiNetworkService: wifiNetworkService,
       );
 
       final hostId = await seedHostWithJump(db, skipJumpHostOnSsids: 'home');
       await service.connectToHost(hostId);
 
       expect(service.capturedConfig?.jumpHost, isNotNull);
+      expect(wifiNetworkService.requestPermissionCallCount, 1);
+      expect(wifiNetworkService.getCurrentSsidCallCount, 1);
     });
   });
 }

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -757,6 +757,31 @@ void main() {
       );
     });
 
+    testWidgets('shows jump host indicator for tunneled sessions', (
+      tester,
+    ) async {
+      session = SshSession(
+        connectionId: 7,
+        hostId: host.id,
+        client: sshClient,
+        config: const SshConnectionConfig(
+          hostname: 'terminal.example.com',
+          port: 22,
+          username: 'root',
+          jumpHost: SshConnectionConfig(
+            hostname: 'bastion.example.com',
+            port: 22,
+            username: 'bastion',
+          ),
+        ),
+      )..getOrCreateTerminal();
+
+      await pumpScreen(tester);
+
+      expect(find.byTooltip('Connected through jump host'), findsOneWidget);
+      expect(find.byIcon(Icons.alt_route), findsOneWidget);
+    });
+
     testWidgets(
       'does not send synthetic terminal reports to an idle shell prompt',
       (tester) async {


### PR DESCRIPTION
## Summary

- Request Wi-Fi/Location permission before evaluating SSID-based jump-host bypass during connection attempts.
- Fall back to the jump host when permission is denied or SSID detection is unavailable, with connection progress and diagnostics reflecting the decision.
- Show a jump-host route indicator next to the connected check mark when a terminal session is tunneled through a jump host.

## Validation

- `dart format --set-exit-if-changed lib/domain/services/ssh_service.dart lib/presentation/screens/terminal_screen.dart test/domain/services/ssh_service_test.dart test/presentation/screens/terminal_screen_test.dart`
- `flutter analyze --no-pub`
- `flutter test --no-pub`
