### PR TITLE
fix: keep agent tool labels in title subtitles

### DIFF
--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -274,8 +274,7 @@ class TmuxWindow {
   String? get agentSessionDisplayTitle {
     final title = _normalizedTmuxTitle(agentSessionTitle);
     if (title == null || title.isEmpty) return null;
-    final tool = foregroundAgentTool;
-    return tool == null ? title : '${tool.label} · $title';
+    return title;
   }
 
   /// Agent-aware title, preferring live session metadata when available.
@@ -405,14 +404,20 @@ class TmuxWindow {
     final sessionDisplayTitle = agentSessionDisplayTitle;
     final sessionTitle = _normalizedTmuxTitle(agentSessionTitle);
     if (sessionDisplayTitle != null) {
-      final tmuxTitle = _tmuxDisplayTitle;
-      final fallbackAgentTitle = _agentFallbackContextTitle;
-      if (_titlesMatch(tmuxTitle, display) ||
-          _titlesMatch(tmuxTitle, sessionTitle) ||
-          _titlesMatch(tmuxTitle, fallbackAgentTitle)) {
-        return null;
+      final toolLabel = foregroundAgentTool?.label;
+      final tmuxTitle = _tmuxSecondaryTitleForAgentSession;
+      final secondaryParts = <String>[
+        if (toolLabel != null && !_titlesMatch(toolLabel, display)) toolLabel,
+        if (tmuxTitle != null &&
+            !_titlesMatch(tmuxTitle, display) &&
+            !_titlesMatch(tmuxTitle, sessionTitle) &&
+            !_titlesMatch(tmuxTitle, toolLabel))
+          tmuxTitle,
+      ];
+      if (secondaryParts.isNotEmpty) {
+        return secondaryParts.join(' · ');
       }
-      return tmuxTitle;
+      return null;
     }
     final normalizedPaneTitle = _normalizedTmuxTitle(
       paneTitle,
@@ -452,6 +457,23 @@ class TmuxWindow {
       return null;
     }
     return normalizedName;
+  }
+
+  String? get _tmuxSecondaryTitleForAgentSession {
+    final tmuxTitle = _tmuxDisplayTitle;
+    final fallbackAgentTitle = _agentFallbackContextTitle;
+    if (_titlesMatch(tmuxTitle, fallbackAgentTitle)) return null;
+
+    final foregroundTool = foregroundAgentTool;
+    if (foregroundTool != null &&
+        _isUnhelpfulAgentTitle(
+          tmuxTitle,
+          tool: foregroundTool,
+          contextLabel: _windowContextLabelFromPath(currentPath),
+        )) {
+      return null;
+    }
+    return tmuxTitle;
   }
 
   /// A human-readable status label for display.

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -318,9 +318,9 @@ void main() {
       );
 
       expect(window.agentSessionId, '12345678-1234-1234-1234-1234567890ab');
-      expect(window.displayTitle, 'Copilot CLI · Fix tmux session labels');
-      expect(window.handleTitle, 'Copilot CLI · Fix tmux session labels');
-      expect(window.secondaryTitle, isNull);
+      expect(window.displayTitle, 'Fix tmux session labels');
+      expect(window.handleTitle, 'Fix tmux session labels');
+      expect(window.secondaryTitle, 'Copilot CLI');
     });
 
     test('shows live session titles alongside useful window titles', () {
@@ -334,9 +334,9 @@ void main() {
         agentSessionTitle: 'Fix tmux session labels',
       );
 
-      expect(window.displayTitle, 'Copilot CLI · Fix tmux session labels');
-      expect(window.handleTitle, 'Copilot CLI · Fix tmux session labels');
-      expect(window.secondaryTitle, 'Editing main.dart');
+      expect(window.displayTitle, 'Fix tmux session labels');
+      expect(window.handleTitle, 'Fix tmux session labels');
+      expect(window.secondaryTitle, 'Copilot CLI · Editing main.dart');
     });
 
     test('copyWith can clear live agent session metadata', () {
@@ -366,15 +366,9 @@ void main() {
         agentSessionTitle: 'Improve Theme Picker Keyboard UX',
       );
 
-      expect(
-        window.displayTitle,
-        'Copilot CLI · Improve Theme Picker Keyboard UX',
-      );
-      expect(
-        window.handleTitle,
-        'Copilot CLI · Improve Theme Picker Keyboard UX',
-      );
-      expect(window.secondaryTitle, isNull);
+      expect(window.displayTitle, 'Improve Theme Picker Keyboard UX');
+      expect(window.handleTitle, 'Improve Theme Picker Keyboard UX');
+      expect(window.secondaryTitle, 'Copilot CLI');
     });
 
     test('handles empty command and path', () {

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -138,14 +138,14 @@ void main() {
 
       expect(
         resolveTmuxBarActiveWindowTitle(windows),
-        'Copilot CLI · Fix tmux session labels',
+        'Fix tmux session labels',
       );
       expect(
         resolveTmuxBarHandleLabel(
           'workspace',
           activeWindowTitle: resolveTmuxBarActiveWindowTitle(windows),
         ),
-        'workspace · Copilot CLI · Fix tmux session labels',
+        'workspace · Fix tmux session labels',
       );
     });
 


### PR DESCRIPTION
## Summary

- Keep live agent session titles as the primary tmux window title
- Move the agent tool label back into subtitle text
- Preserve distinct tmux/pane titles as additional subtitle context

## Validation

- flutter analyze --no-pub
- flutter test --no-pub test/domain/models/tmux_state_test.dart test/widget/terminal_screen_layout_test.dart test/widget/tmux_window_navigator_test.dart test/widget/home_screen_test.dart