### PR TITLE
[codex] fix stale terminal reconnect

### DIFF
--- a/lib/presentation/controllers/terminal_session_controller.dart
+++ b/lib/presentation/controllers/terminal_session_controller.dart
@@ -69,6 +69,18 @@ class TerminalSessionController {
   bool isObservingSession(SshSession session) =>
       identical(_observedSession, session);
 
+  /// Stops observing terminal metadata for the current session.
+  void clearObservedSession({SshSession? session}) {
+    final observedSession = _observedSession;
+    if (observedSession == null ||
+        (session != null && !identical(observedSession, session))) {
+      return;
+    }
+
+    observedSession.removeMetadataListener(_onSessionMetadataChanged);
+    _observedSession = null;
+  }
+
   /// Resolves the session that should receive a coordinated terminal setting.
   SshSession? resolveTargetSession({SshSession? session}) {
     final connectionId = _connectionId();

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2846,6 +2846,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   // when it resumes if the OS killed the socket.
   bool _wasBackgrounded = false;
   bool _connectionLostWhileBackgrounded = false;
+  int? _suppressNextAutomaticReconnectConnectionId;
   bool _restoreKeyboardAfterAppResume = false;
   final GlobalKey _terminalOverflowMenuButtonKey = GlobalKey();
 
@@ -5789,7 +5790,24 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       }
       _clearDetectedSensitiveKeyboardPromptAfterInput(output);
       _handleTerminalOutputForShellCompletion(output);
-      _shell?.write(utf8.encode(output));
+      try {
+        _shell?.write(utf8.encode(output));
+      } on Object catch (error) {
+        DiagnosticsLogService.instance.warning(
+          'terminal.input',
+          'write_failed',
+          fields: {
+            'connectionId': session.connectionId,
+            'errorType': error.runtimeType,
+          },
+        );
+        unawaited(
+          _cleanupUnexpectedDisconnect(
+            session.connectionId,
+            message: 'Connection became unresponsive. Reconnecting…',
+          ),
+        );
+      }
     }
 
     _terminalOutputHandler = handleTerminalOutput;
@@ -7813,11 +7831,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
-    _shell = null;
-    unawaited(_doneSubscription?.cancel());
-    _doneSubscription = null;
+    final suppressAutomaticReconnect =
+        _suppressNextAutomaticReconnectConnectionId == connectionId;
+    _suppressNextAutomaticReconnectConnectionId = null;
+    _prepareTerminalForLostConnection(_observedSession);
     if (_wasBackgrounded) {
-      _connectionLostWhileBackgrounded = true;
+      _connectionLostWhileBackgrounded = !suppressAutomaticReconnect;
       return;
     }
     if (!mounted) {
@@ -7826,12 +7845,48 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     unawaited(SystemChannels.textInput.invokeMethod<void>('TextInput.hide'));
     _terminalFocusNode.unfocus();
+    if (suppressAutomaticReconnect) {
+      setState(() {
+        _isConnecting = false;
+        _error ??= 'Connection closed';
+      });
+      return;
+    }
+
+    _startAutomaticReconnect(
+      connectionId,
+      reason: 'tracked_connection_disconnected',
+    );
+  }
+
+  void _prepareTerminalForLostConnection(SshSession? session) {
+    _shell = null;
+    unawaited(_doneSubscription?.cancel());
+    _doneSubscription = null;
+    unawaited(_shellStdoutSubscription?.cancel());
+    _shellStdoutSubscription = null;
+    _promptOutputImeResetTimer?.cancel();
+    _promptOutputImeResetTimer = null;
+    _stopSharedClipboardSync();
     _hideShellCompletionPopup();
-    setState(() {
-      _clearTmuxState();
-      _isConnecting = false;
-      _error ??= 'Connection closed';
-    });
+    _clearOwnedTerminalCallbacks();
+    _sessionController.clearObservedSession(session: session);
+    _clearTmuxState();
+    _detectedSensitiveKeyboardPrompt = false;
+  }
+
+  void _startAutomaticReconnect(int connectionId, {required String reason}) {
+    if (_isConnecting || _connectionId != connectionId) {
+      return;
+    }
+
+    DiagnosticsLogService.instance.info(
+      'terminal',
+      'auto_reconnect_start',
+      fields: {'connectionId': connectionId, 'reason': reason},
+    );
+    _terminal.write('\r\n[reconnecting...]\r\n');
+    unawaited(_reconnect());
   }
 
   void _handleShellClosed() {
@@ -7856,6 +7911,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (_wasBackgrounded) {
       _connectionLostWhileBackgrounded = true;
     } else {
+      _suppressNextAutomaticReconnectConnectionId = connectionId;
       setState(() {
         _clearTmuxState();
         _detectedSensitiveKeyboardPrompt = false;
@@ -7894,6 +7950,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _clearAppThemeOverride();
     _cancelTerminalThemeRefreshTimers();
     _clearTmuxState();
+    _sessionController.clearObservedSession();
+    _suppressNextAutomaticReconnectConnectionId = null;
     _syncTerminalWakeLock(SshConnectionState.disconnected);
     unawaited(_doneSubscription?.cancel());
     _doneSubscription = null;
@@ -7927,6 +7985,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final previousConnectionId = _connectionId;
     _connectionId = null;
     _clearAppThemeOverride();
+    _sessionController.clearObservedSession();
+    _suppressNextAutomaticReconnectConnectionId = null;
     _syncTerminalWakeLock(SshConnectionState.disconnected);
     _connectionLostWhileBackgrounded = false;
     try {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -131,37 +131,78 @@ class _RecordingLocalNotificationService extends LocalNotificationService {
 }
 
 class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
-  _TestActiveSessionsNotifier(this.session);
+  _TestActiveSessionsNotifier(this.session, {SshSession? reconnectSession})
+    : reconnectSession = reconnectSession ?? session;
 
   final SshSession session;
+  final SshSession reconnectSession;
   final disconnectedConnectionIds = <int>[];
+  final connectForceNewValues = <bool>[];
+
+  Iterable<SshSession> get _sessions sync* {
+    yield session;
+    if (!identical(reconnectSession, session)) {
+      yield reconnectSession;
+    }
+  }
 
   @override
   Map<int, SshConnectionState> build() => <int, SshConnectionState>{
-    if (!disconnectedConnectionIds.contains(session.connectionId))
-      session.connectionId: SshConnectionState.connected,
+    for (final testSession in _sessions)
+      if (!disconnectedConnectionIds.contains(testSession.connectionId))
+        testSession.connectionId: SshConnectionState.connected,
   };
 
   @override
   ConnectionAttemptStatus? getConnectionAttempt(int hostId) => null;
 
   @override
-  List<int> getConnectionsForHost(int hostId) =>
-      hostId == session.hostId ? <int>[session.connectionId] : const <int>[];
+  List<int> getConnectionsForHost(int hostId) => _sessions
+      .where(
+        (testSession) =>
+            testSession.hostId == hostId &&
+            !disconnectedConnectionIds.contains(testSession.connectionId),
+      )
+      .map((testSession) => testSession.connectionId)
+      .toList(growable: false);
 
   @override
   ActiveConnection? getActiveConnection(int connectionId) => null;
 
   @override
-  SshSession? getSession(int connectionId) =>
-      connectionId == session.connectionId &&
-          !disconnectedConnectionIds.contains(connectionId)
-      ? session
-      : null;
+  SshSession? getSession(int connectionId) {
+    for (final testSession in _sessions) {
+      if (testSession.connectionId == connectionId &&
+          !disconnectedConnectionIds.contains(connectionId)) {
+        return testSession;
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<SshConnectionResult> connect(
+    int hostId, {
+    bool forceNew = false,
+    bool useHostThemeOverrides = true,
+  }) async {
+    connectForceNewValues.add(forceNew);
+    disconnectedConnectionIds.remove(reconnectSession.connectionId);
+    state = {
+      ...state,
+      reconnectSession.connectionId: SshConnectionState.connected,
+    };
+    return SshConnectionResult(
+      success: true,
+      connectionId: reconnectSession.connectionId,
+    );
+  }
 
   @override
   Future<void> disconnect(int connectionId) async {
-    disconnectedConnectionIds.add(connectionId);
+    if (!disconnectedConnectionIds.contains(connectionId)) {
+      disconnectedConnectionIds.add(connectionId);
+    }
     state = {...state}..remove(connectionId);
   }
 
@@ -951,6 +992,7 @@ void main() {
     Future<void> pumpScreen(
       WidgetTester tester, {
       ThemeMode themeMode = ThemeMode.light,
+      ActiveSessionsNotifier? activeSessions,
     }) async {
       await tester.pumpWidget(
         ProviderScope(
@@ -966,7 +1008,7 @@ void main() {
             ),
             sharedClipboardProvider.overrideWith((ref) async => false),
             activeSessionsProvider.overrideWith(
-              () => _TestActiveSessionsNotifier(session),
+              () => activeSessions ?? _TestActiveSessionsNotifier(session),
             ),
           ],
           child: MaterialApp(
@@ -1002,6 +1044,62 @@ void main() {
     void enablePlainTuiSignals() {
       session.terminal!.write('\x1b[?1004h');
     }
+
+    testWidgets(
+      'automatically reconnects when the active session disappears unexpectedly',
+      (tester) async {
+        final reconnectClient = _MockSshClient();
+        final reconnectShell = _MockShellChannel();
+        final reconnectDoneCompleter = Completer<void>();
+        final reconnectStdoutController =
+            StreamController<Uint8List>.broadcast();
+        addTearDown(reconnectStdoutController.close);
+
+        when(
+          () => reconnectClient.shell(pty: any(named: 'pty')),
+        ).thenAnswer((_) async => reconnectShell);
+        when(
+          () => reconnectShell.stdout,
+        ).thenAnswer((_) => reconnectStdoutController.stream);
+        when(
+          () => reconnectShell.stderr,
+        ).thenAnswer((_) => const Stream<Uint8List>.empty());
+        when(
+          () => reconnectShell.done,
+        ).thenAnswer((_) => reconnectDoneCompleter.future);
+        when(() => reconnectShell.write(any())).thenAnswer((_) {});
+
+        final reconnectSession = SshSession(
+          connectionId: 8,
+          hostId: host.id,
+          client: reconnectClient,
+          config: const SshConnectionConfig(
+            hostname: 'terminal.example.com',
+            port: 22,
+            username: 'root',
+          ),
+        );
+        final activeSessions = _TestActiveSessionsNotifier(
+          session,
+          reconnectSession: reconnectSession,
+        )..disconnectedConnectionIds.add(reconnectSession.connectionId);
+
+        await pumpScreen(tester, activeSessions: activeSessions);
+        verify(() => sshClient.shell(pty: any(named: 'pty'))).called(1);
+
+        await activeSessions.disconnect(session.connectionId);
+        await tester.pump();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(activeSessions.connectForceNewValues, <bool>[true]);
+        verify(() => reconnectClient.shell(pty: any(named: 'pty'))).called(1);
+        expect(activeSessions.disconnectedConnectionIds, <int>[
+          session.connectionId,
+        ]);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
 
     testWidgets('holds wake lock while an opted-in terminal is active', (
       tester,


### PR DESCRIPTION
## Summary

- Clear terminal callbacks, shell streams, observed session metadata, clipboard sync, and tmux/MonkeyMux UI state when the tracked active SSH session disappears.
- Start an automatic force-new reconnect for unexpected tracked disconnects instead of leaving the terminal bound to the stale connection ID.
- Suppress that automatic reconnect for the foreground shell-close path so an intentional `exit` still lands on the closed-connection state.
- Treat terminal input write failures as a stale connection signal and route them through the existing unexpected-disconnect cleanup.

## Root Cause

Closed-transport exec failures were already reported through the SSH session health-failure stream and removed from `ActiveSessionsNotifier`, but `TerminalScreen` kept its observed session, terminal callbacks, shell subscriptions, and tmux/MonkeyMux state attached to the dead connection. That allowed periodic MonkeyMux foreground and metadata probes to keep hitting the stale SSH client without forcing a new connection.

## Validation

- `flutter test test/presentation/screens/terminal_screen_test.dart --plain-name "automatically reconnects when the active session disappears unexpectedly"`
- `flutter test test/domain/services/ssh_service_test.dart --plain-name "removes stale sessions when channel opens report a closed transport"`
- `flutter test test/presentation/screens/terminal_screen_test.dart --plain-name "disconnects when final MonkeyMux close shuts the control channel"`
- `flutter test test/presentation/screens/terminal_screen_test.dart --plain-name "disconnects when MonkeyMux reports no remaining windows"`
- `flutter analyze lib/presentation/controllers/terminal_session_controller.dart lib/presentation/screens/terminal_screen.dart test/presentation/screens/terminal_screen_test.dart`
- `flutter test test/presentation/screens/terminal_screen_test.dart`
- Pre-commit checks: format, analyzer, full test suite
