### PR TITLE
fix: refresh MonkeyMux window rendering

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2769,6 +2769,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   String? _recentLocalClipboardText;
   DateTime? _recentLocalClipboardAt;
   bool _isTerminalSizeRefreshQueued = false;
+  bool _pendingTerminalSizeRefreshForcesDisplayRefresh = false;
+  bool _pendingTerminalSizeRefreshRevealsLatestOutput = false;
   bool _terminalWakeLockSetting = false;
   int _shellCompletionGeneration = 0;
   String? _shellCompletionPromptPrefix;
@@ -5826,19 +5828,51 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _terminalWithOwnedCallbacks = null;
   }
 
-  void _scheduleTerminalSizeRefresh() {
+  void _scheduleTerminalSizeRefresh({
+    bool forceDisplayRefresh = false,
+    bool revealLatestOutput = false,
+  }) {
+    _pendingTerminalSizeRefreshForcesDisplayRefresh =
+        _pendingTerminalSizeRefreshForcesDisplayRefresh ||
+        forceDisplayRefresh ||
+        revealLatestOutput;
+    _pendingTerminalSizeRefreshRevealsLatestOutput =
+        _pendingTerminalSizeRefreshRevealsLatestOutput || revealLatestOutput;
     if (_isTerminalSizeRefreshQueued) {
       return;
     }
     _isTerminalSizeRefreshQueued = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _isTerminalSizeRefreshQueued = false;
+      final forceDisplayRefresh =
+          _pendingTerminalSizeRefreshForcesDisplayRefresh;
+      final shouldRevealLatestOutput =
+          _pendingTerminalSizeRefreshRevealsLatestOutput;
+      _pendingTerminalSizeRefreshForcesDisplayRefresh = false;
+      _pendingTerminalSizeRefreshRevealsLatestOutput = false;
       if (!mounted) {
         return;
       }
-      _terminalViewKey.currentState?.refreshTerminalSize();
+      final revealLatestOutput =
+          shouldRevealLatestOutput && !_isTerminalOutputFollowPaused;
+      final terminalView = _terminalViewKey.currentState;
+      if (forceDisplayRefresh) {
+        terminalView?.refreshTerminalDisplay(
+          revealLatestOutput: revealLatestOutput,
+        );
+      } else {
+        terminalView?.refreshTerminalSize();
+      }
     });
     WidgetsBinding.instance.ensureVisualUpdate();
+  }
+
+  void _refreshTerminalAfterMonkeyMuxWindowChange() {
+    _followLiveOutput();
+    _scheduleTerminalSizeRefresh(
+      forceDisplayRefresh: true,
+      revealLatestOutput: true,
+    );
   }
 
   SshConnectionState _readCurrentConnectionState() {
@@ -7420,7 +7454,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         forceVisibleTmux: forceVisibleTmux,
       );
     }
-    _scheduleTerminalSizeRefresh();
+    if (backend.remoteMuxBackend == RemoteMuxBackend.monkeyMux) {
+      _refreshTerminalAfterMonkeyMuxWindowChange();
+    } else {
+      _scheduleTerminalSizeRefresh();
+    }
     _scheduleTmuxTerminalThemeRefreshAfterWindowStateChange(
       session: session,
       sessionName: sessionName,
@@ -7467,7 +7505,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (backend.remoteMuxBackend != RemoteMuxBackend.monkeyMux) {
       await _reattachTmuxIfNeeded(session, sessionName);
     }
-    _scheduleTerminalSizeRefresh();
+    if (backend.remoteMuxBackend == RemoteMuxBackend.monkeyMux) {
+      _refreshTerminalAfterMonkeyMuxWindowChange();
+    } else {
+      _scheduleTerminalSizeRefresh();
+    }
     _scheduleTmuxTerminalThemeRefreshAfterWindowStateChange(
       session: session,
       sessionName: sessionName,
@@ -7510,7 +7552,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
     _tmuxCurrentCommand = null;
     _shellCompletionTmuxContextRefreshedAt = null;
-    _scheduleTerminalSizeRefresh();
+    if (_activeMuxBackend == RemoteMuxBackend.monkeyMux) {
+      _refreshTerminalAfterMonkeyMuxWindowChange();
+    } else {
+      _scheduleTerminalSizeRefresh();
+    }
     _scheduleTmuxTerminalThemeRefreshAfterWindowStateChange(
       session: session,
       sessionName: sessionName,

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -677,6 +677,26 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
     }
   }
 
+  /// Forces the visible terminal viewport to repaint after remote replay.
+  void refreshTerminalDisplay({bool revealLatestOutput = false}) {
+    final renderObject = _viewportKey.currentContext?.findRenderObject();
+    if (renderObject is MonkeyRenderTerminal) {
+      renderObject._refreshTerminalDisplay(
+        revealLatestOutput: revealLatestOutput,
+      );
+    }
+    if (!revealLatestOutput) {
+      return;
+    }
+
+    _scrollToBottom();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _scrollToBottom();
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final cursorFocusNode = widget.cursorFocusNode ?? _focusNode;
@@ -2574,6 +2594,20 @@ class MonkeyRenderTerminal extends RenderBox
       return;
     }
     _updateViewportSize(notifyIfUnchanged: true);
+    markNeedsPaint();
+  }
+
+  void _refreshTerminalDisplay({bool revealLatestOutput = false}) {
+    if (revealLatestOutput) {
+      _stickToBottom = true;
+    }
+    if (!hasSize) {
+      markNeedsLayout();
+      return;
+    }
+    _updateViewportSize(notifyIfUnchanged: true);
+    markNeedsLayout();
+    markNeedsPaint();
   }
 
   void _resizeTerminalIfNeeded({

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -725,6 +725,74 @@ void main() {
       },
     );
 
+    testWidgets('refreshTerminalDisplay reveals latest output', (tester) async {
+      final terminal = Terminal(maxLines: 120);
+      for (var row = 0; row < 60; row += 1) {
+        terminal.write('${rowLabel(row)}\r\n');
+      }
+      final controller = TerminalController();
+
+      await pumpSelectableTerminal(
+        tester,
+        terminal: terminal,
+        controller: controller,
+        height: 160,
+      );
+      final scrollableState = tester.state<ScrollableState>(
+        find.descendant(
+          of: find.byType(MonkeyTerminalView),
+          matching: find.byType(Scrollable),
+        ),
+      );
+      final position = scrollableState.position;
+      expect(position.maxScrollExtent, greaterThan(0));
+
+      position.jumpTo(0);
+      await tester.pump();
+      expect(position.pixels, 0);
+
+      tester
+          .state<MonkeyTerminalViewState>(find.byType(MonkeyTerminalView))
+          .refreshTerminalDisplay(revealLatestOutput: true);
+      await tester.pump();
+      await tester.pump();
+
+      expect(position.pixels, position.maxScrollExtent);
+    });
+
+    testWidgets('refreshTerminalDisplay relayouts without revealing output', (
+      tester,
+    ) async {
+      final terminal = Terminal(maxLines: 120);
+      for (var row = 0; row < 60; row += 1) {
+        terminal.write('${rowLabel(row)}\r\n');
+      }
+      final controller = TerminalController();
+
+      final renderTerminal = await pumpSelectableTerminal(
+        tester,
+        terminal: terminal,
+        controller: controller,
+        height: 160,
+      );
+      final scrollableState = tester.state<ScrollableState>(
+        find.descendant(
+          of: find.byType(MonkeyTerminalView),
+          matching: find.byType(Scrollable),
+        ),
+      );
+      final position = scrollableState.position..jumpTo(0);
+      await tester.pump();
+      expect(renderTerminal.debugNeedsLayout, isFalse);
+
+      tester
+          .state<MonkeyTerminalViewState>(find.byType(MonkeyTerminalView))
+          .refreshTerminalDisplay();
+
+      expect(renderTerminal.debugNeedsLayout, isTrue);
+      expect(position.pixels, 0);
+    });
+
     testWidgets(
       'handle drag keeps updating after keyboard-sized resize',
       (tester) async {
@@ -1895,6 +1963,127 @@ void main() {
         expect(shellTextAfterThemeChange, isNot(contains('\x1b]10;')));
         expect(shellTextAfterThemeChange, isNot(contains('\x1b]11;')));
         expect(shellTextAfterThemeChange, isNot(contains('\x1b]4;')));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'MonkeyMux window switches reveal the replayed terminal viewport',
+      (tester) async {
+        final tmuxService = _MockTmuxService();
+        final monkeyMuxService = _MockMonkeyMuxService();
+        final windowEvents = StreamController<TmuxWindowChangeEvent>();
+        addTearDown(windowEvents.close);
+        const sessionName = 'work';
+        const initialWindows = <TmuxWindow>[
+          TmuxWindow(index: 0, name: 'shell', isActive: true, id: '@0'),
+          TmuxWindow(index: 1, name: 'agent', isActive: false, id: '@1'),
+        ];
+        host = _buildHost(
+          id: host.id,
+          tmuxSessionName: sessionName,
+          remoteMuxBackend: RemoteMuxBackend.monkeyMux,
+        );
+        for (var row = 0; row < 120; row += 1) {
+          session.terminal!.write('row $row\r\n');
+        }
+
+        when(
+          () => tmuxService.prefetchInstalledAgentTools(session),
+        ).thenAnswer((_) async {});
+        when(
+          () => monkeyMuxService.hasForegroundClientOrThrow(
+            session,
+            sessionName,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async => true);
+        when(
+          () => monkeyMuxService.listWindows(
+            session,
+            sessionName,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async => initialWindows);
+        when(
+          () => monkeyMuxService.watchWindowChanges(
+            session,
+            sessionName,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) => windowEvents.stream);
+        when(
+          () => monkeyMuxService.selectWindow(
+            session,
+            sessionName,
+            1,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => monkeyMuxService.refreshTerminalTheme(
+            session,
+            sessionName,
+            any(),
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async {});
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+              tmuxServiceProvider.overrideWithValue(tmuxService),
+              monkeyMuxServiceProvider.overrideWithValue(monkeyMuxService),
+            ],
+            child: MaterialApp(
+              home: TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+        final scrollableState = tester.state<ScrollableState>(
+          find.descendant(
+            of: find.byType(MonkeyTerminalView),
+            matching: find.byType(Scrollable),
+          ),
+        );
+        final position = scrollableState.position;
+        expect(position.maxScrollExtent, greaterThan(0));
+
+        position.jumpTo(0);
+        await tester.pump();
+        expect(position.pixels, 0);
+
+        await tester.tap(find.byKey(const ValueKey('tmux-handle-bar')));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+        await tester.tap(find.text('agent'));
+        await tester.pump();
+        await tester.pump();
+        await tester.pump();
+
+        verify(
+          () => monkeyMuxService.selectWindow(session, sessionName, 1),
+        ).called(1);
+        expect(position.pixels, position.maxScrollExtent);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -2081,7 +2081,12 @@ void main() {
         await tester.pump();
 
         verify(
-          () => monkeyMuxService.selectWindow(session, sessionName, 1),
+          () => monkeyMuxService.selectWindow(
+            session,
+            sessionName,
+            1,
+            extraFlags: any(named: 'extraFlags'),
+          ),
         ).called(1);
         expect(position.pixels, position.maxScrollExtent);
       },


### PR DESCRIPTION
## Summary

- Force MonkeyMux window switch/create/close paths through a terminal display refresh so replayed windows relayout and repaint even when the terminal size is unchanged.
- Reveal the latest replayed MonkeyMux output when live-output following is not paused, while still preserving selection/touch pause behavior.
- Add regression coverage for display refresh relayout/reveal behavior and MonkeyMux window switching.

## Tests

- flutter test test/presentation/screens/terminal_screen_test.dart
- flutter analyze
