### PR TITLE
fix: avoid terminal preview rebuild jank

### DIFF
--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -3593,6 +3593,15 @@ final activeSessionsProvider =
       ActiveSessionsNotifier.new,
     );
 
+/// Provider for host-level connection attempt progress.
+final connectionAttemptProvider =
+    Provider.family<ConnectionAttemptStatus?, int>((ref, hostId) {
+      ref.watch(activeSessionsProvider);
+      return ref
+          .read(activeSessionsProvider.notifier)
+          .getConnectionAttempt(hostId);
+    });
+
 /// Notifier for active SSH sessions state.
 class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
   static const _previewStateRefreshInterval = Duration(milliseconds: 150);

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -2967,7 +2967,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   int? _suppressRemoteMuxDetectionConnectionId;
   bool _restoreKeyboardAfterAppResume = false;
   final GlobalKey _terminalOverflowMenuButtonKey = GlobalKey();
-  String? _lastAndroidPredictiveBackDiagnosticsKey;
+  final Map<String, String> _lastAndroidPredictiveBackDiagnosticsKeys =
+      <String, String>{};
   String? _lastAndroidTerminalContentDiagnosticsKey;
   bool _androidPredictiveBackPostFrameDiagnosticsQueued = false;
 
@@ -2980,6 +2981,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   void _queueAndroidPredictiveBackPostFrameDiagnostics(BuildContext context) {
     if (!_isAndroidPlatform ||
+        !DiagnosticsLogService.instance.enabled ||
         _androidPredictiveBackPostFrameDiagnosticsQueued) {
       return;
     }
@@ -3003,7 +3005,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     bool? didPop,
     bool includeGestureEnabled = false,
   }) {
-    if (!_isAndroidPlatform) {
+    final diagnostics = DiagnosticsLogService.instance;
+    if (!_isAndroidPlatform || !diagnostics.enabled) {
       return;
     }
     final route = ModalRoute.of(context);
@@ -3035,15 +3038,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final key = fields.entries
         .map((entry) => '${entry.key}:${entry.value}')
         .join('|');
-    if (key == _lastAndroidPredictiveBackDiagnosticsKey) {
+    if (key == _lastAndroidPredictiveBackDiagnosticsKeys[phase]) {
       return;
     }
-    _lastAndroidPredictiveBackDiagnosticsKey = key;
-    DiagnosticsLogService.instance.debug(
-      'android.back',
-      'terminal_route_state',
-      fields: fields,
-    );
+    _lastAndroidPredictiveBackDiagnosticsKeys[phase] = key;
+    diagnostics.debug('android.back', 'terminal_route_state', fields: fields);
   }
 
   void _logAndroidTerminalContentDiagnostics(
@@ -3054,7 +3053,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     required bool hasOverlayMessage,
     required bool isMobile,
   }) {
-    if (!_isAndroidPlatform) {
+    final diagnostics = DiagnosticsLogService.instance;
+    if (!_isAndroidPlatform || !diagnostics.enabled) {
       return;
     }
     final route = ModalRoute.of(context);
@@ -3086,11 +3086,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
     _lastAndroidTerminalContentDiagnosticsKey = key;
-    DiagnosticsLogService.instance.debug(
-      'android.back',
-      'terminal_content_state',
-      fields: fields,
-    );
+    diagnostics.debug('android.back', 'terminal_content_state', fields: fields);
   }
 
   bool get _hasExpandedNativeOverlaySelection =>
@@ -7713,7 +7709,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                     child: Column(
                       children: [
                         Expanded(
-                          child: _buildTerminalView(terminalTheme, isMobile),
+                          child: _buildTerminalView(
+                            terminalTheme,
+                            isMobile,
+                            connectionState,
+                          ),
                         ),
                         SizedBox(height: animatedBottomPadding),
                       ],
@@ -9633,13 +9633,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     ],
   );
 
-  Widget _buildTerminalView(TerminalThemeData terminalTheme, bool isMobile) {
+  Widget _buildTerminalView(
+    TerminalThemeData terminalTheme,
+    bool isMobile,
+    SshConnectionState connectionState,
+  ) {
     final theme = Theme.of(context);
-    final connectionStates = ref.watch(activeSessionsProvider);
-    final connectionAttempt = ref
-        .read(activeSessionsProvider.notifier)
-        .getConnectionAttempt(widget.hostId);
-    final connectionState = _selectTrackedConnectionState(connectionStates);
+    final connectionAttempt = ref.watch(
+      connectionAttemptProvider(widget.hostId),
+    );
     final showsDisconnectedOverlay =
         _connectionId != null &&
         !_isConnecting &&

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -830,10 +830,13 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
   }
 
   void _logAndroidBackLifecycle(String event) {
-    if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) {
+    final diagnostics = DiagnosticsLogService.instance;
+    if (kIsWeb ||
+        defaultTargetPlatform != TargetPlatform.android ||
+        !diagnostics.enabled) {
       return;
     }
-    DiagnosticsLogService.instance.debug(
+    diagnostics.debug(
       'android.back',
       'terminal_view_lifecycle',
       fields: <String, Object?>{


### PR DESCRIPTION
## Summary
- Avoid rebuilding the active terminal view on every 150ms terminal preview refresh by passing the already-selected connection state into the terminal view builder.
- Add a focused connection-attempt provider so connection progress overlays can still update without subscribing the terminal view to preview churn.
- Gate Android predictive-back diagnostic work when diagnostics are disabled and dedupe build/post-frame entries separately.

## Validation
- `flutter test test/widget/monkey_terminal_view_resize_test.dart test/domain/services/diagnostics_log_service_test.dart`
- `flutter analyze`
- pre-commit checks