### PR TITLE
feat: resolve antigravity session names and titles for tmux windows

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -4380,6 +4380,44 @@ flutty_gemini_recent_session_match() {
     break
   done
 }
+flutty_antigravity_session_title() {
+  session_id=\$1
+  [ -n "\$session_id" ] || return 0
+  title=
+  annotation_file="\$home/.gemini/antigravity-cli/annotations/\${session_id}.pbtxt"
+  if [ -r "\$annotation_file" ]; then
+    title=\$(grep -E '^[[:space:]]*title[[:space:]]*:[[:space:]]*' "\$annotation_file" 2>/dev/null |
+      sed -E 's/^[[:space:]]*title[[:space:]]*:[[:space:]]*"([^"]*)".*/\\1/' | head -n 1)
+  fi
+  if [ -z "\$title" ] && [ -r "\$home/.gemini/antigravity-cli/history.jsonl" ]; then
+    title=\$(grep -F "\$session_id" "\$home/.gemini/antigravity-cli/history.jsonl" 2>/dev/null |
+      grep '"display"' | tail -n 1 | flutty_json_string_field_from_stdin display)
+  fi
+  if [ -z "\$title" ]; then
+    title="\$session_id"
+  fi
+  flutty_clean_session_title "\$title"
+}
+flutty_antigravity_recent_session_match() {
+  process_cwd=\$1
+  process_start_epoch=\$2
+  [ -n "\$process_cwd" ] || return 0
+  case "\$process_start_epoch" in ''|*[!0-9]*) return 0 ;; esac
+  history_file="\$home/.gemini/antigravity-cli/history.jsonl"
+  [ -r "\$history_file" ] || return 0
+  session_id=\$(tail -n 100 "\$history_file" 2>/dev/null |
+    grep -F "\$process_cwd" |
+    tail -n 1 |
+    flutty_json_string_field_from_stdin conversationId)
+  if [ -z "\$session_id" ]; then
+    session_id=\$(tail -n 1 "\$history_file" 2>/dev/null |
+      flutty_json_string_field_from_stdin conversationId)
+  fi
+  if [ -n "\$session_id" ]; then
+    title=\$(flutty_antigravity_session_title "\$session_id")
+    flutty_emit_lsof_match "\$session_id" "\$title"
+  fi
+}
 flutty_emit_lsof_match() {
   value=\$(printf '%s' "\$1" | tr "\\037\\r\\n" "   ")
   title=\$(flutty_clean_session_title "\$2")
@@ -4502,6 +4540,7 @@ END {
         case "\$tool" in
           codex) recent_match=\$(flutty_codex_recent_session_match "\$process_cwd" "\$process_start_epoch" "\$pid" || true) ;;
           gemini) recent_match=\$(flutty_gemini_recent_session_match "\$process_cwd" "\$process_start_epoch" || true) ;;
+          antigravity) recent_match=\$(flutty_antigravity_recent_session_match "\$process_cwd" "\$process_start_epoch" || true) ;;
           *) recent_match= ;;
         esac
         if [ -n "\$recent_match" ]; then
@@ -4515,6 +4554,11 @@ END {
           antigravity) session_id=\$(flutty_arg_value --conversation "\$command_text") ;;
           codex) session_id=\$(flutty_codex_resume_id "\$command_text") ;;
           opencode) session_id=\$(flutty_arg_value --session "\$command_text") ;;
+        esac
+      fi
+      if [ -n "\$session_id" ] && [ -z "\$title" ]; then
+        case "\$tool" in
+          antigravity) title=\$(flutty_antigravity_session_title "\$session_id") ;;
         esac
       fi
       [ -n "\$session_id" ] || continue

--- a/test/domain/services/tmux_service_agent_detection_test.dart
+++ b/test/domain/services/tmux_service_agent_detection_test.dart
@@ -139,6 +139,8 @@ void main() {
         expect(command, contains('flutty_codex_logs_resume_match'));
         expect(command, contains('flutty_codex_recent_session_match'));
         expect(command, contains('flutty_gemini_recent_session_match'));
+        expect(command, contains('flutty_antigravity_recent_session_match'));
+        expect(command, contains('flutty_antigravity_session_title'));
         expect(command, contains('customTitle'));
         expect(command, contains('thread_name'));
         expect(command, contains('summary'));
@@ -194,8 +196,9 @@ void main() {
         'codex${sep}codex-1${sep}502${sep}43${sep}medium$sep\n'
         'gemini${sep}gemini-1${sep}503${sep}44${sep}medium$sep\n'
         'opencode${sep}opencode-1${sep}504${sep}45${sep}medium$sep\n'
+        'antigravity${sep}antigravity-1${sep}506${sep}47${sep}medium${sep}Anti Title\n'
         'copilot${sep}copilot-1${sep}505${sep}46${sep}medium${sep}Title\n',
-        const {42, 43, 44, 45, 46},
+        const {42, 43, 44, 45, 46, 47},
       );
 
       expect(metadata[42]?.tool, AgentLaunchTool.claudeCode);
@@ -205,6 +208,9 @@ void main() {
       expect(metadata[46]?.tool, AgentLaunchTool.copilotCli);
       expect(metadata[46]?.title, 'Title');
       expect(metadata[46]?.confidence, AgentSessionConfidence.medium);
+      expect(metadata[47]?.tool, AgentLaunchTool.antigravity);
+      expect(metadata[47]?.sessionId, 'antigravity-1');
+      expect(metadata[47]?.title, 'Anti Title');
     });
 
     test(


### PR DESCRIPTION
## Summary

This PR adds complete support for resolving and formatting active Antigravity session names, custom title annotations, and matching recent sessions in tmux windows.

### Key Changes
- **Session Title Resolution (`flutty_antigravity_session_title`):** Implemented a shell function inside `TmuxService` to look up Antigravity title annotations in `~/.gemini/antigravity-cli/annotations/<id>.pbtxt` or display summaries in `~/.gemini/antigravity-cli/history.jsonl` on the remote.
- **Recent Session Matching (`flutty_antigravity_recent_session_match`):** Added logic to map running `agy` processes to active session IDs by inspecting directory paths and logs.
- **Active Metadata Generation:** Hooked up the new functions into the active process watcher loop inside `TmuxService`.
- **Tests:** Updated `test/domain/services/tmux_service_agent_detection_test.dart` to verify generated active session queries and metadata parsing.
