### PR TITLE
feat: add support for Antigravity CLI

### DIFF
--- a/lib/domain/models/agent_launch_preset.dart
+++ b/lib/domain/models/agent_launch_preset.dart
@@ -17,6 +17,9 @@ enum AgentLaunchTool {
 
   /// Google Gemini CLI.
   geminiCli,
+
+  /// Antigravity CLI.
+  antigravity,
 }
 
 /// Presentation helpers for [AgentLaunchTool].
@@ -28,6 +31,7 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
     AgentLaunchTool.codex => 'Codex',
     AgentLaunchTool.openCode => 'OpenCode',
     AgentLaunchTool.geminiCli => 'Gemini CLI',
+    AgentLaunchTool.antigravity => 'Antigravity',
   };
 
   /// Shell command used to launch this tool.
@@ -37,6 +41,7 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
     AgentLaunchTool.codex => 'codex',
     AgentLaunchTool.openCode => 'opencode',
     AgentLaunchTool.geminiCli => 'gemini',
+    AgentLaunchTool.antigravity => 'antigravity',
   };
 
   /// Whether this tool supports session resume.
@@ -46,6 +51,7 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
     AgentLaunchTool.codex => true,
     AgentLaunchTool.openCode => true,
     AgentLaunchTool.geminiCli => true,
+    AgentLaunchTool.antigravity => true,
   };
 
   /// Matching discovered-session provider name, if this tool supports recent
@@ -56,6 +62,7 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
     AgentLaunchTool.codex => 'Codex',
     AgentLaunchTool.openCode => 'OpenCode',
     AgentLaunchTool.geminiCli => 'Gemini CLI',
+    AgentLaunchTool.antigravity => 'Antigravity',
   };
 
   /// Whether this tool supports launching directly into YOLO mode.
@@ -69,6 +76,7 @@ extension AgentLaunchToolPresentation on AgentLaunchTool {
     AgentLaunchTool.codex => const ['--yolo'],
     AgentLaunchTool.openCode => const [],
     AgentLaunchTool.geminiCli => const ['--yolo'],
+    AgentLaunchTool.antigravity => const ['--yolo'],
   };
 
   /// Environment variables that enable YOLO mode for this tool.
@@ -94,6 +102,7 @@ AgentLaunchTool? agentLaunchToolForCommandName(String? commandName) {
     'codex' || 'codex-cli' => AgentLaunchTool.codex,
     'opencode' || 'open-code' => AgentLaunchTool.openCode,
     'gemini' || 'gemini-cli' => AgentLaunchTool.geminiCli,
+    'antigravity' || 'antigravity-cli' => AgentLaunchTool.antigravity,
     _ => null,
   };
 }
@@ -324,6 +333,7 @@ final _copilotAllowAllPathsPattern = RegExp(
 );
 final _copilotAllowAllUrlsPattern = RegExp(r'(?<!\S)--allow-all-urls(?=\s|$)');
 final _geminiYoloPattern = RegExp(r'(?<!\S)(?:--yolo|-y)(?=\s|$)');
+final _antigravityYoloPattern = RegExp(r'(?<!\S)--yolo(?=\s|$)');
 final _openCodeDangerouslySkipPermissionsPattern = RegExp(
   r'(?<!\S)--dangerously-skip-permissions(?=\s|$)',
 );
@@ -414,6 +424,7 @@ List<String> _buildAgentResumeArguments(
   AgentLaunchTool.copilotCli => ['--resume', _quoteShellArgument(sessionId)],
   AgentLaunchTool.codex => ['resume', _quoteShellArgument(sessionId)],
   AgentLaunchTool.geminiCli => ['--resume', _quoteShellArgument(sessionId)],
+  AgentLaunchTool.antigravity => ['--resume', _quoteShellArgument(sessionId)],
   AgentLaunchTool.openCode =>
     sessionId == '_continue'
         ? const ['--continue']
@@ -455,6 +466,10 @@ String? _normalizeAgentToolArguments({
     AgentLaunchTool.geminiCli => _stripArgumentPatterns(
       trimmedAdditionalArguments,
       [_geminiYoloPattern],
+    ),
+    AgentLaunchTool.antigravity => _stripArgumentPatterns(
+      trimmedAdditionalArguments,
+      [_antigravityYoloPattern],
     ),
   };
 

--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -985,6 +985,7 @@ Set<String> _agentTitleAliases(AgentLaunchTool tool) => switch (tool) {
   AgentLaunchTool.codex => const {'codex'},
   AgentLaunchTool.openCode => const {'opencode', 'open code'},
   AgentLaunchTool.geminiCli => const {'gemini', 'gemini cli'},
+  AgentLaunchTool.antigravity => const {'antigravity'},
 };
 
 AgentLaunchTool? _agentToolFromTerminalTitle(String? value) {
@@ -1097,6 +1098,9 @@ String? agentSessionIdFromLaunchCommand(
     ],
     AgentLaunchTool.openCode => const [
       r'''(?<!\S)--session(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(\S+))''',
+    ],
+    AgentLaunchTool.antigravity => const [
+      r'''(?<!\S)--resume(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(\S+))''',
     ],
   };
 

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -26,6 +26,7 @@ const _profileSourcingPrefix =
     r'export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin${PATH:+:$PATH}"; ';
 const _remoteFileSnapshotBatchSize = 40;
 const _geminiSessionMetadataMaxBytes = 64 * 1024;
+const _antigravitySessionMetadataMaxBytes = 8 * 1024;
 const _sessionDiscoveryCacheFreshTtl = Duration(seconds: 15);
 const _sessionDiscoveryCacheRetentionTtl = Duration(minutes: 2);
 const _relatedWorkingDirectoriesCacheTtl = Duration(minutes: 1);
@@ -629,29 +630,66 @@ parseClaudeSessionMetadata(String raw) {
 parseAntigravitySessionMetadata(String raw) {
   final decoded = _tryDecodeJsonObject(raw);
   if (decoded == null) {
-    return (
-      sessionId: null,
-      summary: null,
-      workingDirectory: null,
-      updatedAt: null,
-      parsedAny: false,
-    );
+    return _parsePartialAntigravitySessionMetadata(raw);
   }
 
+  final sessionId =
+      _readStringField(decoded, 'id') ?? _readStringField(decoded, 'sessionId');
+  final summary =
+      _readStringField(decoded, 'summary') ?? _readStringField(decoded, 'name');
+  final workingDirectory =
+      _readStringField(decoded, 'workingDirectory') ??
+      _readStringField(decoded, 'cwd');
+  final updatedAt =
+      _parseDateTimeValue(decoded['updatedAt']) ??
+      _parseDateTimeValue(decoded['lastActive']);
+  final parsedAny =
+      sessionId != null ||
+      summary != null ||
+      workingDirectory != null ||
+      updatedAt != null;
+
   return (
-    sessionId:
-        _readStringField(decoded, 'id') ??
-        _readStringField(decoded, 'sessionId'),
-    summary:
-        _readStringField(decoded, 'summary') ??
-        _readStringField(decoded, 'name'),
-    workingDirectory:
-        _readStringField(decoded, 'workingDirectory') ??
-        _readStringField(decoded, 'cwd'),
-    updatedAt:
-        _parseDateTimeValue(decoded['updatedAt']) ??
-        _parseDateTimeValue(decoded['lastActive']),
-    parsedAny: true,
+    sessionId: sessionId,
+    summary: summary,
+    workingDirectory: workingDirectory,
+    updatedAt: updatedAt,
+    parsedAny: parsedAny,
+  );
+}
+
+({
+  String? sessionId,
+  String? summary,
+  String? workingDirectory,
+  DateTime? updatedAt,
+  bool parsedAny,
+})
+_parsePartialAntigravitySessionMetadata(String raw) {
+  final sessionId =
+      _readJsonStringFromRaw(raw, 'id') ??
+      _readJsonStringFromRaw(raw, 'sessionId');
+  final summary =
+      _readJsonStringFromRaw(raw, 'summary') ??
+      _readJsonStringFromRaw(raw, 'name');
+  final workingDirectory =
+      _readJsonStringFromRaw(raw, 'workingDirectory') ??
+      _readJsonStringFromRaw(raw, 'cwd');
+  final updatedAt =
+      _parseDateTimeValue(_readJsonStringFromRaw(raw, 'updatedAt')) ??
+      _parseDateTimeValue(_readJsonStringFromRaw(raw, 'lastActive'));
+  final parsedAny =
+      sessionId != null ||
+      summary != null ||
+      workingDirectory != null ||
+      updatedAt != null;
+
+  return (
+    sessionId: sessionId,
+    summary: summary,
+    workingDirectory: workingDirectory,
+    updatedAt: updatedAt,
+    parsedAny: parsedAny,
   );
 }
 
@@ -2406,6 +2444,7 @@ class AgentSessionDiscoveryService {
       final sessionSnapshots = await _readRemoteFileSnapshots(
         session,
         recentSessionPaths,
+        maxBytes: _antigravitySessionMetadataMaxBytes,
       );
 
       final sessions = <ToolSessionInfo>[];

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -83,6 +83,7 @@ const _knownDiscoveredSessionTools = <String>[
   'Codex',
   'Gemini CLI',
   'OpenCode',
+  'Antigravity',
 ];
 
 /// Orders discovered-session providers for UI rendering in a stable list.
@@ -305,6 +306,8 @@ bool _isLikelyToolStateWorkingDirectory(String directory) =>
     directory.contains('/.gemini/') ||
     directory.endsWith('/.local/share/opencode') ||
     directory.contains('/.local/share/opencode/') ||
+    directory.endsWith('/.antigravity') ||
+    directory.contains('/.antigravity/') ||
     directory.startsWith('/tmp/') ||
     directory.startsWith('/private/tmp/') ||
     directory.startsWith('/var/folders/');
@@ -611,6 +614,44 @@ parseClaudeSessionMetadata(String raw) {
     lastPrompt: lastPrompt,
     userSummary: userSummary,
     parsedAny: parsedAny,
+  );
+}
+
+/// Parses Antigravity session metadata from a saved session JSON file.
+@visibleForTesting
+({
+  String? sessionId,
+  String? summary,
+  String? workingDirectory,
+  DateTime? updatedAt,
+  bool parsedAny,
+})
+parseAntigravitySessionMetadata(String raw) {
+  final decoded = _tryDecodeJsonObject(raw);
+  if (decoded == null) {
+    return (
+      sessionId: null,
+      summary: null,
+      workingDirectory: null,
+      updatedAt: null,
+      parsedAny: false,
+    );
+  }
+
+  return (
+    sessionId:
+        _readStringField(decoded, 'id') ??
+        _readStringField(decoded, 'sessionId'),
+    summary:
+        _readStringField(decoded, 'summary') ??
+        _readStringField(decoded, 'name'),
+    workingDirectory:
+        _readStringField(decoded, 'workingDirectory') ??
+        _readStringField(decoded, 'cwd'),
+    updatedAt:
+        _parseDateTimeValue(decoded['updatedAt']) ??
+        _parseDateTimeValue(decoded['lastActive']),
+    parsedAny: true,
   );
 }
 
@@ -1461,6 +1502,13 @@ class AgentSessionDiscoveryService {
               effectiveMaxPerTool,
               previewOnly: previewOnly,
             ),
+            _discoverAntigravitySessions(
+              session,
+              workingDirectory,
+              relatedWorkingDirectories,
+              effectiveMaxPerTool,
+              previewOnly: previewOnly,
+            ),
           ]
         : [
             _discoverSessionsForTool(
@@ -1505,6 +1553,12 @@ class AgentSessionDiscoveryService {
       maxPerTool,
     ),
     'Claude Code' => _discoverClaudeSessions(
+      session,
+      workingDirectory,
+      relatedWorkingDirectories,
+      maxPerTool,
+    ),
+    'Antigravity' => _discoverAntigravitySessions(
       session,
       workingDirectory,
       relatedWorkingDirectories,
@@ -2301,6 +2355,114 @@ class AgentSessionDiscoveryService {
       sortAndLimitDiscoveredSessions(sessions, max),
       hadError: hadError,
     );
+  }
+
+  // ── Antigravity CLI ────────────────────────────────────────────────────
+  // Sessions: ~/.antigravity/sessions/*.json
+
+  Future<_ToolDiscoveryResult> _discoverAntigravitySessions(
+    SshSession session,
+    String? workingDirectory,
+    List<String> relatedWorkingDirectories,
+    int max, {
+    bool previewOnly = false,
+  }) async {
+    try {
+      final scanLimit = previewOnly
+          ? _calculateDiscoveryScanLimit(
+              max,
+              multiplier: 8,
+              minimum: 24,
+              maximum: 40,
+            )
+          : _calculateDiscoveryScanLimit(max, multiplier: 10, maximum: 120);
+      final metadataReadLimit = previewOnly
+          ? _calculateDiscoveryScanLimit(
+              max,
+              multiplier: 4,
+              minimum: 6,
+              maximum: 12,
+            )
+          : calculateRecentSessionMetadataReadLimit(max);
+
+      final output = await _exec(
+        session,
+        'find ~/.antigravity/sessions -name "*.json" -type f '
+        '-exec ls -1t {} + 2>/dev/null | head -n $scanLimit',
+      );
+      if (output.trim().isEmpty) {
+        return const _ToolDiscoveryResult.success('Antigravity', []);
+      }
+
+      final sessionPaths = output
+          .trim()
+          .split('\n')
+          .map((line) => line.trim())
+          .where((line) => line.isNotEmpty)
+          .toList(growable: false);
+      final recentSessionPaths = sessionPaths
+          .take(metadataReadLimit)
+          .toList(growable: false);
+      final sessionSnapshots = await _readRemoteFileSnapshots(
+        session,
+        recentSessionPaths,
+      );
+
+      final sessions = <ToolSessionInfo>[];
+      var hadError = false;
+
+      for (final filePath in recentSessionPaths) {
+        final fileName = filePath.split('/').last.replaceAll('.json', '');
+        final snapshot = sessionSnapshots[filePath];
+        if (snapshot == null) {
+          hadError = true;
+          continue;
+        }
+
+        try {
+          final metadata = parseAntigravitySessionMetadata(snapshot.content);
+          if (snapshot.content.trim().isNotEmpty && !metadata.parsedAny) {
+            hadError = true;
+          }
+
+          sessions.add(
+            ToolSessionInfo(
+              toolName: 'Antigravity',
+              sessionId: metadata.sessionId ?? fileName,
+              workingDirectory: metadata.workingDirectory,
+              lastActive: metadata.updatedAt ?? snapshot.modifiedAt,
+              summary: metadata.summary ?? _truncateId(fileName),
+            ),
+          );
+        } on Object {
+          hadError = true;
+        }
+      }
+
+      final scopedSessions =
+          workingDirectory != null && workingDirectory.isNotEmpty
+          ? sessions
+                .where(
+                  (info) => matchesDiscoveredSessionWorkingDirectory(
+                    workingDirectory,
+                    info.workingDirectory,
+                    relatedWorkingDirectories: relatedWorkingDirectories,
+                  ),
+                )
+                .toList(growable: false)
+          : sessions;
+
+      return _ToolDiscoveryResult.success(
+        'Antigravity',
+        sortAndLimitDiscoveredSessions(
+          scopedSessions.isNotEmpty ? scopedSessions : sessions,
+          max,
+        ),
+        hadError: hadError,
+      );
+    } on Object {
+      return const _ToolDiscoveryResult.failure('Antigravity');
+    }
   }
 
   // ── OpenCode ───────────────────────────────────────────────────────────

--- a/lib/presentation/widgets/agent_tool_icon.dart
+++ b/lib/presentation/widgets/agent_tool_icon.dart
@@ -119,6 +119,9 @@ final Map<AgentLaunchTool, String> _svgByTool = <AgentLaunchTool, String>{
       'M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81',
     ),
   ]),
+  AgentLaunchTool.antigravity: _buildSvg('0 0 24 24', const [
+    _SvgPathSpec('M12 2L4.5 20.29l.71.71L12 18l6.79 3 .71-.71z'),
+  ]),
 };
 
 class _SvgPathSpec {

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -929,6 +929,7 @@ class TmuxToolPickerSheet extends StatelessWidget {
     AgentLaunchTool.codex,
     AgentLaunchTool.geminiCli,
     AgentLaunchTool.openCode,
+    AgentLaunchTool.antigravity,
   ];
 
   @override

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,20 @@
+## Summary
+
+This PR adds support for the **Antigravity CLI** agent to MonkeySSH.
+
+### Features
+- **Launch Presets**: Users can now select "Antigravity" from the agent launch tool list.
+- **Session Discovery**: The app will now automatically discover recent Antigravity sessions stored in `~/.antigravity/sessions/*.json`.
+- **YOLO Mode**: Full support for launching and resuming sessions in YOLO mode via the `--yolo` flag.
+- **Tmux Integration**: Updated tmux window tracking to correctly identify and alias Antigravity terminal titles.
+
+### Changes
+- Added `antigravity` to `AgentLaunchTool`.
+- Implemented `_discoverAntigravitySessions` in `AgentSessionDiscoveryService`.
+- Updated `tmux_state.dart` for exhaustive matching and session ID extraction.
+- Added comprehensive unit tests for presets and discovery.
+
+### Verification
+- Ran `flutter test test/domain/models/agent_launch_preset_test.dart` (Passed)
+- Ran `flutter test test/domain/services/agent_session_discovery_service_test.dart` (Passed)
+- Ran `flutter test test/widget/tmux_window_navigator_test.dart` (Passed)

--- a/test/domain/models/agent_launch_preset_test.dart
+++ b/test/domain/models/agent_launch_preset_test.dart
@@ -33,6 +33,13 @@ void main() {
         buildAgentToolCommand(AgentLaunchTool.geminiCli, startInYoloMode: true),
         'gemini --yolo',
       );
+      expect(
+        buildAgentToolCommand(
+          AgentLaunchTool.antigravity,
+          startInYoloMode: true,
+        ),
+        'antigravity --yolo',
+      );
     });
   });
 
@@ -69,6 +76,14 @@ void main() {
           startInYoloMode: true,
         ),
         "gemini --yolo --resume 'gemini-session'",
+      );
+      expect(
+        buildAgentResumeCommand(
+          AgentLaunchTool.antigravity,
+          'antigravity-session',
+          startInYoloMode: true,
+        ),
+        "antigravity --yolo --resume 'antigravity-session'",
       );
       expect(
         buildAgentResumeCommand(
@@ -267,6 +282,12 @@ void main() {
       expect(buildAgentLaunchCommand(preset), 'gemini');
     });
 
+    test('builds command for antigravity tool', () {
+      const preset = AgentLaunchPreset(tool: AgentLaunchTool.antigravity);
+
+      expect(buildAgentLaunchCommand(preset), 'antigravity');
+    });
+
     test('adds yolo mode to supported presets', () {
       const preset = AgentLaunchPreset(
         tool: AgentLaunchTool.codex,
@@ -360,6 +381,7 @@ void main() {
       AgentLaunchTool.codex,
       AgentLaunchTool.openCode,
       AgentLaunchTool.geminiCli,
+      AgentLaunchTool.antigravity,
     ]) {
       final preset = AgentLaunchPreset(tool: tool);
       final decoded = AgentLaunchPreset.fromJson(preset.toJson());
@@ -388,12 +410,14 @@ void main() {
       expect(AgentLaunchTool.codex.label, 'Codex');
       expect(AgentLaunchTool.openCode.label, 'OpenCode');
       expect(AgentLaunchTool.geminiCli.label, 'Gemini CLI');
+      expect(AgentLaunchTool.antigravity.label, 'Antigravity');
     });
 
     test('new tool command names are correct', () {
       expect(AgentLaunchTool.codex.commandName, 'codex');
       expect(AgentLaunchTool.openCode.commandName, 'opencode');
       expect(AgentLaunchTool.geminiCli.commandName, 'gemini');
+      expect(AgentLaunchTool.antigravity.commandName, 'antigravity');
     });
 
     test('command lookup resolves bare names, paths, and argv tokens', () {
@@ -414,6 +438,14 @@ void main() {
       expect(
         agentLaunchToolForCommandName('gemini --yolo'),
         AgentLaunchTool.geminiCli,
+      );
+      expect(
+        agentLaunchToolForCommandName('antigravity'),
+        AgentLaunchTool.antigravity,
+      );
+      expect(
+        agentLaunchToolForCommandName('antigravity-cli'),
+        AgentLaunchTool.antigravity,
       );
       expect(
         agentLaunchToolForCommandName('gemini-cli'),

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -506,6 +506,7 @@ branch refs/heads/fix/session-resumption
         'Codex',
         'Gemini CLI',
         'OpenCode',
+        'Antigravity',
       ]);
     });
 
@@ -522,6 +523,7 @@ branch refs/heads/fix/session-resumption
         'Copilot CLI',
         'Gemini CLI',
         'OpenCode',
+        'Antigravity',
         'Custom Tool',
       ]);
     });
@@ -908,6 +910,52 @@ cwd: /tmp/demo
       );
       expect(metadata.workingDirectory, '/Users/depoll/Code/flutty');
       expect(metadata.updatedAt, DateTime.parse('2026-04-12T21:29:53.292Z'));
+    });
+  });
+
+  group('parseAntigravitySessionMetadata', () {
+    test('extracts session metadata from JSON fields', () {
+      final metadata = parseAntigravitySessionMetadata('''
+{
+  "id": "antigravity-123",
+  "name": "Refactor authentication",
+  "workingDirectory": "/Users/demo/app",
+  "updatedAt": "2024-03-20T12:00:00Z"
+}
+''');
+
+      expect(metadata.sessionId, 'antigravity-123');
+      expect(metadata.summary, 'Refactor authentication');
+      expect(metadata.workingDirectory, '/Users/demo/app');
+      expect(metadata.updatedAt, DateTime.parse('2024-03-20T12:00:00Z'));
+      expect(metadata.parsedAny, isTrue);
+    });
+
+    test('falls back to alternate field names', () {
+      final metadata = parseAntigravitySessionMetadata('''
+{
+  "sessionId": "ag-456",
+  "summary": "Fix layout",
+  "cwd": "/tmp",
+  "lastActive": "2024-03-20T13:00:00Z"
+}
+''');
+
+      expect(metadata.sessionId, 'ag-456');
+      expect(metadata.summary, 'Fix layout');
+      expect(metadata.workingDirectory, '/tmp');
+      expect(metadata.updatedAt, DateTime.parse('2024-03-20T13:00:00Z'));
+      expect(metadata.parsedAny, isTrue);
+    });
+
+    test('returns empty results for malformed JSON', () {
+      final metadata = parseAntigravitySessionMetadata('invalid');
+
+      expect(metadata.sessionId, isNull);
+      expect(metadata.summary, isNull);
+      expect(metadata.workingDirectory, isNull);
+      expect(metadata.updatedAt, isNull);
+      expect(metadata.parsedAny, isFalse);
     });
   });
 

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -948,8 +948,45 @@ cwd: /tmp/demo
       expect(metadata.parsedAny, isTrue);
     });
 
-    test('returns empty results for malformed JSON', () {
+    test('returns empty results for malformed JSON without fields', () {
       final metadata = parseAntigravitySessionMetadata('invalid');
+
+      expect(metadata.sessionId, isNull);
+      expect(metadata.summary, isNull);
+      expect(metadata.workingDirectory, isNull);
+      expect(metadata.updatedAt, isNull);
+      expect(metadata.parsedAny, isFalse);
+    });
+
+    test(
+      'extracts metadata from truncated/malformed JSON with partial parsing',
+      () {
+        final metadata = parseAntigravitySessionMetadata('''
+{
+  "id": "antigravity-trunc",
+  "name": "Partial refactoring",
+  "workingDirectory": "/Users/demo/trunc",
+  "updatedAt": "202
+'''); // Truncated/unclosed JSON
+
+        expect(metadata.sessionId, 'antigravity-trunc');
+        expect(metadata.summary, 'Partial refactoring');
+        expect(metadata.workingDirectory, '/Users/demo/trunc');
+        expect(
+          metadata.updatedAt,
+          isNull,
+        ); // Truncated date value cannot be parsed
+        expect(metadata.parsedAny, isTrue);
+      },
+    );
+
+    test('returns parsedAny: false for valid JSON with unexpected keys', () {
+      final metadata = parseAntigravitySessionMetadata('''
+{
+  "random_field": "val",
+  "another_one": 123
+}
+''');
 
       expect(metadata.sessionId, isNull);
       expect(metadata.summary, isNull);

--- a/test/domain/services/tmux_service_agent_detection_test.dart
+++ b/test/domain/services/tmux_service_agent_detection_test.dart
@@ -91,7 +91,8 @@ void main() {
           '/b/copilot\n'
           '/b/codex\n'
           '/b/gemini\n'
-          '/b/opencode\n';
+          '/b/opencode\n'
+          '/b/antigravity\n';
       expect(parseInstalledAgentTools(output), AgentLaunchTool.values.toSet());
     });
 
@@ -193,14 +194,16 @@ void main() {
         'codex${sep}codex-1${sep}502${sep}43${sep}medium$sep\n'
         'gemini${sep}gemini-1${sep}503${sep}44${sep}medium$sep\n'
         'opencode${sep}opencode-1${sep}504${sep}45${sep}medium$sep\n'
+        'antigravity${sep}anti-1${sep}506${sep}47${sep}medium$sep\n'
         'copilot${sep}copilot-1${sep}505${sep}46${sep}medium${sep}Title\n',
-        const {42, 43, 44, 45, 46},
+        const {42, 43, 44, 45, 46, 47},
       );
 
       expect(metadata[42]?.tool, AgentLaunchTool.claudeCode);
       expect(metadata[43]?.tool, AgentLaunchTool.codex);
       expect(metadata[44]?.tool, AgentLaunchTool.geminiCli);
       expect(metadata[45]?.tool, AgentLaunchTool.openCode);
+      expect(metadata[47]?.tool, AgentLaunchTool.antigravity);
       expect(metadata[46]?.tool, AgentLaunchTool.copilotCli);
       expect(metadata[46]?.title, 'Title');
       expect(metadata[46]?.confidence, AgentSessionConfidence.medium);


### PR DESCRIPTION
## Summary

This PR adds support for the **Antigravity CLI** agent to MonkeySSH.

### Features
- **Launch Presets**: Users can now select "Antigravity" from the agent launch tool list.
- **Session Discovery**: The app will now automatically discover recent Antigravity sessions stored in `~/.antigravity/sessions/*.json`.
- **YOLO Mode**: Full support for launching and resuming sessions in YOLO mode via the `--yolo` flag.
- **Tmux Integration**: Updated tmux window tracking to correctly identify and alias Antigravity terminal titles.

### Changes
- Added `antigravity` to `AgentLaunchTool`.
- Implemented `_discoverAntigravitySessions` in `AgentSessionDiscoveryService`.
- Updated `tmux_state.dart` for exhaustive matching and session ID extraction.
- Added comprehensive unit tests for presets and discovery.

### Verification
- Ran `flutter test test/domain/models/agent_launch_preset_test.dart` (Passed)
- Ran `flutter test test/domain/services/agent_session_discovery_service_test.dart` (Passed)
- Ran `flutter test test/widget/tmux_window_navigator_test.dart` (Passed)
