### PR TITLE
fix: forward Android composing backspaces

### DIFF
--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -2299,6 +2299,35 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
   }
 
+  bool _sendComposingDeletionIfNeeded(TextEditingValue value) {
+    final currentText = _extractInputText(value.text);
+    if (_lastSentText.isEmpty || currentText == _lastSentText) {
+      return false;
+    }
+
+    final targetCursorOffset = _collapsedSelectionCursorOffset(
+      currentText,
+      value,
+    );
+    final delta = _computeTextDelta(
+      currentText,
+      cursorOffsetHint: targetCursorOffset,
+    );
+    if (delta.deletedCount == 0 || delta.appendedText.isNotEmpty) {
+      return false;
+    }
+
+    _notifyUserInput();
+    _sendInputDelta(currentText, delta);
+    if (targetCursorOffset != null &&
+        targetCursorOffset != _lastSentCursorOffset) {
+      _moveTerminalCursorTo(targetCursorOffset);
+    }
+    _trimLeadingSuggestionSpaceAfterDelete = true;
+    _trimLeadingSwipeSpaceAfterBufferClear = currentText.isEmpty;
+    return true;
+  }
+
   // -- TextInputClient implementation --
 
   @override
@@ -2373,6 +2402,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       if (!value.composing.isCollapsed) {
         _cancelDeferredTrailingBackspaceImeClear();
         _iosBackspaceRunwayLength = 0;
+        if (_sendComposingDeletionIfNeeded(value)) {
+          _sawImeComposition = true;
+          return;
+        }
         _sawImeComposition = true;
         return;
       }

--- a/test/presentation/widgets/terminal_text_input_handler_test.dart
+++ b/test/presentation/widgets/terminal_text_input_handler_test.dart
@@ -267,5 +267,81 @@ void main() {
         focusNode.dispose();
       },
     );
+
+    testWidgets(
+      'sends repeated backspaces while Android IME keeps text composing',
+      (tester) async {
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add);
+        final focusNode = FocusNode();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TerminalTextInputHandler(
+                terminal: terminal,
+                focusNode: focusNode,
+                deleteDetection: true,
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        tester.testTextInput.updateEditingValue(
+          const TextEditingValue(
+            text: '${_deleteDetectionMarker}nano',
+            selection: TextSelection.collapsed(offset: 6),
+          ),
+        );
+        await tester.pump();
+        terminalOutput.clear();
+
+        tester.testTextInput.updateEditingValue(
+          const TextEditingValue(
+            text: '${_deleteDetectionMarker}nan',
+            selection: TextSelection.collapsed(offset: 5),
+            composing: TextRange(start: 2, end: 5),
+          ),
+        );
+        await tester.pump();
+
+        tester.testTextInput.updateEditingValue(
+          const TextEditingValue(
+            text: '${_deleteDetectionMarker}na',
+            selection: TextSelection.collapsed(offset: 4),
+            composing: TextRange(start: 2, end: 4),
+          ),
+        );
+        await tester.pump();
+
+        expect(terminalOutput, ['\x7f', '\x7f']);
+        expect(
+          _terminalStateFromEvents(
+            terminalOutput,
+            initialText: 'nano',
+            initialCursorOffset: 'nano'.length,
+          ),
+          (text: 'na', cursorOffset: 'na'.length),
+        );
+
+        terminalOutput.clear();
+
+        tester.testTextInput.updateEditingValue(
+          const TextEditingValue(
+            text: '${_deleteDetectionMarker}na',
+            selection: TextSelection.collapsed(offset: 4),
+          ),
+        );
+        await tester.pump();
+
+        expect(terminalOutput, isEmpty);
+
+        focusNode.dispose();
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

- Forward pure deletion deltas while Android IMEs keep terminal text in a composing range.
- Add a widget regression test for repeated Gboard-style backspaces.

## Validation

- `flutter analyze`
- `flutter test test/presentation/widgets/terminal_text_input_handler_test.dart`
