### PR TITLE
fix: force Android photo picker for media paste

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
@@ -62,6 +63,20 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths" />
         </provider>
+        <!-- Triggers Google Play services to install the Photo Picker backport
+             on eligible pre-Android 13 devices. -->
+        <service
+            android:name="com.google.android.gms.metadata.ModuleDependencies"
+            android:enabled="false"
+            android:exported="false"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+            </intent-filter>
+            <meta-data
+                android:name="photopicker_activity:0:required"
+                android:value="" />
+        </service>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1139,6 +1139,17 @@ bool shouldUsePhotoLibraryPickerForTerminalMedia({
     !isWeb &&
     (platform == TargetPlatform.android || platform == TargetPlatform.iOS);
 
+/// Returns an Android image picker implementation configured for Photo Picker.
+@visibleForTesting
+ImagePickerAndroid enableAndroidPhotoPickerForTerminalMedia(
+  ImagePickerPlatform imagePickerImplementation,
+) {
+  final androidImagePicker = imagePickerImplementation is ImagePickerAndroid
+      ? imagePickerImplementation
+      : ImagePickerAndroid();
+  return androidImagePicker..useAndroidPhotoPicker = true;
+}
+
 /// Builds a file-picker upload file from native photo-library media.
 @visibleForTesting
 Future<PlatformFile> platformFileFromPickedTerminalMedia(
@@ -12447,9 +12458,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (!_isAndroidPlatform) {
       return;
     }
-    final imagePickerImplementation = ImagePickerPlatform.instance;
-    if (imagePickerImplementation is ImagePickerAndroid) {
-      imagePickerImplementation.useAndroidPhotoPicker = true;
+    final currentImagePicker = ImagePickerPlatform.instance;
+    final androidImagePicker = enableAndroidPhotoPickerForTerminalMedia(
+      currentImagePicker,
+    );
+    if (!identical(currentImagePicker, androidImagePicker)) {
+      ImagePickerPlatform.instance = androidImagePicker;
     }
   }
 

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -3,9 +3,12 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:image_picker/image_picker.dart';
+import 'package:image_picker_android/image_picker_android.dart';
+import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:xterm/xterm.dart';
+
+class _FakeImagePickerPlatform extends ImagePickerPlatform {}
 
 void main() {
   group('trimTerminalSelectionText', () {
@@ -308,6 +311,31 @@ void main() {
         isFalse,
       );
     });
+  });
+
+  group('enableAndroidPhotoPickerForTerminalMedia', () {
+    test('enables the existing Android image picker implementation', () {
+      final imagePicker = ImagePickerAndroid();
+
+      final configuredPicker = enableAndroidPhotoPickerForTerminalMedia(
+        imagePicker,
+      );
+
+      expect(identical(configuredPicker, imagePicker), isTrue);
+      expect(configuredPicker.useAndroidPhotoPicker, isTrue);
+    });
+
+    test(
+      'replaces fallback implementations with the Android implementation',
+      () {
+        final configuredPicker = enableAndroidPhotoPickerForTerminalMedia(
+          _FakeImagePickerPlatform(),
+        );
+
+        expect(configuredPicker, isA<ImagePickerAndroid>());
+        expect(configuredPicker.useAndroidPhotoPicker, isTrue);
+      },
+    );
   });
 
   group('platformFileFromPickedTerminalMedia', () {


### PR DESCRIPTION
## Summary

- Force Android media paste onto the `image_picker_android` implementation so the Photo Picker flag is actually sent
- Add the Android Photo Picker backport module dependency metadata for eligible pre-Android 13 devices
- Add tests for Android picker configuration fallback handling

## Tests

- `flutter analyze`
- `flutter test test/widget/terminal_screen_selection_test.dart`
- `JAVA_HOME="$(/usr/libexec/java_home -v 17)" flutter build apk --debug --flavor private -t lib/main.dart`
- pre-commit checks
