### PR TITLE
fix: throttle forced SGR touch scroll

### DIFF
--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1225,7 +1225,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
     if (lineHeight <= 0) {
       return 0;
     }
-    if (widget.terminal.mouseMode.reportScroll) {
+    if (widget.terminal.mouseMode.reportScroll || widget.forceSgrTouchScroll) {
       return lineHeight * _touchScrollReportedWheelLinesPerEvent;
     }
     return lineHeight;

--- a/test/widget/monkey_terminal_view_touch_scroll_test.dart
+++ b/test/widget/monkey_terminal_view_touch_scroll_test.dart
@@ -121,6 +121,70 @@ void main() {
     },
   );
 
+  testWidgets('forced SGR touch scroll uses reported-wheel drag threshold', (
+    tester,
+  ) async {
+    final terminal = Terminal();
+    final output = <String>[];
+    terminal.onOutput = output.add;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 300,
+          height: 200,
+          child: MonkeyTerminalView(
+            terminal,
+            hardwareKeyboardOnly: true,
+            touchScrollToTerminal: true,
+            simulateScroll: false,
+            forceSgrTouchScroll: true,
+          ),
+        ),
+      ),
+    );
+
+    final terminalState = tester.state<MonkeyTerminalViewState>(
+      find.byType(MonkeyTerminalView),
+    );
+    final lineHeight = terminalState.renderTerminal.lineHeight;
+    expect(lineHeight, greaterThan(0));
+
+    final detector = tester.widget<MonkeyTerminalGestureDetector>(
+      find.byType(MonkeyTerminalGestureDetector),
+    );
+    detector.onTouchScrollStart!(
+      DragStartDetails(
+        kind: PointerDeviceKind.touch,
+        localPosition: const Offset(150, 100),
+      ),
+    );
+    detector.onTouchScrollUpdate!(
+      DragUpdateDetails(
+        kind: PointerDeviceKind.touch,
+        globalPosition: Offset(150, 100 - lineHeight * 2),
+        localPosition: Offset(150, 100 - lineHeight * 2),
+        delta: Offset(0, -lineHeight * 2),
+      ),
+    );
+    await tester.pump();
+
+    expect(output, isEmpty);
+
+    detector.onTouchScrollUpdate!(
+      DragUpdateDetails(
+        kind: PointerDeviceKind.touch,
+        globalPosition: Offset(150, 100 - lineHeight * 3),
+        localPosition: Offset(150, 100 - lineHeight * 3),
+        delta: Offset(0, -lineHeight),
+      ),
+    );
+    await tester.pump();
+
+    expect(output, hasLength(1));
+    expect(output.single, startsWith('\u001b[<65;'));
+  });
+
   testWidgets(
     'mouse-reporting apps require more drag distance per touch scroll step',
     (tester) async {


### PR DESCRIPTION
## Summary

- Treat forced SGR touch scrolling as wheel-reporting scroll for drag-threshold purposes.
- Add a regression test for MonkeyMux metadata forcing SGR before local mouse mode catches up.

## Tests

- `flutter test test/widget/monkey_terminal_view_touch_scroll_test.dart test/widget/terminal_screen_scroll_policy_test.dart`
- `flutter analyze`
