### PR TITLE
fix: recover stale SFTP and terminal sessions

### DIFF
--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -1907,6 +1907,10 @@ class SshSession {
 
   static const _previewRefreshInterval = Duration(milliseconds: 150);
   static const _shellIoDiagnosticsInterval = Duration(seconds: 1);
+  static const _sftpOpenRetryDelays = [
+    Duration(milliseconds: 250),
+    Duration(milliseconds: 750),
+  ];
   static const _previewLineCount = 3;
   static const _previewMaxChars = 220;
   static final _previewSanitizerPattern = RegExp(r'[\x00-\x08\x0B-\x1F\x7F]');
@@ -2408,27 +2412,67 @@ class SshSession {
       'open_start',
       fields: {'connectionId': connectionId, 'hostId': hostId},
     );
-    try {
-      final sftpClient = await client.sftp();
-      DiagnosticsLogService.instance.info(
-        'ssh.sftp',
-        'open_success',
-        fields: {'connectionId': connectionId, 'hostId': hostId},
-      );
-      return sftpClient;
-    } on Object catch (error) {
-      DiagnosticsLogService.instance.error(
-        'ssh.sftp',
-        'open_failed',
-        fields: {
-          'connectionId': connectionId,
-          'hostId': hostId,
-          ..._diagnosticSshExecErrorFields(error),
-        },
-      );
-      _reportConnectionHealthFailureIfClosed(error, operation: 'sftp');
-      rethrow;
+
+    for (var attempt = 0; ; attempt += 1) {
+      try {
+        final sftpClient = await client.sftp();
+        DiagnosticsLogService.instance.info(
+          'ssh.sftp',
+          'open_success',
+          fields: {
+            'connectionId': connectionId,
+            'hostId': hostId,
+            'attempt': attempt + 1,
+          },
+        );
+        return sftpClient;
+      } on Object catch (error) {
+        final retryDelay = _sftpOpenRetryDelay(error, attempt);
+        if (retryDelay != null) {
+          DiagnosticsLogService.instance.warning(
+            'ssh.sftp',
+            'open_retry',
+            fields: {
+              'connectionId': connectionId,
+              'hostId': hostId,
+              'attempt': attempt + 1,
+              'delayMs': retryDelay.inMilliseconds,
+              ..._diagnosticSshExecErrorFields(error),
+            },
+          );
+          await Future<void>.delayed(retryDelay);
+          continue;
+        }
+
+        DiagnosticsLogService.instance.error(
+          'ssh.sftp',
+          'open_failed',
+          fields: {
+            'connectionId': connectionId,
+            'hostId': hostId,
+            'attempt': attempt + 1,
+            ..._diagnosticSshExecErrorFields(error),
+          },
+        );
+        _reportConnectionHealthFailureIfClosed(error, operation: 'sftp');
+        rethrow;
+      }
     }
+  }
+
+  Duration? _sftpOpenRetryDelay(Object error, int attempt) {
+    if (attempt >= _sftpOpenRetryDelays.length ||
+        !_isTransientSftpOpenError(error)) {
+      return null;
+    }
+    return _sftpOpenRetryDelays[attempt];
+  }
+
+  bool _isTransientSftpOpenError(Object error) {
+    if (error is! SSHChannelOpenError) {
+      return false;
+    }
+    return error.code == 2 || error.code == 4;
   }
 
   /// Start a local port forward tunnel.

--- a/lib/presentation/controllers/terminal_session_controller.dart
+++ b/lib/presentation/controllers/terminal_session_controller.dart
@@ -104,7 +104,7 @@ class TerminalSessionController {
       return;
     }
 
-    observedSession.removeMetadataListener(_onSessionMetadataChanged);
+    observedSession.removeMetadataListener(_handleSessionMetadataChanged);
     _observedSession = null;
   }
 
@@ -152,6 +152,9 @@ class TerminalSessionController {
   ) {
     final connectionId = _connectionId();
     if (connectionId == null) {
+      return SshConnectionState.disconnected;
+    }
+    if (_getSession(connectionId) == null) {
       return SshConnectionState.disconnected;
     }
     return states[connectionId] ?? SshConnectionState.disconnected;

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -467,6 +467,7 @@ class SftpScreen extends ConsumerStatefulWidget {
 
 class _SftpScreenState extends ConsumerState<SftpScreen> {
   SftpClient? _sftp;
+  int? _connectionId;
   final ScrollController _breadcrumbScrollController = ScrollController();
   final ScrollController _fileListScrollController = ScrollController();
   String _currentPath = '/';
@@ -590,18 +591,12 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         return;
       }
 
+      _connectionId = connectionId;
       await sessionsNotifier.syncBackgroundStatus();
       if (!mounted) {
         return;
       }
-      final sftpOpenFuture = session.sftp();
-      late final SftpClient sftp;
-      try {
-        sftp = await withSftpOperationTimeout(sftpOpenFuture);
-      } on TimeoutException {
-        sftpOpenFuture.then((sftp) => sftp.close()).ignore();
-        rethrow;
-      }
+      final sftp = await _openSftpClient(session);
       if (!mounted) {
         sftp.close();
         return;
@@ -640,6 +635,16 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       _handleConnectFailure(e, pendingSftp);
     } on Exception catch (e) {
       _handleConnectFailure(e, pendingSftp);
+    }
+  }
+
+  Future<SftpClient> _openSftpClient(SshSession session) async {
+    final sftpOpenFuture = session.sftp();
+    try {
+      return await withSftpOperationTimeout(sftpOpenFuture);
+    } on TimeoutException {
+      sftpOpenFuture.then((sftp) => sftp.close()).ignore();
+      rethrow;
     }
   }
 
@@ -738,6 +743,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     List<String>? nextHistory,
     bool rethrowTimeout = false,
     bool showError = true,
+    bool allowReconnect = true,
   }) async {
     if (_sftp == null) {
       return false;
@@ -776,28 +782,170 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       _rememberCurrentPath(path);
       _queueScrollBreadcrumbTailIntoView();
       return true;
-    } on Exception catch (e) {
-      if (e is TimeoutException && rethrowTimeout) {
+    } on TimeoutException catch (e) {
+      if (rethrowTimeout) {
         rethrow;
       }
-      DiagnosticsLogService.instance.warning(
-        'sftp',
-        'list_failed',
-        fields: {'errorType': e.runtimeType},
+      return _handleLoadDirectoryFailure(
+        e,
+        path,
+        nextHistory: nextHistory,
+        showError: showError,
+        allowReconnect: allowReconnect,
       );
-      if (!mounted) {
-        return false;
+    } on SSHError catch (e) {
+      return _handleLoadDirectoryFailure(
+        e,
+        path,
+        nextHistory: nextHistory,
+        showError: showError,
+        allowReconnect: allowReconnect,
+      );
+    } on SftpStatusError catch (e) {
+      return _handleLoadDirectoryFailure(e, path, showError: showError);
+    } on SftpError catch (e) {
+      return _handleLoadDirectoryFailure(
+        e,
+        path,
+        nextHistory: nextHistory,
+        showError: showError,
+        allowReconnect: allowReconnect,
+      );
+    } on Exception catch (e) {
+      return _handleLoadDirectoryFailure(e, path, showError: showError);
+    }
+  }
+
+  Future<bool> _handleLoadDirectoryFailure(
+    Object error,
+    String path, {
+    List<String>? nextHistory,
+    bool showError = true,
+    bool allowReconnect = true,
+  }) async {
+    if (allowReconnect && _shouldReconnectSftpAfterDirectoryError(error)) {
+      final reconnected = await _reconnectSftpAndLoadDirectory(
+        path,
+        nextHistory: nextHistory,
+        showError: showError,
+      );
+      if (reconnected || !mounted) {
+        return reconnected;
       }
-      setState(() {
-        _isLoading = false;
-        if (showError) {
-          _error = e is TimeoutException
-              ? sftpTimeoutMessage('listing this directory')
-              : 'Failed to list this directory. Try another folder.';
-        }
-      });
+    }
+    DiagnosticsLogService.instance.warning(
+      'sftp',
+      'list_failed',
+      fields: {'errorType': error.runtimeType},
+    );
+    if (!mounted) {
       return false;
     }
+    setState(() {
+      _isLoading = false;
+      if (showError) {
+        _error = error is TimeoutException
+            ? sftpTimeoutMessage('listing this directory')
+            : 'Failed to list this directory. Try another folder.';
+      }
+    });
+    return false;
+  }
+
+  bool _shouldReconnectSftpAfterDirectoryError(Object error) =>
+      error is TimeoutException ||
+      error is SSHError ||
+      (error is SftpError && error is! SftpStatusError);
+
+  Future<bool> _reconnectSftpAndLoadDirectory(
+    String path, {
+    List<String>? nextHistory,
+    bool showError = true,
+  }) async {
+    final connectionId = _connectionId ?? widget.connectionId;
+    if (connectionId == null) {
+      return false;
+    }
+    final session = ref
+        .read(activeSessionsProvider.notifier)
+        .getSession(connectionId);
+    if (session == null) {
+      return false;
+    }
+
+    DiagnosticsLogService.instance.info(
+      'sftp',
+      'reconnect_start',
+      fields: {'connectionId': connectionId},
+    );
+    _sftp?.close();
+    _sftp = null;
+
+    try {
+      final sftp = await _openSftpClient(session);
+      if (!mounted) {
+        sftp.close();
+        return false;
+      }
+      _sftp = sftp;
+      DiagnosticsLogService.instance.info(
+        'sftp',
+        'reconnect_success',
+        fields: {'connectionId': connectionId},
+      );
+      return _loadDirectory(
+        path,
+        nextHistory: nextHistory,
+        showError: showError,
+        allowReconnect: false,
+      );
+    } on TimeoutException catch (error) {
+      return _handleSftpReconnectFailure(
+        connectionId,
+        error,
+        showError: showError,
+      );
+    } on SSHError catch (error) {
+      return _handleSftpReconnectFailure(
+        connectionId,
+        error,
+        showError: showError,
+      );
+    } on SftpError catch (error) {
+      return _handleSftpReconnectFailure(
+        connectionId,
+        error,
+        showError: showError,
+      );
+    } on Exception catch (error) {
+      return _handleSftpReconnectFailure(
+        connectionId,
+        error,
+        showError: showError,
+      );
+    }
+  }
+
+  bool _handleSftpReconnectFailure(
+    int connectionId,
+    Object error, {
+    required bool showError,
+  }) {
+    DiagnosticsLogService.instance.warning(
+      'sftp',
+      'reconnect_failed',
+      fields: {'connectionId': connectionId, 'errorType': error.runtimeType},
+    );
+    if (!mounted || !showError) {
+      return false;
+    }
+    setState(() {
+      _isLoading = false;
+      _error = error is TimeoutException
+          ? sftpTimeoutMessage('reconnecting the SFTP browser')
+          : 'SFTP connection failed. Check the connection and try again.';
+    });
+    return false;
   }
 
   Future<void> _navigateTo(String path) async {
@@ -838,7 +986,10 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       return;
     }
 
-    final key = (hostId: widget.hostId, connectionId: widget.connectionId);
+    final key = (
+      hostId: widget.hostId,
+      connectionId: _connectionId ?? widget.connectionId,
+    );
     final notifier = ref.read(sftpBrowserLastPathsProvider.notifier);
     notifier.state = <SftpBrowserLocationKey, String>{
       ...notifier.state,

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -5940,6 +5940,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (connectionId == null) {
       return SshConnectionState.disconnected;
     }
+    if (ref.read(activeSessionsProvider.notifier).getSession(connectionId) ==
+        null) {
+      return SshConnectionState.disconnected;
+    }
     return ref.read(activeSessionsProvider)[connectionId] ??
         SshConnectionState.disconnected;
   }
@@ -7930,6 +7934,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _stopSharedClipboardSync();
     _hideShellCompletionPopup();
     _clearOwnedTerminalCallbacks();
+    _disposeTerminalPathVerificationSftp();
     _sessionController.clearObservedSession(session: session);
     _clearTmuxState();
     _detectedSensitiveKeyboardPrompt = false;
@@ -8011,6 +8016,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _cancelTerminalThemeRefreshTimers();
     _clearTmuxState();
     _sessionController.clearObservedSession();
+    _disposeTerminalPathVerificationSftp();
     _suppressNextAutomaticReconnectConnectionId = null;
     _syncTerminalWakeLock(SshConnectionState.disconnected);
     unawaited(_doneSubscription?.cancel());
@@ -8046,6 +8052,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _connectionId = null;
     _clearAppThemeOverride();
     _sessionController.clearObservedSession();
+    _disposeTerminalPathVerificationSftp();
     _suppressNextAutomaticReconnectConnectionId = null;
     _syncTerminalWakeLock(SshConnectionState.disconnected);
     _connectionLostWhileBackgrounded = false;
@@ -9436,6 +9443,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       final initialPath = rememberedPath ?? cwd;
       final shouldRestoreKeyboard = _temporarilyDismissTerminalKeyboard();
       try {
+        _disposeTerminalPathVerificationSftp();
         await context.pushNamed<String>(
           Routes.sftp,
           pathParameters: {'hostId': widget.hostId.toString()},
@@ -11903,6 +11911,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
 
     final remoteFileService = ref.read(remoteFileServiceProvider);
+    _disposeTerminalPathVerificationSftp();
     final sftp = await session.sftp();
     try {
       final homeDirectory = await remoteFileService.resolveInitialDirectory(

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -104,6 +104,8 @@ class _MockSshClient extends Mock implements SSHClient {}
 
 class _MockExecSession extends Mock implements SSHSession {}
 
+class _MockSftpClient extends Mock implements SftpClient {}
+
 class _FakeHostKeySocket implements SSHSocket, HostKeySource {
   _FakeHostKeySocket(this._hostKeyBytes);
 
@@ -882,6 +884,60 @@ void main() {
           pty: const SSHPtyConfig(width: 120, height: 30),
         ),
       ).called(1);
+    });
+
+    test('retries transient SFTP channel open failures', () async {
+      final client = _MockSshClient();
+      final sftp = _MockSftpClient();
+      final session = SshSession(
+        connectionId: 11,
+        hostId: 2,
+        client: client,
+        config: const SshConnectionConfig(
+          hostname: 'example.com',
+          port: 22,
+          username: 'tester',
+        ),
+      );
+      var openAttempts = 0;
+
+      when(client.sftp).thenAnswer((_) {
+        openAttempts++;
+        if (openAttempts == 1) {
+          return Future<SftpClient>.error(
+            SSHChannelOpenError(2, 'open failed'),
+          );
+        }
+        return Future.value(sftp);
+      });
+
+      await expectLater(session.sftp(), completion(same(sftp)));
+      expect(openAttempts, 2);
+    });
+
+    test('does not retry non-transient SFTP channel open failures', () async {
+      final client = _MockSshClient();
+      final session = SshSession(
+        connectionId: 11,
+        hostId: 2,
+        client: client,
+        config: const SshConnectionConfig(
+          hostname: 'example.com',
+          port: 22,
+          username: 'tester',
+        ),
+      );
+      var openAttempts = 0;
+
+      when(client.sftp).thenAnswer((_) {
+        openAttempts++;
+        return Future<SftpClient>.error(
+          SSHChannelOpenError(1, 'administratively prohibited'),
+        );
+      });
+
+      await expectLater(session.sftp(), throwsA(isA<SSHChannelOpenError>()));
+      expect(openAttempts, 1);
     });
 
     test('runs queued exec work against the session connection', () async {

--- a/test/presentation/screens/sftp_screen_test.dart
+++ b/test/presentation/screens/sftp_screen_test.dart
@@ -621,6 +621,71 @@ void main() {
       await tester.pumpWidget(const SizedBox.shrink());
     });
 
+    testWidgets('reopens SFTP when the directory channel goes stale', (
+      tester,
+    ) async {
+      final sshClient = _MockSshClient();
+      final staleSftp = _MockSftpClient();
+      final freshSftp = _MockSftpClient();
+      final monetizationService = _MockMonetizationService();
+      final session = SshSession(
+        connectionId: 7,
+        hostId: 1,
+        client: sshClient,
+        config: const SshConnectionConfig(
+          hostname: 'demo.example.com',
+          port: 22,
+          username: 'demo',
+        ),
+      );
+      var sftpOpenAttempts = 0;
+
+      when(
+        () => monetizationService.currentState,
+      ).thenReturn(_proMonetizationState);
+      when(sshClient.sftp).thenAnswer((_) async {
+        sftpOpenAttempts++;
+        return sftpOpenAttempts == 1 ? staleSftp : freshSftp;
+      });
+      when(() => staleSftp.absolute('.')).thenAnswer((_) async => '/home/demo');
+      when(
+        () => staleSftp.listdir('/home/demo'),
+      ).thenThrow(SSHStateError('Connection closed'));
+      when(() => freshSftp.listdir('/home/demo')).thenAnswer(
+        (_) async => [
+          SftpName(
+            filename: 'notes.txt',
+            longname: 'notes.txt',
+            attr: SftpFileAttrs(mode: const SftpFileMode.value(1 << 15)),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            activeSessionsProvider.overrideWith(
+              () => _TestActiveSessionsNotifier(session),
+            ),
+            monetizationServiceProvider.overrideWithValue(monetizationService),
+            monetizationStateProvider.overrideWith(
+              (ref) => Stream.value(_proMonetizationState),
+            ),
+          ],
+          child: const MaterialApp(
+            home: SftpScreen(hostId: 1, connectionId: 7),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('notes.txt'), findsOneWidget);
+      expect(sftpOpenAttempts, 2);
+      verify(staleSftp.close).called(1);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
+
     testWidgets('video preview deletes cached files when closed', (
       tester,
     ) async {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -206,6 +206,13 @@ class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
     state = {...state}..remove(connectionId);
   }
 
+  void dropSessionButKeepConnectedState(int connectionId) {
+    if (!disconnectedConnectionIds.contains(connectionId)) {
+      disconnectedConnectionIds.add(connectionId);
+    }
+    state = {...state, connectionId: SshConnectionState.connected};
+  }
+
   @override
   Future<void> syncBackgroundStatus() async {}
 }
@@ -1116,6 +1123,59 @@ void main() {
         expect(activeSessions.disconnectedConnectionIds, <int>[
           session.connectionId,
         ]);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'automatically reconnects when the session lookup is stale',
+      (tester) async {
+        final reconnectClient = _MockSshClient();
+        final reconnectShell = _MockShellChannel();
+        final reconnectDoneCompleter = Completer<void>();
+        final reconnectStdoutController =
+            StreamController<Uint8List>.broadcast();
+        addTearDown(reconnectStdoutController.close);
+
+        when(
+          () => reconnectClient.shell(pty: any(named: 'pty')),
+        ).thenAnswer((_) async => reconnectShell);
+        when(
+          () => reconnectShell.stdout,
+        ).thenAnswer((_) => reconnectStdoutController.stream);
+        when(
+          () => reconnectShell.stderr,
+        ).thenAnswer((_) => const Stream<Uint8List>.empty());
+        when(
+          () => reconnectShell.done,
+        ).thenAnswer((_) => reconnectDoneCompleter.future);
+        when(() => reconnectShell.write(any())).thenAnswer((_) {});
+
+        final reconnectSession = SshSession(
+          connectionId: 8,
+          hostId: host.id,
+          client: reconnectClient,
+          config: const SshConnectionConfig(
+            hostname: 'terminal.example.com',
+            port: 22,
+            username: 'root',
+          ),
+        );
+        final activeSessions = _TestActiveSessionsNotifier(
+          session,
+          reconnectSession: reconnectSession,
+        )..disconnectedConnectionIds.add(reconnectSession.connectionId);
+
+        await pumpScreen(tester, activeSessions: activeSessions);
+        verify(() => sshClient.shell(pty: any(named: 'pty'))).called(1);
+
+        activeSessions.dropSessionButKeepConnectedState(session.connectionId);
+        await tester.pump();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(activeSessions.connectForceNewValues, <bool>[true]);
+        verify(() => reconnectClient.shell(pty: any(named: 'pty'))).called(1);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );


### PR DESCRIPTION
## Summary

- retry transient SFTP channel-open failures and reopen stale SFTP browser channels before relisting
- release terminal path-verification SFTP clients before user-visible SFTP operations
- treat missing active sessions as disconnected so terminal screens trigger reconnect instead of staying on a dead shell
- fix terminal metadata listener cleanup and add targeted regression coverage

## Tests

- flutter analyze
- flutter test test/domain/services/ssh_service_test.dart
- flutter test test/presentation/screens/sftp_screen_test.dart
- flutter test test/presentation/screens/terminal_screen_test.dart
- pre-commit checks
