### PR TITLE
Move host and snippet item actions into context menus

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1075,11 +1075,14 @@ class _HostRow extends ConsumerWidget {
                         ),
                       ),
                       const SizedBox(width: 8),
-                      _SmallIconButton(
-                        icon: Icons.add,
-                        tooltip: 'New connection',
-                        onTap: () =>
-                            unawaited(_openNewConnection(context, ref)),
+                      Builder(
+                        builder: (buttonContext) => _SmallIconButton(
+                          icon: Icons.more_vert,
+                          tooltip: 'Host actions',
+                          onTap: () => unawaited(
+                            _showContextMenuAtCenter(buttonContext, ref),
+                          ),
+                        ),
                       ),
                       reorderHandle,
                     ],
@@ -2651,6 +2654,8 @@ class _SnippetsPanelState extends ConsumerState<SnippetsPanel> {
 
 enum _SnippetFolderAction { delete }
 
+enum _SnippetContextAction { copy, edit, delete }
+
 class _SnippetRow extends ConsumerWidget {
   const _SnippetRow({
     required this.snippet,
@@ -2673,6 +2678,9 @@ class _SnippetRow extends ConsumerWidget {
       color: Colors.transparent,
       child: InkWell(
         onTap: () => _copySnippet(context, ref),
+        onLongPress: () => unawaited(_showContextMenuAtCenter(context, ref)),
+        onSecondaryTapDown: (details) =>
+            unawaited(_showContextMenu(context, ref, details.globalPosition)),
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
           decoration: BoxDecoration(
@@ -2741,21 +2749,13 @@ class _SnippetRow extends ConsumerWidget {
                 ),
               ),
 
-              // Actions
-              _SmallIconButton(
-                icon: Icons.copy,
-                tooltip: 'Copy command',
-                onTap: () => _copySnippet(context, ref),
-              ),
-              _SmallIconButton(
-                icon: Icons.edit_outlined,
-                tooltip: 'Edit',
-                onTap: () => context.push('/snippets/edit/${snippet.id}'),
-              ),
-              _SmallIconButton(
-                icon: Icons.delete_outline,
-                tooltip: 'Delete',
-                onTap: () => _confirmDelete(context, ref),
+              Builder(
+                builder: (buttonContext) => _SmallIconButton(
+                  icon: Icons.more_vert,
+                  tooltip: 'Snippet actions',
+                  onTap: () =>
+                      unawaited(_showContextMenuAtCenter(buttonContext, ref)),
+                ),
               ),
               reorderHandle,
             ],
@@ -2763,6 +2763,85 @@ class _SnippetRow extends ConsumerWidget {
         ),
       ),
     );
+  }
+
+  Future<void> _showContextMenuAtCenter(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final renderBox = context.findRenderObject() as RenderBox?;
+    if (renderBox == null) {
+      return;
+    }
+
+    final globalPosition = renderBox.localToGlobal(
+      renderBox.size.center(Offset.zero),
+    );
+    await _showContextMenu(context, ref, globalPosition);
+  }
+
+  Future<void> _showContextMenu(
+    BuildContext context,
+    WidgetRef ref,
+    Offset globalPosition,
+  ) async {
+    final colorScheme = Theme.of(context).colorScheme;
+    final overlay = Overlay.maybeOf(context);
+    final overlayBox = overlay?.context.findRenderObject() as RenderBox?;
+    if (overlayBox == null) {
+      return;
+    }
+
+    final selection = await showMenu<_SnippetContextAction>(
+      context: context,
+      position: RelativeRect.fromRect(
+        Rect.fromLTWH(globalPosition.dx, globalPosition.dy, 0, 0),
+        Offset.zero & overlayBox.size,
+      ),
+      items: [
+        const PopupMenuItem<_SnippetContextAction>(
+          value: _SnippetContextAction.copy,
+          child: ListTile(
+            contentPadding: EdgeInsets.zero,
+            leading: Icon(Icons.copy),
+            title: Text('Copy command'),
+          ),
+        ),
+        const PopupMenuItem<_SnippetContextAction>(
+          value: _SnippetContextAction.edit,
+          child: ListTile(
+            contentPadding: EdgeInsets.zero,
+            leading: Icon(Icons.edit_outlined),
+            title: Text('Edit'),
+          ),
+        ),
+        const PopupMenuDivider(),
+        PopupMenuItem<_SnippetContextAction>(
+          value: _SnippetContextAction.delete,
+          child: ListTile(
+            contentPadding: EdgeInsets.zero,
+            leading: Icon(Icons.delete_outline, color: colorScheme.error),
+            title: Text('Delete', style: TextStyle(color: colorScheme.error)),
+          ),
+        ),
+      ],
+    );
+
+    if (!context.mounted || selection == null) {
+      return;
+    }
+
+    switch (selection) {
+      case _SnippetContextAction.copy:
+        _copySnippet(context, ref);
+        return;
+      case _SnippetContextAction.edit:
+        unawaited(context.push('/snippets/edit/${snippet.id}'));
+        return;
+      case _SnippetContextAction.delete:
+        await _confirmDelete(context, ref);
+        return;
+    }
   }
 
   void _copySnippet(BuildContext context, WidgetRef ref) {

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -542,7 +542,7 @@ void main() {
     });
   });
 
-  testWidgets('small icon actions expose semantics labels', (tester) async {
+  testWidgets('context menu triggers expose semantics labels', (tester) async {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     addTearDown(db.close);
 
@@ -565,7 +565,7 @@ void main() {
       find.byWidgetPredicate(
         (widget) =>
             widget is Semantics &&
-            widget.properties.label == 'New connection' &&
+            widget.properties.label == 'Host actions' &&
             (widget.properties.button ?? false) &&
             widget.properties.onTap != null,
       ),

--- a/test/widget/hosts_screen_test.dart
+++ b/test/widget/hosts_screen_test.dart
@@ -213,7 +213,7 @@ void main() {
     verify(() => hostRepository.reorderByIds([2, 1])).called(1);
   });
 
-  testWidgets('long press opens host context menu without overflow button', (
+  testWidgets('host actions are exposed through the context menu trigger', (
     tester,
   ) async {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
@@ -233,10 +233,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.byIcon(Icons.more_vert), findsNothing);
+    expect(find.byTooltip('Host actions'), findsOneWidget);
     expect(find.byIcon(Icons.edit_outlined), findsNothing);
 
-    await tester.longPress(find.text('Alpha'));
+    await tester.tap(find.byTooltip('Host actions'));
     await tester.pumpAndSettle();
 
     expect(find.text('Connect'), findsOneWidget);

--- a/test/widget/snippets_screen_test.dart
+++ b/test/widget/snippets_screen_test.dart
@@ -86,6 +86,43 @@ void main() {
       expect(find.text('Imported snippet'), findsOneWidget);
     });
 
+    testWidgets(
+      'snippet actions are exposed through the context menu trigger',
+      (tester) async {
+        final snippetRepository = _MockSnippetRepository();
+        when(snippetRepository.watchAll).thenAnswer(
+          (_) => Stream.value([
+            _buildSnippet(id: 1, name: 'Restart API', sortOrder: 0),
+          ]),
+        );
+        when(
+          snippetRepository.watchAllFolders,
+        ).thenAnswer((_) => Stream.value(const <SnippetFolder>[]));
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              snippetRepositoryProvider.overrideWithValue(snippetRepository),
+            ],
+            child: const MaterialApp(home: SnippetsScreen()),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byTooltip('Snippet actions'), findsOneWidget);
+        expect(find.byIcon(Icons.copy), findsNothing);
+        expect(find.byIcon(Icons.edit_outlined), findsNothing);
+        expect(find.byIcon(Icons.delete_outline), findsNothing);
+
+        await tester.tap(find.byTooltip('Snippet actions'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Copy command'), findsOneWidget);
+        expect(find.text('Edit'), findsOneWidget);
+        expect(find.text('Delete'), findsOneWidget);
+      },
+    );
+
     testWidgets('routes empty-state creation to the full snippet editor', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- Move host row item actions into the existing context menu/overflow trigger
- Move snippet row copy/edit/delete actions into a context menu with long-press and secondary-click support
- Update widget tests for the new host/snippet action menu behavior

## Validation

- `flutter analyze --no-pub`
- `flutter test --no-pub test/widget/hosts_screen_test.dart test/widget/snippets_screen_test.dart test/widget/home_screen_test.dart --reporter compact`
- `flutter test --no-pub --reporter compact`
