### PR TITLE
Show jump host in terminal status icon

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -6092,6 +6092,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 ?.config
                 .jumpHost !=
             null;
+    final connectionStatusLabel = isConnectedThroughJumpHost
+        ? 'Connected through jump host'
+        : connectionLabel;
     final connectionIdentity = formatTerminalConnectionIdentity(
       username: _redactStoreScreenshotIdentities ? 'store' : _host?.username,
       hostname: _redactStoreScreenshotIdentities
@@ -6145,14 +6148,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                   ),
                   const SizedBox(width: 6),
                   _TerminalConnectionStatusIcon(
-                    label: connectionLabel,
+                    label: connectionStatusLabel,
                     state: connectionState,
                     isConnecting: _isConnecting,
+                    isConnectedThroughJumpHost: isConnectedThroughJumpHost,
                   ),
-                  if (isConnectedThroughJumpHost) ...[
-                    const SizedBox(width: 4),
-                    const _TerminalJumpHostIndicator(),
-                  ],
                 ],
               ),
               if (titleSubtitle.isNotEmpty)
@@ -10251,13 +10251,19 @@ class _TerminalConnectionStatusIcon extends StatelessWidget {
     required this.label,
     required this.state,
     required this.isConnecting,
+    required this.isConnectedThroughJumpHost,
   });
 
   final String label;
   final SshConnectionState state;
   final bool isConnecting;
+  final bool isConnectedThroughJumpHost;
 
   IconData get _icon {
+    if (isConnectedThroughJumpHost) {
+      return Icons.alt_route;
+    }
+
     if (isConnecting &&
         (state == SshConnectionState.disconnected ||
             state == SshConnectionState.connecting)) {
@@ -10280,6 +10286,10 @@ class _TerminalConnectionStatusIcon extends StatelessWidget {
   }
 
   Color _color(ColorScheme colorScheme) {
+    if (isConnectedThroughJumpHost) {
+      return colorScheme.secondary;
+    }
+
     if (isConnecting &&
         (state == SshConnectionState.disconnected ||
             state == SshConnectionState.connecting)) {
@@ -10310,24 +10320,6 @@ class _TerminalConnectionStatusIcon extends StatelessWidget {
         message: label,
         excludeFromSemantics: true,
         child: Icon(_icon, size: 20, color: statusColor),
-      ),
-    );
-  }
-}
-
-class _TerminalJumpHostIndicator extends StatelessWidget {
-  const _TerminalJumpHostIndicator();
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Semantics(
-      label: 'Connected through jump host',
-      child: Tooltip(
-        message: 'Connected through jump host',
-        excludeFromSemantics: true,
-        child: Icon(Icons.alt_route, size: 18, color: colorScheme.secondary),
       ),
     );
   }

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -940,6 +940,7 @@ void main() {
 
       expect(find.byTooltip('Connected through jump host'), findsOneWidget);
       expect(find.byIcon(Icons.alt_route), findsOneWidget);
+      expect(find.byIcon(Icons.check_circle_outline), findsNothing);
     });
 
     testWidgets(


### PR DESCRIPTION
## Summary

- Replace the terminal title-bar connected icon with the jump-host route icon when the active session is tunneled through a jump host.
- Keep the status tooltip/semantics specific to jump-host connections.
- Update the terminal screen widget test to assert the regular connected icon is replaced.

## Testing

- flutter test test/presentation/screens/terminal_screen_test.dart --name "shows jump host indicator for tunneled sessions"
- flutter analyze
