### PR TITLE
fix: clarify active connection title

### DIFF
--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -2703,6 +2703,7 @@ class ActiveConnection {
     required this.createdAt,
     required this.config,
     this.preview,
+    this.sessionTitle,
     this.windowTitle,
     this.iconName,
     this.workingDirectory,
@@ -2731,6 +2732,9 @@ class ActiveConnection {
 
   /// The latest terminal preview snippet, when available.
   final String? preview;
+
+  /// The active coding-agent session title, when available.
+  final String? sessionTitle;
 
   /// The latest remote window title, when available.
   final String? windowTitle;
@@ -2838,6 +2842,7 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
 
   late final SshService _sshService;
   final Map<int, int> _connectionHostIds = {};
+  final Map<int, String> _connectionSessionTitles = {};
   final Map<int, ConnectionAttemptStatus> _connectionAttempts = {};
   final Map<int, StreamSubscription<void>> _disconnectSubscriptions = {};
   final Map<int, StreamSubscription<_SshConnectionHealthFailure>>
@@ -2863,6 +2868,7 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
       _connectionHealthFailureSubscriptions.clear();
     });
     _connectionHostIds.clear();
+    _connectionSessionTitles.clear();
     _connectionAttempts.clear();
     return {};
   }
@@ -2954,6 +2960,7 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
     _detachSessionListeners(connectionId);
     await _sshService.disconnect(connectionId);
     _connectionHostIds.remove(connectionId);
+    _connectionSessionTitles.remove(connectionId);
     final next = {...state}..remove(connectionId);
     state = next;
     await _queueBackgroundStatusSync();
@@ -2971,6 +2978,7 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
     }
     await _sshService.disconnectAll();
     _connectionHostIds.clear();
+    _connectionSessionTitles.clear();
     _connectionAttempts.clear();
     state = {};
     await _queueBackgroundStatusSync();
@@ -2999,6 +3007,7 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
       createdAt: session.createdAt,
       config: session.config,
       preview: session.terminalPreview,
+      sessionTitle: _connectionSessionTitles[connectionId],
       windowTitle: session.windowTitle,
       iconName: session.iconName,
       workingDirectory: session.workingDirectory,
@@ -3068,6 +3077,7 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
           createdAt: session.createdAt,
           config: session.config,
           preview: session.terminalPreview,
+          sessionTitle: _connectionSessionTitles[connectionId],
           windowTitle: session.windowTitle,
           iconName: session.iconName,
           workingDirectory: session.workingDirectory,
@@ -3172,6 +3182,27 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
     });
   }
 
+  /// Update the active coding-agent session title attached to a connection.
+  void updateConnectionSessionTitle(int connectionId, String? sessionTitle) {
+    final normalizedTitle = _normalizeConnectionSessionTitle(sessionTitle);
+    final currentTitle = _connectionSessionTitles[connectionId];
+    if (normalizedTitle == currentTitle ||
+        (normalizedTitle == null && currentTitle == null)) {
+      return;
+    }
+    if (normalizedTitle == null) {
+      _connectionSessionTitles.remove(connectionId);
+    } else {
+      _connectionSessionTitles[connectionId] = normalizedTitle;
+    }
+    state = {...state};
+  }
+
+  String? _normalizeConnectionSessionTitle(String? sessionTitle) {
+    final trimmed = sessionTitle?.trim();
+    return trimmed == null || trimmed.isEmpty ? null : trimmed;
+  }
+
   void _updateConnectionAttempt(
     int hostId,
     ConnectionProgressUpdate update, {
@@ -3235,6 +3266,7 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
     _detachSessionListeners(connectionId, session: session);
     await _sshService.disconnect(connectionId);
     _connectionHostIds.remove(connectionId);
+    _connectionSessionTitles.remove(connectionId);
     final next = {...state}..remove(connectionId);
     state = next;
     if (hostId != null) {

--- a/lib/presentation/providers/host_row_providers.dart
+++ b/lib/presentation/providers/host_row_providers.dart
@@ -168,6 +168,7 @@ final hostRowDataProvider = Provider.autoDispose
               themeSettings: themeSettings,
               availableThemes: themes,
               preview: connection?.preview,
+              sessionTitle: connection?.sessionTitle,
               windowTitle: connection?.windowTitle,
               iconName: connection?.iconName,
               workingDirectory: connection?.workingDirectory,

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1161,6 +1161,7 @@ class _HostRow extends ConsumerWidget {
                         SshConnectionState.disconnected,
                     endpoint: '${host.username}@${host.hostname}:${host.port}',
                     preview: connection?.preview,
+                    sessionTitle: connection?.sessionTitle,
                     windowTitle: connection?.windowTitle,
                     iconName: connection?.iconName,
                     workingDirectory: connection?.workingDirectory,
@@ -1534,6 +1535,7 @@ class _ConnectionSelectionTile extends StatelessWidget {
     required this.endpoint,
     required this.onTap,
     this.preview,
+    this.sessionTitle,
     this.windowTitle,
     this.iconName,
     this.workingDirectory,
@@ -1547,6 +1549,7 @@ class _ConnectionSelectionTile extends StatelessWidget {
   final SshConnectionState state;
   final String endpoint;
   final String? preview;
+  final String? sessionTitle;
   final String? windowTitle;
   final String? iconName;
   final Uri? workingDirectory;
@@ -1570,6 +1573,7 @@ class _ConnectionSelectionTile extends StatelessWidget {
       subtitle: _ConnectionPreviewText(
         endpoint: subtitle,
         preview: preview,
+        sessionTitle: sessionTitle,
         windowTitle: windowTitle,
         iconName: iconName,
         workingDirectory: workingDirectory,
@@ -1697,6 +1701,7 @@ class _ConnectionsPanel extends ConsumerWidget {
                             endpoint:
                                 '$endpoint  •  Connection #${connection.connectionId}',
                             preview: preview,
+                            sessionTitle: connection.sessionTitle,
                             windowTitle: connection.windowTitle,
                             iconName: connection.iconName,
                             workingDirectory: connection.workingDirectory,
@@ -1768,6 +1773,7 @@ class _ConnectionPreviewText extends StatelessWidget {
   const _ConnectionPreviewText({
     required this.endpoint,
     this.preview,
+    this.sessionTitle,
     this.windowTitle,
     this.iconName,
     this.workingDirectory,
@@ -1778,6 +1784,7 @@ class _ConnectionPreviewText extends StatelessWidget {
 
   final String endpoint;
   final String? preview;
+  final String? sessionTitle;
   final String? windowTitle;
   final String? iconName;
   final Uri? workingDirectory;
@@ -1789,6 +1796,7 @@ class _ConnectionPreviewText extends StatelessWidget {
   Widget build(BuildContext context) => ConnectionPreviewSnippet(
     endpoint: endpoint,
     preview: preview,
+    sessionTitle: sessionTitle,
     windowTitle: windowTitle,
     iconName: iconName,
     workingDirectory: workingDirectory,
@@ -2999,6 +3007,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
           _hasInitializedSessionProviders = false;
         }
       });
+      _syncConnectionSessionTitle(null);
       unawaited(_queryTmux());
     }
   }
@@ -3194,6 +3203,20 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     );
   }
 
+  String? _activeConnectionSessionTitle(List<TmuxWindow>? windows) => windows
+      ?.where((window) => window.isActive)
+      .firstOrNull
+      ?.agentSessionDisplayTitle;
+
+  void _syncConnectionSessionTitle(List<TmuxWindow>? windows) {
+    ref
+        .read(activeSessionsProvider.notifier)
+        .updateConnectionSessionTitle(
+          widget.connectionId,
+          _activeConnectionSessionTitle(windows),
+        );
+  }
+
   Future<void> _prefetchPreferredSessionProvider() async {
     if (!_hasAgentSessionAccess) return;
     final toolName = _preferredSessionToolName;
@@ -3228,6 +3251,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
     final session = sessionsNotifier.getSession(widget.connectionId);
     if (session == null) {
+      _syncConnectionSessionTitle(null);
       // Session not available yet — retry after a delay so the badge
       // still appears for connections that finish establishing shortly.
       await _retryTmuxQuery(retries, expectedGeneration: queryGeneration);
@@ -3242,6 +3266,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       return;
     }
     if (sessionName == null) {
+      _syncConnectionSessionTitle(null);
       await _retryTmuxQuery(retries, expectedGeneration: queryGeneration);
       return;
     }
@@ -3306,18 +3331,21 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
           _muxBackend = muxBackend;
           _queried = true;
         });
+        _syncConnectionSessionTitle(const <TmuxWindow>[]);
         unawaited(_disconnectEndedMonkeyMuxSession(session));
         return;
       }
       final currentWindows = _windows;
+      final nextWindows = currentWindows == null
+          ? event.windows
+          : applyTmuxWindowChangeEvent(currentWindows, event);
       setState(() {
-        _windows = currentWindows == null
-            ? event.windows
-            : applyTmuxWindowChangeEvent(currentWindows, event);
+        _windows = nextWindows;
         _sessionName = sessionName;
         _muxBackend = muxBackend;
         _queried = true;
       });
+      _syncConnectionSessionTitle(nextWindows);
       return;
     }
     final currentWindows = _windows;
@@ -3333,12 +3361,14 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
     _windowReloadGeneration += 1;
     _tmuxRetryTimer?.cancel();
     _tmuxRetryTimer = null;
+    final nextWindows = applyTmuxWindowChangeEvent(currentWindows, event);
     setState(() {
-      _windows = applyTmuxWindowChangeEvent(currentWindows, event);
+      _windows = nextWindows;
       _sessionName = sessionName;
       _muxBackend = muxBackend;
       _queried = true;
     });
+    _syncConnectionSessionTitle(nextWindows);
   }
 
   Future<void> _refreshTmuxWindows(
@@ -3378,6 +3408,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
           _muxBackend = muxBackend;
           _queried = true;
         });
+        _syncConnectionSessionTitle(const <TmuxWindow>[]);
         await _disconnectEndedMonkeyMuxSession(session);
         return;
       }
@@ -3393,6 +3424,7 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         _muxBackend = muxBackend;
         _queried = true;
       });
+      _syncConnectionSessionTitle(windows);
     } on Object {
       if (!_isCurrentTmuxQuery(queryGeneration)) {
         return;

--- a/lib/presentation/widgets/connection_preview_snippet.dart
+++ b/lib/presentation/widgets/connection_preview_snippet.dart
@@ -42,9 +42,13 @@ String? _trimmedNonEmpty(String? value) {
 }
 
 String? _connectionActivityTitle({
+  required String? sessionTitle,
   required String? windowTitle,
   required String? iconName,
-}) => _trimmedNonEmpty(windowTitle) ?? _trimmedNonEmpty(iconName);
+}) =>
+    _trimmedNonEmpty(sessionTitle) ??
+    _trimmedNonEmpty(windowTitle) ??
+    _trimmedNonEmpty(iconName);
 
 /// Builds a stacked preview entry for a connection.
 ConnectionPreviewStackEntry buildConnectionPreviewStackEntry({
@@ -54,6 +58,7 @@ ConnectionPreviewStackEntry buildConnectionPreviewStackEntry({
   required TerminalThemeSettings themeSettings,
   required Iterable<TerminalThemeData> availableThemes,
   String? preview,
+  String? sessionTitle,
   String? windowTitle,
   String? iconName,
   Uri? workingDirectory,
@@ -65,6 +70,7 @@ ConnectionPreviewStackEntry buildConnectionPreviewStackEntry({
   String? connectionDarkThemeId,
 }) {
   final activityTitle = _connectionActivityTitle(
+    sessionTitle: sessionTitle,
     windowTitle: windowTitle,
     iconName: iconName,
   );
@@ -114,6 +120,7 @@ class ConnectionPreviewSnippet extends StatelessWidget {
   const ConnectionPreviewSnippet({
     required this.endpoint,
     this.preview,
+    this.sessionTitle,
     this.windowTitle,
     this.iconName,
     this.workingDirectory,
@@ -131,6 +138,9 @@ class ConnectionPreviewSnippet extends StatelessWidget {
 
   /// Latest terminal preview text, when available.
   final String? preview;
+
+  /// Active coding-agent session title, when available.
+  final String? sessionTitle;
 
   /// Latest remote window title, when available.
   final String? windowTitle;
@@ -165,6 +175,7 @@ class ConnectionPreviewSnippet extends StatelessWidget {
     final theme = Theme.of(context);
     final previewText = preview?.trim();
     final activityTitle = _connectionActivityTitle(
+      sessionTitle: sessionTitle,
       windowTitle: windowTitle,
       iconName: iconName,
     );

--- a/lib/presentation/widgets/connection_preview_snippet.dart
+++ b/lib/presentation/widgets/connection_preview_snippet.dart
@@ -36,6 +36,16 @@ String fallbackConnectionPreviewStatus(SshConnectionState state) =>
       _ => 'Waiting for terminal output…',
     };
 
+String? _trimmedNonEmpty(String? value) {
+  final trimmed = value?.trim();
+  return trimmed == null || trimmed.isEmpty ? null : trimmed;
+}
+
+String? _connectionActivityTitle({
+  required String? windowTitle,
+  required String? iconName,
+}) => _trimmedNonEmpty(windowTitle) ?? _trimmedNonEmpty(iconName);
+
 /// Builds a stacked preview entry for a connection.
 ConnectionPreviewStackEntry buildConnectionPreviewStackEntry({
   required int connectionId,
@@ -54,14 +64,13 @@ ConnectionPreviewStackEntry buildConnectionPreviewStackEntry({
   String? connectionLightThemeId,
   String? connectionDarkThemeId,
 }) {
-  final resolvedWindowTitle = windowTitle?.trim();
-  final resolvedIconName = iconName?.trim();
+  final activityTitle = _connectionActivityTitle(
+    windowTitle: windowTitle,
+    iconName: iconName,
+  );
   final titleSegments = <String>['Connection #$connectionId'];
-  if ((resolvedIconName ?? '').isNotEmpty) {
-    titleSegments.add(resolvedIconName!);
-  }
-  if ((resolvedWindowTitle ?? '').isNotEmpty) {
-    titleSegments.add(resolvedWindowTitle!);
+  if (activityTitle != null) {
+    titleSegments.add(activityTitle);
   }
   final resolvedPreview = preview?.trim();
   final workingDirectoryLabel = formatTerminalWorkingDirectoryLabel(
@@ -126,7 +135,8 @@ class ConnectionPreviewSnippet extends StatelessWidget {
   /// Latest remote window title, when available.
   final String? windowTitle;
 
-  /// Latest remote icon name, when available.
+  /// Latest remote icon name, when available. Used as a fallback when the
+  /// window title is unavailable.
   final String? iconName;
 
   /// Latest working-directory URI, when available.
@@ -154,8 +164,10 @@ class ConnectionPreviewSnippet extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final previewText = preview?.trim();
-    final resolvedWindowTitle = windowTitle?.trim();
-    final resolvedIconName = iconName?.trim();
+    final activityTitle = _connectionActivityTitle(
+      windowTitle: windowTitle,
+      iconName: iconName,
+    );
     final workingDirectoryLabel = formatTerminalWorkingDirectoryLabel(
       workingDirectory,
     );
@@ -187,22 +199,10 @@ class ConnectionPreviewSnippet extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         if (showEndpoint) Text(endpoint, style: endpointStyle),
-        if (resolvedIconName != null && resolvedIconName.isNotEmpty) ...[
+        if (activityTitle != null) ...[
           if (showEndpoint) const SizedBox(height: 2),
           Text(
-            resolvedIconName,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: colorScheme.onSurfaceVariant,
-            ),
-          ),
-        ],
-        if (resolvedWindowTitle != null && resolvedWindowTitle.isNotEmpty) ...[
-          if (showEndpoint || (resolvedIconName?.isNotEmpty ?? false))
-            const SizedBox(height: 2),
-          Text(
-            resolvedWindowTitle,
+            'Active: $activityTitle',
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: theme.textTheme.labelSmall?.copyWith(
@@ -213,10 +213,7 @@ class ConnectionPreviewSnippet extends StatelessWidget {
         ],
         if ((workingDirectoryLabel?.isNotEmpty ?? false) ||
             (shellStatusLabel?.isNotEmpty ?? false)) ...[
-          if (showEndpoint ||
-              (resolvedIconName?.isNotEmpty ?? false) ||
-              (resolvedWindowTitle?.isNotEmpty ?? false))
-            const SizedBox(height: 2),
+          if (showEndpoint || activityTitle != null) const SizedBox(height: 2),
           Text(
             [
               if ((workingDirectoryLabel ?? '').isNotEmpty)
@@ -232,8 +229,7 @@ class ConnectionPreviewSnippet extends StatelessWidget {
         ],
         if (previewText != null && previewText.isNotEmpty) ...[
           if (showEndpoint ||
-              (resolvedIconName?.isNotEmpty ?? false) ||
-              (resolvedWindowTitle?.isNotEmpty ?? false) ||
+              activityTitle != null ||
               (workingDirectoryLabel?.isNotEmpty ?? false) ||
               (shellStatusLabel?.isNotEmpty ?? false))
             const SizedBox(height: 4),

--- a/test/widget/connection_preview_snippet_test.dart
+++ b/test/widget/connection_preview_snippet_test.dart
@@ -1,0 +1,67 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:monkeyssh/domain/models/terminal_themes.dart';
+import 'package:monkeyssh/domain/services/settings_service.dart';
+import 'package:monkeyssh/domain/services/ssh_service.dart';
+import 'package:monkeyssh/presentation/widgets/connection_preview_snippet.dart';
+
+void main() {
+  Widget buildSnippet({String? windowTitle, String? iconName}) => MaterialApp(
+    home: Scaffold(
+      body: ConnectionPreviewSnippet(
+        endpoint: 'depoll@mac-mini.home:22 - Connection #1',
+        preview: 'ready',
+        windowTitle: windowTitle,
+        iconName: iconName,
+      ),
+    ),
+  );
+
+  testWidgets(
+    'shows one active title when the window title and icon name match',
+    (tester) async {
+      await tester.pumpWidget(
+        buildSnippet(
+          windowTitle: 'Designing app prompt',
+          iconName: 'Designing app prompt',
+        ),
+      );
+
+      expect(find.text('Active: Designing app prompt'), findsOneWidget);
+      expect(find.text('Designing app prompt'), findsNothing);
+    },
+  );
+
+  testWidgets('prefers the window title over the icon name', (tester) async {
+    await tester.pumpWidget(
+      buildSnippet(windowTitle: 'Designing app prompt', iconName: 'codex'),
+    );
+
+    expect(find.text('Active: Designing app prompt'), findsOneWidget);
+    expect(find.text('Active: codex'), findsNothing);
+  });
+
+  test('stack preview titles do not duplicate matching metadata', () {
+    final entry = buildConnectionPreviewStackEntry(
+      connectionId: 1,
+      state: SshConnectionState.connected,
+      brightness: Brightness.dark,
+      themeSettings: const TerminalThemeSettings(
+        lightThemeId: TerminalThemes.defaultLightThemeId,
+        darkThemeId: TerminalThemes.defaultDarkThemeId,
+      ),
+      availableThemes: TerminalThemes.all,
+      windowTitle: 'Designing app prompt',
+      iconName: 'Designing app prompt',
+    );
+
+    expect(entry.title, startsWith('Connection #1'));
+    expect(
+      RegExp('Designing app prompt').allMatches(entry.title),
+      hasLength(1),
+    );
+  });
+}

--- a/test/widget/connection_preview_snippet_test.dart
+++ b/test/widget/connection_preview_snippet_test.dart
@@ -9,11 +9,16 @@ import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/presentation/widgets/connection_preview_snippet.dart';
 
 void main() {
-  Widget buildSnippet({String? windowTitle, String? iconName}) => MaterialApp(
+  Widget buildSnippet({
+    String? sessionTitle,
+    String? windowTitle,
+    String? iconName,
+  }) => MaterialApp(
     home: Scaffold(
       body: ConnectionPreviewSnippet(
         endpoint: 'depoll@mac-mini.home:22 - Connection #1',
         preview: 'ready',
+        sessionTitle: sessionTitle,
         windowTitle: windowTitle,
         iconName: iconName,
       ),
@@ -44,7 +49,22 @@ void main() {
     expect(find.text('Active: codex'), findsNothing);
   });
 
-  test('stack preview titles do not duplicate matching metadata', () {
+  testWidgets('prefers the session title over terminal metadata', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildSnippet(
+        sessionTitle: 'Implement onboarding',
+        windowTitle: 'Designing app prompt',
+        iconName: 'codex',
+      ),
+    );
+
+    expect(find.text('Active: Implement onboarding'), findsOneWidget);
+    expect(find.text('Active: Designing app prompt'), findsNothing);
+  });
+
+  test('stack preview titles prefer session title over terminal metadata', () {
     final entry = buildConnectionPreviewStackEntry(
       connectionId: 1,
       state: SshConnectionState.connected,
@@ -54,14 +74,13 @@ void main() {
         darkThemeId: TerminalThemes.defaultDarkThemeId,
       ),
       availableThemes: TerminalThemes.all,
+      sessionTitle: 'Implement onboarding',
       windowTitle: 'Designing app prompt',
       iconName: 'Designing app prompt',
     );
 
     expect(entry.title, startsWith('Connection #1'));
-    expect(
-      RegExp('Designing app prompt').allMatches(entry.title),
-      hasLength(1),
-    );
+    expect(entry.title, contains('Implement onboarding'));
+    expect(RegExp('Designing app prompt').allMatches(entry.title), isEmpty);
   });
 }

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -102,6 +102,36 @@ class _MutableActiveSessionsNotifier extends ActiveSessionsNotifier {
   List<ActiveConnection> getActiveConnections() =>
       _connections.values.toList(growable: false);
 
+  @override
+  void updateConnectionSessionTitle(int connectionId, String? sessionTitle) {
+    final existing = _connections[connectionId];
+    if (existing == null) return;
+    final normalizedTitle = sessionTitle?.trim();
+    final nextSessionTitle = normalizedTitle == null || normalizedTitle.isEmpty
+        ? null
+        : normalizedTitle;
+    if (existing.sessionTitle == nextSessionTitle) return;
+    _connections[connectionId] = ActiveConnection(
+      connectionId: existing.connectionId,
+      hostId: existing.hostId,
+      state: existing.state,
+      createdAt: existing.createdAt,
+      config: existing.config,
+      preview: existing.preview,
+      sessionTitle: nextSessionTitle,
+      windowTitle: existing.windowTitle,
+      iconName: existing.iconName,
+      workingDirectory: existing.workingDirectory,
+      shellStatus: existing.shellStatus,
+      lastExitCode: existing.lastExitCode,
+      remoteMuxBackend: existing.remoteMuxBackend,
+      remoteMuxSessionName: existing.remoteMuxSessionName,
+      terminalThemeLightId: existing.terminalThemeLightId,
+      terminalThemeDarkId: existing.terminalThemeDarkId,
+    );
+    state = {...state};
+  }
+
   void setActiveConnections(List<ActiveConnection> connections) {
     _connections
       ..clear()
@@ -210,6 +240,10 @@ ActiveConnection _buildActiveConnection({
   required int connectionId,
   required int hostId,
   SshConnectionState state = SshConnectionState.connected,
+  String? preview,
+  String? sessionTitle,
+  String? windowTitle,
+  String? iconName,
   RemoteMuxBackend? remoteMuxBackend,
   String? remoteMuxSessionName,
 }) => ActiveConnection(
@@ -222,6 +256,10 @@ ActiveConnection _buildActiveConnection({
     port: 22,
     username: 'root',
   ),
+  preview: preview,
+  sessionTitle: sessionTitle,
+  windowTitle: windowTitle,
+  iconName: iconName,
   remoteMuxBackend: remoteMuxBackend,
   remoteMuxSessionName: remoteMuxSessionName,
 );
@@ -616,6 +654,80 @@ void main() {
         ),
       ).called(greaterThanOrEqualTo(1));
       verifyNever(() => tmuxService.listWindows(session, any()));
+    },
+  );
+
+  testWidgets(
+    'connection preview prefers active agent session title from mux',
+    (tester) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final tmuxService = _MockTmuxService();
+      final sshClient = _MockSshClient();
+      const sessionName = 'work';
+      final session = SshSession(
+        connectionId: 7,
+        hostId: 1,
+        client: sshClient,
+        config: const SshConnectionConfig(
+          hostname: 'alpha.example.com',
+          port: 22,
+          username: 'root',
+        ),
+      );
+      final sessionsNotifier = _MutableActiveSessionsNotifier(
+        initialConnections: [
+          _buildActiveConnection(
+            connectionId: 7,
+            hostId: 1,
+            preview: 'ready',
+            windowTitle: 'Designing app prompt',
+            iconName: 'Designing app prompt',
+          ),
+        ],
+        initialSessions: [session],
+      );
+
+      when(
+        () => tmuxService.watchWindowChanges(session, sessionName),
+      ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+      when(() => tmuxService.listWindows(session, sessionName)).thenAnswer(
+        (_) async => const <TmuxWindow>[
+          TmuxWindow(
+            index: 0,
+            name: 'codex',
+            isActive: true,
+            agentSessionTitle: 'Implement onboarding',
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        buildMobileHomeScreen(
+          db: db,
+          overrides: [
+            activeSessionsProvider.overrideWith(() => sessionsNotifier),
+            allHostsProvider.overrideWith(
+              (ref) => Stream.value([
+                _buildHost(
+                  id: 1,
+                  label: 'Alpha',
+                  sortOrder: 0,
+                  tmuxSessionName: sessionName,
+                ),
+              ]),
+            ),
+            tmuxServiceProvider.overrideWithValue(tmuxService),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.tap(find.text('Connections').first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Active: Implement onboarding'), findsOneWidget);
+      expect(find.text('Active: Designing app prompt'), findsNothing);
     },
   );
 


### PR DESCRIPTION
## Summary

- Show one labeled active title in connection previews instead of separate icon/title metadata lines
- Prefer active coding-agent session titles from tmux/MonkeyMux windows, then terminal window title, then icon name
- Add widget coverage for duplicated title/icon metadata and active session-title preference

## Tests

- `flutter test test/widget/connection_preview_snippet_test.dart`
- `flutter test test/widget/home_screen_test.dart --name "connection preview prefers active agent session title from mux"`
- `flutter analyze`
