### PR TITLE
Group terminal overflow menu actions

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2920,6 +2920,116 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         .dy;
   }
 
+  RelativeRect _terminalOverflowSubmenuPosition(BuildContext context) {
+    final anchorContext = _terminalOverflowMenuButtonKey.currentContext;
+    final overlayRenderObject = Navigator.of(
+      context,
+    ).overlay?.context.findRenderObject();
+    final anchorRenderObject = anchorContext?.findRenderObject();
+    if (anchorRenderObject is! RenderBox ||
+        overlayRenderObject is! RenderBox ||
+        !anchorRenderObject.attached ||
+        !overlayRenderObject.attached) {
+      return RelativeRect.fill;
+    }
+
+    final anchorOffset = anchorRenderObject.localToGlobal(
+      Offset.zero,
+      ancestor: overlayRenderObject,
+    );
+    return RelativeRect.fromRect(
+      anchorOffset & anchorRenderObject.size,
+      Offset.zero & overlayRenderObject.size,
+    );
+  }
+
+  Future<void> _showTerminalOverflowSubmenu({
+    required BuildContext context,
+    required List<PopupMenuEntry<String>> items,
+  }) async {
+    final action = await showMenu<String>(
+      context: context,
+      position: _terminalOverflowSubmenuPosition(context),
+      requestFocus: terminalOverlayRouteRequestFocus(context),
+      constraints: _terminalOverflowMenuConstraints(
+        context: context,
+        isMobilePlatform: _isMobilePlatform,
+      ),
+      items: items,
+    );
+    if (!mounted || action == null) {
+      return;
+    }
+
+    await _handleMenuAction(action);
+  }
+
+  Widget _terminalOverflowMenuRow(
+    IconData icon,
+    String label, {
+    bool showsSubmenu = false,
+  }) => Row(
+    children: [
+      Icon(icon, size: 20),
+      const SizedBox(width: 12),
+      Expanded(child: Text(label)),
+      if (showsSubmenu) ...const [
+        SizedBox(width: 12),
+        Icon(Icons.chevron_right_rounded, size: 20),
+      ],
+    ],
+  );
+
+  List<PopupMenuEntry<String>> _terminalPastingMenuItems() => [
+    PopupMenuItem<String>(
+      value: 'paste',
+      child: _terminalOverflowMenuRow(Icons.paste_rounded, 'Paste'),
+    ),
+    PopupMenuItem<String>(
+      value: 'paste_image',
+      child: _terminalOverflowMenuRow(Icons.image_outlined, 'Paste Images'),
+    ),
+    PopupMenuItem<String>(
+      value: 'paste_file',
+      child: _terminalOverflowMenuRow(Icons.attach_file_rounded, 'Paste Files'),
+    ),
+  ];
+
+  List<PopupMenuEntry<String>> _terminalOptionsMenuItems({
+    required bool hasTerminalInfo,
+    required bool isMobile,
+  }) => [
+    if (hasTerminalInfo)
+      PopupMenuItem<String>(
+        value: 'toggle_terminal_info',
+        child: _terminalOverflowMenuRow(
+          _showsTerminalMetadata
+              ? Icons.info_outlined
+              : Icons.info_outline_rounded,
+          _showsTerminalMetadata ? 'Hide Terminal Info' : 'Show Terminal Info',
+        ),
+      ),
+    if (_isTmuxActive)
+      PopupMenuItem<String>(
+        value: 'toggle_tmux_bar',
+        child: _terminalOverflowMenuRow(
+          _showTmuxBar ? Icons.window_outlined : Icons.window_rounded,
+          _showTmuxBar ? 'Hide tmux Bar' : 'Show tmux Bar',
+        ),
+      ),
+    if (isMobile)
+      CheckedPopupMenuItem<String>(
+        value: 'toggle_tap_keyboard',
+        checked: ref.read(tapToShowKeyboardNotifierProvider),
+        child: const Text('Tap to Show Keyboard'),
+      ),
+    CheckedPopupMenuItem<String>(
+      value: 'toggle_shell_completions',
+      checked: ref.read(shellCompletionsNotifierProvider),
+      child: const Text('Shell Completion Popups'),
+    ),
+  ];
+
   bool get _showsNativeSelectionOverlay => shouldShowNativeSelectionOverlay(
     isNativeSelectionMode: _isNativeSelectionMode,
     routesTouchScrollToTerminal: _routesTouchScrollToTerminal,
@@ -8137,162 +8247,83 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             ),
             PopupMenuButton<String>(
               key: _terminalOverflowMenuButtonKey,
-              onSelected: _handleMenuAction,
+              onSelected: (action) => _handleTerminalOverflowMenuAction(
+                context,
+                action,
+                hasTerminalInfo: statusChips.isNotEmpty,
+                isMobile: isMobile,
+              ),
               requestFocus: terminalOverlayRouteRequestFocus(context),
               constraints: _terminalOverflowMenuConstraints(
                 context: context,
                 isMobilePlatform: isMobile,
               ),
               itemBuilder: (context) => [
-                const PopupMenuItem(
+                PopupMenuItem<String>(
                   value: 'snippets',
-                  child: Row(
-                    children: [
-                      Icon(Icons.code_rounded, size: 20),
-                      SizedBox(width: 12),
-                      Text('Snippets'),
-                    ],
+                  child: _terminalOverflowMenuRow(
+                    Icons.code_rounded,
+                    'Snippets',
                   ),
                 ),
-                const PopupMenuItem(
+                PopupMenuItem<String>(
                   value: 'change_theme',
-                  child: Row(
-                    children: [
-                      Icon(Icons.palette_outlined, size: 20),
-                      SizedBox(width: 12),
-                      Text('Change Theme'),
-                    ],
+                  child: _terminalOverflowMenuRow(
+                    Icons.palette_outlined,
+                    'Change Theme',
                   ),
                 ),
-                if (statusChips.isNotEmpty)
-                  PopupMenuItem(
-                    value: 'toggle_terminal_info',
-                    child: Row(
-                      children: [
-                        Icon(
-                          _showsTerminalMetadata
-                              ? Icons.info_outlined
-                              : Icons.info_outline_rounded,
-                          size: 20,
-                        ),
-                        const SizedBox(width: 12),
-                        Text(
-                          _showsTerminalMetadata
-                              ? 'Hide Terminal Info'
-                              : 'Show Terminal Info',
-                        ),
-                      ],
-                    ),
+                PopupMenuItem<String>(
+                  value: 'options_submenu',
+                  child: _terminalOverflowMenuRow(
+                    Icons.tune_rounded,
+                    'Options',
+                    showsSubmenu: true,
                   ),
-                if (_isTmuxActive)
-                  PopupMenuItem(
-                    value: 'toggle_tmux_bar',
-                    child: Row(
-                      children: [
-                        Icon(
-                          _showTmuxBar
-                              ? Icons.window_outlined
-                              : Icons.window_rounded,
-                          size: 20,
-                        ),
-                        const SizedBox(width: 12),
-                        Text(_showTmuxBar ? 'Hide tmux Bar' : 'Show tmux Bar'),
-                      ],
-                    ),
-                  ),
-                if (isMobile)
-                  CheckedPopupMenuItem(
-                    value: 'toggle_tap_keyboard',
-                    checked: ref.read(tapToShowKeyboardNotifierProvider),
-                    child: const Text('Tap to Show Keyboard'),
-                  ),
-                CheckedPopupMenuItem(
-                  value: 'toggle_shell_completions',
-                  checked: ref.read(shellCompletionsNotifierProvider),
-                  child: const Text('Shell Completion Popups'),
                 ),
                 const PopupMenuDivider(),
                 if (!isMobile)
-                  PopupMenuItem(
+                  PopupMenuItem<String>(
                     value: 'native_select',
-                    child: Row(
-                      children: [
-                        Icon(
-                          _isNativeSelectionMode
-                              ? Icons.deselect_rounded
-                              : Icons.select_all_rounded,
-                          size: 20,
-                        ),
-                        const SizedBox(width: 12),
-                        Text(
-                          _isNativeSelectionMode
-                              ? 'Exit Native Selection'
-                              : 'Native Selection',
-                        ),
-                      ],
+                    child: _terminalOverflowMenuRow(
+                      _isNativeSelectionMode
+                          ? Icons.deselect_rounded
+                          : Icons.select_all_rounded,
+                      _isNativeSelectionMode
+                          ? 'Exit Native Selection'
+                          : 'Native Selection',
                     ),
                   ),
                 if (_workingDirectoryPath != null)
-                  const PopupMenuItem(
+                  PopupMenuItem<String>(
                     value: 'copy_working_directory',
-                    child: Row(
-                      children: [
-                        Icon(Icons.folder_copy_outlined, size: 20),
-                        SizedBox(width: 12),
-                        Text('Copy Current Directory'),
-                      ],
+                    child: _terminalOverflowMenuRow(
+                      Icons.folder_copy_outlined,
+                      'Copy Current Directory',
                     ),
                   ),
                 if (_currentTerminalSelectionText() != null)
-                  const PopupMenuItem(
+                  PopupMenuItem<String>(
                     value: 'create_snippet',
-                    child: Row(
-                      children: [
-                        Icon(Icons.code_rounded, size: 20),
-                        SizedBox(width: 12),
-                        Text('Create Snippet'),
-                      ],
+                    child: _terminalOverflowMenuRow(
+                      Icons.code_rounded,
+                      'Create Snippet',
                     ),
                   ),
-                const PopupMenuItem(
-                  value: 'paste',
-                  child: Row(
-                    children: [
-                      Icon(Icons.paste_rounded, size: 20),
-                      SizedBox(width: 12),
-                      Text('Paste'),
-                    ],
-                  ),
-                ),
-                const PopupMenuItem(
-                  value: 'paste_image',
-                  child: Row(
-                    children: [
-                      Icon(Icons.image_outlined, size: 20),
-                      SizedBox(width: 12),
-                      Text('Paste Images'),
-                    ],
-                  ),
-                ),
-                const PopupMenuItem(
-                  value: 'paste_file',
-                  child: Row(
-                    children: [
-                      Icon(Icons.attach_file_rounded, size: 20),
-                      SizedBox(width: 12),
-                      Text('Paste Files'),
-                    ],
+                PopupMenuItem<String>(
+                  value: 'paste_submenu',
+                  child: _terminalOverflowMenuRow(
+                    Icons.paste_rounded,
+                    'Paste',
+                    showsSubmenu: true,
                   ),
                 ),
                 const PopupMenuDivider(),
-                const PopupMenuItem(
+                PopupMenuItem<String>(
                   value: 'disconnect',
-                  child: Row(
-                    children: [
-                      Icon(Icons.link_off_rounded, size: 20),
-                      SizedBox(width: 12),
-                      Text('Disconnect'),
-                    ],
+                  child: _terminalOverflowMenuRow(
+                    Icons.link_off_rounded,
+                    'Disconnect',
                   ),
                 ),
               ],
@@ -9303,6 +9334,34 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       });
     }
     return paneDirectory;
+  }
+
+  Future<void> _handleTerminalOverflowMenuAction(
+    BuildContext context,
+    String action, {
+    required bool hasTerminalInfo,
+    required bool isMobile,
+  }) async {
+    switch (action) {
+      case 'options_submenu':
+        await _showTerminalOverflowSubmenu(
+          context: context,
+          items: _terminalOptionsMenuItems(
+            hasTerminalInfo: hasTerminalInfo,
+            isMobile: isMobile,
+          ),
+        );
+        break;
+      case 'paste_submenu':
+        await _showTerminalOverflowSubmenu(
+          context: context,
+          items: _terminalPastingMenuItems(),
+        );
+        break;
+      default:
+        await _handleMenuAction(action);
+        break;
+    }
   }
 
   Future<void> _handleMenuAction(String action) async {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -917,6 +917,20 @@ void main() {
       await tester.pump();
     }
 
+    Future<void> openTerminalOverflowMenu(WidgetTester tester) async {
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> openTerminalOverflowSubmenu(
+      WidgetTester tester,
+      String label,
+    ) async {
+      await openTerminalOverflowMenu(tester);
+      await tester.tap(find.widgetWithText(PopupMenuItem<String>, label));
+      await tester.pumpAndSettle();
+    }
+
     void enablePlainTuiSignals() {
       session.terminal!.write('\x1b[?1004h');
     }
@@ -1008,13 +1022,10 @@ void main() {
       expect(utf8.decode(shellWrites.expand((chunk) => chunk).toList()), 'x');
     });
 
-    testWidgets('terminal overflow menu omits standalone copy action', (
-      tester,
-    ) async {
+    testWidgets('terminal overflow menu groups paste actions', (tester) async {
       await pumpScreen(tester);
 
-      await tester.tap(find.byType(PopupMenuButton<String>));
-      await tester.pumpAndSettle();
+      await openTerminalOverflowMenu(tester);
 
       expect(
         find.byWidgetPredicate(
@@ -1026,6 +1037,39 @@ void main() {
         find.byWidgetPredicate(
           (widget) =>
               widget is PopupMenuItem<String> && widget.value == 'paste',
+        ),
+        findsNothing,
+      );
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is PopupMenuItem<String> && widget.value == 'paste_file',
+        ),
+        findsNothing,
+      );
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is PopupMenuItem<String> &&
+              widget.value == 'paste_submenu',
+        ),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.widgetWithText(PopupMenuItem<String>, 'Paste'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is PopupMenuItem<String> && widget.value == 'paste',
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is PopupMenuItem<String> && widget.value == 'paste_image',
         ),
         findsOneWidget,
       );
@@ -1043,8 +1087,7 @@ void main() {
       (tester) async {
         await pumpScreen(tester);
 
-        await tester.tap(find.byType(PopupMenuButton<String>));
-        await tester.pumpAndSettle();
+        await openTerminalOverflowSubmenu(tester, 'Options');
 
         expect(
           find.widgetWithText(
@@ -1079,8 +1122,7 @@ void main() {
               widget.value == 'create_snippet',
         );
 
-        await tester.tap(find.byType(PopupMenuButton<String>));
-        await tester.pumpAndSettle();
+        await openTerminalOverflowMenu(tester);
         expect(createSnippetItem(), findsNothing);
 
         await tester.tapAt(const Offset(2, 2));
@@ -1100,8 +1142,7 @@ void main() {
         );
         await tester.pump();
 
-        await tester.tap(find.byType(PopupMenuButton<String>));
-        await tester.pumpAndSettle();
+        await openTerminalOverflowMenu(tester);
         expect(createSnippetItem(), findsOneWidget);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),
@@ -2434,8 +2475,7 @@ void main() {
     ) async {
       await pumpScreen(tester);
 
-      await tester.tap(find.byType(PopupMenuButton<String>));
-      await tester.pumpAndSettle();
+      await openTerminalOverflowSubmenu(tester, 'Options');
 
       final menuItem = find.widgetWithText(
         CheckedPopupMenuItem<String>,
@@ -3613,8 +3653,7 @@ void main() {
         expect(dismissRegion, findsOneWidget);
         expect(tester.widget<PopScope<Object?>>(popScope).canPop, isFalse);
 
-        await tester.tap(find.byType(PopupMenuButton<String>));
-        await tester.pumpAndSettle();
+        await openTerminalOverflowSubmenu(tester, 'Options');
         await tester.tap(find.text('Hide tmux Bar'));
         await tester.pumpAndSettle();
 
@@ -4147,8 +4186,7 @@ void main() {
           isFalse,
         );
 
-        await tester.tap(find.byType(PopupMenuButton<String>));
-        await tester.pumpAndSettle();
+        await openTerminalOverflowMenu(tester);
 
         expect(find.text('Snippets'), findsOneWidget);
         expect(tester.testTextInput.isVisible, isTrue);
@@ -4169,13 +4207,12 @@ void main() {
             ..resetDevicePixelRatio()
             ..resetViewInsets();
         });
-
         await pumpScreen(tester);
         await tester.tap(find.byType(MonkeyTerminalView));
         await tester.pump();
+        await tester.pump();
 
-        await tester.tap(find.byType(PopupMenuButton<String>));
-        await tester.pumpAndSettle();
+        await openTerminalOverflowMenu(tester);
 
         const keyboardTop = 844 - 500;
         final menuScrollable = find.ancestor(


### PR DESCRIPTION
## Summary

- Group terminal overflow menu paste actions behind a Paste submenu.
- Group terminal info, tmux bar, keyboard, and shell completion toggles behind an Options submenu.
- Update terminal screen widget tests for the new submenu flow.

## Tests

- `dart analyze lib/presentation/screens/terminal_screen.dart test/presentation/screens/terminal_screen_test.dart`
- `flutter test --no-pub test/presentation/screens/terminal_screen_test.dart --name "terminal overflow menu groups paste actions"`
- `flutter test test/presentation/screens/terminal_screen_test.dart --name "terminal overflow menu groups paste actions|mobile terminal overflow menu omits sensitive keyboard action|overflow menu shows Create Snippet|overflow menu toggles shell completion popups|hiding the expanded tmux bar restores normal back handling|terminal overflow menu preserves the visible mobile keyboard|terminal overflow menu stays above the visible mobile keyboard|terminal overflow menu uses default route focus on desktop"`
