### PR TITLE
Remove sensitive keyboard menu option

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2543,7 +2543,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _isConnecting = true;
   String? _error;
   bool _showKeyboardToolbar = !_hideStoreScreenshotKeyboardToolbar;
-  bool _manualSensitiveKeyboardMode = false;
   bool _detectedSensitiveKeyboardPrompt = false;
   bool _isUsingAltBuffer = false;
   bool _terminalReportsMouseWheel = false;
@@ -2687,9 +2686,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   String? _shellCompletionInFlightRequestKey;
   bool _shellCompletionRefreshAfterInFlight = false;
   int _shellCompletionAnchorRetryCount = 0;
-
-  bool get _usesSensitiveKeyboardMode =>
-      _manualSensitiveKeyboardMode || _detectedSensitiveKeyboardPrompt;
 
   bool _isExclusiveTerminalActionRunning(_TerminalExclusiveAction action) =>
       _exclusiveTerminalActions.contains(action);
@@ -7345,12 +7341,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                     checked: ref.read(tapToShowKeyboardNotifierProvider),
                     child: const Text('Tap to Show Keyboard'),
                   ),
-                if (isMobile)
-                  CheckedPopupMenuItem(
-                    value: 'toggle_sensitive_keyboard',
-                    checked: _manualSensitiveKeyboardMode,
-                    child: const Text('Sensitive Keyboard'),
-                  ),
                 CheckedPopupMenuItem(
                   value: 'toggle_shell_completions',
                   checked: ref.read(shellCompletionsNotifierProvider),
@@ -8258,7 +8248,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _toolbarController.applySystemKeyboardModifiers,
       hasActiveToolbarModifier: () =>
           _toolbarController.isCtrlActive || _toolbarController.isAltActive,
-      sensitiveInput: _usesSensitiveKeyboardMode,
+      sensitiveInput: _detectedSensitiveKeyboardPrompt,
       readOnly: _showsNativeSelectionOverlay || overlayMessage != null,
       tapToShowKeyboard:
           ref.watch(tapToShowKeyboardNotifierProvider) &&
@@ -8472,11 +8462,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         final notifier = ref.read(tapToShowKeyboardNotifierProvider.notifier);
         await notifier.setEnabled(
           enabled: !ref.read(tapToShowKeyboardNotifierProvider),
-        );
-        break;
-      case 'toggle_sensitive_keyboard':
-        setState(
-          () => _manualSensitiveKeyboardMode = !_manualSensitiveKeyboardMode,
         );
         break;
       case 'toggle_shell_completions':

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -960,6 +960,34 @@ void main() {
       );
     });
 
+    testWidgets(
+      'mobile terminal overflow menu omits sensitive keyboard action',
+      (tester) async {
+        await pumpScreen(tester);
+
+        await tester.tap(find.byType(PopupMenuButton<String>));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.widgetWithText(
+            CheckedPopupMenuItem<String>,
+            'Tap to Show Keyboard',
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is CheckedPopupMenuItem<String> &&
+                widget.value == 'toggle_sensitive_keyboard',
+          ),
+          findsNothing,
+        );
+        expect(find.text('Sensitive Keyboard'), findsNothing);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
     testWidgets('browse files ignores duplicate taps while SFTP is opening', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- Remove the mobile overflow menu's manual Sensitive Keyboard toggle.
- Keep automatic sensitive prompt detection wired to the terminal text input handler.
- Add a widget test covering that the mobile overflow menu no longer exposes the action.

## Tests

- `flutter analyze`
- `flutter test test/presentation/screens/terminal_screen_test.dart --plain-name "mobile terminal overflow menu omits sensitive keyboard action" --reporter expanded`
