### PR TITLE
fix: tolerate stale port forwards in migration imports

### DIFF
--- a/lib/data/repositories/host_repository.dart
+++ b/lib/data/repositories/host_repository.dart
@@ -227,10 +227,19 @@ class HostRepository {
 
   /// Delete a host.
   Future<int> delete(int id) async {
-    final previousStoredPassword = await _storedPasswordForHost(id);
-    final deleted = await (_db.delete(
+    final host = await (_db.select(
       _db.hosts,
-    )..where((h) => h.id.equals(id))).go();
+    )..where((h) => h.id.equals(id))).getSingleOrNull();
+    if (host == null) {
+      return 0;
+    }
+    final previousStoredPassword = host.password;
+    final deleted = await _db.transaction(() async {
+      await (_db.delete(
+        _db.portForwards,
+      )..where((portForward) => portForward.hostId.equals(id))).go();
+      return (_db.delete(_db.hosts)..where((h) => h.id.equals(id))).go();
+    });
     if (deleted > 0) {
       _evictDecrypted(previousStoredPassword);
     }

--- a/lib/domain/services/secure_transfer_service.dart
+++ b/lib/domain/services/secure_transfer_service.dart
@@ -272,7 +272,20 @@ class SecureTransferService {
               (snippet) => OrderingTerm.asc(snippet.id),
             ]))
             .get();
-    final portForwards = await _db.select(_db.portForwards).get();
+    final rawPortForwards = await _db.select(_db.portForwards).get();
+    final exportedHostIds = hosts.map((host) => host.id).toSet();
+    final portForwards = rawPortForwards
+        .where((portForward) => exportedHostIds.contains(portForward.hostId))
+        .toList(growable: false);
+    final skippedPortForwardCount =
+        rawPortForwards.length - portForwards.length;
+    if (skippedPortForwardCount > 0) {
+      _diagnosticsLogger.warning(
+        'secure_transfer',
+        'migration_export_port_forwards_skipped',
+        fields: {'skippedCount': skippedPortForwardCount},
+      );
+    }
     final knownHosts = includeKnownHosts
         ? await _db.select(_db.knownHosts).get()
         : const <KnownHost>[];
@@ -1105,18 +1118,17 @@ class SecureTransferService {
     List<Map<String, dynamic>> rawPortForwards, {
     required Map<int, int> hostMapping,
   }) async {
+    var skippedPortForwardCount = 0;
     for (final item in rawPortForwards) {
       final oldHostId = _optionalInt(item['hostId']);
       if (oldHostId == null) {
-        throw const FormatException(
-          'Missing host reference in migration payload',
-        );
+        skippedPortForwardCount += 1;
+        continue;
       }
       final mappedHostId = hostMapping[oldHostId];
       if (mappedHostId == null) {
-        throw const FormatException(
-          'Invalid host reference in migration payload',
-        );
+        skippedPortForwardCount += 1;
+        continue;
       }
 
       await _db
@@ -1138,6 +1150,13 @@ class SecureTransferService {
               ),
             ),
           );
+    }
+    if (skippedPortForwardCount > 0) {
+      _diagnosticsLogger.warning(
+        'secure_transfer',
+        'migration_import_port_forwards_skipped',
+        fields: {'skippedCount': skippedPortForwardCount},
+      );
     }
   }
 

--- a/lib/presentation/screens/transfer_screen.dart
+++ b/lib/presentation/screens/transfer_screen.dart
@@ -22,10 +22,15 @@ const _maxTransferPayloadBytes = 10 * 1024 * 1024;
 
 /// Whether the current platform uses the system share sheet for exports.
 ///
-/// On iOS and Android the share sheet provides AirDrop, Quick Share, Messages,
-/// email, Save to Files, and other targets. Desktop platforms keep the
-/// file-save dialog.
-bool get useShareSheet => !kIsWeb && (Platform.isIOS || Platform.isAndroid);
+/// iOS uses the share sheet because Save to Files is exposed as a share target.
+///
+/// Android uses the system create-document picker instead so users can choose a
+/// local Files destination directly.
+bool get useShareSheet => useShareSheetForPlatform(defaultTargetPlatform);
+
+/// Returns whether transfer exports should use the share sheet on [platform].
+bool useShareSheetForPlatform(TargetPlatform platform, {bool isWeb = kIsWeb}) =>
+    !isWeb && platform == TargetPlatform.iOS;
 
 /// Computes the share sheet anchor rect from a widget's [BuildContext].
 ///
@@ -40,9 +45,9 @@ Rect? shareOriginFromContext(BuildContext context) {
 
 /// Exports an encrypted transfer payload.
 ///
-/// On mobile (iOS/Android) this opens the system share sheet so the user can
-/// AirDrop, Quick Share, save to Files, or send via any installed app.
-/// On desktop and web it falls back to a file-save dialog.
+/// On iOS this opens the system share sheet so the user can AirDrop, save to
+/// Files, or send via any installed app. Android, desktop, and web use a
+/// file-save dialog/create-document picker.
 Future<void> saveTransferPayloadToFile({
   required BuildContext context,
   required String payload,
@@ -143,7 +148,7 @@ Future<void> _sharePayloadViaNativeSheet({
   }
 }
 
-/// Saves the transfer payload via a native file-save dialog (desktop / web).
+/// Saves the transfer payload via a native file-save dialog.
 Future<void> _savePayloadToFileDialog({
   required BuildContext context,
   required Uint8List bytes,

--- a/test/data/repositories/host_repository_test.dart
+++ b/test/data/repositories/host_repository_test.dart
@@ -632,6 +632,34 @@ void main() {
       expect(host, isNull);
     });
 
+    test('delete removes host port forwards', () async {
+      final id = await repository.insert(
+        HostsCompanion.insert(
+          label: 'Test Server',
+          hostname: '192.168.1.1',
+          username: 'admin',
+        ),
+      );
+      await db
+          .into(db.portForwards)
+          .insert(
+            PortForwardsCompanion.insert(
+              name: 'Tunnel',
+              hostId: id,
+              forwardType: 'local',
+              localPort: 10022,
+              remoteHost: '127.0.0.1',
+              remotePort: 22,
+            ),
+          );
+
+      final deleted = await repository.delete(id);
+
+      final portForwards = await db.select(db.portForwards).get();
+      expect(deleted, 1);
+      expect(portForwards, isEmpty);
+    });
+
     test('delete returns 0 when host not exists', () async {
       final deleted = await repository.delete(999);
       expect(deleted, 0);

--- a/test/domain/services/secure_transfer_service_test.dart
+++ b/test/domain/services/secure_transfer_service_test.dart
@@ -185,6 +185,75 @@ void main() {
     );
 
     test(
+      'createMigrationData excludes port forwards for missing hosts',
+      () async {
+        final hostId = await hostRepository.insert(
+          HostsCompanion.insert(
+            label: 'Production',
+            hostname: 'prod.example.com',
+            username: 'root',
+          ),
+        );
+        await db
+            .into(db.portForwards)
+            .insert(
+              PortForwardsCompanion.insert(
+                name: 'valid',
+                hostId: hostId,
+                forwardType: 'local',
+                localPort: 10022,
+                remoteHost: '127.0.0.1',
+                remotePort: 22,
+              ),
+            );
+        await db.customStatement('PRAGMA foreign_keys = OFF');
+        await db
+            .into(db.portForwards)
+            .insert(
+              PortForwardsCompanion.insert(
+                name: 'orphaned',
+                hostId: 999,
+                forwardType: 'local',
+                localPort: 10023,
+                remoteHost: '127.0.0.1',
+                remotePort: 22,
+              ),
+            );
+
+        final migrationData = await transferService.createMigrationData(
+          includeKnownHosts: false,
+        );
+        final portForwards = migrationData['portForwards'] as List;
+        final portForwardData = Map<String, dynamic>.from(
+          portForwards.single as Map,
+        );
+
+        expect(portForwardData['name'], 'valid');
+        expect(portForwardData['hostId'], hostId);
+
+        final importedDb = AppDatabase.forTesting(NativeDatabase.memory());
+        addTearDown(importedDb.close);
+        final importedEncryptionService = SecretEncryptionService.forTesting();
+        final importedTransferService = SecureTransferService(
+          importedDb,
+          KeyRepository(importedDb, importedEncryptionService),
+          HostRepository(importedDb, importedEncryptionService),
+        );
+
+        await importedTransferService.importMigrationData(
+          data: migrationData,
+          mode: MigrationImportMode.replace,
+          includeKnownHosts: false,
+        );
+
+        final importedPortForwards = await importedDb
+            .select(importedDb.portForwards)
+            .get();
+        expect(importedPortForwards, hasLength(1));
+      },
+    );
+
+    test(
       'includes referenced key data when requested for host export',
       () async {
         final keyId = await keyRepository.insert(
@@ -626,7 +695,7 @@ void main() {
     });
 
     test(
-      'fails migration when port forward references missing host mapping',
+      'skips migration port forwards that reference missing hosts',
       () async {
         final payload = TransferPayload(
           type: TransferPayloadType.fullMigration,
@@ -647,13 +716,13 @@ void main() {
           },
         );
 
-        await expectLater(
-          transferService.importFullMigrationPayload(
-            payload: payload,
-            mode: MigrationImportMode.merge,
-          ),
-          throwsFormatException,
+        await transferService.importFullMigrationPayload(
+          payload: payload,
+          mode: MigrationImportMode.merge,
         );
+
+        final portForwards = await db.select(db.portForwards).get();
+        expect(portForwards, isEmpty);
       },
     );
 

--- a/test/presentation/screens/transfer_screen_test.dart
+++ b/test/presentation/screens/transfer_screen_test.dart
@@ -53,6 +53,17 @@ void main() {
     });
   });
 
+  group('export destination', () {
+    test('uses the share sheet only for native iOS exports', () {
+      expect(useShareSheetForPlatform(TargetPlatform.iOS), isTrue);
+      expect(useShareSheetForPlatform(TargetPlatform.android), isFalse);
+      expect(
+        useShareSheetForPlatform(TargetPlatform.iOS, isWeb: true),
+        isFalse,
+      );
+    });
+  });
+
   group('picker helpers', () {
     test('uses the native unfiltered picker on iOS', () {
       expect(


### PR DESCRIPTION
## Summary

- skip malformed/stale port forward rows instead of failing full migration imports with `Invalid host reference in migration payload`
- exclude orphaned port forwards from newly-created migration exports
- delete a host's port forwards when the host is deleted to avoid creating stale rows
- add regression coverage for export/import and host deletion cleanup

## Tests

- `flutter test test/domain/services/secure_transfer_service_test.dart test/data/repositories/host_repository_test.dart`
- `flutter analyze`
