### PR TITLE
fix: propagate terminal themes across tmux panes

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -1821,7 +1821,7 @@ String buildTmuxRefreshForegroundClientsCommand(
       'done';
 }
 
-/// Builds a command that updates tmux's pane palette, notifies active TUIs, and
+/// Builds a command that updates tmux's pane palette, notifies TUI panes, and
 /// redraws foreground clients.
 @visibleForTesting
 String buildTmuxRefreshTerminalThemeCommand(
@@ -1865,7 +1865,6 @@ String buildTmuxRefreshTerminalThemeCommand(
       '$setPaneColours '
       '$provideClientThemeReports '
       'injected=0; foreground_tui=0; '
-      r'if [ "$active" = 1 ]; then '
       r'case "${pane_command##*/}" in '
       "''|sh|bash|zsh|fish|nu|pwsh|powershell|cmd|cmd.exe|tmux|ssh|mosh|login) foreground_tui=0 ;; "
       '*) foreground_tui=1 ;; '
@@ -1886,7 +1885,6 @@ String buildTmuxRefreshTerminalThemeCommand(
       '( ${_buildTmuxSendPaneTerminalThemeCommand(theme, extraFlags: extraFlags)} ) & ;; '
       'esac ;; '
       'esac; '
-      'fi; '
       'fi; '
       r'printf "flutty_theme_refresh_pane:%s,%s,%s\n" "$active" "$alternate" "$injected"; '
       'done; wait; }; '

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2222,6 +2222,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   static const _remoteClipboardSyncInterval = Duration(seconds: 1);
   static const _promptOutputImeResetDebounce = Duration(milliseconds: 75);
   static const _tmuxForegroundVerificationInterval = Duration(seconds: 5);
+  static const _tmuxWindowThemeRefreshDebounceDelay = Duration(
+    milliseconds: 150,
+  );
   final _terminalViewKey = GlobalKey<MonkeyTerminalViewState>();
   final _tmuxBarKey = GlobalKey<_TmuxExpandableBarState>();
 
@@ -2380,6 +2383,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   final Set<Timer> _terminalThemeRefreshTimers = <Timer>{};
   bool _isTmuxThemeRefreshRunning = false;
   _TmuxTerminalThemeRefreshRequest? _pendingTmuxThemeRefreshRequest;
+  Timer? _tmuxWindowThemeRefreshDebounceTimer;
+  _TmuxTerminalThemeRefreshRequest? _pendingTmuxWindowThemeRefreshRequest;
   bool _terminalThemeDependencyReloadQueued = false;
   bool _pendingTerminalThemeDependencyReload = false;
   bool _pendingTerminalThemeDependencyForceRemoteRefresh = false;
@@ -3152,6 +3157,72 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
   }
 
+  void _handleTmuxWindowStateChanged(SshSession session, String sessionName) {
+    _scheduleTmuxTerminalThemeRefreshAfterWindowStateChange(
+      session: session,
+      sessionName: sessionName,
+      reason: 'tmux_window_state_changed',
+    );
+  }
+
+  void _scheduleTmuxTerminalThemeRefreshAfterWindowStateChange({
+    required SshSession session,
+    required String sessionName,
+    required String reason,
+  }) {
+    if (!_isTmuxActive ||
+        _tmuxStateConnectionId != session.connectionId ||
+        _tmuxSessionName != sessionName ||
+        session.terminal != _terminal) {
+      return;
+    }
+
+    final theme = session.terminalTheme ?? _resolveEffectiveTerminalTheme();
+    if (session.terminalTheme == null) {
+      _applyTerminalThemeToSession(
+        theme,
+        session: session,
+        forceRemoteRefresh: true,
+        reason: reason,
+      );
+      return;
+    }
+
+    _pendingTmuxWindowThemeRefreshRequest = _TmuxTerminalThemeRefreshRequest(
+      theme: theme,
+      session: session,
+      sessionName: sessionName,
+      refreshGeneration: _terminalThemeRefreshGeneration,
+      reason: reason,
+      extraFlags: _host?.tmuxExtraFlags,
+    );
+    if (_tmuxWindowThemeRefreshDebounceTimer?.isActive ?? false) {
+      return;
+    }
+
+    late final Timer timer;
+    timer = Timer(_tmuxWindowThemeRefreshDebounceDelay, () {
+      _terminalThemeRefreshTimers.remove(timer);
+      if (identical(_tmuxWindowThemeRefreshDebounceTimer, timer)) {
+        _tmuxWindowThemeRefreshDebounceTimer = null;
+      }
+      final pendingRequest = _pendingTmuxWindowThemeRefreshRequest;
+      _pendingTmuxWindowThemeRefreshRequest = null;
+      if (pendingRequest == null ||
+          _tmuxSessionName != pendingRequest.sessionName ||
+          !_isCurrentTerminalThemeRefresh(
+            theme: pendingRequest.theme,
+            session: pendingRequest.session,
+            refreshGeneration: pendingRequest.refreshGeneration,
+          )) {
+        return;
+      }
+      _queueTmuxTerminalThemeRefresh(pendingRequest);
+    });
+    _tmuxWindowThemeRefreshDebounceTimer = timer;
+    _terminalThemeRefreshTimers.add(timer);
+  }
+
   void _scheduleTmuxTerminalThemeRefresh(
     _TmuxTerminalThemeRefreshRequest request, {
     required Duration delay,
@@ -3341,10 +3412,21 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   void _cancelTerminalThemeRefreshTimers() {
+    _cancelPendingTmuxWindowThemeRefresh();
     for (final timer in _terminalThemeRefreshTimers) {
       timer.cancel();
     }
     _terminalThemeRefreshTimers.clear();
+  }
+
+  void _cancelPendingTmuxWindowThemeRefresh() {
+    final timer = _tmuxWindowThemeRefreshDebounceTimer;
+    if (timer != null) {
+      timer.cancel();
+      _terminalThemeRefreshTimers.remove(timer);
+    }
+    _tmuxWindowThemeRefreshDebounceTimer = null;
+    _pendingTmuxWindowThemeRefreshRequest = null;
   }
 
   bool _isCurrentTerminalThemeRefresh({
@@ -4545,6 +4627,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   void _clearTmuxState() {
     _stopTmuxForegroundVerification();
+    _cancelPendingTmuxWindowThemeRefresh();
     _tmuxDetectionGeneration += 1;
     _isTmuxActive = false;
     _tmuxSessionName = null;
@@ -5130,6 +5213,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       ref: ref,
       onAction: _handleTmuxAction,
       onExpandedChanged: _handleTmuxBarExpandedChanged,
+      onWindowStateChanged: _handleTmuxWindowStateChanged,
       onWindowLoadStalled: _recoverTmuxWindowPanel,
       scopeWorkingDirectory: resolveTmuxAiSessionScopeWorkingDirectory(
         liveTerminalWorkingDirectory: _liveWorkingDirectoryPath,
@@ -5336,6 +5420,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       forceVisibleTmux: forceVisibleTmux,
     );
     _scheduleTerminalSizeRefresh();
+    _scheduleTmuxTerminalThemeRefreshAfterWindowStateChange(
+      session: session,
+      sessionName: sessionName,
+      reason: 'tmux_window_switched',
+    );
   }
 
   /// Creates a new tmux window via exec channel, then reattaches the visible
@@ -5381,6 +5470,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _tmuxWorkingDirectory = resolvedWorkingDirectory;
     await _reattachTmuxIfNeeded(session, sessionName);
     _scheduleTerminalSizeRefresh();
+    _scheduleTmuxTerminalThemeRefreshAfterWindowStateChange(
+      session: session,
+      sessionName: sessionName,
+      reason: 'tmux_window_created',
+    );
   }
 
   /// Closes a tmux window via exec channel.
@@ -5397,6 +5491,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           extraFlags: _host?.tmuxExtraFlags,
         );
     _scheduleTerminalSizeRefresh();
+    _scheduleTmuxTerminalThemeRefreshAfterWindowStateChange(
+      session: session,
+      sessionName: sessionName,
+      reason: 'tmux_window_closed',
+    );
   }
 
   Future<void> _reattachTmuxIfNeeded(

--- a/lib/presentation/widgets/tmux_expandable_bar.dart
+++ b/lib/presentation/widgets/tmux_expandable_bar.dart
@@ -20,6 +20,7 @@ class _TmuxExpandableBar extends StatefulWidget {
     required this.onExpandedChanged,
     this.tmuxExtraFlags,
     this.scopeWorkingDirectory,
+    this.onWindowStateChanged,
     this.onWindowLoadStalled,
     super.key,
   });
@@ -56,6 +57,9 @@ class _TmuxExpandableBar extends StatefulWidget {
 
   /// Called when the expanded/collapsed state changes.
   final ValueChanged<bool> onExpandedChanged;
+
+  final void Function(SshSession session, String sessionName)?
+  onWindowStateChanged;
 
   final Future<void> Function(SshSession session, String sessionName)?
   onWindowLoadStalled;
@@ -241,6 +245,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         },
       );
       _loadWindows();
+      _notifyWindowStateChanged();
       return;
     }
     final currentWindows = _windows;
@@ -265,9 +270,14 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       },
     );
     _applyWindows(windows);
+    _notifyWindowStateChanged();
     if (widget.isProUser && _showSessions) {
       unawaited(_prefetchPreferredSessionProvider(windows: windows));
     }
+  }
+
+  void _notifyWindowStateChanged() {
+    widget.onWindowStateChanged?.call(widget.session, widget.tmuxSessionName);
   }
 
   void _applyWindows(List<TmuxWindow> windows) {

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -159,7 +159,7 @@ void main() {
           r'{ while IFS="$SEP" read -r pane active alternate pane_command pane_title',
         ),
       );
-      expect(command, contains(r'[ "$active" = 1 ]'));
+      expect(command, isNot(contains(r'if [ "$active" = 1 ]')));
       expect(command, isNot(contains('window_active')));
       expect(command, contains(r'[ "$alternate" = 1 ]'));
       expect(command, contains(r'[ "$foreground_tui" = 1 ]'));

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1288,6 +1288,14 @@ void main() {
         when(
           () => tmuxService.prefetchInstalledAgentTools(session),
         ).thenAnswer((_) async {});
+        when(
+          () => tmuxService.refreshTerminalTheme(
+            session,
+            tmuxSessionName,
+            any(),
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async {});
 
         await tester.pumpWidget(
           ProviderScope(
@@ -1402,6 +1410,96 @@ void main() {
               .length,
           2,
         );
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'refreshes tmux theme after window state changes',
+      (tester) async {
+        final tmuxService = _MockTmuxService();
+        final windowEvents = StreamController<TmuxWindowChangeEvent>();
+        const tmuxSessionName = 'work';
+        const windows = <TmuxWindow>[
+          TmuxWindow(index: 0, id: '@8', name: 'shell', isActive: true),
+          TmuxWindow(index: 1, id: '@9', name: 'agent', isActive: false),
+        ];
+        var refreshCount = 0;
+
+        addTearDown(windowEvents.close);
+        host = _buildHost(id: host.id, tmuxSessionName: tmuxSessionName);
+        when(
+          () => tmuxService.foregroundSessionNameOrThrow(session),
+        ).thenAnswer((_) async => tmuxSessionName);
+        when(
+          () => tmuxService.listWindows(session, tmuxSessionName),
+        ).thenAnswer((_) async => windows);
+        when(
+          () => tmuxService.watchWindowChanges(session, tmuxSessionName),
+        ).thenAnswer((_) => windowEvents.stream);
+        when(
+          () => tmuxService.detectInstalledAgentTools(session),
+        ).thenAnswer((_) async => const <AgentLaunchTool>{});
+        when(
+          () => tmuxService.prefetchInstalledAgentTools(session),
+        ).thenAnswer((_) async {});
+        when(
+          () => tmuxService.refreshTerminalTheme(
+            session,
+            tmuxSessionName,
+            any(),
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async {
+          refreshCount += 1;
+        });
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+              tmuxServiceProvider.overrideWithValue(tmuxService),
+            ],
+            child: MaterialApp(
+              home: TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+                initialTmuxSessionName: tmuxSessionName,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        final refreshCountBeforeWindowEvent = refreshCount;
+        windowEvents.add(
+          const TmuxWindowSnapshotEvent(
+            TmuxWindow(index: 1, id: '@9', name: 'agent', isActive: true),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 149));
+
+        expect(refreshCount, refreshCountBeforeWindowEvent);
+
+        await tester.pump(const Duration(milliseconds: 1));
+        await tester.pump();
+
+        expect(refreshCount, greaterThan(refreshCountBeforeWindowEvent));
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );


### PR DESCRIPTION
## Summary

- Refresh tmux theme state for every TUI/alternate-screen pane, not only active panes.
- Debounce theme propagation after tmux window state changes and switch/create/close actions.
- Add focused coverage for all-pane tmux refresh command generation and window-state-triggered theme refreshes.

## Validation

- `flutter analyze`
- `flutter test`
- `flutter test test/domain/services/tmux_service_control_mode_test.dart --name "theme refresh command"`
- `flutter test test/presentation/screens/terminal_screen_test.dart --name "refreshes tmux theme after window state changes"`
