### PR TITLE
fix: prevent duplicate terminal actions

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2145,6 +2145,8 @@ bool didTerminalScrollPolicyChange({
     previousIsUsingAltBuffer != nextIsUsingAltBuffer ||
     previousReportsMouseWheel != nextReportsMouseWheel;
 
+enum _TerminalExclusiveAction { sftpBrowser, tmuxNavigator }
+
 /// Terminal screen for SSH sessions.
 class TerminalScreen extends ConsumerStatefulWidget {
   /// Creates a new [TerminalScreen].
@@ -2297,6 +2299,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   Offset? _pendingTerminalPathTapDownPosition;
   Duration? _pendingTerminalPathTapDownTimestamp;
   String? _recentlyOpenedTerminalPathTap;
+  final Set<_TerminalExclusiveAction> _exclusiveTerminalActions =
+      <_TerminalExclusiveAction>{};
   int? _pendingTerminalDoubleTapPointer;
   Offset? _pendingTerminalDoubleTapDownPosition;
   Duration? _pendingTerminalDoubleTapDownTimestamp;
@@ -2369,6 +2373,29 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   bool get _usesSensitiveKeyboardMode =>
       _manualSensitiveKeyboardMode || _detectedSensitiveKeyboardPrompt;
+
+  bool _isExclusiveTerminalActionRunning(_TerminalExclusiveAction action) =>
+      _exclusiveTerminalActions.contains(action);
+
+  Future<void> _runExclusiveTerminalAction(
+    _TerminalExclusiveAction action,
+    Future<void> Function() run,
+  ) async {
+    if (_isExclusiveTerminalActionRunning(action)) {
+      return;
+    }
+
+    setState(() => _exclusiveTerminalActions.add(action));
+    try {
+      await run();
+    } finally {
+      if (mounted) {
+        setState(() => _exclusiveTerminalActions.remove(action));
+      } else {
+        _exclusiveTerminalActions.remove(action);
+      }
+    }
+  }
 
   // Theme state
   Host? _host;
@@ -5293,39 +5320,42 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   /// Opens the tmux window navigator bottom sheet and handles the
   /// selected action.
-  Future<void> _openTmuxNavigator() async {
-    final connectionId = _connectionId;
-    if (connectionId == null || _tmuxSessionName == null) return;
+  Future<void> _openTmuxNavigator() => _runExclusiveTerminalAction(
+    _TerminalExclusiveAction.tmuxNavigator,
+    () async {
+      final connectionId = _connectionId;
+      if (connectionId == null || _tmuxSessionName == null) return;
 
-    final session = _sessionsNotifier?.getSession(connectionId);
-    if (session == null) return;
+      final session = _sessionsNotifier?.getSession(connectionId);
+      if (session == null) return;
 
-    final monetizationState =
-        ref.read(monetizationStateProvider).asData?.value ??
-        ref.read(monetizationServiceProvider).currentState;
-    final isProUser = monetizationState.allowsFeature(
-      MonetizationFeature.agentLaunchPresets,
-    );
+      final monetizationState =
+          ref.read(monetizationStateProvider).asData?.value ??
+          ref.read(monetizationServiceProvider).currentState;
+      final isProUser = monetizationState.allowsFeature(
+        MonetizationFeature.agentLaunchPresets,
+      );
 
-    final action = await showTmuxNavigator(
-      context: context,
-      ref: ref,
-      session: session,
-      tmuxSessionName: _tmuxSessionName!,
-      tmuxExtraFlags: _host?.tmuxExtraFlags,
-      isProUser: isProUser,
-      startClisInYoloMode: _startClisInYoloMode,
-      scopeWorkingDirectory: resolveTmuxAiSessionScopeWorkingDirectory(
-        liveTerminalWorkingDirectory: _liveWorkingDirectoryPath,
-        tmuxWorkingDirectory: _tmuxWorkingDirectory,
-        sessionWorkingDirectory: session.workingDirectory,
-      ),
-    );
+      final action = await showTmuxNavigator(
+        context: context,
+        ref: ref,
+        session: session,
+        tmuxSessionName: _tmuxSessionName!,
+        tmuxExtraFlags: _host?.tmuxExtraFlags,
+        isProUser: isProUser,
+        startClisInYoloMode: _startClisInYoloMode,
+        scopeWorkingDirectory: resolveTmuxAiSessionScopeWorkingDirectory(
+          liveTerminalWorkingDirectory: _liveWorkingDirectoryPath,
+          tmuxWorkingDirectory: _tmuxWorkingDirectory,
+          sessionWorkingDirectory: session.workingDirectory,
+        ),
+      );
 
-    if (!mounted || action == null) return;
+      if (!mounted || action == null) return;
 
-    await _performTmuxNavigatorAction(session, action);
-  }
+      await _performTmuxNavigatorAction(session, action);
+    },
+  );
 
   Future<void> _performTmuxNavigatorAction(
     SshSession session,
@@ -6074,6 +6104,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
     final titleSubtitle = titleSubtitleSegments.join(' • ');
     final statusChips = _buildTerminalStatusChips(theme);
+    final isOpeningSftpBrowser = _isExclusiveTerminalActionRunning(
+      _TerminalExclusiveAction.sftpBrowser,
+    );
+    final isOpeningTmuxNavigator = _isExclusiveTerminalActionRunning(
+      _TerminalExclusiveAction.tmuxNavigator,
+    );
 
     return PopScope(
       canPop: !_isTmuxBarExpanded,
@@ -6151,13 +6187,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 connectionState == SshConnectionState.connected)
               IconButton(
                 icon: const Icon(Icons.window_outlined),
-                onPressed: _connectionId == null ? null : _openTmuxNavigator,
+                onPressed: _connectionId == null || isOpeningTmuxNavigator
+                    ? null
+                    : _openTmuxNavigator,
                 tooltip: 'tmux windows',
               ),
             IconButton(
               icon: const Icon(Icons.folder_outlined),
               onPressed:
                   _connectionId == null ||
+                      isOpeningSftpBrowser ||
                       connectionState != SshConnectionState.connected
                   ? null
                   : () => unawaited(_openConnectionFileBrowser()),
@@ -7015,27 +7054,28 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     return TerminalStyle.fromTextStyle(textStyle);
   }
 
-  Future<void> _openConnectionFileBrowser() async {
-    final connectionId = _connectionId;
-    if (connectionId == null) {
-      return;
-    }
+  Future<void> _openConnectionFileBrowser() => _runExclusiveTerminalAction(
+    _TerminalExclusiveAction.sftpBrowser,
+    () async {
+      final connectionId = _connectionId;
+      if (connectionId == null) {
+        return;
+      }
 
-    final tmuxPaneDirectory = await _resolveCurrentTmuxPaneDirectory();
-    if (!mounted) {
-      return;
-    }
+      final tmuxPaneDirectory = await _resolveCurrentTmuxPaneDirectory();
+      if (!mounted) {
+        return;
+      }
 
-    // Prefer the last browser directory when opening from the toolbar. The
-    // terminal cwd remains available for relative path resolution and as a
-    // quick-jump inside the browser.
-    final cwd = _workingDirectoryPath;
-    final rememberedPath = ref.read(
-      sftpBrowserLastPathsProvider,
-    )[(hostId: widget.hostId, connectionId: connectionId)];
-    final initialPath = rememberedPath ?? cwd;
-    unawaited(
-      context.pushNamed<String>(
+      // Prefer the last browser directory when opening from the toolbar. The
+      // terminal cwd remains available for relative path resolution and as a
+      // quick-jump inside the browser.
+      final cwd = _workingDirectoryPath;
+      final rememberedPath = ref.read(
+        sftpBrowserLastPathsProvider,
+      )[(hostId: widget.hostId, connectionId: connectionId)];
+      final initialPath = rememberedPath ?? cwd;
+      await context.pushNamed<String>(
         Routes.sftp,
         pathParameters: {'hostId': widget.hostId.toString()},
         queryParameters: _buildSftpBrowserQueryParameters(
@@ -7044,9 +7084,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           workingDirectory: cwd,
           tmuxPaneDirectory: tmuxPaneDirectory,
         ),
-      ),
-    );
-  }
+      );
+    },
+  );
 
   Map<String, String> _buildSftpBrowserQueryParameters({
     int? connectionId,
@@ -8621,41 +8661,47 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _showTerminalLinkMessage('Could not open $link');
   }
 
-  Future<void> _openTerminalFilePath(String path) async {
-    final normalizedPath = trimTerminalFilePathCandidate(path);
-    if (!isSupportedTerminalFilePath(normalizedPath)) {
-      _showTerminalLinkMessage('Could not open $path');
-      return;
-    }
+  Future<void> _openTerminalFilePath(String path) =>
+      _runExclusiveTerminalAction(
+        _TerminalExclusiveAction.sftpBrowser,
+        () async {
+          final normalizedPath = trimTerminalFilePathCandidate(path);
+          if (!isSupportedTerminalFilePath(normalizedPath)) {
+            _showTerminalLinkMessage('Could not open $path');
+            return;
+          }
 
-    final verifiedPath = await _resolveVerifiedTerminalFilePath(normalizedPath);
-    if (!mounted || verifiedPath == null) {
-      return;
-    }
+          final verifiedPath = await _resolveVerifiedTerminalFilePath(
+            normalizedPath,
+          );
+          if (!mounted || verifiedPath == null) {
+            return;
+          }
 
-    final connectionId = _connectionId;
-    final cwd = _workingDirectoryPath;
-    final tmuxPaneDirectory = await _resolveCurrentTmuxPaneDirectory();
-    if (!mounted) {
-      return;
-    }
+          final connectionId = _connectionId;
+          final cwd = _workingDirectoryPath;
+          final tmuxPaneDirectory = await _resolveCurrentTmuxPaneDirectory();
+          if (!mounted) {
+            return;
+          }
 
-    final result = await context.pushNamed<String>(
-      Routes.sftp,
-      pathParameters: {'hostId': widget.hostId.toString()},
-      queryParameters: _buildSftpBrowserQueryParameters(
-        connectionId: connectionId,
-        initialPath: verifiedPath,
-        workingDirectory: cwd,
-        tmuxPaneDirectory: tmuxPaneDirectory,
-      ),
-    );
-    if (!mounted || result == null) {
-      return;
-    }
+          final result = await context.pushNamed<String>(
+            Routes.sftp,
+            pathParameters: {'hostId': widget.hostId.toString()},
+            queryParameters: _buildSftpBrowserQueryParameters(
+              connectionId: connectionId,
+              initialPath: verifiedPath,
+              workingDirectory: cwd,
+              tmuxPaneDirectory: tmuxPaneDirectory,
+            ),
+          );
+          if (!mounted || result == null) {
+            return;
+          }
 
-    _showTerminalLinkMessage(result);
-  }
+          _showTerminalLinkMessage(result);
+        },
+      );
 
   Future<void> _createSnippetFromSelection() async {
     final text = _currentTerminalSelectionText();

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -65,6 +65,27 @@ class _FakeWakelockPlusPlatform extends WakelockPlusPlatformInterface {
   Future<bool> get enabled async => _enabled;
 }
 
+class _RecordingSftpPage extends StatefulWidget {
+  const _RecordingSftpPage({required this.onOpened});
+
+  final VoidCallback onOpened;
+
+  @override
+  State<_RecordingSftpPage> createState() => _RecordingSftpPageState();
+}
+
+class _RecordingSftpPageState extends State<_RecordingSftpPage> {
+  @override
+  void initState() {
+    super.initState();
+    widget.onOpened();
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      const Scaffold(body: Text('SFTP opened'));
+}
+
 class _RecordingLocalNotificationService extends LocalNotificationService {
   final shownNotificationIds = <int>[];
   final clearedNotificationIds = <int>[];
@@ -829,6 +850,71 @@ void main() {
         ),
         findsOneWidget,
       );
+    });
+
+    testWidgets('browse files ignores duplicate taps while SFTP is opening', (
+      tester,
+    ) async {
+      var sftpOpenCount = 0;
+      final router = GoRouter(
+        initialLocation:
+            '/terminal/${host.id}?connectionId=${session.connectionId}',
+        routes: [
+          GoRoute(
+            path: '/terminal/:hostId',
+            name: Routes.terminal,
+            builder: (context, state) => TerminalScreen(
+              hostId: host.id,
+              connectionId: session.connectionId,
+            ),
+          ),
+          GoRoute(
+            path: '/sftp/:hostId',
+            name: Routes.sftp,
+            builder: (context, state) =>
+                _RecordingSftpPage(onOpened: () => sftpOpenCount += 1),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            hostRepositoryProvider.overrideWithValue(hostRepository),
+            monetizationServiceProvider.overrideWithValue(monetizationService),
+            monetizationStateProvider.overrideWith(
+              (ref) => Stream.value(_proMonetizationState),
+            ),
+            sharedClipboardProvider.overrideWith((ref) async => false),
+            activeSessionsProvider.overrideWith(
+              () => _TestActiveSessionsNotifier(session),
+            ),
+          ],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final browseFilesButton = find.byTooltip('Browse files');
+      expect(browseFilesButton, findsOneWidget);
+
+      await tester.tap(browseFilesButton);
+      await tester.tap(browseFilesButton);
+      await tester.pumpAndSettle();
+
+      expect(sftpOpenCount, 1);
+      expect(find.text('SFTP opened'), findsOneWidget);
+
+      router.pop();
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Browse files'));
+      await tester.pumpAndSettle();
+
+      expect(sftpOpenCount, 2);
     });
 
     testWidgets('shows jump host indicator for tunneled sessions', (


### PR DESCRIPTION
## Summary

- Add a single-flight guard for terminal actions that open modal/navigation flows.
- Prevent duplicate SFTP browser opens from rapid Browse Files taps or terminal path taps.
- Disable the Browse Files and tmux navigator toolbar buttons while their open action is in flight.
- Add a widget test covering rapid duplicate Browse Files taps.

## Tests

- flutter analyze --no-pub
- flutter test --no-pub test/presentation/screens/terminal_screen_test.dart --name "browse files ignores duplicate taps while SFTP is opening"
- flutter test test/presentation/screens/terminal_screen_test.dart
