### PR TITLE
fix: restore photo picker for terminal media paste

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -13,6 +13,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:image_picker_android/image_picker_android.dart';
+import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 import 'package:pasteboard/pasteboard.dart';
 import 'package:path/path.dart' as path;
 import 'package:url_launcher/url_launcher.dart';
@@ -1126,6 +1129,35 @@ resolveTerminalUploadPickerRequest({required bool media}) => (
   allowMultiple: true,
   failureContext: media ? 'Media picker upload' : 'File picker upload',
 );
+
+/// Whether terminal media paste should use a native photo-library picker.
+@visibleForTesting
+bool shouldUsePhotoLibraryPickerForTerminalMedia({
+  required TargetPlatform platform,
+  required bool isWeb,
+}) =>
+    !isWeb &&
+    (platform == TargetPlatform.android || platform == TargetPlatform.iOS);
+
+/// Builds a file-picker upload file from native photo-library media.
+@visibleForTesting
+Future<PlatformFile> platformFileFromPickedTerminalMedia(
+  XFile file, {
+  int index = 0,
+}) async {
+  final filePath = file.path;
+  if (filePath.isEmpty) {
+    throw FileSystemException('Unable to read selected media', file.name);
+  }
+  final name = file.name.trim().isNotEmpty
+      ? file.name.trim()
+      : path.basename(filePath);
+  return PlatformFile(
+    name: name.isEmpty ? 'selected-media-${index + 1}' : name,
+    path: filePath,
+    size: await file.length(),
+  );
+}
 
 /// Trims punctuation that terminals commonly render immediately after a link.
 @visibleForTesting
@@ -12366,6 +12398,18 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   Future<void> _pastePickedMedia() async {
     final pickerRequest = resolveTerminalUploadPickerRequest(media: true);
+    if (shouldUsePhotoLibraryPickerForTerminalMedia(
+      platform: defaultTargetPlatform,
+      isWeb: kIsWeb,
+    )) {
+      await _pickAndPastePhotoLibraryMedia(
+        itemLabelSingular: pickerRequest.itemLabelSingular,
+        itemLabelPlural: pickerRequest.itemLabelPlural,
+        failureContext: pickerRequest.failureContext,
+      );
+      return;
+    }
+
     await _pickAndPasteFiles(
       dialogTitle: pickerRequest.dialogTitle,
       pickerType: pickerRequest.pickerType,
@@ -12386,6 +12430,89 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       allowMultiple: pickerRequest.allowMultiple,
       failureContext: pickerRequest.failureContext,
     );
+  }
+
+  void _enableAndroidPhotoPickerIfAvailable() {
+    if (!_isAndroidPlatform) {
+      return;
+    }
+    final imagePickerImplementation = ImagePickerPlatform.instance;
+    if (imagePickerImplementation is ImagePickerAndroid) {
+      imagePickerImplementation.useAndroidPhotoPicker = true;
+    }
+  }
+
+  Future<void> _pickAndPastePhotoLibraryMedia({
+    required String itemLabelSingular,
+    required String itemLabelPlural,
+    required String failureContext,
+  }) async {
+    try {
+      _enableAndroidPhotoPickerIfAvailable();
+      final selectedMedia = await ImagePicker().pickMultipleMedia(
+        requestFullMetadata: false,
+      );
+      if (!mounted) {
+        return;
+      }
+      if (selectedMedia.isEmpty) {
+        _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+        return;
+      }
+
+      final selectedFiles = <PlatformFile>[];
+      for (var index = 0; index < selectedMedia.length; index++) {
+        selectedFiles.add(
+          await platformFileFromPickedTerminalMedia(
+            selectedMedia[index],
+            index: index,
+          ),
+        );
+      }
+      if (!mounted) {
+        return;
+      }
+
+      await _pasteSelectedFiles(
+        selectedFiles,
+        itemLabelSingular: itemLabelSingular,
+        itemLabelPlural: itemLabelPlural,
+      );
+    } on PlatformException catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'picker_failed',
+        fields: {'errorType': error.runtimeType},
+      );
+      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+      _showClipboardMessage('$failureContext failed. Try again.');
+    } on FileSystemException catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'picked_file_failed',
+        fields: {'errorType': error.runtimeType},
+      );
+      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+      _showClipboardMessage('$failureContext failed. Try again.');
+    } on SftpError catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'picked_remote_upload_failed',
+        fields: {'errorType': error.runtimeType},
+      );
+      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+      _showClipboardMessage(
+        'Remote upload failed. Check permissions and try again.',
+      );
+    } on Object catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'picked_upload_failed',
+        fields: {'errorType': error.runtimeType},
+      );
+      _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+      _showClipboardMessage('$failureContext failed. Try again.');
+    }
   }
 
   Future<void> _pickAndPasteFiles({

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,11 +6,15 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <pasteboard/pasteboard_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
   flutter_secure_storage_linux
   pasteboard
   url_launcher_linux

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import file_picker
+import file_selector_macos
 import flutter_local_notifications
 import flutter_secure_storage_darwin
 import in_app_purchase_storekit
@@ -20,6 +21,7 @@ import wakelock_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   InAppPurchasePlugin.register(with: registry.registrar(forPlugin: "InAppPurchasePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -313,6 +313,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "12.0.0-beta.4"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+5"
   fixnum:
     dependency: transitive
     description:
@@ -562,6 +594,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "91c025426c2881c551100bce834e201c835a170151545f58d17da5180ca7d9ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  image_picker_android:
+    dependency: "direct main"
+    description:
+      name: image_picker_android
+      sha256: d5b3e1774af29c9ab00103afb0d4614070f924d2e0057ac867ec98800114793f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+17"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+6"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: "direct main"
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   in_app_purchase:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,9 @@ dependencies:
   
   # File handling
   file_picker: ^12.0.0-beta.3
+  image_picker: ^1.2.2
+  image_picker_android: ^0.8.13+17
+  image_picker_platform_interface: ^2.11.1
   share_plus: ^13.1.0
   cryptography: ^2.9.0
   crypto: ^3.0.6

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:xterm/xterm.dart';
 
@@ -263,6 +264,72 @@ void main() {
       expect(request.itemLabelPlural, 'files');
       expect(request.allowMultiple, isTrue);
       expect(request.failureContext, 'File picker upload');
+    });
+  });
+
+  group('shouldUsePhotoLibraryPickerForTerminalMedia', () {
+    test('uses the photo library picker on native mobile platforms', () {
+      expect(
+        shouldUsePhotoLibraryPickerForTerminalMedia(
+          platform: TargetPlatform.android,
+          isWeb: false,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldUsePhotoLibraryPickerForTerminalMedia(
+          platform: TargetPlatform.iOS,
+          isWeb: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('keeps the file picker on web and desktop platforms', () {
+      expect(
+        shouldUsePhotoLibraryPickerForTerminalMedia(
+          platform: TargetPlatform.android,
+          isWeb: true,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldUsePhotoLibraryPickerForTerminalMedia(
+          platform: TargetPlatform.macOS,
+          isWeb: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldUsePhotoLibraryPickerForTerminalMedia(
+          platform: TargetPlatform.windows,
+          isWeb: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('platformFileFromPickedTerminalMedia', () {
+    test('wraps photo-library media for terminal uploads', () async {
+      final directory = Directory.systemTemp.createTempSync(
+        'terminal-media-picker-',
+      );
+      addTearDown(() {
+        if (directory.existsSync()) {
+          directory.deleteSync(recursive: true);
+        }
+      });
+      final mediaFile = File('${directory.path}/photo.jpg')
+        ..writeAsBytesSync([1, 2, 3]);
+
+      final file = await platformFileFromPickedTerminalMedia(
+        XFile(mediaFile.path),
+      );
+
+      expect(file.name, 'photo.jpg');
+      expect(file.path, mediaFile.path);
+      expect(file.size, 3);
     });
   });
 

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_windows/file_selector_windows.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <local_auth_windows/local_auth_plugin.h>
 #include <pasteboard/pasteboard_plugin.h>
@@ -14,6 +15,8 @@
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   LocalAuthPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_windows
   flutter_secure_storage_windows
   local_auth_windows
   pasteboard


### PR DESCRIPTION
## Summary

- Restore native photo-library picking for terminal Paste Media on Android and iOS
- Keep desktop and web Paste Media on the existing file picker path
- Add coverage for mobile picker routing and selected media wrapping

## Tests

- `flutter analyze`
- `flutter test test/widget/terminal_screen_selection_test.dart`
- pre-commit checks
