### PR TITLE
Reset IME completions on terminal context changes

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3826,6 +3826,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   void _handleTmuxWindowStateChanged(SshSession session, String sessionName) {
+    _terminalTextInputController.resetImeCompletions();
     if (_activeMuxBackend == RemoteMuxBackend.monkeyMux) {
       _refreshMuxPaneContextAfterWindowStateChange(session, sessionName);
       return;
@@ -7444,6 +7445,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     } else {
       await backend.selectWindow(windowIndex, windowId: targetWindowId);
     }
+    _terminalTextInputController.resetImeCompletions();
 
     // Clear stale working directory — it will be refreshed from
     // OSC 7 or the next tmux query.
@@ -7502,6 +7504,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       name: name,
       workingDirectory: resolvedWorkingDirectory,
     );
+    _terminalTextInputController.resetImeCompletions();
     _tmuxWorkingDirectory = resolvedWorkingDirectory;
     _tmuxCurrentCommand = null;
     _shellCompletionTmuxContextRefreshedAt = null;
@@ -7553,6 +7556,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       await _handleMuxSessionEnded(session, sessionName);
       return;
     }
+    _terminalTextInputController.resetImeCompletions();
     _tmuxCurrentCommand = null;
     _shellCompletionTmuxContextRefreshedAt = null;
     if (_activeMuxBackend == RemoteMuxBackend.monkeyMux) {
@@ -8457,6 +8461,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       if (!mounted) {
         return;
       }
+      _terminalTextInputController.resetImeCompletions();
       _terminalFocusNode.requestFocus();
       final shouldShowKeyboard =
           forceShowSystemKeyboard ||

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3825,8 +3825,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
   }
 
-  void _handleTmuxWindowStateChanged(SshSession session, String sessionName) {
-    _terminalTextInputController.resetImeCompletions();
+  void _handleTmuxWindowStateChanged(
+    SshSession session,
+    String sessionName, {
+    required bool activeWindowChanged,
+  }) {
+    if (activeWindowChanged) {
+      _terminalTextInputController.resetImeCompletions();
+    }
     if (_activeMuxBackend == RemoteMuxBackend.monkeyMux) {
       _refreshMuxPaneContextAfterWindowStateChange(session, sessionName);
       return;

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -168,6 +168,11 @@ class TerminalTextInputHandlerController {
     _state?._clearImeBufferForFreshInput();
   }
 
+  /// Resets platform IME completions after switching terminal contexts.
+  void resetImeCompletions() {
+    _state?._resetImeCompletions();
+  }
+
   /// Resets stale IME context after remote terminal output returns to a prompt.
   void handleExternalTerminalOutput() {
     _state?._handleExternalTerminalOutput();
@@ -865,6 +870,13 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _modifierChordResetTime = armModifierChordWindow
         ? _readModifierChordClock()
         : null;
+  }
+
+  void _resetImeCompletions() {
+    _clearImeBufferForFreshInput(
+      flushPlatformContext: true,
+      armSplitLeadingTokenNormalization: true,
+    );
   }
 
   void _handleExternalTerminalOutput() {

--- a/lib/presentation/widgets/tmux_expandable_bar.dart
+++ b/lib/presentation/widgets/tmux_expandable_bar.dart
@@ -67,7 +67,11 @@ class _TmuxExpandableBar extends StatefulWidget {
   /// Called when the expanded/collapsed state changes.
   final ValueChanged<bool> onExpandedChanged;
 
-  final void Function(SshSession session, String sessionName)?
+  final void Function(
+    SshSession session,
+    String sessionName, {
+    required bool activeWindowChanged,
+  })?
   onWindowStateChanged;
 
   final Future<void> Function(SshSession session, String sessionName)?
@@ -277,7 +281,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         },
       );
       _loadWindows();
-      _notifyWindowStateChanged();
+      _notifyWindowStateChanged(activeWindowChanged: false);
       return;
     }
     if (event is TmuxWindowListEvent) {
@@ -295,9 +299,12 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       final shouldNotifyWindowStateChanged =
           currentWindows == null ||
           _shouldRefreshTmuxThemeAfterWindowChange(currentWindows, windows);
+      final activeWindowChanged =
+          currentWindows != null &&
+          _didDisplayedTmuxWindowChange(currentWindows, windows);
       _applyWindows(windows);
       if (shouldNotifyWindowStateChanged) {
-        _notifyWindowStateChanged();
+        _notifyWindowStateChanged(activeWindowChanged: activeWindowChanged);
       }
       return;
     }
@@ -316,6 +323,10 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     final windows = applyTmuxWindowChangeEvent(currentWindows, event);
     final shouldNotifyWindowStateChanged =
         _shouldRefreshTmuxThemeAfterWindowChange(currentWindows, windows);
+    final activeWindowChanged = _didDisplayedTmuxWindowChange(
+      currentWindows,
+      windows,
+    );
     DiagnosticsLogService.instance.debug(
       'tmux.ui',
       'bar_snapshot_applied',
@@ -327,12 +338,36 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     );
     _applyWindows(windows);
     if (shouldNotifyWindowStateChanged) {
-      _notifyWindowStateChanged();
+      _notifyWindowStateChanged(activeWindowChanged: activeWindowChanged);
     }
   }
 
-  void _notifyWindowStateChanged() {
-    widget.onWindowStateChanged?.call(widget.session, widget.tmuxSessionName);
+  void _notifyWindowStateChanged({required bool activeWindowChanged}) {
+    widget.onWindowStateChanged?.call(
+      widget.session,
+      widget.tmuxSessionName,
+      activeWindowChanged: activeWindowChanged,
+    );
+  }
+
+  bool _didDisplayedTmuxWindowChange(
+    List<TmuxWindow> previousWindows,
+    List<TmuxWindow> nextWindows,
+  ) =>
+      _displayedTmuxWindowContext(previousWindows) !=
+      _displayedTmuxWindowContext(nextWindows);
+
+  ({String key, int? panePid})? _displayedTmuxWindowContext(
+    List<TmuxWindow> windows,
+  ) {
+    final activeWindow = windows.where((window) => window.isActive).firstOrNull;
+    if (activeWindow == null) {
+      return null;
+    }
+    return (
+      key: activeWindow.id ?? '#${activeWindow.index}',
+      panePid: activeWindow.panePid,
+    );
   }
 
   bool _shouldRefreshTmuxThemeAfterWindowChange(

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1992,6 +1992,13 @@ void main() {
           () => tmuxService.prefetchInstalledAgentTools(session),
         ).thenAnswer((_) async {});
         when(
+          () => tmuxService.currentPaneContext(
+            session,
+            sessionName,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(
           () => monkeyMuxService.hasForegroundClientOrThrow(
             session,
             sessionName,
@@ -2072,6 +2079,12 @@ void main() {
         await tester.pump();
         expect(position.pixels, 0);
 
+        tester.testTextInput.updateEditingValue(
+          _editingValue('stale', selectionOffset: 5),
+        );
+        await tester.pump();
+        tester.testTextInput.log.clear();
+
         await tester.tap(find.byKey(const ValueKey('tmux-handle-bar')));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 350));
@@ -2089,6 +2102,22 @@ void main() {
           ),
         ).called(1);
         expect(position.pixels, position.maxScrollExtent);
+        final client =
+            tester.state(find.byType(TerminalTextInputHandler))
+                as TextInputClient;
+        expect(
+          client.currentTextEditingValue,
+          const TextEditingValue(
+            text: _deleteDetectionMarker,
+            selection: TextSelection.collapsed(offset: 2),
+          ),
+        );
+        expect(
+          tester.testTextInput.log.where(
+            (call) => call.method == 'TextInput.setEditingState',
+          ),
+          isNotEmpty,
+        );
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );
@@ -3028,6 +3057,13 @@ void main() {
         final refreshCountAfterTitleAgent = refreshCount;
 
         shellWrites.clear();
+        tester.testTextInput.updateEditingValue(
+          _editingValue('stale', selectionOffset: 5),
+        );
+        await tester.pump();
+        shellWrites.clear();
+        tester.testTextInput.log.clear();
+
         windowEvents.add(
           const TmuxWindowSnapshotEvent(
             TmuxWindow(index: 1, id: '@9', name: 'agent', isActive: true),
@@ -3052,6 +3088,22 @@ void main() {
         expect(writtenShellText, contains('\x1b]10;'));
         expect(writtenShellText, contains('\x1b]11;'));
         expect(writtenShellText, contains('\x1b]4;'));
+        final client =
+            tester.state(find.byType(TerminalTextInputHandler))
+                as TextInputClient;
+        expect(
+          client.currentTextEditingValue,
+          const TextEditingValue(
+            text: _deleteDetectionMarker,
+            selection: TextSelection.collapsed(offset: 2),
+          ),
+        );
+        expect(
+          tester.testTextInput.log.where(
+            (call) => call.method == 'TextInput.setEditingState',
+          ),
+          isNotEmpty,
+        );
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );
@@ -4336,6 +4388,10 @@ void main() {
         await tester.pump();
 
         expect(tester.testTextInput.isVisible, isTrue);
+        tester.testTextInput.updateEditingValue(
+          _editingValue('resume', selectionOffset: 6),
+        );
+        await tester.pump();
 
         tester.testTextInput.log.clear();
         tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
@@ -4355,6 +4411,22 @@ void main() {
         expect(
           tester.testTextInput.log.where(
             (call) => call.method == 'TextInput.show',
+          ),
+          isNotEmpty,
+        );
+        final client =
+            tester.state(find.byType(TerminalTextInputHandler))
+                as TextInputClient;
+        expect(
+          client.currentTextEditingValue,
+          const TextEditingValue(
+            text: _deleteDetectionMarker,
+            selection: TextSelection.collapsed(offset: 2),
+          ),
+        );
+        expect(
+          tester.testTextInput.log.where(
+            (call) => call.method == 'TextInput.setEditingState',
           ),
           isNotEmpty,
         );

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -3058,6 +3058,45 @@ void main() {
 
         shellWrites.clear();
         tester.testTextInput.updateEditingValue(
+          _editingValue('background', selectionOffset: 10),
+        );
+        await tester.pump();
+        tester.testTextInput.log.clear();
+
+        windowEvents.add(
+          const TmuxWindowSnapshotEvent(
+            TmuxWindow(
+              index: 1,
+              id: '@9',
+              name: 'agent-renamed',
+              isActive: false,
+              currentCommand: 'vim',
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 150));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 60));
+
+        expect(refreshCount, greaterThan(refreshCountAfterTitleAgent));
+        final backgroundClient =
+            tester.state(find.byType(TerminalTextInputHandler))
+                as TextInputClient;
+        expect(
+          backgroundClient.currentTextEditingValue,
+          _editingValue('background', selectionOffset: 10),
+        );
+        expect(
+          tester.testTextInput.log.where(
+            (call) => call.method == 'TextInput.setEditingState',
+          ),
+          isEmpty,
+        );
+        final refreshCountAfterBackgroundWindow = refreshCount;
+
+        shellWrites.clear();
+        tester.testTextInput.updateEditingValue(
           _editingValue('stale', selectionOffset: 5),
         );
         await tester.pump();
@@ -3072,13 +3111,13 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 149));
 
-        expect(refreshCount, refreshCountAfterTitleAgent);
+        expect(refreshCount, refreshCountAfterBackgroundWindow);
 
         await tester.pump(const Duration(milliseconds: 1));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 60));
 
-        expect(refreshCount, greaterThan(refreshCountAfterTitleAgent));
+        expect(refreshCount, greaterThan(refreshCountAfterBackgroundWindow));
         final writtenShellText = utf8.decode(
           shellWrites.expand((chunk) => chunk).toList(growable: false),
         );

--- a/test/presentation/widgets/terminal_text_input_handler_test.dart
+++ b/test/presentation/widgets/terminal_text_input_handler_test.dart
@@ -54,6 +54,62 @@ const _deleteDetectionMarker = '\u200B\u200B';
 
 void main() {
   group('TerminalTextInputHandler', () {
+    testWidgets('controller resets platform IME completions', (tester) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+      final focusNode = FocusNode();
+      final controller = TerminalTextInputHandlerController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalTextInputHandler(
+              terminal: terminal,
+              focusNode: focusNode,
+              controller: controller,
+              deleteDetection: true,
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      tester.testTextInput.updateEditingValue(
+        const TextEditingValue(
+          text: '${_deleteDetectionMarker}hello',
+          selection: TextSelection.collapsed(offset: 7),
+        ),
+      );
+      await tester.pump();
+
+      tester.testTextInput.log.clear();
+
+      controller.resetImeCompletions();
+      await tester.pump();
+
+      final client =
+          tester.state(find.byType(TerminalTextInputHandler))
+              as TextInputClient;
+      expect(
+        client.currentTextEditingValue,
+        const TextEditingValue(
+          text: _deleteDetectionMarker,
+          selection: TextSelection.collapsed(offset: 2),
+        ),
+      );
+      expect(
+        tester.testTextInput.log.where(
+          (call) => call.method == 'TextInput.setEditingState',
+        ),
+        isNotEmpty,
+      );
+
+      focusNode.dispose();
+    });
+
     testWidgets('clears composing IME state after a touch-driven caret move', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- Reset platform IME completions when tmux/MonkeyMux window state changes.
- Reset stale IME context after mux select/create/close actions and when terminal focus is restored.
- Add widget/screen coverage for controller reset, terminal re-entry, MonkeyMux switching, and tmux window-state updates.

## Validation

- `dart format lib/presentation/widgets/terminal_text_input_handler.dart lib/presentation/screens/terminal_screen.dart test/presentation/widgets/terminal_text_input_handler_test.dart test/presentation/screens/terminal_screen_test.dart`
- `git diff --check`
- `flutter analyze`
- `flutter test test/presentation/widgets/terminal_text_input_handler_test.dart test/presentation/screens/terminal_screen_test.dart`
- pre-commit hook: format, analyze, tests
