### PR TITLE
fix: allow video paste media uploads

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1112,13 +1112,15 @@ Stream<List<int>>? resolvePickedTerminalUploadReadStream(PlatformFile file) =>
   bool allowMultiple,
   String failureContext,
 })
-resolveTerminalUploadPickerRequest({required bool images}) => (
-  dialogTitle: images ? 'Select images to upload' : 'Select files to upload',
-  pickerType: images ? FileType.image : FileType.any,
-  itemLabelSingular: images ? 'image' : 'file',
-  itemLabelPlural: images ? 'images' : 'files',
+resolveTerminalUploadPickerRequest({required bool media}) => (
+  dialogTitle: media
+      ? 'Select images or videos to upload'
+      : 'Select files to upload',
+  pickerType: media ? FileType.media : FileType.any,
+  itemLabelSingular: media ? 'image or video' : 'file',
+  itemLabelPlural: media ? 'images or videos' : 'files',
   allowMultiple: true,
-  failureContext: images ? 'Image picker upload' : 'File picker upload',
+  failureContext: media ? 'Media picker upload' : 'File picker upload',
 );
 
 /// Trims punctuation that terminals commonly render immediately after a link.
@@ -3101,9 +3103,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     ),
     _terminalOverflowMenuItem(
       context: context,
-      icon: Icons.image_outlined,
-      label: 'Paste Images',
-      action: 'paste_image',
+      icon: Icons.perm_media_outlined,
+      label: 'Paste Media',
+      action: 'paste_media',
     ),
     _terminalOverflowMenuItem(
       context: context,
@@ -8977,7 +8979,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                     onPasteRequested: _pasteClipboard,
                     onPasteMenuOpened: _refreshKeyboardToolbarSnippetMenu,
                     onSnippetPasteRequested: _pasteKeyboardToolbarSnippet,
-                    onPasteImageRequested: _pastePickedImage,
+                    onPasteMediaRequested: _pastePickedMedia,
                     onPasteFilesRequested: _pastePickedFiles,
                     snippets: _keyboardToolbarSnippets,
                     snippetFolders: _keyboardToolbarSnippetFolders,
@@ -9995,8 +9997,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       case 'paste':
         await _pasteClipboard();
         break;
-      case 'paste_image':
-        await _pastePickedImage();
+      case 'paste_media':
+        await _pastePickedMedia();
         break;
       case 'paste_file':
         await _pastePickedFiles();
@@ -12236,8 +12238,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
-  Future<void> _pastePickedImage() async {
-    final pickerRequest = resolveTerminalUploadPickerRequest(images: true);
+  Future<void> _pastePickedMedia() async {
+    final pickerRequest = resolveTerminalUploadPickerRequest(media: true);
     await _pickAndPasteFiles(
       dialogTitle: pickerRequest.dialogTitle,
       pickerType: pickerRequest.pickerType,
@@ -12249,7 +12251,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   Future<void> _pastePickedFiles() async {
-    final pickerRequest = resolveTerminalUploadPickerRequest(images: false);
+    final pickerRequest = resolveTerminalUploadPickerRequest(media: false);
     await _pickAndPasteFiles(
       dialogTitle: pickerRequest.dialogTitle,
       pickerType: pickerRequest.pickerType,

--- a/lib/presentation/widgets/keyboard_toolbar.dart
+++ b/lib/presentation/widgets/keyboard_toolbar.dart
@@ -233,7 +233,7 @@ class KeyboardToolbar extends StatefulWidget {
     this.onPasteRequested,
     this.onPasteMenuOpened,
     this.onSnippetPasteRequested,
-    this.onPasteImageRequested,
+    this.onPasteMediaRequested,
     this.onPasteFilesRequested,
     this.snippets = const <KeyboardToolbarSnippet>[],
     this.snippetFolders = const <KeyboardToolbarSnippetFolder>[],
@@ -260,8 +260,8 @@ class KeyboardToolbar extends StatefulWidget {
   final FutureOr<void> Function(KeyboardToolbarSnippet snippet)?
   onSnippetPasteRequested;
 
-  /// Optional callback when the Paste key's long-press image option is tapped.
-  final FutureOr<void> Function()? onPasteImageRequested;
+  /// Optional callback when the Paste key's long-press media option is tapped.
+  final FutureOr<void> Function()? onPasteMediaRequested;
 
   /// Optional callback when the Paste key's long-press file option is tapped.
   final FutureOr<void> Function()? onPasteFilesRequested;
@@ -644,7 +644,7 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
           child: _PasteOptionsMenu(
             highlightedAction: _highlightedPasteAction,
             snippetsEnabled: _areSnippetsEnabled,
-            imageEnabled: widget.onPasteImageRequested != null,
+            mediaEnabled: widget.onPasteMediaRequested != null,
             filesEnabled: widget.onPasteFilesRequested != null,
             snippetsTrailingIcon: layout.snippetMenuOpensLeft
                 ? Icons.chevron_left_rounded
@@ -836,7 +836,7 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
 
   bool _isPasteActionEnabled(_PasteToolbarAction action) => switch (action) {
     _PasteToolbarAction.snippets => _areSnippetsEnabled,
-    _PasteToolbarAction.images => widget.onPasteImageRequested != null,
+    _PasteToolbarAction.media => widget.onPasteMediaRequested != null,
     _PasteToolbarAction.files => widget.onPasteFilesRequested != null,
   };
 
@@ -926,8 +926,8 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
     switch (action) {
       case _PasteToolbarAction.snippets:
         _refocusTerminal();
-      case _PasteToolbarAction.images:
-        unawaited(_runToolbarAction(widget.onPasteImageRequested));
+      case _PasteToolbarAction.media:
+        unawaited(_runToolbarAction(widget.onPasteMediaRequested));
       case _PasteToolbarAction.files:
         unawaited(_runToolbarAction(widget.onPasteFilesRequested));
       case null:
@@ -1080,7 +1080,7 @@ enum _Modifier { ctrl, alt, shift }
 
 enum _Arrow { up, down, left, right }
 
-enum _PasteToolbarAction { snippets, images, files }
+enum _PasteToolbarAction { snippets, media, files }
 
 class _PasteMenuHit {
   const _PasteMenuHit({required this.action, this.folder, this.snippet});
@@ -1124,14 +1124,14 @@ class _PasteOptionsMenu extends StatelessWidget {
   const _PasteOptionsMenu({
     required this.highlightedAction,
     required this.snippetsEnabled,
-    required this.imageEnabled,
+    required this.mediaEnabled,
     required this.filesEnabled,
     required this.snippetsTrailingIcon,
   });
 
   final _PasteToolbarAction? highlightedAction;
   final bool snippetsEnabled;
-  final bool imageEnabled;
+  final bool mediaEnabled;
   final bool filesEnabled;
   final IconData snippetsTrailingIcon;
 
@@ -1149,10 +1149,10 @@ class _PasteOptionsMenu extends StatelessWidget {
           trailingIcon: snippetsTrailingIcon,
         ),
         _PasteOptionsMenuItem(
-          icon: Icons.image_outlined,
-          label: 'Paste Images',
-          enabled: imageEnabled,
-          highlighted: highlightedAction == _PasteToolbarAction.images,
+          icon: Icons.perm_media_outlined,
+          label: 'Paste Media',
+          enabled: mediaEnabled,
+          highlighted: highlightedAction == _PasteToolbarAction.media,
         ),
         _PasteOptionsMenuItem(
           icon: Icons.attach_file_rounded,

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1515,7 +1515,7 @@ void main() {
       expect(terminalMenuItemButton('Snippets'), findsOneWidget);
       expect(terminalSubmenuButton('Paste'), findsOneWidget);
       expect(terminalMenuItemButton('Paste'), findsOneWidget);
-      expect(terminalMenuItemButton('Paste Images'), findsOneWidget);
+      expect(terminalMenuItemButton('Paste Media'), findsOneWidget);
       expect(terminalMenuItemButton('Paste Files'), findsOneWidget);
     });
 

--- a/test/widget/keyboard_toolbar_test.dart
+++ b/test/widget/keyboard_toolbar_test.dart
@@ -329,7 +329,7 @@ void main() {
     testWidgets('Paste long press opens an anchored drag-release menu', (
       tester,
     ) async {
-      var imagePasteCount = 0;
+      var mediaPasteCount = 0;
       var filePasteCount = 0;
 
       await tester.pumpWidget(
@@ -340,7 +340,7 @@ void main() {
                 const Spacer(),
                 KeyboardToolbar(
                   terminal: terminal,
-                  onPasteImageRequested: () async => imagePasteCount++,
+                  onPasteMediaRequested: () async => mediaPasteCount++,
                   onPasteFilesRequested: () async => filePasteCount++,
                 ),
               ],
@@ -354,21 +354,21 @@ void main() {
       await tester.pump(kLongPressTimeout + const Duration(milliseconds: 1));
       await tester.pump();
 
-      expect(find.text('Paste Images'), findsOneWidget);
+      expect(find.text('Paste Media'), findsOneWidget);
       expect(find.text('Paste Files'), findsOneWidget);
       expect(
-        tester.getCenter(find.text('Paste Images')).dy,
+        tester.getCenter(find.text('Paste Media')).dy,
         lessThan(pasteCenter.dy),
       );
 
-      await gesture.moveTo(tester.getCenter(find.text('Paste Images')));
+      await gesture.moveTo(tester.getCenter(find.text('Paste Media')));
       await tester.pump();
       await gesture.up();
       await tester.pump();
 
-      expect(imagePasteCount, 1);
+      expect(mediaPasteCount, 1);
       expect(filePasteCount, 0);
-      expect(find.text('Paste Images'), findsNothing);
+      expect(find.text('Paste Media'), findsNothing);
       expect(find.text('Paste Files'), findsNothing);
     });
 
@@ -381,7 +381,7 @@ void main() {
                 const Spacer(),
                 KeyboardToolbar(
                   terminal: terminal,
-                  onPasteImageRequested: () async {},
+                  onPasteMediaRequested: () async {},
                   onPasteFilesRequested: () async {},
                 ),
               ],
@@ -395,11 +395,11 @@ void main() {
       await tester.pump(kLongPressTimeout + const Duration(milliseconds: 1));
       await tester.pump();
 
-      final pasteImages = find.text('Paste Images');
+      final pasteMedia = find.text('Paste Media');
       final menuMaterial = tester.widget<Material>(
-        find.ancestor(of: pasteImages, matching: find.byType(Material)).first,
+        find.ancestor(of: pasteMedia, matching: find.byType(Material)).first,
       );
-      final menuContext = tester.element(pasteImages);
+      final menuContext = tester.element(pasteMedia);
 
       expect(menuMaterial.color, TerminalMenuStyles.surfaceColor(menuContext));
       expect(menuMaterial.elevation, TerminalMenuStyles.elevation);

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -243,19 +243,19 @@ void main() {
   });
 
   group('resolveTerminalUploadPickerRequest', () {
-    test('allows selecting multiple images for terminal uploads', () {
-      final request = resolveTerminalUploadPickerRequest(images: true);
+    test('allows selecting multiple images or videos for terminal uploads', () {
+      final request = resolveTerminalUploadPickerRequest(media: true);
 
-      expect(request.dialogTitle, 'Select images to upload');
-      expect(request.pickerType, FileType.image);
-      expect(request.itemLabelSingular, 'image');
-      expect(request.itemLabelPlural, 'images');
+      expect(request.dialogTitle, 'Select images or videos to upload');
+      expect(request.pickerType, FileType.media);
+      expect(request.itemLabelSingular, 'image or video');
+      expect(request.itemLabelPlural, 'images or videos');
       expect(request.allowMultiple, isTrue);
-      expect(request.failureContext, 'Image picker upload');
+      expect(request.failureContext, 'Media picker upload');
     });
 
     test('allows selecting multiple files for terminal uploads', () {
-      final request = resolveTerminalUploadPickerRequest(images: false);
+      final request = resolveTerminalUploadPickerRequest(media: false);
 
       expect(request.dialogTitle, 'Select files to upload');
       expect(request.pickerType, FileType.any);


### PR DESCRIPTION
## Summary

- Change the terminal paste picker from image-only to media so videos are selectable alongside images after the `file_picker` update.
- Rename the terminal paste action to Paste Media and update the toolbar/menu coverage.

## Testing

- `flutter test test/widget/terminal_screen_selection_test.dart test/widget/keyboard_toolbar_test.dart test/presentation/screens/terminal_screen_test.dart --name 'resolveTerminalUploadPickerRequest|Paste long press opens an anchored drag-release menu|Paste long press uses terminal menu styling|terminal overflow menu folds out paste actions'`
- `flutter analyze`
