### PR TITLE
fix: preserve Wi-Fi skip SSIDs in host copies and exports

### DIFF
--- a/lib/data/repositories/host_repository.dart
+++ b/lib/data/repositories/host_repository.dart
@@ -165,6 +165,7 @@ class HostRepository {
         keyId: Value(host.keyId),
         groupId: Value(host.groupId),
         jumpHostId: Value(host.jumpHostId),
+        skipJumpHostOnSsids: const Value(null),
         isFavorite: Value(host.isFavorite),
         color: Value(host.color),
         notes: Value(host.notes),

--- a/lib/data/repositories/host_repository.dart
+++ b/lib/data/repositories/host_repository.dart
@@ -165,7 +165,7 @@ class HostRepository {
         keyId: Value(host.keyId),
         groupId: Value(host.groupId),
         jumpHostId: Value(host.jumpHostId),
-        skipJumpHostOnSsids: const Value(null),
+        skipJumpHostOnSsids: Value(host.skipJumpHostOnSsids),
         isFavorite: Value(host.isFavorite),
         color: Value(host.color),
         notes: Value(host.notes),

--- a/lib/domain/services/secure_transfer_service.dart
+++ b/lib/domain/services/secure_transfer_service.dart
@@ -189,6 +189,7 @@ class SecureTransferService {
     SettingKeys.agentLaunchPresets,
     SettingKeys.hostCliLaunchPreferences,
   };
+  static const _deviceLocalHostExportFields = {'skipJumpHostOnSsids'};
 
   /// Creates an encrypted host transfer payload.
   Future<String> createHostPayload({
@@ -203,7 +204,7 @@ class SecureTransferService {
     final cliLaunchPreferences = await _hostCliLaunchPreferencesService
         .getPreferencesForHost(host.id);
 
-    final hostData = Map<String, dynamic>.from(host.toJson())
+    final hostData = _exportableHostJson(host)
       ..['keyId'] = referencedKey == null ? null : host.keyId
       ..['groupId'] = null
       ..['jumpHostId'] = null
@@ -285,7 +286,7 @@ class SecureTransferService {
       'settings': filteredSettings,
       'groups': _sortedJsonRecords(groups.map((item) => item.toJson())),
       'keys': _sortedJsonRecords(keys.map((item) => item.toJson())),
-      'hosts': _sortedJsonRecords(hosts.map((item) => item.toJson())),
+      'hosts': _sortedJsonRecords(hosts.map(_exportableHostJson)),
       'snippetFolders': _sortedJsonRecords(
         snippetFolders.map((item) => item.toJson()),
       ),
@@ -1402,6 +1403,14 @@ class SecureTransferService {
         ..sort(
           (first, second) => jsonEncode(first).compareTo(jsonEncode(second)),
         );
+
+  Map<String, dynamic> _exportableHostJson(Host host) {
+    final json = Map<String, dynamic>.from(host.toJson());
+    for (final key in _deviceLocalHostExportFields) {
+      json.remove(key);
+    }
+    return json;
+  }
 
   Object? _canonicalizeJsonValue(Object? value) {
     if (value is Map) {

--- a/lib/domain/services/secure_transfer_service.dart
+++ b/lib/domain/services/secure_transfer_service.dart
@@ -189,7 +189,6 @@ class SecureTransferService {
     SettingKeys.agentLaunchPresets,
     SettingKeys.hostCliLaunchPreferences,
   };
-  static const _deviceLocalHostExportFields = {'skipJumpHostOnSsids'};
 
   /// Creates an encrypted host transfer payload.
   Future<String> createHostPayload({
@@ -204,7 +203,7 @@ class SecureTransferService {
     final cliLaunchPreferences = await _hostCliLaunchPreferencesService
         .getPreferencesForHost(host.id);
 
-    final hostData = _exportableHostJson(host)
+    final hostData = Map<String, dynamic>.from(host.toJson())
       ..['keyId'] = referencedKey == null ? null : host.keyId
       ..['groupId'] = null
       ..['jumpHostId'] = null
@@ -286,7 +285,7 @@ class SecureTransferService {
       'settings': filteredSettings,
       'groups': _sortedJsonRecords(groups.map((item) => item.toJson())),
       'keys': _sortedJsonRecords(keys.map((item) => item.toJson())),
-      'hosts': _sortedJsonRecords(hosts.map(_exportableHostJson)),
+      'hosts': _sortedJsonRecords(hosts.map((item) => item.toJson())),
       'snippetFolders': _sortedJsonRecords(
         snippetFolders.map((item) => item.toJson()),
       ),
@@ -428,6 +427,9 @@ class SecureTransferService {
           keyId: Value(keyId),
           groupId: const Value(null),
           jumpHostId: const Value(null),
+          skipJumpHostOnSsids: Value(
+            _optionalString(hostData['skipJumpHostOnSsids']),
+          ),
           isFavorite: Value((hostData['isFavorite'] as bool?) ?? false),
           color: Value(_optionalString(hostData['color'])),
           notes: Value(_optionalString(hostData['notes'])),
@@ -945,6 +947,9 @@ class SecureTransferService {
           keyId: Value(mappedKeyId),
           groupId: Value(mappedGroupId),
           jumpHostId: const Value(null),
+          skipJumpHostOnSsids: Value(
+            _optionalString(item['skipJumpHostOnSsids']),
+          ),
           isFavorite: Value((item['isFavorite'] as bool?) ?? false),
           color: Value(_optionalString(item['color'])),
           notes: Value(_optionalString(item['notes'])),
@@ -1403,14 +1408,6 @@ class SecureTransferService {
         ..sort(
           (first, second) => jsonEncode(first).compareTo(jsonEncode(second)),
         );
-
-  Map<String, dynamic> _exportableHostJson(Host host) {
-    final json = Map<String, dynamic>.from(host.toJson());
-    for (final key in _deviceLocalHostExportFields) {
-      json.remove(key);
-    }
-    return json;
-  }
 
   Object? _canonicalizeJsonValue(Object? value) {
     if (value is Map) {

--- a/test/data/repositories/host_repository_test.dart
+++ b/test/data/repositories/host_repository_test.dart
@@ -148,7 +148,7 @@ void main() {
       expect(host.autoConnectRequiresConfirmation, isTrue);
     });
 
-    test('duplicate skips device-local SSIDs', () async {
+    test('duplicate copies skip-jump SSIDs', () async {
       final keyId = await db
           .into(db.sshKeys)
           .insert(
@@ -251,7 +251,7 @@ void main() {
       expect(duplicateHost.groupId, sourceHost.groupId);
       expect(duplicateHost.jumpHostId, sourceHost.jumpHostId);
       expect(sourceHost.skipJumpHostOnSsids, 'Home WiFi\nOffice WiFi');
-      expect(duplicateHost.skipJumpHostOnSsids, isNull);
+      expect(duplicateHost.skipJumpHostOnSsids, sourceHost.skipJumpHostOnSsids);
       expect(duplicateHost.isFavorite, sourceHost.isFavorite);
       expect(duplicateHost.color, sourceHost.color);
       expect(duplicateHost.notes, sourceHost.notes);

--- a/test/data/repositories/host_repository_test.dart
+++ b/test/data/repositories/host_repository_test.dart
@@ -148,7 +148,7 @@ void main() {
       expect(host.autoConnectRequiresConfirmation, isTrue);
     });
 
-    test('duplicate copies all host fields and port forwards', () async {
+    test('duplicate skips device-local SSIDs', () async {
       final keyId = await db
           .into(db.sshKeys)
           .insert(
@@ -188,6 +188,7 @@ void main() {
           keyId: Value(keyId),
           groupId: Value(groupId),
           jumpHostId: Value(jumpHostId),
+          skipJumpHostOnSsids: const Value('Home WiFi\nOffice WiFi'),
           isFavorite: const Value(true),
           color: const Value('#112233'),
           notes: const Value('Has extra metadata'),
@@ -249,6 +250,8 @@ void main() {
       expect(duplicateHost.keyId, sourceHost.keyId);
       expect(duplicateHost.groupId, sourceHost.groupId);
       expect(duplicateHost.jumpHostId, sourceHost.jumpHostId);
+      expect(sourceHost.skipJumpHostOnSsids, 'Home WiFi\nOffice WiFi');
+      expect(duplicateHost.skipJumpHostOnSsids, isNull);
       expect(duplicateHost.isFavorite, sourceHost.isFavorite);
       expect(duplicateHost.color, sourceHost.color);
       expect(duplicateHost.notes, sourceHost.notes);

--- a/test/domain/services/secure_transfer_service_test.dart
+++ b/test/domain/services/secure_transfer_service_test.dart
@@ -159,11 +159,11 @@ void main() {
       expect(hostData['hostname'], 'prod.example.com');
       expect(hostData['autoConnectCommand'], 'tmux new -As MonkeySSH');
       expect(hostData['autoConnectSnippetId'], isNull);
-      expect(hostData.containsKey('skipJumpHostOnSsids'), isFalse);
+      expect(hostData['skipJumpHostOnSsids'], 'Home WiFi\nOffice WiFi');
     });
 
     test(
-      'createMigrationData omits device-local skip-jump SSIDs from host exports',
+      'createMigrationData includes skip-jump SSIDs in host exports',
       () async {
         await hostRepository.insert(
           HostsCompanion.insert(
@@ -180,7 +180,7 @@ void main() {
         final hosts = migrationData['hosts'] as List;
         final hostData = Map<String, dynamic>.from(hosts.single as Map);
 
-        expect(hostData.containsKey('skipJumpHostOnSsids'), isFalse);
+        expect(hostData['skipJumpHostOnSsids'], 'Home WiFi\nOffice WiFi');
       },
     );
 
@@ -271,6 +271,7 @@ void main() {
             'port': 22,
             'username': 'root',
             'password': 'host-pass',
+            'skipJumpHostOnSsids': 'Home WiFi\nOffice WiFi',
             'isFavorite': false,
           },
         },
@@ -278,12 +279,14 @@ void main() {
 
       final imported = await transferService.importHostPayload(payload);
       expect(imported.password, 'host-pass');
+      expect(imported.skipJumpHostOnSsids, 'Home WiFi\nOffice WiFi');
       expect(imported.autoConnectRequiresConfirmation, isFalse);
 
       final stored = await (db.select(
         db.hosts,
       )..where((h) => h.id.equals(imported.id))).getSingle();
       expect(stored.password, startsWith('ENCv1:'));
+      expect(stored.skipJumpHostOnSsids, 'Home WiFi\nOffice WiFi');
     });
 
     test('importHostPayload preserves host CLI launch preferences', () async {
@@ -696,6 +699,7 @@ void main() {
                 hostname: 'b.example.com',
                 username: 'root',
                 jumpHostId: Value(hostAId),
+                skipJumpHostOnSsids: const Value('Home WiFi\nOffice WiFi'),
               ),
             );
 
@@ -777,6 +781,7 @@ void main() {
         )..where((s) => s.key.equals('extra'))).getSingleOrNull();
         final hosts = await db.select(db.hosts).get();
         final hostA = hosts.firstWhere((host) => host.label == 'A');
+        final hostB = hosts.firstWhere((host) => host.label == 'B');
         final importedSnippet = await (db.select(
           db.snippets,
         )..where((snippet) => snippet.name.equals('List files'))).getSingle();
@@ -789,6 +794,7 @@ void main() {
         expect(hostA.autoConnectCommand, 'ls -la');
         expect(hostA.autoConnectSnippetId, importedSnippet.id);
         expect(hostA.autoConnectRequiresConfirmation, isTrue);
+        expect(hostB.skipJumpHostOnSsids, 'Home WiFi\nOffice WiFi');
         expect(groups, hasLength(2));
         expect(snippetFolders, hasLength(2));
         expect(portForwards, hasLength(1));

--- a/test/domain/services/secure_transfer_service_test.dart
+++ b/test/domain/services/secure_transfer_service_test.dart
@@ -135,6 +135,7 @@ void main() {
               hostname: 'prod.example.com',
               username: 'root',
               password: const Value('secret'),
+              skipJumpHostOnSsids: const Value('Home WiFi\nOffice WiFi'),
               autoConnectCommand: const Value('tmux new -As MonkeySSH'),
               autoConnectSnippetId: Value(snippetId),
             ),
@@ -158,7 +159,30 @@ void main() {
       expect(hostData['hostname'], 'prod.example.com');
       expect(hostData['autoConnectCommand'], 'tmux new -As MonkeySSH');
       expect(hostData['autoConnectSnippetId'], isNull);
+      expect(hostData.containsKey('skipJumpHostOnSsids'), isFalse);
     });
+
+    test(
+      'createMigrationData omits device-local skip-jump SSIDs from host exports',
+      () async {
+        await hostRepository.insert(
+          HostsCompanion.insert(
+            label: 'Production',
+            hostname: 'prod.example.com',
+            username: 'root',
+            skipJumpHostOnSsids: const Value('Home WiFi\nOffice WiFi'),
+          ),
+        );
+
+        final migrationData = await transferService.createMigrationData(
+          includeKnownHosts: false,
+        );
+        final hosts = migrationData['hosts'] as List;
+        final hostData = Map<String, dynamic>.from(hosts.single as Map);
+
+        expect(hostData.containsKey('skipJumpHostOnSsids'), isFalse);
+      },
+    );
 
     test(
       'includes referenced key data when requested for host export',


### PR DESCRIPTION
## Summary

- Copy skip-jump Wi-Fi SSIDs when duplicating hosts.
- Preserve skip-jump Wi-Fi SSIDs in single-host transfer imports and full migration imports.
- Add targeted coverage that exports include the SSIDs and imports restore them.

## Tests

- `flutter test --no-pub test/data/repositories/host_repository_test.dart test/domain/services/secure_transfer_service_test.dart`
- `flutter analyze --no-pub`
