### PR TITLE
fix: prevent remote editor wrap-off soft wraps

### DIFF
--- a/lib/presentation/screens/remote_text_editor_screen.dart
+++ b/lib/presentation/screens/remote_text_editor_screen.dart
@@ -703,7 +703,14 @@ class _RemoteTextEditorScreenState extends State<RemoteTextEditorScreen> {
       widget.fontFamily,
       platform: theme.platform,
       fontSize: _fontSize,
-    ).copyWith(color: colors.foreground, height: 1.35);
+    ).copyWith(
+      inherit: false,
+      color: colors.foreground,
+      height: 1.35,
+      letterSpacing: 0,
+      textBaseline: TextBaseline.alphabetic,
+      wordSpacing: 0,
+    );
   }
 
   InlineSpan _buildMeasuredTextSpan(BuildContext context, TextStyle style) =>

--- a/test/presentation/screens/remote_text_editor_screen_test.dart
+++ b/test/presentation/screens/remote_text_editor_screen_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: public_member_api_docs
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/presentation/screens/remote_text_editor_screen.dart';
 
@@ -471,5 +472,43 @@ void main() {
         expect(scrollController.offset, closeTo(0.0, 0.5));
       },
     );
+  });
+
+  group('RemoteTextEditorScreen wrapping', () {
+    Widget buildEditor({required TextEditingController controller}) =>
+        MaterialApp(
+          home: buildRemoteTextEditorScreenForTesting(
+            fileName: 'authorized_keys',
+            controller: controller,
+            initialFontSize: 12,
+          ),
+        );
+
+    testWidgets('wrap off keeps long logical lines on one visual row', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(390, 844));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final firstLine = 'ssh-ed25519 ${'A' * 120}';
+      final controller = TextEditingController(text: '$firstLine\nsecond')
+        ..selection = const TextSelection.collapsed(offset: 0);
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(buildEditor(controller: controller));
+      await tester.pump();
+
+      final renderEditable = tester.allRenderObjects
+          .whereType<RenderEditable>()
+          .single;
+      final secondLineCaret = renderEditable.getLocalRectForCaret(
+        TextPosition(offset: firstLine.length + 1),
+      );
+
+      expect(
+        secondLineCaret.top,
+        lessThan(renderEditable.preferredLineHeight * 1.5),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- keep remote editor text metrics isolated from Material input typography so wrap-off measurement matches the rendered EditableText
- add a widget regression test for long authorized_keys-style lines in wrap-off mode

## Validation
- dart format lib/presentation/screens/remote_text_editor_screen.dart test/presentation/screens/remote_text_editor_screen_test.dart
- flutter test test/presentation/screens/remote_text_editor_screen_test.dart
- flutter analyze
- pre-commit hook: format, analyze, tests