### PR TITLE
fix: release terminal-open guard once route is pushed

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -111,15 +111,35 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       return;
     }
     _isOpeningTerminalRoute = true;
+    // Release the double-tap guard once the terminal route has been pushed and
+    // can capture input, rather than when `router.push` resolves. That future
+    // only completes when the route is popped, and is orphaned entirely if the
+    // route is instead removed via `go(...)` (for example navigating home from
+    // SFTP). Tying the guard to it would leave it stuck `true`, permanently
+    // blocking every future terminal open even though connections still open.
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => _releaseTerminalRouteGuard(),
+    );
     try {
       await router.push(route);
     } finally {
+      // Belt-and-suspenders: also release here, before the theme clear (which
+      // can throw if the provider is gone) so a throw can never strand the guard.
+      _releaseTerminalRouteGuard();
       if (mounted) {
         ref.read(terminalAppThemeOverrideProvider.notifier).clear();
-        setState(() => _isOpeningTerminalRoute = false);
-      } else {
-        _isOpeningTerminalRoute = false;
       }
+    }
+  }
+
+  void _releaseTerminalRouteGuard() {
+    if (!_isOpeningTerminalRoute) {
+      return;
+    }
+    if (mounted) {
+      setState(() => _isOpeningTerminalRoute = false);
+    } else {
+      _isOpeningTerminalRoute = false;
     }
   }
 

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -654,6 +654,91 @@ void main() {
       expect(find.text('Terminal /terminal/1?connectionId=7'), findsNothing);
     });
 
+    testWidgets('terminal opens again after the route is removed via go()', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final openedRoutes = <String>[];
+      final sessionsNotifier = _MutableActiveSessionsNotifier(
+        initialConnections: [
+          _buildActiveConnection(
+            connectionId: 7,
+            hostId: 1,
+            state: SshConnectionState.connecting,
+          ),
+        ],
+      );
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) =>
+                const HomeScreen(initialTab: HomeScreenTab.connections),
+          ),
+          GoRoute(
+            path: '/terminal/:hostId',
+            builder: (context, state) => _RecordingTerminalPage(
+              route: state.uri.toString(),
+              openedRoutes: openedRoutes,
+            ),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            transferIntentServiceProvider.overrideWith(
+              (ref) => _TestTransferIntentService(),
+            ),
+            homeScreenShortcutServiceProvider.overrideWith(
+              (ref) => _TestHomeScreenShortcutService(),
+            ),
+            pinnedHomeScreenShortcutHostIdsProvider.overrideWith(
+              (ref) => Stream<Set<int>>.value(const <int>{}),
+            ),
+            activeSessionsProvider.overrideWith(() => sessionsNotifier),
+            allHostsProvider.overrideWith(
+              (ref) => Stream.value([
+                _buildHost(id: 1, label: 'Alpha', sortOrder: 0),
+              ]),
+            ),
+          ],
+          child: MediaQuery(
+            data: const MediaQueryData(size: Size(400, 800)),
+            child: MaterialApp.router(routerConfig: router),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.tapAt(tester.getCenter(find.text('Alpha')));
+      await tester.pumpAndSettle();
+
+      expect(openedRoutes, ['/terminal/1?connectionId=7']);
+
+      // Returning home via go(...) removes the terminal route without popping,
+      // which orphans the push future. The open guard must still be released so
+      // the connection can be reopened instead of becoming permanently stuck.
+      router.go('/');
+      await tester.pumpAndSettle();
+
+      expect(find.text('Alpha'), findsOneWidget);
+
+      await tester.tapAt(tester.getCenter(find.text('Alpha')));
+      await tester.pumpAndSettle();
+
+      expect(openedRoutes, [
+        '/terminal/1?connectionId=7',
+        '/terminal/1?connectionId=7',
+      ]);
+    });
+
     testWidgets('connections preview tap opens terminal route', (tester) async {
       final db = AppDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);


### PR DESCRIPTION
## Problem

A user reported getting stuck in a state where **terminal windows could no longer be opened**: connections still showed as open, but tapping them did nothing. The attached diagnostics confirmed a successful SSH connect (`connect_to_host_success … connectionId=2`) with **no** following `terminal.screen init` — the connection opened but the terminal screen never did.

## Root cause

`HomeScreen._openTerminalRoute` debounces double-taps with an `_isOpeningTerminalRoute` flag that was held until `await router.push(route)` resolved. That future only completes when the terminal route is **popped**, and is **orphaned (never completes)** when the route is removed via `go(...)` instead.

That happens on real paths:
- `lib/presentation/screens/sftp_screen.dart:1292` → `context.go('/')`
- `lib/app/notification_navigation.dart:35` → `router.go(...)` (tmux alert navigation)

Once orphaned, the flag stuck `true` forever, so every later open early-returned. The SSH connect still ran via the progress dialog (so the session "showed as open"), but `_openTerminalRoute` never pushed the screen — exactly the reported symptom.

Verified empirically with go_router 17.2.3: a pushed route's future completes after `pop()` but **not** after `go()`.

## Fix

Release the debounce guard on the next frame after the route is pushed (once it can capture input), decoupled from the push future. Also release it in `finally` before the theme clear so a throw can't strand it. The double-tap debounce is preserved — the guard still blocks re-entrant opens until the pushed route covers the screen. The redundant theme-override clear on return is kept; the terminal screen already clears it in its own `dispose()`.

## Validation

- New regression test `terminal opens again after the route is removed via go()` — fails on the old behavior, passes with the fix.
- `flutter analyze` clean on changed files.
- Full `flutter test` suite passes (2357 tests).