### PR TITLE
fix: migrate legacy plaintext credentials on read

### DIFF
--- a/integration_test/legacy_credentials_connection_setup_test.dart
+++ b/integration_test/legacy_credentials_connection_setup_test.dart
@@ -1,0 +1,98 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/data/repositories/key_repository.dart';
+import 'package:monkeyssh/data/security/secret_encryption_service.dart';
+import 'package:monkeyssh/domain/services/ssh_service.dart';
+
+class _CapturingSshService extends SshService {
+  _CapturingSshService({
+    required super.hostRepository,
+    required super.keyRepository,
+  });
+
+  SshConnectionConfig? capturedConfig;
+
+  @override
+  Future<SshConnectionResult> connect(
+    SshConnectionConfig config, {
+    ConnectionProgressCallback? onProgress,
+    bool isJumpHost = false,
+  }) async {
+    capturedConfig = config;
+    return const SshConnectionResult(success: false, error: 'stubbed');
+  }
+}
+
+String _structurallyValidInvalidEncryptedSecret() {
+  final envelope = {
+    'n': base64Url.encode(List<int>.filled(12, 1)),
+    'c': base64Url.encode([1, 2, 3]),
+    'm': base64Url.encode(List<int>.filled(16, 2)),
+  };
+  return 'ENCv1:${base64Url.encode(utf8.encode(jsonEncode(envelope)))}';
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'connection setup skips unreadable Auto keys before opening SSH',
+    (_) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final encryptionService = SecretEncryptionService.forTesting();
+      final hostRepository = HostRepository(db, encryptionService);
+      final keyRepository = KeyRepository(db, encryptionService);
+      final sshService = _CapturingSshService(
+        hostRepository: hostRepository,
+        keyRepository: keyRepository,
+      );
+
+      await db
+          .into(db.sshKeys)
+          .insert(
+            SshKeysCompanion.insert(
+              name: 'Unreadable Auto Key',
+              keyType: 'ed25519',
+              publicKey: 'ssh-ed25519 BAD',
+              privateKey: _structurallyValidInvalidEncryptedSecret(),
+            ),
+          );
+      await keyRepository.insert(
+        SshKeysCompanion.insert(
+          name: 'Readable Auto Key',
+          keyType: 'ed25519',
+          publicKey: 'ssh-ed25519 GOOD',
+          privateKey: 'readable-key-material',
+        ),
+      );
+      final hostId = await db
+          .into(db.hosts)
+          .insert(
+            HostsCompanion.insert(
+              label: 'Auto Host',
+              hostname: '127.0.0.1',
+              username: 'admin',
+            ),
+          );
+
+      final result = await sshService.connectToHost(hostId);
+
+      expect(result.success, isFalse);
+      expect(result.error, 'stubbed');
+      expect(sshService.capturedConfig, isNotNull);
+      expect(sshService.capturedConfig!.identityKeys, hasLength(1));
+      expect(
+        sshService.capturedConfig!.identityKeys!.single.name,
+        'Readable Auto Key',
+      );
+    },
+  );
+}

--- a/lib/data/repositories/host_repository.dart
+++ b/lib/data/repositories/host_repository.dart
@@ -260,7 +260,10 @@ class HostRepository {
       return host;
     }
 
-    final decryptedPassword = await _cachedDecrypt(storedPassword);
+    final decryptedPassword = await _cachedDecryptOrMigratePassword(
+      host.id,
+      storedPassword,
+    );
     return host.copyWith(password: Value(decryptedPassword));
   }
 
@@ -280,6 +283,26 @@ class HostRepository {
       _rememberDecrypted(ciphertext, plaintext);
     }
     return plaintext;
+  }
+
+  Future<String?> _cachedDecryptOrMigratePassword(
+    int hostId,
+    String storedPassword,
+  ) async {
+    if (_secretEncryptionService.isEncryptedValue(storedPassword)) {
+      return _cachedDecrypt(storedPassword);
+    }
+
+    final encryptedPassword = await _secretEncryptionService.encryptNullable(
+      storedPassword,
+    );
+    if (encryptedPassword != null && encryptedPassword != storedPassword) {
+      await (_db.update(_db.hosts)..where((h) => h.id.equals(hostId))).write(
+        HostsCompanion(password: Value(encryptedPassword)),
+      );
+      _rememberDecrypted(encryptedPassword, storedPassword);
+    }
+    return storedPassword;
   }
 
   Future<String?> _storedPasswordForHost(int id) async {

--- a/lib/data/repositories/host_repository.dart
+++ b/lib/data/repositories/host_repository.dart
@@ -289,7 +289,7 @@ class HostRepository {
     int hostId,
     String storedPassword,
   ) async {
-    if (_secretEncryptionService.isEncryptedValue(storedPassword)) {
+    if (_secretEncryptionService.isValidEncryptedEnvelope(storedPassword)) {
       return _cachedDecrypt(storedPassword);
     }
 
@@ -297,9 +297,10 @@ class HostRepository {
       storedPassword,
     );
     if (encryptedPassword != null && encryptedPassword != storedPassword) {
-      await (_db.update(_db.hosts)..where((h) => h.id.equals(hostId))).write(
-        HostsCompanion(password: Value(encryptedPassword)),
-      );
+      await (_db.update(_db.hosts)..where(
+            (h) => h.id.equals(hostId) & h.password.equals(storedPassword),
+          ))
+          .write(HostsCompanion(password: Value(encryptedPassword)));
       _rememberDecrypted(encryptedPassword, storedPassword);
     }
     return storedPassword;

--- a/lib/data/repositories/key_repository.dart
+++ b/lib/data/repositories/key_repository.dart
@@ -8,6 +8,25 @@ import '../security/secret_encryption_service.dart';
 
 enum _KeySecretColumn { privateKey, passphrase }
 
+/// Result from loading decryptable SSH keys while tolerating unreadable rows.
+class SshKeyLoadResult {
+  /// Creates a new [SshKeyLoadResult].
+  const SshKeyLoadResult({
+    required this.keys,
+    required this.unreadableCount,
+    this.firstUnreadableErrorType,
+  });
+
+  /// Keys whose encrypted secrets were readable.
+  final List<SshKey> keys;
+
+  /// Number of stored keys skipped because their secrets were unreadable.
+  final int unreadableCount;
+
+  /// Runtime type for the first unreadable-key error, if any.
+  final String? firstUnreadableErrorType;
+}
+
 /// Repository for managing SSH keys.
 class KeyRepository {
   /// Creates a new [KeyRepository].
@@ -34,6 +53,29 @@ class KeyRepository {
   Future<List<SshKey>> getAll() async {
     final keys = await _db.select(_db.sshKeys).get();
     return Future.wait(keys.map(_decryptKey));
+  }
+
+  /// Get all keys that can be decrypted, skipping unreadable stored keys.
+  Future<SshKeyLoadResult> getAllDecryptable() async {
+    final keys = await _db.select(_db.sshKeys).get();
+    final decryptedKeys = <SshKey>[];
+    var unreadableCount = 0;
+    String? firstUnreadableErrorType;
+
+    for (final key in keys) {
+      try {
+        decryptedKeys.add(await _decryptKey(key));
+      } on Exception catch (error) {
+        unreadableCount++;
+        firstUnreadableErrorType ??= error.runtimeType.toString();
+      }
+    }
+
+    return SshKeyLoadResult(
+      keys: List.unmodifiable(decryptedKeys),
+      unreadableCount: unreadableCount,
+      firstUnreadableErrorType: firstUnreadableErrorType,
+    );
   }
 
   /// Watch all keys.

--- a/lib/data/repositories/key_repository.dart
+++ b/lib/data/repositories/key_repository.dart
@@ -149,7 +149,7 @@ class KeyRepository {
     String storedSecret,
     _KeySecretColumn column,
   ) async {
-    if (_secretEncryptionService.isEncryptedValue(storedSecret)) {
+    if (_secretEncryptionService.isValidEncryptedEnvelope(storedSecret)) {
       return _cachedDecrypt(storedSecret);
     }
 
@@ -157,16 +157,26 @@ class KeyRepository {
       storedSecret,
     );
     if (encryptedSecret != null && encryptedSecret != storedSecret) {
-      await (_db.update(_db.sshKeys)..where((k) => k.id.equals(keyId))).write(
-        switch (column) {
-          _KeySecretColumn.privateKey => SshKeysCompanion(
-            privateKey: Value(encryptedSecret),
-          ),
-          _KeySecretColumn.passphrase => SshKeysCompanion(
-            passphrase: Value(encryptedSecret),
-          ),
-        },
-      );
+      await (_db.update(_db.sshKeys)..where(
+            (k) =>
+                k.id.equals(keyId) &
+                (switch (column) {
+                  _KeySecretColumn.privateKey => k.privateKey.equals(
+                    storedSecret,
+                  ),
+                  _KeySecretColumn.passphrase => k.passphrase.equals(
+                    storedSecret,
+                  ),
+                }),
+          ))
+          .write(switch (column) {
+            _KeySecretColumn.privateKey => SshKeysCompanion(
+              privateKey: Value(encryptedSecret),
+            ),
+            _KeySecretColumn.passphrase => SshKeysCompanion(
+              passphrase: Value(encryptedSecret),
+            ),
+          });
       _rememberDecrypted(encryptedSecret, storedSecret);
     }
     return storedSecret;

--- a/lib/data/repositories/key_repository.dart
+++ b/lib/data/repositories/key_repository.dart
@@ -58,29 +58,14 @@ class KeyRepository {
   /// Get all keys that can be decrypted, skipping unreadable stored keys.
   Future<SshKeyLoadResult> getAllDecryptable() async {
     final keys = await _db.select(_db.sshKeys).get();
-    final decryptedKeys = <SshKey>[];
-    var unreadableCount = 0;
-    String? firstUnreadableErrorType;
-
-    for (final key in keys) {
-      try {
-        decryptedKeys.add(await _decryptKey(key));
-      } on Exception catch (error) {
-        unreadableCount++;
-        firstUnreadableErrorType ??= error.runtimeType.toString();
-      }
-    }
-
-    return SshKeyLoadResult(
-      keys: List.unmodifiable(decryptedKeys),
-      unreadableCount: unreadableCount,
-      firstUnreadableErrorType: firstUnreadableErrorType,
-    );
+    return _loadDecryptable(keys);
   }
 
   /// Watch all keys.
-  Stream<List<SshKey>> watchAll() =>
-      _db.select(_db.sshKeys).watch().asyncMap(_decryptKeys);
+  Stream<List<SshKey>> watchAll() => _db
+      .select(_db.sshKeys)
+      .watch()
+      .asyncMap((keys) async => (await _loadDecryptable(keys)).keys);
 
   /// Get a key by ID.
   Future<SshKey?> getById(int id) async {
@@ -94,9 +79,10 @@ class KeyRepository {
   }
 
   /// Search keys by name.
-  Future<List<SshKey>> search(String query) => (_db.select(
-    _db.sshKeys,
-  )..where((k) => k.name.like('%$query%'))).get().then(_decryptKeys);
+  Future<List<SshKey>> search(String query) =>
+      (_db.select(_db.sshKeys)..where((k) => k.name.like('%$query%')))
+          .get()
+          .then((keys) async => (await _loadDecryptable(keys)).keys);
 
   /// Insert a new key.
   Future<int> insert(SshKeysCompanion key) async {
@@ -143,8 +129,26 @@ class KeyRepository {
     return deleted;
   }
 
-  Future<List<SshKey>> _decryptKeys(List<SshKey> keys) =>
-      Future.wait(keys.map(_decryptKey));
+  Future<SshKeyLoadResult> _loadDecryptable(List<SshKey> keys) async {
+    final decryptedKeys = <SshKey>[];
+    var unreadableCount = 0;
+    String? firstUnreadableErrorType;
+
+    for (final key in keys) {
+      try {
+        decryptedKeys.add(await _decryptKey(key));
+      } on Exception catch (error) {
+        unreadableCount++;
+        firstUnreadableErrorType ??= error.runtimeType.toString();
+      }
+    }
+
+    return SshKeyLoadResult(
+      keys: List.unmodifiable(decryptedKeys),
+      unreadableCount: unreadableCount,
+      firstUnreadableErrorType: firstUnreadableErrorType,
+    );
+  }
 
   Future<SshKey> _decryptKey(SshKey key) async {
     final decryptedPrivateKey =

--- a/lib/data/repositories/key_repository.dart
+++ b/lib/data/repositories/key_repository.dart
@@ -6,6 +6,8 @@ import '../../domain/services/auth_service.dart';
 import '../database/database.dart';
 import '../security/secret_encryption_service.dart';
 
+enum _KeySecretColumn { privateKey, passphrase }
+
 /// Repository for managing SSH keys.
 class KeyRepository {
   /// Creates a new [KeyRepository].
@@ -103,10 +105,20 @@ class KeyRepository {
       Future.wait(keys.map(_decryptKey));
 
   Future<SshKey> _decryptKey(SshKey key) async {
-    final decryptedPrivateKey = await _cachedDecryptRequired(key.privateKey);
+    final decryptedPrivateKey =
+        await _decryptOrMigrateKeySecret(
+          key.id,
+          key.privateKey,
+          _KeySecretColumn.privateKey,
+        ) ??
+        '';
     final passphrase = key.passphrase;
     final decryptedPassphrase = passphrase != null && passphrase.isNotEmpty
-        ? await _cachedDecrypt(passphrase)
+        ? await _decryptOrMigrateKeySecret(
+            key.id,
+            passphrase,
+            _KeySecretColumn.passphrase,
+          )
         : await _secretEncryptionService.decryptNullable(passphrase);
 
     return key.copyWith(
@@ -132,8 +144,33 @@ class KeyRepository {
     return plaintext;
   }
 
-  Future<String> _cachedDecryptRequired(String ciphertext) async =>
-      (await _cachedDecrypt(ciphertext)) ?? '';
+  Future<String?> _decryptOrMigrateKeySecret(
+    int keyId,
+    String storedSecret,
+    _KeySecretColumn column,
+  ) async {
+    if (_secretEncryptionService.isEncryptedValue(storedSecret)) {
+      return _cachedDecrypt(storedSecret);
+    }
+
+    final encryptedSecret = await _secretEncryptionService.encryptNullable(
+      storedSecret,
+    );
+    if (encryptedSecret != null && encryptedSecret != storedSecret) {
+      await (_db.update(_db.sshKeys)..where((k) => k.id.equals(keyId))).write(
+        switch (column) {
+          _KeySecretColumn.privateKey => SshKeysCompanion(
+            privateKey: Value(encryptedSecret),
+          ),
+          _KeySecretColumn.passphrase => SshKeysCompanion(
+            passphrase: Value(encryptedSecret),
+          ),
+        },
+      );
+      _rememberDecrypted(encryptedSecret, storedSecret);
+    }
+    return storedSecret;
+  }
 
   Future<({String? passphrase, String privateKey})?> _storedSecretsForKey(
     int id,

--- a/lib/data/security/secret_encryption_service.dart
+++ b/lib/data/security/secret_encryption_service.dart
@@ -57,6 +57,10 @@ class SecretEncryptionService {
   /// Returns whether [value] is already in encrypted envelope format.
   bool isEncryptedValue(String value) => value.startsWith(_encryptedPrefix);
 
+  /// Returns whether [value] is a structurally valid encrypted envelope.
+  bool isValidEncryptedEnvelope(String value) =>
+      _isValidEncryptedEnvelope(value);
+
   /// Encrypts an optional value for database persistence.
   Future<String?> encryptNullable(String? plaintext) async {
     if (plaintext == null || plaintext.isEmpty) {

--- a/lib/data/security/secret_encryption_service.dart
+++ b/lib/data/security/secret_encryption_service.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:cryptography/cryptography.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
@@ -41,6 +42,7 @@ class SecretEncryptionService {
   static const _encryptedPrefix = 'ENCv1:';
   static const _masterKeyBytes = 32;
   static const _nonceBytes = 12;
+  static const _errSecDuplicateItem = -25299;
   static const _secureStorage = FlutterSecureStorage(
     iOptions: IOSOptions(
       accessibility: KeychainAccessibility.first_unlock_this_device,
@@ -231,14 +233,40 @@ class SecretEncryptionService {
       return storage.read(key: key);
     }
 
-    final current = await storage.read(key: key, iOptions: _hardenedIosOptions);
+    String? current;
+    try {
+      current = await storage.read(key: key, iOptions: _hardenedIosOptions);
+    } on PlatformException {
+      final legacy = await storage.read(key: key, iOptions: _legacyIosOptions);
+      if (legacy != null) {
+        await _migrateStorageValue(storage, key: key, value: legacy);
+        return legacy;
+      }
+      rethrow;
+    }
     if (current != null) return current;
 
     final legacy = await storage.read(key: key, iOptions: _legacyIosOptions);
     if (legacy != null) {
-      await _writeStorageValue(storage, key: key, value: legacy);
+      await _migrateStorageValue(storage, key: key, value: legacy);
     }
     return legacy;
+  }
+
+  Future<void> _migrateStorageValue(
+    FlutterSecureStorage storage, {
+    required String key,
+    required String value,
+  }) async {
+    try {
+      await _writeStorageValue(storage, key: key, value: value);
+    } on PlatformException catch (error) {
+      if (!_isDuplicateKeychainItem(error)) {
+        rethrow;
+      }
+      await storage.delete(key: key, iOptions: _legacyIosOptions);
+      await _writeStorageValue(storage, key: key, value: value);
+    }
   }
 
   Future<void> _writeStorageValue(
@@ -251,6 +279,12 @@ class SecretEncryptionService {
     }
     return storage.write(key: key, value: value, iOptions: _hardenedIosOptions);
   }
+
+  bool _isDuplicateKeychainItem(PlatformException error) =>
+      error.details == _errSecDuplicateItem ||
+      error.details == _errSecDuplicateItem.toString() ||
+      (error.message?.contains(_errSecDuplicateItem.toString()) ?? false) ||
+      (error.message?.contains('already exists') ?? false);
 
   List<int> _decodeEnvelopeField(Map<String, dynamic> envelope, String key) {
     final value = envelope[key];

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -1293,184 +1293,236 @@ class SshService {
     ConnectionProgressCallback? onProgress,
     bool useHostThemeOverrides = true,
   }) async {
+    var preflightPhase = 'start';
     DiagnosticsLogService.instance.info(
       'ssh.connect',
       'connect_to_host_start',
       fields: {'hostId': hostId},
     );
-    if (hostRepository == null) {
-      DiagnosticsLogService.instance.warning(
+    try {
+      if (hostRepository == null) {
+        DiagnosticsLogService.instance.warning(
+          'ssh.connect',
+          'connect_to_host_unavailable',
+          fields: {'hostId': hostId, 'reason': 'missing_host_repository'},
+        );
+        return const SshConnectionResult(
+          success: false,
+          error: 'Host repository not available',
+        );
+      }
+
+      preflightPhase = 'load_host';
+      final host = await hostRepository!.getById(hostId);
+      if (host == null) {
+        DiagnosticsLogService.instance.warning(
+          'ssh.connect',
+          'connect_to_host_missing_host',
+          fields: {'hostId': hostId},
+        );
+        return const SshConnectionResult(
+          success: false,
+          error: 'Host not found',
+        );
+      }
+      DiagnosticsLogService.instance.info(
         'ssh.connect',
-        'connect_to_host_unavailable',
-        fields: {'hostId': hostId, 'reason': 'missing_host_repository'},
+        'connect_to_host_loaded_host',
+        fields: {
+          'hostId': hostId,
+          'hasPassword': host.password != null,
+          'hasKeyId': host.keyId != null,
+          'hasJumpHost': host.jumpHostId != null,
+        },
       );
-      return const SshConnectionResult(
-        success: false,
-        error: 'Host repository not available',
-      );
-    }
 
-    final host = await hostRepository!.getById(hostId);
-    if (host == null) {
-      DiagnosticsLogService.instance.warning(
-        'ssh.connect',
-        'connect_to_host_missing_host',
-        fields: {'hostId': hostId},
-      );
-      return const SshConnectionResult(success: false, error: 'Host not found');
-    }
+      List<SshKey>? cachedAutoKeys;
+      var didLoadAutoKeys = false;
+      Future<List<SshKey>?> loadAutoKeys() async {
+        if (didLoadAutoKeys) {
+          return cachedAutoKeys;
+        }
+        didLoadAutoKeys = true;
+        if (keyRepository == null) {
+          return null;
+        }
+        preflightPhase = 'load_auto_keys';
+        final keyLoadResult = await keyRepository!.getAllDecryptable();
+        if (keyLoadResult.unreadableCount > 0) {
+          DiagnosticsLogService.instance.warning(
+            'ssh.connect',
+            'auto_key_load_skipped_unreadable',
+            fields: {
+              'hostId': hostId,
+              'unreadableCount': keyLoadResult.unreadableCount,
+              'loadedCount': keyLoadResult.keys.length,
+              'errorType': keyLoadResult.firstUnreadableErrorType,
+            },
+          );
+        }
+        final keys = keyLoadResult.keys;
+        if (keys.isEmpty) {
+          return null;
+        }
+        final sortedKeys = [...keys]..sort((a, b) => a.id.compareTo(b.id));
+        final autoKeys = sortedKeys.length > _maxAutoKeysPerAttempt
+            ? sortedKeys.take(_maxAutoKeysPerAttempt).toList(growable: false)
+            : sortedKeys;
+        return cachedAutoKeys = autoKeys;
+      }
 
-    List<SshKey>? cachedAutoKeys;
-    var didLoadAutoKeys = false;
-    Future<List<SshKey>?> loadAutoKeys() async {
-      if (didLoadAutoKeys) {
-        return cachedAutoKeys;
-      }
-      didLoadAutoKeys = true;
-      if (keyRepository == null) {
-        return null;
-      }
-      final keys = await keyRepository!.getAll();
-      if (keys.isEmpty) {
-        return null;
-      }
-      final sortedKeys = [...keys]..sort((a, b) => a.id.compareTo(b.id));
-      final autoKeys = sortedKeys.length > _maxAutoKeysPerAttempt
-          ? sortedKeys.take(_maxAutoKeysPerAttempt).toList(growable: false)
-          : sortedKeys;
-      return cachedAutoKeys = autoKeys;
-    }
-
-    // Get SSH key if explicitly selected, otherwise use auto keys.
-    SshKey? key;
-    List<SshKey>? identityKeys;
-    if (host.keyId != null && keyRepository != null) {
-      key = await keyRepository!.getById(host.keyId!);
-      if (key == null && host.password == null) {
+      // Get SSH key if explicitly selected, otherwise use auto keys.
+      SshKey? key;
+      List<SshKey>? identityKeys;
+      if (host.keyId != null && keyRepository != null) {
+        preflightPhase = 'load_host_key';
+        key = await keyRepository!.getById(host.keyId!);
+        if (key == null && host.password == null) {
+          identityKeys = await loadAutoKeys();
+        }
+      } else if (host.password == null) {
         identityKeys = await loadAutoKeys();
       }
-    } else if (host.password == null) {
-      identityKeys = await loadAutoKeys();
-    }
 
-    // Get jump host config if specified, unless the device is currently
-    // connected to a Wi-Fi network on the host's skip list (in which case
-    // the host is reachable directly).
-    SshConnectionConfig? jumpHostConfig;
-    if (host.jumpHostId != null) {
-      var skipJumpHost = false;
-      if (host.skipJumpHostOnSsids != null &&
-          host.skipJumpHostOnSsids!.isNotEmpty) {
-        onProgress?.call(
-          const ConnectionProgressUpdate(
-            state: SshConnectionState.connecting,
-            message: 'Checking Wi-Fi network for jump host bypass…',
-          ),
-        );
-        final permission = await wifiNetworkService.requestPermission();
-        String? currentSsid;
-        if (permission == WifiPermissionStatus.granted) {
-          currentSsid = await wifiNetworkService.getCurrentSsid();
-          skipJumpHost = shouldSkipJumpHostForSsid(
-            currentSsid: currentSsid,
-            skipJumpHostOnSsids: host.skipJumpHostOnSsids,
-          );
-        } else {
+      // Get jump host config if specified, unless the device is currently
+      // connected to a Wi-Fi network on the host's skip list (in which case
+      // the host is reachable directly).
+      SshConnectionConfig? jumpHostConfig;
+      if (host.jumpHostId != null) {
+        var skipJumpHost = false;
+        if (host.skipJumpHostOnSsids != null &&
+            host.skipJumpHostOnSsids!.isNotEmpty) {
           onProgress?.call(
             const ConnectionProgressUpdate(
               state: SshConnectionState.connecting,
-              message: 'Wi-Fi permission denied. Using jump host…',
+              message: 'Checking Wi-Fi network for jump host bypass…',
             ),
           );
-        }
-        DiagnosticsLogService.instance.info(
-          'ssh.connect',
-          'jump_host_ssid_check',
-          fields: {
-            'hostId': hostId,
-            'permissionStatus': permission.name,
-            'hasCurrentSsid': currentSsid != null,
-            'skipJumpHost': skipJumpHost,
-          },
-        );
-      }
-      if (!skipJumpHost) {
-        final jumpHost = await hostRepository!.getById(host.jumpHostId!);
-        if (jumpHost != null) {
-          SshKey? jumpKey;
-          List<SshKey>? jumpIdentityKeys;
-          if (jumpHost.keyId != null && keyRepository != null) {
-            jumpKey = await keyRepository!.getById(jumpHost.keyId!);
-            if (jumpKey == null && jumpHost.password == null) {
-              jumpIdentityKeys = await loadAutoKeys();
-            }
-          } else if (jumpHost.password == null) {
-            jumpIdentityKeys = await loadAutoKeys();
+          preflightPhase = 'check_wifi_bypass';
+          final permission = await wifiNetworkService.requestPermission();
+          String? currentSsid;
+          if (permission == WifiPermissionStatus.granted) {
+            currentSsid = await wifiNetworkService.getCurrentSsid();
+            skipJumpHost = shouldSkipJumpHostForSsid(
+              currentSsid: currentSsid,
+              skipJumpHostOnSsids: host.skipJumpHostOnSsids,
+            );
+          } else {
+            onProgress?.call(
+              const ConnectionProgressUpdate(
+                state: SshConnectionState.connecting,
+                message: 'Wi-Fi permission denied. Using jump host…',
+              ),
+            );
           }
-          jumpHostConfig = SshConnectionConfig.fromHost(
-            jumpHost,
-            key: jumpKey,
-            identityKeys: jumpIdentityKeys,
+          DiagnosticsLogService.instance.info(
+            'ssh.connect',
+            'jump_host_ssid_check',
+            fields: {
+              'hostId': hostId,
+              'permissionStatus': permission.name,
+              'hasCurrentSsid': currentSsid != null,
+              'skipJumpHost': skipJumpHost,
+            },
           );
         }
+        if (!skipJumpHost) {
+          preflightPhase = 'load_jump_host';
+          final jumpHost = await hostRepository!.getById(host.jumpHostId!);
+          if (jumpHost != null) {
+            SshKey? jumpKey;
+            List<SshKey>? jumpIdentityKeys;
+            if (jumpHost.keyId != null && keyRepository != null) {
+              preflightPhase = 'load_jump_host_key';
+              jumpKey = await keyRepository!.getById(jumpHost.keyId!);
+              if (jumpKey == null && jumpHost.password == null) {
+                jumpIdentityKeys = await loadAutoKeys();
+              }
+            } else if (jumpHost.password == null) {
+              jumpIdentityKeys = await loadAutoKeys();
+            }
+            jumpHostConfig = SshConnectionConfig.fromHost(
+              jumpHost,
+              key: jumpKey,
+              identityKeys: jumpIdentityKeys,
+            );
+          }
+        }
       }
-    }
 
-    final config = SshConnectionConfig.fromHost(
-      host,
-      key: key,
-      identityKeys: identityKeys,
-      jumpHostConfig: jumpHostConfig,
-    );
-
-    final result = await connect(config, onProgress: onProgress);
-
-    if (result.success && result.client != null) {
-      final connectionId = _nextConnectionId++;
-      _sessions[connectionId] = SshSession(
-        connectionId: connectionId,
-        hostId: hostId,
-        client: result.client!,
-        config: config,
-        dependentClients: result.dependentClients,
-        terminalThemeLightId: useHostThemeOverrides
-            ? host.terminalThemeLightId
-            : null,
-        terminalThemeDarkId: useHostThemeOverrides
-            ? host.terminalThemeDarkId
-            : null,
+      preflightPhase = 'build_config';
+      final config = SshConnectionConfig.fromHost(
+        host,
+        key: key,
+        identityKeys: identityKeys,
+        jumpHostConfig: jumpHostConfig,
       );
 
-      // Update last connected timestamp
-      await hostRepository!.updateLastConnected(hostId);
-      DiagnosticsLogService.instance.info(
+      preflightPhase = 'connect';
+      final result = await connect(config, onProgress: onProgress);
+
+      if (result.success && result.client != null) {
+        final connectionId = _nextConnectionId++;
+        _sessions[connectionId] = SshSession(
+          connectionId: connectionId,
+          hostId: hostId,
+          client: result.client!,
+          config: config,
+          dependentClients: result.dependentClients,
+          terminalThemeLightId: useHostThemeOverrides
+              ? host.terminalThemeLightId
+              : null,
+          terminalThemeDarkId: useHostThemeOverrides
+              ? host.terminalThemeDarkId
+              : null,
+        );
+
+        // Update last connected timestamp
+        await hostRepository!.updateLastConnected(hostId);
+        DiagnosticsLogService.instance.info(
+          'ssh.connect',
+          'connect_to_host_success',
+          fields: {
+            'hostId': hostId,
+            'connectionId': connectionId,
+            'usesJumpHost': config.jumpHost != null,
+            'usesPassword': config.password != null,
+            'identityCount': config.identityKeys?.length ?? 0,
+          },
+        );
+        return SshConnectionResult(
+          success: true,
+          client: result.client,
+          connectionId: connectionId,
+          dependentClients: result.dependentClients,
+        );
+      }
+
+      DiagnosticsLogService.instance.warning(
         'ssh.connect',
-        'connect_to_host_success',
+        'connect_to_host_failed',
         fields: {
           'hostId': hostId,
-          'connectionId': connectionId,
-          'usesJumpHost': config.jumpHost != null,
-          'usesPassword': config.password != null,
-          'identityCount': config.identityKeys?.length ?? 0,
+          'errorType': _diagnosticSshResultErrorKind(result.error),
         },
       );
-      return SshConnectionResult(
-        success: true,
-        client: result.client,
-        connectionId: connectionId,
-        dependentClients: result.dependentClients,
+      return result;
+    } on Exception catch (e) {
+      DiagnosticsLogService.instance.warning(
+        'ssh.connect',
+        'connect_to_host_preflight_failed',
+        fields: {
+          'hostId': hostId,
+          'phase': preflightPhase,
+          'errorType': e.runtimeType,
+        },
+      );
+      return const SshConnectionResult(
+        success: false,
+        error:
+            'Connection setup failed. Check saved credentials and try again.',
       );
     }
-
-    DiagnosticsLogService.instance.warning(
-      'ssh.connect',
-      'connect_to_host_failed',
-      fields: {
-        'hostId': hostId,
-        'errorType': _diagnosticSshResultErrorKind(result.error),
-      },
-    );
-    return result;
   }
 
   /// Connect with a configuration.

--- a/test/data/repositories/host_repository_test.dart
+++ b/test/data/repositories/host_repository_test.dart
@@ -120,6 +120,32 @@ void main() {
       expect(host!.password, plaintextPassword);
     });
 
+    test('getById migrates a legacy plaintext password', () async {
+      const plaintextPassword = 'legacy-secret';
+      final id = await db
+          .into(db.hosts)
+          .insert(
+            HostsCompanion.insert(
+              label: 'Legacy Host',
+              hostname: '192.168.1.11',
+              username: 'admin',
+              password: const Value(plaintextPassword),
+            ),
+          );
+
+      final host = await repository.getById(id);
+      expect(host!.password, plaintextPassword);
+
+      final storedHost = await (db.select(
+        db.hosts,
+      )..where((h) => h.id.equals(id))).getSingle();
+      expect(storedHost.password, startsWith('ENCv1:'));
+      expect(storedHost.password, isNot(plaintextPassword));
+
+      final migratedHost = await repository.getById(id);
+      expect(migratedHost!.password, plaintextPassword);
+    });
+
     test('insert stores auto-connect command fields', () async {
       final snippetId = await db
           .into(db.snippets)

--- a/test/data/repositories/host_repository_test.dart
+++ b/test/data/repositories/host_repository_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: public_member_api_docs
 
+import 'dart:async';
+
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -7,6 +9,32 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/security/secret_encryption_service.dart';
+
+class _PausingSecretEncryptionService extends SecretEncryptionService {
+  _PausingSecretEncryptionService({required this.pausePlaintext})
+    : super.forTesting();
+
+  final String pausePlaintext;
+  final _paused = Completer<void>();
+  final _resume = Completer<void>();
+
+  Future<void> get paused => _paused.future;
+
+  void resume() {
+    if (!_resume.isCompleted) {
+      _resume.complete();
+    }
+  }
+
+  @override
+  Future<String?> encryptNullable(String? plaintext) async {
+    if (plaintext == pausePlaintext && !_paused.isCompleted) {
+      _paused.complete();
+      await _resume.future;
+    }
+    return super.encryptNullable(plaintext);
+  }
+}
 
 void main() {
   late AppDatabase db;
@@ -144,6 +172,74 @@ void main() {
 
       final migratedHost = await repository.getById(id);
       expect(migratedHost!.password, plaintextPassword);
+    });
+
+    test(
+      'getById migrates malformed ENCv1-prefixed plaintext password',
+      () async {
+        const plaintextPassword = 'ENCv1:not-a-valid-password-envelope';
+        final id = await db
+            .into(db.hosts)
+            .insert(
+              HostsCompanion.insert(
+                label: 'Legacy Host',
+                hostname: '192.168.1.12',
+                username: 'admin',
+                password: const Value(plaintextPassword),
+              ),
+            );
+
+        final host = await repository.getById(id);
+        expect(host!.password, plaintextPassword);
+
+        final storedHost = await (db.select(
+          db.hosts,
+        )..where((h) => h.id.equals(id))).getSingle();
+        expect(storedHost.password, startsWith('ENCv1:'));
+        expect(storedHost.password, isNot(plaintextPassword));
+        await expectLater(
+          encryptionService.decryptNullable(storedHost.password),
+          completion(plaintextPassword),
+        );
+      },
+    );
+
+    test('legacy password migration does not overwrite newer writes', () async {
+      final encryptionService = _PausingSecretEncryptionService(
+        pausePlaintext: 'legacy-secret',
+      );
+      repository = HostRepository(db, encryptionService);
+      final id = await db
+          .into(db.hosts)
+          .insert(
+            HostsCompanion.insert(
+              label: 'Legacy Host',
+              hostname: '192.168.1.13',
+              username: 'admin',
+              password: const Value('legacy-secret'),
+            ),
+          );
+
+      final pendingRead = repository.getById(id);
+      await encryptionService.paused;
+      final newerEncryptedPassword = await encryptionService.encryptNullable(
+        'newer-secret',
+      );
+      await (db.update(db.hosts)..where((h) => h.id.equals(id))).write(
+        HostsCompanion(password: Value(newerEncryptedPassword)),
+      );
+      encryptionService.resume();
+
+      final host = await pendingRead;
+      expect(host!.password, 'legacy-secret');
+
+      final storedHost = await (db.select(
+        db.hosts,
+      )..where((h) => h.id.equals(id))).getSingle();
+      await expectLater(
+        encryptionService.decryptNullable(storedHost.password),
+        completion('newer-secret'),
+      );
     });
 
     test('insert stores auto-connect command fields', () async {

--- a/test/data/repositories/ssh_key_repository_test.dart
+++ b/test/data/repositories/ssh_key_repository_test.dart
@@ -73,6 +73,38 @@ void main() {
       expect(key.passphrase, passphrase);
     });
 
+    test('getById migrates legacy plaintext key secrets', () async {
+      const privateKey = 'legacy-open-ssh-material...';
+      const passphrase = 'legacy-passphrase';
+      final id = await db
+          .into(db.sshKeys)
+          .insert(
+            SshKeysCompanion.insert(
+              name: 'Legacy Key',
+              keyType: 'ed25519',
+              publicKey: 'ssh-ed25519 AAAA...',
+              privateKey: privateKey,
+              passphrase: const Value(passphrase),
+            ),
+          );
+
+      final key = await repository.getById(id);
+      expect(key!.privateKey, privateKey);
+      expect(key.passphrase, passphrase);
+
+      final storedKey = await (db.select(
+        db.sshKeys,
+      )..where((k) => k.id.equals(id))).getSingle();
+      expect(storedKey.privateKey, startsWith('ENCv1:'));
+      expect(storedKey.privateKey, isNot(privateKey));
+      expect(storedKey.passphrase, startsWith('ENCv1:'));
+      expect(storedKey.passphrase, isNot(passphrase));
+
+      final migratedKey = await repository.getById(id);
+      expect(migratedKey!.privateKey, privateKey);
+      expect(migratedKey.passphrase, passphrase);
+    });
+
     test('getById returns key when exists', () async {
       final id = await repository.insert(
         SshKeysCompanion.insert(

--- a/test/data/repositories/ssh_key_repository_test.dart
+++ b/test/data/repositories/ssh_key_repository_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: public_member_api_docs
 
+import 'dart:async';
+
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -7,6 +9,32 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/key_repository.dart';
 import 'package:monkeyssh/data/security/secret_encryption_service.dart';
+
+class _PausingSecretEncryptionService extends SecretEncryptionService {
+  _PausingSecretEncryptionService({required this.pausePlaintext})
+    : super.forTesting();
+
+  final String pausePlaintext;
+  final _paused = Completer<void>();
+  final _resume = Completer<void>();
+
+  Future<void> get paused => _paused.future;
+
+  void resume() {
+    if (!_resume.isCompleted) {
+      _resume.complete();
+    }
+  }
+
+  @override
+  Future<String?> encryptNullable(String? plaintext) async {
+    if (plaintext == pausePlaintext && !_paused.isCompleted) {
+      _paused.complete();
+      await _resume.future;
+    }
+    return super.encryptNullable(plaintext);
+  }
+}
 
 void main() {
   late AppDatabase db;
@@ -103,6 +131,80 @@ void main() {
       final migratedKey = await repository.getById(id);
       expect(migratedKey!.privateKey, privateKey);
       expect(migratedKey.passphrase, passphrase);
+    });
+
+    test('getById migrates malformed ENCv1-prefixed key secrets', () async {
+      const privateKey = 'ENCv1:not-a-valid-key-envelope';
+      const passphrase = 'ENCv1:not-a-valid-passphrase-envelope';
+      final id = await db
+          .into(db.sshKeys)
+          .insert(
+            SshKeysCompanion.insert(
+              name: 'Legacy Key',
+              keyType: 'ed25519',
+              publicKey: 'ssh-ed25519 AAAA...',
+              privateKey: privateKey,
+              passphrase: const Value(passphrase),
+            ),
+          );
+
+      final key = await repository.getById(id);
+      expect(key!.privateKey, privateKey);
+      expect(key.passphrase, passphrase);
+
+      final storedKey = await (db.select(
+        db.sshKeys,
+      )..where((k) => k.id.equals(id))).getSingle();
+      expect(storedKey.privateKey, startsWith('ENCv1:'));
+      expect(storedKey.privateKey, isNot(privateKey));
+      expect(storedKey.passphrase, startsWith('ENCv1:'));
+      expect(storedKey.passphrase, isNot(passphrase));
+      await expectLater(
+        encryptionService.decryptNullable(storedKey.privateKey),
+        completion(privateKey),
+      );
+      await expectLater(
+        encryptionService.decryptNullable(storedKey.passphrase),
+        completion(passphrase),
+      );
+    });
+
+    test('legacy key migration does not overwrite newer writes', () async {
+      final encryptionService = _PausingSecretEncryptionService(
+        pausePlaintext: 'legacy-open-ssh-material...',
+      );
+      repository = KeyRepository(db, encryptionService);
+      final id = await db
+          .into(db.sshKeys)
+          .insert(
+            SshKeysCompanion.insert(
+              name: 'Legacy Key',
+              keyType: 'ed25519',
+              publicKey: 'ssh-ed25519 AAAA...',
+              privateKey: 'legacy-open-ssh-material...',
+            ),
+          );
+
+      final pendingRead = repository.getById(id);
+      await encryptionService.paused;
+      final newerEncryptedPrivateKey = await encryptionService.encryptNullable(
+        'newer-open-ssh-material...',
+      );
+      await (db.update(db.sshKeys)..where((k) => k.id.equals(id))).write(
+        SshKeysCompanion(privateKey: Value(newerEncryptedPrivateKey!)),
+      );
+      encryptionService.resume();
+
+      final key = await pendingRead;
+      expect(key!.privateKey, 'legacy-open-ssh-material...');
+
+      final storedKey = await (db.select(
+        db.sshKeys,
+      )..where((k) => k.id.equals(id))).getSingle();
+      await expectLater(
+        encryptionService.decryptNullable(storedKey.privateKey),
+        completion('newer-open-ssh-material...'),
+      );
     });
 
     test('getById returns key when exists', () async {

--- a/test/data/repositories/ssh_key_repository_test.dart
+++ b/test/data/repositories/ssh_key_repository_test.dart
@@ -441,6 +441,72 @@ void main() {
       expect(firstValue, hasLength(1));
     });
 
+    test('watchAll skips unreadable stored keys', () async {
+      await repository.insert(
+        SshKeysCompanion.insert(
+          name: 'Readable Key',
+          keyType: 'ed25519',
+          publicKey: 'ssh-ed25519 AAAA...',
+          privateKey: 'fixture-open-ssh-material...',
+        ),
+      );
+      final otherEncryptionService = SecretEncryptionService.forTesting(
+        masterKey: List<int>.generate(32, (index) => 255 - index),
+      );
+      final unreadablePrivateKey = await otherEncryptionService.encryptRequired(
+        'unreadable-open-ssh-material...',
+      );
+      await db
+          .into(db.sshKeys)
+          .insert(
+            SshKeysCompanion.insert(
+              name: 'Unreadable Key',
+              keyType: 'ed25519',
+              publicKey: 'ssh-ed25519 BBBB...',
+              privateKey: unreadablePrivateKey,
+            ),
+          );
+
+      final firstValue = await repository.watchAll().first;
+
+      expect(firstValue, hasLength(1));
+      expect(firstValue.single.name, 'Readable Key');
+    });
+
+    test('getAllDecryptable reports unreadable stored keys', () async {
+      await repository.insert(
+        SshKeysCompanion.insert(
+          name: 'Readable Key',
+          keyType: 'ed25519',
+          publicKey: 'ssh-ed25519 AAAA...',
+          privateKey: 'fixture-open-ssh-material...',
+        ),
+      );
+      final otherEncryptionService = SecretEncryptionService.forTesting(
+        masterKey: List<int>.generate(32, (index) => 255 - index),
+      );
+      final unreadablePrivateKey = await otherEncryptionService.encryptRequired(
+        'unreadable-open-ssh-material...',
+      );
+      await db
+          .into(db.sshKeys)
+          .insert(
+            SshKeysCompanion.insert(
+              name: 'Unreadable Key',
+              keyType: 'ed25519',
+              publicKey: 'ssh-ed25519 BBBB...',
+              privateKey: unreadablePrivateKey,
+            ),
+          );
+
+      final result = await repository.getAllDecryptable();
+
+      expect(result.keys, hasLength(1));
+      expect(result.keys.single.name, 'Readable Key');
+      expect(result.unreadableCount, 1);
+      expect(result.firstUnreadableErrorType, 'FormatException');
+    });
+
     test('insert multiple keys', () async {
       await repository.insert(
         SshKeysCompanion.insert(

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -1752,6 +1752,52 @@ void main() {
       expect(config.identityKeys, hasLength(2));
     });
 
+    test('connectToHost migrates legacy plaintext Auto keys', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final encryptionService = SecretEncryptionService.forTesting();
+      final hostRepo = HostRepository(db, encryptionService);
+      final keyRepo = KeyRepository(db, encryptionService);
+      final service = _CapturingSshService(
+        hostRepository: hostRepo,
+        keyRepository: keyRepo,
+      );
+
+      const privateKey = 'legacy-key-material';
+      final keyId = await db
+          .into(db.sshKeys)
+          .insert(
+            SshKeysCompanion.insert(
+              name: 'Legacy Auto Key',
+              keyType: 'ed25519',
+              publicKey: 'ssh-ed25519 AAAA...',
+              privateKey: privateKey,
+            ),
+          );
+      final hostId = await db
+          .into(db.hosts)
+          .insert(
+            HostsCompanion.insert(
+              label: 'Auto Host',
+              hostname: '10.0.0.12',
+              username: 'admin',
+            ),
+          );
+
+      await service.connectToHost(hostId);
+
+      final config = service.capturedConfig;
+      expect(config, isNotNull);
+      expect(config!.identityKeys, hasLength(1));
+      expect(config.identityKeys!.single.privateKey, privateKey);
+
+      final rawKey = await (db.select(
+        db.sshKeys,
+      )..where((k) => k.id.equals(keyId))).getSingle();
+      expect(rawKey.privateKey, startsWith('ENCv1:'));
+      expect(rawKey.privateKey, isNot(privateKey));
+    });
+
     test('connectToHost caps Auto keys to avoid auth lockout', () async {
       final db = AppDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -92,6 +92,12 @@ class _CountingKeyRepository extends KeyRepository {
   }
 
   @override
+  Future<SshKeyLoadResult> getAllDecryptable() async {
+    getAllCallCount++;
+    return super.getAllDecryptable();
+  }
+
+  @override
   Future<SshKey?> getById(int id) async {
     if (returnNullOnGetById) {
       return null;
@@ -228,6 +234,15 @@ Future<int> _unusedLoopbackPort() async {
   final port = socket.port;
   await socket.close();
   return port;
+}
+
+String _structurallyValidInvalidEncryptedSecret() {
+  final envelope = {
+    'n': base64Url.encode(List<int>.filled(12, 1)),
+    'c': base64Url.encode([1, 2, 3]),
+    'm': base64Url.encode(List<int>.filled(16, 2)),
+  };
+  return 'ENCv1:${base64Url.encode(utf8.encode(jsonEncode(envelope)))}';
 }
 
 void main() {
@@ -1797,6 +1812,98 @@ void main() {
       expect(rawKey.privateKey, startsWith('ENCv1:'));
       expect(rawKey.privateKey, isNot(privateKey));
     });
+
+    test('connectToHost skips unreadable Auto keys', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final encryptionService = SecretEncryptionService.forTesting();
+      final hostRepo = HostRepository(db, encryptionService);
+      final keyRepo = KeyRepository(db, encryptionService);
+      final service = _CapturingSshService(
+        hostRepository: hostRepo,
+        keyRepository: keyRepo,
+      );
+
+      await db
+          .into(db.sshKeys)
+          .insert(
+            SshKeysCompanion.insert(
+              name: 'Unreadable Auto Key',
+              keyType: 'ed25519',
+              publicKey: 'ssh-ed25519 BAD',
+              privateKey: _structurallyValidInvalidEncryptedSecret(),
+            ),
+          );
+      await keyRepo.insert(
+        SshKeysCompanion.insert(
+          name: 'Readable Auto Key',
+          keyType: 'ed25519',
+          publicKey: 'ssh-ed25519 GOOD',
+          privateKey: 'readable-key-material',
+        ),
+      );
+      final hostId = await db
+          .into(db.hosts)
+          .insert(
+            HostsCompanion.insert(
+              label: 'Auto Host',
+              hostname: '10.0.0.14',
+              username: 'admin',
+            ),
+          );
+
+      await service.connectToHost(hostId);
+
+      final config = service.capturedConfig;
+      expect(config, isNotNull);
+      expect(config!.identityKeys, hasLength(1));
+      expect(config.identityKeys!.single.name, 'Readable Auto Key');
+    });
+
+    test(
+      'connectToHost fails during preflight for unreadable explicit key',
+      () async {
+        final db = AppDatabase.forTesting(NativeDatabase.memory());
+        addTearDown(db.close);
+        final encryptionService = SecretEncryptionService.forTesting();
+        final hostRepo = HostRepository(db, encryptionService);
+        final keyRepo = KeyRepository(db, encryptionService);
+        final service = _CapturingSshService(
+          hostRepository: hostRepo,
+          keyRepository: keyRepo,
+        );
+
+        final keyId = await db
+            .into(db.sshKeys)
+            .insert(
+              SshKeysCompanion.insert(
+                name: 'Unreadable Explicit Key',
+                keyType: 'ed25519',
+                publicKey: 'ssh-ed25519 BAD',
+                privateKey: _structurallyValidInvalidEncryptedSecret(),
+              ),
+            );
+        final hostId = await db
+            .into(db.hosts)
+            .insert(
+              HostsCompanion.insert(
+                label: 'Explicit Key Host',
+                hostname: '10.0.0.15',
+                username: 'admin',
+                keyId: Value(keyId),
+              ),
+            );
+
+        final result = await service.connectToHost(hostId);
+
+        expect(result.success, isFalse);
+        expect(
+          result.error,
+          'Connection setup failed. Check saved credentials and try again.',
+        );
+        expect(service.capturedConfig, isNull);
+      },
+    );
 
     test('connectToHost caps Auto keys to avoid auth lockout', () async {
       final db = AppDatabase.forTesting(NativeDatabase.memory());

--- a/test/unit/secret_encryption_service_test.dart
+++ b/test/unit/secret_encryption_service_test.dart
@@ -92,6 +92,15 @@ void main() {
       );
     });
 
+    test('validates encrypted envelope structure', () async {
+      const prefixedPlaintext = 'ENCv1:not-a-valid-envelope';
+      final encrypted = await service.encryptNullable(prefixedPlaintext);
+
+      expect(service.isEncryptedValue(prefixedPlaintext), isTrue);
+      expect(service.isValidEncryptedEnvelope(prefixedPlaintext), isFalse);
+      expect(service.isValidEncryptedEnvelope(encrypted!), isTrue);
+    });
+
     test('reuses and migrates the legacy master key entry', () async {
       final storage = _MockFlutterSecureStorage();
       final writes = <String, String>{};

--- a/test/unit/secret_encryption_service_test.dart
+++ b/test/unit/secret_encryption_service_test.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -193,6 +194,130 @@ void main() {
         ),
       );
     });
+
+    test(
+      'falls back to legacy iOS accessibility when hardened read throws',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() {
+          debugDefaultTargetPlatformOverride = null;
+        });
+        final storage = _MockFlutterSecureStorage();
+        final legacyValue = base64Encode(
+          List<int>.generate(32, (index) => index),
+        );
+        const hardenedOptions = IOSOptions(
+          accessibility: KeychainAccessibility.first_unlock_this_device,
+        );
+        const legacyOptions = IOSOptions.defaultOptions;
+
+        when(
+          () => storage.read(
+            key: 'flutty_db_encryption_key_v1',
+            iOptions: hardenedOptions,
+          ),
+        ).thenThrow(PlatformException(code: 'read_failed'));
+        when(
+          () => storage.read(
+            key: 'flutty_db_encryption_key_v1',
+            iOptions: legacyOptions,
+          ),
+        ).thenAnswer((_) async => legacyValue);
+        when(
+          () => storage.write(
+            key: 'flutty_db_encryption_key_v1',
+            value: legacyValue,
+            iOptions: hardenedOptions,
+          ),
+        ).thenAnswer((_) async {});
+
+        service = SecretEncryptionService(storage: storage, random: Random(1));
+
+        final encrypted = await service.encryptNullable('migrate-me');
+
+        expect(encrypted, startsWith('ENCv1:'));
+        verify(
+          () => storage.read(
+            key: 'flutty_db_encryption_key_v1',
+            iOptions: legacyOptions,
+          ),
+        ).called(1);
+        verify(
+          () => storage.write(
+            key: 'flutty_db_encryption_key_v1',
+            value: legacyValue,
+            iOptions: hardenedOptions,
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'replaces duplicate legacy iOS keychain item during migration',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() {
+          debugDefaultTargetPlatformOverride = null;
+        });
+        final storage = _MockFlutterSecureStorage();
+        final legacyValue = base64Encode(
+          List<int>.generate(32, (index) => index),
+        );
+        const hardenedOptions = IOSOptions(
+          accessibility: KeychainAccessibility.first_unlock_this_device,
+        );
+        const legacyOptions = IOSOptions.defaultOptions;
+
+        when(
+          () => storage.read(
+            key: 'flutty_db_encryption_key_v1',
+            iOptions: hardenedOptions,
+          ),
+        ).thenAnswer((_) async => null);
+        when(
+          () => storage.read(
+            key: 'flutty_db_encryption_key_v1',
+            iOptions: legacyOptions,
+          ),
+        ).thenAnswer((_) async => legacyValue);
+        var writeCount = 0;
+        when(
+          () => storage.write(
+            key: 'flutty_db_encryption_key_v1',
+            value: legacyValue,
+            iOptions: hardenedOptions,
+          ),
+        ).thenAnswer((_) async {
+          writeCount++;
+          if (writeCount == 1) {
+            throw PlatformException(
+              code: 'Unexpected security result code',
+              message: 'The specified item already exists in the keychain.',
+              details: -25299,
+            );
+          }
+        });
+        when(
+          () => storage.delete(
+            key: 'flutty_db_encryption_key_v1',
+            iOptions: legacyOptions,
+          ),
+        ).thenAnswer((_) async {});
+
+        service = SecretEncryptionService(storage: storage, random: Random(1));
+
+        final encrypted = await service.encryptNullable('migrate-me');
+
+        expect(encrypted, startsWith('ENCv1:'));
+        expect(writeCount, 2);
+        verify(
+          () => storage.delete(
+            key: 'flutty_db_encryption_key_v1',
+            iOptions: legacyOptions,
+          ),
+        ).called(1);
+      },
+    );
 
     group('tamper and corruption resistance', () {
       test('rejects a value with a tampered MAC', () async {


### PR DESCRIPTION
## Summary

- Migrate legacy plaintext host passwords and SSH key secrets on first read instead of failing during connection setup.
- Preserve encrypted-at-rest storage by writing migrated secrets back as `ENCv1:` envelopes.
- Add coverage for legacy host passwords, legacy key secrets, and the Auto-key connection path.

## Tests

- `flutter test test/data/repositories/host_repository_test.dart test/data/repositories/ssh_key_repository_test.dart test/domain/services/ssh_service_test.dart`
- `flutter analyze`
