### PR TITLE
fix: reuse primary SFTP client

### DIFF
--- a/lib/domain/services/monkeymux_installer_service.dart
+++ b/lib/domain/services/monkeymux_installer_service.dart
@@ -298,7 +298,7 @@ class MonkeyMuxInstallerService {
       );
     }
 
-    final sftp = await session.sftp();
+    final sftp = await session.openStandaloneSftp();
     try {
       final homeDirectory = await _remoteFileService.resolveInitialDirectory(
         sftp,

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -6,8 +6,6 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:dartssh2/dartssh2.dart';
-// ignore: implementation_imports
-import 'package:dartssh2/src/sftp/sftp_statvfs.dart' show SftpStatVfs;
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:xterm/xterm.dart';
@@ -1185,10 +1183,6 @@ class SshConnectionResult {
   }
 }
 
-/// Creates a short-lived auxiliary SSH connection for side-channel work.
-typedef SshAuxiliaryClientFactory =
-    Future<SshConnectionResult> Function(SshConnectionConfig config);
-
 /// Progress callback for long-running SSH connection attempts.
 typedef ConnectionProgressCallback =
     void Function(ConnectionProgressUpdate update);
@@ -1499,7 +1493,6 @@ class SshService {
           client: result.client!,
           config: config,
           dependentClients: result.dependentClients,
-          auxiliaryClientFactory: connect,
           terminalThemeLightId: useHostThemeOverrides
               ? host.terminalThemeLightId
               : null,
@@ -2546,14 +2539,12 @@ class SshSession {
     required this.client,
     required this.config,
     this.dependentClients = const <SSHClient>[],
-    SshAuxiliaryClientFactory? auxiliaryClientFactory,
     this.terminalThemeLightId,
     this.terminalThemeDarkId,
     this.terminalFontSize,
     this.clipboardSharingEnabled = false,
     this.localClipboardReadEnabled = false,
-  }) : _auxiliaryClientFactory = auxiliaryClientFactory,
-       createdAt = DateTime.now();
+  }) : createdAt = DateTime.now();
 
   static const _previewRefreshInterval = Duration(milliseconds: 150);
   static const _shellIoDiagnosticsInterval = Duration(seconds: 1);
@@ -2580,8 +2571,6 @@ class SshSession {
 
   /// Additional clients that should be closed with the session client.
   final List<SSHClient> dependentClients;
-
-  final SshAuxiliaryClientFactory? _auxiliaryClientFactory;
 
   /// Session-specific light theme override.
   String? terminalThemeLightId;
@@ -2641,6 +2630,8 @@ class SshSession {
   Uri? _workingDirectory;
   TerminalShellStatus? _shellStatus;
   int? _lastExitCode;
+  SftpClient? _sftpClient;
+  Future<SftpClient>? _sftpClientFuture;
 
   /// The persistent terminal for this session. Created on first shell open.
   Terminal? get terminal => _runtime.terminal;
@@ -3123,16 +3114,70 @@ class SshSession {
 
   /// Start an SFTP session.
   Future<SftpClient> sftp() async {
+    final cachedSftp = _sftpClient;
+    if (cachedSftp != null) {
+      DiagnosticsLogService.instance.debug(
+        'ssh.sftp',
+        'reuse_client',
+        fields: {'connectionId': connectionId, 'hostId': hostId},
+      );
+      return cachedSftp;
+    }
+
+    final inFlight = _sftpClientFuture;
+    if (inFlight != null) {
+      return inFlight;
+    }
+
+    final future = _openSftpClient();
+    _sftpClientFuture = future;
+    try {
+      final sftpClient = await future;
+      if (identical(_sftpClientFuture, future)) {
+        _sftpClient = sftpClient;
+      }
+      return sftpClient;
+    } finally {
+      if (identical(_sftpClientFuture, future)) {
+        _sftpClientFuture = null;
+      }
+    }
+  }
+
+  /// Open a one-off SFTP client without using the session cache.
+  ///
+  /// Prefer [sftp] for normal app SFTP work. This exists for flows that must
+  /// bypass an in-flight shared SFTP open, such as a prompt-capable MonkeyMux
+  /// install superseding a probe-only install.
+  Future<SftpClient> openStandaloneSftp() => _openSftpClient();
+
+  /// Discard the cached SFTP client for this session.
+  ///
+  /// Use this only when an SFTP operation timed out or failed in a way that may
+  /// have left pending requests behind. Normal consumers should leave the
+  /// session-owned client open so future SFTP work can reuse the same channel.
+  void discardSftpClient(SftpClient? sftpClient) {
+    final cachedSftp = _sftpClient;
+    if (sftpClient != null) {
+      if (cachedSftp == null) {
+        sftpClient.close();
+        return;
+      }
+      if (!identical(sftpClient, cachedSftp)) {
+        return;
+      }
+    }
+    _sftpClient = null;
+    _sftpClientFuture = null;
+    cachedSftp?.close();
+  }
+
+  Future<SftpClient> _openSftpClient() async {
     DiagnosticsLogService.instance.info(
       'ssh.sftp',
       'open_start',
       fields: {'connectionId': connectionId, 'hostId': hostId},
     );
-
-    final auxiliarySftp = await _openAuxiliarySftpClient();
-    if (auxiliarySftp != null) {
-      return auxiliarySftp;
-    }
 
     for (var attempt = 0; ; attempt += 1) {
       try {
@@ -3144,7 +3189,6 @@ class SshSession {
             'connectionId': connectionId,
             'hostId': hostId,
             'attempt': attempt + 1,
-            'connectionKind': 'primary',
           },
         );
         return sftpClient;
@@ -3195,62 +3239,6 @@ class SshSession {
       return false;
     }
     return error.code == 2 || error.code == 4;
-  }
-
-  Future<SftpClient?> _openAuxiliarySftpClient() async {
-    final auxiliaryClientFactory = _auxiliaryClientFactory;
-    if (auxiliaryClientFactory == null) {
-      return null;
-    }
-
-    DiagnosticsLogService.instance.debug(
-      'ssh.sftp',
-      'auxiliary_open_start',
-      fields: {'connectionId': connectionId, 'hostId': hostId},
-    );
-    SshConnectionResult? result;
-    try {
-      result = await auxiliaryClientFactory(config);
-      final auxiliaryClient = result.client;
-      if (!result.success || auxiliaryClient == null) {
-        DiagnosticsLogService.instance.warning(
-          'ssh.sftp',
-          'auxiliary_connect_failed',
-          fields: {
-            'connectionId': connectionId,
-            'hostId': hostId,
-            'errorType': _diagnosticSshResultErrorKind(result.error),
-          },
-        );
-        await result.closeAll();
-        return null;
-      }
-
-      final sftpClient = await auxiliaryClient.sftp();
-      DiagnosticsLogService.instance.info(
-        'ssh.sftp',
-        'open_success',
-        fields: {
-          'connectionId': connectionId,
-          'hostId': hostId,
-          'attempt': 1,
-          'connectionKind': 'auxiliary',
-        },
-      );
-      return _ManagedSftpClient(delegate: sftpClient, connectionResult: result);
-    } on Object catch (error) {
-      DiagnosticsLogService.instance.warning(
-        'ssh.sftp',
-        'auxiliary_open_failed',
-        fields: {
-          'connectionId': connectionId,
-          'hostId': hostId,
-          ..._diagnosticSshExecErrorFields(error),
-        },
-      );
-      await result?.closeAll();
-      return null;
-    }
   }
 
   /// Start a local port forward tunnel.
@@ -3467,6 +3455,7 @@ class SshSession {
   Future<void> close() async {
     await stopAllForwards();
     await closeShell();
+    discardSftpClient(null);
     await _connectionHealthFailures.close();
     client.close();
     for (final dependentClient in dependentClients) {
@@ -3503,108 +3492,6 @@ class SshSession {
       ),
     );
   }
-}
-
-class _ManagedSftpClient implements SftpClient {
-  _ManagedSftpClient({
-    required SftpClient delegate,
-    required SshConnectionResult connectionResult,
-  }) : _delegate = delegate,
-       _connectionResult = connectionResult;
-
-  final SftpClient _delegate;
-  final SshConnectionResult _connectionResult;
-  bool _closed = false;
-
-  @override
-  Future<SftpHandsake> get handshake => _delegate.handshake;
-
-  @override
-  SSHPrintHandler? get printDebug => _delegate.printDebug;
-
-  @override
-  SSHPrintHandler? get printTrace => _delegate.printTrace;
-
-  @override
-  Future<String> absolute(String path) => _delegate.absolute(path);
-
-  @override
-  void close() {
-    if (_closed) {
-      return;
-    }
-    _closed = true;
-    try {
-      _delegate.close();
-    } finally {
-      unawaited(_connectionResult.closeAll());
-    }
-  }
-
-  @override
-  Future<int> download(
-    String path,
-    StreamSink<List<int>> destination, {
-    int? length,
-    int offset = 0,
-    void Function(int bytesRead)? onProgress,
-    int chunkSize = 64 * 1024,
-    int maxPendingRequests = 128,
-    bool closeDestination = false,
-  }) => _delegate.download(
-    path,
-    destination,
-    length: length,
-    offset: offset,
-    onProgress: onProgress,
-    chunkSize: chunkSize,
-    maxPendingRequests: maxPendingRequests,
-    closeDestination: closeDestination,
-  );
-
-  @override
-  Future<void> link(String linkPath, String targetPath) =>
-      _delegate.link(linkPath, targetPath);
-
-  @override
-  Future<List<SftpName>> listdir(String path) => _delegate.listdir(path);
-
-  @override
-  Future<void> mkdir(String path, [SftpFileAttrs? attrs]) =>
-      _delegate.mkdir(path, attrs);
-
-  @override
-  Future<SftpFile> open(
-    String path, {
-    SftpFileOpenMode mode = SftpFileOpenMode.read,
-  }) => _delegate.open(path, mode: mode);
-
-  @override
-  Future<void> remove(String filename) => _delegate.remove(filename);
-
-  @override
-  Future<void> rename(String oldPath, String newPath) =>
-      _delegate.rename(oldPath, newPath);
-
-  @override
-  Stream<List<SftpName>> readdir(String path) => _delegate.readdir(path);
-
-  @override
-  Future<String> readlink(String path) => _delegate.readlink(path);
-
-  @override
-  Future<void> rmdir(String dirname) => _delegate.rmdir(dirname);
-
-  @override
-  Future<void> setStat(String path, SftpFileAttrs attrs) =>
-      _delegate.setStat(path, attrs);
-
-  @override
-  Future<SftpFileAttrs> stat(String path, {bool followLink = true}) =>
-      _delegate.stat(path, followLink: followLink);
-
-  @override
-  Future<SftpStatVfs> statvfs(String path) => _delegate.statvfs(path);
 }
 
 class _SshConnectionHealthFailure {

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -6,6 +6,8 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:dartssh2/dartssh2.dart';
+// ignore: implementation_imports
+import 'package:dartssh2/src/sftp/sftp_statvfs.dart' show SftpStatVfs;
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:xterm/xterm.dart';
@@ -1183,6 +1185,10 @@ class SshConnectionResult {
   }
 }
 
+/// Creates a short-lived auxiliary SSH connection for side-channel work.
+typedef SshAuxiliaryClientFactory =
+    Future<SshConnectionResult> Function(SshConnectionConfig config);
+
 /// Progress callback for long-running SSH connection attempts.
 typedef ConnectionProgressCallback =
     void Function(ConnectionProgressUpdate update);
@@ -1493,6 +1499,7 @@ class SshService {
           client: result.client!,
           config: config,
           dependentClients: result.dependentClients,
+          auxiliaryClientFactory: connect,
           terminalThemeLightId: useHostThemeOverrides
               ? host.terminalThemeLightId
               : null,
@@ -2539,12 +2546,14 @@ class SshSession {
     required this.client,
     required this.config,
     this.dependentClients = const <SSHClient>[],
+    SshAuxiliaryClientFactory? auxiliaryClientFactory,
     this.terminalThemeLightId,
     this.terminalThemeDarkId,
     this.terminalFontSize,
     this.clipboardSharingEnabled = false,
     this.localClipboardReadEnabled = false,
-  }) : createdAt = DateTime.now();
+  }) : _auxiliaryClientFactory = auxiliaryClientFactory,
+       createdAt = DateTime.now();
 
   static const _previewRefreshInterval = Duration(milliseconds: 150);
   static const _shellIoDiagnosticsInterval = Duration(seconds: 1);
@@ -2571,6 +2580,8 @@ class SshSession {
 
   /// Additional clients that should be closed with the session client.
   final List<SSHClient> dependentClients;
+
+  final SshAuxiliaryClientFactory? _auxiliaryClientFactory;
 
   /// Session-specific light theme override.
   String? terminalThemeLightId;
@@ -3118,6 +3129,11 @@ class SshSession {
       fields: {'connectionId': connectionId, 'hostId': hostId},
     );
 
+    final auxiliarySftp = await _openAuxiliarySftpClient();
+    if (auxiliarySftp != null) {
+      return auxiliarySftp;
+    }
+
     for (var attempt = 0; ; attempt += 1) {
       try {
         final sftpClient = await client.sftp();
@@ -3128,6 +3144,7 @@ class SshSession {
             'connectionId': connectionId,
             'hostId': hostId,
             'attempt': attempt + 1,
+            'connectionKind': 'primary',
           },
         );
         return sftpClient;
@@ -3178,6 +3195,62 @@ class SshSession {
       return false;
     }
     return error.code == 2 || error.code == 4;
+  }
+
+  Future<SftpClient?> _openAuxiliarySftpClient() async {
+    final auxiliaryClientFactory = _auxiliaryClientFactory;
+    if (auxiliaryClientFactory == null) {
+      return null;
+    }
+
+    DiagnosticsLogService.instance.debug(
+      'ssh.sftp',
+      'auxiliary_open_start',
+      fields: {'connectionId': connectionId, 'hostId': hostId},
+    );
+    SshConnectionResult? result;
+    try {
+      result = await auxiliaryClientFactory(config);
+      final auxiliaryClient = result.client;
+      if (!result.success || auxiliaryClient == null) {
+        DiagnosticsLogService.instance.warning(
+          'ssh.sftp',
+          'auxiliary_connect_failed',
+          fields: {
+            'connectionId': connectionId,
+            'hostId': hostId,
+            'errorType': _diagnosticSshResultErrorKind(result.error),
+          },
+        );
+        await result.closeAll();
+        return null;
+      }
+
+      final sftpClient = await auxiliaryClient.sftp();
+      DiagnosticsLogService.instance.info(
+        'ssh.sftp',
+        'open_success',
+        fields: {
+          'connectionId': connectionId,
+          'hostId': hostId,
+          'attempt': 1,
+          'connectionKind': 'auxiliary',
+        },
+      );
+      return _ManagedSftpClient(delegate: sftpClient, connectionResult: result);
+    } on Object catch (error) {
+      DiagnosticsLogService.instance.warning(
+        'ssh.sftp',
+        'auxiliary_open_failed',
+        fields: {
+          'connectionId': connectionId,
+          'hostId': hostId,
+          ..._diagnosticSshExecErrorFields(error),
+        },
+      );
+      await result?.closeAll();
+      return null;
+    }
   }
 
   /// Start a local port forward tunnel.
@@ -3430,6 +3503,108 @@ class SshSession {
       ),
     );
   }
+}
+
+class _ManagedSftpClient implements SftpClient {
+  _ManagedSftpClient({
+    required SftpClient delegate,
+    required SshConnectionResult connectionResult,
+  }) : _delegate = delegate,
+       _connectionResult = connectionResult;
+
+  final SftpClient _delegate;
+  final SshConnectionResult _connectionResult;
+  bool _closed = false;
+
+  @override
+  Future<SftpHandsake> get handshake => _delegate.handshake;
+
+  @override
+  SSHPrintHandler? get printDebug => _delegate.printDebug;
+
+  @override
+  SSHPrintHandler? get printTrace => _delegate.printTrace;
+
+  @override
+  Future<String> absolute(String path) => _delegate.absolute(path);
+
+  @override
+  void close() {
+    if (_closed) {
+      return;
+    }
+    _closed = true;
+    try {
+      _delegate.close();
+    } finally {
+      unawaited(_connectionResult.closeAll());
+    }
+  }
+
+  @override
+  Future<int> download(
+    String path,
+    StreamSink<List<int>> destination, {
+    int? length,
+    int offset = 0,
+    void Function(int bytesRead)? onProgress,
+    int chunkSize = 64 * 1024,
+    int maxPendingRequests = 128,
+    bool closeDestination = false,
+  }) => _delegate.download(
+    path,
+    destination,
+    length: length,
+    offset: offset,
+    onProgress: onProgress,
+    chunkSize: chunkSize,
+    maxPendingRequests: maxPendingRequests,
+    closeDestination: closeDestination,
+  );
+
+  @override
+  Future<void> link(String linkPath, String targetPath) =>
+      _delegate.link(linkPath, targetPath);
+
+  @override
+  Future<List<SftpName>> listdir(String path) => _delegate.listdir(path);
+
+  @override
+  Future<void> mkdir(String path, [SftpFileAttrs? attrs]) =>
+      _delegate.mkdir(path, attrs);
+
+  @override
+  Future<SftpFile> open(
+    String path, {
+    SftpFileOpenMode mode = SftpFileOpenMode.read,
+  }) => _delegate.open(path, mode: mode);
+
+  @override
+  Future<void> remove(String filename) => _delegate.remove(filename);
+
+  @override
+  Future<void> rename(String oldPath, String newPath) =>
+      _delegate.rename(oldPath, newPath);
+
+  @override
+  Stream<List<SftpName>> readdir(String path) => _delegate.readdir(path);
+
+  @override
+  Future<String> readlink(String path) => _delegate.readlink(path);
+
+  @override
+  Future<void> rmdir(String dirname) => _delegate.rmdir(dirname);
+
+  @override
+  Future<void> setStat(String path, SftpFileAttrs attrs) =>
+      _delegate.setStat(path, attrs);
+
+  @override
+  Future<SftpFileAttrs> stat(String path, {bool followLink = true}) =>
+      _delegate.stat(path, followLink: followLink);
+
+  @override
+  Future<SftpStatVfs> statvfs(String path) => _delegate.statvfs(path);
 }
 
 class _SshConnectionHealthFailure {

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -537,7 +537,6 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   void dispose() {
     _breadcrumbScrollController.dispose();
     _fileListScrollController.dispose();
-    _sftp?.close();
     _sftp = null;
     super.dispose();
   }
@@ -549,13 +548,14 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     });
 
     SftpClient? pendingSftp;
+    SshSession? session;
     try {
       final remoteFileService = ref.read(remoteFileServiceProvider);
       final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
       var connectionId =
           widget.connectionId ??
           sessionsNotifier.getPreferredConnectionForHost(widget.hostId);
-      var session = connectionId == null
+      session = connectionId == null
           ? null
           : sessionsNotifier.getSession(connectionId);
       final monetizationState =
@@ -605,7 +605,6 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       }
       final sftp = await _openSftpClient(session);
       if (!mounted) {
-        sftp.close();
         return;
       }
       pendingSftp = sftp;
@@ -613,10 +612,8 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
         remoteFileService.resolveInitialDirectory(sftp),
       );
       if (!mounted) {
-        sftp.close();
         return;
       }
-      _sftp?.close();
       _sftp = sftp;
       pendingSftp = null;
       _hostLabel = session.config.hostname;
@@ -639,9 +636,9 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       }
       await _openFallbackDirectory(preferredPath: _fallbackDirectoryPath);
     } on SSHError catch (e) {
-      _handleConnectFailure(e, pendingSftp);
+      _handleConnectFailure(e, pendingSftp, session);
     } on Exception catch (e) {
-      _handleConnectFailure(e, pendingSftp);
+      _handleConnectFailure(e, pendingSftp, session);
     }
   }
 
@@ -650,18 +647,24 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     try {
       return await withSftpOperationTimeout(sftpOpenFuture);
     } on TimeoutException {
-      sftpOpenFuture.then((sftp) => sftp.close()).ignore();
+      sftpOpenFuture.then(session.discardSftpClient).ignore();
       rethrow;
     }
   }
 
-  void _handleConnectFailure(Object error, SftpClient? pendingSftp) {
+  void _handleConnectFailure(
+    Object error,
+    SftpClient? pendingSftp,
+    SshSession? session,
+  ) {
     DiagnosticsLogService.instance.warning(
       'sftp',
       'connect_failed',
       fields: {'errorType': error.runtimeType},
     );
-    pendingSftp?.close();
+    if (_shouldReconnectSftpAfterDirectoryError(error)) {
+      session?.discardSftpClient(pendingSftp);
+    }
     if (!mounted) {
       return;
     }
@@ -885,13 +888,12 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
       'reconnect_start',
       fields: {'connectionId': connectionId},
     );
-    _sftp?.close();
+    session.discardSftpClient(_sftp);
     _sftp = null;
 
     try {
       final sftp = await _openSftpClient(session);
       if (!mounted) {
-        sftp.close();
         return false;
       }
       _sftp = sftp;

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -11895,7 +11895,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   void _disposeTerminalPathVerificationSftp() {
-    _terminalPathVerificationSftp?.close();
     _terminalPathVerificationSftp = null;
     _terminalPathVerificationSftpFuture = null;
     _terminalPathVerificationSession = null;
@@ -11912,7 +11911,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     try {
       return await sftpOpenFuture.timeout(_terminalPathVerificationTimeout);
     } on TimeoutException {
-      sftpOpenFuture.then((sftp) => sftp.close()).ignore();
+      sftpOpenFuture.then(session.discardSftpClient).ignore();
       rethrow;
     }
   }
@@ -11948,7 +11947,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final future = _openTerminalPathVerificationSftp(session).then<SftpClient?>(
       (sftp) {
         if (!identical(_terminalPathVerificationSession, session)) {
-          sftp.close();
           return null;
         }
         _terminalPathVerificationBackoffUntil = null;
@@ -12033,7 +12031,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         'errorType': error.runtimeType.toString(),
       },
     );
-    sftp.close();
+    session?.discardSftpClient(sftp);
     _terminalPathVerificationSftp = null;
     _terminalPathVerificationHomeDirectory = null;
   }
@@ -12695,8 +12693,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         mode: remoteUploadDirectoryMode,
       );
       return await action(sftp, remoteFileService, uploadDirectory);
-    } finally {
-      sftp.close();
+    } on TimeoutException {
+      session.discardSftpClient(sftp);
+      rethrow;
+    } on SSHError {
+      session.discardSftpClient(sftp);
+      rethrow;
+    } on SftpError catch (error) {
+      if (error is! SftpStatusError) {
+        session.discardSftpClient(sftp);
+      }
+      rethrow;
     }
   }
 

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -1245,6 +1245,38 @@ void main() {
       expect(openAttempts, 2);
     });
 
+    test('opens SFTP over an auxiliary connection when available', () async {
+      final client = _MockSshClient();
+      final auxiliaryClient = _MockSshClient();
+      final sftp = _MockSftpClient();
+      final session = SshSession(
+        connectionId: 11,
+        hostId: 2,
+        client: client,
+        config: const SshConnectionConfig(
+          hostname: 'example.com',
+          port: 22,
+          username: 'tester',
+        ),
+        auxiliaryClientFactory: (_) async =>
+            SshConnectionResult(success: true, client: auxiliaryClient),
+      );
+
+      when(auxiliaryClient.sftp).thenAnswer((_) async => sftp);
+      when(sftp.close).thenReturn(null);
+      when(auxiliaryClient.close).thenReturn(null);
+
+      final managedSftp = await session.sftp();
+
+      verifyNever(client.sftp);
+      verify(auxiliaryClient.sftp).called(1);
+
+      managedSftp.close();
+
+      verify(sftp.close).called(1);
+      verify(auxiliaryClient.close).called(1);
+    });
+
     test('does not retry non-transient SFTP channel open failures', () async {
       final client = _MockSshClient();
       final session = SshSession(

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -1245,9 +1245,8 @@ void main() {
       expect(openAttempts, 2);
     });
 
-    test('opens SFTP over an auxiliary connection when available', () async {
+    test('reuses the session SFTP client', () async {
       final client = _MockSshClient();
-      final auxiliaryClient = _MockSshClient();
       final sftp = _MockSftpClient();
       final session = SshSession(
         connectionId: 11,
@@ -1258,23 +1257,21 @@ void main() {
           port: 22,
           username: 'tester',
         ),
-        auxiliaryClientFactory: (_) async =>
-            SshConnectionResult(success: true, client: auxiliaryClient),
       );
 
-      when(auxiliaryClient.sftp).thenAnswer((_) async => sftp);
+      when(client.sftp).thenAnswer((_) async => sftp);
       when(sftp.close).thenReturn(null);
-      when(auxiliaryClient.close).thenReturn(null);
 
-      final managedSftp = await session.sftp();
+      final first = await session.sftp();
+      final second = await session.sftp();
 
-      verifyNever(client.sftp);
-      verify(auxiliaryClient.sftp).called(1);
+      expect(first, same(sftp));
+      expect(second, same(sftp));
+      verify(client.sftp).called(1);
 
-      managedSftp.close();
+      session.discardSftpClient(first);
 
       verify(sftp.close).called(1);
-      verify(auxiliaryClient.close).called(1);
     });
 
     test('does not retry non-transient SFTP channel open failures', () async {


### PR DESCRIPTION
## Summary
- cache one primary SFTP client per active SSH session so browser/path verification/clipboard flows reuse the same SFTP channel instead of reopening channels repeatedly
- stop normal SFTP consumers from closing the session-owned client; discard it only after stale-channel/time-out style failures before retrying
- keep MonkeyMux installs on explicit standalone SFTP clients so prompt-capable installs can supersede in-flight probe-only installs without waiting on their SFTP open

## Validation
- flutter analyze
- flutter test
- flutter test test/domain/services/monkeymux_installer_service_test.dart
- flutter test test/domain/services/ssh_service_test.dart --name SFTP
- flutter test test/presentation/screens/sftp_screen_test.dart test/presentation/screens/terminal_screen_test.dart --name SFTP