### PR TITLE
fix: replace paste indicator with ellipsis

### DIFF
--- a/lib/presentation/widgets/keyboard_toolbar.dart
+++ b/lib/presentation/widgets/keyboard_toolbar.dart
@@ -438,7 +438,7 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
       key: _pasteButtonKey,
       icon: Icons.paste_rounded,
       label: 'Paste',
-      longPressIndicatorIcon: Icons.keyboard_arrow_up_rounded,
+      longPressIndicatorIcon: Icons.more_horiz_rounded,
       onTap: _pasteClipboard,
       onLongPressStartWithDetails: _showPasteOptions,
       onLongPressMoveUpdate: _updatePasteOptionsHighlight,

--- a/test/widget/keyboard_toolbar_test.dart
+++ b/test/widget/keyboard_toolbar_test.dart
@@ -307,7 +307,7 @@ void main() {
       expect(keyPressedCount, 1);
     });
 
-    testWidgets('Paste button shows a long-press options indicator', (
+    testWidgets('Paste button shows an ellipsis long-press options indicator', (
       tester,
     ) async {
       await tester.pumpWidget(
@@ -319,7 +319,7 @@ void main() {
       expect(
         find.descendant(
           of: find.byTooltip('Paste'),
-          matching: find.byIcon(Icons.keyboard_arrow_up_rounded),
+          matching: find.byIcon(Icons.more_horiz_rounded),
         ),
         findsOneWidget,
       );


### PR DESCRIPTION
## Summary

- Replace the paste toolbar long-press chevron indicator with a horizontal ellipsis
- Update the keyboard toolbar widget test to expect the ellipsis indicator

## Tests

- flutter test test/widget/keyboard_toolbar_test.dart
- flutter analyze
