### PR TITLE
Fix new tmux window session title refreshes

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -94,6 +94,11 @@ class TmuxService {
       <int, SshSession>{};
   static final _activeAgentSessionMetadataDebouncedPanePids = <int, Set<int>>{};
   static final _activeAgentSessionMetadataDebouncedForced = <int, bool>{};
+  static final _activeAgentSessionMetadataCooldownTimers = <int, Timer>{};
+  static final _activeAgentSessionMetadataCooldownSessions =
+      <int, SshSession>{};
+  static final _activeAgentSessionMetadataCooldownPanePids = <int, Set<int>>{};
+  static final _activeAgentSessionMetadataCooldownForced = <int, bool>{};
   static final _activeAgentSessionMetadataPendingPanePids = <int, Set<int>>{};
   static final _activeAgentSessionMetadataPendingForced = <int, bool>{};
   static final _activeAgentSessionMetadataRefreshes = <int, DateTime>{};
@@ -166,6 +171,10 @@ class TmuxService {
     _activeAgentSessionMetadataDebouncedSessions.remove(connectionId);
     _activeAgentSessionMetadataDebouncedPanePids.remove(connectionId);
     _activeAgentSessionMetadataDebouncedForced.remove(connectionId);
+    _activeAgentSessionMetadataCooldownTimers.remove(connectionId)?.cancel();
+    _activeAgentSessionMetadataCooldownSessions.remove(connectionId);
+    _activeAgentSessionMetadataCooldownPanePids.remove(connectionId);
+    _activeAgentSessionMetadataCooldownForced.remove(connectionId);
     _activeAgentSessionMetadataPendingPanePids.remove(connectionId);
     _activeAgentSessionMetadataPendingForced.remove(connectionId);
     _activeAgentSessionMetadataRefreshes.remove(connectionId);
@@ -920,6 +929,17 @@ class TmuxService {
       return;
     }
 
+    final execCooldown = _execChannelCooldownRemaining(session);
+    if (execCooldown != null) {
+      _deferAgentSessionMetadataRefreshForExecCooldown(
+        session,
+        copilotPanePids,
+        force: force,
+        cooldown: execCooldown,
+      );
+      return;
+    }
+
     DiagnosticsLogService.instance.debug(
       'tmux.agent',
       'active_session_metadata_start',
@@ -939,6 +959,7 @@ class TmuxService {
           session,
           requestToken,
           copilotPanePids,
+          force: force,
         ).whenComplete(() {
           if (identical(
             _activeAgentSessionMetadataRequests[connectionId],
@@ -968,8 +989,9 @@ class TmuxService {
   Future<void> _refreshActiveAgentSessionMetadata(
     SshSession session,
     Object requestToken,
-    Set<int> panePids,
-  ) async {
+    Set<int> panePids, {
+    required bool force,
+  }) async {
     final connectionId = session.connectionId;
     try {
       final output = await _exec(
@@ -1017,7 +1039,73 @@ class TmuxService {
         'active_session_metadata_failed',
         fields: {'connectionId': connectionId, 'errorType': error.runtimeType},
       );
+      final execCooldown = shouldBackOffTmuxExecChannelAfterFailure(error)
+          ? _execChannelCooldownRemaining(session)
+          : null;
+      if (execCooldown != null) {
+        _deferAgentSessionMetadataRefreshForExecCooldown(
+          session,
+          panePids,
+          force: force,
+          cooldown: execCooldown,
+        );
+      }
     }
+  }
+
+  void _deferAgentSessionMetadataRefreshForExecCooldown(
+    SshSession session,
+    Set<int> panePids, {
+    required bool force,
+    required Duration cooldown,
+  }) {
+    final connectionId = session.connectionId;
+    final pendingPanePids =
+        (_activeAgentSessionMetadataCooldownPanePids[connectionId] ?? <int>{})
+          ..addAll(panePids);
+    _activeAgentSessionMetadataCooldownPanePids[connectionId] = pendingPanePids;
+    _activeAgentSessionMetadataCooldownSessions[connectionId] = session;
+    _activeAgentSessionMetadataCooldownForced[connectionId] =
+        (_activeAgentSessionMetadataCooldownForced[connectionId] ?? false) ||
+        force;
+
+    if (_activeAgentSessionMetadataCooldownTimers.containsKey(connectionId)) {
+      return;
+    }
+
+    DiagnosticsLogService.instance.debug(
+      'tmux.agent',
+      'active_session_metadata_deferred',
+      fields: {
+        'connectionId': connectionId,
+        'paneCount': panePids.length,
+        'forced': force,
+        'delayMs': cooldown.inMilliseconds,
+      },
+    );
+    _activeAgentSessionMetadataCooldownTimers[connectionId] = Timer(
+      cooldown,
+      () {
+        _activeAgentSessionMetadataCooldownTimers.remove(connectionId);
+        final queuedPanePids = _activeAgentSessionMetadataCooldownPanePids
+            .remove(connectionId);
+        final queuedSession = _activeAgentSessionMetadataCooldownSessions
+            .remove(connectionId);
+        final queuedForced =
+            _activeAgentSessionMetadataCooldownForced.remove(connectionId) ??
+            false;
+        if (queuedPanePids == null ||
+            queuedPanePids.isEmpty ||
+            queuedSession == null) {
+          return;
+        }
+        _scheduleAgentSessionMetadataRefreshForPanePids(
+          queuedSession,
+          queuedPanePids,
+          force: queuedForced,
+        );
+      },
+    );
   }
 
   Set<int> _copilotPanePids(Iterable<TmuxWindow> windows) => windows
@@ -1496,15 +1584,19 @@ class TmuxService {
 
   // ── Helpers ────────────────────────────────────────────────────────────
 
-  bool _isExecChannelCoolingDown(SshSession session) {
+  Duration? _execChannelCooldownRemaining(SshSession session) {
     final backoff = _execChannelBackoffs[session.connectionId];
-    if (backoff == null) return false;
-    if (backoff.cooldownUntil.isAfter(DateTime.now())) {
-      return true;
+    if (backoff == null) return null;
+    final remaining = backoff.cooldownUntil.difference(DateTime.now());
+    if (remaining > Duration.zero) {
+      return remaining;
     }
     _execChannelBackoffs.remove(session.connectionId);
-    return false;
+    return null;
   }
+
+  bool _isExecChannelCoolingDown(SshSession session) =>
+      _execChannelCooldownRemaining(session) != null;
 
   /// Returns whether optional SSH exec-channel work should be deferred.
   bool isExecChannelCoolingDown(SshSession session) =>

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -575,6 +575,67 @@ void main() {
         await service.clearCache(session.connectionId);
       }
     });
+
+    test('Copilot metadata refreshes wait for exec channel backoff', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client, connectionId: 35);
+      const service = TmuxService(
+        agentSessionMetadataRefreshDebounce: Duration(milliseconds: 10),
+      );
+      var metadataAttempts = 0;
+
+      when(() => client.execute(any(), pty: any(named: 'pty'))).thenAnswer((
+        invocation,
+      ) async {
+        final command = invocation.positionalArguments.first as String;
+        if (command.contains('list-windows')) {
+          return _buildOpenExecSession(
+            stdout:
+                '${_tmuxWindowLine(id: '@42', panePid: 42)}\n${_doneMarker()}',
+          );
+        }
+        if (_isCopilotMetadataCommand(command)) {
+          metadataAttempts += 1;
+          if (metadataAttempts == 1) {
+            return Future<SSHSession>.error(
+              SSHChannelOpenError(2, 'open failed'),
+            );
+          }
+          return _buildOpenExecSession(stdout: _doneMarker());
+        }
+        return _buildOpenExecSession(stdout: _doneMarker());
+      });
+
+      try {
+        await service.listWindows(session, 'main');
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+
+        expect(metadataAttempts, 1);
+        expect(
+          TmuxService.hasExecChannelBackoffEntry(session.connectionId),
+          true,
+        );
+
+        await service.listWindows(session, 'main');
+        await Future<void>.delayed(const Duration(milliseconds: 500));
+
+        expect(
+          metadataAttempts,
+          1,
+          reason: 'metadata refreshes should not hammer SSH during backoff',
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 1800));
+
+        expect(metadataAttempts, 2);
+        expect(
+          TmuxService.hasExecChannelBackoffEntry(session.connectionId),
+          false,
+        );
+      } finally {
+        await service.clearCache(session.connectionId);
+      }
+    });
   });
 
   group('parseTmuxWindowChangeEventFromControlLine', () {


### PR DESCRIPTION
## Summary

- Defer Copilot/agent active-session metadata refreshes while SSH exec channels are in backoff.
- Coalesce pending pane PIDs during cooldown and retry once after the backoff expires.
- Add regression coverage for avoiding repeated metadata exec attempts during cooldown.

## Tests

- `flutter analyze --no-pub`
- `flutter test --no-pub test/domain/services/tmux_service_control_mode_test.dart test/domain/services/tmux_service_agent_detection_test.dart test/domain/models/tmux_state_test.dart`
