### PR TITLE
fix: read system selection for copy and snippet actions

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2317,6 +2317,24 @@ String buildSnippetNameFromTerminalSelection(String text) {
   return 'Terminal selection';
 }
 
+/// Resolves the active terminal selection text, preferring the xterm
+/// controller's selection but falling back to the SelectionArea's content
+/// when system selection (mobile) owns the selection.
+@visibleForTesting
+String? resolveTerminalSelectionPlainText({
+  required String? terminalControllerSelectionText,
+  required String? systemSelectionPlainText,
+}) {
+  if (terminalControllerSelectionText != null &&
+      terminalControllerSelectionText.isNotEmpty) {
+    return terminalControllerSelectionText;
+  }
+  if (systemSelectionPlainText != null && systemSelectionPlainText.isNotEmpty) {
+    return systemSelectionPlainText;
+  }
+  return null;
+}
+
 /// Whether a polled remote clipboard value should replace the local clipboard.
 @visibleForTesting
 bool shouldApplyRemoteClipboardTextToLocal({
@@ -10096,11 +10114,28 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return text.isEmpty ? null : text;
     }
     final selection = _terminalController.selection;
-    if (selection == null) {
+    final terminalControllerText = selection == null
+        ? null
+        : trimTerminalSelectionText(_terminal.buffer.getText(selection));
+    return resolveTerminalSelectionPlainText(
+      terminalControllerSelectionText: terminalControllerText,
+      systemSelectionPlainText: _readSystemSelectionPlainText(),
+    );
+  }
+
+  // Reads the live system selection from the terminal's render object. This is
+  // the source of truth on mobile (`useSystemSelection: true`), where Flutter's
+  // SelectionArea owns the selection rather than the xterm controller.
+  String? _readSystemSelectionPlainText() {
+    final state = _terminalViewKey.currentState;
+    if (state == null) {
       return null;
     }
-    final text = trimTerminalSelectionText(_terminal.buffer.getText(selection));
-    return text.isEmpty ? null : text;
+    try {
+      return state.renderTerminal.getSelectedContent()?.plainText;
+    } on Object {
+      return null;
+    }
   }
 
   Future<void> _lookUpTerminalSelectionText(String text) async {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -403,6 +403,50 @@ void main() {
       );
     });
 
+    test('prefers terminal controller selection over system selection', () {
+      expect(
+        resolveTerminalSelectionPlainText(
+          terminalControllerSelectionText: 'controller text',
+          systemSelectionPlainText: 'system text',
+        ),
+        'controller text',
+      );
+    });
+
+    test('falls back to system selection text when controller is empty', () {
+      expect(
+        resolveTerminalSelectionPlainText(
+          terminalControllerSelectionText: null,
+          systemSelectionPlainText: 'system text',
+        ),
+        'system text',
+      );
+      expect(
+        resolveTerminalSelectionPlainText(
+          terminalControllerSelectionText: '',
+          systemSelectionPlainText: 'system text',
+        ),
+        'system text',
+      );
+    });
+
+    test('returns null when no selection text is available', () {
+      expect(
+        resolveTerminalSelectionPlainText(
+          terminalControllerSelectionText: null,
+          systemSelectionPlainText: null,
+        ),
+        isNull,
+      );
+      expect(
+        resolveTerminalSelectionPlainText(
+          terminalControllerSelectionText: '',
+          systemSelectionPlainText: '',
+        ),
+        isNull,
+      );
+    });
+
     test('hides terminal selection toolbar when action throws', () {
       var didHideToolbar = false;
 
@@ -959,6 +1003,47 @@ void main() {
         findsOneWidget,
       );
     });
+
+    testWidgets(
+      'overflow menu shows Create Snippet when system selection has text',
+      (tester) async {
+        session.terminal!.write('echo hello\n');
+        await pumpScreen(tester);
+        await tester.pump();
+
+        Finder createSnippetItem() => find.byWidgetPredicate(
+          (widget) =>
+              widget is PopupMenuItem<String> &&
+              widget.value == 'create_snippet',
+        );
+
+        await tester.tap(find.byType(PopupMenuButton<String>));
+        await tester.pumpAndSettle();
+        expect(createSnippetItem(), findsNothing);
+
+        await tester.tapAt(const Offset(2, 2));
+        await tester.pumpAndSettle();
+
+        final state = tester.state<MonkeyTerminalViewState>(
+          find.byType(MonkeyTerminalView),
+        );
+        final renderTerminal = state.renderTerminal;
+        renderTerminal.dispatchSelectionEvent(
+          SelectWordSelectionEvent(
+            globalPosition: renderTerminal.localToGlobal(
+              renderTerminal.getOffset(const CellOffset(0, 0)) +
+                  renderTerminal.cellSize.center(Offset.zero),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.byType(PopupMenuButton<String>));
+        await tester.pumpAndSettle();
+        expect(createSnippetItem(), findsOneWidget);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
 
     testWidgets('browse files ignores duplicate taps while SFTP is opening', (
       tester,


### PR DESCRIPTION
## Summary

The Copy item in the mobile system selection toolbar ran but did nothing, and "Create Snippet" was missing from both the selection toolbar and the terminal overflow menu.

## Root cause

`MonkeyTerminalView` is mounted with `useSystemSelection: true` on mobile, so Flutter's `SelectionArea` owns the selection and the xterm `_terminalController.selection` stays null. After PR #406 (selection-to-snippet) merged the terminal-aware menu wrapping back in, `_currentTerminalSelectionText()` only consulted `_terminalController.selection`. As a result:

- The wrapped Copy callback received `null` selection text and silently returned.
- The "Create Snippet" item was hidden because both gates check `_currentTerminalSelectionText() != null`.

## Fix

Read the live system selection from the render terminal (`MonkeyTerminalView.renderTerminal.getSelectedContent()`) when the xterm controller has no selection. The render terminal is the `Selectable` that `SelectionArea` delegates to, so it's the actual source of truth on mobile. Because the existing `GlobalKey<MonkeyTerminalViewState>` rebinds across session swaps, there's no cache to invalidate.

## Tests

- New unit tests for `resolveTerminalSelectionPlainText` covering controller-preferred / system-fallback / both-empty cases.
- New widget test that pumps the screen on iOS, dispatches a `SelectWordSelectionEvent` to the render terminal, opens the overflow menu, and asserts that "Create Snippet" appears.
- All 87 tests in `test/presentation/screens/terminal_screen_test.dart` pass.
- `flutter analyze` clean.

## Manual verification suggestion

On iOS or Android, long-press in the terminal to make a selection, then:
- Tap **Copy** in the system toolbar — clipboard should contain the selected text and a "Copied" snackbar should appear.
- Tap **Create Snippet** — should navigate to the snippet editor prefilled with the selection.
- Open the terminal overflow menu — **Create Snippet** should appear when there's a selection.
