### PR TITLE
fix: pass yolo mode to tmux session resumes

### DIFF
--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -357,6 +357,38 @@ String buildAgentToolCommand(
   return commandParts.join(' ');
 }
 
+/// Builds the base shell command for resuming a saved [tool] session.
+String buildAgentResumeCommand(
+  AgentLaunchTool tool,
+  String sessionId, {
+  bool startInYoloMode = false,
+}) {
+  final commandParts = <String>[
+    ..._buildAgentToolEnvironmentAssignments(
+      tool,
+      startInYoloMode: startInYoloMode,
+    ),
+    tool.commandName,
+    if (startInYoloMode) ...tool.yoloArguments,
+    ..._buildAgentResumeArguments(tool, sessionId),
+  ];
+  return commandParts.join(' ');
+}
+
+List<String> _buildAgentResumeArguments(
+  AgentLaunchTool tool,
+  String sessionId,
+) => switch (tool) {
+  AgentLaunchTool.claudeCode => ['--resume', _quoteShellArgument(sessionId)],
+  AgentLaunchTool.copilotCli => ['--resume', _quoteShellArgument(sessionId)],
+  AgentLaunchTool.codex => ['resume', _quoteShellArgument(sessionId)],
+  AgentLaunchTool.geminiCli => ['--resume', _quoteShellArgument(sessionId)],
+  AgentLaunchTool.openCode =>
+    sessionId == '_continue'
+        ? const ['--continue']
+        : ['--session', _quoteShellArgument(sessionId)],
+};
+
 String? _normalizeAgentToolArguments({
   required AgentLaunchTool tool,
   required String? additionalArguments,

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../models/agent_launch_preset.dart';
 import '../models/tmux_state.dart';
 import 'ssh_exec_queue.dart';
 import 'ssh_service.dart';
@@ -251,6 +252,16 @@ String? _directorySummaryFallback(
 
 String _pathLastSegment(String path) =>
     path.split('/').where((segment) => segment.isNotEmpty).lastOrNull ?? path;
+
+AgentLaunchTool? _agentLaunchToolForSessionToolName(String toolName) {
+  final normalizedToolName = toolName.trim();
+  for (final tool in AgentLaunchTool.values) {
+    if (tool.discoveredSessionToolName == normalizedToolName) {
+      return tool;
+    }
+  }
+  return null;
+}
 
 String _truncateSessionIdValue(String id) {
   if (id.length <= 12) return id;
@@ -1364,18 +1375,18 @@ class AgentSessionDiscoveryService {
   ///
   /// If the session has a [ToolSessionInfo.workingDirectory], the command
   /// `cd`s there first so the CLI finds its project context.
-  String buildResumeCommand(ToolSessionInfo info) {
-    final resume = switch (info.toolName) {
-      'Claude Code' => 'claude --resume ${_shellQuote(info.sessionId)}',
-      'Codex' => 'codex resume ${_shellQuote(info.sessionId)}',
-      'Copilot CLI' => 'copilot --resume ${_shellQuote(info.sessionId)}',
-      'Gemini CLI' => 'gemini --resume ${_shellQuote(info.sessionId)}',
-      'OpenCode' =>
-        info.sessionId == '_continue'
-            ? 'opencode --continue'
-            : 'opencode --session ${_shellQuote(info.sessionId)}',
-      _ => info.toolName.toLowerCase(),
-    };
+  String buildResumeCommand(
+    ToolSessionInfo info, {
+    bool startInYoloMode = false,
+  }) {
+    final tool = _agentLaunchToolForSessionToolName(info.toolName);
+    final resume = tool == null
+        ? info.toolName.toLowerCase()
+        : buildAgentResumeCommand(
+            tool,
+            info.sessionId,
+            startInYoloMode: startInYoloMode,
+          );
 
     final dir = info.workingDirectory;
     if (dir != null && dir.isNotEmpty) {

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2949,9 +2949,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         oldWidget.preferredSessionName != widget.preferredSessionName;
     final tmuxExtraFlagsChanged =
         oldWidget.tmuxExtraFlags != widget.tmuxExtraFlags;
-    if (connectionChanged) {
-      unawaited(_loadHostAgentPreferences());
-    }
+    unawaited(_loadHostAgentPreferences());
     if (connectionChanged || preferredSessionChanged || tmuxExtraFlagsChanged) {
       _tmuxQueryGeneration++;
       _tmuxRetryTimer?.cancel();
@@ -3132,6 +3130,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       await _retryTmuxQuery(retries, expectedGeneration: queryGeneration);
       return;
     }
+    unawaited(_loadHostAgentPreferences(session.hostId));
 
     final tmux = ref.read(tmuxServiceProvider);
     final preferredSessionName = widget.preferredSessionName?.trim();
@@ -3552,9 +3551,9 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     );
   }
 
-  void _resumeSession(ToolSessionInfo info) {
+  Future<void> _resumeSession(ToolSessionInfo info) async {
     if (!_hasAgentSessionAccess) {
-      unawaited(_handleLockedAiSessionsTap());
+      await _handleLockedAiSessionsTap();
       return;
     }
     final session = ref
@@ -3562,13 +3561,18 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         .getSession(widget.connectionId);
     if (session == null || _sessionName == null) return;
 
+    final cliLaunchPreferences = await ref
+        .read(hostCliLaunchPreferencesServiceProvider)
+        .getPreferencesForHost(session.hostId);
+    if (!mounted) return;
+
     final discovery = ref.read(agentSessionDiscoveryServiceProvider);
     final command = discovery.buildResumeCommand(
       info,
-      startInYoloMode: _startClisInYoloMode,
+      startInYoloMode: cliLaunchPreferences.startInYoloMode,
     );
-    final tmux = ref.read(tmuxServiceProvider);
-    tmux
+    await ref
+        .read(tmuxServiceProvider)
         .createWindow(
           session,
           _sessionName!,
@@ -3576,9 +3580,10 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
           name: info.toolName,
           workingDirectory: info.workingDirectory,
           extraFlags: widget.tmuxExtraFlags,
-        )
-        .then((_) => widget.onTap())
-        .ignore();
+        );
+    if (mounted) {
+      widget.onTap();
+    }
   }
 
   Future<void> _showSessionPickerForTool(
@@ -3605,7 +3610,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
           ),
     );
     if (!mounted || selected == null) return;
-    _resumeSession(selected);
+    _runTmuxPreviewAction(_resumeSession(selected));
   }
 
   Widget _buildSessionProviderRow(

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -21,6 +21,7 @@ import '../../domain/services/agent_launch_preset_service.dart';
 import '../../domain/services/agent_session_discovery_service.dart';
 import '../../domain/services/auth_service.dart';
 import '../../domain/services/home_screen_shortcut_service.dart';
+import '../../domain/services/host_cli_launch_preferences_service.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/secure_transfer_service.dart';
 import '../../domain/services/settings_service.dart';
@@ -2918,6 +2919,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   List<TmuxWindow>? _windows;
   String? _preferredSessionToolName;
   String? _sessionName;
+  bool _startClisInYoloMode = false;
   bool _queried = false;
   bool _expanded = false;
   bool _showSessions = false;
@@ -2935,7 +2937,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   @override
   void initState() {
     super.initState();
-    unawaited(_loadPreferredSessionToolName());
+    unawaited(_loadHostAgentPreferences());
     _queryTmux();
   }
 
@@ -2948,7 +2950,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     final tmuxExtraFlagsChanged =
         oldWidget.tmuxExtraFlags != widget.tmuxExtraFlags;
     if (connectionChanged) {
-      unawaited(_loadPreferredSessionToolName());
+      unawaited(_loadHostAgentPreferences());
     }
     if (connectionChanged || preferredSessionChanged || tmuxExtraFlagsChanged) {
       _tmuxQueryGeneration++;
@@ -2982,7 +2984,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     super.dispose();
   }
 
-  Future<void> _loadPreferredSessionToolName([int? hostId]) async {
+  Future<void> _loadHostAgentPreferences([int? hostId]) async {
     final resolvedHostId =
         hostId ??
         ref
@@ -2994,12 +2996,22 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     final preset = await ref
         .read(agentLaunchPresetServiceProvider)
         .getPresetForHost(resolvedHostId);
+    final cliLaunchPreferences = await ref
+        .read(hostCliLaunchPreferencesServiceProvider)
+        .getPreferencesForHost(resolvedHostId);
     if (!mounted) return;
 
     final preferredToolName = preset?.tool.discoveredSessionToolName;
-    if (_preferredSessionToolName == preferredToolName) return;
-    setState(() => _preferredSessionToolName = preferredToolName);
-    if (_showSessions) {
+    final startClisInYoloMode = cliLaunchPreferences.startInYoloMode;
+    final preferredToolChanged = _preferredSessionToolName != preferredToolName;
+    if (!preferredToolChanged && _startClisInYoloMode == startClisInYoloMode) {
+      return;
+    }
+    setState(() {
+      _preferredSessionToolName = preferredToolName;
+      _startClisInYoloMode = startClisInYoloMode;
+    });
+    if (_showSessions && preferredToolChanged) {
       unawaited(_prefetchPreferredSessionProvider());
     }
   }
@@ -3551,7 +3563,10 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     if (session == null || _sessionName == null) return;
 
     final discovery = ref.read(agentSessionDiscoveryServiceProvider);
-    final command = discovery.buildResumeCommand(info);
+    final command = discovery.buildResumeCommand(
+      info,
+      startInYoloMode: _startClisInYoloMode,
+    );
     final tmux = ref.read(tmuxServiceProvider);
     tmux
         .createWindow(

--- a/lib/presentation/widgets/tmux_expandable_bar.dart
+++ b/lib/presentation/widgets/tmux_expandable_bar.dart
@@ -588,7 +588,10 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
 
   void _resumeSession(ToolSessionInfo info) {
     final discovery = widget.ref.read(agentSessionDiscoveryServiceProvider);
-    final command = discovery.buildResumeCommand(info);
+    final command = discovery.buildResumeCommand(
+      info,
+      startInYoloMode: widget.startClisInYoloMode,
+    );
     final wasExpanded = _expanded;
     setState(() => _expanded = false);
     if (wasExpanded) {

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -469,7 +469,10 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
   }
 
   void _resumeSession(ToolSessionInfo info) {
-    final command = _discovery.buildResumeCommand(info);
+    final command = _discovery.buildResumeCommand(
+      info,
+      startInYoloMode: widget.startClisInYoloMode,
+    );
     Navigator.pop(
       context,
       TmuxResumeSessionAction(command, workingDirectory: info.workingDirectory),

--- a/test/domain/models/agent_launch_preset_test.dart
+++ b/test/domain/models/agent_launch_preset_test.dart
@@ -35,6 +35,62 @@ void main() {
     });
   });
 
+  group('buildAgentResumeCommand', () {
+    test('adds yolo flags for supported resume commands', () {
+      expect(
+        buildAgentResumeCommand(
+          AgentLaunchTool.claudeCode,
+          'claude-session',
+          startInYoloMode: true,
+        ),
+        "claude --dangerously-skip-permissions --resume 'claude-session'",
+      );
+      expect(
+        buildAgentResumeCommand(
+          AgentLaunchTool.copilotCli,
+          'copilot-session',
+          startInYoloMode: true,
+        ),
+        "copilot --yolo --resume 'copilot-session'",
+      );
+      expect(
+        buildAgentResumeCommand(
+          AgentLaunchTool.codex,
+          'codex-session',
+          startInYoloMode: true,
+        ),
+        "codex --yolo resume 'codex-session'",
+      );
+      expect(
+        buildAgentResumeCommand(
+          AgentLaunchTool.geminiCli,
+          'gemini-session',
+          startInYoloMode: true,
+        ),
+        "gemini --yolo --resume 'gemini-session'",
+      );
+      expect(
+        buildAgentResumeCommand(
+          AgentLaunchTool.openCode,
+          'opencode-session',
+          startInYoloMode: true,
+        ),
+        r"""OPENCODE_PERMISSION="{\"*\":\"allow\"}" opencode --session 'opencode-session'""",
+      );
+    });
+
+    test('preserves OpenCode continue resume command in yolo mode', () {
+      expect(
+        buildAgentResumeCommand(
+          AgentLaunchTool.openCode,
+          '_continue',
+          startInYoloMode: true,
+        ),
+        r'OPENCODE_PERMISSION="{\"*\":\"allow\"}" opencode --continue',
+      );
+    });
+  });
+
   group('agentLaunchToolForCommandText', () {
     test('detects tools in wrapped shell commands', () {
       expect(

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -510,6 +510,23 @@ branch refs/heads/fix/session-resumption
         "codex resume '019dcbf6-c80e-7c30-b7fa-3d352bda8c4d'",
       );
     });
+
+    test('adds yolo mode when resuming supported sessions', () {
+      const info = ToolSessionInfo(
+        toolName: 'Codex',
+        sessionId: '019dcbf6-c80e-7c30-b7fa-3d352bda8c4d',
+        workingDirectory: '/Users/depoll/Code/flutty',
+      );
+
+      expect(
+        AgentSessionDiscoveryService().buildResumeCommand(
+          info,
+          startInYoloMode: true,
+        ),
+        "cd '/Users/depoll/Code/flutty' && "
+        "codex --yolo resume '019dcbf6-c80e-7c30-b7fa-3d352bda8c4d'",
+      );
+    });
   });
 
   group('compareDiscoveredSessionsByRecency', () {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -21,6 +21,7 @@ import 'package:monkeyssh/domain/models/monetization.dart';
 import 'package:monkeyssh/domain/models/terminal_themes.dart' as monkey_themes;
 import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/domain/services/agent_launch_preset_service.dart';
+import 'package:monkeyssh/domain/services/agent_session_discovery_service.dart';
 import 'package:monkeyssh/domain/services/host_cli_launch_preferences_service.dart';
 import 'package:monkeyssh/domain/services/local_notification_service.dart';
 import 'package:monkeyssh/domain/services/monetization_service.dart';
@@ -50,6 +51,9 @@ class _MockTmuxService extends Mock implements TmuxService {
   @override
   bool isExecChannelCoolingDown(SshSession session) => false;
 }
+
+class _MockAgentSessionDiscoveryService extends Mock
+    implements AgentSessionDiscoveryService {}
 
 class _FakeWakelockPlusPlatform extends WakelockPlusPlatformInterface {
   final toggleCalls = <bool>[];
@@ -1231,8 +1235,10 @@ void main() {
 
     Future<void> pumpTmuxScreen(
       WidgetTester tester,
-      _MockTmuxService tmuxService,
-    ) async {
+      _MockTmuxService tmuxService, {
+      SettingsService? settingsServiceOverride,
+      AgentSessionDiscoveryService? agentSessionDiscoveryServiceOverride,
+    }) async {
       const tmuxSessionName = 'work';
       const windows = <TmuxWindow>[
         TmuxWindow(index: 0, name: 'shell', isActive: true),
@@ -1277,6 +1283,14 @@ void main() {
               () => _TestActiveSessionsNotifier(session),
             ),
             tmuxServiceProvider.overrideWithValue(tmuxService),
+            if (settingsServiceOverride != null)
+              settingsServiceProvider.overrideWithValue(
+                settingsServiceOverride,
+              ),
+            if (agentSessionDiscoveryServiceOverride != null)
+              agentSessionDiscoveryServiceProvider.overrideWithValue(
+                agentSessionDiscoveryServiceOverride,
+              ),
           ],
           child: MaterialApp(
             home: TerminalScreen(
@@ -2286,6 +2300,108 @@ void main() {
 
         expect(dismissRegion, findsNothing);
         expect(tester.widget<PopScope<Object?>>(popScope).canPop, isTrue);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'tmux bar passes host yolo mode when resuming an AI session',
+      (tester) async {
+        final tmuxService = _MockTmuxService();
+        final discoveryService = _MockAgentSessionDiscoveryService();
+        final settingsService = SettingsService(db);
+        final cliLaunchPreferencesService = HostCliLaunchPreferencesService(
+          settingsService,
+        );
+        const codexSession = ToolSessionInfo(
+          toolName: 'Codex',
+          sessionId: 'codex-session',
+          workingDirectory: '/home/demo/project',
+          summary: 'Resume codex work',
+        );
+
+        await cliLaunchPreferencesService.setPreferencesForHost(
+          host.id,
+          const HostCliLaunchPreferences(startInYoloMode: true),
+        );
+        when(
+          () => tmuxService.createWindow(
+            session,
+            'work',
+            command: any(named: 'command'),
+            name: any(named: 'name'),
+            workingDirectory: any(named: 'workingDirectory'),
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => tmuxService.hasForegroundClientOrThrow(
+            session,
+            'work',
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async => true);
+        when(
+          () => discoveryService.discoverSessionsStream(
+            session,
+            workingDirectory: any(named: 'workingDirectory'),
+            maxPerTool: any(named: 'maxPerTool'),
+            toolName: any(named: 'toolName'),
+          ),
+        ).thenAnswer((invocation) {
+          final toolName = invocation.namedArguments[#toolName] as String?;
+          return Stream<DiscoveredSessionsResult>.value(
+            DiscoveredSessionsResult(
+              sessions: toolName == 'Codex'
+                  ? const <ToolSessionInfo>[codexSession]
+                  : const <ToolSessionInfo>[],
+              attemptedTools: toolName == null ? const <String>[] : [toolName],
+            ),
+          );
+        });
+        when(
+          () => discoveryService.buildResumeCommand(
+            codexSession,
+            startInYoloMode: true,
+          ),
+        ).thenReturn("codex --yolo resume 'codex-session'");
+
+        await pumpTmuxScreen(
+          tester,
+          tmuxService,
+          settingsServiceOverride: settingsService,
+          agentSessionDiscoveryServiceOverride: discoveryService,
+        );
+
+        await tester.tap(find.byKey(const ValueKey('tmux-handle-bar')));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+        await tester.ensureVisible(find.text('AI Sessions'));
+        await tester.tap(find.text('AI Sessions'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.ensureVisible(find.text('Codex'));
+        await tester.tap(find.text('Codex'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.tap(find.text('Resume codex work'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        verify(
+          () => discoveryService.buildResumeCommand(
+            codexSession,
+            startInYoloMode: true,
+          ),
+        ).called(1);
+        verify(
+          () => tmuxService.createWindow(
+            session,
+            'work',
+            command: "codex --yolo resume 'codex-session'",
+            workingDirectory: '/home/demo/project',
+          ),
+        ).called(1);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -12,8 +12,14 @@ import 'package:mocktail/mocktail.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/snippet_repository.dart';
+import 'package:monkeyssh/domain/models/host_cli_launch_preferences.dart';
+import 'package:monkeyssh/domain/models/monetization.dart';
 import 'package:monkeyssh/domain/models/tmux_state.dart';
+import 'package:monkeyssh/domain/services/agent_session_discovery_service.dart';
 import 'package:monkeyssh/domain/services/home_screen_shortcut_service.dart';
+import 'package:monkeyssh/domain/services/host_cli_launch_preferences_service.dart';
+import 'package:monkeyssh/domain/services/monetization_service.dart';
+import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/domain/services/tmux_service.dart';
 import 'package:monkeyssh/domain/services/transfer_intent_service.dart';
@@ -28,6 +34,11 @@ class _MockSnippetRepository extends Mock implements SnippetRepository {}
 class _MockSshClient extends Mock implements SSHClient {}
 
 class _MockTmuxService extends Mock implements TmuxService {}
+
+class _MockAgentSessionDiscoveryService extends Mock
+    implements AgentSessionDiscoveryService {}
+
+class _MockMonetizationService extends Mock implements MonetizationService {}
 
 class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
   @override
@@ -205,9 +216,18 @@ ActiveConnection _buildActiveConnection({
   ),
 );
 
+const _proMonetizationState = MonetizationState(
+  billingAvailability: MonetizationBillingAvailability.available,
+  entitlements: MonetizationEntitlements.pro(),
+  offers: [],
+  debugUnlockAvailable: false,
+  debugUnlocked: false,
+);
+
 void main() {
   setUpAll(() {
     registerFallbackValue(<int>[]);
+    registerFallbackValue(MonetizationFeature.agentLaunchPresets);
   });
 
   Widget buildMobileHomeScreen({
@@ -694,6 +714,168 @@ void main() {
       () => tmuxService.listWindows(session, 'work', extraFlags: newFlags),
     ).called(1);
   });
+
+  testWidgets(
+    'home tmux badge uses latest host yolo preference when resuming a session',
+    (tester) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final settingsService = SettingsService(db);
+      final cliLaunchPreferencesService = HostCliLaunchPreferencesService(
+        settingsService,
+      );
+      final tmuxService = _MockTmuxService();
+      final discoveryService = _MockAgentSessionDiscoveryService();
+      final monetizationService = _MockMonetizationService();
+      final sshClient = _MockSshClient();
+
+      final host = _buildHost(
+        id: 1,
+        label: 'Alpha',
+        sortOrder: 0,
+        tmuxSessionName: 'work',
+      );
+      final session = SshSession(
+        connectionId: 7,
+        hostId: host.id,
+        client: sshClient,
+        config: const SshConnectionConfig(
+          hostname: 'alpha.example.com',
+          port: 22,
+          username: 'root',
+        ),
+      );
+      final sessionsNotifier = _MutableActiveSessionsNotifier(
+        initialConnections: [
+          _buildActiveConnection(connectionId: 7, hostId: host.id),
+        ],
+        initialSessions: [session],
+      );
+      const codexSession = ToolSessionInfo(
+        toolName: 'Codex',
+        sessionId: 'codex-session',
+        workingDirectory: '/home/demo/project',
+        summary: 'Resume codex work',
+      );
+
+      when(
+        () => monetizationService.currentState,
+      ).thenReturn(_proMonetizationState);
+      when(
+        () => monetizationService.states,
+      ).thenAnswer((_) => Stream.value(_proMonetizationState));
+      when(
+        monetizationService.initialize,
+      ).thenAnswer((_) => Future<void>.value());
+      when(
+        () => monetizationService.canUseFeature(any()),
+      ).thenAnswer((_) async => true);
+      when(
+        () => tmuxService.watchWindowChanges(session, 'work'),
+      ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+      when(() => tmuxService.listWindows(session, 'work')).thenAnswer(
+        (_) async => const <TmuxWindow>[
+          TmuxWindow(index: 0, name: 'shell', isActive: true),
+        ],
+      );
+      when(
+        () => tmuxService.createWindow(
+          session,
+          'work',
+          command: any(named: 'command'),
+          name: any(named: 'name'),
+          workingDirectory: any(named: 'workingDirectory'),
+          extraFlags: any(named: 'extraFlags'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => discoveryService.discoverSessionsStream(
+          session,
+          workingDirectory: any(named: 'workingDirectory'),
+          maxPerTool: any(named: 'maxPerTool'),
+          toolName: any(named: 'toolName'),
+        ),
+      ).thenAnswer((invocation) {
+        final toolName = invocation.namedArguments[#toolName] as String?;
+        return Stream<DiscoveredSessionsResult>.value(
+          DiscoveredSessionsResult(
+            sessions: toolName == 'Codex'
+                ? const <ToolSessionInfo>[codexSession]
+                : const <ToolSessionInfo>[],
+            attemptedTools: toolName == null ? const <String>[] : [toolName],
+          ),
+        );
+      });
+      when(
+        () => discoveryService.buildResumeCommand(
+          codexSession,
+          startInYoloMode: true,
+        ),
+      ).thenReturn("codex --yolo resume 'codex-session'");
+
+      await tester.pumpWidget(
+        buildMobileHomeScreen(
+          db: db,
+          overrides: [
+            settingsServiceProvider.overrideWithValue(settingsService),
+            monetizationServiceProvider.overrideWithValue(monetizationService),
+            monetizationStateProvider.overrideWith(
+              (ref) => Stream.value(_proMonetizationState),
+            ),
+            activeSessionsProvider.overrideWith(() => sessionsNotifier),
+            allHostsProvider.overrideWith((ref) => Stream.value([host])),
+            tmuxServiceProvider.overrideWithValue(tmuxService),
+            agentSessionDiscoveryServiceProvider.overrideWithValue(
+              discoveryService,
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.tap(find.text('Connections').first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('work · 1 windows'), findsOneWidget);
+
+      await cliLaunchPreferencesService.setPreferencesForHost(
+        host.id,
+        const HostCliLaunchPreferences(startInYoloMode: true),
+      );
+
+      await tester.tap(find.text('work · 1 windows'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.tap(find.text('AI Sessions'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.tap(find.text('Codex'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.tap(find.text('Resume codex work'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      verify(
+        () => discoveryService.buildResumeCommand(
+          codexSession,
+          startInYoloMode: true,
+        ),
+      ).called(1);
+      verify(
+        () => tmuxService.createWindow(
+          session,
+          'work',
+          command: "codex --yolo resume 'codex-session'",
+          name: 'Codex',
+          workingDirectory: '/home/demo/project',
+          extraFlags: null,
+        ),
+      ).called(1);
+    },
+  );
 
   testWidgets('returns to Hosts when the last active connection disappears', (
     tester,

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -287,6 +287,104 @@ void main() {
       ).called(5);
     });
 
+    testWidgets('passes host yolo mode when resuming an AI session', (
+      tester,
+    ) async {
+      final tmuxService = _MockTmuxService();
+      final presetService = _MockAgentLaunchPresetService();
+      final discoveryService = _MockAgentSessionDiscoveryService();
+      final session = SshSession(
+        connectionId: 1,
+        hostId: 1,
+        client: _MockSshClient(),
+        config: const SshConnectionConfig(
+          hostname: 'example.com',
+          port: 22,
+          username: 'demo',
+        ),
+      );
+      const tmuxSessionName = 'main';
+      const codexSession = ToolSessionInfo(
+        toolName: 'Codex',
+        sessionId: 'codex-session',
+        workingDirectory: '/home/demo/project',
+        summary: 'Resume codex work',
+      );
+      TmuxNavigatorAction? selectedAction;
+
+      when(
+        () => presetService.getPresetForHost(session.hostId),
+      ).thenAnswer((_) async => null);
+      when(
+        () => tmuxService.detectInstalledAgentTools(session),
+      ).thenAnswer((_) async => const <AgentLaunchTool>{});
+      when(
+        () => tmuxService.watchWindowChanges(session, tmuxSessionName),
+      ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+      when(
+        () => tmuxService.listWindows(session, tmuxSessionName),
+      ).thenAnswer((_) async => windows);
+      when(
+        () => discoveryService.discoverSessionsStream(
+          session,
+          workingDirectory: any(named: 'workingDirectory'),
+          maxPerTool: any(named: 'maxPerTool'),
+          toolName: any(named: 'toolName'),
+        ),
+      ).thenAnswer((invocation) {
+        final toolName = invocation.namedArguments[#toolName] as String?;
+        return Stream<DiscoveredSessionsResult>.value(
+          DiscoveredSessionsResult(
+            sessions: toolName == 'Codex'
+                ? const <ToolSessionInfo>[codexSession]
+                : const <ToolSessionInfo>[],
+            attemptedTools: toolName == null ? const <String>[] : [toolName],
+          ),
+        );
+      });
+      when(
+        () => discoveryService.buildResumeCommand(
+          codexSession,
+          startInYoloMode: true,
+        ),
+      ).thenReturn("codex --yolo resume 'codex-session'");
+
+      await _pumpNavigatorHost(
+        tester,
+        tmuxService: tmuxService,
+        presetService: presetService,
+        discoveryService: discoveryService,
+        session: session,
+        tmuxSessionName: tmuxSessionName,
+        startClisInYoloMode: true,
+        onActionSelected: (action) => selectedAction = action,
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(find.text('Recent AI Sessions'));
+      await tester.pump();
+      await tester.tap(find.text('Recent AI Sessions'));
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(find.text('Codex'));
+      await tester.pump();
+      await tester.tap(find.text('Codex'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Resume codex work'));
+      await tester.pumpAndSettle();
+
+      expect(selectedAction, isA<TmuxResumeSessionAction>());
+      final resumeAction = selectedAction! as TmuxResumeSessionAction;
+      expect(resumeAction.resumeCommand, "codex --yolo resume 'codex-session'");
+      expect(resumeAction.workingDirectory, '/home/demo/project');
+      verify(
+        () => discoveryService.buildResumeCommand(
+          codexSession,
+          startInYoloMode: true,
+        ),
+      ).called(1);
+    });
+
     testWidgets('recovers from a transient empty window reload', (
       tester,
     ) async {
@@ -433,6 +531,8 @@ Future<void> _pumpNavigatorHost(
   required AgentSessionDiscoveryService discoveryService,
   required SshSession session,
   required String tmuxSessionName,
+  bool startClisInYoloMode = false,
+  ValueChanged<TmuxNavigatorAction?>? onActionSelected,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
@@ -455,8 +555,8 @@ Future<void> _pumpNavigatorHost(
                     session: session,
                     tmuxSessionName: tmuxSessionName,
                     isProUser: true,
-                    startClisInYoloMode: false,
-                  ),
+                    startClisInYoloMode: startClisInYoloMode,
+                  ).then((action) => onActionSelected?.call(action)),
                 );
               },
               child: const Text('Open'),


### PR DESCRIPTION
## Summary

- Pass the host YOLO preference into tmux recent-session resume commands.
- Centralize resume command construction so Claude, Copilot, Codex, Gemini, and OpenCode all get the right YOLO flags/env.
- Load host CLI preferences for the home tmux connection badge before resuming sessions there.

## Testing

- `flutter analyze`
- `flutter test test/domain/models/agent_launch_preset_test.dart test/domain/services/agent_session_discovery_service_test.dart test/widget/tmux_window_navigator_test.dart`
