### PR TITLE
fix: detect stale SSH connections

### DIFF
--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -1614,6 +1614,20 @@ Map<String, Object?> _diagnosticSshExecErrorFields(Object error) => {
   },
 };
 
+String? _diagnosticClosedSshConnectionErrorReason(Object error) {
+  if (error is! SSHStateError) {
+    return null;
+  }
+  final normalized = error.message.toLowerCase();
+  if (normalized.contains('transport is closed')) {
+    return 'transport_closed';
+  }
+  if (normalized.contains('connection closed')) {
+    return 'connection_closed';
+  }
+  return null;
+}
+
 String _diagnosticSshChannelOpenReason(String description) {
   final normalized = description.toLowerCase();
   if (normalized.contains('administratively prohibited')) {
@@ -1954,6 +1968,9 @@ class SshSession {
 
   final _previewListeners = <VoidCallback>{};
   final _metadataListeners = <VoidCallback>{};
+  final _connectionHealthFailures =
+      StreamController<_SshConnectionHealthFailure>.broadcast();
+  bool _connectionHealthFailureReported = false;
   String? _terminalPreview;
   String? _windowTitle;
   String? _iconName;
@@ -1966,6 +1983,9 @@ class SshSession {
 
   /// A plain-text preview of the latest terminal content.
   String? get terminalPreview => _terminalPreview;
+
+  Stream<_SshConnectionHealthFailure> get _connectionHealthFailureStream =>
+      _connectionHealthFailures.stream;
 
   /// The latest terminal window title emitted by the remote session.
   String? get windowTitle => _windowTitle;
@@ -2365,6 +2385,7 @@ class SshSession {
           ..._diagnosticSshExecErrorFields(error),
         },
       );
+      _reportConnectionHealthFailureIfClosed(error, operation: 'exec');
       rethrow;
     }
   }
@@ -2405,6 +2426,7 @@ class SshSession {
           ..._diagnosticSshExecErrorFields(error),
         },
       );
+      _reportConnectionHealthFailureIfClosed(error, operation: 'sftp');
       rethrow;
     }
   }
@@ -2587,11 +2609,52 @@ class SshSession {
   Future<void> close() async {
     await stopAllForwards();
     await closeShell();
+    await _connectionHealthFailures.close();
     client.close();
     for (final dependentClient in dependentClients) {
       dependentClient.close();
     }
   }
+
+  void _reportConnectionHealthFailureIfClosed(
+    Object error, {
+    required String operation,
+  }) {
+    final reason = _diagnosticClosedSshConnectionErrorReason(error);
+    if (reason == null ||
+        _connectionHealthFailureReported ||
+        _connectionHealthFailures.isClosed) {
+      return;
+    }
+    _connectionHealthFailureReported = true;
+    DiagnosticsLogService.instance.warning(
+      'ssh.session',
+      'stale_connection_detected',
+      fields: {
+        'connectionId': connectionId,
+        'hostId': hostId,
+        'operation': operation,
+        'reason': reason,
+        'errorType': error.runtimeType,
+      },
+    );
+    _connectionHealthFailures.add(
+      _SshConnectionHealthFailure(
+        connectionId: connectionId,
+        message: 'Connection became unresponsive. Reconnect to continue.',
+      ),
+    );
+  }
+}
+
+class _SshConnectionHealthFailure {
+  const _SshConnectionHealthFailure({
+    required this.connectionId,
+    required this.message,
+  });
+
+  final int connectionId;
+  final String message;
 }
 
 /// Lightweight active connection metadata for UI.
@@ -2741,6 +2804,8 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
   final Map<int, int> _connectionHostIds = {};
   final Map<int, ConnectionAttemptStatus> _connectionAttempts = {};
   final Map<int, StreamSubscription<void>> _disconnectSubscriptions = {};
+  final Map<int, StreamSubscription<_SshConnectionHealthFailure>>
+  _connectionHealthFailureSubscriptions = {};
   Timer? _previewStateRefreshTimer;
   bool _previewStateRefreshQueued = false;
   Future<void> _backgroundStatusSyncQueue = Future<void>.value();
@@ -2756,6 +2821,10 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
         unawaited(subscription.cancel());
       }
       _disconnectSubscriptions.clear();
+      for (final subscription in _connectionHealthFailureSubscriptions.values) {
+        unawaited(subscription.cancel());
+      }
+      _connectionHealthFailureSubscriptions.clear();
     });
     _connectionHostIds.clear();
     _connectionAttempts.clear();
@@ -2996,6 +3065,11 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
     if (existingSubscription != null) {
       unawaited(existingSubscription.cancel());
     }
+    final existingHealthFailureSubscription =
+        _connectionHealthFailureSubscriptions.remove(session.connectionId);
+    if (existingHealthFailureSubscription != null) {
+      unawaited(existingHealthFailureSubscription.cancel());
+    }
     _disconnectSubscriptions[session.connectionId] = session.client.done
         .asStream()
         .listen(
@@ -3012,6 +3086,16 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
             ),
           ),
         );
+    _connectionHealthFailureSubscriptions[session.connectionId] = session
+        ._connectionHealthFailureStream
+        .listen(
+          (failure) => unawaited(
+            handleUnexpectedDisconnect(
+              failure.connectionId,
+              message: failure.message,
+            ),
+          ),
+        );
   }
 
   void _detachSessionListeners(int connectionId, {SshSession? session}) {
@@ -3021,6 +3105,11 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
     final subscription = _disconnectSubscriptions.remove(connectionId);
     if (subscription != null) {
       unawaited(subscription.cancel());
+    }
+    final healthFailureSubscription = _connectionHealthFailureSubscriptions
+        .remove(connectionId);
+    if (healthFailureSubscription != null) {
+      unawaited(healthFailureSubscription.cancel());
     }
   }
 

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -2467,6 +2467,20 @@ class SshSession {
           final socketToForward = socket.cast<List<int>>().pipe(forward.sink);
 
           await Future.any<void>([forwardToSocket, socketToForward]);
+        } on SSHError catch (e) {
+          DiagnosticsLogService.instance.warning(
+            'ssh.forward',
+            'local_connection_failed',
+            fields: {
+              'connectionId': connectionId,
+              'hostId': hostId,
+              ..._diagnosticSshExecErrorFields(e),
+            },
+          );
+          _reportConnectionHealthFailureIfClosed(e, operation: 'forward_local');
+          if (kDebugMode) {
+            debugPrint('Port forward connection error: $e');
+          }
         } on Exception catch (e) {
           DiagnosticsLogService.instance.warning(
             'ssh.forward',
@@ -2567,6 +2581,21 @@ class SshSession {
       });
 
       return true;
+    } on SSHError catch (e) {
+      DiagnosticsLogService.instance.warning(
+        'ssh.forward',
+        'remote_start_failed',
+        fields: {
+          'connectionId': connectionId,
+          'hostId': hostId,
+          ..._diagnosticSshExecErrorFields(e),
+        },
+      );
+      _reportConnectionHealthFailureIfClosed(e, operation: 'forward_remote');
+      if (kDebugMode) {
+        debugPrint('Failed to start remote forward: $e');
+      }
+      return false;
     } on Exception catch (e) {
       DiagnosticsLogService.instance.warning(
         'ssh.forward',
@@ -2603,7 +2632,14 @@ class SshSession {
     int remotePort, {
     String localHost = 'localhost',
     int localPort = 0,
-  }) => client.forwardLocal(remoteHost, remotePort);
+  }) async {
+    try {
+      return await client.forwardLocal(remoteHost, remotePort);
+    } on SSHError catch (e) {
+      _reportConnectionHealthFailureIfClosed(e, operation: 'forward_local');
+      rethrow;
+    }
+  }
 
   /// Close the session.
   Future<void> close() async {

--- a/lib/domain/services/ssh_session_runtime.dart
+++ b/lib/domain/services/ssh_session_runtime.dart
@@ -133,6 +133,10 @@ class _SshSessionRuntime {
             'commandKind': commandKind,
           },
         );
+        _session._reportConnectionHealthFailureIfClosed(
+          error,
+          operation: 'shell',
+        );
         rethrow;
       }
     } else {
@@ -245,6 +249,10 @@ class _SshSessionRuntime {
                 'errorType': error.runtimeType,
               },
             );
+            _session._reportConnectionHealthFailureIfClosed(
+              error,
+              operation: 'shell_stdout',
+            );
             final stdoutController = _shellStdoutController;
             if (identical(_shell, shell) &&
                 stdoutController != null &&
@@ -278,6 +286,10 @@ class _SshSessionRuntime {
                 'errorType': error.runtimeType,
               },
             );
+            _session._reportConnectionHealthFailureIfClosed(
+              error,
+              operation: 'shell_stderr',
+            );
             final stderrController = _shellStderrController;
             if (identical(_shell, shell) &&
                 stderrController != null &&
@@ -309,6 +321,10 @@ class _SshSessionRuntime {
             'connectionId': _session.connectionId,
             'errorType': error.runtimeType,
           },
+        );
+        _session._reportConnectionHealthFailureIfClosed(
+          error,
+          operation: 'shell_done',
         );
         final doneController = _shellDoneController;
         if (identical(_shell, shell) &&

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -636,23 +636,29 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         return;
       }
       await _openFallbackDirectory(preferredPath: _fallbackDirectoryPath);
+    } on SSHError catch (e) {
+      _handleConnectFailure(e, pendingSftp);
     } on Exception catch (e) {
-      DiagnosticsLogService.instance.warning(
-        'sftp',
-        'connect_failed',
-        fields: {'errorType': e.runtimeType},
-      );
-      pendingSftp?.close();
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _isLoading = false;
-        _error = e is TimeoutException
-            ? sftpTimeoutMessage('opening the SFTP browser')
-            : 'SFTP connection failed. Check the connection and try again.';
-      });
+      _handleConnectFailure(e, pendingSftp);
     }
+  }
+
+  void _handleConnectFailure(Object error, SftpClient? pendingSftp) {
+    DiagnosticsLogService.instance.warning(
+      'sftp',
+      'connect_failed',
+      fields: {'errorType': error.runtimeType},
+    );
+    pendingSftp?.close();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _isLoading = false;
+      _error = error is TimeoutException
+          ? sftpTimeoutMessage('opening the SFTP browser')
+          : 'SFTP connection failed. Check the connection and try again.';
+    });
   }
 
   Future<String?> _resolveHomeDirectoryPath() async {

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -209,6 +209,9 @@ class _FakeActiveSessionsSshService extends SshService {
   @override
   SshSession? getSession(int connectionId) => _sessions[connectionId];
 
+  _MockSshClient clientFor(int connectionId) =>
+      _sessions[connectionId]!.client as _MockSshClient;
+
   void completeConnection(int connectionId) {
     final completer = _clientDoneCompleters[connectionId];
     if (completer != null && !completer.isCompleted) {
@@ -1218,6 +1221,39 @@ void main() {
         'Connection closed',
       );
     });
+
+    test(
+      'removes stale sessions when channel opens report a closed transport',
+      () async {
+        final notifier = container.read(activeSessionsProvider.notifier);
+
+        final result = await notifier.connect(42, forceNew: true);
+        expect(result.success, isTrue);
+        expect(result.connectionId, isNotNull);
+
+        final connectionId = result.connectionId!;
+        final session = fakeSshService.getSession(connectionId)!;
+        when(
+          () => fakeSshService
+              .clientFor(connectionId)
+              .execute(any(), pty: any(named: 'pty')),
+        ).thenThrow(SSHStateError('Transport is closed'));
+
+        await expectLater(
+          session.execute('true'),
+          throwsA(isA<SSHStateError>()),
+        );
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(notifier.getSession(connectionId), isNull);
+        expect(container.read(activeSessionsProvider)[connectionId], isNull);
+        expect(
+          notifier.getConnectionAttempt(42)?.latestMessage,
+          'Connection became unresponsive. Reconnect to continue.',
+        );
+      },
+    );
 
     test('updateSessionTheme skips unchanged theme IDs', () async {
       final notifier = container.read(activeSessionsProvider.notifier);

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 // ignore_for_file: public_member_api_docs
@@ -218,6 +219,13 @@ class _FakeActiveSessionsSshService extends SshService {
       completer.complete();
     }
   }
+}
+
+Future<int> _unusedLoopbackPort() async {
+  final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final port = socket.port;
+  await socket.close();
+  return port;
 }
 
 void main() {
@@ -1242,6 +1250,95 @@ void main() {
         await expectLater(
           session.execute('true'),
           throwsA(isA<SSHStateError>()),
+        );
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(notifier.getSession(connectionId), isNull);
+        expect(container.read(activeSessionsProvider)[connectionId], isNull);
+        expect(
+          notifier.getConnectionAttempt(42)?.latestMessage,
+          'Connection became unresponsive. Reconnect to continue.',
+        );
+      },
+    );
+
+    test(
+      'removes stale sessions when local forwards report a closed transport',
+      () async {
+        final notifier = container.read(activeSessionsProvider.notifier);
+
+        final result = await notifier.connect(42, forceNew: true);
+        expect(result.success, isTrue);
+        expect(result.connectionId, isNotNull);
+
+        final connectionId = result.connectionId!;
+        final session = fakeSshService.getSession(connectionId)!;
+        final localPort = await _unusedLoopbackPort();
+        when(
+          () => fakeSshService
+              .clientFor(connectionId)
+              .forwardLocal('remote.example.com', 80),
+        ).thenThrow(SSHStateError('Transport is closed'));
+
+        addTearDown(session.stopAllForwards);
+
+        expect(
+          await session.startLocalForward(
+            portForwardId: 1,
+            localHost: InternetAddress.loopbackIPv4.address,
+            localPort: localPort,
+            remoteHost: 'remote.example.com',
+            remotePort: 80,
+          ),
+          isTrue,
+        );
+
+        final socket = await Socket.connect(
+          InternetAddress.loopbackIPv4,
+          localPort,
+        );
+        socket.destroy();
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(notifier.getSession(connectionId), isNull);
+        expect(container.read(activeSessionsProvider)[connectionId], isNull);
+        expect(
+          notifier.getConnectionAttempt(42)?.latestMessage,
+          'Connection became unresponsive. Reconnect to continue.',
+        );
+      },
+    );
+
+    test(
+      'removes stale sessions when remote forwards report a closed transport',
+      () async {
+        final notifier = container.read(activeSessionsProvider.notifier);
+
+        final result = await notifier.connect(42, forceNew: true);
+        expect(result.success, isTrue);
+        expect(result.connectionId, isNotNull);
+
+        final connectionId = result.connectionId!;
+        final session = fakeSshService.getSession(connectionId)!;
+        when(
+          () => fakeSshService
+              .clientFor(connectionId)
+              .forwardRemote(host: '127.0.0.1', port: 8022),
+        ).thenThrow(
+          SSHStateError('Connection closed while waiting for channel open'),
+        );
+
+        expect(
+          await session.startRemoteForward(
+            portForwardId: 1,
+            remoteHost: '127.0.0.1',
+            remotePort: 8022,
+            localHost: '127.0.0.1',
+            localPort: 22,
+          ),
+          isFalse,
         );
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);

--- a/test/presentation/screens/sftp_screen_test.dart
+++ b/test/presentation/screens/sftp_screen_test.dart
@@ -570,6 +570,57 @@ void main() {
       },
     );
 
+    testWidgets('handles stale SSH errors while opening the browser', (
+      tester,
+    ) async {
+      final sshClient = _MockSshClient();
+      final monetizationService = _MockMonetizationService();
+      final session = SshSession(
+        connectionId: 7,
+        hostId: 1,
+        client: sshClient,
+        config: const SshConnectionConfig(
+          hostname: 'demo.example.com',
+          port: 22,
+          username: 'demo',
+        ),
+      );
+
+      when(
+        () => monetizationService.currentState,
+      ).thenReturn(_proMonetizationState);
+      when(sshClient.sftp).thenThrow(SSHStateError('Transport is closed'));
+      when(sshClient.close).thenReturn(null);
+      addTearDown(session.close);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            activeSessionsProvider.overrideWith(
+              () => _TestActiveSessionsNotifier(session),
+            ),
+            monetizationServiceProvider.overrideWithValue(monetizationService),
+            monetizationStateProvider.overrideWith(
+              (ref) => Stream.value(_proMonetizationState),
+            ),
+          ],
+          child: const MaterialApp(
+            home: SftpScreen(hostId: 1, connectionId: 7),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(
+          'SFTP connection failed. Check the connection and try again.',
+        ),
+        findsOneWidget,
+      );
+
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
+
     testWidgets('video preview deletes cached files when closed', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- detect closed SSH transports during exec, SFTP, and shell activity
- route stale-connection health failures through the unexpected-disconnect cleanup path
- add coverage for removing a stale active session after a closed-transport channel-open failure

## Validation

- flutter test test/domain/services/ssh_service_test.dart
- flutter analyze --no-pub
