### PR TITLE
fix: place terminal status icons before title

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -6088,18 +6088,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       connectionState,
       isConnecting: _isConnecting,
     );
+    final activeSession = _connectionId == null
+        ? null
+        : ref.read(activeSessionsProvider.notifier).getSession(_connectionId!);
     final isConnectedThroughJumpHost =
         connectionState == SshConnectionState.connected &&
-        _connectionId != null &&
-        ref
-                .read(activeSessionsProvider.notifier)
-                .getSession(_connectionId!)
-                ?.config
-                .jumpHost !=
-            null;
-    final connectionStatusLabel = isConnectedThroughJumpHost
-        ? 'Connected through jump host'
-        : connectionLabel;
+        (_observedSession ?? activeSession)?.config.jumpHost != null;
     final connectionIdentity = formatTerminalConnectionIdentity(
       username: _redactStoreScreenshotIdentities ? 'store' : _host?.username,
       hostname: _redactStoreScreenshotIdentities
@@ -6153,11 +6147,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                   ),
                   const SizedBox(width: 6),
                   _TerminalConnectionStatusIcon(
-                    label: connectionStatusLabel,
+                    label: connectionLabel,
                     state: connectionState,
                     isConnecting: _isConnecting,
-                    isConnectedThroughJumpHost: isConnectedThroughJumpHost,
                   ),
+                  if (isConnectedThroughJumpHost) ...[
+                    const SizedBox(width: 4),
+                    const _TerminalJumpHostIndicator(),
+                  ],
                 ],
               ),
               if (titleSubtitle.isNotEmpty)
@@ -10306,19 +10303,13 @@ class _TerminalConnectionStatusIcon extends StatelessWidget {
     required this.label,
     required this.state,
     required this.isConnecting,
-    required this.isConnectedThroughJumpHost,
   });
 
   final String label;
   final SshConnectionState state;
   final bool isConnecting;
-  final bool isConnectedThroughJumpHost;
 
   IconData get _icon {
-    if (isConnectedThroughJumpHost) {
-      return Icons.alt_route;
-    }
-
     if (isConnecting &&
         (state == SshConnectionState.disconnected ||
             state == SshConnectionState.connecting)) {
@@ -10341,10 +10332,6 @@ class _TerminalConnectionStatusIcon extends StatelessWidget {
   }
 
   Color _color(ColorScheme colorScheme) {
-    if (isConnectedThroughJumpHost) {
-      return colorScheme.secondary;
-    }
-
     if (isConnecting &&
         (state == SshConnectionState.disconnected ||
             state == SshConnectionState.connecting)) {
@@ -10375,6 +10362,24 @@ class _TerminalConnectionStatusIcon extends StatelessWidget {
         message: label,
         excludeFromSemantics: true,
         child: Icon(_icon, size: 20, color: statusColor),
+      ),
+    );
+  }
+}
+
+class _TerminalJumpHostIndicator extends StatelessWidget {
+  const _TerminalJumpHostIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Semantics(
+      label: 'Connected through jump host',
+      child: Tooltip(
+        message: 'Connected through jump host',
+        excludeFromSemantics: true,
+        child: Icon(Icons.alt_route, size: 18, color: colorScheme.secondary),
       ),
     );
   }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -6131,41 +6131,41 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       },
       child: Scaffold(
         appBar: AppBar(
-          title: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
+          titleSpacing: 8,
+          title: Row(
             children: [
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Flexible(
-                    child: Text(
+              _TerminalConnectionStatusIcon(
+                label: connectionLabel,
+                state: connectionState,
+                isConnecting: _isConnecting,
+              ),
+              if (isConnectedThroughJumpHost) ...[
+                const SizedBox(width: 4),
+                const _TerminalJumpHostIndicator(),
+              ],
+              const SizedBox(width: 8),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
                       _host?.label ?? 'Terminal',
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
-                  ),
-                  const SizedBox(width: 6),
-                  _TerminalConnectionStatusIcon(
-                    label: connectionLabel,
-                    state: connectionState,
-                    isConnecting: _isConnecting,
-                  ),
-                  if (isConnectedThroughJumpHost) ...[
-                    const SizedBox(width: 4),
-                    const _TerminalJumpHostIndicator(),
+                    if (titleSubtitle.isNotEmpty)
+                      Text(
+                        titleSubtitle,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
                   ],
-                ],
-              ),
-              if (titleSubtitle.isNotEmpty)
-                Text(
-                  titleSubtitle,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: theme.textTheme.labelSmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
                 ),
+              ),
             ],
           ),
           bottom: !_showsTerminalMetadata || statusChips.isEmpty

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -940,7 +940,8 @@ void main() {
 
       expect(find.byTooltip('Connected through jump host'), findsOneWidget);
       expect(find.byIcon(Icons.alt_route), findsOneWidget);
-      expect(find.byIcon(Icons.check_circle_outline), findsNothing);
+      expect(find.byTooltip('Connected'), findsOneWidget);
+      expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
     });
 
     testWidgets(

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -942,6 +942,15 @@ void main() {
       expect(find.byIcon(Icons.alt_route), findsOneWidget);
       expect(find.byTooltip('Connected'), findsOneWidget);
       expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
+      final titleLeft = tester.getTopLeft(find.text('Terminal test host')).dx;
+      expect(
+        tester.getCenter(find.byIcon(Icons.check_circle_outline)).dx,
+        lessThan(titleLeft),
+      );
+      expect(
+        tester.getCenter(find.byIcon(Icons.alt_route)).dx,
+        lessThan(titleLeft),
+      );
     });
 
     testWidgets(


### PR DESCRIPTION
## Summary

- Move terminal connection status icons to the left of the terminal title, using the space after the back button instead of competing with the title text.
- Restore the jump-host route glyph as a separate tunneled-session indicator while keeping the normal connected status icon visible.
- Prefer the currently observed terminal session when deciding whether the active terminal is using a jump host.

## Validation

- `flutter test test/presentation/screens/terminal_screen_test.dart --name "shows jump host indicator for tunneled sessions"`
- `flutter analyze`
- `flutter test test/presentation/screens/terminal_screen_test.dart`
