### PR TITLE
fix: clean up tmux control-mode watchers on disconnect

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -118,8 +118,8 @@ class TmuxService {
   static bool hasExecChannelBackoffEntry(int connectionId) =>
       _execChannelBackoffs.containsKey(connectionId);
 
-  /// Clears the cached tmux path for a connection.
-  void clearCache(int connectionId) {
+  /// Clears tmux caches and disposes active watchers for a connection.
+  Future<void> clearCache(int connectionId) {
     DiagnosticsLogService.instance.info(
       'tmux.cache',
       'clear',
@@ -148,9 +148,14 @@ class TmuxService {
     final observerKeys = _windowObservers.keys
         .where((key) => key.connectionId == connectionId)
         .toList(growable: false);
+    final observerDisposals = <Future<void>>[];
     for (final key in observerKeys) {
-      unawaited(_windowObservers.remove(key)?.dispose());
+      final observer = _windowObservers.remove(key);
+      if (observer != null) {
+        observerDisposals.add(observer.dispose());
+      }
     }
+    return Future.wait(observerDisposals).then((_) {});
   }
 
   // ── Detection ──────────────────────────────────────────────────────────
@@ -2292,9 +2297,16 @@ const _tmuxWindowSubscriptionFormat =
     '#{@flutty_agent_tool}$tmuxWindowFieldSeparator'
     '#{window_id}';
 
-const _tmuxControlModeClientFlags = 'ignore-size,no-output,wait-exit';
+const _tmuxControlModeClientFlags = 'ignore-size,no-output';
+const _tmuxControlModeDetachInput = 'detach-client -P\n\n';
+const _tmuxControlModeWaitExitInput = '\n';
+const _tmuxControlModeShutdownTimeout = Duration(seconds: 1);
 
 /// Builds the tmux control-mode attach command used for live window updates.
+///
+/// Intentionally omits tmux's `wait-exit` client flag. On an unexpected SSH
+/// disconnect there is no client left to send the empty line `wait-exit`
+/// requires, so the remote control-mode client can linger indefinitely.
 @visibleForTesting
 String buildTmuxControlModeAttachCommand(
   String sessionName, {
@@ -2566,8 +2578,14 @@ class _TmuxWindowChangeObserver {
   final DateTime Function() _now;
   final StreamController<TmuxWindowChangeEvent> _controller;
 
+  // Cancelled in _cleanupControlSession().
+  // ignore: cancel_subscriptions
   StreamSubscription<String>? _stdoutSubscription;
+  // Cancelled in _cleanupControlSession().
+  // ignore: cancel_subscriptions
   StreamSubscription<String>? _stderrSubscription;
+  // Cancelled in _cleanupControlSession().
+  // ignore: cancel_subscriptions
   StreamSubscription<void>? _doneSubscription;
   Timer? _debounceTimer;
   Timer? _restartTimer;
@@ -2760,7 +2778,7 @@ class _TmuxWindowChangeObserver {
         'control_exit',
         fields: {'connectionId': session.connectionId},
       );
-      _handleControlClosed();
+      _handleControlClosed(shutdownInput: _tmuxControlModeWaitExitInput);
       return;
     }
     final event = parseTmuxWindowChangeEventFromControlLine(
@@ -2959,23 +2977,32 @@ class _TmuxWindowChangeObserver {
         'errorType': error.runtimeType,
       },
     );
-    _cleanupControlSession(error, stackTrace);
+    unawaited(
+      _cleanupControlSession(
+        commandError: error,
+        stackTrace: stackTrace,
+        shutdownInput: _tmuxControlModeDetachInput,
+      ),
+    );
     _scheduleRestart(
       channelOpenFailure: shouldBackOffTmuxExecChannelAfterFailure(error),
     );
   }
 
-  void _handleControlClosed() {
+  void _handleControlClosed({String? shutdownInput}) {
     DiagnosticsLogService.instance.info(
       'tmux.watch',
       'control_closed',
       fields: {'connectionId': session.connectionId},
     );
-    _cleanupControlSession(
-      const TmuxCommandException(
-        'tmux control channel closed before command completed',
+    unawaited(
+      _cleanupControlSession(
+        commandError: const TmuxCommandException(
+          'tmux control channel closed before command completed',
+        ),
+        stackTrace: StackTrace.current,
+        shutdownInput: shutdownInput,
       ),
-      StackTrace.current,
     );
     _scheduleRestart();
   }
@@ -3044,22 +3071,60 @@ class _TmuxWindowChangeObserver {
     }
   }
 
-  void _cleanupControlSession([Object? commandError, StackTrace? stackTrace]) {
+  Future<void> _cleanupControlSession({
+    Object? commandError,
+    StackTrace? stackTrace,
+    String? shutdownInput,
+  }) {
     _stopHeartbeat();
     _cancelScheduledReload();
     _failControlCommands(
       commandError ?? const _TmuxControlCommandUnavailable(),
       stackTrace ?? StackTrace.current,
     );
-    unawaited(_stdoutSubscription?.cancel());
-    unawaited(_stderrSubscription?.cancel());
-    unawaited(_doneSubscription?.cancel());
+    final stdoutSubscription = _stdoutSubscription;
+    final stderrSubscription = _stderrSubscription;
+    final doneSubscription = _doneSubscription;
     _stdoutSubscription = null;
     _stderrSubscription = null;
     _doneSubscription = null;
-    _controlSession?.close();
+    final controlSession = _controlSession;
     _controlSession = null;
     _lastControlActivity = null;
+    return Future.wait([
+      if (stdoutSubscription != null) stdoutSubscription.cancel(),
+      if (stderrSubscription != null) stderrSubscription.cancel(),
+      if (doneSubscription != null) doneSubscription.cancel(),
+      if (controlSession != null)
+        _shutdownControlSession(controlSession, shutdownInput: shutdownInput),
+    ]).then((_) {});
+  }
+
+  Future<void> _shutdownControlSession(
+    SSHSession controlSession, {
+    String? shutdownInput,
+  }) async {
+    try {
+      if (shutdownInput != null) {
+        try {
+          controlSession.write(utf8.encode(shutdownInput));
+          await controlSession.stdin.close().timeout(
+            _tmuxControlModeShutdownTimeout,
+          );
+        } on Object catch (error) {
+          DiagnosticsLogService.instance.warning(
+            'tmux.watch',
+            'shutdown_input_failed',
+            fields: {
+              'connectionId': session.connectionId,
+              'errorType': error.runtimeType,
+            },
+          );
+        }
+      }
+    } finally {
+      controlSession.close();
+    }
   }
 
   Future<void> dispose() async {
@@ -3073,7 +3138,7 @@ class _TmuxWindowChangeObserver {
     _stopHeartbeat();
     _restartTimer?.cancel();
     _restartTimer = null;
-    _cleanupControlSession();
+    await _cleanupControlSession(shutdownInput: _tmuxControlModeDetachInput);
     if (!_controller.isClosed) {
       await _controller.close();
     }

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -119,7 +119,7 @@ class TmuxService {
       _execChannelBackoffs.containsKey(connectionId);
 
   /// Clears tmux caches and disposes active watchers for a connection.
-  Future<void> clearCache(int connectionId) {
+  Future<void> clearCache(int connectionId) async {
     DiagnosticsLogService.instance.info(
       'tmux.cache',
       'clear',
@@ -132,12 +132,12 @@ class TmuxService {
     );
     _tmuxPathCache.remove(connectionId);
     _profileSourceCache.remove(connectionId);
-    _tmuxPathRequests.remove(connectionId);
+    _tmuxPathRequests.remove(connectionId)?.ignore();
     _hasSessionRequests.removeWhere(
       (key, _) => key.connectionId == connectionId,
     );
     _installedAgentToolsCache.remove(connectionId);
-    _installedAgentToolRequests.remove(connectionId);
+    _installedAgentToolRequests.remove(connectionId)?.ignore();
     _execChannelBackoffs.remove(connectionId);
     _windowSnapshotCache.removeWhere(
       (key, _) => key.connectionId == connectionId,
@@ -155,7 +155,9 @@ class TmuxService {
         observerDisposals.add(observer.dispose());
       }
     }
-    return Future.wait(observerDisposals).then((_) {});
+    if (observerDisposals.isNotEmpty) {
+      await Future.wait(observerDisposals);
+    }
   }
 
   // ── Detection ──────────────────────────────────────────────────────────
@@ -2299,7 +2301,7 @@ const _tmuxWindowSubscriptionFormat =
 
 const _tmuxControlModeClientFlags = 'ignore-size,no-output';
 const _tmuxControlModeDetachInput = 'detach-client -P\n\n';
-const _tmuxControlModeWaitExitInput = '\n';
+const _tmuxControlModeExitAcknowledgeInput = '\n';
 const _tmuxControlModeShutdownTimeout = Duration(seconds: 1);
 
 /// Builds the tmux control-mode attach command used for live window updates.
@@ -2591,9 +2593,10 @@ class _TmuxWindowChangeObserver {
   Timer? _restartTimer;
   Timer? _heartbeatTimer;
   SSHSession? _controlSession;
+  Future<void>? _startFuture;
+  Future<void>? _disposeFuture;
   final _controlCommandQueue = Queue<_TmuxControlCommandRequest>();
   _TmuxControlCommandRequest? _activeControlCommand;
-  bool _starting = false;
   bool _disposed = false;
   bool _preserveScheduledReloadThroughSnapshots = false;
   int _restartAttempts = 0;
@@ -2675,9 +2678,25 @@ class _TmuxWindowChangeObserver {
     }
   }
 
-  Future<void> _ensureStarted() async {
-    if (_disposed || _starting || _controlSession != null) return;
-    _starting = true;
+  Future<void> _ensureStarted() {
+    if (_disposed || _controlSession != null) return Future<void>.value();
+    final existingStart = _startFuture;
+    if (existingStart != null) {
+      return existingStart;
+    }
+    final startFuture = _startControlSession();
+    _startFuture = startFuture;
+    unawaited(
+      startFuture.whenComplete(() {
+        if (identical(_startFuture, startFuture)) {
+          _startFuture = null;
+        }
+      }),
+    );
+    return startFuture;
+  }
+
+  Future<void> _startControlSession() async {
     DiagnosticsLogService.instance.info(
       'tmux.watch',
       'start',
@@ -2688,6 +2707,9 @@ class _TmuxWindowChangeObserver {
     );
     try {
       await service._cacheTmuxPath(session);
+      if (_disposed) {
+        return;
+      }
       final execSession = await service._openExec(
         session,
         service._wrapCommand(
@@ -2703,7 +2725,10 @@ class _TmuxWindowChangeObserver {
         pty: const SSHPtyConfig(),
       );
       if (_disposed) {
-        execSession.close();
+        await _shutdownControlSession(
+          execSession,
+          shutdownInput: _tmuxControlModeDetachInput,
+        );
         return;
       }
 
@@ -2733,8 +2758,6 @@ class _TmuxWindowChangeObserver {
       );
     } on Object catch (error, stackTrace) {
       _handleControlFailure(error, stackTrace);
-    } finally {
-      _starting = false;
     }
   }
 
@@ -2778,7 +2801,7 @@ class _TmuxWindowChangeObserver {
         'control_exit',
         fields: {'connectionId': session.connectionId},
       );
-      _handleControlClosed(shutdownInput: _tmuxControlModeWaitExitInput);
+      _handleControlClosed(shutdownInput: _tmuxControlModeExitAcknowledgeInput);
       return;
     }
     final event = parseTmuxWindowChangeEventFromControlLine(
@@ -3127,7 +3150,9 @@ class _TmuxWindowChangeObserver {
     }
   }
 
-  Future<void> dispose() async {
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
     if (_disposed) return;
     DiagnosticsLogService.instance.info(
       'tmux.watch',
@@ -3138,6 +3163,10 @@ class _TmuxWindowChangeObserver {
     _stopHeartbeat();
     _restartTimer?.cancel();
     _restartTimer = null;
+    final startFuture = _startFuture;
+    if (startFuture != null) {
+      await startFuture;
+    }
     await _cleanupControlSession(shutdownInput: _tmuxControlModeDetachInput);
     if (!_controller.isClosed) {
       await _controller.close();

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -891,7 +891,7 @@ enum _HostContextAction {
 }
 
 Future<void> _disconnectConnection(WidgetRef ref, int connectionId) async {
-  ref.read(tmuxServiceProvider).clearCache(connectionId);
+  await ref.read(tmuxServiceProvider).clearCache(connectionId);
   await ref.read(activeSessionsProvider.notifier).disconnect(connectionId);
 }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2424,6 +2424,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   // Cache the notifier for use in dispose
   ActiveSessionsNotifier? _sessionsNotifier;
+  late final TmuxService _tmuxService;
 
   // Track whether the app is in the background so we can auto-reconnect
   // when it resumes if the OS killed the socket.
@@ -2579,6 +2580,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         'hasInitialTmuxWindow': widget.initialTmuxWindowIndex != null,
       },
     );
+    _tmuxService = ref.read(tmuxServiceProvider);
     _pendingInitialTmuxWindowTarget = _buildInitialTmuxWindowTarget(widget);
     WidgetsBinding.instance.addObserver(this);
     _sharedClipboardSubscription = ref.listenManual<bool>(
@@ -5793,7 +5795,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (!mounted) {
       if (connectionId != null) {
         unawaited(
-          _sessionsNotifier?.handleUnexpectedDisconnect(
+          _cleanupUnexpectedDisconnect(
             connectionId,
             message: 'Connection closed',
           ),
@@ -5817,14 +5819,24 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
     // Clean up the session state regardless of background/foreground.
     if (connectionId != null) {
-      ref.read(tmuxServiceProvider).clearCache(connectionId);
       unawaited(
-        _sessionsNotifier?.handleUnexpectedDisconnect(
+        _cleanupUnexpectedDisconnect(
           connectionId,
           message: 'Connection closed',
         ),
       );
     }
+  }
+
+  Future<void> _cleanupUnexpectedDisconnect(
+    int connectionId, {
+    required String message,
+  }) async {
+    await _tmuxService.clearCache(connectionId);
+    await _sessionsNotifier?.handleUnexpectedDisconnect(
+      connectionId,
+      message: message,
+    );
   }
 
   Future<void> _disconnect() async {
@@ -5836,7 +5848,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _doneSubscription = null;
     _shell = null;
     if (connectionId != null) {
-      ref.read(tmuxServiceProvider).clearCache(connectionId);
+      await _tmuxService.clearCache(connectionId);
       await _sessionsNotifier?.disconnect(connectionId);
     }
     if (mounted) {
@@ -5870,7 +5882,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _doneSubscription = null;
       _shell = null;
       if (previousConnectionId != null) {
-        ref.read(tmuxServiceProvider).clearCache(previousConnectionId);
+        await _tmuxService.clearCache(previousConnectionId);
         await _sessionsNotifier?.disconnect(previousConnectionId);
       }
       if (!mounted) {

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -1126,6 +1126,133 @@ void main() {
       },
     );
 
+    test(
+      'clearCache waits for disposal that subscription cancel started',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client, connectionId: 74);
+        const service = TmuxService();
+        final stdoutController = StreamController<Uint8List>();
+        final stdinCloseCompleter = Completer<void>();
+        final controlSession = _buildInteractiveExecSession(
+          stdoutController: stdoutController,
+          stdinClose: stdinCloseCompleter.future,
+          onWrite: (value) {
+            if (value.startsWith('refresh-client ')) {
+              scheduleMicrotask(
+                () => stdoutController.add(
+                  _utf8Bytes('%begin 1 1 0\n%end 1 1 0\n'),
+                ),
+              );
+            }
+          },
+        );
+        final execSessions = Queue<SSHSession>.from([
+          _buildOpenExecSession(stdout: 'zsh\n/usr/bin/tmux\n${_doneMarker()}'),
+          controlSession,
+        ]);
+
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => execSessions.removeFirst());
+
+        final subscription = service
+            .watchWindowChanges(session, 'main')
+            .listen((_) {});
+        addTearDown(() async {
+          if (!stdinCloseCompleter.isCompleted) {
+            stdinCloseCompleter.complete();
+          }
+          await subscription.cancel();
+          await stdoutController.close();
+        });
+        await untilCalled(() => controlSession.write(any()));
+
+        await subscription.cancel();
+        await Future<void>.delayed(Duration.zero);
+
+        var clearCacheCompleted = false;
+        final clearCacheFuture = service.clearCache(74).then((_) {
+          clearCacheCompleted = true;
+        });
+        await Future<void>.delayed(Duration.zero);
+
+        expect(clearCacheCompleted, isFalse);
+
+        stdinCloseCompleter.complete();
+        await clearCacheFuture;
+
+        expect(clearCacheCompleted, isTrue);
+        verify(controlSession.close).called(1);
+      },
+    );
+
+    test(
+      'clearCache waits for a starting watcher and detaches it after open',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client, connectionId: 75);
+        const service = TmuxService();
+        final stdoutController = StreamController<Uint8List>.broadcast();
+        final controlOpenCompleter = Completer<SSHSession>();
+        final writes = <String>[];
+        final controlSession = _buildInteractiveExecSession(
+          stdoutController: stdoutController,
+          onWrite: writes.add,
+        );
+        var executeCalls = 0;
+
+        when(() => client.execute(any(), pty: any(named: 'pty'))).thenAnswer((
+          invocation,
+        ) {
+          executeCalls += 1;
+          final command = invocation.positionalArguments.single as String;
+          if (command.contains('command -v tmux')) {
+            return Future.value(
+              _buildOpenExecSession(
+                stdout: 'zsh\n/usr/bin/tmux\n${_doneMarker()}',
+              ),
+            );
+          }
+          expect(command, contains('attach-session'));
+          return controlOpenCompleter.future;
+        });
+
+        final subscription = service
+            .watchWindowChanges(session, 'main')
+            .listen((_) {});
+        addTearDown(() async {
+          if (!controlOpenCompleter.isCompleted) {
+            controlOpenCompleter.complete(controlSession);
+          }
+          await subscription.cancel();
+          await stdoutController.close();
+        });
+        await untilCalled(
+          () => client.execute(
+            any(that: contains('attach-session')),
+            pty: any(named: 'pty'),
+          ),
+        );
+
+        var clearCacheCompleted = false;
+        final clearCacheFuture = service.clearCache(75).then((_) {
+          clearCacheCompleted = true;
+        });
+        await Future<void>.delayed(Duration.zero);
+
+        expect(clearCacheCompleted, isFalse);
+
+        controlOpenCompleter.complete(controlSession);
+        await clearCacheFuture;
+
+        expect(clearCacheCompleted, isTrue);
+        expect(writes, contains('detach-client -P\n\n'));
+        expect(executeCalls, 2);
+        verify(controlSession.close).called(1);
+      },
+    );
+
     test('selectWindow uses an active control-mode watcher', () async {
       final client = _MockSshClient();
       final session = _buildSession(client, connectionId: 70);
@@ -1897,11 +2024,12 @@ SSHSession _buildInteractiveExecSession({
   void Function(String)? onWrite,
   String stderr = '',
   Future<void>? done,
+  Future<void>? stdinClose,
 }) {
   final session = _MockExecSession();
   final doneFuture = done ?? Completer<void>().future;
   final stdinSink = _MockByteSink();
-  when(stdinSink.close).thenAnswer((_) async {});
+  when(stdinSink.close).thenAnswer((_) => stdinClose ?? Future<void>.value());
   when(() => session.stdout).thenAnswer((_) => stdoutController.stream);
   when(() => session.stderr).thenAnswer((_) => _openUtf8Stream(stderr));
   when(() => session.done).thenAnswer((_) => doneFuture);

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -19,17 +19,14 @@ void main() {
   });
 
   group('control mode command builders', () {
-    test(
-      'attach command starts tmux in control mode with safe client flags',
-      () {
-        expect(
-          buildTmuxControlModeAttachCommand('dev\'s session'),
-          'tmux -CC attach-session -f '
-          'ignore-size,no-output,wait-exit '
-          "-t 'dev'\"'\"'s session'",
-        );
-      },
-    );
+    test('attach command starts tmux in control mode without wait-exit', () {
+      expect(
+        buildTmuxControlModeAttachCommand('dev\'s session'),
+        'tmux -CC attach-session -f '
+        'ignore-size,no-output '
+        "-t 'dev'\"'\"'s session'",
+      );
+    });
 
     test(
       'attach command includes reusable tmux client flags when provided',
@@ -40,7 +37,7 @@ void main() {
             extraFlags: '-x 160 -S /tmp/tmux-socket -n editor',
           ),
           "tmux -S '/tmp/tmux-socket' -CC attach-session -f "
-          'ignore-size,no-output,wait-exit '
+          'ignore-size,no-output '
           "-t 'main'",
         );
       },
@@ -1053,7 +1050,7 @@ void main() {
             .listen((_) {});
         addTearDown(() async {
           await subscription.cancel();
-          service.clearCache(1);
+          await service.clearCache(1);
           await stdoutController.close();
         });
         await untilCalled(
@@ -1076,10 +1073,56 @@ void main() {
           command,
           contains(
             "/usr/bin/tmux -u -S '/tmp/socket' -CC attach-session -f "
-            'ignore-size,no-output,wait-exit ',
+            'ignore-size,no-output ',
           ),
         );
         expect(command, isNot(contains('set status off')));
+      },
+    );
+
+    test(
+      'clearCache detaches an active control-mode watcher before closing it',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client, connectionId: 73);
+        const service = TmuxService();
+        final stdoutController = StreamController<Uint8List>();
+        final writes = <String>[];
+        final controlSession = _buildInteractiveExecSession(
+          stdoutController: stdoutController,
+          onWrite: (value) {
+            writes.add(value);
+            if (value.startsWith('refresh-client ')) {
+              scheduleMicrotask(
+                () => stdoutController.add(
+                  _utf8Bytes('%begin 1 1 0\n%end 1 1 0\n'),
+                ),
+              );
+            }
+          },
+        );
+        final execSessions = Queue<SSHSession>.from([
+          _buildOpenExecSession(stdout: 'zsh\n/usr/bin/tmux\n${_doneMarker()}'),
+          controlSession,
+        ]);
+
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => execSessions.removeFirst());
+
+        final subscription = service
+            .watchWindowChanges(session, 'main')
+            .listen((_) {});
+        addTearDown(() async {
+          await subscription.cancel();
+          await stdoutController.close();
+        });
+        await untilCalled(() => controlSession.write(any()));
+
+        await service.clearCache(73);
+
+        expect(writes, contains('detach-client -P\n\n'));
+        verify(controlSession.close).called(1);
       },
     );
 
@@ -1275,7 +1318,7 @@ void main() {
             .watchWindowChanges(session, 'main')
             .listen((_) {});
         addTearDown(() async {
-          service.clearCache(72);
+          await service.clearCache(72);
           await subscription.cancel();
           await stdoutController.close();
         });
@@ -1642,7 +1685,7 @@ void main() {
         expect(TmuxService.hasInstalledAgentToolsCacheEntry(60), isTrue);
 
         // Clear and verify the cache entry is gone.
-        service.clearCache(60);
+        await service.clearCache(60);
         expect(TmuxService.hasInstalledAgentToolsCacheEntry(60), isFalse);
 
         // A subsequent call must re-probe via SSH rather than serve stale data.
@@ -1676,7 +1719,7 @@ void main() {
         expect(TmuxService.hasTmuxPathCacheEntry(61), isTrue);
 
         // Clear and verify the cache entry is gone.
-        service.clearCache(61);
+        await service.clearCache(61);
         expect(TmuxService.hasTmuxPathCacheEntry(61), isFalse);
 
         // A subsequent call must re-probe the tmux binary path.
@@ -1723,7 +1766,7 @@ void main() {
         expect(TmuxService.hasWindowSnapshotCacheEntry(62), isTrue);
 
         // After clearCache the snapshot is gone.
-        service.clearCache(62);
+        await service.clearCache(62);
         expect(TmuxService.hasWindowSnapshotCacheEntry(62), isFalse);
       },
     );
@@ -1747,7 +1790,7 @@ void main() {
         expect(TmuxService.hasExecChannelBackoffEntry(63), isTrue);
 
         // clearCache must remove the backoff so the next open is attempted.
-        service.clearCache(63);
+        await service.clearCache(63);
         expect(TmuxService.hasExecChannelBackoffEntry(63), isFalse);
       },
     );
@@ -1775,12 +1818,12 @@ void main() {
         expect(TmuxService.hasInstalledAgentToolsCacheEntry(65), isTrue);
 
         // Clearing A must not affect B.
-        service.clearCache(64);
+        await service.clearCache(64);
         expect(TmuxService.hasInstalledAgentToolsCacheEntry(64), isFalse);
         expect(TmuxService.hasInstalledAgentToolsCacheEntry(65), isTrue);
 
         // Clean up B.
-        service.clearCache(65);
+        await service.clearCache(65);
       },
     );
   });
@@ -1801,6 +1844,8 @@ SshSession _buildSession(SSHClient client, {int connectionId = 1}) =>
 class _MockSshClient extends Mock implements SSHClient {}
 
 class _MockExecSession extends Mock implements SSHSession {}
+
+class _MockByteSink extends Mock implements StreamSink<Uint8List> {}
 
 const _execDoneMarker = '__flutty_tmux_exec_done__';
 
@@ -1855,9 +1900,12 @@ SSHSession _buildInteractiveExecSession({
 }) {
   final session = _MockExecSession();
   final doneFuture = done ?? Completer<void>().future;
+  final stdinSink = _MockByteSink();
+  when(stdinSink.close).thenAnswer((_) async {});
   when(() => session.stdout).thenAnswer((_) => stdoutController.stream);
   when(() => session.stderr).thenAnswer((_) => _openUtf8Stream(stderr));
   when(() => session.done).thenAnswer((_) => doneFuture);
+  when(() => session.stdin).thenAnswer((_) => stdinSink);
   when(session.close).thenAnswer(_ignoreInvocation);
   when(() => session.write(any())).thenAnswer((invocation) {
     final data = invocation.positionalArguments.single as List<int>;


### PR DESCRIPTION
## Summary

- stop using tmux control-mode `wait-exit` so unexpected SSH disconnects do not leave watcher clients waiting forever
- make tmux cache clearing await control watcher disposal and send `detach-client -P` plus EOF for graceful disconnects
- await tmux watcher cleanup from terminal/home disconnect paths and cover the behavior in tmux service tests

## Validation

- `flutter analyze --no-pub`
- `flutter test --no-pub test/domain/services/tmux_service_control_mode_test.dart`
- `flutter test --no-pub test/presentation/screens/terminal_screen_test.dart`
