### PR TITLE
fix(theme): support resetting host specific terminal themes to default

### DIFF
--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -744,6 +744,12 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                               defaultLabel: 'Use default',
                               onTap: () =>
                                   _handleThemeSelectionTap(isLight: true),
+                              onClear: () {
+                                setState(() {
+                                  _selectedLightThemeId = null;
+                                });
+                                _updateDirtyState();
+                              },
                             ),
                             const SizedBox(height: 8),
                             // Dark mode theme
@@ -754,6 +760,12 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                               defaultLabel: 'Use default',
                               onTap: () =>
                                   _handleThemeSelectionTap(isLight: false),
+                              onClear: () {
+                                setState(() {
+                                  _selectedDarkThemeId = null;
+                                });
+                                _updateDirtyState();
+                              },
                             ),
                             const SizedBox(height: 16),
                             // Terminal font section
@@ -2186,6 +2198,7 @@ class _ThemeSelectionTile extends StatelessWidget {
     required this.themes,
     required this.defaultLabel,
     required this.onTap,
+    this.onClear,
   });
 
   final String label;
@@ -2193,6 +2206,7 @@ class _ThemeSelectionTile extends StatelessWidget {
   final Iterable<TerminalThemeData> themes;
   final String defaultLabel;
   final VoidCallback onTap;
+  final VoidCallback? onClear;
 
   @override
   Widget build(BuildContext context) {
@@ -2234,9 +2248,7 @@ class _ThemeSelectionTile extends StatelessWidget {
           if (themeId != null)
             IconButton(
               icon: const Icon(Icons.clear, size: 18),
-              onPressed: () {
-                // Clear theme selection - handled via callback
-              },
+              onPressed: onClear,
               tooltip: 'Reset to default',
             ),
           const Icon(Icons.chevron_right),

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -34,6 +34,8 @@ Host _testHost({
   String? tmuxWorkingDirectory,
   String? tmuxExtraFlags,
   String? remoteMuxBackend,
+  String? terminalThemeLightId,
+  String? terminalThemeDarkId,
 }) => Host(
   id: id,
   label: label,
@@ -50,6 +52,8 @@ Host _testHost({
   tmuxWorkingDirectory: tmuxWorkingDirectory,
   tmuxExtraFlags: tmuxExtraFlags,
   remoteMuxBackend: remoteMuxBackend,
+  terminalThemeLightId: terminalThemeLightId,
+  terminalThemeDarkId: terminalThemeDarkId,
   sortOrder: 0,
 );
 
@@ -1724,6 +1728,132 @@ void main() {
         ),
       );
       expect(commandField.readOnly, isTrue);
+    });
+
+    testWidgets('clears selected light and dark themes using the clear buttons', (
+      tester,
+    ) async {
+      final database = AppDatabase.forTesting(NativeDatabase.memory());
+      final encryptionService = SecretEncryptionService.forTesting();
+      addTearDown(database.close);
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.binding.setSurfaceSize(const Size(420, 900));
+
+      final hostRepository = _FakeHostRepository(
+        host: _testHost(
+          id: 1,
+          label: 'Themed Host',
+          autoConnectRequiresConfirmation: false,
+          terminalThemeLightId: 'iterm2-monokai-pro',
+          terminalThemeDarkId: 'iterm2-dracula',
+        ),
+        database: database,
+        encryptionService: encryptionService,
+      );
+
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) =>
+                const Scaffold(body: SizedBox.shrink()),
+          ),
+          GoRoute(
+            path: '/edit',
+            builder: (context, state) => const HostEditScreen(hostId: 1),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(database),
+            hostRepositoryProvider.overrideWithValue(hostRepository),
+            keyRepositoryProvider.overrideWithValue(
+              _FakeKeyRepository(
+                database: database,
+                encryptionService: encryptionService,
+              ),
+            ),
+            snippetRepositoryProvider.overrideWithValue(
+              _FakeSnippetRepository(snippets: const [], database: database),
+            ),
+            portForwardRepositoryProvider.overrideWithValue(
+              _FakePortForwardRepository(database: database),
+            ),
+          ],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+
+      unawaited(router.push('/edit'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Expand Advanced tile
+      final advancedTile = find.byKey(const Key('host-advanced-tile'));
+      await tester.scrollUntilVisible(
+        advancedTile,
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.tap(advancedTile);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Scroll to the theme section
+      await tester.scrollUntilVisible(
+        find.text('Terminal Theme'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+
+      // Verify monokai and dracula names are displayed
+      expect(find.text('Monokai Pro'), findsOneWidget);
+      expect(find.text('Dracula'), findsOneWidget);
+
+      // Find the clear buttons and tap them. Since both tiles show a clear button,
+      // we can find by Icon(Icons.clear). Let's verify we have 2 clear icons.
+      final clearButtons = find.byIcon(Icons.clear);
+      expect(clearButtons, findsNWidgets(2));
+
+      // Tap the first one (Light theme clear button)
+      await tester.tap(clearButtons.first);
+      await tester.pump();
+
+      // Verify light theme has been reset to "Use default"
+      expect(find.text('Monokai Pro'), findsNothing);
+      expect(find.text('Dracula'), findsOneWidget);
+
+      // Tap the remaining clear button
+      await tester.tap(find.byIcon(Icons.clear));
+      await tester.pump();
+
+      // Verify both are cleared
+      expect(find.text('Dracula'), findsNothing);
+      expect(find.text('Monokai Pro'), findsNothing);
+
+      // Tap save
+      final saveButton = find.byKey(
+        const Key('host-save-button'),
+        skipOffstage: false,
+      );
+      await tester.scrollUntilVisible(
+        saveButton,
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.ensureVisible(saveButton);
+      tester.widget<FilledButton>(saveButton).onPressed!();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 600));
+
+      // Verify database repositories received updated host with null themes
+      expect(hostRepository.updatedHost, isNotNull);
+      expect(hostRepository.updatedHost!.terminalThemeLightId, isNull);
+      expect(hostRepository.updatedHost!.terminalThemeDarkId, isNull);
     });
   });
 }


### PR DESCRIPTION
## Summary

This PR fixes a bug in `HostEditScreen` where clicking the clear ("X") button next to host-specific terminal theme selections did nothing.

### Changes
1. Added an `onClear` callback parameter to `_ThemeSelectionTile`.
2. Passed the clear action handler into `_ThemeSelectionTile`'s `onClear` callback inside `HostEditScreen`, which resets the respective selected theme ID (`_selectedLightThemeId` or `_selectedDarkThemeId`) to `null` and updates the form's dirty state.
3. Updated `_ThemeSelectionTile`'s clear `IconButton` to execute the `onClear` callback when clicked instead of using an empty block.

## Validation and Testing

### Widget Verification
- Added a comprehensive widget test `clears selected light and dark themes using the clear buttons` in `host_edit_screen_test.dart` that verifies:
  1. Setting up a host with active custom themes displays those themes onstage inside the expanded Advanced panel.
  2. Clicking the light theme clear button resets the light theme text to "Use default".
  3. Clicking the dark theme clear button resets the dark theme text to "Use default".
  4. Saving the form persists the updated host with `null` custom terminal theme IDs back to the database.

- Successfully ran all 24 widget tests in `host_edit_screen_test.dart` and they passed cleanly.
