### PR TITLE
fix: harden telemetry error handling

### DIFF
--- a/lib/domain/services/telemetry_service.dart
+++ b/lib/domain/services/telemetry_service.dart
@@ -228,13 +228,21 @@ class TelemetryService {
       return;
     }
 
-    await analyticsClient.setCollectionEnabled(enabled: enabled);
-    await crashReporter.setCollectionEnabled(enabled: enabled);
-    if (!enabled && wasEnabled) {
-      await analyticsClient.resetAnalyticsData();
-      await crashReporter.deleteUnsentReports();
-    } else {
-      await _setCrashMetadata(this);
+    try {
+      await analyticsClient.setCollectionEnabled(enabled: enabled);
+      await crashReporter.setCollectionEnabled(enabled: enabled);
+      if (!enabled && wasEnabled) {
+        await analyticsClient.resetAnalyticsData();
+        await crashReporter.deleteUnsentReports();
+      } else {
+        await _setCrashMetadata(this);
+      }
+    } on Object catch (error) {
+      _diagnosticsLogger.warning(
+        'telemetry',
+        'collection_update_failed',
+        fields: {'enabled': enabled, 'errorType': error.runtimeType},
+      );
     }
   }
 
@@ -634,10 +642,18 @@ class TelemetryService {
     if (analyticsClient == null) {
       return;
     }
-    await analyticsClient.logEvent(
-      name: _sanitizeFirebaseName(name),
-      parameters: _sanitizeParameters(parameters),
-    );
+    try {
+      await analyticsClient.logEvent(
+        name: _sanitizeFirebaseName(name),
+        parameters: _sanitizeParameters(parameters),
+      );
+    } on Object catch (error) {
+      _diagnosticsLogger.warning(
+        'telemetry',
+        'analytics_event_failed',
+        fields: {'eventName': name, 'errorType': error.runtimeType},
+      );
+    }
   }
 
   bool _canRecordCrash() => isAvailable && _collectionEnabled;

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -745,6 +745,9 @@ class _TelemetryOptInPromptCard extends ConsumerWidget {
     }
     if (promptState.choice == TelemetryOptInPromptChoice.notShown) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted) {
+          return;
+        }
         ref
             .read(telemetryOptInPromptNotifierProvider.notifier)
             .markShown(trigger: trigger);

--- a/test/domain/services/telemetry_service_test.dart
+++ b/test/domain/services/telemetry_service_test.dart
@@ -69,6 +69,32 @@ void main() {
       },
     );
 
+    test('swallows SDK failures while updating collection state', () async {
+      final service = TelemetryService(
+        status: TelemetryServiceStatus.ready,
+        collectionEnabled: true,
+        diagnosticsLogger: const NoopDiagnosticsLogger(),
+        analyticsClient: _ThrowingAnalyticsClient(),
+        crashReporter: _FakeCrashReporter(),
+      );
+
+      await service.setCollectionEnabled(enabled: false);
+
+      expect(service.collectionEnabled, isFalse);
+    });
+
+    test('swallows SDK failures while logging analytics events', () async {
+      final service = TelemetryService(
+        status: TelemetryServiceStatus.ready,
+        collectionEnabled: true,
+        diagnosticsLogger: const NoopDiagnosticsLogger(),
+        analyticsClient: _ThrowingAnalyticsClient(),
+        crashReporter: _FakeCrashReporter(),
+      );
+
+      await service.logFeatureOpened(feature: 'terminal');
+    });
+
     test('sanitizes and allowlists event parameter values', () async {
       final analytics = _FakeAnalyticsClient();
       final service = TelemetryService(
@@ -429,6 +455,26 @@ class _FakeAnalyticsClient implements TelemetryAnalyticsClient {
   @override
   Future<void> setCollectionEnabled({required bool enabled}) async {
     collectionEnabled = enabled;
+  }
+}
+
+class _ThrowingAnalyticsClient implements TelemetryAnalyticsClient {
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {
+    throw StateError('analytics unavailable');
+  }
+
+  @override
+  Future<void> resetAnalyticsData() async {
+    throw StateError('analytics unavailable');
+  }
+
+  @override
+  Future<void> setCollectionEnabled({required bool enabled}) async {
+    throw StateError('analytics unavailable');
   }
 }
 


### PR DESCRIPTION
## Summary
- make telemetry SDK calls best-effort so Firebase platform failures cannot crash settings toggles or unawaited event logging
- guard the analytics opt-in prompt post-frame callback with `context.mounted` before reading Riverpod state
- add tests for SDK failure handling in telemetry collection and event logging

## Validation
- `flutter test test/domain/services/telemetry_service_test.dart`
- `flutter analyze`
- `JAVA_HOME="$(/usr/libexec/java_home -v 17)" flutter build apk --flavor production --debug --target-platform android-arm64 --dart-define=FLUTTY_FIREBASE_ENABLED=true`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer FLUTTER_SWIFT_PACKAGE_MANAGER=false flutter build ios --flavor production --release --no-codesign --no-tree-shake-icons --dart-define=FLUTTY_FIREBASE_ENABLED=true`
- full `flutter test` via pre-commit hook