### PR TITLE
Fix iOS location purpose string warning

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -51,6 +51,8 @@ post_install do |installer|
       definitions = [definitions] if definitions.is_a?(String)
       definitions ||= ['$(inherited)']
       definitions << '$(inherited)' unless definitions.include?('$(inherited)')
+      definitions << 'PERMISSION_LOCATION=0'
+      definitions << 'PERMISSION_LOCATION_ALWAYS=0'
       definitions << 'PERMISSION_LOCATION_WHENINUSE=1'
       config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] =
         definitions.uniq

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -55,6 +55,8 @@
 	<string>$(PRODUCT_NAME) needs camera access to scan sync recovery key QR codes.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>$(PRODUCT_NAME) uses Face ID to unlock your encrypted SSH credentials.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>$(PRODUCT_NAME) reads the current Wi-Fi network name to decide whether to bypass a host's jump host on trusted networks.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>$(PRODUCT_NAME) reads the current Wi-Fi network name to decide whether to bypass a host's jump host on trusted networks.</string>
 	<key>NSAppTransportSecurity</key>

--- a/test/unit/wifi_platform_configuration_test.dart
+++ b/test/unit/wifi_platform_configuration_test.dart
@@ -24,7 +24,14 @@ void main() {
         entitlements,
         contains('com.apple.developer.networking.wifi-info'),
       );
+      expect(
+        infoPlist,
+        contains('NSLocationAlwaysAndWhenInUseUsageDescription'),
+      );
       expect(infoPlist, contains('NSLocationWhenInUseUsageDescription'));
+      expect(infoPlist, contains('current Wi-Fi network name'));
+      expect(podfile, contains('PERMISSION_LOCATION=0'));
+      expect(podfile, contains('PERMISSION_LOCATION_ALWAYS=0'));
       expect(podfile, contains('PERMISSION_LOCATION_WHENINUSE=1'));
     });
   });


### PR DESCRIPTION
Summary:
- Add the missing NSLocationAlwaysAndWhenInUseUsageDescription key for App Store Connect's location purpose-string check.
- Keep permission_handler's iOS location macros explicitly foreground-only by disabling location/always and enabling when-in-use.
- Extend the Wi-Fi platform configuration test to cover the new plist key and macros.

Validation:
- plutil -lint ios/Runner/Info.plist
- ruby -c ios/Podfile
- flutter test test/unit/wifi_platform_configuration_test.dart
- Pre-commit hook: formatting, analyzer, full Flutter test suite