### PR TITLE
fix: polish release QA issues

### DIFF
--- a/ios/Runner/Base.lproj/LaunchScreen.storyboard
+++ b/ios/Runner/Base.lproj/LaunchScreen.storyboard
@@ -19,7 +19,7 @@
                             <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="LaunchImage" translatesAutoresizingMaskIntoConstraints="NO" id="YRO-k0-Ey4">
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" red="0.9725490196" green="0.9764705882" blue="0.9882352941" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="YRO-k0-Ey4" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="1a2-6s-vTC"/>
                             <constraint firstItem="YRO-k0-Ey4" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="4X2-HB-R7a"/>

--- a/ios/Runner/Base.lproj/Main.storyboard
+++ b/ios/Runner/Base.lproj/Main.storyboard
@@ -16,7 +16,7 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="0.9725490196" green="0.9764705882" blue="0.9882352941" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -20,6 +20,19 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>monkeyssh</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -124,7 +124,9 @@ class _BackgroundLifecycleBridgeState
   bool _hasLoadedHomeScreenShortcutHosts = false;
   bool _hasLoadedPinnedHomeScreenShortcutHostIds = false;
   TmuxAlertNotificationPayload? _pendingTmuxAlertNavigation;
+  String? _pendingSshUrlNavigation;
   bool _isTmuxAlertNavigationQueued = false;
+  bool _isSshUrlNavigationQueued = false;
 
   @override
   void initState() {
@@ -160,6 +162,50 @@ class _BackgroundLifecycleBridgeState
     super.dispose();
   }
 
+  @override
+  Future<bool> didPushRoute(String route) async =>
+      _handleIncomingRoute(Uri.tryParse(route));
+
+  @override
+  Future<bool> didPushRouteInformation(
+    RouteInformation routeInformation,
+  ) async => _handleIncomingRoute(routeInformation.uri);
+
+  Future<bool> _handleIncomingRoute(Uri? uri) async {
+    final sshUrl = resolveIncomingSshUrl(uri);
+    if (sshUrl == null) {
+      return false;
+    }
+    _pendingSshUrlNavigation = sshUrl;
+    _queuePendingSshUrlNavigation();
+    return true;
+  }
+
+  void _queuePendingSshUrlNavigation() {
+    if (_isSshUrlNavigationQueued ||
+        _pendingSshUrlNavigation == null ||
+        !_canOpenTmuxAlertNotification(ref.read(authStateProvider))) {
+      return;
+    }
+    _isSshUrlNavigationQueued = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _isSshUrlNavigationQueued = false;
+      if (!mounted ||
+          !_canOpenTmuxAlertNotification(ref.read(authStateProvider))) {
+        return;
+      }
+      final sshUrl = _pendingSshUrlNavigation;
+      if (sshUrl == null) {
+        return;
+      }
+      _pendingSshUrlNavigation = null;
+      ref
+          .read(routerProvider)
+          .push('/hosts/add?sshUrl=${Uri.encodeQueryComponent(sshUrl)}');
+    });
+    WidgetsBinding.instance.ensureVisualUpdate();
+  }
+
   void _startTmuxAlertNotificationRouting() {
     final notificationService = ref.read(localNotificationServiceProvider);
     _tmuxAlertTapSubscription = notificationService.tmuxAlertTaps.listen(
@@ -171,6 +217,7 @@ class _BackgroundLifecycleBridgeState
     ) {
       if (_canOpenTmuxAlertNotification(next)) {
         _queuePendingTmuxAlertNavigation();
+        _queuePendingSshUrlNavigation();
       }
     });
   }
@@ -322,4 +369,37 @@ class _BackgroundLifecycleBridgeState
 
   @override
   Widget build(BuildContext context) => widget.child;
+}
+
+/// Resolves an incoming app route/deep link into a host draft SSH URL.
+@visibleForTesting
+String? resolveIncomingSshUrl(Uri? uri) {
+  if (uri == null) {
+    return null;
+  }
+
+  if (uri.scheme == 'ssh' && uri.host.isNotEmpty) {
+    return uri.toString();
+  }
+
+  if (uri.scheme != 'monkeyssh') {
+    return null;
+  }
+
+  final action = uri.host.toLowerCase();
+  if (action != 'host' && action != 'add-host') {
+    return null;
+  }
+  final hostname = uri.queryParameters['hostname']?.trim();
+  if (hostname == null || hostname.isEmpty) {
+    return null;
+  }
+  final username = uri.queryParameters['username']?.trim();
+  final port = int.tryParse(uri.queryParameters['port'] ?? '');
+  return Uri(
+    scheme: 'ssh',
+    userInfo: username == null || username.isEmpty ? '' : username,
+    host: hostname,
+    port: port,
+  ).toString();
 }

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -655,14 +655,14 @@ abstract final class FluttyTheme {
           child: Icon(
             icon,
             size: emptyStateIconSize,
-            color: colorScheme.onSurface.withAlpha(80),
+            color: colorScheme.onSurface.withAlpha(130),
           ),
         ),
         const SizedBox(height: spacingMd),
         Text(
           title,
           style: theme.textTheme.titleMedium?.copyWith(
-            color: colorScheme.onSurface.withAlpha(180),
+            color: colorScheme.onSurface.withAlpha(220),
             fontWeight: FontWeight.w600,
           ),
         ),
@@ -671,7 +671,7 @@ abstract final class FluttyTheme {
           subtitle,
           textAlign: TextAlign.center,
           style: theme.textTheme.bodySmall?.copyWith(
-            color: colorScheme.onSurface.withAlpha(100),
+            color: colorScheme.onSurface.withAlpha(150),
           ),
         ),
         if (onAction != null && actionLabel != null) ...[

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -1142,7 +1142,29 @@ class SshConnectionConfig {
 
   /// Connection timeout.
   final Duration connectionTimeout;
+
+  /// Whether this config has a password or at least one key candidate.
+  bool get hasConfiguredCredentials =>
+      (password?.isNotEmpty ?? false) ||
+      (privateKey?.isNotEmpty ?? false) ||
+      (identityKeys?.isNotEmpty ?? false);
 }
+
+/// Formats unexpected SSH disconnects into user-facing text.
+@visibleForTesting
+String formatUnexpectedSshDisconnectMessage(
+  Object error, {
+  required SshConnectionConfig config,
+}) {
+  if (!config.hasConfiguredCredentials && _isBrokenPipeError(error)) {
+    return 'Connection lost before the shell opened. Add a password or SSH key, '
+        'or verify that this server supports no-auth SSH connections.';
+  }
+  return 'Connection lost: $error';
+}
+
+bool _isBrokenPipeError(Object error) =>
+    error.toString().toLowerCase().contains('broken pipe');
 
 /// Result of an SSH connection attempt.
 class SshConnectionResult {
@@ -3889,7 +3911,10 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
           onError: (Object error, StackTrace _) => unawaited(
             handleUnexpectedDisconnect(
               session.connectionId,
-              message: 'Connection lost: $error',
+              message: formatUnexpectedSshDisconnectMessage(
+                error,
+                config: session.config,
+              ),
             ),
           ),
         );

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -843,23 +843,31 @@ class HostsPanel extends ConsumerWidget {
   );
 
   Future<void> _openPastedSshUrl(BuildContext context) async {
-    final clipboard = await Clipboard.getData(Clipboard.kTextPlain);
+    ClipboardData? clipboard;
+    try {
+      clipboard = await Clipboard.getData(Clipboard.kTextPlain);
+    } on PlatformException {
+      if (context.mounted) {
+        _showHostPasteSnackBar(
+          context,
+          'Could not read the clipboard. Copy an ssh:// URL and try again.',
+        );
+      }
+      return;
+    }
     final sshUrl = clipboard?.text?.trim();
     if (sshUrl == null || sshUrl.isEmpty) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Copy an ssh:// URL first.')),
-        );
+        _showHostPasteSnackBar(context, 'Copy an ssh:// URL first.');
       }
       return;
     }
     final uri = Uri.tryParse(sshUrl);
     if (uri == null || uri.scheme != 'ssh' || uri.host.isEmpty) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Clipboard does not contain an ssh:// URL.'),
-          ),
+        _showHostPasteSnackBar(
+          context,
+          'Clipboard does not contain an ssh:// URL.',
         );
       }
       return;
@@ -869,6 +877,12 @@ class HostsPanel extends ConsumerWidget {
         context.push('/hosts/add?sshUrl=${Uri.encodeQueryComponent(sshUrl)}'),
       );
     }
+  }
+
+  void _showHostPasteSnackBar(BuildContext context, String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
   }
 
   Widget _buildCenteredHostsState({required Widget child}) => CustomScrollView(

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -110,6 +110,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   bool _disableTmuxStatusBar = false;
   bool _disableAgentTmuxStatusBar = false;
   bool _startClisInYoloMode = false;
+  bool _hasTriedSubmit = false;
 
   List<PortForward> _portForwards = [];
 
@@ -426,6 +427,9 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
               ? const Center(child: CircularProgressIndicator())
               : Form(
                   key: _formKey,
+                  autovalidateMode: _hasTriedSubmit
+                      ? AutovalidateMode.onUserInteraction
+                      : AutovalidateMode.disabled,
                   child: SingleChildScrollView(
                     controller: _scrollController,
                     padding: const EdgeInsets.all(16),
@@ -1414,6 +1418,9 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   );
 
   Future<void> _saveHost() async {
+    if (!_hasTriedSubmit) {
+      setState(() => _hasTriedSubmit = true);
+    }
     final formIsValid = _formKey.currentState!.validate();
     final invalidTarget = _firstInvalidHostField();
     if (!formIsValid || invalidTarget != null) {
@@ -1600,6 +1607,9 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   }
 
   Future<void> _testConnection() async {
+    if (!_hasTriedSubmit) {
+      setState(() => _hasTriedSubmit = true);
+    }
     if (!_formKey.currentState!.validate()) return;
 
     final messenger = ScaffoldMessenger.of(context)

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3216,10 +3216,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     required IconData icon,
     required String label,
     required String action,
+    bool enabled = true,
   }) => MenuItemButton(
     style: TerminalMenuStyles.itemButtonStyle(context),
     leadingIcon: Icon(icon, size: TerminalMenuStyles.iconSize),
-    onPressed: () => unawaited(_handleMenuAction(action)),
+    onPressed: enabled ? () => unawaited(_handleMenuAction(action)) : null,
     child: _terminalOverflowMenuLabel(label),
   );
 
@@ -8862,8 +8863,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _TerminalExclusiveAction.tmuxNavigator,
     );
 
+    final handlesTerminalBack = _isTmuxBarExpanded || systemKeyboardVisible;
+
     return PopScope(
-      canPop: !_isTmuxBarExpanded,
+      canPop: !handlesTerminalBack,
       onPopInvokedWithResult: (didPop, _) {
         _logAndroidPredictiveBackDiagnostics(
           context,
@@ -8874,7 +8877,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _clearAppThemeOverride();
           return;
         }
-        _collapseTmuxBarIfExpanded();
+        if (_collapseTmuxBarIfExpanded()) {
+          return;
+        }
+        if (systemKeyboardVisible) {
+          _toggleSystemKeyboard(true);
+          return;
+        }
       },
       child: Scaffold(
         backgroundColor: theme.colorScheme.surface,
@@ -8950,16 +8959,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                     : _openTmuxNavigator,
                 tooltip: 'tmux windows',
               ),
-            IconButton(
-              icon: const Icon(Icons.folder_outlined),
-              onPressed:
-                  _connectionId == null ||
-                      isOpeningSftpBrowser ||
-                      connectionState != SshConnectionState.connected
-                  ? null
-                  : () => unawaited(_openConnectionFileBrowser()),
-              tooltip: 'Browse files',
-            ),
+            if (!isMobile)
+              IconButton(
+                icon: const Icon(Icons.folder_outlined),
+                onPressed:
+                    _connectionId == null ||
+                        isOpeningSftpBrowser ||
+                        connectionState != SshConnectionState.connected
+                    ? null
+                    : () => unawaited(_openConnectionFileBrowser()),
+                tooltip: 'Browse files',
+              ),
             if (isMobile)
               IconButton(
                 icon: Icon(
@@ -8998,6 +9008,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 isMobilePlatform: isMobile,
               ),
               menuChildren: [
+                _terminalOverflowMenuItem(
+                  context: context,
+                  icon: Icons.folder_outlined,
+                  label: 'Browse Files',
+                  action: 'browse_files',
+                  enabled:
+                      _connectionId != null &&
+                      !isOpeningSftpBrowser &&
+                      connectionState == SshConnectionState.connected,
+                ),
                 _terminalOverflowMenuItem(
                   context: context,
                   icon: Icons.code_rounded,
@@ -9130,6 +9150,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       unawaited(SystemChannels.textInput.invokeMethod<void>('TextInput.hide'));
       _terminalFocusNode.unfocus();
     } else {
+      if (_isMobilePlatform && _showKeyboardToolbar) {
+        setState(() => _showKeyboardToolbar = false);
+      }
       // Explicit user action — always show the keyboard regardless of the
       // tap-to-show setting.
       _restoreTerminalFocus(forceShowSystemKeyboard: true);
@@ -10021,6 +10044,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     () async {
       final connectionId = _connectionId;
       if (connectionId == null) {
+        _showTerminalLinkMessage('Connect before browsing files.');
         return;
       }
 
@@ -10050,6 +10074,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             tmuxPaneDirectory: tmuxPaneDirectory,
           ),
         );
+      } on Exception catch (error) {
+        FlutterError.reportError(
+          FlutterErrorDetails(
+            exception: error,
+            library: 'terminal',
+            context: ErrorDescription('while opening the SFTP browser'),
+          ),
+        );
+        if (mounted) {
+          _showTerminalLinkMessage(
+            'Could not open the file browser. Check the connection and try again.',
+          );
+        }
       } finally {
         _restoreTemporarilyDismissedTerminalKeyboard(shouldRestoreKeyboard);
       }
@@ -10122,6 +10159,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     switch (action) {
       case 'snippets':
         await _showSnippetPicker();
+        break;
+      case 'browse_files':
+        unawaited(_openConnectionFileBrowser());
         break;
       case 'change_theme':
         unawaited(_showThemePicker());

--- a/test/app/app_lifecycle_coordinator_test.dart
+++ b/test/app/app_lifecycle_coordinator_test.dart
@@ -5,9 +5,35 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:monkeyssh/app/app.dart';
 import 'package:monkeyssh/app/app_lifecycle_coordinator.dart';
 
 void main() {
+  group('resolveIncomingSshUrl', () {
+    test('accepts direct ssh URLs', () {
+      expect(
+        resolveIncomingSshUrl(Uri.parse('ssh://qa@example.com:2222')),
+        'ssh://qa@example.com:2222',
+      );
+    });
+
+    test('builds ssh URLs from monkeyssh host links', () {
+      expect(
+        resolveIncomingSshUrl(
+          Uri.parse(
+            'monkeyssh://host?hostname=127.0.0.1&port=2226&username=qa',
+          ),
+        ),
+        'ssh://qa@127.0.0.1:2226',
+      );
+    });
+
+    test('ignores unrelated routes', () {
+      expect(resolveIncomingSshUrl(Uri.parse('/settings')), isNull);
+      expect(resolveIncomingSshUrl(Uri.parse('monkeyssh://settings')), isNull);
+    });
+  });
+
   group('AppBootstrapController', () {
     test('starts startup tasks in app bootstrap order', () async {
       final calls = <String>[];

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -262,6 +262,39 @@ void main() {
     });
   });
 
+  group('formatUnexpectedSshDisconnectMessage', () {
+    test('explains broken pipe disconnects without credentials', () {
+      const config = SshConnectionConfig(
+        hostname: 'example.com',
+        port: 22,
+        username: 'qa',
+      );
+
+      expect(
+        formatUnexpectedSshDisconnectMessage(
+          'SSHSocketError(SocketException: Write failed (OS Error: Broken pipe))',
+          config: config,
+        ),
+        'Connection lost before the shell opened. Add a password or SSH key, '
+        'or verify that this server supports no-auth SSH connections.',
+      );
+    });
+
+    test('keeps raw error detail when credentials are configured', () {
+      const config = SshConnectionConfig(
+        hostname: 'example.com',
+        port: 22,
+        username: 'qa',
+        password: 'secret',
+      );
+
+      expect(
+        formatUnexpectedSshDisconnectMessage('closed', config: config),
+        'Connection lost: closed',
+      );
+    });
+  });
+
   group('terminal metadata helpers', () {
     test('parses and formats working directory metadata', () {
       final uri = parseTerminalWorkingDirectoryUri([

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1573,70 +1573,74 @@ void main() {
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),
     );
 
-    testWidgets('browse files ignores duplicate taps while SFTP is opening', (
-      tester,
-    ) async {
-      var sftpOpenCount = 0;
-      final router = GoRouter(
-        initialLocation:
-            '/terminal/${host.id}?connectionId=${session.connectionId}',
-        routes: [
-          GoRoute(
-            path: '/terminal/:hostId',
-            name: Routes.terminal,
-            builder: (context, state) => TerminalScreen(
-              hostId: host.id,
-              connectionId: session.connectionId,
+    testWidgets(
+      'browse files ignores duplicate taps while SFTP is opening',
+      (tester) async {
+        var sftpOpenCount = 0;
+        final router = GoRouter(
+          initialLocation:
+              '/terminal/${host.id}?connectionId=${session.connectionId}',
+          routes: [
+            GoRoute(
+              path: '/terminal/:hostId',
+              name: Routes.terminal,
+              builder: (context, state) => TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+              ),
             ),
-          ),
-          GoRoute(
-            path: '/sftp/:hostId',
-            name: Routes.sftp,
-            builder: (context, state) =>
-                _RecordingSftpPage(onOpened: () => sftpOpenCount += 1),
-          ),
-        ],
-      );
-      addTearDown(router.dispose);
-
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            databaseProvider.overrideWithValue(db),
-            hostRepositoryProvider.overrideWithValue(hostRepository),
-            monetizationServiceProvider.overrideWithValue(monetizationService),
-            monetizationStateProvider.overrideWith(
-              (ref) => Stream.value(_proMonetizationState),
-            ),
-            sharedClipboardProvider.overrideWith((ref) async => false),
-            activeSessionsProvider.overrideWith(
-              () => _TestActiveSessionsNotifier(session),
+            GoRoute(
+              path: '/sftp/:hostId',
+              name: Routes.sftp,
+              builder: (context, state) =>
+                  _RecordingSftpPage(onOpened: () => sftpOpenCount += 1),
             ),
           ],
-          child: MaterialApp.router(routerConfig: router),
-        ),
-      );
-      await tester.pump();
-      await tester.pump();
+        );
+        addTearDown(router.dispose);
 
-      final browseFilesButton = find.byTooltip('Browse files');
-      expect(browseFilesButton, findsOneWidget);
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+            ],
+            child: MaterialApp.router(routerConfig: router),
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
 
-      await tester.tap(browseFilesButton);
-      await tester.tap(browseFilesButton);
-      await tester.pumpAndSettle();
+        final browseFilesButton = find.byTooltip('Browse files');
+        expect(browseFilesButton, findsOneWidget);
 
-      expect(sftpOpenCount, 1);
-      expect(find.text('SFTP opened'), findsOneWidget);
+        await tester.tap(browseFilesButton);
+        await tester.tap(browseFilesButton);
+        await tester.pumpAndSettle();
 
-      router.pop();
-      await tester.pumpAndSettle();
+        expect(sftpOpenCount, 1);
+        expect(find.text('SFTP opened'), findsOneWidget);
 
-      await tester.tap(find.byTooltip('Browse files'));
-      await tester.pumpAndSettle();
+        router.pop();
+        await tester.pumpAndSettle();
 
-      expect(sftpOpenCount, 2);
-    });
+        await tester.tap(find.byTooltip('Browse files'));
+        await tester.pumpAndSettle();
+
+        expect(sftpOpenCount, 2);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.macOS),
+    );
 
     testWidgets('shows jump host indicator for tunneled sessions', (
       tester,
@@ -5903,7 +5907,8 @@ void main() {
         expect(tester.testTextInput.isVisible, isTrue);
         tester.testTextInput.log.clear();
 
-        await tester.tap(find.byTooltip('Browse files'));
+        await openTerminalOverflowMenu(tester);
+        await tester.tap(terminalMenuItemButton('Browse Files'));
         await tester.pumpAndSettle();
 
         expect(openedPaths, ['']);

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:dartssh2/dartssh2.dart';
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
@@ -542,6 +543,54 @@ void main() {
       expect(find.text('Import config'), findsNothing);
       expect(find.text('Paste SSH URL'), findsOneWidget);
       expect(find.text('Try local test host'), findsNothing);
+    });
+
+    testWidgets('paste SSH URL reports clipboard read failures', (
+      tester,
+    ) async {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.getData') {
+            throw PlatformException(code: 'clipboard-unavailable');
+          }
+          return null;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        ),
+      );
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      await tester.pumpWidget(
+        buildMobileHomeScreen(
+          db: db,
+          overrides: [
+            activeSessionsProvider.overrideWith(
+              _TestActiveSessionsNotifier.new,
+            ),
+            allHostsProvider.overrideWith(
+              (ref) => Stream.value(const <Host>[]),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.tap(find.text('Paste SSH URL'));
+      await tester.pump();
+
+      expect(
+        find.text(
+          'Could not read the clipboard. Copy an ssh:// URL and try again.',
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('connections empty state explains where sessions appear', (

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -336,6 +336,25 @@ void main() {
       },
     );
 
+    testWidgets(
+      'clears submitted validation errors while fields are corrected',
+      (tester) async {
+        await _pumpHostCreateScreen(tester);
+
+        await _tapBottomSave(tester);
+        expect(find.text('Please enter a label'), findsOneWidget);
+
+        await tester.enterText(
+          find.byKey(const Key('host-label-field')),
+          'QA Host',
+        );
+        await tester.pump();
+
+        expect(find.text('Please enter a label'), findsNothing);
+        expect(find.text('Please enter a hostname'), findsOneWidget);
+      },
+    );
+
     testWidgets('warns before leaving with unsaved host changes', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- Improve host creation polish: validation errors now clear as fields are corrected, and Paste SSH URL reports clipboard/format problems instead of silently doing nothing.
- Improve terminal polish: mobile back hides the IME before leaving, the file browser is exposed from the overflow menu on phones with failure feedback, keyboard launch hides the extra toolbar to preserve terminal rows, and no-credential broken-pipe disconnects get an actionable message.
- Improve iOS polish: add `monkeyssh://host?...` deep-link routing into Add Host, align launch storyboard backgrounds with app light background, and raise empty-state text contrast.

## Validation

- `flutter test test/widget/host_edit_screen_test.dart test/widget/home_screen_test.dart test/app/app_lifecycle_coordinator_test.dart test/domain/services/ssh_service_test.dart test/presentation/screens/terminal_screen_test.dart`
- `flutter analyze`
- `flutter test`
- Pre-commit hook reran `dart format .`, `flutter analyze`, and `flutter test`
