### PR TITLE
fix: avoid copilot theme refresh spew

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -1872,13 +1872,16 @@ String buildTmuxRefreshTerminalThemeCommand(
       r'if [ "$alternate" = 1 ] || [ "$foreground_tui" = 1 ]; then '
       'injected=1; '
       r'case "${pane_command##*/}" in '
-      'codex|codex-*) '
+      'codex|codex-*|copilot|copilot-*) '
       '( ${_buildTmuxSendPaneFocusRefreshCommand(extraFlags: extraFlags)} '
       '2>/dev/null || true ) & ;; '
       'opencode|opencode-*) '
       '( ${_buildTmuxSendPaneTerminalThemeCommand(theme, extraFlags: extraFlags, forceFocusTransition: true, includeLateFocusTransition: true)} ) & ;; '
       '*) '
       r'case "$pane_title" in '
+      '*Copilot*|*copilot*) '
+      '( ${_buildTmuxSendPaneFocusRefreshCommand(extraFlags: extraFlags)} '
+      '2>/dev/null || true ) & ;; '
       '*OpenCode*|*opencode*) '
       '( ${_buildTmuxSendPaneTerminalThemeCommand(theme, extraFlags: extraFlags, forceFocusTransition: true, includeLateFocusTransition: true)} ) & ;; '
       '*) '
@@ -2023,9 +2026,10 @@ String _buildTmuxSendPaneTerminalThemeCommand(
   //
   // OSC 10/11 default color replies are intentionally sent after the private
   // mode report. That gives OpenTUI/OpenCode a complete theme-mode plus default
-  // color cycle even when tmux consumes the outer OSC responses. Codex panes
-  // are routed to the focus-only refresh above because unsolicited mode/color
-  // reports can reset its composer input while the user is typing.
+  // color cycle even when tmux consumes the outer OSC responses. Codex/Copilot
+  // panes are routed to the focus-only refresh above because unsolicited
+  // mode/color reports can reset or appear in their composer input while the
+  // user is typing.
   final focusCommand = forceFocusTransition
       ? _buildTmuxSendPaneFocusTransitionCommand(extraFlags: extraFlags)
       : _buildTmuxSendPaneFocusRefreshCommand(extraFlags: extraFlags);

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -6704,11 +6704,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
     setState(() => _sessionThemeOverride = theme);
     _lastBuildAppliedTheme = theme;
-    _applyTerminalThemeToSession(
-      theme,
-      allowRemoteRefresh: false,
-      reason: 'theme_picker_preview',
-    );
+    _applyTerminalThemeToSession(theme, reason: 'theme_picker_preview');
   }
 
   void _restoreThemePickerPreview({
@@ -6717,11 +6713,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }) {
     setState(() => _sessionThemeOverride = previousSessionThemeOverride);
     _lastBuildAppliedTheme = previousTheme;
-    _applyTerminalThemeToSession(
-      previousTheme,
-      allowRemoteRefresh: false,
-      reason: 'theme_picker_cancel',
-    );
+    _applyTerminalThemeToSession(previousTheme, reason: 'theme_picker_cancel');
   }
 
   Future<void> _saveThemeToHost(

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -168,9 +168,10 @@ void main() {
       expect(command, contains('flutty_theme_refresh_pane'));
       expect(command, contains(') & ;;'));
       expect(command, contains('done; wait; };'));
-      expect(command, contains('codex|codex-*)'));
+      expect(command, contains('codex|codex-*|copilot|copilot-*)'));
       expect(command, contains('opencode|opencode-*)'));
       expect(command, contains(r'case "$pane_title" in'));
+      expect(command, contains('*Copilot*|*copilot*)'));
       expect(command, contains('*OpenCode*|*opencode*)'));
       expect(command, contains(r'send-keys -t "$pane" -H'));
       expect(command, contains(r'refresh-client -t "$client" -r "$pane":'));
@@ -197,7 +198,9 @@ void main() {
       expect(command, contains('1b 5b 3f 39 39 37 3b 31 6e'));
       expect(command, contains('1b 5b 4f'));
       expect(command, contains('1b 5b 49'));
-      final codexBranchStart = command.indexOf('codex|codex-*)');
+      final codexBranchStart = command.indexOf(
+        'codex|codex-*|copilot|copilot-*)',
+      );
       final opencodeBranchStart = command.indexOf('opencode|opencode-*)');
       expect(codexBranchStart, isNonNegative);
       expect(opencodeBranchStart, greaterThan(codexBranchStart));
@@ -208,6 +211,16 @@ void main() {
       expect(
         command.indexOf('1b 5b 4f', opencodeBranchStart),
         greaterThan(opencodeBranchStart),
+      );
+      final copilotTitleBranchStart = command.indexOf('*Copilot*|*copilot*)');
+      final openCodeTitleBranchStart = command.indexOf(
+        '*OpenCode*|*opencode*)',
+      );
+      expect(copilotTitleBranchStart, greaterThan(opencodeBranchStart));
+      expect(openCodeTitleBranchStart, greaterThan(copilotTitleBranchStart));
+      expect(
+        command.substring(copilotTitleBranchStart, openCodeTitleBranchStart),
+        isNot(contains('1b 5b 4f')),
       );
       expect(command, contains('sleep 0.25'));
       expect(command, contains('sleep 0.08'));


### PR DESCRIPTION
## Summary

- Treat Copilot CLI tmux panes like Codex during theme refreshes so they receive focus-only refreshes instead of unsolicited OSC color/mode bytes.
- Let theme picker preview/cancel use the safe remote refresh path so Copilot re-queries the current terminal colors while previewing.
- Updates tmux refresh command coverage for Copilot command/title detection.

## Validation

- `flutter test --no-pub test/domain/services/tmux_service_control_mode_test.dart test/presentation/screens/terminal_screen_test.dart`
- `flutter analyze --fatal-warnings`
