### PR TITLE
fix: reset IME state for keyboard modifiers

### DIFF
--- a/lib/presentation/widgets/keyboard_toolbar.dart
+++ b/lib/presentation/widgets/keyboard_toolbar.dart
@@ -528,36 +528,42 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
   void _toggleCtrl() {
     HapticFeedback.selectionClick();
     _controller.toggleCtrl();
+    widget.onKeyPressed?.call();
     _refocusTerminal();
   }
 
   void _toggleAlt() {
     HapticFeedback.selectionClick();
     _controller.toggleAlt();
+    widget.onKeyPressed?.call();
     _refocusTerminal();
   }
 
   void _toggleShift() {
     HapticFeedback.selectionClick();
     _controller.toggleShift();
+    widget.onKeyPressed?.call();
     _refocusTerminal();
   }
 
   void _lockCtrl() {
     HapticFeedback.mediumImpact();
     _controller.lockCtrl();
+    widget.onKeyPressed?.call();
     _refocusTerminal();
   }
 
   void _lockAlt() {
     HapticFeedback.mediumImpact();
     _controller.lockAlt();
+    widget.onKeyPressed?.call();
     _refocusTerminal();
   }
 
   void _lockShift() {
     HapticFeedback.mediumImpact();
     _controller.lockShift();
+    widget.onKeyPressed?.call();
     _refocusTerminal();
   }
 

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -1876,6 +1876,8 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     return applyModifiers(normalizedText);
   }
 
+  String _lastGrapheme(String text) => text.characters.last;
+
   int _deltaCursorScore(
     ({int deletedCount, String appendedText, int deleteCursorOffset}) delta,
     int cursorOffsetHint,
@@ -2503,6 +2505,23 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         previousTextOverride: deleteResetContinuation?.previousText,
         lastCursorOffsetOverride: deleteResetContinuation?.previousCursorOffset,
       );
+      final hadActiveToolbarModifier =
+          widget.hasActiveToolbarModifier?.call() ?? false;
+      if (hadActiveToolbarModifier && delta.appendedText.isNotEmpty) {
+        // One-shot terminal modifiers apply to a single key. Some IMEs can send
+        // stale composing text in the same batch, so keep only the newest key.
+        _cancelDeferredTrailingBackspaceImeClear();
+        _notifyUserInput();
+        widget.terminal.textInput(
+          _applyTerminalTextInputModifiers(_lastGrapheme(delta.appendedText)),
+        );
+        _clearImeBufferForFreshInput(
+          armModifierChordWindow: true,
+          armSplitLeadingTokenNormalization: true,
+        );
+        _sawImeComposition = false;
+        return;
+      }
       if (_sendSingleBackspaceForPendingTouchDeletion(delta: delta)) {
         _sawImeComposition = false;
         return;
@@ -2535,12 +2554,6 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       }
       final previousText = deltaPreviousText;
 
-      // Capture modifier state BEFORE sending the delta. The send path
-      // synchronously fires terminal.onOutput which may consume one-shot
-      // toolbar modifiers (e.g. Ctrl). Checking after would always be false.
-      final hadActiveToolbarModifier =
-          widget.hasActiveToolbarModifier?.call() ?? false;
-
       if (deleteResetContinuation != null) {
         _lastSentText = deltaPreviousText;
         _lastSentCursorOffset = deltaPreviousCursorOffset;
@@ -2554,9 +2567,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       }
 
       // Detect non-additive operations that should clear the IME suggestion
-      // context: pure deletions (backspace with no replacement text) and
-      // modifier chords (Ctrl/Alt + character) where the typed character
-      // becomes a control code instead of visible text.
+      // context: pure deletions (backspace with no replacement text).
       //
       // IME replacements (e.g. autocorrect changing "teh" to "the") may
       // also shorten text but include appended replacement text, so they
@@ -2567,10 +2578,6 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
           delta.appendedText.isEmpty;
       final wasTrailingPureDeletion =
           wasPureDeletion && pendingInputIsTrailingPureDeletion;
-      final wasModifiedSingleChar =
-          delta.deletedCount == 0 &&
-          delta.appendedText.characters.length == 1 &&
-          hadActiveToolbarModifier;
 
       // Also detect the second character of a two-part chord like tmux's
       // Ctrl+b, c. After the first modifier character resets, the follow-up
@@ -2590,15 +2597,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
           delta.deletedCount == 0 &&
           delta.appendedText.characters.length == 1;
 
-      if (wasModifiedSingleChar || wasChordFollowUp) {
-        // The character was transformed into a control code by the toolbar
-        // modifier (or is the follow-up of a two-part chord), so it does
-        // not represent visible terminal text. Do a full reset — the
-        // shell's response to a control code is unpredictable.
-        _clearImeBufferForFreshInput(
-          armModifierChordWindow: wasModifiedSingleChar,
-          armSplitLeadingTokenNormalization: true,
-        );
+      if (wasChordFollowUp) {
+        // The character is the follow-up of a two-part chord, so it should not
+        // remain in the IME suggestion context.
+        _clearImeBufferForFreshInput(armSplitLeadingTokenNormalization: true);
         _sawImeComposition = false;
         return;
       }

--- a/test/widget/keyboard_toolbar_test.dart
+++ b/test/widget/keyboard_toolbar_test.dart
@@ -232,6 +232,28 @@ void main() {
       expect(callCount, 1);
     });
 
+    testWidgets('modifier taps call onKeyPressed to reset IME context', (
+      tester,
+    ) async {
+      var callCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: KeyboardToolbar(
+              terminal: terminal,
+              onKeyPressed: () => callCount++,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byTooltip('Ctrl'));
+      await tester.pump();
+
+      expect(callCount, 1);
+    });
+
     testWidgets('special characters render correctly', (tester) async {
       await tester.pumpWidget(
         MaterialApp(

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/domain/models/auto_connect_command.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
+import 'package:monkeyssh/presentation/widgets/keyboard_toolbar.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
 import 'package:xterm/xterm.dart';
 
@@ -8033,6 +8034,37 @@ void main() {
 
       expect(harness.terminalOutput, <String>['\x11']);
       expect(modifierActive, isFalse);
+      expect(
+        _terminalTextInputClient(tester).currentTextEditingValue,
+        const TextEditingValue(
+          text: _deleteDetectionMarker,
+          selection: TextSelection.collapsed(offset: 2),
+        ),
+      );
+
+      await _disposeTerminalHarness(tester, harness);
+    });
+
+    testWidgets('modifier chords ignore stale multi-character IME batches', (
+      tester,
+    ) async {
+      final toolbarController = KeyboardToolbarController()..toggleCtrl();
+      addTearDown(toolbarController.dispose);
+      final harness = await _pumpTerminalHarness(
+        tester,
+        hasActiveToolbarModifier: () =>
+            toolbarController.isCtrlActive || toolbarController.isAltActive,
+        applyTerminalTextInputModifiers:
+            toolbarController.applySystemKeyboardModifiers,
+      );
+
+      tester.testTextInput.updateEditingValue(
+        _editingValue('staleq', selectionOffset: 'staleq'.length),
+      );
+      await tester.pump();
+
+      expect(harness.terminalOutput, <String>['\x11']);
+      expect(toolbarController.isCtrlActive, isFalse);
       expect(
         _terminalTextInputClient(tester).currentTextEditingValue,
         const TextEditingValue(


### PR DESCRIPTION
## Summary

- Reset terminal IME state when toolbar modifier keys are toggled/locked so stale suggestions do not survive into the next key.
- Treat active toolbar Ctrl/Alt modifiers as one-key chords even if the IME delivers a stale multi-character batch, sending only the newest key through the modifier path.
- Add regression coverage for modifier taps and stale IME batches.

## Validation

- `flutter test test/widget/terminal_text_input_handler_test.dart test/presentation/widgets/terminal_text_input_handler_test.dart test/widget/keyboard_toolbar_test.dart`
- `flutter analyze`
