### PR TITLE
[codex] Fix MonkeyMux agent title fallback

### DIFF
--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -911,6 +911,7 @@ bool _isUnhelpfulTmuxTitle(
   String? normalizedCommand,
 }) {
   if (value == null || value.isEmpty) return true;
+  if (_isDecorativeShellTitle(value)) return true;
   final lowered = value.toLowerCase();
   if (_genericTmuxTitles.contains(lowered)) return true;
   if (normalizedName != null && lowered == normalizedName.toLowerCase()) {
@@ -939,6 +940,7 @@ bool _isUnhelpfulAgentTitle(
   required String? contextLabel,
 }) {
   if (value == null || value.isEmpty) return true;
+  if (_isDecorativeShellTitle(value)) return true;
   final lowered = _normalizeAgentTitleForComparison(value);
   if (lowered.isEmpty) return true;
   if (_agentTitleAliases(tool).contains(lowered)) return true;
@@ -959,6 +961,13 @@ bool _isUnhelpfulAgentTitle(
   return statusContext == null ||
       statusContext.isEmpty ||
       statusContext == loweredContext;
+}
+
+bool _isDecorativeShellTitle(String value) {
+  final trimmed = value.trim();
+  if (trimmed.isEmpty) return true;
+  if (trimmed == '~' || trimmed.endsWith('|~')) return true;
+  return !trimmed.runes.any(_isAsciiLetterOrDigit);
 }
 
 String _normalizeAgentTitleForComparison(String value) =>

--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -758,13 +758,6 @@ class MonkeyMuxService implements RemoteMultiplexerService {
         final panePid = window.panePid;
         final metadata = panePid == null ? null : metadataByPanePid[panePid];
         if (metadata == null || metadata.tool != window.foregroundAgentTool) {
-          if (panePid != null &&
-              refreshedPanePids != null &&
-              refreshedPanePids.contains(panePid) &&
-              _hasMonkeyMuxAgentSessionMetadata(window)) {
-            changed = true;
-            return window.copyWith(clearActiveAgentSessionMetadata: true);
-          }
           return window;
         }
         if (window.activeAgentSessionId == metadata.sessionId &&
@@ -782,11 +775,6 @@ class MonkeyMuxService implements RemoteMultiplexerService {
       .toList(growable: false);
   return (windows: changed ? enriched : windows, changed: changed);
 }
-
-bool _hasMonkeyMuxAgentSessionMetadata(TmuxWindow window) =>
-    window.activeAgentSessionId != null ||
-    window.agentSessionTitle != null ||
-    window.activeAgentSessionConfidence != null;
 
 /// Applies live Copilot metadata to MonkeyMux windows for regression tests.
 @visibleForTesting

--- a/test/domain/models/tmux_state_test.dart
+++ b/test/domain/models/tmux_state_test.dart
@@ -327,6 +327,22 @@ void main() {
       expect(window.secondaryTitle, isNull);
     });
 
+    test('ignores decorative shell titles for agent windows', () {
+      const window = TmuxWindow(
+        index: 2,
+        name: '|~',
+        isActive: false,
+        currentCommand: 'copilot',
+        currentPath: '/Users/depoll/Code/flutty',
+        paneTitle: '|~',
+      );
+
+      expect(window.foregroundAgentTool, AgentLaunchTool.copilotCli);
+      expect(window.displayTitle, 'Copilot CLI · flutty');
+      expect(window.handleTitle, 'Copilot CLI · flutty');
+      expect(window.secondaryTitle, isNull);
+    });
+
     test('shows live agent session titles when available', () {
       const window = TmuxWindow(
         index: 1,

--- a/test/domain/services/monkeymux_service_test.dart
+++ b/test/domain/services/monkeymux_service_test.dart
@@ -214,7 +214,7 @@ void main() {
       expect(windows.single.displayTitle, 'Implement MonkeyMux refresh');
     });
 
-    test('clears stale Copilot session titles after a refreshed miss', () {
+    test('keeps Copilot session titles after a transient refreshed miss', () {
       const window = TmuxWindow(
         index: 1,
         id: '@7',
@@ -233,9 +233,9 @@ void main() {
         refreshedPanePids: const {42},
       );
 
-      expect(windows.single.activeAgentSessionId, isNull);
-      expect(windows.single.agentSessionTitle, isNull);
-      expect(windows.single.displayTitle, 'Copilot CLI');
+      expect(windows.single.activeAgentSessionId, 'stale-session');
+      expect(windows.single.agentSessionTitle, 'Stale Copilot session');
+      expect(windows.single.displayTitle, 'Stale Copilot session');
     });
 
     test('keeps existing Copilot metadata when pane was not refreshed', () {


### PR DESCRIPTION
## Summary

- Treat decorative shell titles such as `|~` as unhelpful for agent windows so the UI falls back to the agent/context label.
- Keep existing MonkeyMux agent session metadata through transient refreshed misses instead of clearing a good Copilot title after one failed metadata probe.
- Add regressions for the `|~` fallback and transient MonkeyMux metadata miss behavior.

## Root Cause

Copilot windows could briefly receive the correct live session title, then lose it when a later MonkeyMux metadata refresh failed to match the pane. Once cleared, the title logic accepted tmux's decorative shell title (`|~`) as useful, so the navigator showed that as the primary title.

## Validation

- `flutter analyze`
- `flutter test test/domain/models/tmux_state_test.dart test/domain/services/monkeymux_service_test.dart`
- Pre-commit hook: format, analyze, full `flutter test` suite (`2250` tests)
