### PR TITLE
fix: reduce tmux channel pressure for sftp

### DIFF
--- a/lib/domain/services/ssh_exec_queue.dart
+++ b/lib/domain/services/ssh_exec_queue.dart
@@ -5,8 +5,8 @@ import 'package:flutter/foundation.dart';
 
 import 'diagnostics_log_service.dart';
 
-const _maxExecJobsPerConnection = 4;
-const _maxLowPriorityExecJobsPerConnection = 3;
+const _maxExecJobsPerConnection = 2;
+const _maxLowPriorityExecJobsPerConnection = 1;
 
 final _execQueues = <int, _SshExecQueue>{};
 

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -2362,7 +2362,32 @@ class SshSession {
   }) => runQueuedSshExec(connectionId, operation, priority: priority);
 
   /// Start an SFTP session.
-  Future<SftpClient> sftp() => client.sftp();
+  Future<SftpClient> sftp() async {
+    DiagnosticsLogService.instance.info(
+      'ssh.sftp',
+      'open_start',
+      fields: {'connectionId': connectionId, 'hostId': hostId},
+    );
+    try {
+      final sftpClient = await client.sftp();
+      DiagnosticsLogService.instance.info(
+        'ssh.sftp',
+        'open_success',
+        fields: {'connectionId': connectionId},
+      );
+      return sftpClient;
+    } on Object catch (error) {
+      DiagnosticsLogService.instance.error(
+        'ssh.sftp',
+        'open_failed',
+        fields: {
+          'connectionId': connectionId,
+          ..._diagnosticSshExecErrorFields(error),
+        },
+      );
+      rethrow;
+    }
+  }
 
   /// Start a local port forward tunnel.
   ///

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -2379,7 +2379,7 @@ class SshSession {
       DiagnosticsLogService.instance.info(
         'ssh.sftp',
         'open_success',
-        fields: {'connectionId': connectionId},
+        fields: {'connectionId': connectionId, 'hostId': hostId},
       );
       return sftpClient;
     } on Object catch (error) {
@@ -2388,6 +2388,7 @@ class SshSession {
         'open_failed',
         fields: {
           'connectionId': connectionId,
+          'hostId': hostId,
           ..._diagnosticSshExecErrorFields(error),
         },
       );

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -154,6 +154,11 @@ class TmuxService {
   static bool hasExecChannelBackoffEntry(int connectionId) =>
       _execChannelBackoffs.containsKey(connectionId);
 
+  /// Returns the exec-channel failure count for [connectionId], if any.
+  @visibleForTesting
+  static int? execChannelBackoffFailureCountForTesting(int connectionId) =>
+      _execChannelBackoffs[connectionId]?.failureCount;
+
   /// Clears tmux caches and disposes active watchers for a connection.
   Future<void> clearCache(int connectionId) async {
     DiagnosticsLogService.instance.info(

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -36,6 +36,17 @@ class TmuxCommandException implements Exception {
   String toString() => message;
 }
 
+class _TmuxExecChannelCoolingDownException implements Exception {
+  _TmuxExecChannelCoolingDownException(this.cooldownUntil);
+
+  final DateTime cooldownUntil;
+
+  @override
+  String toString() =>
+      'Tmux exec channel is cooling down until '
+      '${cooldownUntil.toIso8601String()}';
+}
+
 /// Introspects and controls tmux sessions on remote hosts via SSH exec
 /// channels.
 ///
@@ -890,6 +901,20 @@ class TmuxService {
     bool force = false,
   }) {
     final connectionId = session.connectionId;
+    final cooldownUntil = _execChannelCooldownUntil(session);
+    if (cooldownUntil != null) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.agent',
+        'active_session_metadata_deferred',
+        fields: {
+          'connectionId': connectionId,
+          'paneCount': copilotPanePids.length,
+          'forced': force,
+          'remainingMs': _remainingExecChannelCooldownMs(cooldownUntil),
+        },
+      );
+      return;
+    }
     if (_activeAgentSessionMetadataRequests.containsKey(connectionId)) {
       final activePanePids =
           _activeAgentSessionMetadataRequestPanePids[connectionId] ??
@@ -1012,6 +1037,9 @@ class TmuxService {
         refreshedPanePids: panePids,
       );
     } on Object catch (error) {
+      if (shouldBackOffTmuxExecChannelAfterFailure(error)) {
+        _activeAgentSessionMetadataRefreshes[connectionId] = DateTime.now();
+      }
       DiagnosticsLogService.instance.debug(
         'tmux.agent',
         'active_session_metadata_failed',
@@ -1122,6 +1150,31 @@ class TmuxService {
     String sessionName, {
     String? extraFlags,
   }) async {
+    final cachedPath = _cachedCurrentPanePath(
+      session,
+      sessionName,
+      extraFlags: extraFlags,
+    );
+    if (cachedPath != null) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.query',
+        'current_pane_path_cached',
+        fields: {'connectionId': session.connectionId},
+      );
+      return cachedPath;
+    }
+    final cooldownUntil = _execChannelCooldownUntil(session);
+    if (cooldownUntil != null) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.query',
+        'current_pane_path_deferred',
+        fields: {
+          'connectionId': session.connectionId,
+          'remainingMs': _remainingExecChannelCooldownMs(cooldownUntil),
+        },
+      );
+      return null;
+    }
     DiagnosticsLogService.instance.debug(
       'tmux.query',
       'current_pane_path_start',
@@ -1153,6 +1206,23 @@ class TmuxService {
       );
       return null;
     }
+  }
+
+  String? _cachedCurrentPanePath(
+    SshSession session,
+    String sessionName, {
+    String? extraFlags,
+  }) {
+    final windows =
+        _windowSnapshotCache[_TmuxWindowWatchKey(
+          connectionId: session.connectionId,
+          sessionName: sessionName,
+          extraFlags: resolveTmuxClientFlagsFromExtraFlags(extraFlags),
+        )];
+    if (windows == null || windows.isEmpty) {
+      return null;
+    }
+    return windows.where((window) => window.isActive).firstOrNull?.currentPath;
   }
 
   /// Returns whether [sessionName] is attached in the primary SSH terminal.
@@ -1496,19 +1566,27 @@ class TmuxService {
 
   // ── Helpers ────────────────────────────────────────────────────────────
 
-  bool _isExecChannelCoolingDown(SshSession session) {
+  DateTime? _execChannelCooldownUntil(SshSession session) {
     final backoff = _execChannelBackoffs[session.connectionId];
-    if (backoff == null) return false;
+    if (backoff == null) return null;
     if (backoff.cooldownUntil.isAfter(DateTime.now())) {
-      return true;
+      return backoff.cooldownUntil;
     }
     _execChannelBackoffs.remove(session.connectionId);
-    return false;
+    return null;
   }
+
+  bool _isExecChannelCoolingDown(SshSession session) =>
+      _execChannelCooldownUntil(session) != null;
 
   /// Returns whether optional SSH exec-channel work should be deferred.
   bool isExecChannelCoolingDown(SshSession session) =>
       _isExecChannelCoolingDown(session);
+
+  int _remainingExecChannelCooldownMs(DateTime cooldownUntil) {
+    final remainingMs = cooldownUntil.difference(DateTime.now()).inMilliseconds;
+    return remainingMs < 0 ? 0 : remainingMs;
+  }
 
   void _recordExecChannelFailure(int connectionId, Object error) {
     final failureCount =
@@ -1628,6 +1706,20 @@ class TmuxService {
     String command, {
     SSHPtyConfig? pty,
   }) async {
+    final cooldownUntil = _execChannelCooldownUntil(session);
+    if (cooldownUntil != null) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.exec',
+        'open_deferred_during_backoff',
+        fields: {
+          'connectionId': session.connectionId,
+          'commandKind': _diagnosticTmuxCommandKind(command),
+          'remainingMs': _remainingExecChannelCooldownMs(cooldownUntil),
+          'pty': pty != null,
+        },
+      );
+      throw _TmuxExecChannelCoolingDownException(cooldownUntil);
+    }
     DiagnosticsLogService.instance.debug(
       'tmux.exec',
       'open_start',
@@ -2041,7 +2133,9 @@ class _TmuxExecChannelBackoff {
 /// Returns whether a failed tmux exec open should trigger channel backoff.
 @visibleForTesting
 bool shouldBackOffTmuxExecChannelAfterFailure(Object error) =>
-    error is SSHChannelOpenError || error is TimeoutException;
+    error is SSHChannelOpenError ||
+    error is TimeoutException ||
+    error is _TmuxExecChannelCoolingDownException;
 
 /// Returns whether stale tmux windows are safer than failing a refresh.
 @visibleForTesting

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -1050,9 +1050,14 @@ class TmuxService {
         'active_session_metadata_failed',
         fields: {'connectionId': connectionId, 'errorType': error.runtimeType},
       );
-      final execCooldown = shouldBackOffTmuxExecChannelAfterFailure(error)
-          ? _execChannelCooldownRemaining(session)
-          : null;
+      final Duration? execCooldown;
+      if (error is _TmuxExecChannelCoolingDownException) {
+        execCooldown = error.cooldownRemaining;
+      } else if (shouldBackOffTmuxExecChannelAfterFailure(error)) {
+        execCooldown = _execChannelCooldownRemaining(session);
+      } else {
+        execCooldown = null;
+      }
       if (execCooldown != null) {
         _deferAgentSessionMetadataRefreshForExecCooldown(
           session,
@@ -2197,17 +2202,19 @@ class _TmuxExecChannelBackoff {
   final DateTime cooldownUntil;
 }
 
-/// Returns whether a failed tmux exec open should trigger channel backoff.
+/// Returns whether a failed tmux exec open should create or extend backoff.
 @visibleForTesting
 bool shouldBackOffTmuxExecChannelAfterFailure(Object error) =>
-    error is SSHChannelOpenError ||
-    error is TimeoutException ||
+    error is SSHChannelOpenError || error is TimeoutException;
+
+bool _shouldTreatTmuxExecChannelAsUnavailable(Object error) =>
+    shouldBackOffTmuxExecChannelAfterFailure(error) ||
     error is _TmuxExecChannelCoolingDownException;
 
 /// Returns whether stale tmux windows are safer than failing a refresh.
 @visibleForTesting
 bool shouldUseCachedTmuxWindowsAfterListFailure(Object error) =>
-    shouldBackOffTmuxExecChannelAfterFailure(error);
+    _shouldTreatTmuxExecChannelAsUnavailable(error);
 
 /// Resolves the tmux exec channel cooldown after repeated open failures.
 @visibleForTesting
@@ -3564,7 +3571,7 @@ class _TmuxWindowChangeObserver {
       ),
     );
     _scheduleRestart(
-      channelOpenFailure: shouldBackOffTmuxExecChannelAfterFailure(error),
+      channelOpenFailure: _shouldTreatTmuxExecChannelAsUnavailable(error),
     );
   }
 

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -1240,24 +1240,24 @@ class TmuxService {
     SshExecPriority priority = SshExecPriority.normal,
     String? extraFlags,
   }) async {
-    final cachedPath = _cachedCurrentPanePath(
+    final cachedContext = _cachedCurrentPaneContext(
       session,
       sessionName,
       extraFlags: extraFlags,
     );
-    if (cachedPath != null) {
+    if (cachedContext != null) {
       DiagnosticsLogService.instance.debug(
         'tmux.query',
-        'current_pane_path_cached',
+        'current_pane_context_cached',
         fields: {'connectionId': session.connectionId},
       );
-      return cachedPath;
+      return cachedContext;
     }
     final execCooldown = _execChannelCooldownRemaining(session);
     if (execCooldown != null) {
       DiagnosticsLogService.instance.debug(
         'tmux.query',
-        'current_pane_path_deferred',
+        'current_pane_context_deferred',
         fields: {
           'connectionId': session.connectionId,
           'remainingMs': execCooldown.inMilliseconds,
@@ -1303,7 +1303,7 @@ class TmuxService {
     }
   }
 
-  String? _cachedCurrentPanePath(
+  TmuxPaneContext? _cachedCurrentPaneContext(
     SshSession session,
     String sessionName, {
     String? extraFlags,
@@ -1317,7 +1317,15 @@ class TmuxService {
     if (windows == null || windows.isEmpty) {
       return null;
     }
-    return windows.where((window) => window.isActive).firstOrNull?.currentPath;
+    final activeWindow = windows.where((window) => window.isActive).firstOrNull;
+    final currentPath = activeWindow?.currentPath;
+    if (currentPath == null) {
+      return null;
+    }
+    return TmuxPaneContext(
+      currentPath: currentPath,
+      currentCommand: activeWindow?.currentCommand,
+    );
   }
 
   /// Returns whether [sessionName] is attached in the primary SSH terminal.

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3344,6 +3344,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
 
     try {
+      final tmux = ref.read(tmuxServiceProvider);
       DiagnosticsLogService.instance.info(
         'terminal.theme',
         'tmux_refresh_start',
@@ -3354,24 +3355,33 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           'terminalViewReady': _terminalViewKey.currentState != null,
         },
       );
-      await ref
-          .read(tmuxServiceProvider)
-          .refreshTerminalTheme(
-            request.session,
-            request.sessionName,
-            request.theme,
-            extraFlags: request.extraFlags,
-          );
-      DiagnosticsLogService.instance.info(
-        'terminal.theme',
-        'tmux_refresh_complete',
-        fields: {
-          'reason': request.reason,
-          'connectionId': request.session.connectionId,
-          'shellReady': _shell != null,
-          'terminalViewReady': _terminalViewKey.currentState != null,
-        },
-      );
+      if (tmux.isExecChannelCoolingDown(request.session)) {
+        DiagnosticsLogService.instance.debug(
+          'terminal.theme',
+          'tmux_refresh_deferred',
+          fields: {
+            'reason': request.reason,
+            'connectionId': request.session.connectionId,
+          },
+        );
+      } else {
+        await tmux.refreshTerminalTheme(
+          request.session,
+          request.sessionName,
+          request.theme,
+          extraFlags: request.extraFlags,
+        );
+        DiagnosticsLogService.instance.info(
+          'terminal.theme',
+          'tmux_refresh_complete',
+          fields: {
+            'reason': request.reason,
+            'connectionId': request.session.connectionId,
+            'shellReady': _shell != null,
+            'terminalViewReady': _terminalViewKey.currentState != null,
+          },
+        );
+      }
     } on Object catch (error) {
       DiagnosticsLogService.instance.warning(
         'terminal.theme',
@@ -4711,12 +4721,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     _tmuxForegroundVerificationInFlight = true;
     try {
-      final foregroundSessionName = await ref
-          .read(tmuxServiceProvider)
-          .foregroundSessionNameOrThrow(
-            session,
-            extraFlags: _host?.tmuxExtraFlags,
-          );
+      final tmux = ref.read(tmuxServiceProvider);
+      if (tmux.isExecChannelCoolingDown(session)) {
+        DiagnosticsLogService.instance.debug(
+          'tmux.ui',
+          'foreground_verify_deferred',
+          fields: {'connectionId': session.connectionId},
+        );
+        return;
+      }
+      final foregroundSessionName = await tmux.foregroundSessionNameOrThrow(
+        session,
+        extraFlags: _host?.tmuxExtraFlags,
+      );
       if (!mounted ||
           generation != _tmuxForegroundVerificationGeneration ||
           _connectionId != session.connectionId ||

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3413,6 +3413,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
+    var outerRefreshReason = '${request.reason}_tmux_complete_outer';
     try {
       final tmux = ref.read(tmuxServiceProvider);
       DiagnosticsLogService.instance.info(
@@ -3434,6 +3435,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             'connectionId': request.session.connectionId,
           },
         );
+        outerRefreshReason = '${request.reason}_tmux_deferred_outer';
       } else {
         await tmux.refreshTerminalTheme(
           request.session,
@@ -3462,6 +3464,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           'errorType': error.runtimeType,
         },
       );
+      outerRefreshReason = '${request.reason}_tmux_failed_outer';
     }
 
     if (!_isCurrentTerminalThemeRefresh(
@@ -3474,7 +3477,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _refreshTerminalThemeReportsForTui(
       request.theme,
       includeColorReports: true,
-      reason: '${request.reason}_tmux_complete_outer',
+      reason: outerRefreshReason,
     );
     _scheduleTerminalThemeRefreshForTui(
       theme: request.theme,
@@ -3482,7 +3485,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       refreshGeneration: request.refreshGeneration,
       delay: const Duration(milliseconds: 25),
       includeColorReports: true,
-      reason: '${request.reason}_tmux_complete_outer_25ms',
+      reason: '${outerRefreshReason}_25ms',
     );
     _scheduleTerminalThemeRefreshForTui(
       theme: request.theme,
@@ -3490,7 +3493,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       refreshGeneration: request.refreshGeneration,
       delay: const Duration(milliseconds: 275),
       includeColorReports: true,
-      reason: '${request.reason}_tmux_complete_outer_275ms',
+      reason: '${outerRefreshReason}_275ms',
     );
   }
 

--- a/lib/presentation/widgets/tmux_expandable_bar.dart
+++ b/lib/presentation/widgets/tmux_expandable_bar.dart
@@ -260,21 +260,57 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     _windowReloadGeneration += 1;
     _resetWindowReloadRecovery();
     final windows = applyTmuxWindowChangeEvent(currentWindows, event);
+    final shouldNotifyWindowStateChanged =
+        _shouldRefreshTmuxThemeAfterWindowChange(currentWindows, windows);
     DiagnosticsLogService.instance.debug(
       'tmux.ui',
       'bar_snapshot_applied',
       fields: {
         'connectionId': widget.session.connectionId,
         'windowCount': windows.length,
+        'themeRefreshNeeded': shouldNotifyWindowStateChanged,
       },
     );
     _applyWindows(windows);
-    _notifyWindowStateChanged();
+    if (shouldNotifyWindowStateChanged) {
+      _notifyWindowStateChanged();
+    }
   }
 
   void _notifyWindowStateChanged() {
     widget.onWindowStateChanged?.call(widget.session, widget.tmuxSessionName);
   }
+
+  bool _shouldRefreshTmuxThemeAfterWindowChange(
+    List<TmuxWindow> previousWindows,
+    List<TmuxWindow> nextWindows,
+  ) {
+    final previousActiveWindow = previousWindows
+        .where((window) => window.isActive)
+        .firstOrNull;
+    final nextActiveWindow = nextWindows
+        .where((window) => window.isActive)
+        .firstOrNull;
+    if (previousActiveWindow == null || nextActiveWindow == null) {
+      return previousActiveWindow != nextActiveWindow;
+    }
+    if (_tmuxWindowRefreshIdentity(previousActiveWindow) !=
+        _tmuxWindowRefreshIdentity(nextActiveWindow)) {
+      return true;
+    }
+    return previousActiveWindow.panePid != nextActiveWindow.panePid ||
+        previousActiveWindow.foregroundAgentTool !=
+            nextActiveWindow.foregroundAgentTool ||
+        previousActiveWindow.currentCommand !=
+            nextActiveWindow.currentCommand ||
+        previousActiveWindow.paneTitle != nextActiveWindow.paneTitle ||
+        previousActiveWindow.name != nextActiveWindow.name ||
+        previousActiveWindow.paneStartCommand !=
+            nextActiveWindow.paneStartCommand;
+  }
+
+  Object _tmuxWindowRefreshIdentity(TmuxWindow window) =>
+      window.id ?? (index: window.index);
 
   void _applyWindows(List<TmuxWindow> windows) {
     // Detect new alerts that weren't in the previous window list.

--- a/test/domain/services/ssh_exec_queue_test.dart
+++ b/test/domain/services/ssh_exec_queue_test.dart
@@ -19,16 +19,16 @@ void main() {
 
     await pumpEventQueue();
 
-    expect(startedJobs, [0, 1, 2, 3]);
-    expect(activeQueuedSshExecCountForTesting(1), 4);
-    expect(pendingQueuedSshExecCountForTesting(1), 1);
+    expect(startedJobs, [0, 1]);
+    expect(activeQueuedSshExecCountForTesting(1), 2);
+    expect(pendingQueuedSshExecCountForTesting(1), 3);
 
     completers[0].complete(0);
     await pumpEventQueue();
 
-    expect(startedJobs, [0, 1, 2, 3, 4]);
-    expect(activeQueuedSshExecCountForTesting(1), 4);
-    expect(pendingQueuedSshExecCountForTesting(1), 0);
+    expect(startedJobs, [0, 1, 2]);
+    expect(activeQueuedSshExecCountForTesting(1), 2);
+    expect(pendingQueuedSshExecCountForTesting(1), 2);
 
     for (var index = 1; index < completers.length; index++) {
       completers[index].complete(index);
@@ -52,9 +52,9 @@ void main() {
 
     await pumpEventQueue();
 
-    expect(startedJobs, ['low-0', 'low-1', 'low-2']);
-    expect(activeQueuedSshExecCountForTesting(2), 3);
-    expect(pendingQueuedSshExecCountForTesting(2), 1);
+    expect(startedJobs, ['low-0']);
+    expect(activeQueuedSshExecCountForTesting(2), 1);
+    expect(pendingQueuedSshExecCountForTesting(2), 3);
 
     final normalFuture = runQueuedSshExec(2, () {
       startedJobs.add('normal');
@@ -63,19 +63,19 @@ void main() {
 
     await pumpEventQueue();
 
-    expect(startedJobs, ['low-0', 'low-1', 'low-2', 'normal']);
-    expect(activeQueuedSshExecCountForTesting(2), 4);
-    expect(pendingQueuedSshExecCountForTesting(2), 1);
+    expect(startedJobs, ['low-0', 'normal']);
+    expect(activeQueuedSshExecCountForTesting(2), 2);
+    expect(pendingQueuedSshExecCountForTesting(2), 3);
 
     normal.complete('normal');
     await pumpEventQueue();
 
-    expect(startedJobs, ['low-0', 'low-1', 'low-2', 'normal']);
+    expect(startedJobs, ['low-0', 'normal']);
 
     lows[0].complete('low-0');
     await pumpEventQueue();
 
-    expect(startedJobs, ['low-0', 'low-1', 'low-2', 'normal', 'low-3']);
+    expect(startedJobs, ['low-0', 'normal', 'low-1']);
 
     for (var index = 1; index < lows.length; index++) {
       lows[index].complete('low-$index');
@@ -105,9 +105,9 @@ void main() {
 
     await pumpEventQueue();
 
-    expect(startedJobs, ['low-0', 'low-1', 'low-2']);
-    expect(activeQueuedSshExecCountForTesting(3), 3);
-    expect(pendingQueuedSshExecCountForTesting(3), 1);
+    expect(startedJobs, ['low-0']);
+    expect(activeQueuedSshExecCountForTesting(3), 1);
+    expect(pendingQueuedSshExecCountForTesting(3), 3);
 
     final normalFuture = runQueuedSshExec(3, () {
       startedJobs.add('normal');
@@ -116,19 +116,19 @@ void main() {
 
     await pumpEventQueue();
 
-    expect(startedJobs, ['low-0', 'low-1', 'low-2', 'normal']);
-    expect(activeQueuedSshExecCountForTesting(3), 4);
-    expect(pendingQueuedSshExecCountForTesting(3), 1);
+    expect(startedJobs, ['low-0', 'normal']);
+    expect(activeQueuedSshExecCountForTesting(3), 2);
+    expect(pendingQueuedSshExecCountForTesting(3), 3);
 
     normal.complete('normal');
     await pumpEventQueue();
 
-    expect(startedJobs, ['low-0', 'low-1', 'low-2', 'normal']);
+    expect(startedJobs, ['low-0', 'normal']);
 
     lows[0].complete('low-0');
     await pumpEventQueue();
 
-    expect(startedJobs, ['low-0', 'low-1', 'low-2', 'normal', 'low-3']);
+    expect(startedJobs, ['low-0', 'normal', 'low-1']);
 
     for (var index = 1; index < lows.length; index++) {
       lows[index].complete('low-$index');

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -897,9 +897,9 @@ void main() {
 
       await pumpEventQueue();
 
-      expect(started, [0, 1, 2]);
-      expect(activeQueuedSshExecCountForTesting(9), 3);
-      expect(pendingQueuedSshExecCountForTesting(9), 0);
+      expect(started, [0, 1]);
+      expect(activeQueuedSshExecCountForTesting(9), 2);
+      expect(pendingQueuedSshExecCountForTesting(9), 1);
 
       for (var index = 0; index < completers.length; index++) {
         completers[index].complete(index);

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -596,8 +596,11 @@ void main() {
         await service.listWindows(session, 'main');
 
         final path = await service.currentPanePath(session, 'main');
+        final context = await service.currentPaneContext(session, 'main');
 
         expect(path, '/tmp/project');
+        expect(context?.currentPath, '/tmp/project');
+        expect(context?.currentCommand, 'copilot');
         expect(executeCalls, 1);
       } finally {
         await service.clearCache(37);

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -564,6 +564,12 @@ void main() {
           );
 
           expect(executeCalls, 1);
+          expect(TmuxService.hasExecChannelBackoffEntry(35), true);
+
+          await Future<void>.delayed(const Duration(milliseconds: 2200));
+
+          expect(service.isExecChannelCoolingDown(session), false);
+          expect(TmuxService.hasExecChannelBackoffEntry(35), false);
         } finally {
           await service.clearCache(35);
         }

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -529,6 +529,75 @@ void main() {
       },
     );
 
+    test(
+      'tmux exec opens are deferred while channel backoff is active',
+      () async {
+        final client = _MockSshClient();
+        final session = _buildSession(client, connectionId: 35);
+        const service = TmuxService();
+        var executeCalls = 0;
+
+        when(() => client.execute(any(), pty: any(named: 'pty'))).thenAnswer((
+          _,
+        ) async {
+          executeCalls += 1;
+          return Future<SSHSession>.error(
+            SSHChannelOpenError(2, 'open failed'),
+          );
+        });
+
+        try {
+          await expectLater(
+            service.listWindows(session, 'main'),
+            throwsA(isA<SSHChannelOpenError>()),
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          await expectLater(
+            service.listWindows(session, 'main'),
+            throwsA(
+              predicate<Object>(
+                (error) => error is! SSHChannelOpenError,
+                'does not open another SSH channel',
+              ),
+            ),
+          );
+
+          expect(executeCalls, 1);
+        } finally {
+          await service.clearCache(35);
+        }
+      },
+    );
+
+    test('currentPanePath reuses cached active window snapshots', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client, connectionId: 37);
+      const service = TmuxService();
+      var executeCalls = 0;
+
+      when(() => client.execute(any(), pty: any(named: 'pty'))).thenAnswer((
+        _,
+      ) async {
+        executeCalls += 1;
+        return _buildOpenExecSession(
+          stdout:
+              '${_tmuxWindowLine(id: '@77', panePid: 77)}\n${_doneMarker()}',
+        );
+      });
+
+      try {
+        await service.listWindows(session, 'main');
+
+        final path = await service.currentPanePath(session, 'main');
+
+        expect(path, '/tmp/project');
+        expect(executeCalls, 1);
+      } finally {
+        await service.clearCache(37);
+      }
+    });
+
     test('listWindows debounces Copilot metadata refresh bursts', () async {
       final client = _MockSshClient();
       final session = _buildSession(client, connectionId: 34);
@@ -879,17 +948,21 @@ void main() {
   group('tmux exec recovery', () {
     test('listWindows propagates exec channel open timeouts', () async {
       final client = _MockSshClient();
-      final session = _buildSession(client);
+      final session = _buildSession(client, connectionId: 36);
       const service = TmuxService(execOpenTimeout: Duration(milliseconds: 1));
 
       when(
         () => client.execute(any(), pty: any(named: 'pty')),
       ).thenAnswer((_) => Completer<SSHSession>().future);
 
-      await expectLater(
-        service.listWindows(session, 'main'),
-        throwsA(isA<TimeoutException>()),
-      );
+      try {
+        await expectLater(
+          service.listWindows(session, 'main'),
+          throwsA(isA<TimeoutException>()),
+        );
+      } finally {
+        await service.clearCache(36);
+      }
     });
 
     test(

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -565,11 +565,7 @@ void main() {
 
           expect(executeCalls, 1);
           expect(TmuxService.hasExecChannelBackoffEntry(35), true);
-
-          await Future<void>.delayed(const Duration(milliseconds: 2200));
-
-          expect(service.isExecChannelCoolingDown(session), false);
-          expect(TmuxService.hasExecChannelBackoffEntry(35), false);
+          expect(TmuxService.execChannelBackoffFailureCountForTesting(35), 1);
         } finally {
           await service.clearCache(35);
         }

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1616,6 +1616,97 @@ void main() {
     );
 
     testWidgets(
+      'does not refresh tmux theme for inactive window activity snapshots',
+      (tester) async {
+        final tmuxService = _MockTmuxService();
+        final windowEvents = StreamController<TmuxWindowChangeEvent>();
+        const tmuxSessionName = 'work';
+        const windows = <TmuxWindow>[
+          TmuxWindow(index: 0, id: '@8', name: 'shell', isActive: true),
+          TmuxWindow(index: 1, id: '@9', name: 'agent', isActive: false),
+        ];
+        var refreshCount = 0;
+
+        addTearDown(windowEvents.close);
+        host = _buildHost(id: host.id, tmuxSessionName: tmuxSessionName);
+        when(
+          () => tmuxService.foregroundSessionNameOrThrow(session),
+        ).thenAnswer((_) async => tmuxSessionName);
+        when(
+          () => tmuxService.listWindows(session, tmuxSessionName),
+        ).thenAnswer((_) async => windows);
+        when(
+          () => tmuxService.watchWindowChanges(session, tmuxSessionName),
+        ).thenAnswer((_) => windowEvents.stream);
+        when(
+          () => tmuxService.detectInstalledAgentTools(session),
+        ).thenAnswer((_) async => const <AgentLaunchTool>{});
+        when(
+          () => tmuxService.prefetchInstalledAgentTools(session),
+        ).thenAnswer((_) async {});
+        when(
+          () => tmuxService.refreshTerminalTheme(
+            session,
+            tmuxSessionName,
+            any(),
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async {
+          refreshCount += 1;
+        });
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+              tmuxServiceProvider.overrideWithValue(tmuxService),
+            ],
+            child: MaterialApp(
+              home: TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+                initialTmuxSessionName: tmuxSessionName,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        final refreshCountBeforeWindowEvent = refreshCount;
+        windowEvents.add(
+          const TmuxWindowSnapshotEvent(
+            TmuxWindow(
+              index: 1,
+              id: '@9',
+              name: 'agent',
+              isActive: false,
+              lastActivityEpochSeconds: 123,
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(refreshCount, refreshCountBeforeWindowEvent);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
       'keeps a primed tmux bar visible after transient detection failure',
       (tester) async {
         final tmuxService = _MockTmuxService();


### PR DESCRIPTION
## Summary

- Gate tmux exec opens during channel backoff so failed tmux probes stop retrying into exhausted SSH channel capacity.
- Reduce tmux channel pressure by deferring background metadata/foreground checks, avoiding inactive-window theme refreshes, and reusing cached tmux pane paths.
- Add SFTP channel open diagnostics and adjust exec queue limits to preserve headroom for SFTP and other long-lived channels.

## Validation

- `flutter test --no-pub test/domain/services/ssh_exec_queue_test.dart test/domain/services/ssh_service_test.dart test/domain/services/tmux_service_control_mode_test.dart test/domain/services/tmux_service_agent_detection_test.dart test/presentation/screens/terminal_screen_test.dart test/presentation/screens/sftp_screen_test.dart test/widget/sftp_screen_path_resolution_test.dart`
- `flutter analyze --no-pub`
