### PR TITLE
feat: replace xterm with kterm

### DIFF
--- a/integration_test/codex_theme_validation_test.dart
+++ b/integration_test/codex_theme_validation_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:kterm/kterm.dart' hide TerminalThemes;
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/key_repository.dart';
@@ -23,7 +24,6 @@ import 'package:monkeyssh/domain/services/monetization_service.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
-import 'package:xterm/xterm.dart' hide TerminalThemes;
 
 const _sshPort = int.fromEnvironment('CODEX_THEME_SSH_PORT');
 const _sshUser = String.fromEnvironment('CODEX_THEME_SSH_USER');
@@ -319,8 +319,8 @@ double _minimumTokenContrast(
   TerminalThemeData theme,
   String token,
 ) {
-  final xtermTheme = theme.toXtermTheme();
-  final palette = _buildTerminalPalette(xtermTheme);
+  final ktermTheme = theme.toKtermTheme();
+  final palette = _buildTerminalPalette(ktermTheme);
   final cell = CellData.empty();
 
   for (var row = 0; row < terminal.buffer.lines.length; row += 1) {
@@ -334,7 +334,7 @@ double _minimumTokenContrast(
     var minimum = double.infinity;
     for (var offset = 0; offset < token.length; offset += 1) {
       line.getCellData(startColumn + offset, cell);
-      final colors = _effectiveCellColors(cell, xtermTheme, palette);
+      final colors = _effectiveCellColors(cell, ktermTheme, palette);
       minimum = math.min(
         minimum,
         _contrastRatio(colors.foreground, colors.background),
@@ -351,8 +351,8 @@ double _minimumTokenContrast(
   TerminalThemeData theme,
   String token,
 ) {
-  final xtermTheme = theme.toXtermTheme();
-  final palette = _buildTerminalPalette(xtermTheme);
+  final ktermTheme = theme.toKtermTheme();
+  final palette = _buildTerminalPalette(ktermTheme);
   final cell = CellData.empty();
 
   for (var row = 0; row < terminal.buffer.lines.length; row += 1) {
@@ -367,7 +367,7 @@ double _minimumTokenContrast(
     final tokenSurfaceColor = _effectiveBackgroundCellColor(cell);
     final background = _effectiveCellColors(
       cell,
-      xtermTheme,
+      ktermTheme,
       palette,
     ).background;
     var sampledCells = 0;
@@ -390,15 +390,15 @@ int _effectiveBackgroundCellColor(CellData cell) =>
 
 ({Color foreground, Color background}) _effectiveCellColors(
   CellData cell,
-  TerminalTheme xtermTheme,
+  TerminalTheme ktermTheme,
   List<Color> palette,
 ) {
   var foreground = (cell.flags & CellFlags.inverse) == 0
-      ? _resolveForegroundColor(cell.foreground, xtermTheme, palette)
-      : _resolveBackgroundColor(cell.background, xtermTheme, palette);
+      ? _resolveForegroundColor(cell.foreground, ktermTheme, palette)
+      : _resolveBackgroundColor(cell.background, ktermTheme, palette);
   final background = (cell.flags & CellFlags.inverse) == 0
-      ? _resolveBackgroundColor(cell.background, xtermTheme, palette)
-      : _resolveForegroundColor(cell.foreground, xtermTheme, palette);
+      ? _resolveBackgroundColor(cell.background, ktermTheme, palette)
+      : _resolveForegroundColor(cell.foreground, ktermTheme, palette);
 
   if ((cell.flags & CellFlags.faint) != 0) {
     foreground = resolveMonkeyTerminalFaintForegroundColor(
@@ -411,13 +411,13 @@ int _effectiveBackgroundCellColor(CellData cell) =>
 
 Color _resolveForegroundColor(
   int cellColor,
-  TerminalTheme xtermTheme,
+  TerminalTheme ktermTheme,
   List<Color> palette,
 ) {
   final colorType = cellColor & CellColor.typeMask;
   final colorValue = cellColor & CellColor.valueMask;
   return switch (colorType) {
-    CellColor.normal => xtermTheme.foreground,
+    CellColor.normal => ktermTheme.foreground,
     CellColor.named || CellColor.palette => palette[colorValue],
     _ => Color.fromARGB(
       0xFF,
@@ -430,13 +430,13 @@ Color _resolveForegroundColor(
 
 Color _resolveBackgroundColor(
   int cellColor,
-  TerminalTheme xtermTheme,
+  TerminalTheme ktermTheme,
   List<Color> palette,
 ) {
   final colorType = cellColor & CellColor.typeMask;
   final colorValue = cellColor & CellColor.valueMask;
   return switch (colorType) {
-    CellColor.normal => xtermTheme.background,
+    CellColor.normal => ktermTheme.background,
     CellColor.named || CellColor.palette => palette[colorValue],
     _ => Color.fromARGB(
       0xFF,
@@ -447,10 +447,10 @@ Color _resolveBackgroundColor(
   };
 }
 
-List<Color> _buildTerminalPalette(TerminalTheme xtermTheme) =>
+List<Color> _buildTerminalPalette(TerminalTheme ktermTheme) =>
     List<Color>.generate(
       256,
-      (index) => resolveMonkeyTerminalPaletteColor(xtermTheme, index),
+      (index) => resolveMonkeyTerminalPaletteColor(ktermTheme, index),
       growable: false,
     );
 

--- a/integration_test/keyboard_toolbar_device_test.dart
+++ b/integration_test/keyboard_toolbar_device_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/presentation/widgets/keyboard_toolbar.dart';
-import 'package:xterm/xterm.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/integration_test/terminal_path_links_device_test.dart
+++ b/integration_test/terminal_path_links_device_test.dart
@@ -3,9 +3,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
-import 'package:xterm/xterm.dart';
 
 const _absolutePath = '/var/log/app.log';
 const _tildePath = '~/.ssh/config';

--- a/integration_test/terminal_screen_ime_ssh_device_test.dart
+++ b/integration_test/terminal_screen_ime_ssh_device_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/key_repository.dart';
@@ -14,7 +15,6 @@ import 'package:monkeyssh/domain/services/host_key_prompt_handler_provider.dart'
 import 'package:monkeyssh/domain/services/host_key_verification.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
-import 'package:xterm/xterm.dart';
 
 const _deleteDetectionMarker = '\u200B\u200B';
 const _testHost = String.fromEnvironment('TEST_SSH_HOST');

--- a/integration_test/terminal_screen_selection_live_ssh_device_test.dart
+++ b/integration_test/terminal_screen_selection_live_ssh_device_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/key_repository.dart';
@@ -14,7 +15,6 @@ import 'package:monkeyssh/domain/services/host_key_prompt_handler_provider.dart'
 import 'package:monkeyssh/domain/services/host_key_verification.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
-import 'package:xterm/xterm.dart';
 
 const _testHost = String.fromEnvironment('TEST_SSH_HOST');
 const _testPort = int.fromEnvironment('TEST_SSH_PORT');

--- a/integration_test/terminal_screen_system_selection_test.dart
+++ b/integration_test/terminal_screen_system_selection_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
@@ -14,7 +15,6 @@ import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
-import 'package:xterm/xterm.dart';
 
 class _MockHostRepository extends Mock implements HostRepository {}
 

--- a/integration_test/terminal_selection_reentry_device_test.dart
+++ b/integration_test/terminal_selection_reentry_device_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
@@ -16,7 +17,6 @@ import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
-import 'package:xterm/xterm.dart';
 
 class _MockHostRepository extends Mock implements HostRepository {}
 

--- a/integration_test/terminal_system_selection_test.dart
+++ b/integration_test/terminal_system_selection_test.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
-import 'package:xterm/xterm.dart';
 
 const _selectionPaintColor = Color(0xFFFF00FF);
 const _testTerminalTheme = TerminalTheme(

--- a/integration_test/terminal_text_input_handler_device_test.dart
+++ b/integration_test/terminal_text_input_handler_device_test.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show TextInputClient;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/domain/models/auto_connect_command.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
-import 'package:xterm/xterm.dart';
 
 const _deleteDetectionMarker = '\u200B\u200B';
 

--- a/integration_test/terminal_text_input_handler_validation_test.dart
+++ b/integration_test/terminal_text_input_handler_validation_test.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show TextInputClient;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
-import 'package:xterm/xterm.dart';
 
 const _deleteDetectionMarker = '\u200B\u200B';
 

--- a/integration_test/terminal_tmux_scroll_validation_test.dart
+++ b/integration_test/terminal_tmux_scroll_validation_test.dart
@@ -7,9 +7,9 @@ import 'package:dartssh2/dartssh2.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_pinch_zoom_gesture_handler.dart';
-import 'package:xterm/xterm.dart';
 
 const _tmuxSessionName = 'flutty-touch-scroll';
 const _sshPort = String.fromEnvironment('FLUTTY_SCROLL_SSH_PORT');

--- a/integration_test/terminal_tmux_touch_interactions_validation_test.dart
+++ b/integration_test/terminal_tmux_touch_interactions_validation_test.dart
@@ -3,10 +3,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/domain/services/terminal_hyperlink_tracker.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
-import 'package:xterm/xterm.dart';
 
 const _terminalLink = 'https://github.com/features/copilot';
 const _hiddenTerminalLink = 'https://github.com/orgs/community/discussions/1';

--- a/integration_test/tui_theme_realssh_proof_test.dart
+++ b/integration_test/tui_theme_realssh_proof_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:kterm/kterm.dart' hide TerminalThemes;
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/key_repository.dart';
@@ -23,7 +24,6 @@ import 'package:monkeyssh/domain/services/monetization_service.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
-import 'package:xterm/xterm.dart' hide TerminalThemes;
 
 const _sshPort = int.fromEnvironment('TUI_THEME_PROOF_SSH_PORT');
 const _sshUser = String.fromEnvironment('TUI_THEME_PROOF_SSH_USER');
@@ -568,8 +568,8 @@ double _minimumTokenContrast(
   TerminalThemeData theme,
   String token,
 ) {
-  final xtermTheme = theme.toXtermTheme();
-  final palette = _buildTerminalPalette(xtermTheme);
+  final ktermTheme = theme.toKtermTheme();
+  final palette = _buildTerminalPalette(ktermTheme);
   final cell = CellData.empty();
 
   for (var row = 0; row < terminal.buffer.lines.length; row += 1) {
@@ -588,7 +588,7 @@ double _minimumTokenContrast(
         continue;
       }
       line.getCellData(column, cell);
-      final colors = _effectiveCellColors(cell, xtermTheme, palette);
+      final colors = _effectiveCellColors(cell, ktermTheme, palette);
       minimum = math.min(
         minimum,
         _contrastRatio(colors.foreground, colors.background),
@@ -608,8 +608,8 @@ double _minimumTokenContrast(
   TerminalThemeData theme,
   String token,
 ) {
-  final xtermTheme = theme.toXtermTheme();
-  final palette = _buildTerminalPalette(xtermTheme);
+  final ktermTheme = theme.toKtermTheme();
+  final palette = _buildTerminalPalette(ktermTheme);
   final cell = CellData.empty();
 
   for (var row = 0; row < terminal.buffer.lines.length; row += 1) {
@@ -624,7 +624,7 @@ double _minimumTokenContrast(
     final tokenSurfaceColor = _effectiveBackgroundCellColor(cell);
     final background = _effectiveCellColors(
       cell,
-      xtermTheme,
+      ktermTheme,
       palette,
     ).background;
     var sampledCells = 0;
@@ -647,8 +647,8 @@ double _minimumTokenContrast(
   TerminalThemeData theme,
   String text,
 ) {
-  final xtermTheme = theme.toXtermTheme();
-  final palette = _buildTerminalPalette(xtermTheme);
+  final ktermTheme = theme.toKtermTheme();
+  final palette = _buildTerminalPalette(ktermTheme);
   final cell = CellData.empty();
 
   for (var row = 0; row < terminal.buffer.lines.length; row += 1) {
@@ -661,7 +661,7 @@ double _minimumTokenContrast(
 
     line.getCellData(startColumn, cell);
     return (
-      background: _effectiveCellColors(cell, xtermTheme, palette).background,
+      background: _effectiveCellColors(cell, ktermTheme, palette).background,
     );
   }
 
@@ -670,8 +670,8 @@ double _minimumTokenContrast(
 
 ({int sampledCells, int oppositeThemeCells, double oppositeThemeFraction})
 _viewportBackgroundStats(Terminal terminal, TerminalThemeData theme) {
-  final xtermTheme = theme.toXtermTheme();
-  final palette = _buildTerminalPalette(xtermTheme);
+  final ktermTheme = theme.toKtermTheme();
+  final palette = _buildTerminalPalette(ktermTheme);
   final cell = CellData.empty();
   var sampledCells = 0;
   var oppositeThemeCells = 0;
@@ -684,7 +684,7 @@ _viewportBackgroundStats(Terminal terminal, TerminalThemeData theme) {
       line.getCellData(column, cell);
       final background = _effectiveCellColors(
         cell,
-        xtermTheme,
+        ktermTheme,
         palette,
       ).background;
       final luminance = background.computeLuminance();
@@ -710,15 +710,15 @@ int _effectiveBackgroundCellColor(CellData cell) =>
 
 ({Color foreground, Color background}) _effectiveCellColors(
   CellData cell,
-  TerminalTheme xtermTheme,
+  TerminalTheme ktermTheme,
   List<Color> palette,
 ) {
   var foreground = (cell.flags & CellFlags.inverse) == 0
-      ? _resolveForegroundColor(cell.foreground, xtermTheme, palette)
-      : _resolveBackgroundColor(cell.background, xtermTheme, palette);
+      ? _resolveForegroundColor(cell.foreground, ktermTheme, palette)
+      : _resolveBackgroundColor(cell.background, ktermTheme, palette);
   final background = (cell.flags & CellFlags.inverse) == 0
-      ? _resolveBackgroundColor(cell.background, xtermTheme, palette)
-      : _resolveForegroundColor(cell.foreground, xtermTheme, palette);
+      ? _resolveBackgroundColor(cell.background, ktermTheme, palette)
+      : _resolveForegroundColor(cell.foreground, ktermTheme, palette);
 
   if ((cell.flags & CellFlags.faint) != 0) {
     foreground = resolveMonkeyTerminalFaintForegroundColor(
@@ -731,13 +731,13 @@ int _effectiveBackgroundCellColor(CellData cell) =>
 
 Color _resolveForegroundColor(
   int cellColor,
-  TerminalTheme xtermTheme,
+  TerminalTheme ktermTheme,
   List<Color> palette,
 ) {
   final colorType = cellColor & CellColor.typeMask;
   final colorValue = cellColor & CellColor.valueMask;
   return switch (colorType) {
-    CellColor.normal => xtermTheme.foreground,
+    CellColor.normal => ktermTheme.foreground,
     CellColor.named || CellColor.palette => palette[colorValue],
     _ => Color.fromARGB(
       0xFF,
@@ -750,13 +750,13 @@ Color _resolveForegroundColor(
 
 Color _resolveBackgroundColor(
   int cellColor,
-  TerminalTheme xtermTheme,
+  TerminalTheme ktermTheme,
   List<Color> palette,
 ) {
   final colorType = cellColor & CellColor.typeMask;
   final colorValue = cellColor & CellColor.valueMask;
   return switch (colorType) {
-    CellColor.normal => xtermTheme.background,
+    CellColor.normal => ktermTheme.background,
     CellColor.named || CellColor.palette => palette[colorValue],
     _ => Color.fromARGB(
       0xFF,
@@ -767,10 +767,10 @@ Color _resolveBackgroundColor(
   };
 }
 
-List<Color> _buildTerminalPalette(TerminalTheme xtermTheme) =>
+List<Color> _buildTerminalPalette(TerminalTheme ktermTheme) =>
     List<Color>.generate(
       256,
-      (index) => resolveMonkeyTerminalPaletteColor(xtermTheme, index),
+      (index) => resolveMonkeyTerminalPaletteColor(ktermTheme, index),
       growable: false,
     );
 

--- a/lib/domain/models/terminal_preview.dart
+++ b/lib/domain/models/terminal_preview.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:xterm/xterm.dart';
+import 'package:kterm/kterm.dart';
 
 /// A value-equal snapshot of terminal rows used by connection preview cards.
 @immutable
@@ -33,7 +33,7 @@ class TerminalPreviewLine {
   /// Sanitized plain text for the row.
   final String text;
 
-  /// Copied xterm cell data for this display row.
+  /// Copied kterm cell data for this display row.
   final BufferLine cells;
 
   @override

--- a/lib/domain/models/terminal_theme.dart
+++ b/lib/domain/models/terminal_theme.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:xterm/xterm.dart';
+import 'package:kterm/kterm.dart';
 
 /// Builds an xterm/tmux theme-mode report for the current terminal theme.
 ///
@@ -294,7 +294,7 @@ const _terminalThemeOptionalColorKeys = <String>[
 /// Data model for a terminal color theme.
 ///
 /// Contains all 16 ANSI colors plus special colors for cursor, selection,
-/// foreground, and background. Can be converted to xterm's [TerminalTheme].
+/// foreground, and background. Can be converted to kterm's [TerminalTheme].
 @immutable
 class TerminalThemeData {
   /// Creates a new [TerminalThemeData].
@@ -493,8 +493,8 @@ class TerminalThemeData {
     selection: selection,
   );
 
-  /// Converts this theme data to xterm's [TerminalTheme].
-  TerminalTheme toXtermTheme() => TerminalTheme(
+  /// Converts this theme data to kterm's [TerminalTheme].
+  TerminalTheme toKtermTheme() => TerminalTheme(
     cursor: cursor,
     selection: readableSelection,
     foreground: foreground,

--- a/lib/domain/services/clipboard_sharing_service.dart
+++ b/lib/domain/services/clipboard_sharing_service.dart
@@ -36,7 +36,7 @@ class ClipboardSharingService {
 
   /// Handles an incoming OSC 52 sequence from the remote terminal.
   ///
-  /// [args] is the list produced by xterm's OSC parser, split on `;`.
+  /// [args] is the list produced by kterm's OSC parser, split on `;`.
   /// For `ESC ] 52 ; c ; <base64> ST` this is `['c', '<base64>']`.
   /// For a query `ESC ] 52 ; c ; ? ST` this is `['c', '?']`.
   ///
@@ -73,7 +73,7 @@ class ClipboardSharingService {
     if (args.isEmpty) return null;
 
     // Some terminals send the target and payload as a single semicolon-
-    // delimited string (e.g. `['c;SGVsbG8=']`), while xterm's parser already
+    // delimited string (e.g. `['c;SGVsbG8=']`), while kterm's parser already
     // splits them into separate list elements (`['c', 'SGVsbG8=']`).
     if (args.length == 1) {
       final parts = args[0].split(';');

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -8,7 +8,7 @@ import 'dart:typed_data';
 import 'package:dartssh2/dartssh2.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:xterm/xterm.dart';
+import 'package:kterm/kterm.dart';
 
 import '../../data/database/database.dart';
 import '../../data/repositories/host_repository.dart';
@@ -52,7 +52,7 @@ typedef TerminalControlModeState = ({
 ///
 /// Apps running inside tmux wrap terminal queries as
 /// `DCS tmux; <escaped sequence> ST`. The inner ESC bytes are doubled by tmux;
-/// this returns a stream that xterm can parse normally while preserving split
+/// this returns a stream that kterm can parse normally while preserving split
 /// passthrough sequences across chunks.
 ({String output, String pendingInput}) unwrapTerminalTmuxPassthroughSequences({
   required String input,
@@ -159,10 +159,97 @@ buildTerminalWindowControlQueryResponses({
   );
 }
 
+/// Removes OSC 52 clipboard operations so MonkeySSH validates them before kterm.
+///
+/// kterm decodes OSC 52 payloads before invoking callbacks. MonkeySSH strips
+/// them from terminal rendering and sends the raw arguments through
+/// [ClipboardSharingService] so disabled clipboard sharing and payload limits
+/// are enforced before any base64 decode.
+@visibleForTesting
+({String output, List<List<String>> osc52Args}) extractTerminalClipboardOsc52({
+  required String input,
+}) {
+  final output = StringBuffer();
+  final osc52Args = <List<String>>[];
+  var cursor = 0;
+
+  while (cursor < input.length) {
+    final codeUnit = input.codeUnitAt(cursor);
+    if (codeUnit != _terminalEscapeCodeUnit) {
+      output.writeCharCode(codeUnit);
+      cursor += 1;
+      continue;
+    }
+
+    final endIndex = _terminalEscapeSequenceEndIndex(input, cursor);
+    if (endIndex == null) {
+      output.write(input.substring(cursor));
+      break;
+    }
+
+    final sequence = input.substring(cursor, endIndex);
+    final args = _terminalOscArgs(sequence, expectedCode: '52');
+    if (args == null) {
+      output.write(sequence);
+    } else {
+      osc52Args.add(args);
+    }
+    cursor = endIndex;
+  }
+
+  return (output: output.toString(), osc52Args: osc52Args);
+}
+
+/// Removes OSC color queries that MonkeySSH answers before terminal rendering.
+///
+/// kterm handles some OSC values internally (notably OSC 10), so remote color
+/// queries must be answered before the escape sequence reaches kterm.
+@visibleForTesting
+({String output, String? response}) extractTerminalThemeOscQueryResponses({
+  required String input,
+  required TerminalThemeData? theme,
+}) {
+  final output = StringBuffer();
+  final responses = StringBuffer();
+  var cursor = 0;
+
+  while (cursor < input.length) {
+    final codeUnit = input.codeUnitAt(cursor);
+    if (codeUnit != _terminalEscapeCodeUnit) {
+      output.writeCharCode(codeUnit);
+      cursor += 1;
+      continue;
+    }
+
+    final endIndex = _terminalEscapeSequenceEndIndex(input, cursor);
+    if (endIndex == null) {
+      output.write(input.substring(cursor));
+      break;
+    }
+
+    final sequence = input.substring(cursor, endIndex);
+    final themeResponse = _terminalThemeOscQueryResponse(
+      sequence: sequence,
+      theme: theme,
+    );
+    if (themeResponse == null) {
+      output.write(sequence);
+    } else if (themeResponse.isNotEmpty) {
+      responses.write(themeResponse);
+    }
+    cursor = endIndex;
+  }
+
+  return (
+    output: output.toString(),
+    response: responses.isEmpty ? null : responses.toString(),
+  );
+}
+
 /// Extracts terminal color-scheme update mode changes from shell output.
 ///
 /// Some TUIs enable DEC private mode 2031 to request a report when the
-/// terminal switches between light and dark color schemes. xterm.dart does not
+/// terminal switches between light and dark color schemes. kterm does not
 /// currently model that mode, so MonkeySSH tracks it while scanning the same
 /// shell output used for other terminal control queries.
 ({bool? colorSchemeUpdatesMode, String pendingInput})
@@ -191,7 +278,7 @@ extractTerminalControlModeUpdates({
 
 /// Normalizes terminal-generated output before it is sent to the remote shell.
 ///
-/// xterm.dart currently emits cursor-position reports using its internal
+/// kterm currently emits cursor-position reports using its internal
 /// zero-based cursor coordinates. The terminal DSR wire protocol is one-based,
 /// and TUIs such as Codex can stall or mis-detect terminal state after receiving
 /// `CSI 0;0 R`.
@@ -202,25 +289,25 @@ String normalizeTerminalOutputForRemoteShell(String data) =>
       return '\x1b[${row + 1};${column + 1}R';
     });
 
-/// Adapts remote terminal output so xterm.dart renders it correctly.
+/// Adapts remote terminal output so kterm renders it correctly.
 ///
-/// xterm.dart 4.0.0 tracks IRM (`CSI 4 h/l`) but does not shift existing cells
+/// kterm 4.0.0 tracks IRM (`CSI 4 h/l`) but does not shift existing cells
 /// when printable characters arrive while the mode is active. Injecting ICH
 /// before each printable cell preserves behavior from editors such as nano,
 /// while [pendingInput] keeps split escape sequences from leaking printable
 /// bytes into the renderer.
 ///
-/// xterm.dart 4.0.0 also corrupts its line buffer when RI (`ESC M`) scrolls a
+/// kterm 4.0.0 also corrupts its line buffer when RI (`ESC M`) scrolls a
 /// vertical margin region down. When cursor state is provided, that RI is
 /// rewritten to IL (`CSI L`), which has the same effect at the top margin
 /// without reusing detached buffer lines internally.
 ///
-/// xterm.dart also treats private `CSI > ... m` keyboard modifier controls as
+/// kterm also treats private `CSI > ... m` keyboard modifier controls as
 /// SGR attributes. Dropping those controls prevents TUIs such as OpenCode from
 /// accidentally enabling underline/bold while painting spaces.
 @visibleForTesting
 ({String output, String pendingInput, bool insertMode})
-adaptTerminalInsertModeOutputForXterm({
+adaptTerminalInsertModeOutputForKterm({
   required String input,
   required String pendingInput,
   required bool insertMode,
@@ -259,7 +346,7 @@ adaptTerminalInsertModeOutputForXterm({
       }
 
       final sequence = combinedInput.substring(cursor, endIndex);
-      if (!_shouldDropTerminalOutputSequenceForXterm(sequence)) {
+      if (!_shouldDropTerminalOutputSequenceForKterm(sequence)) {
         output.write(cursorTracker.adaptEscapeSequence(sequence));
         final insertModeUpdate = _terminalInsertModeUpdate(sequence);
         if (insertModeUpdate != null) {
@@ -525,6 +612,96 @@ final _terminalCursorPositionReportPattern = RegExp(
   r'\x1b\[([0-9]+);([0-9]+)R',
 );
 final _terminalCsiNumericParamsPattern = RegExp(r'^[0-9;]*$');
+
+String? _terminalThemeOscQueryResponse({
+  required String sequence,
+  required TerminalThemeData? theme,
+}) {
+  final osc = _terminalOscArgsWithCode(sequence);
+  if (osc == null) return null;
+  final (code, args) = osc;
+  if (!_isTerminalThemeOscQuery(code, args)) {
+    return null;
+  }
+
+  if (theme == null) {
+    return '';
+  }
+
+  return buildTerminalThemeOscResponse(theme: theme, code: code, args: args) ??
+      '';
+}
+
+List<String>? _terminalOscArgs(
+  String sequence, {
+  required String expectedCode,
+}) {
+  final osc = _terminalOscArgsWithCode(sequence);
+  if (osc == null || osc.$1 != expectedCode) {
+    return null;
+  }
+  return osc.$2;
+}
+
+(String code, List<String> args)? _terminalOscArgsWithCode(String sequence) {
+  final payload = _terminalOscPayload(sequence);
+  if (payload == null) {
+    return null;
+  }
+
+  final separator = payload.indexOf(';');
+  if (separator == -1) {
+    return null;
+  }
+
+  return (
+    payload.substring(0, separator),
+    payload.substring(separator + 1).split(';'),
+  );
+}
+
+String? _terminalOscPayload(String sequence) {
+  if (sequence.length < 4 ||
+      sequence.codeUnitAt(0) != _terminalEscapeCodeUnit ||
+      sequence.codeUnitAt(1) != _terminalOscIntroducerCodeUnit) {
+    return null;
+  }
+
+  if (sequence.codeUnitAt(sequence.length - 1) == _terminalBellCodeUnit) {
+    return sequence.substring(2, sequence.length - 1);
+  }
+
+  if (sequence.length >= 4 &&
+      sequence.codeUnitAt(sequence.length - 2) == _terminalEscapeCodeUnit &&
+      sequence.codeUnitAt(sequence.length - 1) ==
+          _terminalStringTerminatorCodeUnit) {
+    return sequence.substring(2, sequence.length - 2);
+  }
+
+  return null;
+}
+
+bool _isTerminalThemeOscQuery(String code, List<String> args) {
+  if (args.isEmpty) {
+    return false;
+  }
+
+  return switch (code) {
+    '4' => _hasAnsiPaletteQueryArg(args),
+    '10' || '11' || '12' || '17' || '19' => args.first.trim() == '?',
+    _ => false,
+  };
+}
+
+bool _hasAnsiPaletteQueryArg(List<String> args) {
+  for (var index = 0; index + 1 < args.length; index += 2) {
+    if (int.tryParse(args[index].trim()) != null &&
+        args[index + 1].trim() == '?') {
+      return true;
+    }
+  }
+  return false;
+}
 
 String? _buildTerminalWindowQueryResponse(
   String primaryParam,
@@ -819,7 +996,7 @@ bool? _terminalDecOriginModeUpdate(String sequence) {
   return null;
 }
 
-bool _shouldDropTerminalOutputSequenceForXterm(String sequence) {
+bool _shouldDropTerminalOutputSequenceForKterm(String sequence) {
   if (sequence.length < 4 ||
       sequence.codeUnitAt(0) != _terminalEscapeCodeUnit ||
       sequence.codeUnitAt(1) != _terminalCsiIntroducerCodeUnit ||
@@ -2953,6 +3130,14 @@ class SshSession {
             }
           }),
     );
+  }
+
+  void _handleTerminalClipboardRead(String target) {
+    _handleOsc52([target, '?']);
+  }
+
+  void _handleTerminalClipboardWrite(String data, String target) {
+    _handleOsc52([target, base64Encode(utf8.encode(data))]);
   }
 
   /// Builds a plain-text preview from the latest terminal display rows.

--- a/lib/domain/services/ssh_session_runtime.dart
+++ b/lib/domain/services/ssh_session_runtime.dart
@@ -90,7 +90,9 @@ class _SshSessionRuntime {
     _terminal ??= Terminal(maxLines: maxLines);
     _terminal!
       ..onTitleChange = _session._handleWindowTitleChange
-      ..onIconChange = _session._handleIconNameChange;
+      ..onIconChange = _session._handleIconNameChange
+      ..onClipboardRead = _session._handleTerminalClipboardRead
+      ..onClipboardWrite = _session._handleTerminalClipboardWrite;
     _session.terminalHyperlinkTracker.attach(_terminal!);
     _terminal!.onPrivateOSC = _session._handlePrivateOsc;
     _refreshTerminalPreview();
@@ -489,7 +491,7 @@ class _SshSessionRuntime {
 
     final output = _drainPendingShellOutputs(drainAll: drainAll);
     if (output.terminalData.isNotEmpty) {
-      final terminalOutput = adaptTerminalInsertModeOutputForXterm(
+      final terminalOutput = adaptTerminalInsertModeOutputForKterm(
         input: output.terminalData,
         pendingInput: _terminalInsertModePendingInput,
         insertMode: _terminalInsertMode,
@@ -504,7 +506,25 @@ class _SshSessionRuntime {
       _terminalInsertModePendingInput = terminalOutput.pendingInput;
       _terminalInsertMode = terminalOutput.insertMode;
       if (terminalOutput.output.isNotEmpty) {
-        terminal.write(terminalOutput.output);
+        final clipboardOutput = extractTerminalClipboardOsc52(
+          input: terminalOutput.output,
+        );
+        for (final args in clipboardOutput.osc52Args) {
+          _session._handleOsc52(args);
+        }
+        final themeOscOutput = extractTerminalThemeOscQueryResponses(
+          input: clipboardOutput.output,
+          theme: _session.terminalTheme,
+        );
+        final themeResponse = themeOscOutput.response;
+        if (themeResponse != null) {
+          _shell?.write(utf8.encode(themeResponse));
+        }
+        final terminalWriteOutput = _session.terminalHyperlinkTracker
+            .normalizeTerminalOutput(themeOscOutput.output);
+        if (terminalWriteOutput.isNotEmpty) {
+          terminal.write(terminalWriteOutput);
+        }
       }
       _respondToTerminalWindowControlQueries(output.terminalData, terminal);
       if (terminalOutput.output.isNotEmpty) {

--- a/lib/domain/services/terminal_hyperlink_tracker.dart
+++ b/lib/domain/services/terminal_hyperlink_tracker.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:xterm/xterm.dart';
+import 'package:kterm/kterm.dart';
 
 /// Tracks OSC 8 terminal hyperlinks so taps can open links whose labels do not
 /// visibly contain the destination URL.
@@ -16,6 +16,9 @@ class TerminalHyperlinkTracker {
   final _trackedHyperlinks = <_TrackedTerminalHyperlink>[];
   _PendingTerminalHyperlink? _pendingHyperlink;
   final int _maxRetainedLinks;
+  final _normalizedHyperlinkUris = <String, String>{};
+  final _normalizedHyperlinkTokens = <String, String>{};
+  var _nextHyperlinkToken = 1;
 
   /// Attaches this tracker to [terminal].
   ///
@@ -39,10 +42,41 @@ class TerminalHyperlinkTracker {
       hyperlink.dispose();
     }
     _trackedHyperlinks.clear();
+    _normalizedHyperlinkUris.clear();
+    _normalizedHyperlinkTokens.clear();
+    _nextHyperlinkToken = 1;
 
     if (!keepTerminalReference) {
       _terminal = null;
     }
+  }
+
+  /// Rewrites OSC 8 hyperlinks that kterm cannot parse losslessly.
+  ///
+  /// kterm treats semicolons inside the URI as OSC argument delimiters. Replacing
+  /// those URIs with internal tokens lets kterm retain the rendered cell
+  /// hyperlink while this tracker maps taps back to the original destination.
+  String normalizeTerminalOutput(String input) {
+    final output = StringBuffer();
+    var cursor = 0;
+    while (cursor < input.length) {
+      final start = input.indexOf(_osc8Prefix, cursor);
+      if (start == -1) {
+        output.write(input.substring(cursor));
+        break;
+      }
+
+      output.write(input.substring(cursor, start));
+      final end = _oscTerminatorIndex(input, start + _osc8Prefix.length);
+      if (end == null) {
+        output.write(input.substring(start));
+        break;
+      }
+
+      output.write(_normalizeOsc8Sequence(input.substring(start, end)));
+      cursor = end;
+    }
+    return output.toString();
   }
 
   /// Handles private OSC sequences emitted by the terminal.
@@ -84,6 +118,11 @@ class TerminalHyperlinkTracker {
 
     _pruneDetachedHyperlinks();
 
+    final nativeLink = _resolveNativeLinkAt(terminal, offset);
+    if (nativeLink != null) {
+      return nativeLink;
+    }
+
     final activeHyperlink = _pendingHyperlink;
     if (activeHyperlink != null &&
         _containsOffset(
@@ -105,7 +144,14 @@ class TerminalHyperlinkTracker {
 
   /// Number of fully tracked hyperlinks currently retained in memory.
   @visibleForTesting
-  int get trackedHyperlinkCount => _trackedHyperlinks.length;
+  int get trackedHyperlinkCount {
+    _pruneDetachedHyperlinks();
+    final terminal = _terminal;
+    final nativeCount = terminal == null
+        ? 0
+        : _cappedNativeHyperlinkIds(terminal).length;
+    return nativeCount + _trackedHyperlinks.length;
+  }
 
   Uri? _parseHyperlinkUri(List<String> args) {
     if (args.length < 2) {
@@ -161,8 +207,145 @@ class TerminalHyperlinkTracker {
     });
   }
 
+  String? _resolveNativeLinkAt(Terminal terminal, CellOffset offset) {
+    if (offset.y < 0 || offset.y >= terminal.buffer.height || offset.x < 0) {
+      return null;
+    }
+
+    final line = terminal.buffer.lines[offset.y];
+    if (offset.x >= line.length) {
+      return null;
+    }
+
+    final hyperlinkId = line.getHyperlinkId(offset.x);
+    if (hyperlinkId == 0 ||
+        !_cappedNativeHyperlinkIds(terminal).contains(hyperlinkId)) {
+      return null;
+    }
+
+    final uri = terminal.getHyperlinkUri(hyperlinkId);
+    if (uri == null) {
+      return null;
+    }
+    return _normalizedHyperlinkUris[uri] ?? uri;
+  }
+
+  Set<int> _cappedNativeHyperlinkIds(Terminal terminal) {
+    if (_maxRetainedLinks <= 0) {
+      return const {};
+    }
+
+    final orderedIds = <int>[];
+    final seenIds = <int>{};
+    final activeUris = <String>{};
+    for (var y = 0; y < terminal.buffer.height; y++) {
+      final line = terminal.buffer.lines[y];
+      for (var x = 0; x < line.length; x++) {
+        final hyperlinkId = line.getHyperlinkId(x);
+        if (hyperlinkId == 0) {
+          continue;
+        }
+        final uri = terminal.getHyperlinkUri(hyperlinkId);
+        if (uri == null) {
+          continue;
+        }
+        activeUris.add(uri);
+        if (!seenIds.add(hyperlinkId)) {
+          continue;
+        }
+        orderedIds.add(hyperlinkId);
+      }
+    }
+    _pruneNormalizedHyperlinkTokens(activeUris);
+
+    if (orderedIds.length <= _maxRetainedLinks) {
+      return seenIds;
+    }
+
+    return orderedIds.skip(orderedIds.length - _maxRetainedLinks).toSet();
+  }
+
+  void _pruneNormalizedHyperlinkTokens(Set<String> activeUris) {
+    _normalizedHyperlinkUris.removeWhere(
+      (token, _) => !activeUris.contains(token),
+    );
+    _normalizedHyperlinkTokens.removeWhere(
+      (_, token) => !_normalizedHyperlinkUris.containsKey(token),
+    );
+  }
+
   CellOffset _currentCursorOffset(Terminal terminal) =>
       CellOffset(terminal.buffer.cursorX, terminal.buffer.absoluteCursorY);
+
+  String _normalizeOsc8Sequence(String sequence) {
+    final terminator = _oscTerminator(sequence);
+    if (terminator == null) {
+      return sequence;
+    }
+
+    final payload = sequence.substring(
+      _oscPrefix.length,
+      sequence.length - terminator.length,
+    );
+    final paramsStart = payload.indexOf(';');
+    if (paramsStart == -1) {
+      return sequence;
+    }
+    final uriStart = payload.indexOf(';', paramsStart + 1);
+    if (uriStart == -1) {
+      return sequence;
+    }
+
+    final uri = payload.substring(uriStart + 1);
+    if (uri.isEmpty || !uri.contains(';')) {
+      return sequence;
+    }
+
+    final token = _normalizedHyperlinkTokens.putIfAbsent(uri, () {
+      final nextToken = 'monkeyssh-internal-hyperlink:${_nextHyperlinkToken++}';
+      _normalizedHyperlinkUris[nextToken] = uri;
+      return nextToken;
+    });
+    return '${sequence.substring(0, _oscPrefix.length + uriStart + 1)}'
+        '$token$terminator';
+  }
+}
+
+const _oscPrefix = '\x1b]';
+const _osc8Prefix = '${_oscPrefix}8;';
+const _oscStringTerminator = '\x1b\\';
+const _oscBellTerminator = '\x07';
+
+int? _oscTerminatorIndex(String input, int start) {
+  var cursor = start;
+  while (cursor < input.length) {
+    final codeUnit = input.codeUnitAt(cursor);
+    if (codeUnit == 0x07) {
+      return cursor + 1;
+    }
+    if (codeUnit == 0x1B) {
+      if (cursor + 1 >= input.length) {
+        return null;
+      }
+      if (input.codeUnitAt(cursor + 1) == 0x5C) {
+        return cursor + 2;
+      }
+      cursor += 1;
+      continue;
+    }
+    cursor += 1;
+  }
+  return null;
+}
+
+String? _oscTerminator(String sequence) {
+  if (sequence.endsWith(_oscStringTerminator)) {
+    return _oscStringTerminator;
+  }
+  if (sequence.endsWith(_oscBellTerminator)) {
+    return _oscBellTerminator;
+  }
+  return null;
 }
 
 class _PendingTerminalHyperlink {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -16,10 +16,10 @@ import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:image_picker_android/image_picker_android.dart';
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
+import 'package:kterm/kterm.dart' hide TerminalThemes;
 import 'package:pasteboard/pasteboard.dart';
 import 'package:path/path.dart' as path;
 import 'package:url_launcher/url_launcher.dart';
-import 'package:xterm/xterm.dart' hide TerminalThemes;
 
 import '../../app/routes.dart';
 import '../../data/database/database.dart';
@@ -2135,7 +2135,7 @@ int resolveTerminalLineSnapshotTextLength({
       : clampedPreserveOffset;
 }
 
-/// Whether to let xterm synthesize Up/Down keys for alt-buffer scroll.
+/// Whether to let kterm synthesize Up/Down keys for alt-buffer scroll.
 ///
 /// We prefer explicit mouse-wheel reporting from terminal applications like
 /// tmux, but still need the synthetic fallback whenever the active alt-buffer
@@ -2204,7 +2204,7 @@ bool isAgentToolActiveForTerminalScroll({
 }
 
 /// Whether touch scroll should send SGR wheel reports from mux metadata even
-/// when local xterm mouse-mode state is stale.
+/// when local terminal mouse-mode state is stale.
 @visibleForTesting
 bool shouldForceSgrTouchScroll({
   bool? activeWindowReportsMouseWheel,
@@ -2228,7 +2228,7 @@ bool hasActiveNativeOverlaySelection(TextSelection selection) =>
 
 /// Resolves the terminal range to select for a touch long-press.
 ///
-/// xterm's word selection returns null on separators and blank cells. Mobile
+/// kterm's word selection returns null on separators and blank cells. Mobile
 /// touch selection should still start when the finger lands on punctuation in a
 /// path/URL or slightly misses a word, so this falls back to separator runs and
 /// nearby selectable cells on the same row.
@@ -2487,7 +2487,7 @@ String buildSnippetNameFromTerminalSelection(String text) {
   return 'Terminal selection';
 }
 
-/// Resolves the active terminal selection text, preferring the xterm
+/// Resolves the active terminal selection text, preferring the kterm
 /// controller's selection but falling back to the SelectionArea's content
 /// when system selection (mobile) owns the selection.
 @visibleForTesting
@@ -9819,7 +9819,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           : null,
       focusNode: _terminalFocusNode,
       cursorFocusNode: isMobile ? _terminalFocusNode : null,
-      theme: terminalTheme.toXtermTheme(),
+      theme: terminalTheme.toKtermTheme(),
       textStyle: terminalTextStyle,
       inlineUnderlines: inlineUnderlines,
       keyboardAppearance: keyboardAppearance,
@@ -11903,7 +11903,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   // Reads the live system selection from the terminal's render object. This is
   // the source of truth on mobile (`useSystemSelection: true`), where Flutter's
-  // SelectionArea owns the selection rather than the xterm controller.
+  // SelectionArea owns the selection rather than the kterm controller.
   String? _readSystemSelectionPlainText() {
     final state = _terminalViewKey.currentState;
     if (state == null) {

--- a/lib/presentation/widgets/connection_preview_snippet.dart
+++ b/lib/presentation/widgets/connection_preview_snippet.dart
@@ -1,7 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
-import 'package:xterm/xterm.dart' hide TerminalThemes;
+import 'package:kterm/kterm.dart' hide TerminalThemes;
 
 import '../../app/theme.dart';
 import '../../domain/models/terminal_preview.dart';
@@ -803,7 +803,7 @@ MonkeyTerminalPainter _buildStyledPreviewPainter({
   required double fontSize,
   required TextScaler textScaler,
 }) => MonkeyTerminalPainter(
-  theme: terminalTheme.toXtermTheme(),
+  theme: terminalTheme.toKtermTheme(),
   textStyle: TerminalStyle.fromTextStyle(
     FluttyTheme.monoStyle.copyWith(
       fontSize: fontSize,

--- a/lib/presentation/widgets/keyboard_toolbar.dart
+++ b/lib/presentation/widgets/keyboard_toolbar.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:xterm/xterm.dart';
+import 'package:kterm/kterm.dart';
 
 import 'terminal_key_input.dart';
 import 'terminal_menu_style.dart';

--- a/lib/presentation/widgets/monkey_terminal_gesture_detector.dart
+++ b/lib/presentation/widgets/monkey_terminal_gesture_detector.dart
@@ -1,5 +1,5 @@
-// Adapted from package:xterm 4.0.0 gesture detector internals used by
-// TerminalView. Keep this aligned with the pinned xterm dependency when
+// Adapted from package:kterm 4.0.0 gesture detector internals used by
+// TerminalView. Keep this aligned with the pinned kterm dependency when
 // upgrading.
 // ignore_for_file: public_member_api_docs
 

--- a/lib/presentation/widgets/monkey_terminal_gesture_handler.dart
+++ b/lib/presentation/widgets/monkey_terminal_gesture_handler.dart
@@ -1,18 +1,18 @@
-// Adapted from package:xterm 4.0.0 gesture internals used by TerminalView.
-// Keep this aligned with the pinned xterm dependency when upgrading.
+// Adapted from package:kterm 4.0.0 gesture internals used by TerminalView.
+// Keep this aligned with the pinned kterm dependency when upgrading.
 // ignore_for_file: implementation_imports, public_member_api_docs, directives_ordering, always_put_required_named_parameters_first, use_late_for_private_fields_and_variables, prefer_expression_function_bodies, sort_child_properties_last, invalid_use_of_internal_member
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
-import 'package:xterm/src/core/mouse/button.dart';
-import 'package:xterm/src/core/mouse/button_state.dart';
-import 'package:xterm/src/ui/controller.dart';
-import 'package:xterm/src/ui/pointer_input.dart';
+import 'package:kterm/src/core/mouse/button.dart';
+import 'package:kterm/src/core/mouse/button_state.dart';
+import 'package:kterm/src/ui/controller.dart';
+import 'package:kterm/src/ui/pointer_input.dart';
 
 import 'monkey_terminal_gesture_detector.dart';
 import 'monkey_terminal_view.dart';
 
-/// Adapted xterm gesture handler for [MonkeyTerminalView].
+/// Adapted kterm gesture handler for [MonkeyTerminalView].
 class MonkeyTerminalGestureHandler extends StatefulWidget {
   const MonkeyTerminalGestureHandler({
     super.key,
@@ -85,13 +85,13 @@ class MonkeyTerminalGestureHandler extends StatefulWidget {
 
   final bool readOnly;
 
-  /// When true, suppresses xterm's drag-to-extend behavior during a touch
+  /// When true, suppresses kterm's drag-to-extend behavior during a touch
   /// long-press while still allowing the initial long-press to set a word
   /// selection. Useful when the parent widget renders its own selection UI
   /// and doesn't want to be re-entered on every drag update.
   final bool suppressLongPressDragSelection;
 
-  /// Whether this handler should install xterm-owned selection gestures.
+  /// Whether this handler should install kterm-owned selection gestures.
   final bool enableTerminalSelectionGestures;
 
   @override
@@ -279,7 +279,7 @@ class _TerminalGestureHandlerState extends State<MonkeyTerminalGestureHandler> {
       return;
     }
     if (widget.suppressLongPressDragSelection) {
-      // Skip xterm's drag-to-extend on touch so the parent's selection UI
+      // Skip kterm's drag-to-extend on touch so the parent's selection UI
       // (e.g. native selection overlay) isn't thrashed by repeated selection
       // changes during a long-press drag.
       return;

--- a/lib/presentation/widgets/monkey_terminal_scroll_gesture_handler.dart
+++ b/lib/presentation/widgets/monkey_terminal_scroll_gesture_handler.dart
@@ -1,8 +1,8 @@
 // ignore_for_file: implementation_imports, public_member_api_docs, always_put_required_named_parameters_first, type_annotate_public_apis, use_setters_to_change_properties
 
 import 'package:flutter/widgets.dart';
-import 'package:xterm/core.dart';
-import 'package:xterm/src/ui/infinite_scroll_view.dart';
+import 'package:kterm/core.dart';
+import 'package:kterm/src/ui/infinite_scroll_view.dart';
 
 import 'terminal_scroll_mouse_input.dart';
 
@@ -31,7 +31,7 @@ class MonkeyTerminalScrollGestureHandler extends StatefulWidget {
   /// is the default behavior of most terminals.
   final bool simulateScroll;
 
-  /// Whether to send SGR wheel reports even if xterm has not observed mouse
+  /// Whether to send SGR wheel reports even if kterm has not observed mouse
   /// reporting mode yet.
   final bool forceSgr;
 

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1,6 +1,6 @@
-// Adapted from package:xterm 4.0.0 TerminalView internals to keep local
+// Adapted from package:kterm 4.0.0 TerminalView internals to keep local
 // terminal layout and trackpad/mobile gesture fixes. Keep this aligned with the
-// pinned xterm dependency when upgrading.
+// pinned kterm dependency when upgrading.
 // ignore_for_file: implementation_imports, public_member_api_docs, directives_ordering, always_put_required_named_parameters_first, cast_nullable_to_non_nullable, prefer_expression_function_bodies, sort_child_properties_last, use_if_null_to_convert_nulls_to_bools, avoid_bool_literals_in_conditional_expressions, avoid_setters_without_getters, prefer_int_literals, cascade_invocations, unnecessary_null_checks, invalid_use_of_internal_member
 
 import 'dart:async';
@@ -21,34 +21,34 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:monkeyssh/domain/models/terminal_theme.dart';
 import 'package:monkeyssh/domain/services/diagnostics_log_service.dart';
-import 'package:xterm/src/core/buffer/cell_offset.dart';
-import 'package:xterm/src/core/buffer/cell_flags.dart';
-import 'package:xterm/src/core/buffer/line.dart';
-import 'package:xterm/src/core/buffer/range.dart';
-import 'package:xterm/src/core/buffer/range_line.dart';
-import 'package:xterm/src/core/buffer/segment.dart';
-import 'package:xterm/src/core/cell.dart';
-import 'package:xterm/src/core/input/keys.dart';
-import 'package:xterm/src/core/mouse/button.dart';
-import 'package:xterm/src/core/mouse/button_state.dart';
-import 'package:xterm/src/terminal.dart';
-import 'package:xterm/src/ui/controller.dart';
-import 'package:xterm/src/ui/cursor_type.dart';
-import 'package:xterm/src/ui/custom_text_edit.dart';
-import 'package:xterm/src/ui/input_map.dart';
-import 'package:xterm/src/ui/keyboard_listener.dart';
-import 'package:xterm/src/ui/keyboard_visibility.dart';
-import 'package:xterm/src/ui/palette_builder.dart';
-import 'package:xterm/src/ui/paragraph_cache.dart';
-import 'package:xterm/src/ui/painter.dart';
-import 'package:xterm/src/ui/pointer_input.dart';
-import 'package:xterm/src/ui/render.dart';
-import 'package:xterm/src/ui/selection_mode.dart';
-import 'package:xterm/src/ui/shortcut/shortcuts.dart';
-import 'package:xterm/src/ui/terminal_size.dart';
-import 'package:xterm/src/ui/terminal_text_style.dart';
-import 'package:xterm/src/ui/terminal_theme.dart';
-import 'package:xterm/src/ui/themes.dart';
+import 'package:kterm/src/core/buffer/cell_offset.dart';
+import 'package:kterm/src/core/buffer/cell_flags.dart';
+import 'package:kterm/src/core/buffer/line.dart';
+import 'package:kterm/src/core/buffer/range.dart';
+import 'package:kterm/src/core/buffer/range_line.dart';
+import 'package:kterm/src/core/buffer/segment.dart';
+import 'package:kterm/src/core/cell.dart';
+import 'package:kterm/src/core/input/keys.dart';
+import 'package:kterm/src/core/mouse/button.dart';
+import 'package:kterm/src/core/mouse/button_state.dart';
+import 'package:kterm/src/terminal.dart';
+import 'package:kterm/src/ui/controller.dart';
+import 'package:kterm/src/ui/cursor_type.dart';
+import 'package:kterm/src/ui/custom_text_edit.dart';
+import 'package:kterm/src/ui/input_map.dart';
+import 'package:kterm/src/ui/keyboard_listener.dart';
+import 'package:kterm/src/ui/keyboard_visibility.dart';
+import 'package:kterm/src/ui/palette_builder.dart';
+import 'package:kterm/src/ui/paragraph_cache.dart';
+import 'package:kterm/src/ui/painter.dart';
+import 'package:kterm/src/ui/pointer_input.dart';
+import 'package:kterm/src/ui/render.dart';
+import 'package:kterm/src/ui/selection_mode.dart';
+import 'package:kterm/src/ui/shortcut/shortcuts.dart';
+import 'package:kterm/src/ui/terminal_size.dart';
+import 'package:kterm/src/ui/terminal_text_style.dart';
+import 'package:kterm/src/ui/terminal_theme.dart';
+import 'package:kterm/src/ui/themes.dart';
 
 import 'monkey_terminal_gesture_handler.dart';
 import 'monkey_terminal_scroll_gesture_handler.dart';
@@ -161,7 +161,7 @@ bool _terminalThemesEqual(TerminalTheme a, TerminalTheme b) =>
 
 /// Resolves SGR 2 faint text while preserving readable contrast.
 ///
-/// xterm paints faint text at 50% opacity, which drops many dark-theme
+/// kterm paints faint text at 50% opacity, which drops many dark-theme
 /// secondary labels below WCAG AA contrast. Keep 50% when it is readable, then
 /// raise only as much as needed for the active foreground/background pair.
 @visibleForTesting
@@ -494,7 +494,7 @@ const _terminalFocusTransitionDelay = Duration(milliseconds: 50);
 /// A terminal cell range rendered with text underline decoration.
 typedef TerminalTextUnderline = ({int row, int startColumn, int endColumn});
 
-/// Adapted xterm terminal view with a trackpad scroll fix for alt-buffer apps.
+/// Adapted kterm terminal view with a trackpad scroll fix for alt-buffer apps.
 class MonkeyTerminalView extends StatefulWidget {
   const MonkeyTerminalView(
     this.terminal, {
@@ -687,7 +687,7 @@ class MonkeyTerminalView extends StatefulWidget {
   /// Called before inserted text is sent to the terminal.
   final Future<bool> Function(String text)? onInsertText;
 
-  /// Called to handle paste shortcuts before xterm pastes clipboard text.
+  /// Called to handle paste shortcuts before kterm pastes clipboard text.
   final Future<void> Function()? onPasteText;
 
   /// Cell ranges that should be painted with inline text underlines.
@@ -871,9 +871,9 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
   /// foreground/background colors without waiting for a real focus transition.
   ///
   /// Set [force] to send the report even when [Terminal.reportFocusMode] is
-  /// off. Inside tmux the outer xterm rarely sees the inner app's
+  /// off. Inside tmux the outer terminal rarely sees the inner app's
   /// `CSI ? 1004 h` request because tmux intercepts and re-emits it for its
-  /// own clients, so the outer xterm's tracking flag is unreliable as a gate.
+  /// own clients, so the outer kterm's tracking flag is unreliable as a gate.
   void refreshFocusReport({bool forceTransition = false, bool force = false}) {
     if (!force && !widget.terminal.reportFocusMode) {
       return;

--- a/lib/presentation/widgets/terminal_key_input.dart
+++ b/lib/presentation/widgets/terminal_key_input.dart
@@ -1,4 +1,4 @@
-import 'package:xterm/xterm.dart';
+import 'package:kterm/kterm.dart';
 
 const _terminalAlternateEnterInput = '\x1b\r';
 
@@ -11,7 +11,7 @@ bool sendTerminalEnterInput(
 }) {
   if (shiftActive || altActive) {
     // Prompt UIs such as Copilot CLI use ESC+CR as their terminal-agnostic
-    // multiline Enter sequence; xterm.dart's legacy Shift+Return emits ESCOM.
+    // multiline Enter sequence; kterm's legacy Shift+Return emits ESCOM.
     terminal.textInput(_terminalAlternateEnterInput);
     return true;
   }

--- a/lib/presentation/widgets/terminal_scroll_mouse_input.dart
+++ b/lib/presentation/widgets/terminal_scroll_mouse_input.dart
@@ -1,4 +1,4 @@
-import 'package:xterm/core.dart';
+import 'package:kterm/core.dart';
 
 /// Sends terminal scroll mouse input with corrected SGR wheel button IDs.
 bool sendTerminalScrollMouseInput({

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -4,11 +4,11 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-// xterm 4.0.0 does not expose keyToTerminalKey via a public API.
-// Pinned to xterm 4.0.0.
+import 'package:kterm/kterm.dart';
+// kterm 1.1.11 does not expose keyToTerminalKey via a public API.
+// Pinned to kterm 1.1.11.
 // ignore: implementation_imports
-import 'package:xterm/src/ui/input_map.dart';
-import 'package:xterm/xterm.dart';
+import 'package:kterm/src/ui/input_map.dart';
 
 import '../../domain/models/auto_connect_command.dart';
 import 'terminal_key_input.dart';
@@ -182,7 +182,7 @@ class TerminalTextInputHandlerController {
 /// Wraps a [TerminalView] to provide soft keyboard input on mobile with
 /// proper IME configuration for swipe typing.
 ///
-/// The xterm package's built-in [CustomTextEdit] hard-codes
+/// The kterm package's built-in [CustomTextEdit] hard-codes
 /// `autocorrect: false` and `enableSuggestions: false`, which hides voice
 /// input on some system keyboards and causes most IMEs to drop spaces between
 /// swiped words. This widget replaces that text input handling with a normal

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -735,6 +735,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.12.0"
+  kitty_protocol:
+    dependency: transitive
+    description:
+      name: kitty_protocol
+      sha256: ad41d5b1284b035de20e1d6a23f87b0f04a3a59913c7c20cef3e26cb5ebf1929
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  kterm:
+    dependency: "direct main"
+    description:
+      name: kterm
+      sha256: "7380efea3b2b4858534427dd7f85d4edf31071005e188fb7664cc8d5d885c971"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.11"
   leak_tracker:
     dependency: transitive
     description:
@@ -903,6 +919,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.3.0"
+  overlay_support:
+    dependency: transitive
+    description:
+      name: overlay_support
+      sha256: fc39389bfd94e6985e1e13b2a88a125fc4027608485d2d4e2847afe1b2bb339c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   package_config:
     dependency: transitive
     description:
@@ -1668,14 +1692,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.6.1"
-  xterm:
-    dependency: "direct main"
-    description:
-      name: xterm
-      sha256: "168dfedca77cba33fdb6f52e2cd001e9fde216e398e89335c19b524bb22da3a2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.0"
   yaml:
     dependency: transitive
     description:
@@ -1684,14 +1700,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
-  zmodem:
+  zmodem_lbp:
     dependency: transitive
     description:
-      name: zmodem
-      sha256: "3b7e5b29f3a7d8aee472029b05165a68438eff2f3f7766edf13daba1e297adbf"
+      name: zmodem_lbp
+      sha256: fb5a1c93d448cd0896ec431a42b7ecdaa83df38578202ecf5fd0a1a466a9060d
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.6"
+    version: "0.0.10"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  flutter: ">=3.38.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   dartssh2: ^2.15.0
   
   # Terminal
-  xterm: ^4.0.0
+  kterm: ^1.1.11
   
   # Syntax highlighting
   highlight: ^0.7.0

--- a/test/domain/models/terminal_theme_test.dart
+++ b/test/domain/models/terminal_theme_test.dart
@@ -211,10 +211,10 @@ void main() {
       expect(modified.foreground, original.foreground);
     });
 
-    test('toXtermTheme converts to xterm TerminalTheme', () {
+    test('toKtermTheme converts to kterm TerminalTheme', () {
       const theme = TerminalThemeData(
-        id: 'xterm-test',
-        name: 'Xterm Test',
+        id: 'kterm-test',
+        name: 'Kterm Test',
         isDark: true,
         foreground: Color(0xFFFFFFFF),
         background: Color(0xFF000000),
@@ -238,9 +238,9 @@ void main() {
         brightWhite: Color(0xFFFFFFFF),
       );
 
-      final xtermTheme = theme.toXtermTheme();
+      final ktermTheme = theme.toKtermTheme();
 
-      expect(xtermTheme, isNotNull);
+      expect(ktermTheme, isNotNull);
     });
 
     test('buildTerminalThemeOscResponse answers special color queries', () {
@@ -380,7 +380,7 @@ void main() {
       );
     });
 
-    test('toXtermTheme normalizes unreadable selection backgrounds', () {
+    test('toKtermTheme normalizes unreadable selection backgrounds', () {
       const theme = TerminalThemeData(
         id: 'selection-test',
         name: 'Selection Test',
@@ -407,12 +407,12 @@ void main() {
         brightWhite: Color(0xFFFFFFFF),
       );
 
-      final xtermTheme = theme.toXtermTheme();
+      final ktermTheme = theme.toKtermTheme();
 
       expect(
         _contrastRatio(
           theme.foreground,
-          _compositeOver(xtermTheme.selection, theme.background),
+          _compositeOver(ktermTheme.selection, theme.background),
         ),
         greaterThanOrEqualTo(3.5),
       );
@@ -626,11 +626,11 @@ void main() {
 
     test('default search hit colors stay readable', () {
       for (final theme in TerminalThemes.all) {
-        final xtermTheme = theme.toXtermTheme();
+        final ktermTheme = theme.toKtermTheme();
         expect(
           _contrastRatio(
-            xtermTheme.searchHitForeground,
-            xtermTheme.searchHitBackground,
+            ktermTheme.searchHitForeground,
+            ktermTheme.searchHitBackground,
           ),
           greaterThanOrEqualTo(4.5),
           reason:
@@ -638,8 +638,8 @@ void main() {
         );
         expect(
           _contrastRatio(
-            xtermTheme.searchHitForeground,
-            xtermTheme.searchHitBackgroundCurrent,
+            ktermTheme.searchHitForeground,
+            ktermTheme.searchHitBackgroundCurrent,
           ),
           greaterThanOrEqualTo(4.5),
           reason:

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -12,6 +12,7 @@ import 'package:drift/native.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
@@ -21,11 +22,11 @@ import 'package:monkeyssh/data/security/secret_encryption_service.dart';
 import 'package:monkeyssh/domain/models/terminal_theme.dart';
 import 'package:monkeyssh/domain/models/terminal_themes.dart' as monkey_themes;
 import 'package:monkeyssh/domain/services/background_ssh_service.dart';
+import 'package:monkeyssh/domain/services/clipboard_sharing_service.dart';
 import 'package:monkeyssh/domain/services/host_key_verification.dart';
 import 'package:monkeyssh/domain/services/ssh_exec_queue.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/domain/services/wifi_network_service.dart';
-import 'package:xterm/xterm.dart';
 
 const _backgroundSshChannel = MethodChannel(
   'xyz.depollsoft.monkeyssh/ssh_service',
@@ -347,9 +348,9 @@ void main() {
       },
     );
 
-    test('adapts insert mode output so xterm shifts existing cells', () {
+    test('adapts insert mode output so kterm shifts existing cells', () {
       final terminal = Terminal(maxLines: 100);
-      final result = adaptTerminalInsertModeOutputForXterm(
+      final result = adaptTerminalInsertModeOutputForKterm(
         input: 'abcdef\r\x1b[3C\x1b[4hXY',
         pendingInput: '',
         insertMode: false,
@@ -364,14 +365,14 @@ void main() {
 
     test('adapts split insert mode sequences across chunks', () {
       final terminal = Terminal(maxLines: 100);
-      final first = adaptTerminalInsertModeOutputForXterm(
+      final first = adaptTerminalInsertModeOutputForKterm(
         input: 'abcdef\r\x1b[3C\x1b[',
         pendingInput: '',
         insertMode: false,
       );
       terminal.write(first.output);
 
-      final second = adaptTerminalInsertModeOutputForXterm(
+      final second = adaptTerminalInsertModeOutputForKterm(
         input: '4hZ\x1b[4lQ',
         pendingInput: first.pendingInput,
         insertMode: first.insertMode,
@@ -386,7 +387,7 @@ void main() {
     });
 
     test('does not inject insert blanks into OSC payloads', () {
-      final result = adaptTerminalInsertModeOutputForXterm(
+      final result = adaptTerminalInsertModeOutputForKterm(
         input: '\x1b[4h\x1b]0;nano title\x07Z',
         pendingInput: '',
         insertMode: false,
@@ -397,13 +398,13 @@ void main() {
       expect(result.output, '\x1b[4h\x1b]0;nano title\x07\x1b[@Z');
     });
 
-    test('strips private CSI modifier controls that xterm treats as SGR', () {
-      final first = adaptTerminalInsertModeOutputForXterm(
+    test('strips private CSI modifier controls that kterm treats as SGR', () {
+      final first = adaptTerminalInsertModeOutputForKterm(
         input: 'before\x1b[>4;',
         pendingInput: '',
         insertMode: false,
       );
-      final second = adaptTerminalInsertModeOutputForXterm(
+      final second = adaptTerminalInsertModeOutputForKterm(
         input: '1mafter',
         pendingInput: first.pendingInput,
         insertMode: first.insertMode,
@@ -417,7 +418,7 @@ void main() {
     });
 
     test('clears tracked insert mode on terminal reset sequences', () {
-      final fullReset = adaptTerminalInsertModeOutputForXterm(
+      final fullReset = adaptTerminalInsertModeOutputForKterm(
         input: '\x1b[4hA\x1bcB',
         pendingInput: '',
         insertMode: false,
@@ -427,7 +428,7 @@ void main() {
       expect(fullReset.insertMode, isFalse);
       expect(fullReset.output, '\x1b[4h\x1b[@A\x1bcB');
 
-      final softReset = adaptTerminalInsertModeOutputForXterm(
+      final softReset = adaptTerminalInsertModeOutputForKterm(
         input: '\x1b[4hA\x1b[!pB',
         pendingInput: '',
         insertMode: false,
@@ -439,13 +440,13 @@ void main() {
     });
 
     test('does not inject insert blanks into DCS payloads', () {
-      final first = adaptTerminalInsertModeOutputForXterm(
+      final first = adaptTerminalInsertModeOutputForKterm(
         input: '\x1b[4h\x1bP1+r',
         pendingInput: '',
         insertMode: false,
       );
 
-      final second = adaptTerminalInsertModeOutputForXterm(
+      final second = adaptTerminalInsertModeOutputForKterm(
         input: 'abc\x1b\\Z',
         pendingInput: first.pendingInput,
         insertMode: first.insertMode,
@@ -460,7 +461,7 @@ void main() {
     });
 
     test('treats emoji modifiers as zero-width insert-mode cells', () {
-      final result = adaptTerminalInsertModeOutputForXterm(
+      final result = adaptTerminalInsertModeOutputForKterm(
         input: '\x1b[4h\u{1F44D}\u{1F3FD}Z',
         pendingInput: '',
         insertMode: false,
@@ -472,12 +473,12 @@ void main() {
     });
 
     test(
-      'adapts reverse index at top margin to keep xterm buffer attached',
+      'adapts reverse index at top margin to keep kterm buffer attached',
       () {
         final terminal = Terminal(maxLines: 100)..resize(61, 37);
         final reverseIndexes = List.filled(9, '\x1bM').join();
         final insertLines = List.filled(9, '\x1b[L').join();
-        final result = adaptTerminalInsertModeOutputForXterm(
+        final result = adaptTerminalInsertModeOutputForKterm(
           input: '\x1b[1;37r\x1b[1;1H$reverseIndexes',
           pendingInput: '',
           insertMode: false,
@@ -505,7 +506,7 @@ void main() {
     );
 
     test('preserves reverse index when cursor is below the top margin', () {
-      final result = adaptTerminalInsertModeOutputForXterm(
+      final result = adaptTerminalInsertModeOutputForKterm(
         input: '\x1b[5;4H\x1bM',
         pendingInput: '',
         insertMode: false,
@@ -521,7 +522,7 @@ void main() {
     });
 
     test('restores cursor column after adapted reverse index', () {
-      final result = adaptTerminalInsertModeOutputForXterm(
+      final result = adaptTerminalInsertModeOutputForKterm(
         input: '\x1b[1;4H\x1bM',
         pendingInput: '',
         insertMode: false,
@@ -538,7 +539,7 @@ void main() {
 
     test('adapts origin-mode reverse index at the top margin', () {
       final terminal = Terminal(maxLines: 100)..resize(61, 37);
-      final result = adaptTerminalInsertModeOutputForXterm(
+      final result = adaptTerminalInsertModeOutputForKterm(
         input: '\x1b[2;10r\x1b[?6h\x1b[1;1H\x1bM',
         pendingInput: '',
         insertMode: false,
@@ -1516,6 +1517,77 @@ void main() {
         ),
       );
     });
+
+    test(
+      'answers OSC 10 foreground queries before kterm handles them',
+      () async {
+        final shell = await openShell();
+        final session = shell.session;
+        final terminal = session.terminal!;
+        session.terminalTheme = monkey_themes.TerminalThemes.defaultLightTheme;
+
+        shell.stdout.add(Uint8List.fromList(utf8.encode('\x1b]10;?\x1b\\')));
+        await pumpEventQueue();
+
+        expect(firstLineText(terminal), isEmpty);
+        expect(
+          utf8.decode(shell.shellWrites.expand((chunk) => chunk).toList()),
+          buildTerminalThemeOscResponse(
+            theme: monkey_themes.TerminalThemes.defaultLightTheme,
+            code: '10',
+            args: const ['?'],
+          ),
+        );
+      },
+    );
+
+    test('extracts raw OSC 52 payloads before kterm handles them', () {
+      final oversizedPayload =
+          'A' * (ClipboardSharingService.maxEncodedLength + 1);
+
+      final result = extractTerminalClipboardOsc52(
+        input: 'before\x1b]52;c;$oversizedPayload\x1b\\after',
+      );
+
+      expect(result.output, 'beforeafter');
+      expect(result.osc52Args, [
+        ['c', oversizedPayload],
+      ]);
+    });
+
+    test(
+      'answers OSC 52 clipboard queries before kterm handles them',
+      () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+              if (call.method == 'Clipboard.getData') {
+                return <String, Object?>{'text': 'local-secret'};
+              }
+              return null;
+            });
+        addTearDown(
+          () => TestDefaultBinaryMessengerBinding
+              .instance
+              .defaultBinaryMessenger
+              .setMockMethodCallHandler(SystemChannels.platform, null),
+        );
+        final shell = await openShell();
+        shell.session
+          ..clipboardSharingEnabled = true
+          ..localClipboardReadEnabled = true;
+
+        shell.stdout.add(Uint8List.fromList(utf8.encode('\x1b]52;c;?\x1b\\')));
+        await pumpEventQueue();
+
+        expect(
+          utf8.decode(shell.shellWrites.expand((chunk) => chunk).toList()),
+          ClipboardSharingService.buildOsc52Response(
+            'c',
+            base64Encode(utf8.encode('local-secret')),
+          ),
+        );
+      },
+    );
 
     test(
       'flushes tmux-wrapped terminal theme OSC queries without frame delay',

--- a/test/domain/services/terminal_hyperlink_tracker_test.dart
+++ b/test/domain/services/terminal_hyperlink_tracker_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/domain/services/terminal_hyperlink_tracker.dart';
-import 'package:xterm/xterm.dart';
 
 void main() {
   group('TerminalHyperlinkTracker', () {
@@ -31,11 +31,13 @@ void main() {
 
     test('reassembles OSC 8 destinations containing semicolons', () {
       terminal.write(
-        [
-          '\u001b]8;;https://example.com/docs;topic=tmux\u0007',
-          'tmux docs',
-          '\u001b]8;;\u0007',
-        ].join(),
+        tracker.normalizeTerminalOutput(
+          [
+            '\u001b]8;;https://example.com/docs;topic=tmux\u0007',
+            'tmux docs',
+            '\u001b]8;;\u0007',
+          ].join(),
+        ),
       );
 
       expect(
@@ -61,39 +63,42 @@ void main() {
       );
     });
 
-    test('prunes detached hyperlinks while processing later OSC 8 output', () {
-      terminal = Terminal(maxLines: 200);
-      tracker = TerminalHyperlinkTracker()..attach(terminal);
-      terminal
-        ..onPrivateOSC = tracker.handlePrivateOsc
-        ..write(
+    test(
+      'ignores scrolled-out native hyperlinks before later OSC 8 output',
+      () {
+        terminal = Terminal(maxLines: 200);
+        tracker = TerminalHyperlinkTracker()..attach(terminal);
+        terminal
+          ..onPrivateOSC = tracker.handlePrivateOsc
+          ..write(
+            [
+              '\u001b]8;;https://example.com/one\u0007',
+              'one',
+              '\u001b]8;;\u0007\n',
+              for (var i = 0; i < 220; i++) 'filler $i\n',
+            ].join(),
+          );
+
+        expect(tracker.trackedHyperlinkCount, 0);
+
+        terminal.write(
           [
-            '\u001b]8;;https://example.com/one\u0007',
-            'one',
-            '\u001b]8;;\u0007\n',
-            for (var i = 0; i < 220; i++) 'filler $i\n',
+            '\u001b]8;;https://example.com/two\u0007',
+            'two',
+            '\u001b]8;;\u0007',
           ].join(),
         );
 
-      expect(tracker.trackedHyperlinkCount, 1);
-
-      terminal.write(
-        [
-          '\u001b]8;;https://example.com/two\u0007',
-          'two',
-          '\u001b]8;;\u0007',
-        ].join(),
-      );
-
-      expect(tracker.trackedHyperlinkCount, 1);
-      String? resolvedLink;
-      for (var y = 0; y <= terminal.buffer.absoluteCursorY; y++) {
-        for (var x = 0; x < terminal.buffer.viewWidth; x++) {
-          resolvedLink ??= tracker.resolveLinkAt(CellOffset(x, y));
+        expect(tracker.trackedHyperlinkCount, 1);
+        String? resolvedLink;
+        for (var y = 0; y <= terminal.buffer.absoluteCursorY; y++) {
+          for (var x = 0; x < terminal.buffer.viewWidth; x++) {
+            resolvedLink ??= tracker.resolveLinkAt(CellOffset(x, y));
+          }
         }
-      }
-      expect(resolvedLink, 'https://example.com/two');
-    });
+        expect(resolvedLink, 'https://example.com/two');
+      },
+    );
 
     group('retained-link cap / LRU eviction', () {
       test('caps retained hyperlinks at maxRetainedLinks', () {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kterm/kterm.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:monkeyssh/app/routes.dart';
 import 'package:monkeyssh/data/database/database.dart';
@@ -40,7 +41,6 @@ import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:wakelock_plus_platform_interface/wakelock_plus_platform_interface.dart';
-import 'package:xterm/xterm.dart';
 
 const _deleteDetectionMarker = '\u200B\u200B';
 const _trueColorLoginShellCommand =

--- a/test/presentation/widgets/terminal_text_input_handler_test.dart
+++ b/test/presentation/widgets/terminal_text_input_handler_test.dart
@@ -3,8 +3,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show TextInputClient;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
-import 'package:xterm/xterm.dart';
 
 const _deleteDetectionMarker = '\u200B\u200B';
 

--- a/test/widget/connection_preview_snippet_test.dart
+++ b/test/widget/connection_preview_snippet_test.dart
@@ -2,12 +2,11 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:kterm/kterm.dart' hide TerminalThemes;
 import 'package:monkeyssh/domain/models/terminal_themes.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/presentation/widgets/connection_preview_snippet.dart';
-import 'package:xterm/xterm.dart' hide TerminalThemes;
 
 void main() {
   Widget buildSnippet({

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -33,7 +33,7 @@ import 'package:monkeyssh/presentation/providers/entity_list_providers.dart';
 import 'package:monkeyssh/presentation/providers/host_row_providers.dart';
 import 'package:monkeyssh/presentation/screens/home_screen.dart';
 import 'package:monkeyssh/presentation/widgets/connection_preview_snippet.dart';
-import 'package:xterm/xterm.dart' hide TerminalThemes;
+import 'package:kterm/kterm.dart' hide TerminalThemes;
 
 class _MockHostRepository extends Mock implements HostRepository {}
 

--- a/test/widget/keyboard_toolbar_test.dart
+++ b/test/widget/keyboard_toolbar_test.dart
@@ -2,9 +2,9 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/presentation/widgets/keyboard_toolbar.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_menu_style.dart';
-import 'package:xterm/xterm.dart';
 
 const _terminalAlternateEnterInput = '\x1b\r';
 

--- a/test/widget/monkey_terminal_gesture_handler_test.dart
+++ b/test/widget/monkey_terminal_gesture_handler_test.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_gesture_detector.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_gesture_handler.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
-import 'package:xterm/xterm.dart';
 
 void main() {
   testWidgets('tertiary taps invoke tertiary callbacks', (tester) async {

--- a/test/widget/monkey_terminal_scroll_gesture_handler_test.dart
+++ b/test/widget/monkey_terminal_scroll_gesture_handler_test.dart
@@ -3,8 +3,8 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_scroll_gesture_handler.dart';
-import 'package:xterm/xterm.dart';
 
 void main() {
   testWidgets(

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -4,9 +4,9 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kterm/kterm.dart' hide TerminalThemes;
 import 'package:monkeyssh/domain/models/terminal_themes.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
-import 'package:xterm/xterm.dart' hide TerminalThemes;
 
 double _contrastRatio(Color a, Color b) {
   final luminanceA = a.computeLuminance();
@@ -241,7 +241,7 @@ void main() {
       'clears normal-background cells before drawing terminal rows',
       () async {
         final terminal = Terminal()..resize(8, 1);
-        final theme = TerminalThemes.defaultDarkTheme.toXtermTheme();
+        final theme = TerminalThemes.defaultDarkTheme.toKtermTheme();
         final painter = MonkeyTerminalPainter(
           theme: theme,
           textStyle: const TerminalStyle(fontSize: 20),
@@ -302,7 +302,7 @@ void main() {
 
     test('keeps bright-black backgrounds readable across built-in themes', () {
       for (final themeData in TerminalThemes.all) {
-        final theme = themeData.toXtermTheme();
+        final theme = themeData.toKtermTheme();
         final background = resolveMonkeyTerminalReadableBackgroundColor(
           foreground: theme.foreground,
           background: theme.brightBlack,
@@ -396,7 +396,7 @@ void main() {
         final terminal = Terminal()
           ..resize(12, 2)
           ..write('\x1b[38;2;215;119;87m ▐\x1b[48;2;0;0;0m▛███▜\x1b[49m▌');
-        final theme = TerminalThemes.defaultLightTheme.toXtermTheme();
+        final theme = TerminalThemes.defaultLightTheme.toKtermTheme();
         final painter = MonkeyTerminalPainter(
           theme: theme,
           textStyle: const TerminalStyle(fontSize: 32),
@@ -456,7 +456,7 @@ void main() {
         ..resize(24, 2)
         ..write('\x1b[100m> fix contrast\x1b[49m');
       final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
+        theme: TerminalThemes.defaultLightTheme.toKtermTheme(),
         textStyle: const TerminalStyle(),
         textScaler: TextScaler.noScaling,
       );
@@ -479,7 +479,7 @@ void main() {
         ..resize(32, 2)
         ..write('\x1b[48;2;95;95;95mAsk Codex\x1b[49m');
       final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultDarkTheme.toXtermTheme(),
+        theme: TerminalThemes.defaultDarkTheme.toKtermTheme(),
         textStyle: const TerminalStyle(),
         textScaler: TextScaler.noScaling,
       );
@@ -504,7 +504,7 @@ void main() {
           ..resize(32, 2)
           ..write('\x1b[2C\x1b[48;2;95;95;95mAsk Codex\x1b[49m');
         final painter = MonkeyTerminalPainter(
-          theme: TerminalThemes.defaultDarkTheme.toXtermTheme(),
+          theme: TerminalThemes.defaultDarkTheme.toKtermTheme(),
           textStyle: const TerminalStyle(),
           textScaler: TextScaler.noScaling,
         );
@@ -523,7 +523,7 @@ void main() {
         ..resize(24, 2)
         ..write('x \x1b[100mstatus\x1b[49m');
       final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
+        theme: TerminalThemes.defaultLightTheme.toKtermTheme(),
         textStyle: const TerminalStyle(),
         textScaler: TextScaler.noScaling,
       );
@@ -541,7 +541,7 @@ void main() {
         ..resize(24, 2)
         ..write('\x1b[41mERROR\x1b[49m');
       final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
+        theme: TerminalThemes.defaultLightTheme.toKtermTheme(),
         textStyle: const TerminalStyle(),
         textScaler: TextScaler.noScaling,
       );
@@ -559,7 +559,7 @@ void main() {
         ..resize(24, 2)
         ..write('\x1b[48;2;168;47;69mERROR\x1b[49m');
       final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
+        theme: TerminalThemes.defaultLightTheme.toKtermTheme(),
         textStyle: const TerminalStyle(),
         textScaler: TextScaler.noScaling,
       );
@@ -576,7 +576,7 @@ void main() {
       final terminal = Terminal()
         ..resize(24, 2)
         ..write('\x1b[90mforeground only');
-      final theme = TerminalThemes.defaultDarkTheme.toXtermTheme();
+      final theme = TerminalThemes.defaultDarkTheme.toKtermTheme();
       final painter = MonkeyTerminalPainter(
         theme: theme,
         textStyle: const TerminalStyle(),
@@ -600,7 +600,7 @@ void main() {
       final terminal = Terminal()
         ..resize(24, 2)
         ..write('\x1b[96mforeground only');
-      final theme = TerminalThemes.defaultDarkTheme.toXtermTheme();
+      final theme = TerminalThemes.defaultDarkTheme.toKtermTheme();
       final painter = MonkeyTerminalPainter(
         theme: theme,
         textStyle: const TerminalStyle(),

--- a/test/widget/monkey_terminal_view_resize_test.dart
+++ b/test/widget/monkey_terminal_view_resize_test.dart
@@ -2,9 +2,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/domain/models/terminal_themes.dart' as monkey_themes;
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
-import 'package:xterm/xterm.dart';
 
 double _contrastRatio(Color a, Color b) {
   final luminanceA = a.computeLuminance();
@@ -492,7 +492,7 @@ void main() {
     expect(output, ['\x1b[O', '\x1b[I']);
   });
 
-  testWidgets('refreshThemeModeReport sends xterm theme mode report', (
+  testWidgets('refreshThemeModeReport sends terminal theme mode report', (
     tester,
   ) async {
     final output = <String>[];
@@ -557,7 +557,7 @@ void main() {
           background: backgroundColor,
           cursor: hiddenColor,
         )
-        .toXtermTheme();
+        .toKtermTheme();
 
     await tester.pumpWidget(
       MaterialApp(
@@ -609,9 +609,9 @@ void main() {
 
   test('explicit xterm palette grayscale colors stay standard', () {
     final darkTheme = monkey_themes.TerminalThemes.defaultDarkTheme
-        .toXtermTheme();
+        .toKtermTheme();
     final lightTheme = monkey_themes.TerminalThemes.defaultLightTheme
-        .toXtermTheme();
+        .toKtermTheme();
     final darkPainter = MonkeyTerminalPainter(
       theme: darkTheme,
       textStyle: const TerminalStyle(),
@@ -637,9 +637,9 @@ void main() {
 
   test('ANSI bright colors follow the active theme palette', () {
     final darkTheme = monkey_themes.TerminalThemes.defaultDarkTheme
-        .toXtermTheme();
+        .toKtermTheme();
     final lightTheme = monkey_themes.TerminalThemes.defaultLightTheme
-        .toXtermTheme();
+        .toKtermTheme();
     final darkPainter = MonkeyTerminalPainter(
       theme: darkTheme,
       textStyle: const TerminalStyle(),

--- a/test/widget/monkey_terminal_view_touch_scroll_test.dart
+++ b/test/widget/monkey_terminal_view_touch_scroll_test.dart
@@ -3,9 +3,9 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_gesture_detector.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
-import 'package:xterm/xterm.dart';
 
 int _countOccurrences(String text, String pattern) {
   var count = 0;

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -5,8 +5,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker_android/image_picker_android.dart';
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
-import 'package:xterm/xterm.dart';
 
 class _FakeImagePickerPlatform extends ImagePickerPlatform {}
 

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -7,11 +7,11 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/domain/models/auto_connect_command.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:monkeyssh/presentation/widgets/keyboard_toolbar.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
-import 'package:xterm/xterm.dart';
 
 const _deleteDetectionMarker = '\u200B\u200B';
 const _terminalAlternateEnterInput = '\x1b\r';

--- a/test/widget/terminal_text_input_handler_unicode_test.dart
+++ b/test/widget/terminal_text_input_handler_unicode_test.dart
@@ -3,9 +3,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kterm/kterm.dart';
 import 'package:monkeyssh/domain/models/auto_connect_command.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
-import 'package:xterm/xterm.dart';
 
 const _deleteDetectionMarker = '\u200B\u200B';
 


### PR DESCRIPTION
## Summary
- replace the xterm dependency/import surface with kterm
- update MonkeySSH terminal rendering, input, theme, preview, and test surfaces for kterm types
- preserve app-level terminal behavior by handling OSC 52 clipboard, OSC color queries, and OSC 8 hyperlink edge cases before kterm consumes them

## Validation
- flutter analyze
- flutter test
- focused terminal tests: ssh_service_test, terminal_theme_test, monkey_terminal_view_layout_test, monkey_terminal_view_resize_test, terminal_text_input_handler_unicode_test, monkey_terminal_scroll_gesture_handler_test, monkey_terminal_gesture_handler_test, terminal_hyperlink_tracker_test

## Notes
- Attempted local integration tests with flutter test integration_test, but the only available app target was macOS and the Flutter runner failed before assertions with Failed to foreground app; open returned 1 followed by a 0x0 root semantics assertion. No Android/iOS simulator was available locally.