### PR TITLE
Fix modified Enter newline input

### DIFF
--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -52,6 +52,7 @@ import 'package:xterm/src/ui/themes.dart';
 
 import 'monkey_terminal_gesture_handler.dart';
 import 'monkey_terminal_scroll_gesture_handler.dart';
+import 'terminal_key_input.dart';
 import 'terminal_scroll_mouse_input.dart';
 import 'terminal_selection_text.dart';
 
@@ -1380,12 +1381,17 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
       return KeyEventResult.ignored;
     }
 
-    final handled = widget.terminal.keyInput(
-      key,
-      ctrl: HardwareKeyboard.instance.isControlPressed,
-      alt: HardwareKeyboard.instance.isAltPressed,
-      shift: HardwareKeyboard.instance.isShiftPressed,
-    );
+    final ctrl = HardwareKeyboard.instance.isControlPressed;
+    final alt = HardwareKeyboard.instance.isAltPressed;
+    final shift = HardwareKeyboard.instance.isShiftPressed;
+    final handled = key == TerminalKey.enter
+        ? sendTerminalEnterInput(
+            widget.terminal,
+            shiftActive: shift,
+            altActive: alt,
+            ctrlActive: ctrl,
+          )
+        : widget.terminal.keyInput(key, ctrl: ctrl, alt: alt, shift: shift);
 
     if (handled) {
       _scrollToBottom();

--- a/lib/presentation/widgets/terminal_key_input.dart
+++ b/lib/presentation/widgets/terminal_key_input.dart
@@ -1,13 +1,22 @@
 import 'package:xterm/xterm.dart';
 
+const _terminalAlternateEnterInput = '\x1b\r';
+
 /// Sends Enter with the active terminal modifiers applied.
-void sendTerminalEnterInput(
+bool sendTerminalEnterInput(
   Terminal terminal, {
   required bool shiftActive,
   required bool altActive,
   required bool ctrlActive,
 }) {
-  terminal.keyInput(
+  if (shiftActive || altActive) {
+    // Prompt UIs such as Copilot CLI use ESC+CR as their terminal-agnostic
+    // multiline Enter sequence; xterm.dart's legacy Shift+Return emits ESCOM.
+    terminal.textInput(_terminalAlternateEnterInput);
+    return true;
+  }
+
+  return terminal.keyInput(
     TerminalKey.enter,
     shift: shiftActive,
     alt: altActive,

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -625,12 +625,14 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     required bool shift,
     required bool hasShortcutModifier,
   }) {
-    final handled = widget.terminal.keyInput(
-      key,
-      ctrl: ctrl,
-      alt: alt,
-      shift: shift,
-    );
+    final handled = key == TerminalKey.enter
+        ? sendTerminalEnterInput(
+            widget.terminal,
+            shiftActive: shift,
+            altActive: alt,
+            ctrlActive: ctrl,
+          )
+        : widget.terminal.keyInput(key, ctrl: ctrl, alt: alt, shift: shift);
 
     if (handled) {
       _notifyUserInput();

--- a/test/widget/keyboard_toolbar_test.dart
+++ b/test/widget/keyboard_toolbar_test.dart
@@ -6,6 +6,8 @@ import 'package:monkeyssh/presentation/widgets/keyboard_toolbar.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_menu_style.dart';
 import 'package:xterm/xterm.dart';
 
+const _terminalAlternateEnterInput = '\x1b\r';
+
 String _terminalKeyOutput(
   TerminalKey key, {
   bool shift = false,
@@ -617,11 +619,27 @@ void main() {
       await tester.tap(find.byTooltip('Enter'));
       await tester.pump();
 
-      expect(
-        output,
-        contains(_terminalKeyOutput(TerminalKey.enter, shift: true)),
-      );
+      expect(output, contains(_terminalAlternateEnterInput));
     });
+
+    testWidgets('toolbar Alt applies to Enter', (tester) async {
+      final output = <String>[];
+      terminal.onOutput = output.add;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: KeyboardToolbar(terminal: terminal)),
+        ),
+      );
+
+      await tester.tap(find.byTooltip('Alt'));
+      await tester.pump();
+      await tester.tap(find.byTooltip('Enter'));
+      await tester.pump();
+
+      expect(output, contains(_terminalAlternateEnterInput));
+    });
+
     test('keeps bottom safe-area padding when keyboard is closed', () {
       const mediaQuery = MediaQueryData(padding: EdgeInsets.only(bottom: 34));
 

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -14,6 +14,7 @@ import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart'
 import 'package:xterm/xterm.dart';
 
 const _deleteDetectionMarker = '\u200B\u200B';
+const _terminalAlternateEnterInput = '\x1b\r';
 
 typedef _LoggedEditingState = ({
   String text,
@@ -4794,12 +4795,32 @@ void main() {
 
       expect(
         harness.terminalOutput.join(),
-        _terminalKeyOutput(TerminalKey.enter, shift: true) +
-            _terminalKeyOutput(TerminalKey.enter),
+        _terminalAlternateEnterInput + _terminalKeyOutput(TerminalKey.enter),
       );
 
       await _disposeTerminalHarness(tester, harness);
     });
+
+    for (final scenario in [
+      (name: 'Shift+Enter', modifier: LogicalKeyboardKey.shiftLeft),
+      (name: 'Alt+Enter', modifier: LogicalKeyboardKey.altLeft),
+    ]) {
+      testWidgets('hardware ${scenario.name} sends alternate enter', (
+        tester,
+      ) async {
+        final harness = await _pumpTerminalHarness(tester);
+
+        await tester.sendKeyDownEvent(scenario.modifier);
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.enter);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.enter);
+        await tester.sendKeyUpEvent(scenario.modifier);
+        await tester.pump();
+
+        expect(harness.terminalOutput.join(), _terminalAlternateEnterInput);
+
+        await _disposeTerminalHarness(tester, harness);
+      });
+    }
 
     testWidgets('keeps ctrl combos working while IME composition is active', (
       tester,


### PR DESCRIPTION
## Summary

- Send Shift+Enter and Alt+Enter as `ESC` + `CR` instead of xterm.dart's legacy modified Return sequence.
- Route modified Enter through the shared helper for toolbar, text input handler hardware keys, and terminal view hardware keys.
- Add widget coverage for toolbar and hardware modified Enter behavior.

## Validation

- `flutter test test/widget/terminal_text_input_handler_test.dart test/widget/keyboard_toolbar_test.dart`
- `flutter analyze lib/presentation/widgets/terminal_key_input.dart lib/presentation/widgets/terminal_text_input_handler.dart lib/presentation/widgets/monkey_terminal_view.dart test/widget/terminal_text_input_handler_test.dart test/widget/keyboard_toolbar_test.dart`
