### PR TITLE
Fix terminal overflow menu keyboard overlap

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -207,6 +207,9 @@ double resolveTmuxBarMaxContentHeight(
 }
 
 const _tmuxBarRevealDuration = Duration(milliseconds: 300);
+const _terminalOverflowMenuScreenPadding = 8.0;
+const _terminalOverflowMenuMinWidth = 2.0 * 56.0;
+const _terminalOverflowMenuMaxWidth = 5.0 * 56.0;
 const _tmuxDetectionRetrySchedule = <Duration>[
   Duration.zero,
   Duration(milliseconds: 150),
@@ -219,6 +222,26 @@ const _tmuxDetectionRetrySchedule = <Duration>[
 @visibleForTesting
 List<Duration> resolveTmuxDetectionRetrySchedule({bool skipDelay = false}) =>
     skipDelay ? const <Duration>[Duration.zero] : _tmuxDetectionRetrySchedule;
+
+/// Resolves the terminal overflow menu height when the mobile keyboard is up.
+@visibleForTesting
+double? resolveTerminalOverflowMenuMaxHeight({
+  required MediaQueryData mediaQuery,
+  required bool isMobilePlatform,
+  double? anchorTop,
+}) {
+  final keyboardInset = mediaQuery.viewInsets.bottom;
+  if (!isMobilePlatform || keyboardInset <= 0) {
+    return null;
+  }
+
+  final visibleBottom = mediaQuery.size.height - keyboardInset;
+  final effectiveAnchorTop =
+      anchorTop ?? mediaQuery.padding.top + kToolbarHeight;
+  final maxHeight =
+      visibleBottom - effectiveAnchorTop - _terminalOverflowMenuScreenPadding;
+  return maxHeight > 0 ? maxHeight : null;
+}
 
 /// Returns whether tmux detection should keep the terminal's current tmux UI.
 ///
@@ -2431,6 +2454,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _wasBackgrounded = false;
   bool _connectionLostWhileBackgrounded = false;
   bool _restoreKeyboardAfterAppResume = false;
+  final GlobalKey _terminalOverflowMenuButtonKey = GlobalKey();
 
   bool get _isMobilePlatform =>
       defaultTargetPlatform == TargetPlatform.android ||
@@ -2461,6 +2485,49 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     isUsingAltBuffer: _isUsingAltBuffer,
     terminalReportsMouseWheel: _terminalReportsMouseWheel,
   );
+
+  BoxConstraints? _terminalOverflowMenuConstraints({
+    required BuildContext context,
+    required bool isMobilePlatform,
+  }) {
+    final mediaQuery = MediaQuery.of(context);
+    final anchorTop = _terminalOverflowMenuAnchorTop(context);
+    final maxHeight = resolveTerminalOverflowMenuMaxHeight(
+      mediaQuery: mediaQuery,
+      isMobilePlatform: isMobilePlatform,
+      anchorTop: anchorTop,
+    );
+    if (maxHeight == null) {
+      return null;
+    }
+
+    return BoxConstraints(
+      minWidth: _terminalOverflowMenuMinWidth,
+      maxWidth: _terminalOverflowMenuMaxWidth,
+      maxHeight: maxHeight,
+    );
+  }
+
+  double? _terminalOverflowMenuAnchorTop(BuildContext context) {
+    final anchorContext = _terminalOverflowMenuButtonKey.currentContext;
+    if (anchorContext == null) {
+      return null;
+    }
+    final anchorRenderObject = anchorContext.findRenderObject();
+    final overlayRenderObject = Navigator.of(
+      context,
+    ).overlay?.context.findRenderObject();
+    if (anchorRenderObject is! RenderBox ||
+        overlayRenderObject is! RenderBox ||
+        !anchorRenderObject.attached ||
+        !overlayRenderObject.attached) {
+      return null;
+    }
+
+    return anchorRenderObject
+        .localToGlobal(Offset.zero, ancestor: overlayRenderObject)
+        .dy;
+  }
 
   bool get _showsNativeSelectionOverlay => shouldShowNativeSelectionOverlay(
     isNativeSelectionMode: _isNativeSelectionMode,
@@ -6252,8 +6319,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                   : 'Show extra keys',
             ),
             PopupMenuButton<String>(
+              key: _terminalOverflowMenuButtonKey,
               onSelected: _handleMenuAction,
               requestFocus: terminalOverlayRouteRequestFocus(context),
+              constraints: _terminalOverflowMenuConstraints(
+                context: context,
+                isMobilePlatform: isMobile,
+              ),
               itemBuilder: (context) => [
                 const PopupMenuItem(
                   value: 'snippets',

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -297,6 +297,41 @@ void main() {
       expect(selectedText, isNull);
     });
 
+    test(
+      'limits mobile terminal overflow menu to the visible keyboard area',
+      () {
+        const mediaQuery = MediaQueryData(
+          size: Size(390, 844),
+          viewInsets: EdgeInsets.only(bottom: 320),
+        );
+
+        expect(
+          resolveTerminalOverflowMenuMaxHeight(
+            mediaQuery: mediaQuery,
+            isMobilePlatform: true,
+            anchorTop: 120,
+          ),
+          396,
+        );
+        expect(
+          resolveTerminalOverflowMenuMaxHeight(
+            mediaQuery: mediaQuery,
+            isMobilePlatform: false,
+            anchorTop: 120,
+          ),
+          isNull,
+        );
+        expect(
+          resolveTerminalOverflowMenuMaxHeight(
+            mediaQuery: const MediaQueryData(size: Size(390, 844)),
+            isMobilePlatform: true,
+            anchorTop: 120,
+          ),
+          isNull,
+        );
+      },
+    );
+
     test('adds create snippet action after copy in terminal menu', () {
       var didCreateSnippet = false;
 
@@ -2588,6 +2623,51 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('Snippets'), findsOneWidget);
+        expect(tester.testTextInput.isVisible, isTrue);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
+      'terminal overflow menu stays above the visible mobile keyboard',
+      (tester) async {
+        tester.view
+          ..physicalSize = const Size(390, 844)
+          ..devicePixelRatio = 1
+          ..viewInsets = const FakeViewPadding(bottom: 500);
+        addTearDown(() {
+          tester.view
+            ..resetPhysicalSize()
+            ..resetDevicePixelRatio()
+            ..resetViewInsets();
+        });
+
+        await pumpScreen(tester);
+        await tester.tap(find.byType(MonkeyTerminalView));
+        await tester.pump();
+
+        await tester.tap(find.byType(PopupMenuButton<String>));
+        await tester.pumpAndSettle();
+
+        const keyboardTop = 844 - 500;
+        final menuScrollable = find.ancestor(
+          of: find.text('Snippets'),
+          matching: find.byType(SingleChildScrollView),
+        );
+        expect(menuScrollable, findsOneWidget);
+        expect(
+          tester.getBottomLeft(menuScrollable).dy,
+          lessThanOrEqualTo(keyboardTop),
+        );
+
+        await tester.drag(menuScrollable, const Offset(0, -320));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Disconnect'), findsOneWidget);
+        expect(
+          tester.getBottomLeft(find.text('Disconnect')).dy,
+          lessThanOrEqualTo(keyboardTop),
+        );
         expect(tester.testTextInput.isVisible, isTrue);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),


### PR DESCRIPTION
## Summary

- Constrain the terminal overflow menu to the visible area above the mobile keyboard.
- Preserve mobile keyboard focus while making the menu scrollable instead of extending under the keyboard.
- Add widget coverage for the keyboard-overlap case and a helper test for menu height calculation.

## Tests

- `flutter analyze`
- `flutter test test/presentation/screens/terminal_screen_test.dart --name 'terminal overflow menu|limits mobile terminal overflow menu'`
- `flutter test test/presentation/screens/terminal_screen_test.dart`
