### PR TITLE
Make SFTP browser a slide-up popover

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -133,21 +133,35 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/sftp/:hostId',
         name: Routes.sftp,
-        builder: (context, state) {
+        pageBuilder: (context, state) {
           final hostId = int.tryParse(state.pathParameters['hostId'] ?? '');
           final connectionId = int.tryParse(
             state.uri.queryParameters['connectionId'] ?? '',
           );
           final initialPath = state.uri.queryParameters['path'];
           final initialWorkingDirectory = state.uri.queryParameters['cwd'];
+          final connectionStartDirectory =
+              state.uri.queryParameters['connectionCwd'];
+          final tmuxPaneDirectory = state.uri.queryParameters['tmuxCwd'];
           if (hostId == null) {
-            return const Scaffold(body: Center(child: Text('Invalid host ID')));
+            return _buildSlideUpPage<String>(
+              key: state.pageKey,
+              child: const Scaffold(
+                body: Center(child: Text('Invalid host ID')),
+              ),
+            );
           }
-          return SftpScreen(
-            hostId: hostId,
-            connectionId: connectionId,
-            initialPath: initialPath,
-            initialWorkingDirectory: initialWorkingDirectory,
+          return _buildSlideUpPage<String>(
+            key: state.pageKey,
+            child: SftpScreen(
+              hostId: hostId,
+              connectionId: connectionId,
+              initialPath: initialPath,
+              initialWorkingDirectory: initialWorkingDirectory,
+              connectionStartDirectory: connectionStartDirectory,
+              tmuxPaneDirectory: tmuxPaneDirectory,
+              showCloseButton: true,
+            ),
           );
         },
       ),
@@ -217,6 +231,27 @@ HomeScreenTab _homeScreenTabFromRoute(String? tab) => switch (tab) {
   'connections' => HomeScreenTab.connections,
   _ => HomeScreenTab.hosts,
 };
+
+CustomTransitionPage<T> _buildSlideUpPage<T>({
+  required LocalKey key,
+  required Widget child,
+}) => CustomTransitionPage<T>(
+  key: key,
+  fullscreenDialog: true,
+  transitionDuration: const Duration(milliseconds: 280),
+  reverseTransitionDuration: const Duration(milliseconds: 220),
+  transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+      SlideTransition(
+        position: animation.drive(
+          Tween<Offset>(
+            begin: const Offset(0, 1),
+            end: Offset.zero,
+          ).chain(CurveTween(curve: Curves.easeOutCubic)),
+        ),
+        child: child,
+      ),
+  child: child,
+);
 
 /// Computes the route redirect for the given authentication state.
 String? redirectForAuthState({

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -136,37 +136,25 @@ resolveRequestedSftpNavigationTarget(
 
 /// Resolves quick-jump locations for the SFTP browser.
 @visibleForTesting
-List<({String label, String path})> resolveSftpLocationShortcuts({
+List<String> resolveSftpLocationShortcuts({
   String? homeDirectory,
   String? connectionStartDirectory,
   String? tmuxPaneDirectory,
 }) {
-  final shortcuts = <({String label, String path})>[];
+  final shortcuts = <String>[];
 
-  void addShortcut(String label, String? directory) {
+  void addShortcut(String? directory) {
     final normalizedDirectory = normalizeSftpAbsolutePath(directory);
-    if (normalizedDirectory == null) {
+    if (normalizedDirectory == null ||
+        shortcuts.contains(normalizedDirectory)) {
       return;
     }
-
-    final existingIndex = shortcuts.indexWhere(
-      (shortcut) => shortcut.path == normalizedDirectory,
-    );
-    if (existingIndex >= 0) {
-      final existing = shortcuts[existingIndex];
-      shortcuts[existingIndex] = (
-        label: '${existing.label} / $label',
-        path: existing.path,
-      );
-      return;
-    }
-
-    shortcuts.add((label: label, path: normalizedDirectory));
+    shortcuts.add(normalizedDirectory);
   }
 
-  addShortcut('Home', homeDirectory);
-  addShortcut('Connection start', connectionStartDirectory);
-  addShortcut('tmux pane', tmuxPaneDirectory);
+  addShortcut(homeDirectory);
+  addShortcut(connectionStartDirectory);
+  addShortcut(tmuxPaneDirectory);
 
   return shortcuts;
 }
@@ -1118,22 +1106,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
             for (final shortcut in shortcuts)
               Padding(
                 padding: const EdgeInsets.only(right: 8),
-                child: ActionChip(
-                  avatar: Icon(
-                    _iconForLocationShortcut(shortcut.label),
-                    size: 18,
-                  ),
-                  label: Text(
-                    '${shortcut.label}: '
-                    '${_formatLocationShortcutPath(shortcut.path)}',
-                  ),
-                  onPressed: shortcut.path == _currentPath
-                      ? null
-                      : () => unawaited(_navigateTo(shortcut.path)),
-                  tooltip: shortcut.path == _currentPath
-                      ? '${shortcut.label}: ${shortcut.path} (current)'
-                      : '${shortcut.label}: ${shortcut.path}',
-                ),
+                child: _buildLocationShortcutChip(shortcut, theme),
               ),
           ],
         ),
@@ -1141,23 +1114,38 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     );
   }
 
-  IconData _iconForLocationShortcut(String label) {
-    if (label.contains('Home')) {
-      return Icons.home_outlined;
+  Widget _buildLocationShortcutChip(String shortcutPath, ThemeData theme) {
+    final isCurrent = shortcutPath == _currentPath;
+    if (isCurrent) {
+      return Tooltip(
+        message: 'Current folder: $shortcutPath',
+        child: Chip(
+          avatar: Icon(
+            Icons.check_circle_rounded,
+            color: theme.colorScheme.onPrimaryContainer,
+            size: 18,
+          ),
+          label: Text(shortcutPath),
+          labelStyle: theme.textTheme.labelLarge?.copyWith(
+            color: theme.colorScheme.onPrimaryContainer,
+            fontWeight: FontWeight.w700,
+          ),
+          backgroundColor: theme.colorScheme.primaryContainer,
+          side: BorderSide(color: theme.colorScheme.primary),
+        ),
+      );
     }
-    if (label.contains('tmux')) {
-      return Icons.view_week_outlined;
-    }
-    return Icons.flag_outlined;
-  }
 
-  String _formatLocationShortcutPath(String remotePath) {
-    if (remotePath == '/') {
-      return '/';
-    }
-
-    final basename = path.posix.basename(remotePath);
-    return basename.isEmpty ? remotePath : basename;
+    return ActionChip(
+      label: Text(shortcutPath),
+      labelStyle: theme.textTheme.labelLarge?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
+      backgroundColor: theme.colorScheme.surface,
+      side: BorderSide(color: theme.colorScheme.outlineVariant),
+      onPressed: () => unawaited(_navigateTo(shortcutPath)),
+      tooltip: 'Go to $shortcutPath',
+    );
   }
 
   Widget _buildBreadcrumbs() {

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -8,7 +8,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
@@ -42,6 +44,14 @@ const _sftpFileRowExtentEstimate = 64.0;
 const _sftpHighlightedFileScrollPadding = 16.0;
 const _sftpScrollAnimationDuration = Duration(milliseconds: 220);
 const _videoPreviewCacheDirectoryName = 'monkeyssh-sftp-video-preview';
+
+/// Identifies a remembered SFTP browser location.
+typedef SftpBrowserLocationKey = ({int hostId, int? connectionId});
+
+/// Last successfully opened SFTP directory, keyed by host and connection.
+final StateProvider<Map<SftpBrowserLocationKey, String>>
+sftpBrowserLastPathsProvider =
+    StateProvider<Map<SftpBrowserLocationKey, String>>((ref) => const {});
 
 /// Bounds SFTP operations so stale SSH channels don't leave the browser loading
 /// forever.
@@ -123,6 +133,43 @@ resolveRequestedSftpNavigationTarget(
       : parentRemotePath(normalizedPath),
   highlightedFileName: isDirectory ? null : path.posix.basename(normalizedPath),
 );
+
+/// Resolves quick-jump locations for the SFTP browser.
+@visibleForTesting
+List<({String label, String path})> resolveSftpLocationShortcuts({
+  String? homeDirectory,
+  String? connectionStartDirectory,
+  String? tmuxPaneDirectory,
+}) {
+  final shortcuts = <({String label, String path})>[];
+
+  void addShortcut(String label, String? directory) {
+    final normalizedDirectory = normalizeSftpAbsolutePath(directory);
+    if (normalizedDirectory == null) {
+      return;
+    }
+
+    final existingIndex = shortcuts.indexWhere(
+      (shortcut) => shortcut.path == normalizedDirectory,
+    );
+    if (existingIndex >= 0) {
+      final existing = shortcuts[existingIndex];
+      shortcuts[existingIndex] = (
+        label: '${existing.label} / $label',
+        path: existing.path,
+      );
+      return;
+    }
+
+    shortcuts.add((label: label, path: normalizedDirectory));
+  }
+
+  addShortcut('Home', homeDirectory);
+  addShortcut('Connection start', connectionStartDirectory);
+  addShortcut('tmux pane', tmuxPaneDirectory);
+
+  return shortcuts;
+}
 
 /// Whether the file name should be previewable as an image.
 @visibleForTesting
@@ -399,6 +446,9 @@ class SftpScreen extends ConsumerStatefulWidget {
     this.connectionId,
     this.initialPath,
     this.initialWorkingDirectory,
+    this.connectionStartDirectory,
+    this.tmuxPaneDirectory,
+    this.showCloseButton = false,
     super.key,
   });
 
@@ -413,6 +463,15 @@ class SftpScreen extends ConsumerStatefulWidget {
 
   /// Optional terminal working directory used to resolve relative paths.
   final String? initialWorkingDirectory;
+
+  /// Optional directory where the terminal connection first opened.
+  final String? connectionStartDirectory;
+
+  /// Optional working directory reported by the active tmux pane.
+  final String? tmuxPaneDirectory;
+
+  /// Whether to show an explicit close affordance in the app bar.
+  final bool showCloseButton;
 
   @override
   ConsumerState<SftpScreen> createState() => _SftpScreenState();
@@ -433,17 +492,36 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   String? _highlightedFileName;
   String? _homeDirectoryPath;
   String? _fallbackDirectoryPath;
+  String? _connectionStartDirectoryPath;
+  String? _tmuxPaneDirectoryPath;
 
   @override
   void initState() {
     super.initState();
     _pendingInitialPath = _sanitizeRequestedPath(widget.initialPath);
+    _connectionStartDirectoryPath = normalizeSftpAbsolutePath(
+      widget.connectionStartDirectory,
+    );
+    _tmuxPaneDirectoryPath = normalizeSftpAbsolutePath(
+      widget.tmuxPaneDirectory,
+    );
     _connect();
   }
 
   @override
   void didUpdateWidget(covariant SftpScreen oldWidget) {
     super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.connectionStartDirectory != widget.connectionStartDirectory) {
+      _connectionStartDirectoryPath = normalizeSftpAbsolutePath(
+        widget.connectionStartDirectory,
+      );
+    }
+    if (oldWidget.tmuxPaneDirectory != widget.tmuxPaneDirectory) {
+      _tmuxPaneDirectoryPath = normalizeSftpAbsolutePath(
+        widget.tmuxPaneDirectory,
+      );
+    }
 
     if (oldWidget.initialPath == widget.initialPath &&
         oldWidget.initialWorkingDirectory == widget.initialWorkingDirectory) {
@@ -553,6 +631,8 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       pendingSftp = null;
       _hostLabel = session.config.hostname;
       _fallbackDirectoryPath = normalizeSftpAbsolutePath(initialPath) ?? '/';
+      _homeDirectoryPath ??= _fallbackDirectoryPath;
+      _connectionStartDirectoryPath ??= _fallbackDirectoryPath;
       final requestedPath = _pendingInitialPath;
       if (requestedPath != null) {
         _pendingInitialPath = null;
@@ -699,6 +779,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         _isLoading = false;
         _error = null;
       });
+      _rememberCurrentPath(path);
       _queueScrollBreadcrumbTailIntoView();
       return true;
     } on Exception catch (e) {
@@ -752,6 +833,20 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     }
     final nextHistory = popSftpPathHistory(_pathHistory);
     await _loadDirectory(nextHistory.last, nextHistory: nextHistory);
+  }
+
+  void _rememberCurrentPath(String remotePath) {
+    final normalizedPath = normalizeSftpAbsolutePath(remotePath);
+    if (normalizedPath == null) {
+      return;
+    }
+
+    final key = (hostId: widget.hostId, connectionId: widget.connectionId);
+    final notifier = ref.read(sftpBrowserLastPathsProvider.notifier);
+    notifier.state = <SftpBrowserLocationKey, String>{
+      ...notifier.state,
+      key: normalizedPath,
+    };
   }
 
   Future<bool> _openRequestedPath(String requestedPath) async {
@@ -951,6 +1046,13 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     },
     child: Scaffold(
       appBar: AppBar(
+        leading: widget.showCloseButton
+            ? IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: _closeBrowser,
+                tooltip: 'Close file browser',
+              )
+            : null,
         title: Text(_hostLabel == null ? 'Files' : 'Files - $_hostLabel'),
         actions: [
           IconButton(
@@ -967,6 +1069,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       ),
       body: Column(
         children: [
+          _buildLocationShortcuts(),
           _buildBreadcrumbs(),
           Expanded(child: _buildFileList()),
         ],
@@ -978,6 +1081,84 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       ),
     ),
   );
+
+  void _closeBrowser() {
+    final navigator = Navigator.of(context);
+    if (navigator.canPop()) {
+      navigator.pop();
+      return;
+    }
+    context.go('/');
+  }
+
+  Widget _buildLocationShortcuts() {
+    final shortcuts = resolveSftpLocationShortcuts(
+      homeDirectory: _homeDirectoryPath,
+      connectionStartDirectory: _connectionStartDirectoryPath,
+      tmuxPaneDirectory: _tmuxPaneDirectoryPath,
+    );
+    if (shortcuts.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 6),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        border: Border(
+          bottom: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
+      ),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            for (final shortcut in shortcuts)
+              Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: ActionChip(
+                  avatar: Icon(
+                    _iconForLocationShortcut(shortcut.label),
+                    size: 18,
+                  ),
+                  label: Text(
+                    '${shortcut.label}: '
+                    '${_formatLocationShortcutPath(shortcut.path)}',
+                  ),
+                  onPressed: shortcut.path == _currentPath
+                      ? null
+                      : () => unawaited(_navigateTo(shortcut.path)),
+                  tooltip: shortcut.path == _currentPath
+                      ? '${shortcut.label}: ${shortcut.path} (current)'
+                      : '${shortcut.label}: ${shortcut.path}',
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  IconData _iconForLocationShortcut(String label) {
+    if (label.contains('Home')) {
+      return Icons.home_outlined;
+    }
+    if (label.contains('tmux')) {
+      return Icons.view_week_outlined;
+    }
+    return Icons.flag_outlined;
+  }
+
+  String _formatLocationShortcutPath(String remotePath) {
+    if (remotePath == '/') {
+      return '/';
+    }
+
+    final basename = path.posix.basename(remotePath);
+    return basename.isEmpty ? remotePath : basename;
+  }
 
   Widget _buildBreadcrumbs() {
     final parts = _currentPath.split('/').where((p) => p.isNotEmpty).toList();

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -58,6 +58,7 @@ import '../widgets/terminal_text_style.dart';
 import '../widgets/terminal_theme_picker.dart';
 import '../widgets/tmux_window_navigator.dart';
 import '../widgets/tmux_window_status_badge.dart';
+import 'sftp_screen.dart';
 
 part '../widgets/tmux_expandable_bar.dart';
 
@@ -2128,6 +2129,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   _InitialTmuxWindowTarget? _pendingInitialTmuxWindowTarget;
   bool _showTmuxBar = true;
   bool _isTmuxBarExpanded = false;
+  String? _connectionOpenedWorkingDirectory;
   String? _tmuxLaunchWorkingDirectory;
   String? _tmuxWorkingDirectory;
   int _tmuxDetectionGeneration = 0;
@@ -2539,6 +2541,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   void _observeSessionMetadata(SshSession session) {
     if (_sessionController.isObservingSession(session)) {
+      _captureConnectionOpenedWorkingDirectory();
       return;
     }
 
@@ -2546,14 +2549,26 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _disposeTerminalPathVerificationSftp();
     }
     _sessionController.observeSessionMetadata(session);
+    _captureConnectionOpenedWorkingDirectory();
   }
 
   void _handleSessionMetadataChanged() {
     if (!mounted) {
       return;
     }
+    _captureConnectionOpenedWorkingDirectory();
     _syncVerifiedTerminalPathCacheScope();
     setState(() {});
+  }
+
+  void _captureConnectionOpenedWorkingDirectory() {
+    if (_connectionOpenedWorkingDirectory != null) {
+      return;
+    }
+
+    _connectionOpenedWorkingDirectory = normalizeSftpAbsolutePath(
+      _liveWorkingDirectoryPath ?? _tmuxLaunchWorkingDirectory,
+    );
   }
 
   Future<void> _applySharedClipboardSetting({
@@ -3791,6 +3806,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     setState(() {
       _isConnecting = true;
       _error = null;
+      _connectionOpenedWorkingDirectory = null;
     });
 
     _sessionsNotifier = ref.read(activeSessionsProvider.notifier);
@@ -4662,6 +4678,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _tmuxStateConnectionId = session.connectionId;
           _tmuxLaunchWorkingDirectory = tmuxLaunchCwd;
           _tmuxWorkingDirectory = tmuxCwd;
+          _connectionOpenedWorkingDirectory ??= normalizeSftpAbsolutePath(
+            tmuxLaunchCwd,
+          );
         });
         _startTmuxForegroundVerification(session, sessionName);
         DiagnosticsLogService.instance.info(
@@ -5842,7 +5861,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                   _connectionId == null ||
                       connectionState != SshConnectionState.connected
                   ? null
-                  : _openConnectionFileBrowser,
+                  : () => unawaited(_openConnectionFileBrowser()),
               tooltip: 'Browse files',
             ),
             if (isMobile)
@@ -6638,23 +6657,92 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     return TerminalStyle.fromTextStyle(textStyle);
   }
 
-  void _openConnectionFileBrowser() {
+  Future<void> _openConnectionFileBrowser() async {
     final connectionId = _connectionId;
     if (connectionId == null) {
       return;
     }
 
-    // Pass the terminal's working directory (from OSC 7) as both the
-    // initial path and the working directory for relative path resolution.
+    final tmuxPaneDirectory = await _resolveCurrentTmuxPaneDirectory();
+    if (!mounted) {
+      return;
+    }
+
+    // Prefer the last browser directory when opening from the toolbar. The
+    // terminal cwd remains available for relative path resolution and as a
+    // quick-jump inside the browser.
     final cwd = _workingDirectoryPath;
-    context.pushNamed(
-      Routes.sftp,
-      pathParameters: {'hostId': widget.hostId.toString()},
-      queryParameters: {
-        'connectionId': connectionId.toString(),
-        if (cwd != null) ...{'path': cwd, 'cwd': cwd},
-      },
+    final rememberedPath = ref.read(
+      sftpBrowserLastPathsProvider,
+    )[(hostId: widget.hostId, connectionId: connectionId)];
+    final initialPath = rememberedPath ?? cwd;
+    unawaited(
+      context.pushNamed<String>(
+        Routes.sftp,
+        pathParameters: {'hostId': widget.hostId.toString()},
+        queryParameters: _buildSftpBrowserQueryParameters(
+          connectionId: connectionId,
+          initialPath: initialPath,
+          workingDirectory: cwd,
+          tmuxPaneDirectory: tmuxPaneDirectory,
+        ),
+      ),
     );
+  }
+
+  Map<String, String> _buildSftpBrowserQueryParameters({
+    int? connectionId,
+    String? initialPath,
+    String? workingDirectory,
+    String? tmuxPaneDirectory,
+  }) {
+    final queryParameters = <String, String>{};
+
+    void addParameter(String key, String? value) {
+      if (value == null) {
+        return;
+      }
+      queryParameters[key] = value;
+    }
+
+    addParameter('connectionId', connectionId?.toString());
+    addParameter('path', initialPath);
+    addParameter('cwd', workingDirectory);
+    addParameter('connectionCwd', _connectionOpenedWorkingDirectory);
+    addParameter('tmuxCwd', tmuxPaneDirectory);
+
+    return queryParameters;
+  }
+
+  Future<String?> _resolveCurrentTmuxPaneDirectory() async {
+    final fallbackDirectory = normalizeSftpAbsolutePath(_tmuxWorkingDirectory);
+    final connectionId = _connectionId;
+    final sessionName = _tmuxSessionName;
+    if (!_isTmuxActive || connectionId == null || sessionName == null) {
+      return fallbackDirectory;
+    }
+
+    final session = _sessionsNotifier?.getSession(connectionId);
+    if (session == null) {
+      return fallbackDirectory;
+    }
+
+    final paneDirectory = normalizeSftpAbsolutePath(
+      await ref
+          .read(tmuxServiceProvider)
+          .currentPanePath(
+            session,
+            sessionName,
+            extraFlags: _host?.tmuxExtraFlags,
+          ),
+    );
+    if (paneDirectory == null) {
+      return fallbackDirectory;
+    }
+    if (mounted && paneDirectory != _tmuxWorkingDirectory) {
+      setState(() => _tmuxWorkingDirectory = paneDirectory);
+    }
+    return paneDirectory;
   }
 
   Future<void> _handleMenuAction(String action) async {
@@ -8180,13 +8268,21 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
 
     final connectionId = _connectionId;
+    final cwd = _workingDirectoryPath;
+    final tmuxPaneDirectory = await _resolveCurrentTmuxPaneDirectory();
+    if (!mounted) {
+      return;
+    }
+
     final result = await context.pushNamed<String>(
       Routes.sftp,
       pathParameters: {'hostId': widget.hostId.toString()},
-      queryParameters: {
-        if (connectionId != null) 'connectionId': connectionId.toString(),
-        'path': verifiedPath,
-      },
+      queryParameters: _buildSftpBrowserQueryParameters(
+        connectionId: connectionId,
+        initialPath: verifiedPath,
+        workingDirectory: cwd,
+        tmuxPaneDirectory: tmuxPaneDirectory,
+      ),
     );
     if (!mounted || result == null) {
       return;

--- a/test/presentation/screens/sftp_screen_test.dart
+++ b/test/presentation/screens/sftp_screen_test.dart
@@ -52,17 +52,14 @@ void main() {
       },
     );
 
-    test('location shortcuts normalize and de-duplicate directories', () {
+    test('location shortcuts normalize and de-duplicate paths', () {
       expect(
         resolveSftpLocationShortcuts(
           homeDirectory: '/home/depoll',
           connectionStartDirectory: '/home/depoll/./',
           tmuxPaneDirectory: '/home/depoll/project',
         ),
-        [
-          (label: 'Home / Connection start', path: '/home/depoll'),
-          (label: 'tmux pane', path: '/home/depoll/project'),
-        ],
+        ['/home/depoll', '/home/depoll/project'],
       );
     });
 

--- a/test/presentation/screens/sftp_screen_test.dart
+++ b/test/presentation/screens/sftp_screen_test.dart
@@ -52,6 +52,20 @@ void main() {
       },
     );
 
+    test('location shortcuts normalize and de-duplicate directories', () {
+      expect(
+        resolveSftpLocationShortcuts(
+          homeDirectory: '/home/depoll',
+          connectionStartDirectory: '/home/depoll/./',
+          tmuxPaneDirectory: '/home/depoll/project',
+        ),
+        [
+          (label: 'Home / Connection start', path: '/home/depoll'),
+          (label: 'tmux pane', path: '/home/depoll/project'),
+        ],
+      );
+    });
+
     test('scrolls upward when the highlighted file is above the viewport', () {
       expect(
         resolveSftpHighlightedFileScrollOffset(


### PR DESCRIPTION
## Summary

- Present the SFTP browser route as a full-screen slide-up popover with an explicit close affordance.
- Remember the last successfully opened SFTP directory per host/connection so toolbar reopening resumes where the user left off, while path/link opens still jump to the requested file or directory.
- Add quick location chips for home, connection start directory, and the active tmux pane directory when available.

## Validation

- `flutter analyze`
- `flutter test test/presentation/screens/sftp_screen_test.dart test/presentation/screens/terminal_screen_test.dart`
