### PR TITLE
fix: open SFTP file links directly

### DIFF
--- a/lib/presentation/screens/remote_text_editor_screen.dart
+++ b/lib/presentation/screens/remote_text_editor_screen.dart
@@ -310,12 +310,14 @@ List<int> computeRemoteEditorLineStartOffsets(String text) {
 Widget buildRemoteTextEditorScreenForTesting({
   required String fileName,
   required TextEditingController controller,
+  String? filePath,
   ScrollController? horizontalScrollController,
   TerminalThemeData? terminalTheme,
   String fontFamily = 'monospace',
   double initialFontSize = 14,
 }) => RemoteTextEditorScreen(
   fileName: fileName,
+  filePath: filePath,
   controller: controller,
   horizontalScrollController: horizontalScrollController,
   terminalTheme: terminalTheme,
@@ -347,6 +349,7 @@ class RemoteTextEditorScreen extends StatefulWidget {
     required this.controller,
     required this.fontFamily,
     required this.initialFontSize,
+    this.filePath,
     this.horizontalScrollController,
     this.terminalTheme,
     super.key,
@@ -354,6 +357,9 @@ class RemoteTextEditorScreen extends StatefulWidget {
 
   /// File name shown in the app bar.
   final String fileName;
+
+  /// Full remote path shown in the app bar when available.
+  final String? filePath;
 
   /// Text controller for the editable content.
   final TextEditingController controller;
@@ -817,6 +823,7 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
     );
     final lineHeight = _measureLineHeight(context, editorTextStyle);
     final caretPosition = _caretPosition;
+    final title = 'Edit ${widget.filePath ?? widget.fileName}';
 
     return Theme(
       data: theme.copyWith(
@@ -841,7 +848,10 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
               tooltip: 'Close editor',
               onPressed: () => unawaited(Navigator.of(context).maybePop()),
             ),
-            title: Text('Edit ${widget.fileName}'),
+            title: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Text(title),
+            ),
             actions: [
               if (_showDesktopZoomButtons(theme.platform))
                 IconButton(

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -1190,10 +1190,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       ),
       backgroundColor: theme.colorScheme.surface,
       side: BorderSide(color: theme.colorScheme.outlineVariant),
-      onPressed: () {
-        _clearHighlightedFile();
-        unawaited(_navigateTo(shortcutPath));
-      },
+      onPressed: () => unawaited(_navigateTo(shortcutPath)),
       tooltip: 'Go to $shortcutPath',
     );
   }
@@ -1235,10 +1232,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
               child: Row(
                 children: [
                   InkWell(
-                    onTap: () {
-                      _clearHighlightedFile();
-                      unawaited(_navigateTo('/'));
-                    },
+                    onTap: () => unawaited(_navigateTo('/')),
                     child: const Padding(
                       padding: EdgeInsets.symmetric(horizontal: 4, vertical: 8),
                       child: Text('/'),
@@ -1253,7 +1247,6 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
                     InkWell(
                       onTap: () {
                         final path = '/${parts.sublist(0, i + 1).join('/')}';
-                        _clearHighlightedFile();
                         unawaited(_navigateTo(path));
                       },
                       child: Padding(

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -795,6 +795,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   }
 
   Future<void> _navigateTo(String path) async {
+    _clearHighlightedFile();
     if (path == _currentPath) {
       return;
     }
@@ -805,6 +806,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   }
 
   Future<void> _navigateUp() async {
+    _clearHighlightedFile();
     if (_currentPath == '/') {
       return;
     }
@@ -816,6 +818,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   }
 
   Future<void> _goBack() async {
+    _clearHighlightedFile();
     if (_pathHistory.length <= 1) {
       return;
     }
@@ -926,16 +929,51 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       if (!mounted) {
         return true;
       }
-      setState(() {
-        _highlightedDirectoryPath = navigationTarget.directoryPath;
-        _highlightedFileName = fileName;
-      });
-      _queueScrollHighlightedFileIntoView();
+      _highlightFile(navigationTarget.directoryPath, fileName);
+      await _openFileFromRequestedPath(matchingEntry);
       return true;
     }
 
     _closeRequestedPathWithError('Could not open "$normalizedPath" in SFTP');
     return false;
+  }
+
+  Future<void> _openFileFromRequestedPath(SftpName file) async {
+    switch (resolveSftpFileTapIntent(
+      isDirectory: file.attr.isDirectory,
+      filename: file.filename,
+    )) {
+      case SftpFileTapIntent.navigate:
+        return;
+      case SftpFileTapIntent.preview:
+        await _previewImageFile(file);
+      case SftpFileTapIntent.previewVideo:
+        await _previewVideoFile(file);
+      case SftpFileTapIntent.edit:
+        await _editTextFile(file);
+    }
+    if (!mounted) {
+      return;
+    }
+    _highlightFile(_currentPath, file.filename);
+  }
+
+  void _highlightFile(String directoryPath, String fileName) {
+    setState(() {
+      _highlightedDirectoryPath = directoryPath;
+      _highlightedFileName = fileName;
+    });
+    _queueScrollHighlightedFileIntoView();
+  }
+
+  void _clearHighlightedFile() {
+    if (_highlightedFileName == null && _highlightedDirectoryPath == null) {
+      return;
+    }
+    setState(() {
+      _highlightedDirectoryPath = null;
+      _highlightedFileName = null;
+    });
   }
 
   void _closeRequestedPathWithError(String message) {
@@ -1045,12 +1083,18 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
-            onPressed: () => _loadDirectory(_currentPath),
+            onPressed: () {
+              _clearHighlightedFile();
+              unawaited(_loadDirectory(_currentPath));
+            },
             tooltip: 'Refresh',
           ),
           IconButton(
             icon: const Icon(Icons.create_new_folder),
-            onPressed: _showCreateDirectoryDialog,
+            onPressed: () {
+              _clearHighlightedFile();
+              unawaited(_showCreateDirectoryDialog());
+            },
             tooltip: 'New folder',
           ),
         ],
@@ -1063,7 +1107,10 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         ],
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: _showUploadDialog,
+        onPressed: () {
+          _clearHighlightedFile();
+          unawaited(_showUploadDialog());
+        },
         tooltip: 'Upload files',
         child: const Icon(Icons.upload_file),
       ),
@@ -1143,7 +1190,10 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       ),
       backgroundColor: theme.colorScheme.surface,
       side: BorderSide(color: theme.colorScheme.outlineVariant),
-      onPressed: () => unawaited(_navigateTo(shortcutPath)),
+      onPressed: () {
+        _clearHighlightedFile();
+        unawaited(_navigateTo(shortcutPath));
+      },
       tooltip: 'Go to $shortcutPath',
     );
   }
@@ -1185,7 +1235,10 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
               child: Row(
                 children: [
                   InkWell(
-                    onTap: () => unawaited(_navigateTo('/')),
+                    onTap: () {
+                      _clearHighlightedFile();
+                      unawaited(_navigateTo('/'));
+                    },
                     child: const Padding(
                       padding: EdgeInsets.symmetric(horizontal: 4, vertical: 8),
                       child: Text('/'),
@@ -1200,6 +1253,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
                     InkWell(
                       onTap: () {
                         final path = '/${parts.sublist(0, i + 1).join('/')}';
+                        _clearHighlightedFile();
                         unawaited(_navigateTo(path));
                       },
                       child: Padding(
@@ -1274,6 +1328,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
 
     return RefreshIndicator(
       onRefresh: () async {
+        _clearHighlightedFile();
         await _loadDirectory(_currentPath);
       },
       child: ListView.builder(
@@ -1300,6 +1355,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   }
 
   void _handleFileTap(SftpName file) {
+    _clearHighlightedFile();
     switch (resolveSftpFileTapIntent(
       isDirectory: file.attr.isDirectory,
       filename: file.filename,
@@ -1316,6 +1372,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   }
 
   void _showFileOptions(SftpName file) {
+    _clearHighlightedFile();
     final previewKind = resolveSftpPreviewKind(
       isDirectory: file.attr.isDirectory,
       filename: file.filename,
@@ -1718,7 +1775,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         MaterialPageRoute(
           fullscreenDialog: true,
           builder: (context) => _RemoteImageViewerScreen(
-            fileName: file.filename,
+            remotePath: remotePath,
             bytes: bytes,
             isSvg: isSvgFileName(file.filename),
           ),
@@ -2085,6 +2142,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
           fullscreenDialog: true,
           builder: (context) => RemoteTextEditorScreen(
             fileName: file.filename,
+            filePath: remotePath,
             controller: controller,
             terminalTheme: editorTheme,
             fontFamily: fontFamily,
@@ -2657,7 +2715,12 @@ class _RemoteVideoViewerScreenState extends State<_RemoteVideoViewerScreen> {
     final controller = _controller;
 
     return Scaffold(
-      appBar: AppBar(title: Text(widget.fileName)),
+      appBar: AppBar(
+        title: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Text(widget.remotePath),
+        ),
+      ),
       body: error != null
           ? _buildErrorBody(context, error)
           : controller == null || !controller.value.isInitialized
@@ -2919,19 +2982,24 @@ class _RemoteVideoViewerScreenState extends State<_RemoteVideoViewerScreen> {
 
 class _RemoteImageViewerScreen extends StatelessWidget {
   const _RemoteImageViewerScreen({
-    required this.fileName,
+    required this.remotePath,
     required this.bytes,
     required this.isSvg,
   });
 
-  final String fileName;
+  final String remotePath;
   final Uint8List bytes;
   final bool isSvg;
 
   @override
   Widget build(BuildContext context) => Scaffold(
     backgroundColor: Colors.black,
-    appBar: AppBar(title: Text(fileName)),
+    appBar: AppBar(
+      title: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Text(remotePath),
+      ),
+    ),
     body: InteractiveViewer(
       maxScale: 8,
       minScale: 0.5,

--- a/lib/presentation/widgets/syntax_highlight_controller.dart
+++ b/lib/presentation/widgets/syntax_highlight_controller.dart
@@ -35,9 +35,10 @@ class SyntaxHighlightController extends TextEditingController {
   /// Highlight.js theme map (class name → [TextStyle]).
   Map<String, TextStyle> theme;
 
-  // Cached spans keyed on the raw text value so we only re-highlight on edits.
+  // Cached highlight children keyed on the raw text value so base styles can
+  // change without re-tokenizing unchanged text.
   String? _cachedText;
-  TextSpan? _cachedSpan;
+  List<TextSpan>? _cachedChildren;
 
   @override
   TextSpan buildTextSpan({
@@ -70,8 +71,9 @@ class SyntaxHighlightController extends TextEditingController {
     }
 
     // Return cached result when the text has not changed.
-    if (source == _cachedText && _cachedSpan != null) {
-      return TextSpan(style: style, children: [_cachedSpan!]);
+    final cachedChildren = _cachedChildren;
+    if (source == _cachedText && cachedChildren != null) {
+      return TextSpan(style: style, children: cachedChildren);
     }
 
     try {
@@ -85,13 +87,11 @@ class SyntaxHighlightController extends TextEditingController {
         );
       }
 
-      final highlighted = TextSpan(
-        style: style,
-        children: _convertNodes(nodes),
-      );
+      final highlightedChildren = _convertNodes(nodes);
+      final highlighted = TextSpan(style: style, children: highlightedChildren);
 
       _cachedText = source;
-      _cachedSpan = highlighted;
+      _cachedChildren = highlightedChildren;
       return highlighted;
     } on Object {
       // If the highlighter fails for any reason, fall through to plain text.
@@ -130,6 +130,6 @@ class SyntaxHighlightController extends TextEditingController {
   /// re-highlight from scratch.
   void invalidateHighlightCache() {
     _cachedText = null;
-    _cachedSpan = null;
+    _cachedChildren = null;
   }
 }

--- a/test/presentation/screens/sftp_screen_test.dart
+++ b/test/presentation/screens/sftp_screen_test.dart
@@ -1,12 +1,59 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:dartssh2/dartssh2.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:monkeyssh/domain/models/monetization.dart';
+import 'package:monkeyssh/domain/services/monetization_service.dart';
+import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/presentation/screens/remote_text_editor_screen.dart';
 import 'package:monkeyssh/presentation/screens/sftp_screen.dart';
+
+const _proMonetizationState = MonetizationState(
+  billingAvailability: MonetizationBillingAvailability.available,
+  entitlements: MonetizationEntitlements.pro(),
+  offers: [],
+  debugUnlockAvailable: false,
+  debugUnlocked: false,
+);
+
+final _onePixelPngBytes = Uint8List.fromList(
+  base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/luzp0wAAAABJRU5ErkJggg==',
+  ),
+);
+
+class _MockSshClient extends Mock implements SSHClient {}
+
+class _MockSftpClient extends Mock implements SftpClient {}
+
+class _MockSftpFile extends Mock implements SftpFile {}
+
+class _MockMonetizationService extends Mock implements MonetizationService {}
+
+class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
+  _TestActiveSessionsNotifier(this.session);
+
+  final SshSession session;
+
+  @override
+  Map<int, SshConnectionState> build() => <int, SshConnectionState>{
+    session.connectionId: SshConnectionState.connected,
+  };
+
+  @override
+  SshSession? getSession(int connectionId) =>
+      connectionId == session.connectionId ? session : null;
+
+  @override
+  Future<void> syncBackgroundStatus() async {}
+}
 
 void main() {
   group('SFTP path helpers', () {
@@ -39,18 +86,15 @@ void main() {
       );
     });
 
-    test(
-      'requested files open their parent directory and highlight the file',
-      () {
-        expect(
-          resolveRequestedSftpNavigationTarget(
-            '/var/log/app.log',
-            isDirectory: false,
-          ),
-          (directoryPath: '/var/log', highlightedFileName: 'app.log'),
-        );
-      },
-    );
+    test('requested files target their parent directory and file row', () {
+      expect(
+        resolveRequestedSftpNavigationTarget(
+          '/var/log/app.log',
+          isDirectory: false,
+        ),
+        (directoryPath: '/var/log', highlightedFileName: 'app.log'),
+      );
+    });
 
     test('location shortcuts normalize and de-duplicate paths', () {
       expect(
@@ -426,13 +470,105 @@ void main() {
 
       expect(find.text('Could not play video preview'), findsOneWidget);
       expect(find.text('Unsupported codec'), findsOneWidget);
-      expect(find.text('/home/depoll/screen-recording.mp4'), findsOneWidget);
+      expect(
+        find.text('/home/depoll/screen-recording.mp4'),
+        findsAtLeastNWidgets(1),
+      );
       expect(find.text('42 B'), findsOneWidget);
       expect(find.text('video/mp4'), findsOneWidget);
       expect(find.text('Cached copy'), findsOneWidget);
       expect(find.text('Save copy'), findsOneWidget);
       expect(find.text('Open/Share'), findsOneWidget);
     });
+
+    testWidgets(
+      'requested image files open directly and return to a highlighted row',
+      (tester) async {
+        final sshClient = _MockSshClient();
+        final sftp = _MockSftpClient();
+        final remoteFile = _MockSftpFile();
+        final monetizationService = _MockMonetizationService();
+        final session = SshSession(
+          connectionId: 7,
+          hostId: 1,
+          client: sshClient,
+          config: const SshConnectionConfig(
+            hostname: 'demo.example.com',
+            port: 22,
+            username: 'demo',
+          ),
+        );
+
+        when(
+          () => monetizationService.currentState,
+        ).thenReturn(_proMonetizationState);
+        when(sshClient.sftp).thenAnswer((_) async => sftp);
+        when(() => sftp.absolute('.')).thenAnswer((_) async => '/home/demo');
+        when(() => sftp.stat('/home/demo/picture.png')).thenAnswer(
+          (_) async => SftpFileAttrs(
+            size: _onePixelPngBytes.length,
+            mode: const SftpFileMode.value(1 << 15),
+          ),
+        );
+        when(() => sftp.listdir('/home/demo')).thenAnswer(
+          (_) async => [
+            SftpName(
+              filename: 'picture.png',
+              longname: 'picture.png',
+              attr: SftpFileAttrs(
+                size: _onePixelPngBytes.length,
+                mode: const SftpFileMode.value(1 << 15),
+              ),
+            ),
+          ],
+        );
+        when(
+          () => sftp.open('/home/demo/picture.png'),
+        ).thenAnswer((_) async => remoteFile);
+        when(
+          () => remoteFile.readBytes(length: any(named: 'length')),
+        ).thenAnswer((_) async => _onePixelPngBytes);
+        when(remoteFile.close).thenAnswer((_) async {});
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+            ],
+            child: const MaterialApp(
+              home: SftpScreen(
+                hostId: 1,
+                connectionId: 7,
+                initialPath: '/home/demo/picture.png',
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('/home/demo/picture.png'), findsOneWidget);
+
+        Navigator.of(tester.element(find.text('/home/demo/picture.png'))).pop();
+        await tester.pumpAndSettle();
+
+        final tile = tester.widget<ListTile>(
+          find.ancestor(
+            of: find.text('picture.png'),
+            matching: find.byType(ListTile),
+          ),
+        );
+        expect(tile.tileColor, isNotNull);
+        verify(() => sftp.open('/home/demo/picture.png')).called(1);
+      },
+    );
 
     testWidgets('video preview deletes cached files when closed', (
       tester,

--- a/test/unit/syntax_highlight_controller_test.dart
+++ b/test/unit/syntax_highlight_controller_test.dart
@@ -67,10 +67,35 @@ void main() {
         withComposing: false,
       );
 
-      // On the second call the cached highlighted span is reused as the
-      // single child of the returned wrapper, so it must be identical to
-      // the first span that was originally returned.
-      expect(span2.children!.first, same(span1));
+      // On the second call the cached highlighted children are reused.
+      expect(span2.children, same(span1.children));
+    });
+
+    test('uses latest base style with cached highlighted children', () {
+      controller = SyntaxHighlightController(
+        theme: const {
+          'keyword': TextStyle(color: Color(0xFFFF00FF)),
+          'string': TextStyle(color: Color(0xFF00FF00)),
+        },
+        text: 'void main() { print("hello"); }',
+        language: 'dart',
+      );
+
+      final smallSpan = controller.buildTextSpan(
+        context: _FakeBuildContext(),
+        style: const TextStyle(fontSize: 12),
+        withComposing: false,
+      );
+      final largeSpan = controller.buildTextSpan(
+        context: _FakeBuildContext(),
+        style: const TextStyle(fontSize: 20),
+        withComposing: false,
+      );
+
+      expect(smallSpan.style!.fontSize, 12);
+      expect(largeSpan.style!.fontSize, 20);
+      expect(largeSpan.children, same(smallSpan.children));
+      _expectChildrenDoNotSetFontSize(largeSpan, 12);
     });
 
     test('re-highlights after text changes', () {
@@ -132,8 +157,8 @@ void main() {
         withComposing: false,
       );
 
-      // After cache invalidation, the inner span objects should differ.
-      expect(identical(span1.children!.first, span2.children!.first), isFalse);
+      // After cache invalidation, the cached children should differ.
+      expect(identical(span1.children, span2.children), isFalse);
     });
 
     test('handles language change at runtime', () {
@@ -205,3 +230,12 @@ void main() {
 /// Minimal fake [BuildContext] for testing [buildTextSpan] which does not
 /// use the context for syntax-highlighting purposes.
 class _FakeBuildContext extends Fake implements BuildContext {}
+
+void _expectChildrenDoNotSetFontSize(TextSpan span, double fontSize) {
+  for (final child in span.children ?? const <InlineSpan>[]) {
+    if (child is TextSpan) {
+      expect(child.style?.fontSize, isNot(fontSize));
+      _expectChildrenDoNotSetFontSize(child, fontSize);
+    }
+  }
+}

--- a/test/widget/sftp_screen_test.dart
+++ b/test/widget/sftp_screen_test.dart
@@ -206,6 +206,26 @@ void main() {
       expect(find.byIcon(Icons.close), findsOneWidget);
     });
 
+    testWidgets('shows the full remote path in the editor app bar', (
+      tester,
+    ) async {
+      final controller = TextEditingController(text: 'alpha');
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: buildRemoteTextEditorScreenForTesting(
+            fileName: 'notes.txt',
+            filePath: '/home/demo/project/notes.txt',
+            controller: controller,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit /home/demo/project/notes.txt'), findsOneWidget);
+    });
+
     testWidgets('close affordance warns before discarding unsaved edits', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- Open SFTP file links directly in the matching viewer/editor after resolving and loading their containing folder.
- Keep the containing folder scrolled to and highlighting the linked file when returning from the viewer/editor, until another SFTP browser action is taken.
- Show full remote file paths in the image/video/text editor app bars.

## Validation

- `flutter analyze`
- `flutter test test/presentation/screens/sftp_screen_test.dart test/widget/sftp_screen_test.dart test/widget/sftp_screen_path_resolution_test.dart`
- `flutter test`
