### PR TITLE
fix: strip leaked iOS terminal input sentinels

### DIFF
--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -1222,8 +1222,28 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   String _extractRawInputText(String text) =>
       text.substring(_editingPrefixLength(text));
 
+  String _stripLeakedDeleteSentinelPrefix(String text) {
+    if (!widget.deleteDetection || text.isEmpty) {
+      return text;
+    }
+
+    // iOS can replay hidden backspace runway sentinels with the next composed
+    // text update; those sentinels must never reach the terminal stream.
+    var prefixLength = 0;
+    while (prefixLength < text.length &&
+        text.codeUnitAt(prefixLength) == _iosBackspaceRepeatRunwayCodeUnit) {
+      prefixLength++;
+    }
+    if (prefixLength == 0) {
+      return text;
+    }
+    return text.substring(prefixLength);
+  }
+
   String _extractInputText(String text) {
-    final extractedText = _extractRawInputText(text);
+    final extractedText = _stripLeakedDeleteSentinelPrefix(
+      _extractRawInputText(text),
+    );
     final sanitizedText = extractedText.replaceFirst(
       _leadingSwipeNewlineArtifactPattern,
       '',

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -1223,14 +1223,19 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       text.substring(_editingPrefixLength(text));
 
   String _stripLeakedDeleteSentinelPrefix(String text) {
-    if (!widget.deleteDetection || text.isEmpty) {
+    if (!_shouldUseIosBackspaceRunway ||
+        _iosBackspaceRunwayLength == 0 ||
+        text.isEmpty) {
       return text;
     }
 
     // iOS can replay hidden backspace runway sentinels with the next composed
     // text update; those sentinels must never reach the terminal stream.
+    final maxPrefixLength = text.length < _iosBackspaceRunwayLength
+        ? text.length
+        : _iosBackspaceRunwayLength;
     var prefixLength = 0;
-    while (prefixLength < text.length &&
+    while (prefixLength < maxPrefixLength &&
         text.codeUnitAt(prefixLength) == _iosBackspaceRepeatRunwayCodeUnit) {
       prefixLength++;
     }
@@ -2300,6 +2305,22 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     return true;
   }
 
+  void _preserveIosBackspaceRunwayForComposing(TextEditingValue value) {
+    if (!_shouldUseIosBackspaceRunway || _iosBackspaceRunwayLength == 0) {
+      _iosBackspaceRunwayLength = 0;
+      return;
+    }
+    if (_editingPrefixLength(value.text) != _initEditingState.text.length) {
+      _iosBackspaceRunwayLength = 0;
+      return;
+    }
+
+    final runwayPrefixLength = _leadingIosBackspaceRunwayLength(
+      _extractRawInputText(value.text),
+    );
+    _iosBackspaceRunwayLength = runwayPrefixLength;
+  }
+
   TextEditingValue _stripIosBackspaceRunway(TextEditingValue value) {
     if (!_shouldUseIosBackspaceRunway || _iosBackspaceRunwayLength == 0) {
       return value;
@@ -2472,7 +2493,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       // Handle composing (IME input in progress).
       if (!value.composing.isCollapsed) {
         _cancelDeferredTrailingBackspaceImeClear();
-        _iosBackspaceRunwayLength = 0;
+        _preserveIosBackspaceRunwayForComposing(value);
         if (_sendComposingDeletionIfNeeded(value)) {
           _sawImeComposition = true;
           return;

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -7077,6 +7077,28 @@ void main() {
     );
 
     testWidgets(
+      'preserves leading zero-width text outside iOS backspace runway state',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        try {
+          final harness = await _pumpTerminalHarness(tester);
+          const input = '\u200B/help';
+
+          tester.testTextInput.updateEditingValue(
+            _editingValue(input, selectionOffset: input.length),
+          );
+          await tester.pump();
+
+          expect(harness.terminalOutput, [input]);
+
+          await _disposeTerminalHarness(tester, harness);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testWidgets(
       'keeps iOS held backspace fast after visible text is exhausted',
       (tester) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.iOS;

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -976,6 +976,20 @@ TextEditingValue _iosBackspaceRunwayValue(int length, {String suffix = ''}) {
   );
 }
 
+TextEditingValue _iosBackspaceRunwayComposingValue(
+  int length, {
+  required String suffix,
+}) {
+  final runway = _iosBackspaceRunwayPayload(length);
+  final text = '$_deleteDetectionMarker$runway$suffix';
+  final suffixStart = _deleteDetectionMarker.length + runway.length;
+  return TextEditingValue(
+    text: text,
+    selection: TextSelection.collapsed(offset: text.length),
+    composing: TextRange(start: suffixStart, end: text.length),
+  );
+}
+
 String _terminalKeyOutput(
   TerminalKey key, {
   bool shift = false,
@@ -6999,6 +7013,60 @@ void main() {
               (call) => call.method == 'TextInput.setEditingState',
             ),
             isEmpty,
+          );
+
+          await _disposeTerminalHarness(tester, harness);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testWidgets(
+      'strips leaked iOS backspace runways before a composed slash command',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        try {
+          final harness = await _pumpTerminalHarness(tester);
+
+          tester.testTextInput.updateEditingValue(
+            _editingValue('x', selectionOffset: 1),
+          );
+          await tester.pump();
+          tester.testTextInput.updateEditingValue(
+            _editingValue('', selectionOffset: 0),
+          );
+          await tester.pump();
+
+          expect(
+            _terminalTextInputClient(tester).currentTextEditingValue,
+            _iosBackspaceRunwayValue(terminalIosBackspaceRepeatRunwayLength),
+          );
+
+          harness.terminalOutput.clear();
+
+          tester.testTextInput.updateEditingValue(
+            _iosBackspaceRunwayComposingValue(
+              terminalIosBackspaceRepeatRunwayLength,
+              suffix: '/help',
+            ),
+          );
+          await tester.pump();
+
+          expect(harness.terminalOutput, isEmpty);
+
+          tester.testTextInput.updateEditingValue(
+            _iosBackspaceRunwayValue(
+              terminalIosBackspaceRepeatRunwayLength,
+              suffix: '/help',
+            ),
+          );
+          await tester.pump();
+
+          expect(harness.terminalOutput, ['/help']);
+          expect(
+            _terminalTextInputClient(tester).currentTextEditingValue,
+            _editingValue('/help', selectionOffset: '/help'.length),
           );
 
           await _disposeTerminalHarness(tester, harness);


### PR DESCRIPTION
## Summary
- Strip leaked iOS hidden backspace sentinels before terminal text is diffed/sent
- Add regression coverage for composed slash-command input after iOS backspace runway state

## Validation
- flutter test test/widget/terminal_text_input_handler_test.dart
- flutter analyze
- pre-commit hook checks