### PR TITLE
fix: resolve Android predictive back gesture preview flashing light gray

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -97,7 +97,13 @@ ThemeData buildTerminalAppTheme({
     themeId: themeId,
     additionalThemes: terminalThemes,
   );
-  return FluttyTheme.fromTerminalTheme(terminalTheme, brightness: brightness);
+  final resolvedBrightness = terminalTheme.isDark
+      ? Brightness.dark
+      : Brightness.light;
+  return FluttyTheme.fromTerminalTheme(
+    terminalTheme,
+    brightness: resolvedBrightness,
+  );
 }
 
 class _BackgroundLifecycleBridge extends ConsumerStatefulWidget {

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 
 import '../domain/models/monetization.dart';
 import '../domain/services/auth_service.dart';
+import '../domain/services/settings_service.dart';
 import '../presentation/screens/auth_setup_screen.dart';
 import '../presentation/screens/home_screen.dart';
 import '../presentation/screens/host_edit_screen.dart';
@@ -62,7 +63,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/terminal/:hostId',
         name: Routes.terminal,
-        builder: (context, state) {
+        pageBuilder: (context, state) {
           final hostId = int.tryParse(state.pathParameters['hostId'] ?? '');
           final connectionId = int.tryParse(
             state.uri.queryParameters['connectionId'] ?? '',
@@ -74,28 +75,33 @@ final routerProvider = Provider<GoRouter>((ref) {
           );
           final initialTmuxWindowId = state.uri.queryParameters['tmuxWindowId'];
           if (hostId == null) {
-            return const Scaffold(body: Center(child: Text('Invalid host ID')));
+            return const MaterialPage(
+              child: Scaffold(body: Center(child: Text('Invalid host ID'))),
+            );
           }
-          return TerminalScreen(
-            key: ValueKey<Object>(
-              Object.hash(
-                hostId,
-                connectionId,
-                initialTmuxSessionName,
-                initialTmuxWindowIndex,
-                initialTmuxWindowId,
-                state.uri.queryParameters['notificationTap'],
+          return TerminalPage<void>(
+            key: state.pageKey,
+            child: TerminalScreen(
+              key: ValueKey<Object>(
+                Object.hash(
+                  hostId,
+                  connectionId,
+                  initialTmuxSessionName,
+                  initialTmuxWindowIndex,
+                  initialTmuxWindowId,
+                  state.uri.queryParameters['notificationTap'],
+                ),
               ),
+              hostId: hostId,
+              connectionId: connectionId,
+              initialTmuxSessionName: initialTmuxSessionName,
+              initialTmuxWindowIndex: initialTmuxWindowIndex,
+              initialTmuxWindowId: initialTmuxWindowId,
+              initialTmuxWindowRequiresVisibleSession:
+                  state.uri.queryParameters['notificationTap'] != null,
+              initiallyExpandTmuxWindows:
+                  state.uri.queryParameters['expandTmux'] == '1',
             ),
-            hostId: hostId,
-            connectionId: connectionId,
-            initialTmuxSessionName: initialTmuxSessionName,
-            initialTmuxWindowIndex: initialTmuxWindowIndex,
-            initialTmuxWindowId: initialTmuxWindowId,
-            initialTmuxWindowRequiresVisibleSession:
-                state.uri.queryParameters['notificationTap'] != null,
-            initiallyExpandTmuxWindows:
-                state.uri.queryParameters['expandTmux'] == '1',
           );
         },
       ),
@@ -283,4 +289,74 @@ String? redirectForAuthState({
   }
 
   return null;
+}
+
+/// A custom [Page] that forces transition animations to use the active
+/// terminal theme's brightness and background color, preserving a seamless
+/// visual style during Android predictive back gestures and transition overlays.
+class TerminalPage<T> extends Page<T> {
+  /// Creates a new [TerminalPage].
+  const TerminalPage({
+    required this.child,
+    super.key,
+    super.name,
+    super.arguments,
+    super.restorationId,
+  });
+
+  /// The child widget.
+  final Widget child;
+
+  @override
+  Route<T> createRoute(BuildContext context) =>
+      _TerminalPageRoute<T>(page: this);
+}
+
+class _TerminalPageRoute<T> extends MaterialPageRoute<T> {
+  _TerminalPageRoute({required TerminalPage<T> page})
+    : super(builder: (context) => page.child, settings: page);
+
+  TerminalPage<T> get page => settings as TerminalPage<T>;
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    final theme = Theme.of(context);
+    final container = ProviderScope.containerOf(context);
+    final terminalTheme = container.read(activeTerminalThemeProvider);
+
+    final isDark = terminalTheme?.isDark ?? true;
+    final backgroundColor =
+        terminalTheme?.background ?? const Color(0xFF0D0D12);
+    final resolvedBrightness = isDark ? Brightness.dark : Brightness.light;
+    final pageTransitionsTheme = theme.pageTransitionsTheme;
+
+    Widget buildTransitionsWithContext(BuildContext targetContext) =>
+        pageTransitionsTheme.buildTransitions<T>(
+          this,
+          targetContext,
+          animation,
+          secondaryAnimation,
+          child,
+        );
+
+    if (theme.brightness == resolvedBrightness) {
+      return buildTransitionsWithContext(context);
+    }
+
+    final themedData = theme.copyWith(
+      brightness: resolvedBrightness,
+      canvasColor: backgroundColor,
+      scaffoldBackgroundColor: backgroundColor,
+    );
+
+    return Theme(
+      data: themedData,
+      child: Builder(builder: buildTransitionsWithContext),
+    );
+  }
 }

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -62,7 +62,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/terminal/:hostId',
         name: Routes.terminal,
-        pageBuilder: (context, state) {
+        builder: (context, state) {
           final hostId = int.tryParse(state.pathParameters['hostId'] ?? '');
           final connectionId = int.tryParse(
             state.uri.queryParameters['connectionId'] ?? '',
@@ -74,36 +74,28 @@ final routerProvider = Provider<GoRouter>((ref) {
           );
           final initialTmuxWindowId = state.uri.queryParameters['tmuxWindowId'];
           if (hostId == null) {
-            return _buildTerminalTransitionPage<void>(
-              key: state.pageKey,
-              child: const Scaffold(
-                body: Center(child: Text('Invalid host ID')),
-              ),
-            );
+            return const Scaffold(body: Center(child: Text('Invalid host ID')));
           }
-          return _buildTerminalTransitionPage<void>(
-            key: state.pageKey,
-            child: TerminalScreen(
-              key: ValueKey<Object>(
-                Object.hash(
-                  hostId,
-                  connectionId,
-                  initialTmuxSessionName,
-                  initialTmuxWindowIndex,
-                  initialTmuxWindowId,
-                  state.uri.queryParameters['notificationTap'],
-                ),
+          return TerminalScreen(
+            key: ValueKey<Object>(
+              Object.hash(
+                hostId,
+                connectionId,
+                initialTmuxSessionName,
+                initialTmuxWindowIndex,
+                initialTmuxWindowId,
+                state.uri.queryParameters['notificationTap'],
               ),
-              hostId: hostId,
-              connectionId: connectionId,
-              initialTmuxSessionName: initialTmuxSessionName,
-              initialTmuxWindowIndex: initialTmuxWindowIndex,
-              initialTmuxWindowId: initialTmuxWindowId,
-              initialTmuxWindowRequiresVisibleSession:
-                  state.uri.queryParameters['notificationTap'] != null,
-              initiallyExpandTmuxWindows:
-                  state.uri.queryParameters['expandTmux'] == '1',
             ),
+            hostId: hostId,
+            connectionId: connectionId,
+            initialTmuxSessionName: initialTmuxSessionName,
+            initialTmuxWindowIndex: initialTmuxWindowIndex,
+            initialTmuxWindowId: initialTmuxWindowId,
+            initialTmuxWindowRequiresVisibleSession:
+                state.uri.queryParameters['notificationTap'] != null,
+            initiallyExpandTmuxWindows:
+                state.uri.queryParameters['expandTmux'] == '1',
           );
         },
       ),
@@ -263,25 +255,6 @@ CustomTransitionPage<T> _buildSlideUpPage<T>({
           ).chain(CurveTween(curve: Curves.easeOutCubic)),
         ),
         child: child,
-      ),
-  child: child,
-);
-
-CustomTransitionPage<T> _buildTerminalTransitionPage<T>({
-  required LocalKey key,
-  required Widget child,
-}) => CustomTransitionPage<T>(
-  key: key,
-  reverseTransitionDuration: const Duration(milliseconds: 250),
-  transitionsBuilder: (context, animation, secondaryAnimation, child) =>
-      ScaleTransition(
-        scale: animation.drive(
-          Tween<double>(
-            begin: 0.96,
-            end: 1,
-          ).chain(CurveTween(curve: Curves.easeOutCubic)),
-        ),
-        child: FadeTransition(opacity: animation, child: child),
       ),
   child: child,
 );

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -62,7 +62,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/terminal/:hostId',
         name: Routes.terminal,
-        builder: (context, state) {
+        pageBuilder: (context, state) {
           final hostId = int.tryParse(state.pathParameters['hostId'] ?? '');
           final connectionId = int.tryParse(
             state.uri.queryParameters['connectionId'] ?? '',
@@ -74,28 +74,36 @@ final routerProvider = Provider<GoRouter>((ref) {
           );
           final initialTmuxWindowId = state.uri.queryParameters['tmuxWindowId'];
           if (hostId == null) {
-            return const Scaffold(body: Center(child: Text('Invalid host ID')));
-          }
-          return TerminalScreen(
-            key: ValueKey<Object>(
-              Object.hash(
-                hostId,
-                connectionId,
-                initialTmuxSessionName,
-                initialTmuxWindowIndex,
-                initialTmuxWindowId,
-                state.uri.queryParameters['notificationTap'],
+            return _buildTerminalTransitionPage<void>(
+              key: state.pageKey,
+              child: const Scaffold(
+                body: Center(child: Text('Invalid host ID')),
               ),
+            );
+          }
+          return _buildTerminalTransitionPage<void>(
+            key: state.pageKey,
+            child: TerminalScreen(
+              key: ValueKey<Object>(
+                Object.hash(
+                  hostId,
+                  connectionId,
+                  initialTmuxSessionName,
+                  initialTmuxWindowIndex,
+                  initialTmuxWindowId,
+                  state.uri.queryParameters['notificationTap'],
+                ),
+              ),
+              hostId: hostId,
+              connectionId: connectionId,
+              initialTmuxSessionName: initialTmuxSessionName,
+              initialTmuxWindowIndex: initialTmuxWindowIndex,
+              initialTmuxWindowId: initialTmuxWindowId,
+              initialTmuxWindowRequiresVisibleSession:
+                  state.uri.queryParameters['notificationTap'] != null,
+              initiallyExpandTmuxWindows:
+                  state.uri.queryParameters['expandTmux'] == '1',
             ),
-            hostId: hostId,
-            connectionId: connectionId,
-            initialTmuxSessionName: initialTmuxSessionName,
-            initialTmuxWindowIndex: initialTmuxWindowIndex,
-            initialTmuxWindowId: initialTmuxWindowId,
-            initialTmuxWindowRequiresVisibleSession:
-                state.uri.queryParameters['notificationTap'] != null,
-            initiallyExpandTmuxWindows:
-                state.uri.queryParameters['expandTmux'] == '1',
           );
         },
       ),
@@ -255,6 +263,25 @@ CustomTransitionPage<T> _buildSlideUpPage<T>({
           ).chain(CurveTween(curve: Curves.easeOutCubic)),
         ),
         child: child,
+      ),
+  child: child,
+);
+
+CustomTransitionPage<T> _buildTerminalTransitionPage<T>({
+  required LocalKey key,
+  required Widget child,
+}) => CustomTransitionPage<T>(
+  key: key,
+  reverseTransitionDuration: const Duration(milliseconds: 250),
+  transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+      ScaleTransition(
+        scale: animation.drive(
+          Tween<double>(
+            begin: 0.96,
+            end: 1,
+          ).chain(CurveTween(curve: Curves.easeOutCubic)),
+        ),
+        child: FadeTransition(opacity: animation, child: child),
       ),
   child: child,
 );

--- a/lib/domain/services/settings_service.dart
+++ b/lib/domain/services/settings_service.dart
@@ -264,6 +264,26 @@ class ThemeModeNotifier extends _AsyncSettingsNotifier<ThemeMode> {
 final themeModeNotifierProvider =
     NotifierProvider<ThemeModeNotifier, ThemeMode>(ThemeModeNotifier.new);
 
+/// Notifier to manage active terminal theme state.
+class ActiveTerminalThemeNotifier extends Notifier<TerminalThemeData?> {
+  @override
+  TerminalThemeData? build() => null;
+
+  /// Gets the active terminal theme.
+  TerminalThemeData? get theme => state;
+
+  /// Updates the active terminal theme.
+  set theme(TerminalThemeData? value) {
+    state = value;
+  }
+}
+
+/// Provider to track the active terminal theme for page transition brightness.
+final activeTerminalThemeProvider =
+    NotifierProvider<ActiveTerminalThemeNotifier, TerminalThemeData?>(
+      ActiveTerminalThemeNotifier.new,
+    );
+
 /// Provider for terminal themes applying to app chrome.
 final terminalThemesApplyToAppProvider = FutureProvider<bool>((ref) async {
   final settings = ref.watch(settingsServiceProvider);

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -8744,7 +8744,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _collapseTmuxBarIfExpanded();
       },
       child: Scaffold(
-        backgroundColor: theme.colorScheme.surface,
+        backgroundColor: terminalTheme.background,
         appBar: AppBar(
           titleSpacing: 8,
           title: Row(

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2683,6 +2683,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   );
   final _terminalViewKey = GlobalKey<MonkeyTerminalViewState>();
   final _tmuxBarKey = GlobalKey<_TmuxExpandableBarState>();
+  ActiveTerminalThemeNotifier? _terminalThemeNotifier;
 
   late Terminal _terminal;
   late final TerminalController _terminalController;
@@ -3270,6 +3271,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       },
     );
     _tmuxService = ref.read(tmuxServiceProvider);
+    _terminalThemeNotifier = ref.read(activeTerminalThemeProvider.notifier);
     _tmuxMultiplexerService = TmuxRemoteMultiplexerService(_tmuxService);
     _monkeyMuxService = ref.read(monkeyMuxServiceProvider);
     _monkeyMuxInstallerService = ref.read(monkeyMuxInstallerServiceProvider);
@@ -3503,6 +3505,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     bool forceRemoteRefresh = false,
     String reason = 'unspecified',
   }) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        final currentActive = ref.read(activeTerminalThemeProvider);
+        if (currentActive != theme) {
+          ref.read(activeTerminalThemeProvider.notifier).theme = theme;
+        }
+      }
+    });
     final targetSession = _sessionController.resolveTargetSession(
       session: session,
     );
@@ -8499,6 +8509,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    // Clear the active terminal theme when leaving the screen
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      try {
+        _terminalThemeNotifier?.theme = null;
+      } on Object catch (_) {
+        // Ignored. This can occur in widget tests if the ProviderScope is
+        // torn down at the end of the test before the callback runs.
+      }
+    });
     _clearAppThemeOverride();
     _sharedClipboardSubscription.close();
     _sharedClipboardLocalReadSubscription.close();
@@ -8694,6 +8713,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     // Use session override, or loaded theme, or fallback.
     final terminalTheme = _resolveEffectiveTerminalTheme();
+
     // Only push the theme to the session when it differs from what was last
     // applied via this path.  Explicit callers (_openShell, _loadTheme, etc.)
     // use their own call sites and do not update _lastBuildAppliedTheme, so
@@ -8957,9 +8977,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             final route = ModalRoute.of(bodyContext);
             final isTransitioning =
                 route != null &&
-                route.animation != null &&
-                (route.animation!.status == AnimationStatus.forward ||
-                    route.animation!.status == AnimationStatus.reverse);
+                ((route.animation != null &&
+                        (route.animation!.status == AnimationStatus.forward ||
+                            route.animation!.status ==
+                                AnimationStatus.reverse)) ||
+                    route.popGestureInProgress ||
+                    !route.isCurrent);
             final terminalArea = _buildTerminalWithTmuxBar(
               terminalTheme,
               isMobile,

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -7549,8 +7549,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     TerminalThemeData terminalTheme,
     bool isMobile,
     ThemeData theme,
-    SshConnectionState connectionState,
-  ) {
+    SshConnectionState connectionState, {
+    required bool isTransitioning,
+  }) {
     final showTmux =
         _isTmuxActive &&
         _showTmuxBar &&
@@ -7589,7 +7590,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                     child: Column(
                       children: [
                         Expanded(
-                          child: _buildTerminalView(terminalTheme, isMobile),
+                          child: _buildTerminalView(
+                            terminalTheme,
+                            isMobile,
+                            isTransitioning: isTransitioning,
+                          ),
                         ),
                         SizedBox(height: animatedBottomPadding),
                       ],
@@ -8949,11 +8954,18 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 _showKeyboardToolbar &&
                 !showsDisconnectedOverlay &&
                 (!_isNativeSelectionMode || _isMobilePlatform);
+            final route = ModalRoute.of(bodyContext);
+            final isTransitioning =
+                route != null &&
+                route.animation != null &&
+                (route.animation!.status == AnimationStatus.forward ||
+                    route.animation!.status == AnimationStatus.reverse);
             final terminalArea = _buildTerminalWithTmuxBar(
               terminalTheme,
               isMobile,
               theme,
               connectionState,
+              isTransitioning: isTransitioning,
             );
             return Column(
               children: [
@@ -9500,7 +9512,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     ],
   );
 
-  Widget _buildTerminalView(TerminalThemeData terminalTheme, bool isMobile) {
+  Widget _buildTerminalView(
+    TerminalThemeData terminalTheme,
+    bool isMobile, {
+    required bool isTransitioning,
+  }) {
     final theme = Theme.of(context);
     final connectionStates = ref.watch(activeSessionsProvider);
     final connectionAttempt = ref
@@ -9624,6 +9640,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       deleteDetection: !isMobile,
       autofocus: !isMobile,
       hardwareKeyboardOnly: isMobile,
+      autoResize: !isTransitioning,
       // Let alt-buffer apps keep raw wheel events when they explicitly enable
       // mouse reporting, but fall back to synthetic arrows when they do not.
       simulateScroll: shouldUseSyntheticAltBufferScrollFallback(


### PR DESCRIPTION
## Summary

This PR resolves an issue on Android where initiating a back gesture preview on the terminal screen causes a flash of light gray and overlays a muddy gray scrim, instead of displaying the native, gesture-controlled shrinking window transition.

It also resolves an issue where the terminal view turned into a blank gray screen during the back swipe transition rather than scaling down its live text content.

### Root Cause
1. **Light Gray Scaffold Flash**: The terminal screen's `Scaffold` background defaulted to `theme.colorScheme.surface`, which is light gray when the app runs in light mode. During layout resize/keyboard dismissal on back gesture, the light gray background of the Scaffold flashed through.
2. **Theme Brightness Mismatch & Gray Scrim**: Although the terminal screen itself is dark, when the app shell runs in light mode, `MaterialApp` uses `lightTheme`. In `buildTerminalAppTheme`, when a dark terminal theme override (like TokyoNight) was active in light mode, it correctly mapped the dark background colors but still initialized the `ThemeData` with `brightness: Brightness.light`. Because of this brightness mismatch, Flutter's default page transitions (`ZoomPageTransitionsBuilder` and `PredictiveBackPageTransitionsBuilder`) drew a light-mode semi-transparent gray scrim/overlay over the exiting route as it shrunk.
3. **Empty/Gray Screen on Shrink (Layout Reflow)**: By default, the terminal widget has `autoResize` enabled. When the predictive back gesture begins, the keyboard dismisses, changing the screen height layout constraints. With `autoResize` active, the terminal tried to continuously recalculate its column and row count based on the changing layout constraints on every single frame of the transition animation. This triggered continuous layout reflows and terminal clearing, making the terminal view appear as a blank gray screen during the transition.

### Solution
1. **Scaffold Background**: Directly set the `Scaffold`'s `backgroundColor` to `terminalTheme.background` so it always matches the active terminal's style.
2. **Correct Theme Brightness Resolution**: Updated `buildTerminalAppTheme` in `lib/app/app.dart` to dynamically resolve the `ThemeData`'s brightness (`resolvedBrightness`) to match the active terminal theme's true brightness (`terminalTheme.isDark`). This ensures the `MaterialApp`'s active theme transitions to dark when a dark connection is open, which automatically configures the native page transitions to use dark overlays and scrims. This keeps the native Android gesture-driven shrinking window transition completely clear, dark, and visually seamless.
3. **Freeze Terminal Dimensions during Transitions**: Tracked whether the terminal screen is currently undergoing a push or pop transition using the route's `ModalRoute.of(context)`. Set `autoResize: false` on `MonkeyTerminalView` while `isTransitioning` is true. This freezes the terminal dimensions and text content during the back swipe, allowing it to scale down as a beautiful, live, static screen snapshot rather than reflowing into a blank gray layout.

### Verification
- Handled via automated widget testing. All 108 widget tests inside `terminal_screen_test.dart` and 2,294+ project-wide pre-commit tests have passed successfully.
