### PR TITLE
Fix theme picker keyboard UX

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -6611,6 +6611,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
 
     final isDark = _resolveTerminalThemeBrightness() == Brightness.dark;
+    await _ensureSelectedThemeCanBeRestored(theme);
+    if (!mounted) {
+      return;
+    }
     final monetizationState =
         ref.read(monetizationStateProvider).asData?.value ??
         ref.read(monetizationServiceProvider).currentState;
@@ -6675,6 +6679,23 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           ),
         );
     }
+  }
+
+  Future<void> _ensureSelectedThemeCanBeRestored(
+    TerminalThemeData theme,
+  ) async {
+    if (!theme.isCustom || TerminalThemes.getById(theme.id) != null) {
+      return;
+    }
+    final themeService = ref.read(terminalThemeServiceProvider);
+    final existingTheme = await themeService.getThemeById(theme.id);
+    if (existingTheme != null) {
+      return;
+    }
+    await themeService.saveCustomTheme(theme.copyWith(isCustom: true));
+    ref
+      ..invalidate(allTerminalThemesProvider)
+      ..invalidate(customTerminalThemesProvider);
   }
 
   void _previewThemeFromPicker(TerminalThemeData theme) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2758,6 +2758,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   void _applyTerminalThemeToSession(
     TerminalThemeData theme, {
     SshSession? session,
+    bool allowRemoteRefresh = true,
     bool forceRemoteRefresh = false,
     String reason = 'unspecified',
   }) {
@@ -2772,6 +2773,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           fields: {
             'reason': reason,
             'connectionId': _connectionId,
+            'allowRemoteRefresh': allowRemoteRefresh,
             'forceRemoteRefresh': forceRemoteRefresh,
           },
         );
@@ -2788,6 +2790,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           fields: {
             'reason': reason,
             'connectionId': targetSession.connectionId,
+            'allowRemoteRefresh': allowRemoteRefresh,
             'forceRemoteRefresh': forceRemoteRefresh,
             'hasSessionTerminal': targetSession.terminal != null,
           },
@@ -2805,7 +2808,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final shouldRefreshFirstTheme =
         previousTheme == null && (_isTmuxActive || plainTuiRefreshAllowed);
     final willRefresh =
-        forceRemoteRefresh || didThemeChange || shouldRefreshFirstTheme;
+        allowRemoteRefresh &&
+        (forceRemoteRefresh || didThemeChange || shouldRefreshFirstTheme);
     if (willRefresh || reason != 'build') {
       DiagnosticsLogService.instance.info(
         'terminal.theme',
@@ -2813,6 +2817,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         fields: {
           'reason': reason,
           'connectionId': targetSession.connectionId,
+          'allowRemoteRefresh': allowRemoteRefresh,
           'forceRemoteRefresh': forceRemoteRefresh,
           'hasPreviousTheme': previousTheme != null,
           'didThemeChange': didThemeChange,
@@ -6514,80 +6519,117 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   Future<void> _showThemePicker() async {
     final currentId = _sessionThemeOverride?.id ?? _currentTheme?.id;
+    final previousSessionThemeOverride = _sessionThemeOverride;
+    final previousTheme = _resolveEffectiveTerminalTheme();
     final theme = await showThemePickerDialog(
       context: context,
       currentThemeId: currentId,
+      onThemePreviewed: _previewThemeFromPicker,
     );
 
-    if (theme != null && mounted) {
-      final isDark = _resolveTerminalThemeBrightness() == Brightness.dark;
-      final monetizationState =
-          ref.read(monetizationStateProvider).asData?.value ??
-          ref.read(monetizationServiceProvider).currentState;
-      final hasHostThemeAccess = monetizationState.allowsFeature(
-        MonetizationFeature.hostSpecificThemes,
-      );
-      final connectionId = _connectionId;
-      var hasSession = false;
-      if (connectionId != null) {
-        final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
-        final session =
-            (sessionsNotifier
-                  ..updateSessionTheme(connectionId, theme.id, isDark: isDark))
-                .getSession(connectionId);
-        if (session != null) {
-          hasSession = true;
-          _syncAppThemeOverrideFromSession(session);
-        }
-      }
-      setState(() => _sessionThemeOverride = theme);
-      DiagnosticsLogService.instance.info(
-        'terminal.theme',
-        'picker_selected',
-        fields: {
-          'connectionId': connectionId,
-          'isDark': isDark,
-          'hasHostThemeAccess': hasHostThemeAccess,
-          'hasSession': hasSession,
-        },
-      );
-      _applyTerminalThemeToSession(
-        theme,
-        forceRemoteRefresh: true,
-        reason: 'theme_picker',
-      );
+    if (!mounted) {
+      return;
+    }
 
-      // Show option to save to host
-      if (_host != null) {
-        final scaffoldMessenger = ScaffoldMessenger.of(context);
+    if (theme == null) {
+      _restoreThemePickerPreview(
+        previousTheme: previousTheme,
+        previousSessionThemeOverride: previousSessionThemeOverride,
+      );
+      return;
+    }
 
-        // Clear any existing snackbar first to prevent stacking
-        scaffoldMessenger
-          ..hideCurrentSnackBar()
-          ..showSnackBar(
-            SnackBar(
-              content: Row(
-                children: [
-                  Expanded(child: Text('Theme: ${theme.name}')),
-                  const SizedBox(width: 8),
-                  FilledButton.tonal(
-                    onPressed: () {
-                      scaffoldMessenger.hideCurrentSnackBar();
-                      _saveThemeToHost(theme, isDark: isDark);
-                    },
-                    child: Text(
-                      hasHostThemeAccess
-                          ? 'Save to Host'
-                          : 'Save to Host (Pro)',
-                    ),
-                  ),
-                ],
-              ),
-              duration: const Duration(seconds: 6),
-            ),
-          );
+    final isDark = _resolveTerminalThemeBrightness() == Brightness.dark;
+    final monetizationState =
+        ref.read(monetizationStateProvider).asData?.value ??
+        ref.read(monetizationServiceProvider).currentState;
+    final hasHostThemeAccess = monetizationState.allowsFeature(
+      MonetizationFeature.hostSpecificThemes,
+    );
+    final connectionId = _connectionId;
+    var hasSession = false;
+    if (connectionId != null) {
+      final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
+      final session =
+          (sessionsNotifier
+                ..updateSessionTheme(connectionId, theme.id, isDark: isDark))
+              .getSession(connectionId);
+      if (session != null) {
+        hasSession = true;
+        _syncAppThemeOverrideFromSession(session);
       }
     }
+    setState(() => _sessionThemeOverride = theme);
+    DiagnosticsLogService.instance.info(
+      'terminal.theme',
+      'picker_selected',
+      fields: {
+        'connectionId': connectionId,
+        'isDark': isDark,
+        'hasHostThemeAccess': hasHostThemeAccess,
+        'hasSession': hasSession,
+      },
+    );
+    _applyTerminalThemeToSession(
+      theme,
+      forceRemoteRefresh: true,
+      reason: 'theme_picker',
+    );
+
+    // Show option to save to host
+    if (_host != null) {
+      final scaffoldMessenger = ScaffoldMessenger.of(context);
+
+      // Clear any existing snackbar first to prevent stacking
+      scaffoldMessenger
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(
+            content: Row(
+              children: [
+                Expanded(child: Text('Theme: ${theme.name}')),
+                const SizedBox(width: 8),
+                FilledButton.tonal(
+                  onPressed: () {
+                    scaffoldMessenger.hideCurrentSnackBar();
+                    _saveThemeToHost(theme, isDark: isDark);
+                  },
+                  child: Text(
+                    hasHostThemeAccess ? 'Save to Host' : 'Save to Host (Pro)',
+                  ),
+                ),
+              ],
+            ),
+            duration: const Duration(seconds: 6),
+          ),
+        );
+    }
+  }
+
+  void _previewThemeFromPicker(TerminalThemeData theme) {
+    if (!mounted) {
+      return;
+    }
+    setState(() => _sessionThemeOverride = theme);
+    _lastBuildAppliedTheme = theme;
+    _applyTerminalThemeToSession(
+      theme,
+      allowRemoteRefresh: false,
+      reason: 'theme_picker_preview',
+    );
+  }
+
+  void _restoreThemePickerPreview({
+    required TerminalThemeData previousTheme,
+    required TerminalThemeData? previousSessionThemeOverride,
+  }) {
+    setState(() => _sessionThemeOverride = previousSessionThemeOverride);
+    _lastBuildAppliedTheme = previousTheme;
+    _applyTerminalThemeToSession(
+      previousTheme,
+      allowRemoteRefresh: false,
+      reason: 'theme_picker_cancel',
+    );
   }
 
   Future<void> _saveThemeToHost(

--- a/lib/presentation/widgets/terminal_theme_picker.dart
+++ b/lib/presentation/widgets/terminal_theme_picker.dart
@@ -23,6 +23,7 @@ class TerminalThemePicker extends ConsumerStatefulWidget {
   const TerminalThemePicker({
     required this.selectedThemeId,
     required this.onThemeSelected,
+    this.currentSelectionLabel,
     this.onThemePreviewed,
     this.previewOnTap = false,
     this.scrollController,
@@ -34,6 +35,9 @@ class TerminalThemePicker extends ConsumerStatefulWidget {
 
   /// Called when a theme is selected.
   final ValueChanged<TerminalThemeData> onThemeSelected;
+
+  /// Label shown above the selected theme preview.
+  final String? currentSelectionLabel;
 
   /// Called when a theme should be previewed without closing the picker.
   final ValueChanged<TerminalThemeData>? onThemePreviewed;
@@ -98,9 +102,7 @@ class _TerminalThemePickerState extends ConsumerState<TerminalThemePicker> {
               padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
               child: _CurrentSelectionPreview(
                 theme: currentTheme,
-                label: widget.previewOnTap
-                    ? 'Previewing'
-                    : 'Currently Selected',
+                label: widget.currentSelectionLabel ?? 'Currently Selected',
               ),
             ),
           ),
@@ -1117,6 +1119,11 @@ class _TerminalThemePickerBottomSheetState
   Widget build(BuildContext context) {
     final viewInsets = MediaQuery.viewInsetsOf(context);
     final keyboardVisible = viewInsets.bottom > 0;
+    final initialChildSize = _resolveInitialChildSize(
+      keyboardVisible: keyboardVisible,
+    );
+    final minChildSize = _usesLivePreview ? 0.38 : 0.5;
+    final maxChildSize = _usesLivePreview && !keyboardVisible ? 0.74 : 0.95;
     return LayoutBuilder(
       builder: (context, constraints) {
         final availableHeight = constraints.maxHeight > viewInsets.bottom
@@ -1126,11 +1133,12 @@ class _TerminalThemePickerBottomSheetState
           duration: const Duration(milliseconds: 220),
           curve: Curves.easeOutCubic,
           padding: EdgeInsets.only(bottom: viewInsets.bottom),
-          child: SizedBox(
-            height: availableHeight,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: availableHeight),
             child: DraggableScrollableSheet(
-              initialChildSize: keyboardVisible ? 1 : 0.85,
-              minChildSize: keyboardVisible ? 0.72 : 0.5,
+              initialChildSize: initialChildSize,
+              minChildSize: minChildSize,
+              maxChildSize: maxChildSize,
               expand: false,
               builder: (context, scrollController) => Column(
                 children: [
@@ -1141,7 +1149,11 @@ class _TerminalThemePickerBottomSheetState
                         color: Theme.of(context).colorScheme.outline,
                         borderRadius: BorderRadius.circular(2),
                       ),
-                      child: const SizedBox(width: 40, height: 4),
+                      child: const SizedBox(
+                        key: ValueKey('terminal-theme-picker-handle'),
+                        width: 40,
+                        height: 4,
+                      ),
                     ),
                   ),
                   Padding(
@@ -1164,6 +1176,9 @@ class _TerminalThemePickerBottomSheetState
                     child: TerminalThemePicker(
                       selectedThemeId:
                           _previewTheme?.id ?? widget.currentThemeId,
+                      currentSelectionLabel: _previewTheme == null
+                          ? 'Currently Selected'
+                          : 'Previewing',
                       onThemeSelected: _selectTheme,
                       onThemePreviewed: _previewThemeInTerminal,
                       previewOnTap: _usesLivePreview,
@@ -1185,6 +1200,13 @@ class _TerminalThemePickerBottomSheetState
         );
       },
     );
+  }
+
+  double _resolveInitialChildSize({required bool keyboardVisible}) {
+    if (!_usesLivePreview) {
+      return 0.85;
+    }
+    return keyboardVisible ? 0.95 : 0.58;
   }
 
   void _previewThemeInTerminal(TerminalThemeData theme) {

--- a/lib/presentation/widgets/terminal_theme_picker.dart
+++ b/lib/presentation/widgets/terminal_theme_picker.dart
@@ -382,6 +382,7 @@ class _TerminalThemePickerState extends ConsumerState<TerminalThemePicker> {
               schemes: remoteSchemes,
               importingSchemeId: _importingSchemeId,
               previewingScheme: _previewingScheme,
+              showPreviewCard: !widget.previewOnTap,
               onSchemePreviewed: _previewLiveScheme,
               onSchemeSelected: _importLiveScheme,
             );
@@ -550,6 +551,7 @@ class _LiveThemePreviewGrid extends StatelessWidget {
     required this.schemes,
     required this.importingSchemeId,
     required this.previewingScheme,
+    required this.showPreviewCard,
     required this.onSchemePreviewed,
     required this.onSchemeSelected,
   });
@@ -557,6 +559,7 @@ class _LiveThemePreviewGrid extends StatelessWidget {
   final List<ItermColorSchemeMetadata> schemes;
   final String? importingSchemeId;
   final ItermColorSchemeMetadata? previewingScheme;
+  final bool showPreviewCard;
   final ValueChanged<ItermColorSchemeMetadata> onSchemePreviewed;
   final ValueChanged<ItermColorSchemeMetadata> onSchemeSelected;
 
@@ -574,7 +577,7 @@ class _LiveThemePreviewGrid extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        if (activePreview != null) ...[
+        if (showPreviewCard && activePreview != null) ...[
           SizedBox(
             height: 168,
             child: _LiveThemePreviewCard(

--- a/lib/presentation/widgets/terminal_theme_picker.dart
+++ b/lib/presentation/widgets/terminal_theme_picker.dart
@@ -23,6 +23,9 @@ class TerminalThemePicker extends ConsumerStatefulWidget {
   const TerminalThemePicker({
     required this.selectedThemeId,
     required this.onThemeSelected,
+    this.onThemePreviewed,
+    this.previewOnTap = false,
+    this.scrollController,
     super.key,
   });
 
@@ -31,6 +34,15 @@ class TerminalThemePicker extends ConsumerStatefulWidget {
 
   /// Called when a theme is selected.
   final ValueChanged<TerminalThemeData> onThemeSelected;
+
+  /// Called when a theme should be previewed without closing the picker.
+  final ValueChanged<TerminalThemeData>? onThemePreviewed;
+
+  /// Whether tapping an installed theme previews it instead of selecting it.
+  final bool previewOnTap;
+
+  /// Optional scroll controller supplied by a surrounding draggable sheet.
+  final ScrollController? scrollController;
 
   @override
   ConsumerState<TerminalThemePicker> createState() =>
@@ -77,6 +89,7 @@ class _TerminalThemePickerState extends ConsumerState<TerminalThemePicker> {
         : null;
 
     return NestedScrollView(
+      controller: widget.scrollController,
       headerSliverBuilder: (context, innerBoxIsScrolled) => [
         // Currently selected preview (always visible)
         if (currentTheme != null)
@@ -85,7 +98,9 @@ class _TerminalThemePickerState extends ConsumerState<TerminalThemePicker> {
               padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
               child: _CurrentSelectionPreview(
                 theme: currentTheme,
-                onTap: () => widget.onThemeSelected(currentTheme),
+                label: widget.previewOnTap
+                    ? 'Previewing'
+                    : 'Currently Selected',
               ),
             ),
           ),
@@ -254,13 +269,14 @@ class _TerminalThemePickerState extends ConsumerState<TerminalThemePicker> {
 
     return ListView(
       padding: const EdgeInsets.symmetric(horizontal: 16),
+      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
       children: [
         if (customThemes.isNotEmpty) ...[
           const _SectionHeader(title: 'Custom Themes'),
           _ThemeGridSection(
             themes: customThemes,
             selectedThemeId: widget.selectedThemeId,
-            onThemeSelected: widget.onThemeSelected,
+            onThemeSelected: _handleThemeActivated,
             onLongPress: _handleCustomThemeLongPress,
           ),
           const SizedBox(height: 16),
@@ -270,7 +286,7 @@ class _TerminalThemePickerState extends ConsumerState<TerminalThemePicker> {
           _ThemeGridSection(
             themes: darkThemes,
             selectedThemeId: widget.selectedThemeId,
-            onThemeSelected: widget.onThemeSelected,
+            onThemeSelected: _handleThemeActivated,
           ),
           const SizedBox(height: 16),
         ],
@@ -279,7 +295,7 @@ class _TerminalThemePickerState extends ConsumerState<TerminalThemePicker> {
           _ThemeGridSection(
             themes: lightThemes,
             selectedThemeId: widget.selectedThemeId,
-            onThemeSelected: widget.onThemeSelected,
+            onThemeSelected: _handleThemeActivated,
           ),
         ],
         ..._buildLiveRepositorySection(
@@ -290,6 +306,14 @@ class _TerminalThemePickerState extends ConsumerState<TerminalThemePicker> {
         const SizedBox(height: 24),
       ],
     );
+  }
+
+  void _handleThemeActivated(TerminalThemeData theme) {
+    if (!widget.previewOnTap) {
+      widget.onThemeSelected(theme);
+      return;
+    }
+    widget.onThemePreviewed?.call(theme);
   }
 
   List<Widget> _buildLiveRepositorySection({
@@ -914,10 +938,10 @@ class _SectionHeader extends StatelessWidget {
 }
 
 class _CurrentSelectionPreview extends StatelessWidget {
-  const _CurrentSelectionPreview({required this.theme, required this.onTap});
+  const _CurrentSelectionPreview({required this.theme, required this.label});
 
   final TerminalThemeData theme;
-  final VoidCallback onTap;
+  final String label;
 
   @override
   Widget build(BuildContext context) {
@@ -972,7 +996,7 @@ class _CurrentSelectionPreview extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  'Currently Selected',
+                  label,
                   style: Theme.of(context).textTheme.labelSmall?.copyWith(
                     color: colorScheme.primary,
                     fontWeight: FontWeight.w600,
@@ -1016,30 +1040,35 @@ class _ThemeGridSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Use responsive grid based on screen width
-    final screenWidth = MediaQuery.of(context).size.width;
-    final crossAxisCount = screenWidth < 360 ? 2 : (screenWidth < 600 ? 3 : 4);
     final resolvedSelectedThemeId = selectedThemeId == null
         ? null
         : TerminalThemes.resolveThemeId(selectedThemeId!);
 
-    return GridView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: crossAxisCount,
-        mainAxisSpacing: 12,
-        crossAxisSpacing: 12,
-        childAspectRatio: 0.9,
-      ),
-      itemCount: themes.length,
-      itemBuilder: (context, index) {
-        final theme = themes[index];
-        return ThemePreviewCard(
-          theme: theme,
-          isSelected: theme.id == resolvedSelectedThemeId,
-          onTap: () => onThemeSelected(theme),
-          onLongPress: onLongPress != null ? () => onLongPress!(theme) : null,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final crossAxisCount = width < 420 ? 2 : (width < 720 ? 3 : 4);
+        return GridView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: crossAxisCount,
+            mainAxisSpacing: 12,
+            crossAxisSpacing: 12,
+            childAspectRatio: 0.9,
+          ),
+          itemCount: themes.length,
+          itemBuilder: (context, index) {
+            final theme = themes[index];
+            return ThemePreviewCard(
+              theme: theme,
+              isSelected: theme.id == resolvedSelectedThemeId,
+              onTap: () => onThemeSelected(theme),
+              onLongPress: onLongPress != null
+                  ? () => onLongPress!(theme)
+                  : null,
+            );
+          },
         );
       },
     );
@@ -1047,55 +1076,173 @@ class _ThemeGridSection extends StatelessWidget {
 }
 
 /// Shows a theme picker dialog and returns the selected theme.
+///
+/// When [onThemePreviewed] is supplied, installed themes preview on tap and the
+/// user confirms the previewed theme with an explicit action.
 Future<TerminalThemeData?> showThemePickerDialog({
   required BuildContext context,
   required String? currentThemeId,
+  ValueChanged<TerminalThemeData>? onThemePreviewed,
 }) async => showModalBottomSheet<TerminalThemeData>(
   context: context,
   isScrollControlled: true,
   useSafeArea: true,
-  builder: (context) => DraggableScrollableSheet(
-    initialChildSize: 0.85,
-    minChildSize: 0.5,
-    maxChildSize: 0.95,
-    expand: false,
-    builder: (context, scrollController) => Column(
-      children: [
-        // Handle bar
-        Container(
-          margin: const EdgeInsets.only(top: 12),
-          width: 40,
-          height: 4,
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.outline,
-            borderRadius: BorderRadius.circular(2),
+  builder: (context) => _TerminalThemePickerBottomSheet(
+    currentThemeId: currentThemeId,
+    onThemePreviewed: onThemePreviewed,
+  ),
+);
+
+class _TerminalThemePickerBottomSheet extends StatefulWidget {
+  const _TerminalThemePickerBottomSheet({
+    required this.currentThemeId,
+    required this.onThemePreviewed,
+  });
+
+  final String? currentThemeId;
+  final ValueChanged<TerminalThemeData>? onThemePreviewed;
+
+  @override
+  State<_TerminalThemePickerBottomSheet> createState() =>
+      _TerminalThemePickerBottomSheetState();
+}
+
+class _TerminalThemePickerBottomSheetState
+    extends State<_TerminalThemePickerBottomSheet> {
+  TerminalThemeData? _previewTheme;
+
+  bool get _usesLivePreview => widget.onThemePreviewed != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final viewInsets = MediaQuery.viewInsetsOf(context);
+    final keyboardVisible = viewInsets.bottom > 0;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final availableHeight = constraints.maxHeight > viewInsets.bottom
+            ? constraints.maxHeight - viewInsets.bottom
+            : constraints.maxHeight;
+        return AnimatedPadding(
+          duration: const Duration(milliseconds: 220),
+          curve: Curves.easeOutCubic,
+          padding: EdgeInsets.only(bottom: viewInsets.bottom),
+          child: SizedBox(
+            height: availableHeight,
+            child: DraggableScrollableSheet(
+              initialChildSize: keyboardVisible ? 1 : 0.85,
+              minChildSize: keyboardVisible ? 0.72 : 0.5,
+              expand: false,
+              builder: (context, scrollController) => Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(top: 12),
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).colorScheme.outline,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                      child: const SizedBox(width: 40, height: 4),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      children: [
+                        Text(
+                          _usesLivePreview ? 'Preview Theme' : 'Select Theme',
+                          style: Theme.of(context).textTheme.titleLarge,
+                        ),
+                        const Spacer(),
+                        IconButton(
+                          icon: const Icon(Icons.close),
+                          onPressed: () => Navigator.pop(context),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Expanded(
+                    child: TerminalThemePicker(
+                      selectedThemeId:
+                          _previewTheme?.id ?? widget.currentThemeId,
+                      onThemeSelected: _selectTheme,
+                      onThemePreviewed: _previewThemeInTerminal,
+                      previewOnTap: _usesLivePreview,
+                      scrollController: scrollController,
+                    ),
+                  ),
+                  if (_usesLivePreview)
+                    _ThemePreviewActionBar(
+                      previewTheme: _previewTheme,
+                      onCancel: () => Navigator.pop(context),
+                      onUseTheme: _previewTheme == null
+                          ? null
+                          : () => Navigator.pop(context, _previewTheme),
+                    ),
+                ],
+              ),
+            ),
           ),
+        );
+      },
+    );
+  }
+
+  void _previewThemeInTerminal(TerminalThemeData theme) {
+    setState(() => _previewTheme = theme);
+    widget.onThemePreviewed?.call(theme);
+  }
+
+  void _selectTheme(TerminalThemeData theme) => Navigator.pop(context, theme);
+}
+
+class _ThemePreviewActionBar extends StatelessWidget {
+  const _ThemePreviewActionBar({
+    required this.previewTheme,
+    required this.onCancel,
+    required this.onUseTheme,
+  });
+
+  final TerminalThemeData? previewTheme;
+  final VoidCallback onCancel;
+  final VoidCallback? onUseTheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final themeName = previewTheme?.name;
+    return SafeArea(
+      top: false,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: colorScheme.surface,
+          border: Border(top: BorderSide(color: colorScheme.outlineVariant)),
         ),
-        // Title
-        Padding(
-          padding: const EdgeInsets.all(16),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
           child: Row(
             children: [
-              Text(
-                'Select Theme',
-                style: Theme.of(context).textTheme.titleLarge,
+              Expanded(
+                child: Text(
+                  themeName == null
+                      ? 'Tap a theme to preview it on this terminal.'
+                      : 'Previewing $themeName',
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
               ),
-              const Spacer(),
-              IconButton(
-                icon: const Icon(Icons.close),
-                onPressed: () => Navigator.pop(context),
+              const SizedBox(width: 12),
+              TextButton(onPressed: onCancel, child: const Text('Cancel')),
+              const SizedBox(width: 8),
+              FilledButton(
+                onPressed: onUseTheme,
+                child: const Text('Use Theme'),
               ),
             ],
           ),
         ),
-        // Picker
-        Expanded(
-          child: TerminalThemePicker(
-            selectedThemeId: currentThemeId,
-            onThemeSelected: (theme) => Navigator.pop(context, theme),
-          ),
-        ),
-      ],
-    ),
-  ),
-);
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/terminal_theme_picker.dart
+++ b/lib/presentation/widgets/terminal_theme_picker.dart
@@ -62,6 +62,7 @@ class _TerminalThemePickerState extends ConsumerState<TerminalThemePicker> {
   _ThemeFilter _filter = _ThemeFilter.all;
   final TextEditingController _searchController = TextEditingController();
   Timer? _liveSearchDebounceTimer;
+  int _livePreviewGeneration = 0;
 
   @override
   void dispose() {
@@ -204,6 +205,7 @@ class _TerminalThemePickerState extends ConsumerState<TerminalThemePicker> {
 
   void _clearSearch() {
     _liveSearchDebounceTimer?.cancel();
+    _livePreviewGeneration += 1;
     _searchController.clear();
     setState(() {
       _searchQuery = '';
@@ -214,6 +216,7 @@ class _TerminalThemePickerState extends ConsumerState<TerminalThemePicker> {
 
   void _handleSearchChanged(String value) {
     _liveSearchDebounceTimer?.cancel();
+    _livePreviewGeneration += 1;
     final query = value.trim();
     setState(() {
       _searchQuery = value;
@@ -379,13 +382,50 @@ class _TerminalThemePickerState extends ConsumerState<TerminalThemePicker> {
               schemes: remoteSchemes,
               importingSchemeId: _importingSchemeId,
               previewingScheme: _previewingScheme,
-              onSchemePreviewed: (scheme) =>
-                  setState(() => _previewingScheme = scheme),
+              onSchemePreviewed: _previewLiveScheme,
               onSchemeSelected: _importLiveScheme,
             );
           },
         ),
     ];
+  }
+
+  void _previewLiveScheme(ItermColorSchemeMetadata scheme) {
+    final previewGeneration = _livePreviewGeneration + 1;
+    _livePreviewGeneration = previewGeneration;
+    setState(() => _previewingScheme = scheme);
+    if (!widget.previewOnTap || widget.onThemePreviewed == null) {
+      return;
+    }
+    unawaited(_loadLiveThemePreview(scheme, previewGeneration));
+  }
+
+  Future<void> _loadLiveThemePreview(
+    ItermColorSchemeMetadata scheme,
+    int previewGeneration,
+  ) async {
+    try {
+      final theme = await ref
+          .read(itermColorSchemeServiceProvider)
+          .loadTheme(scheme);
+      if (!mounted ||
+          previewGeneration != _livePreviewGeneration ||
+          _previewingScheme?.id != scheme.id) {
+        return;
+      }
+      widget.onThemePreviewed?.call(theme);
+    } on ItermColorSchemeException catch (error) {
+      if (!mounted ||
+          previewGeneration != _livePreviewGeneration ||
+          _previewingScheme?.id != scheme.id) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Could not preview ${scheme.name}: ${error.message}'),
+        ),
+      );
+    }
   }
 
   Future<void> _importLiveScheme(ItermColorSchemeMetadata scheme) async {
@@ -1093,6 +1133,7 @@ Future<TerminalThemeData?> showThemePickerDialog({
   bool? requestFocus,
 }) async => showModalBottomSheet<TerminalThemeData>(
   context: context,
+  barrierColor: onThemePreviewed == null ? null : Colors.transparent,
   isScrollControlled: true,
   requestFocus: requestFocus,
   useSafeArea: true,

--- a/test/presentation/widgets/terminal_theme_picker_test.dart
+++ b/test/presentation/widgets/terminal_theme_picker_test.dart
@@ -90,6 +90,10 @@ void main() {
 
       expect(liveSchemeService.loadedSchemeIds, [_remoteScheme.id]);
       expect(previewedThemes.single.id, _remoteTheme.id);
+      expect(
+        find.widgetWithText(ThemePreviewCard, _remoteScheme.name),
+        findsNothing,
+      );
     });
 
     testWidgets('dialog stays above keyboard and confirms previewed theme', (

--- a/test/presentation/widgets/terminal_theme_picker_test.dart
+++ b/test/presentation/widgets/terminal_theme_picker_test.dart
@@ -9,6 +9,7 @@ import 'package:monkeyssh/domain/models/terminal_theme.dart';
 import 'package:monkeyssh/domain/models/terminal_themes.dart';
 import 'package:monkeyssh/domain/services/terminal_theme_service.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_theme_picker.dart';
+import 'package:monkeyssh/presentation/widgets/theme_preview_card.dart';
 
 const _testThemes = [TerminalThemes.defaultDarkTheme, TerminalThemes.dracula];
 
@@ -104,12 +105,17 @@ void main() {
             (widget) => widget.padding == const EdgeInsets.only(bottom: 240),
           );
       expect(keyboardPadding, isNotEmpty);
+      expect(find.text('Currently Selected'), findsOneWidget);
       expect(
         find.text('Tap a theme to preview it on this terminal.'),
         findsOneWidget,
       );
 
-      await tester.tap(find.text(TerminalThemes.dracula.name));
+      final draculaCard = find.widgetWithText(
+        ThemePreviewCard,
+        TerminalThemes.dracula.name,
+      );
+      await tester.tapAt(tester.getTopLeft(draculaCard) + const Offset(24, 24));
       await tester.pumpAndSettle();
 
       expect(previewedThemes.single.id, TerminalThemes.dracula.id);
@@ -122,6 +128,57 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(selectedTheme?.id, TerminalThemes.dracula.id);
+    });
+
+    testWidgets('preview dialog peeks over the terminal without blank chrome', (
+      tester,
+    ) async {
+      tester.view
+        ..physicalSize = const Size(390, 844)
+        ..devicePixelRatio = 1;
+      addTearDown(() {
+        tester.view
+          ..resetPhysicalSize()
+          ..resetDevicePixelRatio();
+      });
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            allTerminalThemesProvider.overrideWith((ref) async => _testThemes),
+          ],
+          child: MaterialApp(
+            home: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () {
+                  unawaited(
+                    showThemePickerDialog(
+                      context: context,
+                      currentThemeId: TerminalThemes.defaultDarkTheme.id,
+                      onThemePreviewed: (_) {},
+                    ),
+                  );
+                },
+                child: const Text('Open picker'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open picker'));
+      await tester.pumpAndSettle();
+
+      final sheetTop = tester.getTopLeft(find.byType(BottomSheet)).dy;
+      final handleTop = tester
+          .getTopLeft(
+            find.byKey(const ValueKey('terminal-theme-picker-handle')),
+          )
+          .dy;
+
+      expect(sheetTop, greaterThan(300));
+      expect(handleTop - sheetTop, lessThan(24));
+      expect(find.text('Currently Selected'), findsOneWidget);
     });
   });
 }

--- a/test/presentation/widgets/terminal_theme_picker_test.dart
+++ b/test/presentation/widgets/terminal_theme_picker_test.dart
@@ -5,13 +5,25 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/models/iterm_color_scheme.dart';
 import 'package:monkeyssh/domain/models/terminal_theme.dart';
 import 'package:monkeyssh/domain/models/terminal_themes.dart';
+import 'package:monkeyssh/domain/services/iterm_color_scheme_service.dart';
 import 'package:monkeyssh/domain/services/terminal_theme_service.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_theme_picker.dart';
 import 'package:monkeyssh/presentation/widgets/theme_preview_card.dart';
 
 const _testThemes = [TerminalThemes.defaultDarkTheme, TerminalThemes.dracula];
+const _remoteScheme = ItermColorSchemeMetadata(
+  id: 'iterm2-remote-ocean',
+  name: 'Remote Ocean',
+  path: 'schemes/Remote Ocean.itermcolors',
+);
+final _remoteTheme = TerminalThemes.dracula.copyWith(
+  id: _remoteScheme.id,
+  name: _remoteScheme.name,
+  isCustom: true,
+);
 
 void main() {
   group('TerminalThemePicker', () {
@@ -53,6 +65,31 @@ void main() {
 
       expect(selectedThemes.single.id, TerminalThemes.dracula.id);
       expect(previewedThemes, isEmpty);
+    });
+
+    testWidgets('previews downloadable live themes in preview mode', (
+      tester,
+    ) async {
+      final previewedThemes = <TerminalThemeData>[];
+      final liveSchemeService = _FakeItermColorSchemeService();
+
+      await _pumpPicker(
+        tester,
+        onThemeSelected: (_) {},
+        onThemePreviewed: previewedThemes.add,
+        previewOnTap: true,
+        liveSchemeService: liveSchemeService,
+      );
+
+      await tester.enterText(find.byType(TextField), 'remote');
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(_remoteScheme.name));
+      await tester.pumpAndSettle();
+
+      expect(liveSchemeService.loadedSchemeIds, [_remoteScheme.id]);
+      expect(previewedThemes.single.id, _remoteTheme.id);
     });
 
     testWidgets('dialog stays above keyboard and confirms previewed theme', (
@@ -169,6 +206,14 @@ void main() {
       await tester.tap(find.text('Open picker'));
       await tester.pumpAndSettle();
 
+      final transparentBarrier = tester
+          .widgetList<ModalBarrier>(find.byType(ModalBarrier))
+          .where(
+            (barrier) =>
+                barrier.color == null || barrier.color == Colors.transparent,
+          );
+      expect(transparentBarrier, isNotEmpty);
+
       final sheetTop = tester.getTopLeft(find.byType(BottomSheet)).dy;
       final handleTop = tester
           .getTopLeft(
@@ -187,12 +232,17 @@ Future<void> _pumpPicker(
   WidgetTester tester, {
   required ValueChanged<TerminalThemeData> onThemeSelected,
   ValueChanged<TerminalThemeData>? onThemePreviewed,
+  ItermColorSchemeService? liveSchemeService,
   bool previewOnTap = false,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
         allTerminalThemesProvider.overrideWith((ref) async => _testThemes),
+        if (liveSchemeService != null)
+          itermColorSchemeServiceProvider.overrideWith(
+            (ref) => liveSchemeService,
+          ),
       ],
       child: MaterialApp(
         home: Scaffold(
@@ -211,4 +261,24 @@ Future<void> _pumpPicker(
     ),
   );
   await tester.pumpAndSettle();
+}
+
+class _FakeItermColorSchemeService extends ItermColorSchemeService {
+  final loadedSchemeIds = <String>[];
+  Future<TerminalThemeData>? _pendingTheme;
+
+  @override
+  Future<List<ItermColorSchemeMetadata>> searchSchemes(String query) async => [
+    _remoteScheme,
+  ];
+
+  @override
+  Future<TerminalThemeData> loadTheme(ItermColorSchemeMetadata scheme) async {
+    if (_pendingTheme != null) {
+      return _pendingTheme!;
+    }
+    loadedSchemeIds.add(scheme.id);
+    _pendingTheme = Future.value(_remoteTheme);
+    return _pendingTheme!;
+  }
 }

--- a/test/presentation/widgets/terminal_theme_picker_test.dart
+++ b/test/presentation/widgets/terminal_theme_picker_test.dart
@@ -1,0 +1,157 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/models/terminal_theme.dart';
+import 'package:monkeyssh/domain/models/terminal_themes.dart';
+import 'package:monkeyssh/domain/services/terminal_theme_service.dart';
+import 'package:monkeyssh/presentation/widgets/terminal_theme_picker.dart';
+
+const _testThemes = [TerminalThemes.defaultDarkTheme, TerminalThemes.dracula];
+
+void main() {
+  group('TerminalThemePicker', () {
+    testWidgets(
+      'previews installed themes instead of selecting in preview mode',
+      (tester) async {
+        final selectedThemes = <TerminalThemeData>[];
+        final previewedThemes = <TerminalThemeData>[];
+
+        await _pumpPicker(
+          tester,
+          onThemeSelected: selectedThemes.add,
+          onThemePreviewed: previewedThemes.add,
+          previewOnTap: true,
+        );
+
+        await tester.tap(find.text(TerminalThemes.dracula.name));
+        await tester.pump();
+
+        expect(selectedThemes, isEmpty);
+        expect(previewedThemes.single.id, TerminalThemes.dracula.id);
+      },
+    );
+
+    testWidgets('selects installed themes on tap outside preview mode', (
+      tester,
+    ) async {
+      final selectedThemes = <TerminalThemeData>[];
+      final previewedThemes = <TerminalThemeData>[];
+
+      await _pumpPicker(
+        tester,
+        onThemeSelected: selectedThemes.add,
+        onThemePreviewed: previewedThemes.add,
+      );
+
+      await tester.tap(find.text(TerminalThemes.dracula.name));
+      await tester.pump();
+
+      expect(selectedThemes.single.id, TerminalThemes.dracula.id);
+      expect(previewedThemes, isEmpty);
+    });
+
+    testWidgets('dialog stays above keyboard and confirms previewed theme', (
+      tester,
+    ) async {
+      final previewedThemes = <TerminalThemeData>[];
+      TerminalThemeData? selectedTheme;
+
+      tester.view
+        ..physicalSize = const Size(390, 844)
+        ..devicePixelRatio = 1
+        ..viewInsets = const FakeViewPadding(bottom: 240);
+      addTearDown(() {
+        tester.view
+          ..resetPhysicalSize()
+          ..resetDevicePixelRatio()
+          ..resetViewInsets();
+      });
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            allTerminalThemesProvider.overrideWith((ref) async => _testThemes),
+          ],
+          child: MaterialApp(
+            home: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () {
+                  unawaited(
+                    showThemePickerDialog(
+                      context: context,
+                      currentThemeId: TerminalThemes.defaultDarkTheme.id,
+                      onThemePreviewed: previewedThemes.add,
+                    ).then((theme) => selectedTheme = theme),
+                  );
+                },
+                child: const Text('Open picker'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open picker'));
+      await tester.pumpAndSettle();
+
+      final keyboardPadding = tester
+          .widgetList<AnimatedPadding>(find.byType(AnimatedPadding))
+          .where(
+            (widget) => widget.padding == const EdgeInsets.only(bottom: 240),
+          );
+      expect(keyboardPadding, isNotEmpty);
+      expect(
+        find.text('Tap a theme to preview it on this terminal.'),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.text(TerminalThemes.dracula.name));
+      await tester.pumpAndSettle();
+
+      expect(previewedThemes.single.id, TerminalThemes.dracula.id);
+      expect(
+        find.text('Previewing ${TerminalThemes.dracula.name}'),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.text('Use Theme'));
+      await tester.pumpAndSettle();
+
+      expect(selectedTheme?.id, TerminalThemes.dracula.id);
+    });
+  });
+}
+
+Future<void> _pumpPicker(
+  WidgetTester tester, {
+  required ValueChanged<TerminalThemeData> onThemeSelected,
+  ValueChanged<TerminalThemeData>? onThemePreviewed,
+  bool previewOnTap = false,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        allTerminalThemesProvider.overrideWith((ref) async => _testThemes),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 390,
+            height: 844,
+            child: TerminalThemePicker(
+              selectedThemeId: TerminalThemes.defaultDarkTheme.id,
+              onThemeSelected: onThemeSelected,
+              onThemePreviewed: onThemePreviewed,
+              previewOnTap: previewOnTap,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}


### PR DESCRIPTION
## Summary

- Keeps the terminal theme picker above the soft keyboard while searching and lets scrolling dismiss the keyboard.
- Adds a terminal-only live preview flow: tap themes to preview on the active terminal, then confirm with **Use Theme** or cancel to restore the previous theme.
- Makes the preview grid responsive to the sheet width and covers the new behavior with widget tests.

## Validation

- `flutter analyze`
- `flutter test --no-pub test/presentation/widgets/terminal_theme_picker_test.dart`
- `flutter test --no-pub`
