### PR TITLE
Tone down paste command warnings

### DIFF
--- a/integration_test/terminal_text_input_handler_device_test.dart
+++ b/integration_test/terminal_text_input_handler_device_test.dart
@@ -983,7 +983,7 @@ void main() {
       },
     );
 
-    testWidgets('reviews suspicious IME paste before sending it', (
+    testWidgets('reviews high-risk IME paste before sending it', (
       tester,
     ) async {
       final terminalOutput = <String>[];
@@ -1014,8 +1014,8 @@ void main() {
       (tester.state(find.byType(TerminalTextInputHandler)) as TextInputClient)
           .updateEditingValue(
             const TextEditingValue(
-              text: '\u200B\u200Becho ready\necho deploy',
-              selection: TextSelection.collapsed(offset: 24),
+              text: '\u200B\u200Becho \$(id)',
+              selection: TextSelection.collapsed(offset: 12),
             ),
           );
       await tester.pump();
@@ -1024,7 +1024,7 @@ void main() {
       expect(reviews, hasLength(1));
       expect(
         reviews.single.reasons,
-        contains(TerminalCommandReviewReason.multiline),
+        contains(TerminalCommandReviewReason.commandSubstitution),
       );
       expect(terminalOutput, isEmpty);
 

--- a/integration_test/terminal_text_input_handler_device_test.dart
+++ b/integration_test/terminal_text_input_handler_device_test.dart
@@ -983,7 +983,7 @@ void main() {
       },
     );
 
-    testWidgets('reviews high-risk IME paste before sending it', (
+    testWidgets('reviews unbracketed multiline IME paste before sending it', (
       tester,
     ) async {
       final terminalOutput = <String>[];
@@ -1014,8 +1014,8 @@ void main() {
       (tester.state(find.byType(TerminalTextInputHandler)) as TextInputClient)
           .updateEditingValue(
             const TextEditingValue(
-              text: '\u200B\u200Becho \$(id)',
-              selection: TextSelection.collapsed(offset: 12),
+              text: '\u200B\u200Becho ready\necho deploy',
+              selection: TextSelection.collapsed(offset: 24),
             ),
           );
       await tester.pump();
@@ -1024,7 +1024,7 @@ void main() {
       expect(reviews, hasLength(1));
       expect(
         reviews.single.reasons,
-        contains(TerminalCommandReviewReason.commandSubstitution),
+        contains(TerminalCommandReviewReason.multiline),
       );
       expect(terminalOutput, isEmpty);
 

--- a/lib/domain/models/auto_connect_command.dart
+++ b/lib/domain/models/auto_connect_command.dart
@@ -135,13 +135,16 @@ bool importedAutoConnectRequiresReview({
     resolveAutoConnectCommandMode(command: command, snippetId: snippetId) !=
     AutoConnectCommandMode.none;
 
-/// Assesses a clipboard paste for multiline or suspicious shell content.
+/// Assesses pasted text for shell content that still deserves review.
 TerminalCommandReview assessClipboardPasteCommand(
   String command, {
   required bool bracketedPasteModeEnabled,
 }) => TerminalCommandReview(
   command: command,
-  reasons: _collectSuspiciousCommandReasons(command),
+  reasons: _collectPasteCommandReviewReasons(
+    command,
+    bracketedPasteModeEnabled: bracketedPasteModeEnabled,
+  ),
   bracketedPasteModeEnabled: bracketedPasteModeEnabled,
 );
 
@@ -198,6 +201,50 @@ List<TerminalCommandReviewReason> _collectSuspiciousCommandReasons(
     reasons.add(TerminalCommandReviewReason.commandSubstitution);
   }
   return reasons;
+}
+
+List<TerminalCommandReviewReason> _collectPasteCommandReviewReasons(
+  String command, {
+  required bool bracketedPasteModeEnabled,
+}) {
+  final suspiciousReasons = _collectSuspiciousCommandReasons(command);
+  final hasMultiline = suspiciousReasons.contains(
+    TerminalCommandReviewReason.multiline,
+  );
+  final hasShellChaining = suspiciousReasons.contains(
+    TerminalCommandReviewReason.shellChaining,
+  );
+  final hasRedirection = suspiciousReasons.contains(
+    TerminalCommandReviewReason.redirection,
+  );
+  final hasControlCharacters = suspiciousReasons.contains(
+    TerminalCommandReviewReason.controlCharacters,
+  );
+  final hasCommandSubstitution = suspiciousReasons.contains(
+    TerminalCommandReviewReason.commandSubstitution,
+  );
+
+  final shouldReviewUnbracketedMultilineShellText =
+      !bracketedPasteModeEnabled &&
+      hasMultiline &&
+      (hasShellChaining || hasRedirection);
+
+  if (!shouldReviewUnbracketedMultilineShellText &&
+      !hasControlCharacters &&
+      !hasCommandSubstitution) {
+    return const <TerminalCommandReviewReason>[];
+  }
+
+  return [
+    if (shouldReviewUnbracketedMultilineShellText)
+      TerminalCommandReviewReason.multiline,
+    if (hasControlCharacters) TerminalCommandReviewReason.controlCharacters,
+    if (shouldReviewUnbracketedMultilineShellText && hasShellChaining)
+      TerminalCommandReviewReason.shellChaining,
+    if (shouldReviewUnbracketedMultilineShellText && hasRedirection)
+      TerminalCommandReviewReason.redirection,
+    if (hasCommandSubstitution) TerminalCommandReviewReason.commandSubstitution,
+  ];
 }
 
 ({bool shellChaining, bool redirection, bool commandSubstitution})

--- a/lib/domain/models/auto_connect_command.dart
+++ b/lib/domain/models/auto_connect_command.dart
@@ -224,24 +224,22 @@ List<TerminalCommandReviewReason> _collectPasteCommandReviewReasons(
     TerminalCommandReviewReason.commandSubstitution,
   );
 
-  final shouldReviewUnbracketedMultilineShellText =
-      !bracketedPasteModeEnabled &&
-      hasMultiline &&
-      (hasShellChaining || hasRedirection);
+  final shouldReviewUnbracketedMultilineText =
+      !bracketedPasteModeEnabled && hasMultiline;
 
-  if (!shouldReviewUnbracketedMultilineShellText &&
+  if (!shouldReviewUnbracketedMultilineText &&
       !hasControlCharacters &&
       !hasCommandSubstitution) {
     return const <TerminalCommandReviewReason>[];
   }
 
   return [
-    if (shouldReviewUnbracketedMultilineShellText)
+    if (shouldReviewUnbracketedMultilineText)
       TerminalCommandReviewReason.multiline,
     if (hasControlCharacters) TerminalCommandReviewReason.controlCharacters,
-    if (shouldReviewUnbracketedMultilineShellText && hasShellChaining)
+    if (shouldReviewUnbracketedMultilineText && hasShellChaining)
       TerminalCommandReviewReason.shellChaining,
-    if (shouldReviewUnbracketedMultilineShellText && hasRedirection)
+    if (shouldReviewUnbracketedMultilineText && hasRedirection)
       TerminalCommandReviewReason.redirection,
     if (hasCommandSubstitution) TerminalCommandReviewReason.commandSubstitution,
   ];

--- a/test/domain/models/auto_connect_command_test.dart
+++ b/test/domain/models/auto_connect_command_test.dart
@@ -128,33 +128,34 @@ void main() {
       );
     });
 
-    test('flags standalone ampersands as shell chaining', () {
-      final snippetReview = assessSnippetCommandInsertion(
-        'echo ready & echo done',
-        hadVariableSubstitution: false,
-      );
-      final clipboardReview = assessClipboardPasteCommand(
-        'echo ready &',
-        bracketedPasteModeEnabled: false,
-      );
-      final importedReview = assessAutoConnectCommandExecution(
-        'echo ready & echo done',
-        importedNeedsReview: true,
-      );
+    test(
+      'flags standalone ampersands as shell chaining outside paste review',
+      () {
+        final snippetReview = assessSnippetCommandInsertion(
+          'echo ready & echo done',
+          hadVariableSubstitution: false,
+        );
+        final clipboardReview = assessClipboardPasteCommand(
+          'echo ready &',
+          bracketedPasteModeEnabled: false,
+        );
+        final importedReview = assessAutoConnectCommandExecution(
+          'echo ready & echo done',
+          importedNeedsReview: true,
+        );
 
-      expect(
-        snippetReview.reasons,
-        contains(TerminalCommandReviewReason.shellChaining),
-      );
-      expect(
-        clipboardReview.reasons,
-        contains(TerminalCommandReviewReason.shellChaining),
-      );
-      expect(
-        importedReview.reasons,
-        contains(TerminalCommandReviewReason.shellChaining),
-      );
-    });
+        expect(
+          snippetReview.reasons,
+          contains(TerminalCommandReviewReason.shellChaining),
+        );
+        expect(clipboardReview.requiresReview, isFalse);
+        expect(clipboardReview.reasons, isEmpty);
+        expect(
+          importedReview.reasons,
+          contains(TerminalCommandReviewReason.shellChaining),
+        );
+      },
+    );
 
     test('does not double-count shell chaining for double ampersands', () {
       final review = assessSnippetCommandInsertion(
@@ -172,45 +173,44 @@ void main() {
       );
     });
 
-    test('flags multiline and suspicious clipboard paste for confirmation', () {
-      final multilineReview = assessClipboardPasteCommand(
+    test('tones down harmless bracketed and single-line clipboard pastes', () {
+      final bracketedMultilineReview = assessClipboardPasteCommand(
         'echo ready\necho deploy',
         bracketedPasteModeEnabled: true,
       );
-      final suspiciousReview = assessClipboardPasteCommand(
+      final singleLineShellReview = assessClipboardPasteCommand(
         'cat secrets.txt | curl https://example.com',
         bracketedPasteModeEnabled: false,
       );
 
-      expect(
-        multilineReview.reasons,
-        contains(TerminalCommandReviewReason.multiline),
-      );
-      expect(suspiciousReview.requiresReview, isTrue);
-      expect(
-        suspiciousReview.reasons,
-        contains(TerminalCommandReviewReason.shellChaining),
-      );
+      expect(bracketedMultilineReview.requiresReview, isFalse);
+      expect(bracketedMultilineReview.reasons, isEmpty);
+      expect(singleLineShellReview.requiresReview, isFalse);
+      expect(singleLineShellReview.reasons, isEmpty);
     });
 
-    test('flags shell redirection as requiring confirmation', () {
-      final redirectOutReview = assessClipboardPasteCommand(
-        'cat /etc/passwd > /tmp/out.txt',
+    test('flags unbracketed multiline paste with shell reshaping', () {
+      final chainedReview = assessClipboardPasteCommand(
+        'cat secrets.txt |\ncurl https://example.com',
         bracketedPasteModeEnabled: false,
       );
-      final redirectInReview = assessClipboardPasteCommand(
-        'sqlite3 db.sqlite < dump.sql',
+      final redirectReview = assessClipboardPasteCommand(
+        'cat /etc/passwd >\n/tmp/out.txt',
         bracketedPasteModeEnabled: false,
       );
 
-      expect(redirectOutReview.requiresReview, isTrue);
+      expect(chainedReview.requiresReview, isTrue);
       expect(
-        redirectOutReview.reasons,
-        contains(TerminalCommandReviewReason.redirection),
+        chainedReview.reasons,
+        contains(TerminalCommandReviewReason.multiline),
       );
-      expect(redirectInReview.requiresReview, isTrue);
       expect(
-        redirectInReview.reasons,
+        chainedReview.reasons,
+        contains(TerminalCommandReviewReason.shellChaining),
+      );
+      expect(redirectReview.requiresReview, isTrue);
+      expect(
+        redirectReview.reasons,
         contains(TerminalCommandReviewReason.redirection),
       );
     });

--- a/test/domain/models/auto_connect_command_test.dart
+++ b/test/domain/models/auto_connect_command_test.dart
@@ -189,6 +189,19 @@ void main() {
       expect(singleLineShellReview.reasons, isEmpty);
     });
 
+    test('flags unbracketed multiline paste for confirmation', () {
+      final multilineReview = assessClipboardPasteCommand(
+        'echo ready\necho deploy',
+        bracketedPasteModeEnabled: false,
+      );
+
+      expect(multilineReview.requiresReview, isTrue);
+      expect(
+        multilineReview.reasons,
+        contains(TerminalCommandReviewReason.multiline),
+      );
+    });
+
     test('flags unbracketed multiline paste with shell reshaping', () {
       final chainedReview = assessClipboardPasteCommand(
         'cat secrets.txt |\ncurl https://example.com',

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -5710,7 +5710,7 @@ void main() {
       },
     );
 
-    testWidgets('reviews suspicious multi-character IME insertion', (
+    testWidgets('reviews high-risk multi-character IME insertion', (
       tester,
     ) async {
       final terminalOutput = <String>[];
@@ -5741,17 +5741,17 @@ void main() {
 
       tester.testTextInput.updateEditingValue(
         const TextEditingValue(
-          text: '\u200B\u200Becho ready; rm -rf /',
-          selection: TextSelection.collapsed(offset: 21),
+          text: '\u200B\u200Becho \$(id)',
+          selection: TextSelection.collapsed(offset: 12),
         ),
       );
       await tester.pump();
 
       expect(reviews, hasLength(1));
-      expect(reviews.single.command, 'echo ready; rm -rf /');
+      expect(reviews.single.command, r'echo $(id)');
       expect(
         reviews.single.reasons,
-        contains(TerminalCommandReviewReason.shellChaining),
+        contains(TerminalCommandReviewReason.commandSubstitution),
       );
       expect(terminalOutput, isEmpty);
 
@@ -5760,8 +5760,8 @@ void main() {
       await tester.pump();
 
       expect(_terminalStateFromEvents(terminalOutput), (
-        text: 'echo ready; rm -rf /',
-        cursorOffset: 'echo ready; rm -rf '.length,
+        text: r'echo $(id)',
+        cursorOffset: r'echo $(id)'.length,
       ));
 
       focusNode.dispose();
@@ -5815,7 +5815,7 @@ void main() {
     );
 
     testWidgets(
-      'reviews a suspicious committed IME payload after composition ends',
+      'reviews a high-risk committed IME payload after composition ends',
       (tester) async {
         final terminalOutput = <String>[];
         final terminal = Terminal(onOutput: terminalOutput.add);
@@ -5845,9 +5845,9 @@ void main() {
 
         tester.testTextInput.updateEditingValue(
           const TextEditingValue(
-            text: '\u200B\u200Becho ready; rm -rf /',
-            selection: TextSelection.collapsed(offset: 21),
-            composing: TextRange(start: 2, end: 21),
+            text: '\u200B\u200Becho \$(id)',
+            selection: TextSelection.collapsed(offset: 12),
+            composing: TextRange(start: 2, end: 12),
           ),
         );
         await tester.pump();
@@ -5857,14 +5857,14 @@ void main() {
 
         tester.testTextInput.updateEditingValue(
           const TextEditingValue(
-            text: '\u200B\u200Becho ready; rm -rf /',
-            selection: TextSelection.collapsed(offset: 21),
+            text: '\u200B\u200Becho \$(id)',
+            selection: TextSelection.collapsed(offset: 12),
           ),
         );
         await tester.pump();
 
         expect(reviews, hasLength(1));
-        expect(reviews.single.command, 'echo ready; rm -rf /');
+        expect(reviews.single.command, r'echo $(id)');
         expect(terminalOutput, isEmpty);
 
         decision.complete(true);
@@ -5872,21 +5872,20 @@ void main() {
         await tester.pump();
 
         expect(_terminalStateFromEvents(terminalOutput), (
-          text: 'echo ready; rm -rf /',
-          cursorOffset: 'echo ready; rm -rf '.length,
+          text: r'echo $(id)',
+          cursorOffset: r'echo $(id)'.length,
         ));
 
         focusNode.dispose();
       },
     );
 
-    testWidgets('reviews a committed IME payload with a standalone ampersand', (
+    testWidgets('does not review harmless IME text with standalone ampersand', (
       tester,
     ) async {
       final terminalOutput = <String>[];
       final terminal = Terminal(onOutput: terminalOutput.add);
       final focusNode = FocusNode();
-      final decision = Completer<bool>();
       final reviews = <TerminalCommandReview>[];
 
       await tester.pumpWidget(
@@ -5896,9 +5895,9 @@ void main() {
               terminal: terminal,
               focusNode: focusNode,
               deleteDetection: true,
-              onReviewInsertedText: (review) {
+              onReviewInsertedText: (review) async {
                 reviews.add(review);
-                return decision.future;
+                return true;
               },
               child: const SizedBox.expand(),
             ),
@@ -5917,25 +5916,14 @@ void main() {
       );
       await tester.pump();
 
-      expect(reviews, hasLength(1));
-      expect(reviews.single.command, 'echo ready & echo done');
-      expect(
-        reviews.single.reasons,
-        contains(TerminalCommandReviewReason.shellChaining),
-      );
-      expect(terminalOutput, isEmpty);
-
-      decision.complete(true);
-      await tester.pump();
-      await tester.pump();
-
+      expect(reviews, isEmpty);
       expect(terminalOutput.join(), 'echo ready & echo done');
 
       focusNode.dispose();
     });
 
     testWidgets(
-      'reviews a suspicious committed IME payload while keeping its selection',
+      'reviews a high-risk committed IME payload while keeping its selection',
       (tester) async {
         final terminalOutput = <String>[];
         final terminal = Terminal(onOutput: terminalOutput.add);
@@ -5963,8 +5951,8 @@ void main() {
         focusNode.requestFocus();
         await tester.pump();
 
-        const suspiciousUserText = 'echo ready; rm -rf /';
-        const suspiciousText = '\u200B\u200Becho ready; rm -rf /';
+        const suspiciousUserText = r'echo $(id)';
+        const suspiciousText = '\u200B\u200Becho \$(id)';
         const suspiciousSelection = TextSelection(
           baseOffset: _deleteDetectionMarker.length,
           extentOffset: suspiciousText.length,
@@ -5983,7 +5971,7 @@ void main() {
         expect(reviews.single.command, suspiciousUserText);
         expect(
           reviews.single.reasons,
-          contains(TerminalCommandReviewReason.shellChaining),
+          contains(TerminalCommandReviewReason.commandSubstitution),
         );
         expect(terminalOutput, isEmpty);
         expect(
@@ -6020,7 +6008,7 @@ void main() {
       },
     );
 
-    testWidgets('rejects suspicious IME insertion until the user approves', (
+    testWidgets('rejects high-risk IME insertion until the user approves', (
       tester,
     ) async {
       final terminalOutput = <String>[];
@@ -6046,8 +6034,8 @@ void main() {
 
       tester.testTextInput.updateEditingValue(
         const TextEditingValue(
-          text: '\u200B\u200Becho ready\necho deploy',
-          selection: TextSelection.collapsed(offset: 24),
+          text: '\u200B\u200Becho \$(id)',
+          selection: TextSelection.collapsed(offset: 12),
         ),
       );
       await tester.pump();
@@ -6063,7 +6051,7 @@ void main() {
     });
 
     testWidgets(
-      'reviews IME insertions against the full terminal line context',
+      'reviews high-risk IME insertions against the full terminal line context',
       (tester) async {
         final terminalOutput = <String>[];
         final terminal = Terminal(onOutput: terminalOutput.add);
@@ -6090,7 +6078,7 @@ void main() {
         focusNode.requestFocus();
         await tester.pump();
 
-        const existingCommand = 'echo ready &';
+        const existingCommand = r'echo $(';
         for (var index = 1; index <= existingCommand.length; index++) {
           final currentCommand = existingCommand.substring(0, index);
           tester.testTextInput.updateEditingValue(
@@ -6106,7 +6094,7 @@ void main() {
 
         reviews.clear();
 
-        const combinedCommand = '$existingCommand echo done';
+        const combinedCommand = '${existingCommand}id)';
         tester.testTextInput.updateEditingValue(
           const TextEditingValue(
             text: '$_deleteDetectionMarker$combinedCommand',
@@ -6123,7 +6111,7 @@ void main() {
         expect(reviews.single.command, combinedCommand);
         expect(
           reviews.single.reasons,
-          contains(TerminalCommandReviewReason.shellChaining),
+          contains(TerminalCommandReviewReason.commandSubstitution),
         );
 
         focusNode.dispose();
@@ -6161,8 +6149,8 @@ void main() {
 
         tester.testTextInput.updateEditingValue(
           const TextEditingValue(
-            text: '\u200B\u200Becho ready; rm -rf /',
-            selection: TextSelection.collapsed(offset: 21),
+            text: '\u200B\u200Becho \$(id)',
+            selection: TextSelection.collapsed(offset: 12),
           ),
         );
         await tester.pump();
@@ -6232,8 +6220,8 @@ void main() {
 
         tester.testTextInput.updateEditingValue(
           const TextEditingValue(
-            text: '\u200B\u200Becho ready; rm -rf /',
-            selection: TextSelection.collapsed(offset: 21),
+            text: '\u200B\u200Becho \$(id)',
+            selection: TextSelection.collapsed(offset: 12),
           ),
         );
         await tester.pump();
@@ -6285,8 +6273,8 @@ void main() {
 
         tester.testTextInput.updateEditingValue(
           const TextEditingValue(
-            text: '\u200B\u200Becho ready; rm -rf /',
-            selection: TextSelection.collapsed(offset: 21),
+            text: '\u200B\u200Becho \$(id)',
+            selection: TextSelection.collapsed(offset: 12),
           ),
         );
         await tester.pump();
@@ -6324,89 +6312,86 @@ void main() {
       },
     );
 
-    testWidgets(
-      'reviews IME insertions against terminal state after input resets',
-      (tester) async {
-        final terminalOutput = <String>[];
-        final terminal = Terminal(onOutput: terminalOutput.add);
-        final focusNode = FocusNode();
-        final reviews = <TerminalCommandReview>[];
-        var readOnly = false;
+    testWidgets('reviews high-risk IME insertions after input resets', (
+      tester,
+    ) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+      final focusNode = FocusNode();
+      final reviews = <TerminalCommandReview>[];
+      var readOnly = false;
 
-        Widget buildHandler() => MaterialApp(
-          home: Scaffold(
-            body: TerminalTextInputHandler(
-              terminal: terminal,
-              focusNode: focusNode,
-              deleteDetection: true,
-              readOnly: readOnly,
-              buildReviewTextForInsertedText: (delta, currentText) =>
-                  applyTerminalInputDelta(
-                    currentText: _terminalTextFromEvents(terminalOutput),
-                    cursorOffset: _terminalTextFromEvents(
-                      terminalOutput,
-                    ).length,
-                    deletedCount: delta.deletedCount,
-                    appendedText: delta.appendedText,
-                  ),
-              onReviewInsertedText: (review) async {
-                reviews.add(review);
-                return false;
-              },
-              child: const SizedBox.expand(),
-            ),
+      Widget buildHandler() => MaterialApp(
+        home: Scaffold(
+          body: TerminalTextInputHandler(
+            terminal: terminal,
+            focusNode: focusNode,
+            deleteDetection: true,
+            readOnly: readOnly,
+            buildReviewTextForInsertedText: (delta, currentText) =>
+                applyTerminalInputDelta(
+                  currentText: _terminalTextFromEvents(terminalOutput),
+                  cursorOffset: _terminalTextFromEvents(terminalOutput).length,
+                  deletedCount: delta.deletedCount,
+                  appendedText: delta.appendedText,
+                ),
+            onReviewInsertedText: (review) async {
+              reviews.add(review);
+              return false;
+            },
+            child: const SizedBox.expand(),
           ),
-        );
+        ),
+      );
 
-        await tester.pumpWidget(buildHandler());
+      await tester.pumpWidget(buildHandler());
 
-        focusNode.requestFocus();
-        await tester.pump();
+      focusNode.requestFocus();
+      await tester.pump();
 
-        const existingCommand = 'echo ready &';
-        for (var index = 1; index <= existingCommand.length; index++) {
-          final currentCommand = existingCommand.substring(0, index);
-          tester.testTextInput.updateEditingValue(
-            TextEditingValue(
-              text: '$_deleteDetectionMarker$currentCommand',
-              selection: TextSelection.collapsed(
-                offset: _deleteDetectionMarker.length + currentCommand.length,
-              ),
-            ),
-          );
-          await tester.pump();
-        }
-
-        readOnly = true;
-        await tester.pumpWidget(buildHandler());
-        await tester.pump();
-
-        readOnly = false;
-        await tester.pumpWidget(buildHandler());
-        await tester.pump();
-
-        reviews.clear();
-
+      const existingCommand = r'echo $(';
+      for (var index = 1; index <= existingCommand.length; index++) {
+        final currentCommand = existingCommand.substring(0, index);
         tester.testTextInput.updateEditingValue(
-          const TextEditingValue(
-            text: '$_deleteDetectionMarker echo done',
-            selection: TextSelection.collapsed(offset: 12),
+          TextEditingValue(
+            text: '$_deleteDetectionMarker$currentCommand',
+            selection: TextSelection.collapsed(
+              offset: _deleteDetectionMarker.length + currentCommand.length,
+            ),
           ),
         );
         await tester.pump();
-        await tester.pump();
+      }
 
-        expect(reviews, hasLength(1));
-        expect(reviews.single.command, 'echo ready & echo done');
-        expect(
-          reviews.single.reasons,
-          contains(TerminalCommandReviewReason.shellChaining),
-        );
-        expect(_terminalTextFromEvents(terminalOutput), existingCommand);
+      readOnly = true;
+      await tester.pumpWidget(buildHandler());
+      await tester.pump();
 
-        focusNode.dispose();
-      },
-    );
+      readOnly = false;
+      await tester.pumpWidget(buildHandler());
+      await tester.pump();
+
+      reviews.clear();
+
+      tester.testTextInput.updateEditingValue(
+        const TextEditingValue(
+          text: '$_deleteDetectionMarker id)',
+          selection: TextSelection.collapsed(offset: 6),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(reviews, hasLength(1));
+      expect(reviews.single.command, r'echo $( id)');
+      expect(
+        reviews.single.reasons,
+        contains(TerminalCommandReviewReason.commandSubstitution),
+      );
+      expect(_terminalTextFromEvents(terminalOutput), existingCommand);
+
+      focusNode.dispose();
+    });
   });
 
   group('shouldRequestKeyboardForTerminalPointerUp', () {


### PR DESCRIPTION
## Summary

- Reduce paste/IME command review to rare high-risk cases: command substitution, hidden control characters, or unbracketed multiline shell reshaping.
- Stop warning for harmless bracketed multiline pastes, single-line shell punctuation, and IME text such as standalone ampersands.
- Update terminal input tests to cover the narrower review behavior.

## Testing

- flutter analyze
- flutter test test/domain/models/auto_connect_command_test.dart test/widget/terminal_text_input_handler_test.dart
- flutter test -d macos integration_test/terminal_text_input_handler_device_test.dart --name "reviews high-risk IME paste before sending it"

Note: Running the full local integration test file hit an unrelated macOS hit-test failure in `touch-driven caret moves clear the IME buffer after a replacement selection collapses elsewhere`.
