### PR TITLE
fix: keep shell completion popup while typing

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -4921,6 +4921,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       if (_shellCompletionAnchorRetryCount < _shellCompletionMaxAnchorRetries) {
         _shellCompletionAnchorRetryCount += 1;
         _queueShellCompletionRefreshAfterFrame(generation);
+      } else if (_filterVisibleShellCompletionsForCurrentInput()) {
+        return;
       } else {
         _hideShellCompletionPopup(resetPromptPrefix: false);
       }
@@ -4942,14 +4944,36 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           !ref.read(shellCompletionsNotifierProvider)) {
         return;
       }
-      if (suggestions.isEmpty) {
+      final latestInvocation = _buildCurrentShellCompletionInvocation(
+        workingDirectory: invocation.workingDirectory,
+        shellCommand: invocation.shellCommand,
+      );
+      if (latestInvocation == null) {
+        if (_filterVisibleShellCompletionsForCurrentInput()) {
+          return;
+        }
         _hideShellCompletionPopup(resetPromptPrefix: false);
         return;
       }
-      _showShellCompletions(
-        invocation: invocation,
+      final latestSuggestions = filterShellCompletionSuggestionsForCurrentInput(
+        originalInvocation: invocation,
+        currentInvocation: latestInvocation,
         suggestions: suggestions,
-        anchor: anchor,
+      );
+      if (latestSuggestions.isEmpty) {
+        if (_filterVisibleShellCompletionsForCurrentInput()) {
+          return;
+        }
+        _hideShellCompletionPopup(resetPromptPrefix: false);
+        return;
+      }
+      final latestAnchor = _resolveTerminalCursorGlobalRect() ?? anchor;
+      _showShellCompletions(
+        invocation: latestInvocation,
+        suggestions: latestSuggestions,
+        anchor: latestAnchor,
+        sourceInvocation: invocation,
+        sourceSuggestions: suggestions,
       );
     } on Object catch (error) {
       DiagnosticsLogService.instance.debug(
@@ -4960,7 +4984,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           'errorType': error.runtimeType,
         },
       );
-      if (mounted && generation == _shellCompletionGeneration) {
+      if (mounted &&
+          generation == _shellCompletionGeneration &&
+          !_filterVisibleShellCompletionsForCurrentInput()) {
         _hideShellCompletionPopup(resetPromptPrefix: false);
       }
     } finally {
@@ -5198,10 +5224,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     required ShellCompletionInvocation invocation,
     required List<ShellCompletionSuggestion> suggestions,
     required Rect anchor,
+    ShellCompletionInvocation? sourceInvocation,
+    List<ShellCompletionSuggestion>? sourceSuggestions,
   }) {
     setState(() {
-      _shellCompletionSourceInvocation = invocation;
-      _shellCompletionSourceSuggestions = suggestions;
+      _shellCompletionSourceInvocation = sourceInvocation ?? invocation;
+      _shellCompletionSourceSuggestions = sourceSuggestions ?? suggestions;
       _shellCompletionInvocation = invocation;
       _shellCompletionSuggestions = suggestions;
       _shellCompletionAnchorGlobalRect = anchor;

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -845,6 +845,54 @@ void main() {
       },
     );
 
+    test(
+      'keeps visible command completions as typing reaches the suggestion',
+      () {
+        const originalInvocation = ShellCompletionInvocation(
+          commandLine: 'br',
+          cursorOffset: 2,
+          token: 'br',
+          tokenStart: 0,
+          mode: ShellCompletionMode.command,
+          workingDirectory: '/repo',
+        );
+        const brewSuggestion = ShellCompletionSuggestion(
+          label: 'brew',
+          replacement: 'brew',
+          replacementStart: 0,
+          replacementEnd: 2,
+          kind: ShellCompletionSuggestionKind.command,
+          commitSuffix: ' ',
+        );
+        const brootSuggestion = ShellCompletionSuggestion(
+          label: 'broot',
+          replacement: 'broot',
+          replacementStart: 0,
+          replacementEnd: 2,
+          kind: ShellCompletionSuggestionKind.command,
+          commitSuffix: ' ',
+        );
+
+        final filtered = filterShellCompletionSuggestionsForCurrentInput(
+          originalInvocation: originalInvocation,
+          currentInvocation: const ShellCompletionInvocation(
+            commandLine: 'brew',
+            cursorOffset: 4,
+            token: 'brew',
+            tokenStart: 0,
+            mode: ShellCompletionMode.command,
+            workingDirectory: '/repo',
+          ),
+          suggestions: const <ShellCompletionSuggestion>[
+            brewSuggestion,
+            brootSuggestion,
+          ],
+        );
+
+        expect(filtered, [brewSuggestion]);
+      },
+    );
+
     test('accepts and filters empty-token argument suggestions', () {
       const originalInvocation = ShellCompletionInvocation(
         commandLine: 'tmux ',


### PR DESCRIPTION
## Summary

- Keep visible shell completion suggestions filtered against the latest typed command instead of hiding them when async refreshes are stale, empty, fail, or lose their cursor anchor.
- Preserve the original completion source while showing narrowed suggestions so continued typing can keep filtering the same result set.
- Add coverage for narrowing a command completion from `br` to `brew`.

## Validation

- `flutter test --no-pub test/widget/terminal_screen_layout_test.dart`
- `flutter analyze --no-pub`
