### PR TITLE
fix: recover terminal SFTP verifier clients

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -11744,6 +11744,18 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _verifyingTerminalPathCacheKeys.clear();
   }
 
+  Future<SftpClient> _openTerminalPathVerificationSftp(
+    SshSession session,
+  ) async {
+    final sftpOpenFuture = session.sftp();
+    try {
+      return await sftpOpenFuture.timeout(_terminalPathVerificationTimeout);
+    } on TimeoutException {
+      sftpOpenFuture.then((sftp) => sftp.close()).ignore();
+      rethrow;
+    }
+  }
+
   Future<SftpClient?> _resolveTerminalPathVerificationSftp(
     SshSession session, {
     required bool allowBackoff,
@@ -11772,18 +11784,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return null;
     }
 
-    final future = session
-        .sftp()
-        .timeout(_terminalPathVerificationTimeout)
-        .then<SftpClient?>((sftp) {
-          if (!identical(_terminalPathVerificationSession, session)) {
-            sftp.close();
-            return null;
-          }
-          _terminalPathVerificationBackoffUntil = null;
-          _terminalPathVerificationSftp = sftp;
-          return sftp;
-        });
+    final future = _openTerminalPathVerificationSftp(session).then<SftpClient?>(
+      (sftp) {
+        if (!identical(_terminalPathVerificationSession, session)) {
+          sftp.close();
+          return null;
+        }
+        _terminalPathVerificationBackoffUntil = null;
+        _terminalPathVerificationSftp = sftp;
+        return sftp;
+      },
+    );
     _terminalPathVerificationSftpFuture = future;
     try {
       return await future;
@@ -11817,7 +11828,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     SshSession session,
     Object error,
   ) {
-    if (error is! SSHChannelOpenError && error is! TimeoutException) {
+    if (!_isRecoverableTerminalPathVerificationSftpError(error)) {
       return;
     }
     _terminalPathVerificationBackoffUntil = DateTime.now().add(
@@ -11834,6 +11845,38 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
   }
 
+  bool _isRecoverableTerminalPathVerificationSftpError(Object error) =>
+      error is TimeoutException ||
+      error is SSHError ||
+      error is SftpError && error is! SftpStatusError;
+
+  void _handleTerminalPathVerificationSftpFailure(
+    SftpClient sftp,
+    Object error,
+  ) {
+    if (!_isRecoverableTerminalPathVerificationSftpError(error)) {
+      return;
+    }
+    final session = _terminalPathVerificationSession;
+    if (session != null) {
+      _recordTerminalPathVerificationBackoff(session, error);
+    }
+    if (!identical(_terminalPathVerificationSftp, sftp)) {
+      return;
+    }
+    DiagnosticsLogService.instance.debug(
+      'terminal',
+      'sftp_path_resolution_client_discarded',
+      fields: {
+        if (session != null) 'connectionId': session.connectionId,
+        'errorType': error.runtimeType.toString(),
+      },
+    );
+    sftp.close();
+    _terminalPathVerificationSftp = null;
+    _terminalPathVerificationHomeDirectory = null;
+  }
+
   Future<String?> _resolveTerminalPathVerificationHomeDirectory(
     SftpClient sftp,
     String terminalPath,
@@ -11847,10 +11890,31 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
 
     final homeDirectory = normalizeSftpAbsolutePath(
-      await sftp.absolute('.').timeout(_terminalPathVerificationTimeout),
+      await _resolveTerminalPathVerificationSftpOperation(
+        sftp,
+        () => sftp.absolute('.'),
+      ),
     );
     _terminalPathVerificationHomeDirectory = homeDirectory;
     return homeDirectory;
+  }
+
+  Future<T> _resolveTerminalPathVerificationSftpOperation<T>(
+    SftpClient sftp,
+    Future<T> Function() operation,
+  ) async {
+    try {
+      return await operation().timeout(_terminalPathVerificationTimeout);
+    } on TimeoutException catch (error) {
+      _handleTerminalPathVerificationSftpFailure(sftp, error);
+      rethrow;
+    } on SSHError catch (error) {
+      _handleTerminalPathVerificationSftpFailure(sftp, error);
+      rethrow;
+    } on SftpError catch (error) {
+      _handleTerminalPathVerificationSftpFailure(sftp, error);
+      rethrow;
+    }
   }
 
   _VerifiedTerminalPath? _verifiedTerminalPath(String terminalPath) {
@@ -11967,9 +12031,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           );
           verifiedAny = verifiedAny || verifiedPath != null;
         } on TimeoutException {
-          // Background path verification is opportunistic.
+          rethrow;
         } on SftpStatusError {
           // Background path verification is opportunistic.
+        } on SSHError {
+          rethrow;
+        } on SftpError {
+          rethrow;
         } on Object catch (error, stackTrace) {
           DiagnosticsLogService.instance.warning(
             'terminal',
@@ -12045,7 +12113,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       }
 
       try {
-        await sftp.stat(resolvedPath).timeout(_terminalPathVerificationTimeout);
+        await _resolveTerminalPathVerificationSftpOperation(
+          sftp,
+          () => sftp.stat(resolvedPath),
+        );
       } on SftpStatusError catch (error) {
         if (error.code == SftpStatusCode.noSuchFile) {
           continue;

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -6439,6 +6439,91 @@ void main() {
     );
 
     testWidgets(
+      'background path verification closes late SFTP clients after open timeout',
+      (tester) async {
+        const relativePath = 'lib/presentation/screens/terminal_screen.dart';
+        const workingDirectory = '/Users/tester/project';
+        final sftp = _MockSftpClient();
+        final sftpOpenCompleter = Completer<SftpClient>();
+
+        when(
+          () => sshClient.sftp(),
+        ).thenAnswer((_) => sftpOpenCompleter.future);
+
+        await pumpScreen(tester);
+        shellStdoutController.add(
+          Uint8List.fromList(
+            utf8.encode(
+              '\u001b]7;file://remote.example.com$workingDirectory\u0007',
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        session.terminal!.write('git add $relativePath');
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 75));
+        verify(() => sshClient.sftp()).called(1);
+
+        await tester.pump(const Duration(seconds: 5, milliseconds: 1));
+        verifyNever(sftp.close);
+
+        sftpOpenCompleter.complete(sftp);
+        await tester.pump();
+
+        verify(sftp.close).called(1);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(seconds: 11));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'background path verification discards cached SFTP clients after stat timeout',
+      (tester) async {
+        const relativePath = 'lib/presentation/screens/terminal_screen.dart';
+        const workingDirectory = '/Users/tester/project';
+        final sftp = _MockSftpClient();
+        final statStarted = Completer<void>();
+        final statCompleter = Completer<SftpFileAttrs>();
+
+        when(() => sshClient.sftp()).thenAnswer((_) async => sftp);
+        when(() => sftp.stat('$workingDirectory/$relativePath')).thenAnswer((
+          _,
+        ) {
+          if (!statStarted.isCompleted) {
+            statStarted.complete();
+          }
+          return statCompleter.future;
+        });
+
+        await pumpScreen(tester);
+        shellStdoutController.add(
+          Uint8List.fromList(
+            utf8.encode(
+              '\u001b]7;file://remote.example.com$workingDirectory\u0007',
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        session.terminal!.write('git add $relativePath');
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 75));
+        await statStarted.future.timeout(const Duration(seconds: 1));
+
+        await tester.pump(const Duration(seconds: 5, milliseconds: 1));
+
+        verify(sftp.close).called(1);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(seconds: 11));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
       'mobile path underline taps open SFTP while system selection is enabled',
       (tester) async {
         const remotePath = '/var/log/app.log';


### PR DESCRIPTION
## Summary

- Close terminal path-verification SFTP clients that finish opening after the verifier timeout.
- Drop cached verifier SFTP clients after recoverable SSH/SFTP channel failures so background path checks can reopen a fresh channel instead of staying stuck.
- Add regression coverage for late-open cleanup and stale verifier channel discard.

## Tests

- `flutter test test/presentation/screens/terminal_screen_test.dart --name "background path verification"`
- `flutter test test/presentation/screens/terminal_screen_test.dart --name "mobile path underline taps open SFTP"`
- `flutter analyze`
