### PR TITLE
fix: avoid duplicate MonkeyMux update prompts

### DIFF
--- a/lib/domain/services/monkeymux_installer_service.dart
+++ b/lib/domain/services/monkeymux_installer_service.dart
@@ -318,7 +318,6 @@ class MonkeyMuxInstallerService {
           executablePath: executablePath,
           platform: platform,
           version: manifest.version,
-          installedDuringCall: true,
         );
       }
 
@@ -432,6 +431,7 @@ class MonkeyMuxInstallerService {
         executablePath: executablePath,
         platform: platform,
         version: manifest.version,
+        installedDuringCall: true,
       );
     } finally {
       sftp.close();

--- a/test/domain/services/monkeymux_installer_service_test.dart
+++ b/test/domain/services/monkeymux_installer_service_test.dart
@@ -36,6 +36,7 @@ class _FakeAssetBundle extends CachingAssetBundle {
 
 class _FakeRemoteFileService extends RemoteFileService {
   bool uploaded = false;
+  int uploadCount = 0;
 
   @override
   Future<String> resolveInitialDirectory(SftpClient sftp) async =>
@@ -55,6 +56,7 @@ class _FakeRemoteFileService extends RemoteFileService {
     required Uint8List bytes,
   }) async {
     uploaded = true;
+    uploadCount++;
   }
 }
 
@@ -135,6 +137,7 @@ void main() {
         const Duration(seconds: 2),
       );
       expect(installation.version, '9.9.9');
+      expect(installation.installedDuringCall, isTrue);
       expect(acceptedConfirmations, <bool>[true]);
       expect(sftpOpenCount, 2);
 
@@ -142,6 +145,62 @@ void main() {
       await probeOnlyInstall;
     },
   );
+
+  test('reused helper is not marked as installed during the call', () async {
+    final assetBytes = Uint8List.fromList(utf8.encode('monkeymux-binary'));
+    final expectedSha = sha256.convert(assetBytes).toString();
+    final remoteFileService = _FakeRemoteFileService()..uploaded = true;
+    final installer = MonkeyMuxInstallerService(
+      manifestFuture: Future.value(
+        MonkeyMuxManifest(
+          version: '9.9.9',
+          entries: [
+            MonkeyMuxManifestEntry(
+              platform: 'darwin-arm64',
+              asset: 'assets/test/monkeymux',
+              sha256: expectedSha,
+              size: assetBytes.length,
+            ),
+          ],
+        ),
+      ),
+      remoteFileService: remoteFileService,
+      assetBundle: _FakeAssetBundle({'assets/test/monkeymux': assetBytes}),
+    );
+    const connectionId = 246810;
+    final client = _MockSshClient();
+    final sftp = _MockSftpClient();
+    when(sftp.close).thenReturn(null);
+    when(client.sftp).thenAnswer((_) async => sftp);
+    when(() => client.execute(any(), pty: any(named: 'pty'))).thenAnswer((
+      invocation,
+    ) async {
+      final command = invocation.positionalArguments.single as String;
+      final output = _outputForCommand(
+        command,
+        expectedSha: expectedSha,
+        remoteFileService: remoteFileService,
+      );
+      return _execSession(output);
+    });
+    final session = SshSession(
+      connectionId: connectionId,
+      hostId: 1,
+      client: client,
+      config: const SshConnectionConfig(
+        hostname: 'example.com',
+        port: 22,
+        username: 'proof',
+      ),
+    );
+    addTearDown(() => installer.clearCache(connectionId));
+
+    final installation = await installer.ensureInstalled(session);
+
+    expect(installation.version, '9.9.9');
+    expect(installation.installedDuringCall, isFalse);
+    expect(remoteFileService.uploadCount, 0);
+  });
 }
 
 String _outputForCommand(

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -58,6 +58,11 @@ class _MockTmuxService extends Mock implements TmuxService {
 }
 
 class _MockMonkeyMuxService extends Mock implements MonkeyMuxService {
+  MonkeyMuxServerStatus? runningStatus;
+  MonkeyMuxServerStatus? installedHelpersStatus;
+  int runningServerStatusCalls = 0;
+  int runningServerStatusFromInstalledHelpersCalls = 0;
+
   @override
   bool isExecChannelCoolingDown(SshSession session) => false;
 
@@ -67,14 +72,20 @@ class _MockMonkeyMuxService extends Mock implements MonkeyMuxService {
     MonkeyMuxInstallation installation,
     String sessionName, {
     SshExecPriority priority = SshExecPriority.normal,
-  }) async => null;
+  }) async {
+    runningServerStatusCalls++;
+    return runningStatus;
+  }
 
   @override
   Future<MonkeyMuxServerStatus?> runningServerStatusFromInstalledHelpers(
     SshSession session,
     String sessionName, {
     SshExecPriority priority = SshExecPriority.normal,
-  }) async => null;
+  }) async {
+    runningServerStatusFromInstalledHelpersCalls++;
+    return installedHelpersStatus;
+  }
 }
 
 class _MockMonkeyMuxInstallerService extends Mock
@@ -106,6 +117,7 @@ class _PromptingMonkeyMuxInstallerService implements MonkeyMuxInstallerService {
       executablePath: '/tmp/monkeymux',
       platform: request.platform,
       version: request.version,
+      installedDuringCall: true,
     );
   }
 
@@ -4811,6 +4823,128 @@ void main() {
         verifyNever(() => sshClient.shell(pty: any(named: 'pty')));
         expect(monkeyMuxInstallerService.ensureInstalledCalls, 1);
         expect(monkeyMuxInstallerService.acceptedConfirmations, <bool>[true]);
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
+      'uses MonkeyMux helper update prompt as server update approval',
+      (tester) async {
+        final monkeyMuxInstallerService = _PromptingMonkeyMuxInstallerService(
+          request: const MonkeyMuxInstallRequest(
+            platform: 'darwin-arm64',
+            version: '0.1.14',
+            size: 1536,
+          ),
+        );
+        final monkeyMuxService = _MockMonkeyMuxService()
+          ..installedHelpersStatus = const MonkeyMuxServerStatus(
+            version: '0.1.13',
+            capabilities: {'shutdown'},
+          )
+          ..runningStatus = const MonkeyMuxServerStatus(
+            version: '0.1.13',
+            capabilities: {'shutdown'},
+          );
+        final tmuxService = _MockTmuxService();
+        const sessionName = 'work';
+        session = SshSession(
+          connectionId: 7,
+          hostId: host.id,
+          client: sshClient,
+          config: const SshConnectionConfig(
+            hostname: 'terminal.example.com',
+            port: 22,
+            username: 'root',
+          ),
+        );
+        host = _buildHost(
+          id: host.id,
+          tmuxSessionName: sessionName,
+          remoteMuxBackend: RemoteMuxBackend.monkeyMux,
+        );
+        final executedCommands = <String>[];
+        when(
+          () => sshClient.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((invocation) async {
+          executedCommands.add(invocation.positionalArguments.single as String);
+          return shellChannel;
+        });
+        when(
+          () =>
+              monkeyMuxService.hasForegroundClientOrThrow(session, sessionName),
+        ).thenAnswer((_) async => true);
+        when(
+          () => monkeyMuxService.listWindows(session, sessionName),
+        ).thenAnswer(
+          (_) async => const <TmuxWindow>[
+            TmuxWindow(index: 0, name: 'shell', isActive: true),
+          ],
+        );
+        when(
+          () => monkeyMuxService.watchWindowChanges(session, sessionName),
+        ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+        when(
+          () => tmuxService.prefetchInstalledAgentTools(session),
+        ).thenAnswer((_) async {});
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+              monkeyMuxInstallerServiceProvider.overrideWithValue(
+                monkeyMuxInstallerService,
+              ),
+              tmuxServiceProvider.overrideWithValue(tmuxService),
+              monkeyMuxServiceProvider.overrideWithValue(monkeyMuxService),
+            ],
+            child: MaterialApp(
+              home: TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Update MonkeyMux helper?'), findsOneWidget);
+        expect(find.text('Running version: 0.1.13'), findsOneWidget);
+        expect(find.text('Update MonkeyMux?'), findsNothing);
+        expect(executedCommands, isEmpty);
+
+        await tester.tap(find.widgetWithText(FilledButton, 'Update'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text('Update MonkeyMux helper?'), findsNothing);
+        expect(find.text('Update MonkeyMux?'), findsNothing);
+        final startupCommands = executedCommands
+            .where((command) => command.contains("'/tmp/monkeymux' attach"))
+            .toList(growable: false);
+        expect(startupCommands, hasLength(1));
+        expect(startupCommands.single, contains('--update-policy always'));
+        expect(monkeyMuxInstallerService.acceptedConfirmations, <bool>[true]);
+        expect(
+          monkeyMuxService.runningServerStatusFromInstalledHelpersCalls,
+          1,
+        );
+        expect(monkeyMuxService.runningServerStatusCalls, 1);
         await tester.pumpWidget(const SizedBox.shrink());
         await tester.pump();
       },


### PR DESCRIPTION
## Summary

- Fix MonkeyMux installer bookkeeping so reused helpers are not treated as newly installed
- Treat the helper install/update approval as approval to restart an outdated running MonkeyMux server
- Add installer and terminal screen coverage for the single-dialog update flow

## Tests

- `dart format --set-exit-if-changed lib/domain/services/monkeymux_installer_service.dart test/domain/services/monkeymux_installer_service_test.dart test/presentation/screens/terminal_screen_test.dart`
- `flutter analyze`
- `flutter test test/domain/services/monkeymux_installer_service_test.dart test/presentation/screens/terminal_screen_test.dart --name "MonkeyMux"`
- pre-commit checks
