### PR TITLE
fix: address review findings

### DIFF
--- a/ios/exportOptions.plist
+++ b/ios/exportOptions.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>method</key>
 	<string>app-store</string>
-	<key>uploadBitcode</key>
-	<false/>
 	<key>uploadSymbols</key>
 	<true/>
 </dict>

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -73,6 +73,8 @@ final routerProvider = Provider<GoRouter>((ref) {
             state.uri.queryParameters['tmuxWindow'] ?? '',
           );
           final initialTmuxWindowId = state.uri.queryParameters['tmuxWindowId'];
+          final initiallyExpandTmuxWindows =
+              state.uri.queryParameters['expandTmux'] == '1';
           if (hostId == null) {
             return _buildTerminalPage(
               state: state,
@@ -92,6 +94,7 @@ final routerProvider = Provider<GoRouter>((ref) {
                   initialTmuxWindowIndex,
                   initialTmuxWindowId,
                   state.uri.queryParameters['notificationTap'],
+                  initiallyExpandTmuxWindows,
                 ),
               ),
               hostId: hostId,
@@ -101,8 +104,7 @@ final routerProvider = Provider<GoRouter>((ref) {
               initialTmuxWindowId: initialTmuxWindowId,
               initialTmuxWindowRequiresVisibleSession:
                   state.uri.queryParameters['notificationTap'] != null,
-              initiallyExpandTmuxWindows:
-                  state.uri.queryParameters['expandTmux'] == '1',
+              initiallyExpandTmuxWindows: initiallyExpandTmuxWindows,
             ),
           );
         },

--- a/lib/data/repositories/host_repository.dart
+++ b/lib/data/repositories/host_repository.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../domain/services/auth_service.dart';
 import '../database/database.dart';
 import '../security/secret_encryption_service.dart';
+import 'like_query.dart';
 
 /// Repository for managing host entities.
 class HostRepository {
@@ -103,13 +104,16 @@ class HostRepository {
   /// The query is treated as a literal string: `%` and `_` are matched
   /// exactly rather than acting as SQL LIKE wildcards.
   Future<List<Host>> search(String query) {
-    final escaped = _escapeLike(query);
+    final escaped = escapeSqlLikeQuery(query);
     return (_db.select(_db.hosts)
           ..where(
             (h) =>
-                h.label.like('%$escaped%', escapeChar: r'\') |
-                h.hostname.like('%$escaped%', escapeChar: r'\') |
-                h.tags.like('%$escaped%', escapeChar: r'\'),
+                h.label.like('%$escaped%', escapeChar: sqlLikeEscapeCharacter) |
+                h.hostname.like(
+                  '%$escaped%',
+                  escapeChar: sqlLikeEscapeCharacter,
+                ) |
+                h.tags.like('%$escaped%', escapeChar: sqlLikeEscapeCharacter),
           )
           ..orderBy([
             (h) => OrderingTerm.asc(h.sortOrder),
@@ -118,13 +122,6 @@ class HostRepository {
         .get()
         .then(_decryptHosts);
   }
-
-  /// Escapes SQLite LIKE metacharacters so that `%`, `_`, and `\` in the
-  /// [query] are matched literally rather than as pattern characters.
-  static String _escapeLike(String query) => query
-      .replaceAll(r'\', r'\\')
-      .replaceAll('%', r'\%')
-      .replaceAll('_', r'\_');
 
   /// Insert a new host.
   Future<int> insert(HostsCompanion host) async {

--- a/lib/data/repositories/key_repository.dart
+++ b/lib/data/repositories/key_repository.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../domain/services/auth_service.dart';
 import '../database/database.dart';
 import '../security/secret_encryption_service.dart';
+import 'like_query.dart';
 
 enum _KeySecretColumn { privateKey, passphrase }
 
@@ -79,10 +80,14 @@ class KeyRepository {
   }
 
   /// Search keys by name.
-  Future<List<SshKey>> search(String query) =>
-      (_db.select(_db.sshKeys)..where((k) => k.name.like('%$query%')))
-          .get()
-          .then((keys) async => (await _loadDecryptable(keys)).keys);
+  Future<List<SshKey>> search(String query) {
+    final escaped = escapeSqlLikeQuery(query);
+    return (_db.select(_db.sshKeys)..where(
+          (k) => k.name.like('%$escaped%', escapeChar: sqlLikeEscapeCharacter),
+        ))
+        .get()
+        .then((keys) async => (await _loadDecryptable(keys)).keys);
+  }
 
   /// Insert a new key.
   Future<int> insert(SshKeysCompanion key) async {

--- a/lib/data/repositories/like_query.dart
+++ b/lib/data/repositories/like_query.dart
@@ -1,0 +1,11 @@
+/// Escape character used for repository SQL LIKE clauses.
+const sqlLikeEscapeCharacter = r'\';
+
+/// Escapes SQLite LIKE metacharacters in [query] for literal substring search.
+String escapeSqlLikeQuery(String query) => query
+    .replaceAll(
+      sqlLikeEscapeCharacter,
+      '$sqlLikeEscapeCharacter$sqlLikeEscapeCharacter',
+    )
+    .replaceAll('%', '$sqlLikeEscapeCharacter%')
+    .replaceAll('_', '${sqlLikeEscapeCharacter}_');

--- a/lib/data/repositories/snippet_repository.dart
+++ b/lib/data/repositories/snippet_repository.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../database/database.dart';
+import 'like_query.dart';
 
 /// Repository for managing snippets.
 class SnippetRepository {
@@ -43,19 +44,27 @@ class SnippetRepository {
           .get();
 
   /// Search snippets.
-  Future<List<Snippet>> search(String query) =>
-      (_db.select(_db.snippets)
-            ..where(
-              (s) =>
-                  s.name.like('%$query%') |
-                  s.command.like('%$query%') |
-                  s.description.like('%$query%'),
-            )
-            ..orderBy([
-              (s) => OrderingTerm.asc(s.sortOrder),
-              (s) => OrderingTerm.asc(s.id),
-            ]))
-          .get();
+  Future<List<Snippet>> search(String query) {
+    final escaped = escapeSqlLikeQuery(query);
+    return (_db.select(_db.snippets)
+          ..where(
+            (s) =>
+                s.name.like('%$escaped%', escapeChar: sqlLikeEscapeCharacter) |
+                s.command.like(
+                  '%$escaped%',
+                  escapeChar: sqlLikeEscapeCharacter,
+                ) |
+                s.description.like(
+                  '%$escaped%',
+                  escapeChar: sqlLikeEscapeCharacter,
+                ),
+          )
+          ..orderBy([
+            (s) => OrderingTerm.asc(s.sortOrder),
+            (s) => OrderingTerm.asc(s.id),
+          ]))
+        .get();
+  }
 
   /// Get a snippet by ID.
   Future<Snippet?> getById(int id) => (_db.select(

--- a/lib/domain/services/settings_service.dart
+++ b/lib/domain/services/settings_service.dart
@@ -146,7 +146,11 @@ class SettingsService {
     final value = await getString(key);
     if (value == null) return null;
     try {
-      return jsonDecode(value) as Map<String, dynamic>;
+      final decoded = jsonDecode(value);
+      if (decoded is Map<String, dynamic>) {
+        return decoded;
+      }
+      return null;
     } on FormatException {
       return null;
     }

--- a/lib/presentation/widgets/unsaved_changes_guard.dart
+++ b/lib/presentation/widgets/unsaved_changes_guard.dart
@@ -98,12 +98,7 @@ class _UnsavedChangesGuardState extends State<UnsavedChangesGuard> {
       if (!mounted) {
         return;
       }
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) {
-          return;
-        }
-        unawaited(_popGuardedRoute());
-      });
+      unawaited(_popGuardedRoute());
     });
   }
 

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -61,10 +61,11 @@ const terminalScreenClearSequence = "\x1b[H\x1b[2J\x1b[3J"
 
 const terminalAllScreensClearSequence = terminalScreenClearSequence + "\x1b[?1049h" + terminalScreenClearSequence + "\x1b[?1049l" + terminalScreenClearSequence
 
-const activeWindowReplayPrefix = terminalParserResetSequence + "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1004l\x1b[?1007l\x1b[?2004l\x1b[?2031l\x1b[?1049l\x1b[?1l\x1b[?6l\x1b[?7h\x1b[4l\x1b>\x1b[r" + terminalCharacterSetResetSequence + "\x1b[0m" + terminalAllScreensClearSequence
+const activeWindowReplayPrefix = terminalParserResetSequence + "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1004l\x1b[?1007l\x1b[?2004l\x1b[?2031l\x1b[?1047l\x1b[?1049l\x1b[?1l\x1b[?6l\x1b[?7h\x1b[4l\x1b>\x1b[r" + terminalCharacterSetResetSequence + "\x1b[0m" + terminalAllScreensClearSequence
 
 var (
 	preReplayPrivateModes = []string{
+		"1047",
 		"1049",
 		"6",
 		"7",
@@ -100,6 +101,7 @@ var (
 		"1004": {},
 		"1006": {},
 		"1007": {},
+		"1047": {},
 		"1049": {},
 		"2004": {},
 		"2031": {},
@@ -2549,11 +2551,15 @@ func (w *muxWindow) usesFullHistoryForReplayLocked() bool {
 	if w == nil {
 		return false
 	}
-	if w.privateModes["1049"] || w.agentToolLocked() != "" {
+	if w.alternateScreenModeActiveLocked() || w.agentToolLocked() != "" {
 		return true
 	}
 	command := strings.TrimSpace(w.currentCommandLocked())
 	return command != "" && !isShellCommandName(command)
+}
+
+func (w *muxWindow) alternateScreenModeActiveLocked() bool {
+	return w.privateModes["1047"] || w.privateModes["1049"]
 }
 
 func (w *muxWindow) reportsMouseWheelLocked() bool {
@@ -2607,7 +2613,7 @@ func terminalModePreReplaySequence(window *muxWindow) []byte {
 }
 
 func terminalPreHistoryClearSequence(window *muxWindow) []byte {
-	if window == nil || !window.privateModes["1049"] {
+	if window == nil || !window.alternateScreenModeActiveLocked() {
 		return nil
 	}
 	return []byte(terminalScreenClearSequence)

--- a/remote/monkeymux/main_test.go
+++ b/remote/monkeymux/main_test.go
@@ -790,39 +790,45 @@ func TestActiveReplayIsCappedForResponsiveSwitching(t *testing.T) {
 }
 
 func TestActiveReplayKeepsFullAlternateScreenHistory(t *testing.T) {
-	server := newMuxServer("test")
-	history := []byte(
-		"\x1b[?1049h" +
-			"alternate-screen-start" +
-			strings.Repeat("\x1b]66;semantic\a", windowReplayLimitBytes/8) +
-			"alternate-screen-end",
-	)
-	window := &muxWindow{
-		id:           "@1",
-		index:        0,
-		history:      history,
-		lastActivity: time.Now(),
-	}
-	server.windows = []*muxWindow{window}
-	server.activeID = "@1"
+	for _, mode := range []string{"1047", "1049"} {
+		t.Run(mode, func(t *testing.T) {
+			server := newMuxServer("test")
+			enterAlternateScreen := "\x1b[?" + mode + "h"
+			history := []byte(
+				enterAlternateScreen +
+					"alternate-screen-start" +
+					strings.Repeat("\x1b]66;semantic\a", windowReplayLimitBytes/8) +
+					"alternate-screen-end",
+			)
+			window := &muxWindow{
+				id:           "@1",
+				index:        0,
+				history:      history,
+				lastActivity: time.Now(),
+			}
+			server.windows = []*muxWindow{window}
+			server.activeID = "@1"
 
-	window.observeTerminalModesLocked(history)
-	replay := string(server.activeReplayLocked())
+			window.observeTerminalModesLocked(history)
+			replay := string(server.activeReplayLocked())
 
-	if !strings.Contains(replay, "alternate-screen-start") {
-		t.Fatalf("alternate-screen replay was capped before screen start")
-	}
-	if !strings.Contains(
-		replay,
-		"\x1b[?1049h"+terminalScreenClearSequence+"\x1b[?1049halternate-screen-start",
-	) {
-		t.Fatalf("alternate-screen replay did not clear stale alternate buffer before history: %q", replay)
-	}
-	if !strings.Contains(replay, "alternate-screen-end") {
-		t.Fatalf("alternate-screen replay lost screen end")
-	}
-	if got, want := len(window.history), len(history); got != want {
-		t.Fatalf("history length = %d, want %d", got, want)
+			if !strings.Contains(replay, "alternate-screen-start") {
+				t.Fatalf("alternate-screen replay was capped before screen start")
+			}
+			if !strings.Contains(
+				replay,
+				enterAlternateScreen+terminalScreenClearSequence+
+					enterAlternateScreen+"alternate-screen-start",
+			) {
+				t.Fatalf("alternate-screen replay did not clear stale alternate buffer before history: %q", replay)
+			}
+			if !strings.Contains(replay, "alternate-screen-end") {
+				t.Fatalf("alternate-screen replay lost screen end")
+			}
+			if got, want := len(window.history), len(history); got != want {
+				t.Fatalf("history length = %d, want %d", got, want)
+			}
+		})
 	}
 }
 
@@ -940,30 +946,36 @@ func TestActiveReplayPrefixClearsMainAndAlternateScreens(t *testing.T) {
 }
 
 func TestActiveReplayCapsExitedAlternateScreenHistory(t *testing.T) {
-	server := newMuxServer("test")
-	history := []byte(
-		"\x1b[?1049h" +
-			"stale-alt-screen-start" +
-			strings.Repeat("main-screen-output", windowReplayLimitBytes/8) +
-			"main-screen-suffix",
-	)
-	window := &muxWindow{
-		id:           "@1",
-		index:        0,
-		history:      history,
-		lastActivity: time.Now(),
-	}
-	server.windows = []*muxWindow{window}
-	server.activeID = "@1"
+	for _, mode := range []string{"1047", "1049"} {
+		t.Run(mode, func(t *testing.T) {
+			server := newMuxServer("test")
+			history := []byte(
+				"\x1b[?" + mode + "h" +
+					"stale-alt-screen-start" +
+					strings.Repeat("main-screen-output", windowReplayLimitBytes/8) +
+					"main-screen-suffix",
+			)
+			window := &muxWindow{
+				id:           "@1",
+				index:        0,
+				history:      history,
+				lastActivity: time.Now(),
+			}
+			server.windows = []*muxWindow{window}
+			server.activeID = "@1"
 
-	window.observeTerminalModesLocked([]byte("\x1b[?1049h\x1b[?1049l"))
-	replay := string(server.activeReplayLocked())
+			window.observeTerminalModesLocked(
+				[]byte("\x1b[?" + mode + "h" + "\x1b[?" + mode + "l"),
+			)
+			replay := string(server.activeReplayLocked())
 
-	if strings.Contains(replay, "stale-alt-screen-start") {
-		t.Fatalf("main-screen replay retained stale alternate-screen prefix")
-	}
-	if !strings.Contains(replay, "main-screen-suffix") {
-		t.Fatalf("main-screen replay lost recent suffix")
+			if strings.Contains(replay, "stale-alt-screen-start") {
+				t.Fatalf("main-screen replay retained stale alternate-screen prefix")
+			}
+			if !strings.Contains(replay, "main-screen-suffix") {
+				t.Fatalf("main-screen replay lost recent suffix")
+			}
+		})
 	}
 }
 
@@ -1621,6 +1633,7 @@ func TestReplayPrefixResetsStaleInputModes(t *testing.T) {
 		"\x1b[?1004l",
 		"\x1b[?1007l",
 		"\x1b[?2004l",
+		"\x1b[?1047l",
 		"\x1b[?1l",
 		"\x1b[?6l",
 		"\x1b[?7h",

--- a/test/app/router_test.dart
+++ b/test/app/router_test.dart
@@ -9,6 +9,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:monkeyssh/app/router.dart';
 import 'package:monkeyssh/app/routes.dart';
 import 'package:monkeyssh/domain/services/auth_service.dart';
+import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
@@ -276,6 +277,26 @@ void main() {
       expect(route.allowSnapshotting, isFalse);
     });
 
+    test('terminal route keys distinguish expand tmux requests', () {
+      final router = container.read(routerProvider);
+      final terminalRoute = router.configuration.routes
+          .whereType<GoRoute>()
+          .singleWhere((route) => route.name == Routes.terminal);
+
+      final collapsed = _terminalScreenFor(
+        router: router,
+        route: terminalRoute,
+        uri: Uri.parse('/terminal/1?connectionId=7'),
+      );
+      final expanded = _terminalScreenFor(
+        router: router,
+        route: terminalRoute,
+        uri: Uri.parse('/terminal/1?connectionId=7&expandTmux=1'),
+      );
+
+      expect(collapsed.key, isNot(expanded.key));
+    });
+
     test('intentionally returns a new GoRouter instance when authState changes '
         'to reset protected back-stack history', () async {
       // Initialise the auth notifier and let it settle to notConfigured.
@@ -389,4 +410,43 @@ void main() {
       );
     });
   });
+}
+
+TerminalScreen _terminalScreenFor({
+  required GoRouter router,
+  required GoRoute route,
+  required Uri uri,
+}) {
+  final page = route.pageBuilder!(
+    _MockBuildContext(),
+    GoRouterState(
+      router.configuration,
+      uri: uri,
+      matchedLocation: '/terminal/1',
+      name: Routes.terminal,
+      path: '/terminal/:hostId',
+      fullPath: '/terminal/:hostId',
+      pathParameters: const {'hostId': '1'},
+      pageKey: const ValueKey<String>('/terminal/:hostId'),
+      topRoute: route,
+    ),
+  );
+  final terminalRoute =
+      page.createRoute(_MockBuildContext()) as PageRoute<void>;
+  final pageWidget = terminalRoute.buildPage(
+    _MockBuildContext(),
+    kAlwaysCompleteAnimation,
+    kAlwaysDismissedAnimation,
+  );
+  return _findTerminalScreen(pageWidget);
+}
+
+TerminalScreen _findTerminalScreen(Widget widget) {
+  if (widget is TerminalScreen) {
+    return widget;
+  }
+  if (widget is Semantics && widget.child != null) {
+    return _findTerminalScreen(widget.child!);
+  }
+  throw StateError('TerminalScreen not found in terminal route page.');
 }

--- a/test/data/repositories/snippet_repository_test.dart
+++ b/test/data/repositories/snippet_repository_test.dart
@@ -196,6 +196,38 @@ void main() {
       expect(results.first.name, 'Cleanup');
     });
 
+    test(
+      'search treats percent as a literal character, not a wildcard',
+      () async {
+        await repository.insert(
+          SnippetsCompanion.insert(name: 'Disk 100%', command: 'df -h'),
+        );
+        await repository.insert(
+          SnippetsCompanion.insert(name: 'List files', command: 'ls -la'),
+        );
+
+        final results = await repository.search('%');
+        expect(results, hasLength(1));
+        expect(results.first.name, 'Disk 100%');
+      },
+    );
+
+    test(
+      'search treats underscore as a literal character, not a wildcard',
+      () async {
+        await repository.insert(
+          SnippetsCompanion.insert(name: 'deploy_app', command: 'deploy app'),
+        );
+        await repository.insert(
+          SnippetsCompanion.insert(name: 'deploy app', command: 'deploy app'),
+        );
+
+        final results = await repository.search('deploy_');
+        expect(results, hasLength(1));
+        expect(results.first.name, 'deploy_app');
+      },
+    );
+
     test('getFrequent returns snippets ordered by usage count', () async {
       final id1 = await repository.insert(
         SnippetsCompanion.insert(name: 'Snippet 1', command: 'cmd1'),

--- a/test/data/repositories/ssh_key_repository_test.dart
+++ b/test/data/repositories/ssh_key_repository_test.dart
@@ -426,6 +426,58 @@ void main() {
       expect(results, hasLength(1));
     });
 
+    test(
+      'search treats percent as a literal character, not a wildcard',
+      () async {
+        await repository.insert(
+          SshKeysCompanion.insert(
+            name: '100% Production Key',
+            keyType: 'ed25519',
+            publicKey: 'ssh-ed25519 AAAA1...',
+            privateKey: 'fixture-open-ssh-material-1...',
+          ),
+        );
+        await repository.insert(
+          SshKeysCompanion.insert(
+            name: 'Development Key',
+            keyType: 'rsa',
+            publicKey: 'ssh-rsa AAAA2...',
+            privateKey: 'fixture-rsa-material-2...',
+          ),
+        );
+
+        final results = await repository.search('%');
+        expect(results, hasLength(1));
+        expect(results.first.name, '100% Production Key');
+      },
+    );
+
+    test(
+      'search treats underscore as a literal character, not a wildcard',
+      () async {
+        await repository.insert(
+          SshKeysCompanion.insert(
+            name: 'deploy_key',
+            keyType: 'ed25519',
+            publicKey: 'ssh-ed25519 AAAA1...',
+            privateKey: 'fixture-open-ssh-material-1...',
+          ),
+        );
+        await repository.insert(
+          SshKeysCompanion.insert(
+            name: 'deploy key',
+            keyType: 'rsa',
+            publicKey: 'ssh-rsa AAAA2...',
+            privateKey: 'fixture-rsa-material-2...',
+          ),
+        );
+
+        final results = await repository.search('deploy_');
+        expect(results, hasLength(1));
+        expect(results.first.name, 'deploy_key');
+      },
+    );
+
     test('watchAll emits updates when keys change', () async {
       await repository.insert(
         SshKeysCompanion.insert(

--- a/test/domain/services/settings_service_test.dart
+++ b/test/domain/services/settings_service_test.dart
@@ -111,6 +111,18 @@ void main() {
         expect(value, isNull);
       });
 
+      test('getJson returns null for JSON arrays', () async {
+        await service.setString('json_array', '[]');
+        final value = await service.getJson('json_array');
+        expect(value, isNull);
+      });
+
+      test('getJson returns null for JSON strings', () async {
+        await service.setString('json_string', '"not an object"');
+        final value = await service.getJson('json_string');
+        expect(value, isNull);
+      });
+
       test('setJson handles nested objects', () async {
         await service.setJson('nested', {
           'level1': {


### PR DESCRIPTION
## Summary

- Treat `%`, `_`, and `\` as literal characters in key/snippet/host repository search by sharing one LIKE escaping helper.
- Harden JSON settings reads against non-object JSON, refresh terminal route keys for `expandTmux`, and simplify the unsaved-changes discard pop path.
- Preserve MonkeyMux alternate-screen replay behavior for DECSET 1047 as well as 1049, and remove obsolete iOS bitcode export config.

## Validation

- `flutter analyze --fatal-warnings --fatal-infos`
- `flutter test`
- `go test ./...` in `remote/monkeymux`
