### PR TITLE
fix: render terminal insert mode output

### DIFF
--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -356,11 +356,18 @@ const _terminalEscape = '\x1b';
 const _terminalEscapeCodeUnit = 0x1B;
 const _terminalBellCodeUnit = 0x07;
 const _terminalCsiIntroducerCodeUnit = 0x5B;
+const _terminalDcsIntroducerCodeUnit = 0x50;
 const _terminalOscIntroducerCodeUnit = 0x5D;
+const _terminalSosIntroducerCodeUnit = 0x58;
+const _terminalPmIntroducerCodeUnit = 0x5E;
+const _terminalApcIntroducerCodeUnit = 0x5F;
+const _terminalStringTerminatorCodeUnit = 0x5C;
 const _terminalDeleteCodeUnit = 0x7F;
 const _terminalInsertMode = 4;
 const _terminalSetModeFinalCodeUnit = 0x68;
 const _terminalResetModeFinalCodeUnit = 0x6C;
+const _terminalSoftResetFinalCodeUnit = 0x70;
+const _terminalFullResetFinalCodeUnit = 0x63;
 const _terminalInsertBlankCharacterSequence = '\x1b[@';
 const _escapedTerminalEscape = '$_terminalEscape$_terminalEscape';
 const _terminalStringTerminator = '$_terminalEscape\\';
@@ -413,8 +420,12 @@ int? _terminalEscapeSequenceEndIndex(String input, int start) {
   switch (introducer) {
     case _terminalCsiIntroducerCodeUnit:
       return _terminalCsiEndIndex(input, start + 2);
+    case _terminalDcsIntroducerCodeUnit:
     case _terminalOscIntroducerCodeUnit:
-      return _terminalOscEndIndex(input, start + 2);
+    case _terminalSosIntroducerCodeUnit:
+    case _terminalPmIntroducerCodeUnit:
+    case _terminalApcIntroducerCodeUnit:
+      return _terminalStringEndIndex(input, start + 2);
   }
 
   var cursor = start + 1;
@@ -440,7 +451,7 @@ int? _terminalCsiEndIndex(String input, int start) {
   return null;
 }
 
-int? _terminalOscEndIndex(String input, int start) {
+int? _terminalStringEndIndex(String input, int start) {
   var cursor = start;
   while (cursor < input.length) {
     final codeUnit = input.codeUnitAt(cursor);
@@ -451,7 +462,11 @@ int? _terminalOscEndIndex(String input, int start) {
       if (cursor + 1 >= input.length) {
         return null;
       }
-      return cursor + 2;
+      if (input.codeUnitAt(cursor + 1) == _terminalStringTerminatorCodeUnit) {
+        return cursor + 2;
+      }
+      cursor += 1;
+      continue;
     }
     cursor += 1;
   }
@@ -462,19 +477,30 @@ bool _isTerminalEscapeIntermediate(int codeUnit) =>
     codeUnit >= 0x20 && codeUnit <= 0x2F;
 
 bool? _terminalInsertModeUpdate(String sequence) {
+  if (sequence.length < 2 ||
+      sequence.codeUnitAt(0) != _terminalEscapeCodeUnit) {
+    return null;
+  }
+  if (sequence.length == 2 &&
+      sequence.codeUnitAt(1) == _terminalFullResetFinalCodeUnit) {
+    return false;
+  }
   if (sequence.length < 4 ||
-      sequence.codeUnitAt(0) != _terminalEscapeCodeUnit ||
       sequence.codeUnitAt(1) != _terminalCsiIntroducerCodeUnit) {
     return null;
   }
 
   final finalCodeUnit = sequence.codeUnitAt(sequence.length - 1);
+  final params = sequence.substring(2, sequence.length - 1);
+  if (finalCodeUnit == _terminalSoftResetFinalCodeUnit &&
+      (params == '!' || params.endsWith('"'))) {
+    return false;
+  }
   if (finalCodeUnit != _terminalSetModeFinalCodeUnit &&
       finalCodeUnit != _terminalResetModeFinalCodeUnit) {
     return null;
   }
 
-  final params = sequence.substring(2, sequence.length - 1);
   if (params.startsWith('?')) {
     return null;
   }
@@ -528,6 +554,7 @@ bool _isTerminalZeroWidthRune(int rune) =>
     (rune >= 0x20D0 && rune <= 0x20FF) ||
     (rune >= 0xFE00 && rune <= 0xFE0F) ||
     (rune >= 0xFE20 && rune <= 0xFE2F) ||
+    (rune >= 0x1F3FB && rune <= 0x1F3FF) ||
     (rune >= 0xE0100 && rune <= 0xE01EF);
 
 bool _isTerminalWideRune(int rune) =>

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -200,6 +200,66 @@ String normalizeTerminalOutputForRemoteShell(String data) =>
       return '\x1b[${row + 1};${column + 1}R';
     });
 
+/// Adapts remote terminal output so xterm.dart renders insert mode correctly.
+///
+/// xterm.dart 4.0.0 tracks IRM (`CSI 4 h/l`) but does not shift existing cells
+/// when printable characters arrive while the mode is active. Injecting ICH
+/// before each printable cell preserves behavior from editors such as nano,
+/// while [pendingInput] keeps split escape sequences from leaking printable
+/// bytes into the renderer.
+@visibleForTesting
+({String output, String pendingInput, bool insertMode})
+adaptTerminalInsertModeOutputForXterm({
+  required String input,
+  required String pendingInput,
+  required bool insertMode,
+}) {
+  final combinedInput = pendingInput + input;
+  final output = StringBuffer();
+  var cursor = 0;
+  var nextInsertMode = insertMode;
+
+  while (cursor < combinedInput.length) {
+    final codeUnit = combinedInput.codeUnitAt(cursor);
+    if (codeUnit == _terminalEscapeCodeUnit) {
+      final endIndex = _terminalEscapeSequenceEndIndex(combinedInput, cursor);
+      if (endIndex == null) {
+        return (
+          output: output.toString(),
+          pendingInput: combinedInput.substring(cursor),
+          insertMode: nextInsertMode,
+        );
+      }
+
+      final sequence = combinedInput.substring(cursor, endIndex);
+      output.write(sequence);
+      final insertModeUpdate = _terminalInsertModeUpdate(sequence);
+      if (insertModeUpdate != null) {
+        nextInsertMode = insertModeUpdate;
+      }
+      cursor = endIndex;
+      continue;
+    }
+
+    final rune = _terminalRuneAt(combinedInput, cursor);
+    final runeLength = _terminalRuneLength(rune);
+    if (nextInsertMode && _isTerminalGraphicRune(rune)) {
+      final width = _terminalCellWidth(rune);
+      for (var cell = 0; cell < width; cell += 1) {
+        output.write(_terminalInsertBlankCharacterSequence);
+      }
+    }
+    output.write(combinedInput.substring(cursor, cursor + runeLength));
+    cursor += runeLength;
+  }
+
+  return (
+    output: output.toString(),
+    pendingInput: '',
+    insertMode: nextInsertMode,
+  );
+}
+
 final _terminalWindowQueryPattern = RegExp(r'\x1b\[([0-9;?]*)t');
 final _terminalModeReportQueryPattern = RegExp(r'\x1b\[\?([0-9;]+)\$p');
 final _terminalThemeModeQueryPattern = RegExp(r'\x1b\[\?996n');
@@ -293,6 +353,15 @@ const _terminalModeSet = 1;
 const _terminalModeReset = 2;
 
 const _terminalEscape = '\x1b';
+const _terminalEscapeCodeUnit = 0x1B;
+const _terminalBellCodeUnit = 0x07;
+const _terminalCsiIntroducerCodeUnit = 0x5B;
+const _terminalOscIntroducerCodeUnit = 0x5D;
+const _terminalDeleteCodeUnit = 0x7F;
+const _terminalInsertMode = 4;
+const _terminalSetModeFinalCodeUnit = 0x68;
+const _terminalResetModeFinalCodeUnit = 0x6C;
+const _terminalInsertBlankCharacterSequence = '\x1b[@';
 const _escapedTerminalEscape = '$_terminalEscape$_terminalEscape';
 const _terminalStringTerminator = '$_terminalEscape\\';
 const _terminalTmuxPassthroughStart = '${_terminalEscape}Ptmux;';
@@ -334,6 +403,147 @@ String _terminalTmuxPassthroughPendingSuffix(String input) {
   }
   return '';
 }
+
+int? _terminalEscapeSequenceEndIndex(String input, int start) {
+  if (start + 1 >= input.length) {
+    return null;
+  }
+
+  final introducer = input.codeUnitAt(start + 1);
+  switch (introducer) {
+    case _terminalCsiIntroducerCodeUnit:
+      return _terminalCsiEndIndex(input, start + 2);
+    case _terminalOscIntroducerCodeUnit:
+      return _terminalOscEndIndex(input, start + 2);
+  }
+
+  var cursor = start + 1;
+  while (cursor < input.length &&
+      _isTerminalEscapeIntermediate(input.codeUnitAt(cursor))) {
+    cursor += 1;
+  }
+  if (cursor >= input.length) {
+    return null;
+  }
+  return cursor + 1;
+}
+
+int? _terminalCsiEndIndex(String input, int start) {
+  var cursor = start;
+  while (cursor < input.length) {
+    final codeUnit = input.codeUnitAt(cursor);
+    if (codeUnit >= 0x40 && codeUnit <= 0x7E) {
+      return cursor + 1;
+    }
+    cursor += 1;
+  }
+  return null;
+}
+
+int? _terminalOscEndIndex(String input, int start) {
+  var cursor = start;
+  while (cursor < input.length) {
+    final codeUnit = input.codeUnitAt(cursor);
+    if (codeUnit == _terminalBellCodeUnit) {
+      return cursor + 1;
+    }
+    if (codeUnit == _terminalEscapeCodeUnit) {
+      if (cursor + 1 >= input.length) {
+        return null;
+      }
+      return cursor + 2;
+    }
+    cursor += 1;
+  }
+  return null;
+}
+
+bool _isTerminalEscapeIntermediate(int codeUnit) =>
+    codeUnit >= 0x20 && codeUnit <= 0x2F;
+
+bool? _terminalInsertModeUpdate(String sequence) {
+  if (sequence.length < 4 ||
+      sequence.codeUnitAt(0) != _terminalEscapeCodeUnit ||
+      sequence.codeUnitAt(1) != _terminalCsiIntroducerCodeUnit) {
+    return null;
+  }
+
+  final finalCodeUnit = sequence.codeUnitAt(sequence.length - 1);
+  if (finalCodeUnit != _terminalSetModeFinalCodeUnit &&
+      finalCodeUnit != _terminalResetModeFinalCodeUnit) {
+    return null;
+  }
+
+  final params = sequence.substring(2, sequence.length - 1);
+  if (params.startsWith('?')) {
+    return null;
+  }
+  for (final param in params.split(';')) {
+    if (int.tryParse(param) == _terminalInsertMode) {
+      return finalCodeUnit == _terminalSetModeFinalCodeUnit;
+    }
+  }
+  return null;
+}
+
+int _terminalRuneAt(String input, int index) {
+  final first = input.codeUnitAt(index);
+  if (_isTerminalHighSurrogate(first) && index + 1 < input.length) {
+    final second = input.codeUnitAt(index + 1);
+    if (_isTerminalLowSurrogate(second)) {
+      return 0x10000 + ((first - 0xD800) << 10) + second - 0xDC00;
+    }
+  }
+  return first;
+}
+
+int _terminalRuneLength(int rune) => rune > 0xFFFF ? 2 : 1;
+
+bool _isTerminalHighSurrogate(int codeUnit) =>
+    codeUnit >= 0xD800 && codeUnit <= 0xDBFF;
+
+bool _isTerminalLowSurrogate(int codeUnit) =>
+    codeUnit >= 0xDC00 && codeUnit <= 0xDFFF;
+
+bool _isTerminalGraphicRune(int rune) =>
+    rune >= 0x20 &&
+    rune != _terminalDeleteCodeUnit &&
+    !(rune >= 0x80 && rune <= 0x9F);
+
+int _terminalCellWidth(int rune) {
+  if (!_isTerminalGraphicRune(rune) || _isTerminalZeroWidthRune(rune)) {
+    return 0;
+  }
+  if (_isTerminalWideRune(rune)) {
+    return 2;
+  }
+  return 1;
+}
+
+bool _isTerminalZeroWidthRune(int rune) =>
+    rune == 0x200D ||
+    (rune >= 0x0300 && rune <= 0x036F) ||
+    (rune >= 0x1AB0 && rune <= 0x1AFF) ||
+    (rune >= 0x1DC0 && rune <= 0x1DFF) ||
+    (rune >= 0x20D0 && rune <= 0x20FF) ||
+    (rune >= 0xFE00 && rune <= 0xFE0F) ||
+    (rune >= 0xFE20 && rune <= 0xFE2F) ||
+    (rune >= 0xE0100 && rune <= 0xE01EF);
+
+bool _isTerminalWideRune(int rune) =>
+    rune >= 0x1100 &&
+    (rune <= 0x115F ||
+        rune == 0x2329 ||
+        rune == 0x232A ||
+        (rune >= 0x2E80 && rune <= 0xA4CF && rune != 0x303F) ||
+        (rune >= 0xAC00 && rune <= 0xD7A3) ||
+        (rune >= 0xF900 && rune <= 0xFAFF) ||
+        (rune >= 0xFE10 && rune <= 0xFE19) ||
+        (rune >= 0xFE30 && rune <= 0xFE6F) ||
+        (rune >= 0xFF00 && rune <= 0xFF60) ||
+        (rune >= 0xFFE0 && rune <= 0xFFE6) ||
+        (rune >= 0x1F300 && rune <= 0x1FAFF) ||
+        (rune >= 0x20000 && rune <= 0x3FFFD));
 
 bool _hasValidTerminalWindowMetrics(TerminalWindowMetrics? metrics) =>
     metrics != null &&

--- a/lib/domain/services/ssh_session_runtime.dart
+++ b/lib/domain/services/ssh_session_runtime.dart
@@ -30,7 +30,9 @@ class _SshSessionRuntime {
   String _terminalWindowQueryPendingInput = '';
   String _terminalTmuxPassthroughPendingInput = '';
   String _terminalControlModeUpdatePendingInput = '';
+  String _terminalInsertModePendingInput = '';
   bool _terminalColorSchemeUpdatesMode = false;
+  bool _terminalInsertMode = false;
 
   Terminal? _terminal;
 
@@ -199,7 +201,9 @@ class _SshSessionRuntime {
     _terminalWindowQueryPendingInput = '';
     _terminalTmuxPassthroughPendingInput = '';
     _terminalControlModeUpdatePendingInput = '';
+    _terminalInsertModePendingInput = '';
     _terminalColorSchemeUpdatesMode = false;
+    _terminalInsertMode = false;
     _terminal = null;
     DiagnosticsLogService.instance.info(
       'ssh.shell',
@@ -450,9 +454,20 @@ class _SshSessionRuntime {
 
     final output = _drainPendingShellOutputs(drainAll: drainAll);
     if (output.terminalData.isNotEmpty) {
-      terminal.write(output.terminalData);
+      final terminalOutput = adaptTerminalInsertModeOutputForXterm(
+        input: output.terminalData,
+        pendingInput: _terminalInsertModePendingInput,
+        insertMode: _terminalInsertMode,
+      );
+      _terminalInsertModePendingInput = terminalOutput.pendingInput;
+      _terminalInsertMode = terminalOutput.insertMode;
+      if (terminalOutput.output.isNotEmpty) {
+        terminal.write(terminalOutput.output);
+      }
       _respondToTerminalWindowControlQueries(output.terminalData, terminal);
-      _scheduleTerminalPreviewRefresh();
+      if (terminalOutput.output.isNotEmpty) {
+        _scheduleTerminalPreviewRefresh();
+      }
     }
 
     if (output.stdoutData.isNotEmpty) {

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -332,6 +332,56 @@ void main() {
       },
     );
 
+    test('adapts insert mode output so xterm shifts existing cells', () {
+      final terminal = Terminal(maxLines: 100);
+      final result = adaptTerminalInsertModeOutputForXterm(
+        input: 'abcdef\r\x1b[3C\x1b[4hXY',
+        pendingInput: '',
+        insertMode: false,
+      );
+
+      terminal.write(result.output);
+
+      expect(result.pendingInput, isEmpty);
+      expect(result.insertMode, isTrue);
+      expect(terminal.lines[0].getText(0, 8), 'abcXYdef');
+    });
+
+    test('adapts split insert mode sequences across chunks', () {
+      final terminal = Terminal(maxLines: 100);
+      final first = adaptTerminalInsertModeOutputForXterm(
+        input: 'abcdef\r\x1b[3C\x1b[',
+        pendingInput: '',
+        insertMode: false,
+      );
+      terminal.write(first.output);
+
+      final second = adaptTerminalInsertModeOutputForXterm(
+        input: '4hZ\x1b[4lQ',
+        pendingInput: first.pendingInput,
+        insertMode: first.insertMode,
+      );
+      terminal.write(second.output);
+
+      expect(first.pendingInput, '\x1b[');
+      expect(second.pendingInput, isEmpty);
+      expect(second.insertMode, isFalse);
+      expect(second.output, '\x1b[4h\x1b[@Z\x1b[4lQ');
+      expect(terminal.lines[0].getText(0, 7), 'abcZQef');
+    });
+
+    test('does not inject insert blanks into OSC payloads', () {
+      final result = adaptTerminalInsertModeOutputForXterm(
+        input: '\x1b[4h\x1b]0;nano title\x07Z',
+        pendingInput: '',
+        insertMode: false,
+      );
+
+      expect(result.pendingInput, isEmpty);
+      expect(result.insertMode, isTrue);
+      expect(result.output, '\x1b[4h\x1b]0;nano title\x07\x1b[@Z');
+    });
+
     test('unwraps complete tmux passthrough sequences', () {
       final result = unwrapTerminalTmuxPassthroughSequences(
         input: 'before\x1bPtmux;\x1b\x1b]11;?\x07\x1b\\after',

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -382,6 +382,61 @@ void main() {
       expect(result.output, '\x1b[4h\x1b]0;nano title\x07\x1b[@Z');
     });
 
+    test('clears tracked insert mode on terminal reset sequences', () {
+      final fullReset = adaptTerminalInsertModeOutputForXterm(
+        input: '\x1b[4hA\x1bcB',
+        pendingInput: '',
+        insertMode: false,
+      );
+
+      expect(fullReset.pendingInput, isEmpty);
+      expect(fullReset.insertMode, isFalse);
+      expect(fullReset.output, '\x1b[4h\x1b[@A\x1bcB');
+
+      final softReset = adaptTerminalInsertModeOutputForXterm(
+        input: '\x1b[4hA\x1b[!pB',
+        pendingInput: '',
+        insertMode: false,
+      );
+
+      expect(softReset.pendingInput, isEmpty);
+      expect(softReset.insertMode, isFalse);
+      expect(softReset.output, '\x1b[4h\x1b[@A\x1b[!pB');
+    });
+
+    test('does not inject insert blanks into DCS payloads', () {
+      final first = adaptTerminalInsertModeOutputForXterm(
+        input: '\x1b[4h\x1bP1+r',
+        pendingInput: '',
+        insertMode: false,
+      );
+
+      final second = adaptTerminalInsertModeOutputForXterm(
+        input: 'abc\x1b\\Z',
+        pendingInput: first.pendingInput,
+        insertMode: first.insertMode,
+      );
+
+      expect(first.output, '\x1b[4h');
+      expect(first.pendingInput, '\x1bP1+r');
+      expect(first.insertMode, isTrue);
+      expect(second.pendingInput, isEmpty);
+      expect(second.insertMode, isTrue);
+      expect(second.output, '\x1bP1+rabc\x1b\\\x1b[@Z');
+    });
+
+    test('treats emoji modifiers as zero-width insert-mode cells', () {
+      final result = adaptTerminalInsertModeOutputForXterm(
+        input: '\x1b[4h\u{1F44D}\u{1F3FD}Z',
+        pendingInput: '',
+        insertMode: false,
+      );
+
+      expect(result.pendingInput, isEmpty);
+      expect(result.insertMode, isTrue);
+      expect(result.output, '\x1b[4h\x1b[@\x1b[@\u{1F44D}\u{1F3FD}\x1b[@Z');
+    });
+
     test('unwraps complete tmux passthrough sequences', () {
       final result = unwrapTerminalTmuxPassthroughSequences(
         input: 'before\x1bPtmux;\x1b\x1b]11;?\x07\x1b\\after',


### PR DESCRIPTION
## Summary

- Adapt SSH terminal output so xterm.dart renders IRM (`CSI 4 h/l`) as inserted cells instead of overwrites.
- Preserve split escape sequences across flush chunks and avoid injecting insert blanks into OSC payloads.
- Add coverage for nano-style insert rendering, split insert-mode sequences, and OSC title handling.

## Tests

- `flutter analyze`
- `flutter test test/domain/services/ssh_service_test.dart`
- `flutter test`
