### PR TITLE
Prompt before MonkeyMux helper install

### DIFF
--- a/lib/domain/services/monkeymux_installer_service.dart
+++ b/lib/domain/services/monkeymux_installer_service.dart
@@ -132,6 +132,29 @@ class MonkeyMuxInstallation {
   final String version;
 }
 
+/// Details for a pending MonkeyMux helper install.
+class MonkeyMuxInstallRequest {
+  /// Creates pending MonkeyMux install details.
+  const MonkeyMuxInstallRequest({
+    required this.platform,
+    required this.version,
+    required this.size,
+  });
+
+  /// Remote platform key for the helper, for example `linux-amd64`.
+  final String platform;
+
+  /// MonkeyMux helper version that would be installed.
+  final String version;
+
+  /// Helper binary size in bytes.
+  final int size;
+}
+
+/// Confirms whether MonkeyMux may install its helper on the connected host.
+typedef MonkeyMuxInstallConfirmation =
+    Future<bool> Function(MonkeyMuxInstallRequest request);
+
 /// Error thrown when MonkeyMux cannot be installed or used.
 class MonkeyMuxInstallException implements Exception {
   /// Creates a MonkeyMux installation error.
@@ -142,6 +165,21 @@ class MonkeyMuxInstallException implements Exception {
 
   @override
   String toString() => message;
+}
+
+/// Error thrown when MonkeyMux needs app-level install confirmation.
+class MonkeyMuxInstallConfirmationRequiredException
+    extends MonkeyMuxInstallException {
+  /// Creates a confirmation-required install error.
+  const MonkeyMuxInstallConfirmationRequiredException()
+    : super('MonkeyMux install requires confirmation.');
+}
+
+/// Error thrown when the user declines a MonkeyMux helper install.
+class MonkeyMuxInstallDeclinedException extends MonkeyMuxInstallException {
+  /// Creates a declined install error.
+  const MonkeyMuxInstallDeclinedException()
+    : super('MonkeyMux install was canceled.');
 }
 
 /// Installs and verifies the bundled MonkeyMux helper on a remote host.
@@ -165,6 +203,7 @@ class MonkeyMuxInstallerService {
   Future<MonkeyMuxInstallation> ensureInstalled(
     SshSession session, {
     SshExecPriority priority = SshExecPriority.low,
+    MonkeyMuxInstallConfirmation? confirmInstall,
   }) async {
     final connectionId = session.connectionId;
     final cachedInstallation = _installCache[connectionId];
@@ -190,7 +229,11 @@ class MonkeyMuxInstallerService {
       return existingRequest;
     }
 
-    final request = _ensureInstalled(session, priority: priority);
+    final request = _ensureInstalled(
+      session,
+      priority: priority,
+      confirmInstall: confirmInstall,
+    );
     _installRequests[connectionId] = request;
     request.then((installation) {
       if (identical(_installRequests[connectionId], request)) {
@@ -214,6 +257,7 @@ class MonkeyMuxInstallerService {
   Future<MonkeyMuxInstallation> _ensureInstalled(
     SshSession session, {
     required SshExecPriority priority,
+    required MonkeyMuxInstallConfirmation? confirmInstall,
   }) async {
     final platform = await probePlatform(session, priority: priority);
     final manifest = await _manifestFuture;
@@ -258,6 +302,43 @@ class MonkeyMuxInstallerService {
           version: manifest.version,
         );
       }
+
+      final installRequest = MonkeyMuxInstallRequest(
+        platform: platform,
+        version: manifest.version,
+        size: entry.size,
+      );
+      if (confirmInstall == null) {
+        DiagnosticsLogService.instance.warning(
+          'monkeymux.install',
+          'confirmation_required',
+          fields: {'connectionId': session.connectionId, 'platform': platform},
+        );
+        throw const MonkeyMuxInstallConfirmationRequiredException();
+      }
+      DiagnosticsLogService.instance.info(
+        'monkeymux.install',
+        'confirmation_requested',
+        fields: {
+          'connectionId': session.connectionId,
+          'platform': platform,
+          'size': entry.size,
+        },
+      );
+      final confirmed = await confirmInstall(installRequest);
+      if (!confirmed) {
+        DiagnosticsLogService.instance.info(
+          'monkeymux.install',
+          'confirmation_declined',
+          fields: {'connectionId': session.connectionId, 'platform': platform},
+        );
+        throw const MonkeyMuxInstallDeclinedException();
+      }
+      DiagnosticsLogService.instance.info(
+        'monkeymux.install',
+        'confirmation_accepted',
+        fields: {'connectionId': session.connectionId, 'platform': platform},
+      );
 
       DiagnosticsLogService.instance.info(
         'monkeymux.install',

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -6232,7 +6232,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         host,
         tmuxSession,
       );
-      if (command != null && command.backend == RemoteMuxBackend.monkeyMux) {
+      if (command != null) {
         _applyPreparedRemoteMuxCommand(session, command);
         return command;
       }
@@ -6310,6 +6310,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         final installation = await _monkeyMuxInstallerService.ensureInstalled(
           session,
           priority: SshExecPriority.normal,
+          confirmInstall: _confirmMonkeyMuxInstall,
         );
         final updatePolicy = await _resolveMonkeyMuxServerUpdatePolicy(
           session,
@@ -6409,6 +6410,63 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     return MonkeyMuxServerUpdatePolicy.always;
   }
 
+  Future<bool> _confirmMonkeyMuxInstall(MonkeyMuxInstallRequest request) async {
+    if (!mounted) {
+      return false;
+    }
+    final confirmed = await showDialog<bool>(
+      context: context,
+      requestFocus: terminalOverlayRouteRequestFocus(context),
+      builder: (context) => AlertDialog(
+        title: const Text('Install MonkeyMux helper?'),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'MonkeySSH needs to upload its bundled MonkeyMux helper before '
+                'using MonkeyMux on this connected host.',
+              ),
+              const SizedBox(height: 12),
+              Text('Version: ${request.version}'),
+              Text('Platform: ${request.platform}'),
+              Text('Size: ${_formatMonkeyMuxInstallSize(request.size)}'),
+              const SizedBox(height: 12),
+              const Text(
+                'It will be installed under ~/.monkeyssh/bin/monkeymux on the '
+                'connected host.',
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Use tmux'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Install'),
+          ),
+        ],
+      ),
+    );
+    return confirmed ?? false;
+  }
+
+  String _formatMonkeyMuxInstallSize(int bytes) {
+    if (bytes < 1024) {
+      return '$bytes B';
+    }
+    final kibibytes = bytes / 1024;
+    if (kibibytes < 1024) {
+      return '${kibibytes.toStringAsFixed(kibibytes < 10 ? 1 : 0)} KB';
+    }
+    final mebibytes = kibibytes / 1024;
+    return '${mebibytes.toStringAsFixed(mebibytes < 10 ? 1 : 0)} MB';
+  }
+
   Future<void> _runMonkeyMuxAgentLaunchCommand(
     SshSession session,
     Host host,
@@ -6466,6 +6524,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       final installation = await _monkeyMuxInstallerService.ensureInstalled(
         session,
         priority: SshExecPriority.normal,
+        confirmInstall: _confirmMonkeyMuxInstall,
       );
       DiagnosticsLogService.instance.info(
         'terminal.agent_launch',

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2848,6 +2848,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _wasBackgrounded = false;
   bool _connectionLostWhileBackgrounded = false;
   int? _suppressNextAutomaticReconnectConnectionId;
+  int? _suppressAutoConnectAfterStartupConnectionId;
+  int? _suppressRemoteMuxDetectionConnectionId;
   bool _restoreKeyboardAfterAppResume = false;
   final GlobalKey _terminalOverflowMenuButtonKey = GlobalKey();
 
@@ -5721,8 +5723,21 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
       // Start port forwards
       await _startPortForwards(session);
+      final suppressAutoConnect =
+          _suppressAutoConnectAfterStartupConnectionId == session.connectionId;
+      if (suppressAutoConnect) {
+        _suppressAutoConnectAfterStartupConnectionId = null;
+      }
       if (startupCommand == null) {
-        await _runAutoConnectCommand(session);
+        if (suppressAutoConnect) {
+          DiagnosticsLogService.instance.info(
+            'terminal',
+            'auto_connect_suppressed',
+            fields: {'connectionId': session.connectionId},
+          );
+        } else {
+          await _runAutoConnectCommand(session);
+        }
       } else {
         DiagnosticsLogService.instance.info(
           'terminal.agent_launch',
@@ -5739,7 +5754,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       // Detect tmux after the auto-connect command has had time to start.
       // A small delay ensures tmux has initialized if the auto-connect
       // command launches a tmux session.
-      unawaited(_detectTmux(session));
+      final suppressRemoteMuxDetection =
+          _suppressRemoteMuxDetectionConnectionId == session.connectionId;
+      if (suppressRemoteMuxDetection) {
+        _suppressRemoteMuxDetectionConnectionId = null;
+      } else {
+        unawaited(_detectTmux(session));
+      }
     } on Object catch (e) {
       DiagnosticsLogService.instance.error(
         'terminal',
@@ -6236,6 +6257,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _applyPreparedRemoteMuxCommand(session, command);
         return command;
       }
+      _suppressAutoConnectAfterStartupConnectionId = session.connectionId;
       return null;
     }
 
@@ -6271,6 +6293,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       host,
       sessionName,
     );
+    if (attachCommand == null) {
+      return null;
+    }
     final review = assessAutoConnectCommandExecution(
       attachCommand.command,
       importedNeedsReview: host.autoConnectRequiresConfirmation,
@@ -6296,7 +6321,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
   }
 
-  Future<({String command, RemoteMuxBackend backend})>
+  Future<({String command, RemoteMuxBackend backend})?>
   _buildRemoteMuxAttachCommand(
     SshSession session,
     Host host,
@@ -6339,6 +6364,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           ),
           backend: RemoteMuxBackend.monkeyMux,
         );
+      } on MonkeyMuxInstallDeclinedException {
+        _suppressRemoteMuxDetectionConnectionId = session.connectionId;
+        DiagnosticsLogService.instance.info(
+          'monkeymux.install',
+          'attach_declined',
+          fields: {
+            'connectionId': session.connectionId,
+            'configuredBackend': configuredBackend.storageValue,
+          },
+        );
+        return null;
       } on Exception catch (error) {
         DiagnosticsLogService.instance.warning(
           'monkeymux.install',
@@ -7809,6 +7845,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         host,
         sessionName,
       );
+      if (attachCommand == null) {
+        return;
+      }
       _activeMuxBackend = attachCommand.backend;
       reattachCommand = attachCommand.command;
     }

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -4611,7 +4611,7 @@ void main() {
     );
 
     testWidgets(
-      'falls back to tmux when MonkeyMux install prompt is declined',
+      'opens a regular terminal when MonkeyMux install prompt is declined',
       (tester) async {
         final monkeyMuxInstallerService = _PromptingMonkeyMuxInstallerService(
           request: const MonkeyMuxInstallRequest(
@@ -4647,41 +4647,6 @@ void main() {
         });
         when(
           () => tmuxService.prefetchInstalledAgentTools(session),
-        ).thenAnswer((_) async {});
-        when(
-          () => tmuxService.foregroundSessionNameOrThrow(
-            session,
-            extraFlags: any(named: 'extraFlags'),
-          ),
-        ).thenAnswer((_) async => sessionName);
-        when(
-          () => tmuxService.listWindows(
-            session,
-            sessionName,
-            extraFlags: any(named: 'extraFlags'),
-          ),
-        ).thenAnswer(
-          (_) async => const <TmuxWindow>[
-            TmuxWindow(index: 0, name: 'shell', isActive: true),
-          ],
-        );
-        when(
-          () => tmuxService.watchWindowChanges(
-            session,
-            sessionName,
-            extraFlags: any(named: 'extraFlags'),
-          ),
-        ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
-        when(
-          () => tmuxService.detectInstalledAgentTools(session),
-        ).thenAnswer((_) async => const <AgentLaunchTool>{});
-        when(
-          () => tmuxService.refreshTerminalTheme(
-            session,
-            sessionName,
-            any(),
-            extraFlags: any(named: 'extraFlags'),
-          ),
         ).thenAnswer((_) async {});
 
         await tester.pumpWidget(
@@ -4724,22 +4689,15 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 100));
 
-        expect(
-          executedCommands.where((command) => command.contains('monkeymux')),
-          isEmpty,
-        );
-        final writtenShellText = utf8.decode(
-          shellWrites.expand((chunk) => chunk).toList(growable: false),
-        );
-        final launchedText = [...executedCommands, writtenShellText].join('\n');
-        expect(launchedText, contains('tmux'));
-        expect(launchedText, isNot(contains('monkeymux')));
+        expect(executedCommands, isEmpty);
+        expect(shellWrites, isEmpty);
         expect(find.text('Install MonkeyMux helper?'), findsNothing);
-        expect(session.remoteMuxBackend, RemoteMuxBackend.tmux);
-        expect(session.remoteMuxSessionName, sessionName);
+        expect(session.remoteMuxBackend, isNull);
+        expect(session.remoteMuxSessionName, isNull);
         expect(monkeyMuxInstallerService.ensureInstalledCalls, 1);
         expect(monkeyMuxInstallerService.acceptedConfirmations, <bool>[false]);
-        await tester.pump(const Duration(milliseconds: 200));
+        verify(() => sshClient.shell(pty: any(named: 'pty'))).called(1);
+        verifyNever(() => sshClient.execute(any(), pty: any(named: 'pty')));
         await tester.pumpWidget(const SizedBox.shrink());
         await tester.pump();
       },

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -72,6 +72,45 @@ class _MockMonkeyMuxService extends Mock implements MonkeyMuxService {
 class _MockMonkeyMuxInstallerService extends Mock
     implements MonkeyMuxInstallerService {}
 
+class _PromptingMonkeyMuxInstallerService implements MonkeyMuxInstallerService {
+  _PromptingMonkeyMuxInstallerService({required this.request});
+
+  final MonkeyMuxInstallRequest request;
+  final acceptedConfirmations = <bool>[];
+  int ensureInstalledCalls = 0;
+
+  @override
+  Future<MonkeyMuxInstallation> ensureInstalled(
+    SshSession session, {
+    SshExecPriority priority = SshExecPriority.low,
+    MonkeyMuxInstallConfirmation? confirmInstall,
+  }) async {
+    ensureInstalledCalls++;
+    if (confirmInstall == null) {
+      throw const MonkeyMuxInstallConfirmationRequiredException();
+    }
+    final accepted = await confirmInstall(request);
+    acceptedConfirmations.add(accepted);
+    if (!accepted) {
+      throw const MonkeyMuxInstallDeclinedException();
+    }
+    return MonkeyMuxInstallation(
+      executablePath: '/tmp/monkeymux',
+      platform: request.platform,
+      version: request.version,
+    );
+  }
+
+  @override
+  void clearCache(int connectionId) {}
+
+  @override
+  Future<String> probePlatform(
+    SshSession session, {
+    SshExecPriority priority = SshExecPriority.low,
+  }) async => request.platform;
+}
+
 class _MockAgentSessionDiscoveryService extends Mock
     implements AgentSessionDiscoveryService {}
 
@@ -4353,6 +4392,7 @@ void main() {
           () => monkeyMuxInstallerService.ensureInstalled(
             session,
             priority: any(named: 'priority'),
+            confirmInstall: any(named: 'confirmInstall'),
           ),
         ).thenAnswer(
           (_) async => const MonkeyMuxInstallation(
@@ -4441,6 +4481,7 @@ void main() {
           () => monkeyMuxInstallerService.ensureInstalled(
             session,
             priority: SshExecPriority.normal,
+            confirmInstall: any(named: 'confirmInstall'),
           ),
         ).called(1);
         verifyNever(
@@ -4455,9 +4496,15 @@ void main() {
     );
 
     testWidgets(
-      'opens structured MonkeyMux attach as the foreground shell command',
+      'prompts before installing MonkeyMux for foreground attach',
       (tester) async {
-        final monkeyMuxInstallerService = _MockMonkeyMuxInstallerService();
+        final monkeyMuxInstallerService = _PromptingMonkeyMuxInstallerService(
+          request: const MonkeyMuxInstallRequest(
+            platform: 'darwin-arm64',
+            version: '0.1.14',
+            size: 1536,
+          ),
+        );
         final monkeyMuxService = _MockMonkeyMuxService();
         final tmuxService = _MockTmuxService();
         const sessionName = 'work';
@@ -4475,18 +4522,6 @@ void main() {
           id: host.id,
           tmuxSessionName: sessionName,
           remoteMuxBackend: RemoteMuxBackend.monkeyMux,
-        );
-        when(
-          () => monkeyMuxInstallerService.ensureInstalled(
-            session,
-            priority: any(named: 'priority'),
-          ),
-        ).thenAnswer(
-          (_) async => const MonkeyMuxInstallation(
-            executablePath: '/tmp/monkeymux',
-            platform: 'darwin-arm64',
-            version: '0.1.14',
-          ),
         );
         final executedCommands = <String>[];
         when(
@@ -4545,6 +4580,15 @@ void main() {
 
         await tester.pump();
         await tester.pump();
+
+        expect(find.text('Install MonkeyMux helper?'), findsOneWidget);
+        expect(find.text('Version: 0.1.14'), findsOneWidget);
+        expect(find.text('Platform: darwin-arm64'), findsOneWidget);
+        expect(find.text('Size: 1.5 KB'), findsOneWidget);
+        expect(executedCommands, isEmpty);
+
+        await tester.tap(find.widgetWithText(FilledButton, 'Install'));
+        await tester.pump();
         await tester.pump(const Duration(milliseconds: 100));
 
         expect(shellWrites, isEmpty);
@@ -4558,6 +4602,144 @@ void main() {
         expect(session.remoteMuxSessionName, sessionName);
         expect(find.byKey(const ValueKey('tmux-handle-bar')), findsOneWidget);
         verifyNever(() => sshClient.shell(pty: any(named: 'pty')));
+        expect(monkeyMuxInstallerService.ensureInstalledCalls, 1);
+        expect(monkeyMuxInstallerService.acceptedConfirmations, <bool>[true]);
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
+      'falls back to tmux when MonkeyMux install prompt is declined',
+      (tester) async {
+        final monkeyMuxInstallerService = _PromptingMonkeyMuxInstallerService(
+          request: const MonkeyMuxInstallRequest(
+            platform: 'darwin-arm64',
+            version: '0.1.14',
+            size: 1536,
+          ),
+        );
+        final monkeyMuxService = _MockMonkeyMuxService();
+        final tmuxService = _MockTmuxService();
+        const sessionName = 'work';
+        session = SshSession(
+          connectionId: 7,
+          hostId: host.id,
+          client: sshClient,
+          config: const SshConnectionConfig(
+            hostname: 'terminal.example.com',
+            port: 22,
+            username: 'root',
+          ),
+        );
+        host = _buildHost(
+          id: host.id,
+          tmuxSessionName: sessionName,
+          remoteMuxBackend: RemoteMuxBackend.monkeyMux,
+        );
+        final executedCommands = <String>[];
+        when(
+          () => sshClient.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((invocation) async {
+          executedCommands.add(invocation.positionalArguments.single as String);
+          return shellChannel;
+        });
+        when(
+          () => tmuxService.prefetchInstalledAgentTools(session),
+        ).thenAnswer((_) async {});
+        when(
+          () => tmuxService.foregroundSessionNameOrThrow(
+            session,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async => sessionName);
+        when(
+          () => tmuxService.listWindows(
+            session,
+            sessionName,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer(
+          (_) async => const <TmuxWindow>[
+            TmuxWindow(index: 0, name: 'shell', isActive: true),
+          ],
+        );
+        when(
+          () => tmuxService.watchWindowChanges(
+            session,
+            sessionName,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+        when(
+          () => tmuxService.detectInstalledAgentTools(session),
+        ).thenAnswer((_) async => const <AgentLaunchTool>{});
+        when(
+          () => tmuxService.refreshTerminalTheme(
+            session,
+            sessionName,
+            any(),
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async {});
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+              monkeyMuxInstallerServiceProvider.overrideWithValue(
+                monkeyMuxInstallerService,
+              ),
+              tmuxServiceProvider.overrideWithValue(tmuxService),
+              monkeyMuxServiceProvider.overrideWithValue(monkeyMuxService),
+            ],
+            child: MaterialApp(
+              home: TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Install MonkeyMux helper?'), findsOneWidget);
+        expect(executedCommands, isEmpty);
+
+        await tester.tap(find.widgetWithText(TextButton, 'Use tmux'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(
+          executedCommands.where((command) => command.contains('monkeymux')),
+          isEmpty,
+        );
+        final writtenShellText = utf8.decode(
+          shellWrites.expand((chunk) => chunk).toList(growable: false),
+        );
+        final launchedText = [...executedCommands, writtenShellText].join('\n');
+        expect(launchedText, contains('tmux'));
+        expect(launchedText, isNot(contains('monkeymux')));
+        expect(find.text('Install MonkeyMux helper?'), findsNothing);
+        expect(session.remoteMuxBackend, RemoteMuxBackend.tmux);
+        expect(session.remoteMuxSessionName, sessionName);
+        expect(monkeyMuxInstallerService.ensureInstalledCalls, 1);
+        expect(monkeyMuxInstallerService.acceptedConfirmations, <bool>[false]);
+        await tester.pump(const Duration(milliseconds: 200));
         await tester.pumpWidget(const SizedBox.shrink());
         await tester.pump();
       },


### PR DESCRIPTION
## Summary

- require app-level confirmation before uploading the bundled MonkeyMux helper to a connected host
- show a Flutter dialog with version/platform/size details before the first helper install
- open a regular interactive terminal when the user declines the install prompt instead of falling back to tmux

## Validation

- `flutter test test/presentation/screens/terminal_screen_test.dart --name "MonkeyMux"`
- `flutter analyze`
