### PR TITLE
[codex] Fix terminal overflow submenu foldouts

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2938,8 +2938,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         .dy;
   }
 
-  Widget _terminalOverflowMenuLabel(String label) =>
-      Text(label, overflow: TextOverflow.ellipsis);
+  Widget _terminalOverflowMenuLabel(String label) => Text(
+    label,
+    maxLines: 1,
+    overflow: TextOverflow.ellipsis,
+    softWrap: false,
+  );
 
   Widget _terminalOverflowMenuItem({
     required IconData icon,
@@ -8489,7 +8493,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                   action: 'disconnect',
                 ),
               ],
-              builder: (context, controller, child) => IconButton(
+              builder: (context, controller, _) => IconButton(
                 icon: const Icon(Icons.more_vert),
                 tooltip: MaterialLocalizations.of(context).showMenuTooltip,
                 onPressed: () {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2881,7 +2881,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     terminalReportsMouseWheel: _terminalReportsMouseWheel,
   );
 
-  BoxConstraints? _terminalOverflowMenuConstraints({
+  MenuStyle _terminalOverflowMenuStyle({
     required BuildContext context,
     required bool isMobilePlatform,
   }) {
@@ -2892,14 +2892,28 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       isMobilePlatform: isMobilePlatform,
       anchorTop: anchorTop,
     );
-    if (maxHeight == null) {
-      return null;
-    }
+    return MenuStyle(
+      minimumSize: const WidgetStatePropertyAll<Size>(
+        Size(_terminalOverflowMenuMinWidth, 0),
+      ),
+      maximumSize: WidgetStatePropertyAll<Size>(
+        Size(_terminalOverflowMenuMaxWidth, maxHeight ?? double.infinity),
+      ),
+    );
+  }
 
-    return BoxConstraints(
-      minWidth: _terminalOverflowMenuMinWidth,
-      maxWidth: _terminalOverflowMenuMaxWidth,
-      maxHeight: maxHeight,
+  EdgeInsetsGeometry _terminalOverflowMenuReservedPadding({
+    required BuildContext context,
+    required bool isMobilePlatform,
+  }) {
+    final mediaQuery = MediaQuery.of(context);
+    return EdgeInsets.only(
+      left: _terminalOverflowMenuScreenPadding,
+      top: _terminalOverflowMenuScreenPadding,
+      right: _terminalOverflowMenuScreenPadding,
+      bottom:
+          _terminalOverflowMenuScreenPadding +
+          (isMobilePlatform ? mediaQuery.viewInsets.bottom : 0),
     );
   }
 
@@ -2924,113 +2938,99 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         .dy;
   }
 
-  RelativeRect _terminalOverflowSubmenuPosition(BuildContext context) {
-    final anchorContext = _terminalOverflowMenuButtonKey.currentContext;
-    final overlayRenderObject = Navigator.of(
-      context,
-    ).overlay?.context.findRenderObject();
-    final anchorRenderObject = anchorContext?.findRenderObject();
-    if (anchorRenderObject is! RenderBox ||
-        overlayRenderObject is! RenderBox ||
-        !anchorRenderObject.attached ||
-        !overlayRenderObject.attached) {
-      return RelativeRect.fill;
-    }
+  Widget _terminalOverflowMenuLabel(String label) =>
+      Text(label, overflow: TextOverflow.ellipsis);
 
-    final anchorOffset = anchorRenderObject.localToGlobal(
-      Offset.zero,
-      ancestor: overlayRenderObject,
-    );
-    return RelativeRect.fromRect(
-      anchorOffset & anchorRenderObject.size,
-      Offset.zero & overlayRenderObject.size,
-    );
-  }
-
-  Future<void> _showTerminalOverflowSubmenu({
-    required BuildContext context,
-    required List<PopupMenuEntry<String>> items,
-  }) async {
-    final action = await showMenu<String>(
-      context: context,
-      position: _terminalOverflowSubmenuPosition(context),
-      requestFocus: terminalOverlayRouteRequestFocus(context),
-      constraints: _terminalOverflowMenuConstraints(
-        context: context,
-        isMobilePlatform: _isMobilePlatform,
-      ),
-      items: items,
-    );
-    if (!mounted || action == null) {
-      return;
-    }
-
-    await _handleMenuAction(action);
-  }
-
-  Widget _terminalOverflowMenuRow(
-    IconData icon,
-    String label, {
-    bool showsSubmenu = false,
-  }) => Row(
-    children: [
-      Icon(icon, size: 20),
-      const SizedBox(width: 12),
-      Expanded(child: Text(label)),
-      if (showsSubmenu) ...const [
-        SizedBox(width: 12),
-        Icon(Icons.chevron_right_rounded, size: 20),
-      ],
-    ],
+  Widget _terminalOverflowMenuItem({
+    required IconData icon,
+    required String label,
+    required String action,
+  }) => MenuItemButton(
+    leadingIcon: Icon(icon, size: 20),
+    onPressed: () => unawaited(_handleMenuAction(action)),
+    child: _terminalOverflowMenuLabel(label),
   );
 
-  List<PopupMenuEntry<String>> _terminalPastingMenuItems() => [
-    PopupMenuItem<String>(
-      value: 'paste',
-      child: _terminalOverflowMenuRow(Icons.paste_rounded, 'Paste'),
+  Widget _terminalOverflowCheckboxMenuItem({
+    required String label,
+    required bool checked,
+    required String action,
+  }) => CheckboxMenuButton(
+    value: checked,
+    onChanged: (_) => unawaited(_handleMenuAction(action)),
+    child: _terminalOverflowMenuLabel(label),
+  );
+
+  Widget _terminalOverflowSubmenuButton({
+    required BuildContext context,
+    required bool isMobile,
+    required IconData icon,
+    required String label,
+    required List<Widget> menuChildren,
+  }) => SubmenuButton(
+    leadingIcon: Icon(icon, size: 20),
+    menuStyle: _terminalOverflowMenuStyle(
+      context: context,
+      isMobilePlatform: isMobile,
     ),
-    PopupMenuItem<String>(
-      value: 'paste_image',
-      child: _terminalOverflowMenuRow(Icons.image_outlined, 'Paste Images'),
+    menuChildren: menuChildren,
+    child: _terminalOverflowMenuLabel(label),
+  );
+
+  Widget _terminalOverflowMenuDivider(BuildContext context) => Divider(
+    height: 1,
+    thickness: 1,
+    color: Theme.of(context).colorScheme.outlineVariant,
+  );
+
+  List<Widget> _terminalPastingMenuItems() => [
+    _terminalOverflowMenuItem(
+      icon: Icons.paste_rounded,
+      label: 'Paste',
+      action: 'paste',
     ),
-    PopupMenuItem<String>(
-      value: 'paste_file',
-      child: _terminalOverflowMenuRow(Icons.attach_file_rounded, 'Paste Files'),
+    _terminalOverflowMenuItem(
+      icon: Icons.image_outlined,
+      label: 'Paste Images',
+      action: 'paste_image',
+    ),
+    _terminalOverflowMenuItem(
+      icon: Icons.attach_file_rounded,
+      label: 'Paste Files',
+      action: 'paste_file',
     ),
   ];
 
-  List<PopupMenuEntry<String>> _terminalOptionsMenuItems({
+  List<Widget> _terminalOptionsMenuItems({
     required bool hasTerminalInfo,
     required bool isMobile,
   }) => [
     if (hasTerminalInfo)
-      PopupMenuItem<String>(
-        value: 'toggle_terminal_info',
-        child: _terminalOverflowMenuRow(
-          _showsTerminalMetadata
-              ? Icons.info_outlined
-              : Icons.info_outline_rounded,
-          _showsTerminalMetadata ? 'Hide Terminal Info' : 'Show Terminal Info',
-        ),
+      _terminalOverflowMenuItem(
+        icon: _showsTerminalMetadata
+            ? Icons.info_outlined
+            : Icons.info_outline_rounded,
+        label: _showsTerminalMetadata
+            ? 'Hide Terminal Info'
+            : 'Show Terminal Info',
+        action: 'toggle_terminal_info',
       ),
     if (_isTmuxActive)
-      PopupMenuItem<String>(
-        value: 'toggle_tmux_bar',
-        child: _terminalOverflowMenuRow(
-          _showTmuxBar ? Icons.window_outlined : Icons.window_rounded,
-          _showTmuxBar ? 'Hide tmux Bar' : 'Show tmux Bar',
-        ),
+      _terminalOverflowMenuItem(
+        icon: _showTmuxBar ? Icons.window_outlined : Icons.window_rounded,
+        label: _showTmuxBar ? 'Hide tmux Bar' : 'Show tmux Bar',
+        action: 'toggle_tmux_bar',
       ),
     if (isMobile)
-      CheckedPopupMenuItem<String>(
-        value: 'toggle_tap_keyboard',
+      _terminalOverflowCheckboxMenuItem(
+        label: 'Tap to Show Keyboard',
         checked: ref.read(tapToShowKeyboardNotifierProvider),
-        child: const Text('Tap to Show Keyboard'),
+        action: 'toggle_tap_keyboard',
       ),
-    CheckedPopupMenuItem<String>(
-      value: 'toggle_shell_completions',
+    _terminalOverflowCheckboxMenuItem(
+      label: 'Shell Completion Popups',
       checked: ref.read(shellCompletionsNotifierProvider),
-      child: const Text('Shell Completion Popups'),
+      action: 'toggle_shell_completions',
     ),
   ];
 
@@ -8421,88 +8421,85 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                   ? 'Hide extra keys'
                   : 'Show extra keys',
             ),
-            PopupMenuButton<String>(
+            MenuAnchor(
               key: _terminalOverflowMenuButtonKey,
-              onSelected: (action) => _handleTerminalOverflowMenuAction(
-                context,
-                action,
-                hasTerminalInfo: statusChips.isNotEmpty,
-                isMobile: isMobile,
-              ),
-              requestFocus: terminalOverlayRouteRequestFocus(context),
-              constraints: _terminalOverflowMenuConstraints(
+              style: _terminalOverflowMenuStyle(
                 context: context,
                 isMobilePlatform: isMobile,
               ),
-              itemBuilder: (context) => [
-                PopupMenuItem<String>(
-                  value: 'snippets',
-                  child: _terminalOverflowMenuRow(
-                    Icons.code_rounded,
-                    'Snippets',
+              reservedPadding: _terminalOverflowMenuReservedPadding(
+                context: context,
+                isMobilePlatform: isMobile,
+              ),
+              menuChildren: [
+                _terminalOverflowMenuItem(
+                  icon: Icons.code_rounded,
+                  label: 'Snippets',
+                  action: 'snippets',
+                ),
+                _terminalOverflowMenuItem(
+                  icon: Icons.palette_outlined,
+                  label: 'Change Theme',
+                  action: 'change_theme',
+                ),
+                _terminalOverflowSubmenuButton(
+                  context: context,
+                  isMobile: isMobile,
+                  icon: Icons.tune_rounded,
+                  label: 'Options',
+                  menuChildren: _terminalOptionsMenuItems(
+                    hasTerminalInfo: statusChips.isNotEmpty,
+                    isMobile: isMobile,
                   ),
                 ),
-                PopupMenuItem<String>(
-                  value: 'change_theme',
-                  child: _terminalOverflowMenuRow(
-                    Icons.palette_outlined,
-                    'Change Theme',
-                  ),
-                ),
-                PopupMenuItem<String>(
-                  value: 'options_submenu',
-                  child: _terminalOverflowMenuRow(
-                    Icons.tune_rounded,
-                    'Options',
-                    showsSubmenu: true,
-                  ),
-                ),
-                const PopupMenuDivider(),
+                _terminalOverflowMenuDivider(context),
                 if (!isMobile)
-                  PopupMenuItem<String>(
-                    value: 'native_select',
-                    child: _terminalOverflowMenuRow(
-                      _isNativeSelectionMode
-                          ? Icons.deselect_rounded
-                          : Icons.select_all_rounded,
-                      _isNativeSelectionMode
-                          ? 'Exit Native Selection'
-                          : 'Native Selection',
-                    ),
+                  _terminalOverflowMenuItem(
+                    icon: _isNativeSelectionMode
+                        ? Icons.deselect_rounded
+                        : Icons.select_all_rounded,
+                    label: _isNativeSelectionMode
+                        ? 'Exit Native Selection'
+                        : 'Native Selection',
+                    action: 'native_select',
                   ),
                 if (_workingDirectoryPath != null)
-                  PopupMenuItem<String>(
-                    value: 'copy_working_directory',
-                    child: _terminalOverflowMenuRow(
-                      Icons.folder_copy_outlined,
-                      'Copy Current Directory',
-                    ),
+                  _terminalOverflowMenuItem(
+                    icon: Icons.folder_copy_outlined,
+                    label: 'Copy Current Directory',
+                    action: 'copy_working_directory',
                   ),
                 if (_currentTerminalSelectionText() != null)
-                  PopupMenuItem<String>(
-                    value: 'create_snippet',
-                    child: _terminalOverflowMenuRow(
-                      Icons.code_rounded,
-                      'Create Snippet',
-                    ),
+                  _terminalOverflowMenuItem(
+                    icon: Icons.code_rounded,
+                    label: 'Create Snippet',
+                    action: 'create_snippet',
                   ),
-                PopupMenuItem<String>(
-                  value: 'paste_submenu',
-                  child: _terminalOverflowMenuRow(
-                    Icons.paste_rounded,
-                    'Paste',
-                    showsSubmenu: true,
-                  ),
+                _terminalOverflowSubmenuButton(
+                  context: context,
+                  isMobile: isMobile,
+                  icon: Icons.paste_rounded,
+                  label: 'Paste',
+                  menuChildren: _terminalPastingMenuItems(),
                 ),
-                const PopupMenuDivider(),
-                PopupMenuItem<String>(
-                  value: 'disconnect',
-                  child: _terminalOverflowMenuRow(
-                    Icons.link_off_rounded,
-                    'Disconnect',
-                  ),
+                _terminalOverflowMenuDivider(context),
+                _terminalOverflowMenuItem(
+                  icon: Icons.link_off_rounded,
+                  label: 'Disconnect',
+                  action: 'disconnect',
                 ),
               ],
+              builder: (context, controller, child) => IconButton(
+                icon: const Icon(Icons.more_vert),
+                tooltip: MaterialLocalizations.of(context).showMenuTooltip,
+                onPressed: () {
+                  if (controller.isOpen) {
+                    controller.close();
+                  } else {
+                    controller.open();
+                  }
+                },
+              ),
             ),
           ],
         ),
@@ -9511,34 +9508,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       });
     }
     return paneDirectory;
-  }
-
-  Future<void> _handleTerminalOverflowMenuAction(
-    BuildContext context,
-    String action, {
-    required bool hasTerminalInfo,
-    required bool isMobile,
-  }) async {
-    switch (action) {
-      case 'options_submenu':
-        await _showTerminalOverflowSubmenu(
-          context: context,
-          items: _terminalOptionsMenuItems(
-            hasTerminalInfo: hasTerminalInfo,
-            isMobile: isMobile,
-          ),
-        );
-        break;
-      case 'paste_submenu':
-        await _showTerminalOverflowSubmenu(
-          context: context,
-          items: _terminalPastingMenuItems(),
-        );
-        break;
-      default:
-        await _handleMenuAction(action);
-        break;
-    }
   }
 
   Future<void> _handleMenuAction(String action) async {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1028,16 +1028,35 @@ void main() {
     }
 
     Future<void> openTerminalOverflowMenu(WidgetTester tester) async {
-      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.tap(find.byIcon(Icons.more_vert));
       await tester.pumpAndSettle();
     }
+
+    String? terminalMenuLabel(Widget? child) =>
+        child is Text ? child.data : null;
+
+    Finder terminalMenuItemButton(String label) => find.byWidgetPredicate(
+      (widget) =>
+          widget is MenuItemButton && terminalMenuLabel(widget.child) == label,
+    );
+
+    Finder terminalSubmenuButton(String label) => find.byWidgetPredicate(
+      (widget) =>
+          widget is SubmenuButton && terminalMenuLabel(widget.child) == label,
+    );
+
+    Finder terminalCheckboxMenuButton(String label) => find.byWidgetPredicate(
+      (widget) =>
+          widget is CheckboxMenuButton &&
+          terminalMenuLabel(widget.child) == label,
+    );
 
     Future<void> openTerminalOverflowSubmenu(
       WidgetTester tester,
       String label,
     ) async {
       await openTerminalOverflowMenu(tester);
-      await tester.tap(find.widgetWithText(PopupMenuItem<String>, label));
+      await tester.tap(terminalSubmenuButton(label));
       await tester.pumpAndSettle();
     }
 
@@ -1188,64 +1207,25 @@ void main() {
       expect(utf8.decode(shellWrites.expand((chunk) => chunk).toList()), 'x');
     });
 
-    testWidgets('terminal overflow menu groups paste actions', (tester) async {
+    testWidgets('terminal overflow menu folds out paste actions', (
+      tester,
+    ) async {
       await pumpScreen(tester);
 
       await openTerminalOverflowMenu(tester);
 
-      expect(
-        find.byWidgetPredicate(
-          (widget) => widget is PopupMenuItem<String> && widget.value == 'copy',
-        ),
-        findsNothing,
-      );
-      expect(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is PopupMenuItem<String> && widget.value == 'paste',
-        ),
-        findsNothing,
-      );
-      expect(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is PopupMenuItem<String> && widget.value == 'paste_file',
-        ),
-        findsNothing,
-      );
-      expect(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is PopupMenuItem<String> &&
-              widget.value == 'paste_submenu',
-        ),
-        findsOneWidget,
-      );
+      expect(terminalMenuItemButton('Paste'), findsNothing);
+      expect(terminalMenuItemButton('Paste Files'), findsNothing);
+      expect(terminalSubmenuButton('Paste'), findsOneWidget);
 
-      await tester.tap(find.widgetWithText(PopupMenuItem<String>, 'Paste'));
+      await tester.tap(terminalSubmenuButton('Paste'));
       await tester.pumpAndSettle();
 
-      expect(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is PopupMenuItem<String> && widget.value == 'paste',
-        ),
-        findsOneWidget,
-      );
-      expect(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is PopupMenuItem<String> && widget.value == 'paste_image',
-        ),
-        findsOneWidget,
-      );
-      expect(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is PopupMenuItem<String> && widget.value == 'paste_file',
-        ),
-        findsOneWidget,
-      );
+      expect(terminalMenuItemButton('Snippets'), findsOneWidget);
+      expect(terminalSubmenuButton('Paste'), findsOneWidget);
+      expect(terminalMenuItemButton('Paste'), findsOneWidget);
+      expect(terminalMenuItemButton('Paste Images'), findsOneWidget);
+      expect(terminalMenuItemButton('Paste Files'), findsOneWidget);
     });
 
     testWidgets(
@@ -1256,19 +1236,8 @@ void main() {
         await openTerminalOverflowSubmenu(tester, 'Options');
 
         expect(
-          find.widgetWithText(
-            CheckedPopupMenuItem<String>,
-            'Tap to Show Keyboard',
-          ),
+          terminalCheckboxMenuButton('Tap to Show Keyboard'),
           findsOneWidget,
-        );
-        expect(
-          find.byWidgetPredicate(
-            (widget) =>
-                widget is CheckedPopupMenuItem<String> &&
-                widget.value == 'toggle_sensitive_keyboard',
-          ),
-          findsNothing,
         );
         expect(find.text('Sensitive Keyboard'), findsNothing);
       },
@@ -1282,11 +1251,7 @@ void main() {
         await pumpScreen(tester);
         await tester.pump();
 
-        Finder createSnippetItem() => find.byWidgetPredicate(
-          (widget) =>
-              widget is PopupMenuItem<String> &&
-              widget.value == 'create_snippet',
-        );
+        Finder createSnippetItem() => terminalMenuItemButton('Create Snippet');
 
         await openTerminalOverflowMenu(tester);
         expect(createSnippetItem(), findsNothing);
@@ -2932,15 +2897,9 @@ void main() {
 
       await openTerminalOverflowSubmenu(tester, 'Options');
 
-      final menuItem = find.widgetWithText(
-        CheckedPopupMenuItem<String>,
-        'Shell Completion Popups',
-      );
+      final menuItem = terminalCheckboxMenuButton('Shell Completion Popups');
       expect(menuItem, findsOneWidget);
-      expect(
-        tester.widget<CheckedPopupMenuItem<String>>(menuItem).checked,
-        isTrue,
-      );
+      expect(tester.widget<CheckboxMenuButton>(menuItem).value, isTrue);
 
       await tester.tap(menuItem);
       await tester.pumpAndSettle();
@@ -4714,14 +4673,7 @@ void main() {
         await tester.pump();
 
         expect(tester.testTextInput.isVisible, isTrue);
-        expect(
-          tester
-              .widget<PopupMenuButton<String>>(
-                find.byType(PopupMenuButton<String>),
-              )
-              .requestFocus,
-          isFalse,
-        );
+        expect(find.byType(MenuAnchor), findsOneWidget);
 
         await openTerminalOverflowMenu(tester);
 
@@ -4776,18 +4728,15 @@ void main() {
     );
 
     testWidgets(
-      'terminal overflow menu uses default route focus on desktop',
+      'terminal overflow menu uses a cascading menu anchor on desktop',
       (tester) async {
         await pumpScreen(tester);
 
-        expect(
-          tester
-              .widget<PopupMenuButton<String>>(
-                find.byType(PopupMenuButton<String>),
-              )
-              .requestFocus,
-          isNull,
-        );
+        expect(find.byType(MenuAnchor), findsOneWidget);
+
+        await openTerminalOverflowMenu(tester);
+
+        expect(terminalSubmenuButton('Options'), findsOneWidget);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.macOS),
     );


### PR DESCRIPTION
## Summary

- Replace the terminal overflow menu's PopupMenuButton/showMenu submenu flow with MenuAnchor/SubmenuButton cascading menus.
- Keep the mobile keyboard-aware menu height and reserved padding so overflow menus stay above the keyboard.
- Update terminal screen widget tests to assert that submenu entries fold out while the parent menu remains visible.

## Root Cause

The old overflow menu handled nested levels by selecting a PopupMenuItem, closing the parent popup route, and then opening a new showMenu route from the toolbar button. That made each submenu replace the previous level instead of folding out from it.

## Validation

- `flutter test test/presentation/screens/terminal_screen_test.dart`
- `flutter analyze`
- pre-commit hook: formatter, analyzer, and broader Flutter test suite passed; Flutter emitted an existing temporary test-listener cleanup warning during finalization.
