### PR TITLE
fix: keep tmux new window picker above keyboard

### DIFF
--- a/lib/presentation/widgets/tmux_expandable_bar.dart
+++ b/lib/presentation/widgets/tmux_expandable_bar.dart
@@ -616,6 +616,23 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     _resumeSession(selected);
   }
 
+  Future<void> _showNewWindowPicker() async {
+    final installedToolsFuture = _tmux.detectInstalledAgentTools(
+      widget.session,
+    );
+    final action = await showTmuxNewWindowPicker(
+      context: context,
+      isProUser: widget.isProUser,
+      startClisInYoloMode: widget.startClisInYoloMode,
+      installedToolsFuture: installedToolsFuture,
+      preferredTool: _preferredLaunchTool,
+    );
+    if (!mounted || action == null) {
+      return;
+    }
+    await widget.onAction(action);
+  }
+
   int _tmuxAlertNotificationId(
     SshSession session,
     String tmuxSessionName,
@@ -992,36 +1009,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
               if (wasExpanded) {
                 widget.onExpandedChanged(false);
               }
-              final installedToolsFuture = _tmux.detectInstalledAgentTools(
-                widget.session,
-              );
-              showModalBottomSheet<AgentLaunchTool?>(
-                context: context,
-                requestFocus: terminalOverlayRouteRequestFocus(context),
-                builder: (ctx) => TmuxToolPickerSheet(
-                  isProUser: widget.isProUser,
-                  installedToolsFuture: installedToolsFuture,
-                  preferredTool: _preferredLaunchTool,
-                  onToolSelected: (tool) => Navigator.pop(ctx, tool),
-                  onEmptyWindow: () {
-                    Navigator.pop(ctx);
-                    widget.onAction(const TmuxNewWindowAction());
-                  },
-                ),
-              ).then((tool) {
-                if (!mounted || tool == null) {
-                  return;
-                }
-                widget.onAction(
-                  TmuxNewWindowAction(
-                    command: buildAgentToolCommand(
-                      tool,
-                      startInYoloMode: widget.startClisInYoloMode,
-                    ),
-                    windowName: tool.commandName,
-                  ),
-                );
-              });
+              unawaited(_showNewWindowPicker());
             },
           ),
           if (widget.isProUser) ...[

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -998,11 +998,18 @@ class TmuxToolPickerSheet extends StatelessWidget {
                         ),
                       );
                     }
-                    final installed = snapshot.data;
+                    final Iterable<AgentLaunchTool> availableTools;
+                    if (installedToolsFuture == null) {
+                      availableTools = _allTools;
+                    } else if (snapshot.hasError) {
+                      availableTools = const <AgentLaunchTool>[];
+                    } else {
+                      final installed =
+                          snapshot.data ?? const <AgentLaunchTool>{};
+                      availableTools = _allTools.where(installed.contains);
+                    }
                     final tools = _orderedAgentLaunchTools(
-                      installed != null
-                          ? _allTools.where(installed.contains)
-                          : _allTools,
+                      availableTools,
                       preferredTool: preferredTool,
                     );
                     if (tools.isEmpty) {

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -73,6 +73,39 @@ Future<TmuxNavigatorAction?> showTmuxNavigator({
   ),
 );
 
+/// Shows the tmux new-window picker bottom sheet.
+Future<TmuxNewWindowAction?> showTmuxNewWindowPicker({
+  required BuildContext context,
+  required bool isProUser,
+  required bool startClisInYoloMode,
+  Future<Set<AgentLaunchTool>>? installedToolsFuture,
+  AgentLaunchTool? preferredTool,
+}) => showModalBottomSheet<TmuxNewWindowAction>(
+  context: context,
+  isScrollControlled: true,
+  requestFocus: terminalOverlayRouteRequestFocus(context),
+  builder: (context) => TmuxToolPickerSheet(
+    isProUser: isProUser,
+    installedToolsFuture: installedToolsFuture,
+    preferredTool: preferredTool,
+    onToolSelected: (tool) {
+      Navigator.pop(
+        context,
+        TmuxNewWindowAction(
+          command: buildAgentToolCommand(
+            tool,
+            startInYoloMode: startClisInYoloMode,
+          ),
+          windowName: tool.commandName,
+        ),
+      );
+    },
+    onEmptyWindow: () {
+      Navigator.pop(context, const TmuxNewWindowAction());
+    },
+  ),
+);
+
 /// An action selected from the tmux navigator.
 sealed class TmuxNavigatorAction {
   /// Creates a new [TmuxNavigatorAction].
@@ -504,32 +537,20 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     _resumeSession(selected);
   }
 
-  void _showNewWindowPicker() {
+  Future<void> _showNewWindowPicker() async {
     final installedToolsFuture = _installedToolsFuture ??= _tmux
         .detectInstalledAgentTools(widget.session);
-    showModalBottomSheet<void>(
+    final action = await showTmuxNewWindowPicker(
       context: context,
-      requestFocus: terminalOverlayRouteRequestFocus(context),
-      builder: (context) => TmuxToolPickerSheet(
-        isProUser: widget.isProUser,
-        installedToolsFuture: installedToolsFuture,
-        preferredTool: _preferredLaunchTool,
-        onToolSelected: (tool) {
-          Navigator.pop(context);
-          _createNewWindow(
-            command: buildAgentToolCommand(
-              tool,
-              startInYoloMode: widget.startClisInYoloMode,
-            ),
-            name: tool.commandName,
-          );
-        },
-        onEmptyWindow: () {
-          Navigator.pop(context);
-          _createNewWindow();
-        },
-      ),
+      isProUser: widget.isProUser,
+      startClisInYoloMode: widget.startClisInYoloMode,
+      installedToolsFuture: installedToolsFuture,
+      preferredTool: _preferredLaunchTool,
     );
+    if (!mounted || action == null) {
+      return;
+    }
+    _createNewWindow(command: action.command, name: action.windowName);
   }
 
   @override
@@ -610,7 +631,7 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
                     ),
                     title: const Text('New Window'),
                     dense: true,
-                    onTap: _showNewWindowPicker,
+                    onTap: () => unawaited(_showNewWindowPicker()),
                   ),
                   // Recent AI Sessions
                   if (widget.isProUser) ...[
@@ -739,7 +760,16 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
           color: theme.colorScheme.onSurfaceVariant,
         ),
         title: const Row(
-          children: [Text('Recent AI Sessions'), Spacer(), PremiumBadge()],
+          children: [
+            Expanded(
+              child: Text(
+                'Recent AI Sessions',
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            SizedBox(width: 8),
+            PremiumBadge(),
+          ],
         ),
         trailing: Icon(
           _showSessions ? Icons.expand_less : Icons.expand_more,
@@ -910,111 +940,127 @@ class TmuxToolPickerSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final screenHeight = MediaQuery.sizeOf(context).height;
-    final maxSheetHeight = math.min(
+    final mediaQuery = MediaQuery.of(context);
+    final screenHeight = mediaQuery.size.height;
+    final viewInsets = mediaQuery.viewInsets;
+    final visibleHeight = screenHeight > viewInsets.bottom
+        ? screenHeight - viewInsets.bottom
+        : screenHeight;
+    final preferredSheetHeight = math.min(
       screenHeight * _tmuxToolPickerMaxHeightFactor,
       _tmuxToolPickerMaxHeightCap,
     );
+    final maxSheetHeight = math.min(visibleHeight, preferredSheetHeight);
 
-    return SafeArea(
-      child: ConstrainedBox(
-        constraints: BoxConstraints(maxHeight: maxSheetHeight),
-        child: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-                child: Text('New Window', style: theme.textTheme.titleMedium),
-              ),
-              FutureBuilder<Set<AgentLaunchTool>>(
-                future: installedToolsFuture,
-                builder: (context, snapshot) {
-                  if (installedToolsFuture != null &&
-                      snapshot.connectionState != ConnectionState.done) {
-                    return const Padding(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 12,
-                      ),
-                      child: Row(
-                        children: [
-                          SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator.adaptive(
-                              strokeWidth: 2,
-                            ),
-                          ),
-                          SizedBox(width: 12),
-                          Text('Detecting installed CLIs…'),
-                        ],
-                      ),
-                    );
-                  }
-                  final installed = snapshot.data;
-                  final tools = _orderedAgentLaunchTools(
-                    installed != null
-                        ? _allTools.where(installed.contains)
-                        : _allTools,
-                    preferredTool: preferredTool,
-                  );
-                  if (tools.isEmpty) {
-                    return Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 12,
-                      ),
-                      child: Text(
-                        'No supported CLIs found on PATH.',
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                    );
-                  }
-                  return Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      for (final tool in tools)
-                        ListTile(
-                          visualDensity: _tmuxNavigatorDenseVisualDensity,
-                          minTileHeight: 42,
-                          contentPadding: _tmuxNavigatorTilePadding,
-                          horizontalTitleGap: 12,
-                          minLeadingWidth: 20,
-                          leading: TmuxToolPickerSheet._iconForTool(
-                            tool,
-                            theme,
-                          ),
-                          title: Text(tool.label),
-                          trailing: !isProUser ? const PremiumBadge() : null,
-                          enabled: isProUser,
-                          onTap: () => onToolSelected(tool),
-                        ),
-                    ],
-                  );
-                },
-              ),
-              const Divider(height: 1),
-              ListTile(
-                visualDensity: _tmuxNavigatorDenseVisualDensity,
-                minTileHeight: 42,
-                contentPadding: _tmuxNavigatorTilePadding,
-                horizontalTitleGap: 12,
-                minLeadingWidth: 20,
-                leading: Icon(
-                  Icons.terminal,
-                  color: theme.colorScheme.onSurfaceVariant,
-                  size: 18,
+    return AnimatedPadding(
+      duration: const Duration(milliseconds: 220),
+      curve: Curves.easeOutCubic,
+      padding: EdgeInsets.only(bottom: viewInsets.bottom),
+      child: SafeArea(
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxHeight: maxSheetHeight),
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                  child: Text('New Window', style: theme.textTheme.titleMedium),
                 ),
-                title: const Text('Empty window'),
-                onTap: onEmptyWindow,
-              ),
-              const SizedBox(height: 8),
-            ],
+                FutureBuilder<Set<AgentLaunchTool>>(
+                  future: installedToolsFuture,
+                  builder: (context, snapshot) {
+                    if (installedToolsFuture != null &&
+                        snapshot.connectionState != ConnectionState.done) {
+                      return const Padding(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 12,
+                        ),
+                        child: Row(
+                          children: [
+                            SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator.adaptive(
+                                strokeWidth: 2,
+                              ),
+                            ),
+                            SizedBox(width: 12),
+                            Expanded(
+                              child: Text(
+                                'Detecting installed CLIs…',
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    }
+                    final installed = snapshot.data;
+                    final tools = _orderedAgentLaunchTools(
+                      installed != null
+                          ? _allTools.where(installed.contains)
+                          : _allTools,
+                      preferredTool: preferredTool,
+                    );
+                    if (tools.isEmpty) {
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 12,
+                        ),
+                        child: Text(
+                          'No supported CLIs found on PATH.',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      );
+                    }
+                    return Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        for (final tool in tools)
+                          ListTile(
+                            visualDensity: _tmuxNavigatorDenseVisualDensity,
+                            minTileHeight: 42,
+                            contentPadding: _tmuxNavigatorTilePadding,
+                            horizontalTitleGap: 12,
+                            minLeadingWidth: 20,
+                            leading: TmuxToolPickerSheet._iconForTool(
+                              tool,
+                              theme,
+                            ),
+                            title: Text(tool.label),
+                            trailing: !isProUser ? const PremiumBadge() : null,
+                            enabled: isProUser,
+                            onTap: () => onToolSelected(tool),
+                          ),
+                      ],
+                    );
+                  },
+                ),
+                const Divider(height: 1),
+                ListTile(
+                  visualDensity: _tmuxNavigatorDenseVisualDensity,
+                  minTileHeight: 42,
+                  contentPadding: _tmuxNavigatorTilePadding,
+                  horizontalTitleGap: 12,
+                  minLeadingWidth: 20,
+                  leading: Icon(
+                    Icons.terminal,
+                    color: theme.colorScheme.onSurfaceVariant,
+                    size: 18,
+                  ),
+                  title: const Text('Empty window'),
+                  onTap: onEmptyWindow,
+                ),
+                const SizedBox(height: 8),
+              ],
+            ),
           ),
         ),
       ),

--- a/test/widget/tmux_tool_picker_sheet_test.dart
+++ b/test/widget/tmux_tool_picker_sheet_test.dart
@@ -139,7 +139,7 @@ void main() {
       },
     );
 
-    testWidgets('falls back to all tools when detection fails', (tester) async {
+    testWidgets('shows fallback message when detection fails', (tester) async {
       final completer = Completer<Set<AgentLaunchTool>>();
       await tester.pumpWidget(
         _wrap(
@@ -154,9 +154,10 @@ void main() {
       completer.completeError(StateError('detection failed'));
       await tester.pump();
 
-      expect(find.text('No supported CLIs found on PATH.'), findsNothing);
+      expect(find.text('No supported CLIs found on PATH.'), findsOneWidget);
+      expect(find.text('Empty window'), findsOneWidget);
       for (final tool in AgentLaunchTool.values) {
-        expect(find.text(tool.label), findsOneWidget);
+        expect(find.text(tool.label), findsNothing);
       }
     });
 

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -178,6 +178,87 @@ void main() {
       expect(find.text('Resume'), findsOneWidget);
     });
 
+    testWidgets('new window picker stays above the visible keyboard', (
+      tester,
+    ) async {
+      tester.view
+        ..physicalSize = const Size(390, 844)
+        ..devicePixelRatio = 1
+        ..viewInsets = const FakeViewPadding(bottom: 240);
+      addTearDown(() {
+        tester.view
+          ..resetPhysicalSize()
+          ..resetDevicePixelRatio()
+          ..resetViewInsets();
+      });
+
+      final tmuxService = _MockTmuxService();
+      final presetService = _MockAgentLaunchPresetService();
+      final discoveryService = _MockAgentSessionDiscoveryService();
+      final session = SshSession(
+        connectionId: 1,
+        hostId: 1,
+        client: _MockSshClient(),
+        config: const SshConnectionConfig(
+          hostname: 'example.com',
+          port: 22,
+          username: 'demo',
+        ),
+      );
+      const tmuxSessionName = 'main';
+
+      when(
+        () => presetService.getPresetForHost(session.hostId),
+      ).thenAnswer((_) async => null);
+      when(
+        () => tmuxService.detectInstalledAgentTools(session),
+      ).thenAnswer((_) async => {AgentLaunchTool.claudeCode});
+      when(
+        () => tmuxService.watchWindowChanges(session, tmuxSessionName),
+      ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+      when(
+        () => tmuxService.listWindows(session, tmuxSessionName),
+      ).thenAnswer((_) async => windows);
+      when(
+        () => discoveryService.discoverSessionsStream(
+          session,
+          workingDirectory: any(named: 'workingDirectory'),
+          maxPerTool: any(named: 'maxPerTool'),
+          toolName: any(named: 'toolName'),
+        ),
+      ).thenAnswer(
+        (_) => Stream<DiscoveredSessionsResult>.value(
+          DiscoveredSessionsResult(sessions: const <ToolSessionInfo>[]),
+        ),
+      );
+
+      await _pumpNavigatorHost(
+        tester,
+        tmuxService: tmuxService,
+        presetService: presetService,
+        discoveryService: discoveryService,
+        session: session,
+        tmuxSessionName: tmuxSessionName,
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('New Window'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Empty window'), findsOneWidget);
+      expect(
+        tester.getBottomLeft(find.text('Empty window')).dy,
+        lessThan(844 - 240),
+      );
+      final keyboardPadding = tester
+          .widgetList<AnimatedPadding>(find.byType(AnimatedPadding))
+          .where(
+            (widget) => widget.padding == const EdgeInsets.only(bottom: 240),
+          );
+      expect(keyboardPadding, isNotEmpty);
+    });
+
     testWidgets('loads AI session providers only after expanding the section', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- Make the tmux new-window tool picker route scroll-controlled and keyboard-inset aware so it stays above the soft keyboard.
- Reuse the same picker route from the tmux navigator sheet and expandable tmux bar.
- Add a phone-width widget regression test for opening New Window while the keyboard is visible.

## Tests

- `flutter test test/widget/tmux_window_navigator_test.dart`
- `flutter test test/widget/tmux_tool_picker_sheet_test.dart`
- `flutter analyze`
