### PR TITLE
[codex] fix Codex composer background rendering

### DIFF
--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1663,16 +1663,13 @@ class MonkeyTerminalPainter extends TerminalPainter {
     }
 
     final firstCell = CellData.empty();
-    line.getCellData(0, firstCell);
-    if (_cellBackgroundColorType(firstCell) == CellColor.normal) {
-      return null;
-    }
-    if (!_shouldExtendTrailingBackgroundFill(firstCell)) {
+    final runStartColumn = _trailingBackgroundRunStartColumn(line, firstCell);
+    if (runStartColumn == null) {
       return null;
     }
 
     final background = firstCell.background;
-    var fillStartColumn = 0;
+    var fillStartColumn = runStartColumn;
     var hasHighlightedContent = false;
     for (; fillStartColumn < line.length; fillStartColumn += 1) {
       if (line.getBackground(fillStartColumn) != background) {
@@ -1696,6 +1693,29 @@ class MonkeyTerminalPainter extends TerminalPainter {
       startColumn: fillStartColumn,
       color: _resolveCellBackgroundPaintColor(firstCell),
     );
+  }
+
+  int? _trailingBackgroundRunStartColumn(BufferLine line, CellData firstCell) {
+    line.getCellData(0, firstCell);
+    if (_shouldExtendTrailingBackgroundFill(firstCell)) {
+      return 0;
+    }
+
+    for (var column = 0; column < line.length; column += 1) {
+      line.getCellData(column, firstCell);
+      if (_shouldExtendTrailingBackgroundFill(firstCell)) {
+        return column;
+      }
+      final charCode = firstCell.content & CellContent.codepointMask;
+      final isBlankNormalCell =
+          charCode == 0 &&
+          (firstCell.flags & CellFlags.inverse) == 0 &&
+          _cellBackgroundColorType(firstCell) == CellColor.normal;
+      if (!isBlankNormalCell) {
+        return null;
+      }
+    }
+    return null;
   }
 
   @override
@@ -1974,13 +1994,19 @@ class MonkeyTerminalPainter extends TerminalPainter {
       return false;
     }
     final backgroundType = _cellBackgroundColorType(firstCell);
-    if (backgroundType != CellColor.named &&
-        backgroundType != CellColor.palette) {
+    if (backgroundType == CellColor.normal) {
       return false;
     }
     // ANSI bright black is commonly used as a neutral prompt/message row
     // background; semantic color labels should stay text-width.
-    return _cellColorValue(firstCell.background) == 8;
+    if ((backgroundType == CellColor.named ||
+            backgroundType == CellColor.palette) &&
+        _cellColorValue(firstCell.background) == 8) {
+      return true;
+    }
+    return _isNeutralTerminalColor(
+      resolveBackgroundColor(firstCell.background),
+    );
   }
 
   Color _resolveCellBackgroundPaintColor(

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -434,6 +434,51 @@ void main() {
       );
     });
 
+    test('extends neutral truecolor composer rows to line end', () {
+      const neutralBackground = Color(0xFF5F5F5F);
+      final terminal = Terminal()
+        ..resize(32, 2)
+        ..write('\x1b[48;2;95;95;95mAsk Codex\x1b[49m');
+      final painter = MonkeyTerminalPainter(
+        theme: TerminalThemes.defaultDarkTheme.toXtermTheme(),
+        textStyle: const TerminalStyle(),
+        textScaler: TextScaler.noScaling,
+      );
+
+      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
+        terminal.buffer.lines[0],
+      );
+
+      expect(fill, isNotNull);
+      expect(fill!.startColumn, 'Ask Codex'.length);
+      expect(fill.color, isNot(neutralBackground));
+      expect(
+        _contrastRatio(fill.color, TerminalThemes.defaultDarkTheme.background),
+        inInclusiveRange(1.04, 1.75),
+      );
+    });
+
+    test(
+      'extends neutral truecolor composer rows after blank leading cells',
+      () {
+        final terminal = Terminal()
+          ..resize(32, 2)
+          ..write('\x1b[2C\x1b[48;2;95;95;95mAsk Codex\x1b[49m');
+        final painter = MonkeyTerminalPainter(
+          theme: TerminalThemes.defaultDarkTheme.toXtermTheme(),
+          textStyle: const TerminalStyle(),
+          textScaler: TextScaler.noScaling,
+        );
+
+        final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
+          terminal.buffer.lines[0],
+        );
+
+        expect(fill, isNotNull);
+        expect(fill!.startColumn, 2 + 'Ask Codex'.length);
+      },
+    );
+
     test('does not extend inset highlighted runs', () {
       final terminal = Terminal()
         ..resize(24, 2)
@@ -456,6 +501,24 @@ void main() {
       final terminal = Terminal()
         ..resize(24, 2)
         ..write('\x1b[41mERROR\x1b[49m');
+      final painter = MonkeyTerminalPainter(
+        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
+        textStyle: const TerminalStyle(),
+        textScaler: TextScaler.noScaling,
+      );
+
+      expect(
+        painter.resolveMonkeyTerminalTrailingBackgroundFill(
+          terminal.buffer.lines[0],
+        ),
+        isNull,
+      );
+    });
+
+    test('does not extend saturated truecolor labels', () {
+      final terminal = Terminal()
+        ..resize(24, 2)
+        ..write('\x1b[48;2;168;47;69mERROR\x1b[49m');
       final painter = MonkeyTerminalPainter(
         theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
         textStyle: const TerminalStyle(),


### PR DESCRIPTION
## Summary

- Extend terminal trailing background fills for neutral truecolor composer surfaces, not just ANSI bright-black rows.
- Allow the fill to start after blank leading terminal cells so inset Codex composer rows still render full-width.
- Keep semantic/saturated labels text-width to avoid overpainting status badges.

## Root Cause

Codex can render its composer with neutral RGB backgrounds and sometimes with blank leading cells. The renderer only extended trailing backgrounds for rows starting with ANSI bright black, so the rest of the composer row could remain the terminal default background.

## Validation

- `flutter test test/widget/monkey_terminal_view_layout_test.dart`
- Full pre-commit hook: formatting, analyzer, and Flutter test suite
