### PR TITLE
fix: prevent tmux agent theme spew

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -2544,8 +2544,8 @@ String buildTmuxRefreshForegroundClientsCommand(
       'done';
 }
 
-/// Builds a command that updates tmux's pane palette, notifies theme-aware TUI
-/// panes, and redraws foreground clients.
+/// Builds a command that updates tmux's pane palette, refreshes tmux's theme
+/// report cache, nudges theme-aware TUI panes, and redraws foreground clients.
 @visibleForTesting
 String buildTmuxRefreshTerminalThemeCommand(
   String sessionName,
@@ -2626,31 +2626,13 @@ String buildTmuxRefreshTerminalThemeCommand(
       'fi; '
       r'if [ -n "$current_agent_tool" ]; then '
       r'case "$agent_tool" in '
-      'copilot) '
+      'copilot|codex) '
       'injected=1; '
-      '( ${_buildTmuxSendPaneThemeModeReportCommand(theme, extraFlags: extraFlags)} '
-      '2>/dev/null || true; sleep 0.05; '
-      '${_buildTmuxSendPaneBackgroundColorReportCommand(theme, extraFlags: extraFlags)} '
-      '2>/dev/null || true; sleep 0.05; '
-      '${_buildTmuxSendPaneFocusRefreshCommand(extraFlags: extraFlags)} '
+      '( ${_buildTmuxSendPaneFocusRefreshCommand(extraFlags: extraFlags)} '
       '2>/dev/null || true ) & ;; '
-      'codex) '
+      'gemini|opencode|claude|antigravity) '
       'injected=1; '
-      '( ${_buildTmuxSendPaneBackgroundColorReportCommand(theme, extraFlags: extraFlags)} '
-      '2>/dev/null || true; sleep 0.05; '
-      '${_buildTmuxSendPaneFocusRefreshCommand(extraFlags: extraFlags)} '
-      '2>/dev/null || true ) & ;; '
-      'gemini) '
-      'injected=1; '
-      '( ${_buildTmuxSendPaneBackgroundColorReportCommand(theme, extraFlags: extraFlags)} '
-      '2>/dev/null || true; sleep 0.05; '
-      '${_buildTmuxSendPaneFocusTransitionCommand(extraFlags: extraFlags)} '
-      '2>/dev/null || true ) & ;; '
-      'opencode|claude|antigravity) '
-      'injected=1; '
-      '( ${_buildTmuxSendPaneBackgroundColorReportCommand(theme, extraFlags: extraFlags)} '
-      '2>/dev/null || true; sleep 0.05; '
-      '${_buildTmuxSendPaneFocusTransitionCommand(extraFlags: extraFlags)} '
+      '( ${_buildTmuxSendPaneFocusTransitionCommand(extraFlags: extraFlags)} '
       '2>/dev/null || true ) & ;; '
       'esac; '
       'fi; '
@@ -2795,22 +2777,6 @@ String _buildTmuxSendPaneFocusTransitionCommand({String? extraFlags}) =>
     '${_buildTmuxSendPaneFocusReportCommand('\x1b[O', extraFlags: extraFlags)} '
     '2>/dev/null || true; sleep 0.12; '
     '${_buildTmuxSendPaneFocusReportCommand('\x1b[I', extraFlags: extraFlags)}';
-
-String _buildTmuxSendPaneThemeModeReportCommand(
-  TerminalThemeData theme, {
-  String? extraFlags,
-}) => _buildTmuxSendPaneReportCommand(
-  buildTerminalThemeModeReport(isDark: theme.isDark),
-  extraFlags: extraFlags,
-);
-
-String _buildTmuxSendPaneBackgroundColorReportCommand(
-  TerminalThemeData theme, {
-  String? extraFlags,
-}) => _buildTmuxSendPaneReportCommand(
-  buildTerminalThemeBackgroundColorReport(theme),
-  extraFlags: extraFlags,
-);
 
 String _buildTmuxSendPaneFocusReportCommand(
   String report, {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2645,7 +2645,6 @@ class _TmuxTerminalThemeRefreshRequest {
     required this.reason,
     required this.extraFlags,
     this.sendOuterFocusReport = false,
-    this.sendOuterThemeReports = false,
   });
 
   final TerminalThemeData theme;
@@ -2655,7 +2654,6 @@ class _TmuxTerminalThemeRefreshRequest {
   final String reason;
   final String? extraFlags;
   final bool sendOuterFocusReport;
-  final bool sendOuterThemeReports;
 
   _TmuxTerminalThemeRefreshRequest copyWith({
     TerminalThemeData? theme,
@@ -2665,7 +2663,6 @@ class _TmuxTerminalThemeRefreshRequest {
     String? reason,
     String? extraFlags,
     bool? sendOuterFocusReport,
-    bool? sendOuterThemeReports,
   }) => _TmuxTerminalThemeRefreshRequest(
     theme: theme ?? this.theme,
     session: session ?? this.session,
@@ -2674,7 +2671,6 @@ class _TmuxTerminalThemeRefreshRequest {
     reason: reason ?? this.reason,
     extraFlags: extraFlags ?? this.extraFlags,
     sendOuterFocusReport: sendOuterFocusReport ?? this.sendOuterFocusReport,
-    sendOuterThemeReports: sendOuterThemeReports ?? this.sendOuterThemeReports,
   );
 }
 
@@ -3937,16 +3933,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     return _isShellCommandName(command);
   }
 
-  /// Whether outer-tmux theme/focus reports are safe to push through the SSH
-  /// stream right now.
+  /// Whether outer-tmux focus reports are safe to push through the SSH stream.
   ///
-  /// tmux normally consumes outer OSC theme reports for its own pane cache,
-  /// but if the user has detached the tmux client (or tmux exited entirely)
-  /// while the screen still believes [_isTmuxActive] is true, those bytes
-  /// reach a bare shell and become typed input. Reuses the same foreground
-  /// TUI signals as [_shouldRefreshPlainTerminalTui]: if no app has enabled
-  /// any of the modes a real TUI uses, the foreground is almost certainly a
-  /// shell prompt.
+  /// If the user has detached the tmux client (or tmux exited entirely) while
+  /// the screen still believes [_isTmuxActive] is true, even synthetic focus
+  /// bytes reach a bare shell as typed input. Reuses the same foreground TUI
+  /// signals as [_shouldRefreshPlainTerminalTui]: if no app has enabled any of
+  /// the modes a real TUI uses, the foreground is almost certainly a shell
+  /// prompt.
   bool _isOuterTuiSignalingActive(SshSession session) =>
       _shouldRefreshPlainTerminalTui(session);
 
@@ -3962,19 +3956,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   ///
   /// Called whenever tmux is freshly detected or re-detected, regardless of
   /// whether a theme switch just happened. tmux caches the outer terminal's
-  /// default colors per-pane, populated either when tmux first queries the
-  /// outer client or via unsolicited OSC reports. If MonkeySSH attaches to a
-  /// tmux session that was started under a different (or wrong) outer
-  /// terminal — or if a previous attach landed before [SshSession.terminalTheme]
-  /// was set — the cache can answer inner-pane OSC 10/11/12 queries with stale
-  /// values forever. TUIs like Codex CLI bake those answers into their
-  /// composer/surface colors, leaving them mismatched until the cache is
-  /// refreshed.
-  ///
-  /// This priming sends tmux-scoped client responses + tmux pane palette update
-  /// + foreground-client redraw that a theme switch would. It also writes the
-  /// full theme reports to the outer tmux client so tmux updates its own
-  /// terminal cache and notifies panes that requested theme updates.
+  /// default colors per-pane, so priming refreshes tmux's pane palette and
+  /// client report cache through tmux control commands instead of writing
+  /// unsolicited OSC responses into the interactive shell.
   void _primeTmuxTerminalTheme(SshSession session) {
     if (!_isTmuxActive || _tmuxStateConnectionId != session.connectionId) {
       return;
@@ -3993,11 +3977,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         'shellReady': _shell != null,
         'terminalViewReady': _terminalViewKey.currentState != null,
       },
-    );
-    _refreshTerminalThemeReportsForTui(
-      theme,
-      includeColorReports: true,
-      reason: 'tmux_prime_outer_theme',
     );
     final tmuxSessionName = _tmuxSessionName;
     if (tmuxSessionName == null) {
@@ -4018,7 +3997,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         refreshGeneration: refreshGeneration,
         reason: 'tmux_prime',
         extraFlags: extraFlags,
-        sendOuterThemeReports: true,
+        sendOuterFocusReport: true,
       ),
     );
     for (final (:delay, :reason) in const [
@@ -4033,7 +4012,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           refreshGeneration: refreshGeneration,
           reason: reason,
           extraFlags: extraFlags,
-          sendOuterThemeReports: true,
+          sendOuterFocusReport: true,
         ),
         delay: delay,
       );
@@ -4065,7 +4044,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         reason: reason,
         extraFlags: _activeTmuxExtraFlags,
         sendOuterFocusReport: true,
-        sendOuterThemeReports: true,
       ),
       delay: const Duration(milliseconds: 75),
     );
@@ -4231,7 +4209,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       refreshGeneration: _terminalThemeRefreshGeneration,
       reason: reason,
       extraFlags: _activeTmuxExtraFlags,
-      sendOuterThemeReports: true,
+      sendOuterFocusReport: true,
     );
     if (_tmuxWindowThemeRefreshDebounceTimer?.isActive ?? false) {
       return;
@@ -4323,25 +4301,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           session: pendingRequest.session,
           refreshGeneration: pendingRequest.refreshGeneration,
         );
-    final preservePendingOuterTheme =
-        pendingRequest != null &&
-        pendingRequest.sendOuterThemeReports &&
-        _isCurrentTerminalThemeRefresh(
-          theme: pendingRequest.theme,
-          session: pendingRequest.session,
-          refreshGeneration: pendingRequest.refreshGeneration,
-        );
-    if (!preservePendingOuterFocus && !preservePendingOuterTheme) {
+    if (!preservePendingOuterFocus) {
       return request;
     }
     return request.copyWith(
-      reason: request.sendOuterFocusReport || request.sendOuterThemeReports
+      reason: request.sendOuterFocusReport
           ? request.reason
           : pendingRequest.reason,
       sendOuterFocusReport:
           request.sendOuterFocusReport || preservePendingOuterFocus,
-      sendOuterThemeReports:
-          request.sendOuterThemeReports || preservePendingOuterTheme,
     );
   }
 
@@ -4419,7 +4387,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             'reason': request.reason,
             'connectionId': request.session.connectionId,
             'sendOuterFocusReport': request.sendOuterFocusReport,
-            'sendOuterThemeReports': request.sendOuterThemeReports,
             'shellReady': _shell != null,
             'terminalViewReady': _terminalViewKey.currentState != null,
           },
@@ -4450,51 +4417,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           'reason': request.reason,
           'connectionId': request.session.connectionId,
           'sendOuterFocusReport': request.sendOuterFocusReport,
-          'sendOuterThemeReports': request.sendOuterThemeReports,
           'tmuxCommandDeferred': tmuxCommandDeferred,
         },
       );
       return;
     }
-    if (request.sendOuterThemeReports) {
-      if (!_isOuterTuiSignalingActive(request.session)) {
-        DiagnosticsLogService.instance.info(
-          'terminal.theme',
-          'tmux_outer_reports_skipped',
-          fields: {
-            'reason': '${outerRefreshReason}_no_foreground_tui',
-            'connectionId': request.session.connectionId,
-            'colorSchemeUpdatesMode':
-                request.session.terminalColorSchemeUpdatesMode,
-            'focusMode': _terminal.reportFocusMode,
-            'altBuffer': _terminal.isUsingAltBuffer,
-            'mouseMode': _terminal.mouseMode != MouseMode.none,
-          },
-        );
-        return;
-      }
-      _refreshTerminalThemeReportsForTui(
-        request.theme,
-        includeColorReports: true,
-        reason: '${outerRefreshReason}_tmux_outer_theme',
-      );
-      _scheduleTerminalThemeRefreshForTui(
-        theme: request.theme,
-        session: request.session,
-        refreshGeneration: request.refreshGeneration,
-        delay: const Duration(milliseconds: 150),
-        includeColorReports: true,
-        reason: '${outerRefreshReason}_tmux_outer_theme_late',
-      );
-      _scheduleTerminalThemeRefreshForTui(
-        theme: request.theme,
-        session: request.session,
-        refreshGeneration: request.refreshGeneration,
-        delay: const Duration(milliseconds: 300),
-        includeThemeModeReport: false,
-        reason: '${outerRefreshReason}_tmux_outer_focus_late',
-      );
-    } else if (request.sendOuterFocusReport) {
+    if (request.sendOuterFocusReport) {
       if (!_isOuterTuiSignalingActive(request.session)) {
         DiagnosticsLogService.instance.info(
           'terminal.theme',

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -205,10 +205,8 @@ void main() {
       expect(command, contains('done; wait; };'));
       expect(command, contains(r'if [ -n "$current_agent_tool" ]; then'));
       expect(command, contains(r'case "$agent_tool" in'));
-      expect(command, contains('copilot)'));
-      expect(command, contains('codex)'));
-      expect(command, contains('gemini)'));
-      expect(command, contains('opencode|claude|antigravity)'));
+      expect(command, contains('copilot|codex)'));
+      expect(command, contains('gemini|opencode|claude|antigravity)'));
       final directBranchStart = command.indexOf(
         r'if [ -n "$current_agent_tool" ]; then',
       );
@@ -248,59 +246,29 @@ void main() {
       );
       expect(command, contains('1b 5b 4f'));
       expect(command, contains('1b 5b 49'));
-      final copilotBranchStart = directBranch.indexOf('copilot)');
-      final codexBranchStart = directBranch.indexOf('codex)');
-      final geminiBranchStart = directBranch.indexOf('gemini)');
-      final opencodeBranchStart = directBranch.indexOf(
-        'opencode|claude|antigravity)',
+      final copilotCodexBranchStart = directBranch.indexOf('copilot|codex)');
+      final otherAgentBranchStart = directBranch.indexOf(
+        'gemini|opencode|claude|antigravity)',
       );
-      final backgroundReportHex = _tmuxSendKeysHex(
-        buildTerminalThemeBackgroundColorReport(TerminalThemes.dracula),
+      final focusOutHex = _tmuxSendKeysHex('\x1b[O');
+      final focusInHex = _tmuxSendKeysHex('\x1b[I');
+      final themeModeHexPrefix = _tmuxSendKeysHex('\x1b[?997;');
+      final oscHexPrefix = _tmuxSendKeysHex('\x1b]');
+      expect(copilotCodexBranchStart, isNonNegative);
+      expect(otherAgentBranchStart, greaterThan(copilotCodexBranchStart));
+      final copilotCodexBranch = directBranch.substring(
+        copilotCodexBranchStart,
+        otherAgentBranchStart,
       );
-      expect(copilotBranchStart, isNonNegative);
-      expect(codexBranchStart, greaterThan(copilotBranchStart));
-      expect(geminiBranchStart, greaterThan(codexBranchStart));
-      expect(opencodeBranchStart, greaterThan(geminiBranchStart));
-      expect(
-        directBranch.substring(copilotBranchStart, codexBranchStart),
-        contains('1b 5b 3f 39 39 37 3b 31 6e'),
-      );
-      expect(
-        directBranch.substring(copilotBranchStart, codexBranchStart),
-        contains(backgroundReportHex),
-      );
-      expect(
-        directBranch.substring(codexBranchStart, geminiBranchStart),
-        isNot(contains('1b 5b 3f 39 39 37')),
-      );
-      expect(
-        directBranch.substring(codexBranchStart, geminiBranchStart),
-        contains(backgroundReportHex),
-      );
-      expect(
-        directBranch.substring(geminiBranchStart, opencodeBranchStart),
-        isNot(contains('1b 5b 3f 39 39 37')),
-      );
-      expect(
-        directBranch.substring(codexBranchStart, geminiBranchStart),
-        isNot(contains('1b 5b 4f')),
-      );
-      expect(
-        directBranch.substring(geminiBranchStart, opencodeBranchStart),
-        contains(backgroundReportHex),
-      );
-      expect(
-        directBranch.substring(opencodeBranchStart),
-        contains(backgroundReportHex),
-      );
-      expect(
-        directBranch.indexOf('1b 5b 4f', geminiBranchStart),
-        greaterThan(geminiBranchStart),
-      );
-      expect(
-        directBranch.indexOf('1b 5b 4f', opencodeBranchStart),
-        greaterThan(opencodeBranchStart),
-      );
+      final otherAgentBranch = directBranch.substring(otherAgentBranchStart);
+      expect(copilotCodexBranch, contains(focusInHex));
+      expect(copilotCodexBranch, isNot(contains(focusOutHex)));
+      expect(copilotCodexBranch, isNot(contains(themeModeHexPrefix)));
+      expect(copilotCodexBranch, isNot(contains(oscHexPrefix)));
+      expect(otherAgentBranch, contains(focusOutHex));
+      expect(otherAgentBranch, contains(focusInHex));
+      expect(otherAgentBranch, isNot(contains(themeModeHexPrefix)));
+      expect(otherAgentBranch, isNot(contains(oscHexPrefix)));
       expect(command, isNot(contains('sleep 0.25')));
       final tmuxCacheReports = [
         buildTerminalThemeModeReport(isDark: TerminalThemes.dracula.isDark),
@@ -321,15 +289,13 @@ void main() {
           buildTerminalThemeRefreshReportList(TerminalThemes.dracula).join(),
         ),
       );
+      expect(command, contains(r'send-keys -t "$pane" -H 1b 5b 49'));
+      expect(command, contains(r'send-keys -t "$pane" -H 1b 5b 4f'));
       expect(
         command,
-        contains(r'send-keys -t "$pane" -H 1b 5b 3f 39 39 37 3b 31 6e'),
+        isNot(contains(r'send-keys -t "$pane" -H 1b 5b 3f 39 39 37')),
       );
-      expect(command, isNot(contains(r'send-keys -t "$pane" -H 1b 5d 31 30')));
-      expect(command, contains(r'send-keys -t "$pane" -H 1b 5d 31 31'));
-      expect(command, isNot(contains(r'send-keys -t "$pane" -H 1b 5d 34')));
-      expect(RegExp('1b 5d 31 30 3b').allMatches(command), isEmpty);
-      expect(RegExp('1b 5d 31 31 3b').allMatches(command), hasLength(4));
+      expect(command, isNot(contains(r'send-keys -t "$pane" -H 1b 5d')));
       expect(
         command,
         contains("tmux -u list-clients -t 'dev'\"'\"'s session'"),

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1972,7 +1972,7 @@ void main() {
 
       if (simulateAttachedTuiSignals) {
         // Real tmux clients enable focus reports + alt buffer on attach. The
-        // outer reports gate uses these to skip pushing OSC bytes through SSH
+        // outer focus gate uses these to skip pushing focus bytes through SSH
         // when the foreground is a bare shell, so tests that exercise the
         // attached-tmux happy path need the same signals to be visible before
         // the prime/refresh paths fire on initial pumps.
@@ -2128,7 +2128,7 @@ void main() {
     );
 
     testWidgets(
-      'primes tmux with outer theme reports after attach',
+      'primes tmux without outer OSC reports after attach',
       (tester) async {
         final tmuxService = _MockTmuxService();
         await pumpTmuxScreen(
@@ -2141,17 +2141,17 @@ void main() {
         final writtenShellText = utf8.decode(
           shellWrites.expand((chunk) => chunk).toList(growable: false),
         );
-        expect(writtenShellText, contains('\x1b[O'));
         expect(writtenShellText, contains('\x1b[I'));
-        expect(writtenShellText, contains('\x1b]10;'));
-        expect(writtenShellText, contains('\x1b]11;'));
-        expect(writtenShellText, contains('\x1b]4;'));
+        expect(writtenShellText, isNot(contains('\x1b[?997;')));
+        expect(writtenShellText, isNot(contains('\x1b]10;')));
+        expect(writtenShellText, isNot(contains('\x1b]11;')));
+        expect(writtenShellText, isNot(contains('\x1b]4;')));
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );
 
     testWidgets(
-      'sends outer tmux theme reports after theme changes',
+      'sends outer tmux focus without OSC reports after theme changes',
       (tester) async {
         final tmuxService = _MockTmuxService();
         await pumpTmuxScreen(
@@ -2177,10 +2177,10 @@ void main() {
         );
         expect(writtenShellText, contains('\x1b[O'));
         expect(writtenShellText, contains('\x1b[I'));
-        expect(writtenShellText, contains('\x1b[?997;1n'));
-        expect(writtenShellText, contains('\x1b]10;'));
-        expect(writtenShellText, contains('\x1b]11;'));
-        expect(writtenShellText, contains('\x1b]4;'));
+        expect(writtenShellText, isNot(contains('\x1b[?997;')));
+        expect(writtenShellText, isNot(contains('\x1b]10;')));
+        expect(writtenShellText, isNot(contains('\x1b]11;')));
+        expect(writtenShellText, isNot(contains('\x1b]4;')));
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );
@@ -3013,7 +3013,7 @@ void main() {
     );
 
     testWidgets(
-      'does not leak outer tmux theme reports to a bare shell after detach',
+      'does not leak outer tmux focus to a bare shell after detach',
       (tester) async {
         final tmuxService = _MockTmuxService();
         await pumpTmuxScreen(tester, tmuxService);
@@ -3031,10 +3031,10 @@ void main() {
         await tester.pump(const Duration(milliseconds: 400));
 
         // tmux attach has been torn down (no focus tracking, alt buffer, mouse
-        // mode, or DEC 2031 subscription), so OSC theme reports would land on
-        // a bare zsh prompt and be echoed back as typed input. Even though
-        // tmux state is still primed locally, the gate on foreground TUI
-        // signals must suppress the outer reports entirely.
+        // mode, or DEC 2031 subscription), so synthetic focus would land on a
+        // bare zsh prompt and be echoed back as typed input. Even though tmux
+        // state is still primed locally, the gate on foreground TUI signals
+        // must suppress the outer focus entirely.
         final writtenShellText = utf8.decode(
           shellWrites.expand((chunk) => chunk).toList(growable: false),
         );
@@ -3060,7 +3060,7 @@ void main() {
 
         addTearDown(windowEvents.close);
         // Real tmux clients enable focus tracking + alt buffer on attach;
-        // the outer reports gate skips OSC sends to a bare shell, so simulate
+        // the outer focus gate skips focus sends to a bare shell, so simulate
         // those signals on the session terminal before the screen pumps.
         session.terminal!.write('\x1b[?1004h');
         host = _buildHost(
@@ -3167,30 +3167,15 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 150));
 
-        expect(
-          utf8.decode(
-            shellWrites.expand((chunk) => chunk).toList(growable: false),
-          ),
-          contains('\x1b[O'),
+        final writtenShellText = utf8.decode(
+          shellWrites.expand((chunk) => chunk).toList(growable: false),
         );
-        expect(
-          utf8.decode(
-            shellWrites.expand((chunk) => chunk).toList(growable: false),
-          ),
-          contains('\x1b[I'),
-        );
-        expect(
-          utf8.decode(
-            shellWrites.expand((chunk) => chunk).toList(growable: false),
-          ),
-          contains('\x1b[?997;1n'),
-        );
-        expect(
-          utf8.decode(
-            shellWrites.expand((chunk) => chunk).toList(growable: false),
-          ),
-          contains('\x1b]10;'),
-        );
+        expect(writtenShellText, contains('\x1b[O'));
+        expect(writtenShellText, contains('\x1b[I'));
+        expect(writtenShellText, isNot(contains('\x1b[?997;')));
+        expect(writtenShellText, isNot(contains('\x1b]10;')));
+        expect(writtenShellText, isNot(contains('\x1b]11;')));
+        expect(writtenShellText, isNot(contains('\x1b]4;')));
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );
@@ -3207,7 +3192,7 @@ void main() {
         ];
 
         // Real tmux clients enable focus tracking + alt buffer on attach;
-        // the outer reports gate skips OSC sends to a bare shell, so simulate
+        // the outer focus gate skips focus sends to a bare shell, so simulate
         // those signals on the session terminal before the screen pumps.
         session.terminal!.write('\x1b[?1004h');
         host = _buildHost(
@@ -3327,11 +3312,10 @@ void main() {
         final writtenShellText = utf8.decode(
           shellWrites.expand((chunk) => chunk).toList(growable: false),
         );
-        expect(writtenShellText, contains('\x1b[?997;2n'));
-        expect(writtenShellText, isNot(contains('\x1b[?997;1n')));
-        expect(writtenShellText, contains('\x1b]10;'));
-        expect(writtenShellText, contains('\x1b]11;'));
-        expect(writtenShellText, contains('\x1b]4;'));
+        expect(writtenShellText, isNot(contains('\x1b[?997;')));
+        expect(writtenShellText, isNot(contains('\x1b]10;')));
+        expect(writtenShellText, isNot(contains('\x1b]11;')));
+        expect(writtenShellText, isNot(contains('\x1b]4;')));
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );
@@ -3633,7 +3617,7 @@ void main() {
 
         addTearDown(windowEvents.close);
         // Real tmux clients enable focus tracking + alt buffer on attach;
-        // the outer reports gate skips OSC sends to a bare shell, so simulate
+        // the outer focus gate skips focus sends to a bare shell, so simulate
         // those signals on the session terminal before the screen pumps.
         session.terminal!.write('\x1b[?1004h');
         host = _buildHost(
@@ -3796,7 +3780,7 @@ void main() {
 
         addTearDown(windowEvents.close);
         // Real tmux clients enable focus tracking + alt buffer on attach;
-        // the outer reports gate skips OSC sends to a bare shell, so simulate
+        // the outer focus gate skips focus sends to a bare shell, so simulate
         // those signals on the session terminal before the screen pumps.
         session.terminal!.write('\x1b[?1004h');
         host = _buildHost(
@@ -3968,10 +3952,10 @@ void main() {
         );
         expect(writtenShellText, contains('\x1b[O'));
         expect(writtenShellText, contains('\x1b[I'));
-        expect(writtenShellText, contains('\x1b[?997;2n'));
-        expect(writtenShellText, contains('\x1b]10;'));
-        expect(writtenShellText, contains('\x1b]11;'));
-        expect(writtenShellText, contains('\x1b]4;'));
+        expect(writtenShellText, isNot(contains('\x1b[?997;')));
+        expect(writtenShellText, isNot(contains('\x1b]10;')));
+        expect(writtenShellText, isNot(contains('\x1b]11;')));
+        expect(writtenShellText, isNot(contains('\x1b]4;')));
         final client =
             tester.state(find.byType(TerminalTextInputHandler))
                 as TextInputClient;
@@ -4006,7 +3990,7 @@ void main() {
 
         addTearDown(windowEvents.close);
         // Real tmux clients enable focus tracking + alt buffer on attach;
-        // the outer reports gate skips OSC sends to a bare shell, so simulate
+        // the outer focus gate skips focus sends to a bare shell, so simulate
         // those signals on the session terminal before the screen pumps.
         session.terminal!.write('\x1b[?1004h');
         host = _buildHost(id: host.id, tmuxSessionName: tmuxSessionName);


### PR DESCRIPTION
## Summary

- Stop writing unsolicited tmux OSC/private theme reports through the interactive shell during tmux theme refreshes.
- Stop injecting OSC/background reports into detected agent panes with `tmux send-keys`; keep focus nudges and tmux `refresh-client -r` cache updates.
- Update tmux command and terminal-screen tests to assert OSC reports no longer leak through shell/send-keys paths.

## Validation

- `flutter test test/domain/services/tmux_service_control_mode_test.dart`
- `flutter test test/presentation/screens/terminal_screen_test.dart --name "primes tmux without outer OSC reports|sends outer tmux focus without OSC reports|preserves outer focus after coalesced tmux window refreshes|does not send stale outer focus after superseded tmux theme refresh|refreshes tmux theme after window state changes"`
- `flutter analyze`
- pre-commit hook: format, analyzer, tests
