### PR TITLE
fix: isolate telemetry SDK updates

### DIFF
--- a/lib/domain/services/telemetry_service.dart
+++ b/lib/domain/services/telemetry_service.dart
@@ -228,20 +228,29 @@ class TelemetryService {
       return;
     }
 
-    try {
-      await analyticsClient.setCollectionEnabled(enabled: enabled);
-      await crashReporter.setCollectionEnabled(enabled: enabled);
-      if (!enabled && wasEnabled) {
-        await analyticsClient.resetAnalyticsData();
-        await crashReporter.deleteUnsentReports();
-      } else {
-        await _setCrashMetadata(this);
-      }
-    } on Object catch (error) {
-      _diagnosticsLogger.warning(
-        'telemetry',
-        'collection_update_failed',
-        fields: {'enabled': enabled, 'errorType': error.runtimeType},
+    await _runSdkUpdate(
+      'analytics_collection_update_failed',
+      fields: {'enabled': enabled},
+      operation: () => analyticsClient.setCollectionEnabled(enabled: enabled),
+    );
+    await _runSdkUpdate(
+      'crash_collection_update_failed',
+      fields: {'enabled': enabled},
+      operation: () => crashReporter.setCollectionEnabled(enabled: enabled),
+    );
+    if (!enabled && wasEnabled) {
+      await _runSdkUpdate(
+        'analytics_reset_failed',
+        operation: analyticsClient.resetAnalyticsData,
+      );
+      await _runSdkUpdate(
+        'crash_unsent_report_delete_failed',
+        operation: crashReporter.deleteUnsentReports,
+      );
+    } else if (enabled) {
+      await _runSdkUpdate(
+        'crash_metadata_update_failed',
+        operation: () => _setCrashMetadata(this),
       );
     }
   }
@@ -652,6 +661,22 @@ class TelemetryService {
         'telemetry',
         'analytics_event_failed',
         fields: {'eventName': name, 'errorType': error.runtimeType},
+      );
+    }
+  }
+
+  Future<void> _runSdkUpdate(
+    String failureEventName, {
+    required Future<void> Function() operation,
+    Map<String, Object?> fields = const <String, Object?>{},
+  }) async {
+    try {
+      await operation();
+    } on Object catch (error) {
+      _diagnosticsLogger.warning(
+        'telemetry',
+        failureEventName,
+        fields: <String, Object?>{...fields, 'errorType': error.runtimeType},
       );
     }
   }

--- a/test/domain/services/telemetry_service_test.dart
+++ b/test/domain/services/telemetry_service_test.dart
@@ -70,17 +70,20 @@ void main() {
     );
 
     test('swallows SDK failures while updating collection state', () async {
+      final crashReporter = _FakeCrashReporter();
       final service = TelemetryService(
         status: TelemetryServiceStatus.ready,
         collectionEnabled: true,
         diagnosticsLogger: const NoopDiagnosticsLogger(),
         analyticsClient: _ThrowingAnalyticsClient(),
-        crashReporter: _FakeCrashReporter(),
+        crashReporter: crashReporter,
       );
 
       await service.setCollectionEnabled(enabled: false);
 
       expect(service.collectionEnabled, isFalse);
+      expect(crashReporter.collectionEnabled, isFalse);
+      expect(crashReporter.deleteUnsentReportsCount, 1);
     });
 
     test('swallows SDK failures while logging analytics events', () async {


### PR DESCRIPTION
## Summary
- make Analytics and Crashlytics collection toggles best-effort independently, so one SDK failure cannot prevent the other from updating
- isolate analytics reset and Crashlytics unsent-report deletion as separate guarded operations
- strengthen telemetry tests to verify Crashlytics is still disabled and unsent reports are deleted when Analytics throws

## Validation
- `flutter test test/domain/services/telemetry_service_test.dart`
- `flutter analyze`
- full `flutter test` via pre-commit hook