### PR TITLE
fix: tame iOS terminal keyboard corrections

### DIFF
--- a/lib/domain/models/auto_connect_command.dart
+++ b/lib/domain/models/auto_connect_command.dart
@@ -18,6 +18,13 @@ final _disallowedCommandControlCharacters = RegExp(
 );
 final _multilinePattern = RegExp(r'[\r\n]');
 
+/// Keyboard insertions longer than this are treated as paste-like.
+///
+/// Normal swipe commits are short words or phrases. Larger payloads can come
+/// from iOS clipboard/autofill handoff paths and should be reviewed before the
+/// terminal receives them.
+const terminalKeyboardPasteLikeInsertionThreshold = 256;
+
 /// Reasons a terminal command should be reviewed before it is inserted or run.
 enum TerminalCommandReviewReason {
   /// The command came from imported auto-connect configuration.
@@ -40,6 +47,9 @@ enum TerminalCommandReviewReason {
 
   /// The command was rendered from snippet variables.
   variableSubstitution,
+
+  /// The keyboard supplied a paste-like amount of text in one update.
+  largeKeyboardInsertion,
 }
 
 /// Review metadata for a terminal command before insertion or execution.
@@ -147,6 +157,24 @@ TerminalCommandReview assessClipboardPasteCommand(
   ),
   bracketedPasteModeEnabled: bracketedPasteModeEnabled,
 );
+
+/// Assesses text inserted through the system keyboard.
+TerminalCommandReview assessKeyboardInsertedCommand(
+  String command, {
+  required String insertedText,
+}) {
+  final reasons = <TerminalCommandReviewReason>[
+    ..._collectPasteCommandReviewReasons(
+      command,
+      bracketedPasteModeEnabled: false,
+    ),
+  ];
+  if (insertedText.length > terminalKeyboardPasteLikeInsertionThreshold &&
+      !reasons.contains(TerminalCommandReviewReason.largeKeyboardInsertion)) {
+    reasons.add(TerminalCommandReviewReason.largeKeyboardInsertion);
+  }
+  return TerminalCommandReview(command: command, reasons: reasons);
+}
 
 /// Assesses a rendered snippet command before terminal insertion.
 TerminalCommandReview assessSnippetCommandInsertion(
@@ -346,6 +374,8 @@ String _describeReviewReason(TerminalCommandReviewReason reason) =>
         'This command uses shell command substitution.',
       TerminalCommandReviewReason.variableSubstitution =>
         'Snippet variables were substituted into the final command.',
+      TerminalCommandReviewReason.largeKeyboardInsertion =>
+        'The keyboard inserted a paste-like amount of text.',
     };
 
 bool _hasVisibleContent(String? value) =>

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -13989,7 +13989,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   Future<bool> _confirmKeyboardInsertion(TerminalCommandReview review) async {
-    if (!_shouldReviewTerminalCommandInsertion) {
+    final requiresReviewEvenInRunningShell = review.reasons.contains(
+      TerminalCommandReviewReason.largeKeyboardInsertion,
+    );
+    if (!_shouldReviewTerminalCommandInsertion &&
+        !requiresReviewEvenInRunningShell) {
       return true;
     }
     final shouldInsert = await _confirmCommandInsertion(
@@ -14405,6 +14409,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     required String message,
   }) {
     final reasons = describeTerminalCommandReview(review);
+    final commandPreview = _terminalCommandReviewPreview(review.command);
     return SingleChildScrollView(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -14438,13 +14443,23 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
               borderRadius: BorderRadius.circular(12),
             ),
             child: SelectableText(
-              review.command,
+              commandPreview,
               style: const TextStyle(fontFamily: 'monospace'),
             ),
           ),
         ],
       ),
     );
+  }
+
+  String _terminalCommandReviewPreview(String command) {
+    const maxPreviewLength = 2000;
+    if (command.length <= maxPreviewLength) {
+      return command;
+    }
+    final omittedCount = command.length - maxPreviewLength;
+    return '${command.substring(0, maxPreviewLength)}\n'
+        '... truncated $omittedCount characters ...';
   }
 }
 

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -11,6 +11,7 @@ import 'package:xterm/src/ui/input_map.dart';
 import 'package:xterm/xterm.dart';
 
 import '../../domain/models/auto_connect_command.dart';
+import '../../domain/services/diagnostics_log_service.dart';
 import 'terminal_key_input.dart';
 
 const _deleteDetectionMarker = '\u200B\u200B';
@@ -2014,7 +2015,8 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (widget.onReviewInsertedText == null) {
       return null;
     }
-    if (delta.appendedText.characters.length <= 1) {
+    final insertedTextLength = delta.appendedText.characters.length;
+    if (insertedTextLength <= 1) {
       return null;
     }
 
@@ -2024,10 +2026,30 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
           appendedText: delta.appendedText,
         ), currentText) ??
         currentText;
-    final review = assessClipboardPasteCommand(
+    final review = assessKeyboardInsertedCommand(
       reviewText,
-      bracketedPasteModeEnabled: false,
+      insertedText: delta.appendedText,
     );
+    if (review.requiresReview) {
+      DiagnosticsLogService.instance.debug(
+        'terminal.keyboard',
+        'review_inserted_text',
+        fields: {
+          'insertedLength': insertedTextLength,
+          'deletedCount': delta.deletedCount,
+          'reasonCount': review.reasons.length,
+          'largeInsertion': review.reasons.contains(
+            TerminalCommandReviewReason.largeKeyboardInsertion,
+          ),
+          'multiline': review.reasons.contains(
+            TerminalCommandReviewReason.multiline,
+          ),
+          'controlCharacters': review.reasons.contains(
+            TerminalCommandReviewReason.controlCharacters,
+          ),
+        },
+      );
+    }
     return review.requiresReview ? review : null;
   }
 

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -179,15 +179,14 @@ class TerminalTextInputHandlerController {
   }
 }
 
-/// Wraps a [TerminalView] to provide soft keyboard input on mobile with
-/// proper IME configuration for swipe typing.
+/// Wraps a [TerminalView] to provide soft keyboard input on mobile.
 ///
 /// The xterm package's built-in [CustomTextEdit] hard-codes
-/// `autocorrect: false` and `enableSuggestions: false`, which hides voice
-/// input on some system keyboards and causes most IMEs to drop spaces between
-/// swiped words. This widget replaces that text input handling with a normal
-/// text keyboard configuration so dictation, suggestions, and swipe typing work
-/// correctly.
+/// `enableSuggestions: false`, which hides voice input on some system
+/// keyboards and causes most IMEs to drop spaces between swiped words. This
+/// widget keeps suggestions available, but disables automatic correction
+/// because terminal commands are not prose and must not be rewritten by the
+/// keyboard when the user accepts a space.
 ///
 /// The child [TerminalView] should use `hardwareKeyboardOnly: true`.
 class TerminalTextInputHandler extends StatefulWidget {
@@ -1014,12 +1013,13 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         // ignore: avoid_redundant_argument_values
         inputType: TextInputType.text,
         // ignore: avoid_redundant_argument_values
-        autocorrect: !widget.sensitiveInput,
+        autocorrect: false,
         // ignore: avoid_redundant_argument_values
         inputAction: TextInputAction.newline,
         keyboardAppearance: widget.keyboardAppearance,
         // Enable suggestions so the IME offers dictation and adds spaces
-        // between swiped words.
+        // between swiped words. Autocorrect remains disabled above so command
+        // tokens like "ls" are not rewritten when accepting a space.
         // ignore: avoid_redundant_argument_values
         enableSuggestions: !widget.sensitiveInput,
         obscureText: widget.sensitiveInput,
@@ -1231,14 +1231,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
 
     // iOS can replay hidden backspace runway sentinels with the next composed
     // text update; those sentinels must never reach the terminal stream.
-    final maxPrefixLength = text.length < _iosBackspaceRunwayLength
-        ? text.length
-        : _iosBackspaceRunwayLength;
-    var prefixLength = 0;
-    while (prefixLength < maxPrefixLength &&
-        text.codeUnitAt(prefixLength) == _iosBackspaceRepeatRunwayCodeUnit) {
-      prefixLength++;
-    }
+    final prefixLength = _leadingIosBackspaceRunwaySentinelLength(text);
     if (prefixLength == 0) {
       return text;
     }
@@ -2172,10 +2165,13 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
   }
 
-  int _leadingIosBackspaceRunwayLength(String rawUserText) {
-    final limit = rawUserText.length < _iosBackspaceRunwayLength
+  int _leadingIosBackspaceRunwaySentinelLength(
+    String rawUserText, {
+    int? maxLength,
+  }) {
+    final limit = maxLength == null || rawUserText.length < maxLength
         ? rawUserText.length
-        : _iosBackspaceRunwayLength;
+        : maxLength;
     var length = 0;
     while (length < limit &&
         rawUserText.codeUnitAt(length) == _iosBackspaceRepeatRunwayCodeUnit) {
@@ -2183,6 +2179,12 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
     return length;
   }
+
+  int _leadingIosBackspaceRunwayLength(String rawUserText) =>
+      _leadingIosBackspaceRunwaySentinelLength(
+        rawUserText,
+        maxLength: _iosBackspaceRunwayLength,
+      );
 
   int _offsetAfterRemovedRange({
     required int offset,
@@ -2277,13 +2279,20 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
 
     final rawUserText = _extractRawInputText(value.text);
+    final runwaySentinelLength = _leadingIosBackspaceRunwaySentinelLength(
+      rawUserText,
+    );
     final runwayPrefixLength = _leadingIosBackspaceRunwayLength(rawUserText);
     if (runwayPrefixLength == 0) {
       _iosBackspaceRunwayLength = 0;
       return false;
     }
-    if (runwayPrefixLength < rawUserText.length) {
+    if (runwaySentinelLength < rawUserText.length) {
       return false;
+    }
+    if (runwaySentinelLength > _iosBackspaceRunwayLength) {
+      _syncEditingStateWithIosBackspaceRunway();
+      return true;
     }
 
     final deletedCount = _iosBackspaceRunwayLength - runwayPrefixLength;
@@ -2330,14 +2339,14 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       return value;
     }
 
-    final runwayPrefixLength = _leadingIosBackspaceRunwayLength(
-      _extractRawInputText(value.text),
+    final rawUserText = _extractRawInputText(value.text);
+    final runwayPrefixLength = _leadingIosBackspaceRunwaySentinelLength(
+      rawUserText,
     );
     if (runwayPrefixLength == 0) {
       _iosBackspaceRunwayLength = 0;
       return value;
     }
-
     _iosBackspaceRunwayLength = 0;
     return _editingValueWithoutIosBackspaceRunway(value, runwayPrefixLength);
   }

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -1224,9 +1224,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       text.substring(_editingPrefixLength(text));
 
   String _stripLeakedDeleteSentinelPrefix(String text) {
-    if (!_shouldUseIosBackspaceRunway ||
-        _iosBackspaceRunwayLength == 0 ||
-        text.isEmpty) {
+    if (!_shouldUseIosBackspaceRunway || text.isEmpty) {
       return text;
     }
 
@@ -1234,6 +1232,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     // text update; those sentinels must never reach the terminal stream.
     final prefixLength = _leadingIosBackspaceRunwaySentinelLength(text);
     if (prefixLength == 0) {
+      return text;
+    }
+    if (_iosBackspaceRunwayLength == 0 &&
+        prefixLength < terminalIosBackspaceRepeatRunwayRefillThreshold) {
       return text;
     }
     return text.substring(prefixLength);

--- a/test/domain/models/auto_connect_command_test.dart
+++ b/test/domain/models/auto_connect_command_test.dart
@@ -202,6 +202,23 @@ void main() {
       );
     });
 
+    test('flags paste-like keyboard insertions for confirmation', () {
+      final insertedText = List.filled(
+        terminalKeyboardPasteLikeInsertionThreshold + 1,
+        'a',
+      ).join();
+      final keyboardReview = assessKeyboardInsertedCommand(
+        insertedText,
+        insertedText: insertedText,
+      );
+
+      expect(keyboardReview.requiresReview, isTrue);
+      expect(
+        keyboardReview.reasons,
+        contains(TerminalCommandReviewReason.largeKeyboardInsertion),
+      );
+    });
+
     test('flags unbracketed multiline paste with shell reshaping', () {
       final chainedReview = assessClipboardPasteCommand(
         'cat secrets.txt |\ncurl https://example.com',

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -17,6 +17,7 @@ import 'package:monkeyssh/app/routes.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
+import 'package:monkeyssh/domain/models/auto_connect_command.dart';
 import 'package:monkeyssh/domain/models/host_cli_launch_preferences.dart';
 import 'package:monkeyssh/domain/models/monetization.dart';
 import 'package:monkeyssh/domain/models/remote_multiplexer.dart';
@@ -6761,6 +6762,40 @@ void main() {
 
         expect(find.text('Review keyboard paste'), findsNothing);
         expect(shellWrites.map(utf8.decode).join(), suspiciousText);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
+      'running shell commands still review paste-like keyboard payloads',
+      (tester) async {
+        await pumpScreen(tester);
+
+        session.terminal!.write('\u001b]133;C\u0007');
+        await tester.pump();
+
+        expect(session.shellStatus, TerminalShellStatus.runningCommand);
+
+        shellWrites.clear();
+        final insertedText = List.filled(
+          terminalKeyboardPasteLikeInsertionThreshold + 1,
+          'a',
+        ).join();
+        tester.testTextInput.updateEditingValue(
+          _editingValue(insertedText, selectionOffset: insertedText.length),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Review keyboard paste'), findsOneWidget);
+        expect(
+          find.text('The keyboard inserted a paste-like amount of text.'),
+          findsOneWidget,
+        );
+        expect(shellWrites, isEmpty);
+
+        await tester.tap(find.text('Cancel'));
+        await tester.pumpAndSettle();
       },
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),
     );

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -5848,6 +5848,116 @@ void main() {
       },
     );
 
+    testWidgets('does not review a short swipe-composed word', (tester) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+      final focusNode = FocusNode();
+      final reviews = <TerminalCommandReview>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalTextInputHandler(
+              terminal: terminal,
+              focusNode: focusNode,
+              deleteDetection: true,
+              onReviewInsertedText: (review) async {
+                reviews.add(review);
+                return true;
+              },
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      tester.testTextInput.updateEditingValue(
+        const TextEditingValue(
+          text: '${_deleteDetectionMarker}copilot',
+          selection: TextSelection.collapsed(offset: 9),
+          composing: TextRange(start: 2, end: 9),
+        ),
+      );
+      await tester.pump();
+
+      expect(reviews, isEmpty);
+      expect(terminalOutput, isEmpty);
+
+      tester.testTextInput.updateEditingValue(
+        const TextEditingValue(
+          text: '${_deleteDetectionMarker}copilot ',
+          selection: TextSelection.collapsed(offset: 10),
+        ),
+      );
+      await tester.pump();
+
+      expect(reviews, isEmpty);
+      expect(terminalOutput.join(), 'copilot ');
+
+      focusNode.dispose();
+    });
+
+    testWidgets('reviews paste-like keyboard payloads', (tester) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+      final focusNode = FocusNode();
+      final reviews = <TerminalCommandReview>[];
+      final insertedText = List.filled(
+        terminalKeyboardPasteLikeInsertionThreshold + 1,
+        'a',
+      ).join();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalTextInputHandler(
+              terminal: terminal,
+              focusNode: focusNode,
+              deleteDetection: true,
+              onReviewInsertedText: (review) async {
+                reviews.add(review);
+                return false;
+              },
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      tester.testTextInput.updateEditingValue(
+        TextEditingValue(
+          text: '$_deleteDetectionMarker$insertedText',
+          selection: TextSelection.collapsed(
+            offset: _deleteDetectionMarker.length + insertedText.length,
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(reviews, hasLength(1));
+      expect(
+        reviews.single.reasons,
+        contains(TerminalCommandReviewReason.largeKeyboardInsertion),
+      );
+      expect(terminalOutput, isEmpty);
+      expect(
+        _terminalTextInputClient(tester).currentTextEditingValue,
+        const TextEditingValue(
+          text: _deleteDetectionMarker,
+          selection: TextSelection.collapsed(offset: 2),
+        ),
+      );
+
+      focusNode.dispose();
+    });
+
     testWidgets(
       'reviews a high-risk committed IME payload after composition ends',
       (tester) async {

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -7229,6 +7229,58 @@ void main() {
     });
 
     testWidgets(
+      'strips stale iOS backspace runways after the platform drops state',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        try {
+          final harness = await _pumpTerminalHarness(tester);
+
+          tester.testTextInput.updateEditingValue(
+            _editingValue('x', selectionOffset: 1),
+          );
+          await tester.pump();
+          tester.testTextInput.updateEditingValue(
+            _editingValue('', selectionOffset: 0),
+          );
+          await tester.pump();
+
+          expect(
+            _terminalTextInputClient(tester).currentTextEditingValue,
+            _iosBackspaceRunwayValue(terminalIosBackspaceRepeatRunwayLength),
+          );
+
+          tester.testTextInput.updateEditingValue(
+            const TextEditingValue(
+              text: _deleteDetectionMarker,
+              selection: TextSelection.collapsed(offset: 2),
+            ),
+          );
+          await tester.pump();
+
+          harness.terminalOutput.clear();
+
+          tester.testTextInput.updateEditingValue(
+            _iosBackspaceRunwayValue(
+              terminalIosBackspaceRepeatRunwayLength,
+              suffix: 'add ',
+            ),
+          );
+          await tester.pump();
+
+          expect(harness.terminalOutput, ['add ']);
+          expect(
+            _terminalTextInputClient(tester).currentTextEditingValue,
+            _editingValue('add ', selectionOffset: 'add '.length),
+          );
+
+          await _disposeTerminalHarness(tester, harness);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testWidgets(
       'preserves leading zero-width text outside iOS backspace runway state',
       (tester) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -1323,21 +1323,20 @@ void main() {
   });
 
   group('TerminalTextInputHandler', () {
-    testWidgets(
-      'uses a normal text IME configuration for keyboard voice input',
-      (tester) async {
-        final harness = await _pumpTerminalHarness(tester);
-        final configuration = _latestTextInputSetClientConfiguration(tester);
-        final inputType = configuration['inputType']! as Map<dynamic, dynamic>;
+    testWidgets('disables autocorrect while preserving keyboard suggestions', (
+      tester,
+    ) async {
+      final harness = await _pumpTerminalHarness(tester);
+      final configuration = _latestTextInputSetClientConfiguration(tester);
+      final inputType = configuration['inputType']! as Map<dynamic, dynamic>;
 
-        expect(inputType['name'], 'TextInputType.text');
-        expect(configuration['autocorrect'], isTrue);
-        expect(configuration['enableSuggestions'], isTrue);
-        expect(configuration['enableIMEPersonalizedLearning'], isTrue);
+      expect(inputType['name'], 'TextInputType.text');
+      expect(configuration['autocorrect'], isFalse);
+      expect(configuration['enableSuggestions'], isTrue);
+      expect(configuration['enableIMEPersonalizedLearning'], isTrue);
 
-        await _disposeTerminalHarness(tester, harness);
-      },
-    );
+      await _disposeTerminalHarness(tester, harness);
+    });
 
     testWidgets('uses a password-friendly IME configuration for secrets', (
       tester,
@@ -7075,6 +7074,49 @@ void main() {
         }
       },
     );
+
+    testWidgets('strips duplicated iOS backspace runways before typed text', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      try {
+        final harness = await _pumpTerminalHarness(tester);
+
+        tester.testTextInput.updateEditingValue(
+          _editingValue('x', selectionOffset: 1),
+        );
+        await tester.pump();
+        tester.testTextInput.updateEditingValue(
+          _editingValue('', selectionOffset: 0),
+        );
+        await tester.pump();
+
+        expect(
+          _terminalTextInputClient(tester).currentTextEditingValue,
+          _iosBackspaceRunwayValue(terminalIosBackspaceRepeatRunwayLength),
+        );
+
+        harness.terminalOutput.clear();
+
+        tester.testTextInput.updateEditingValue(
+          _iosBackspaceRunwayValue(
+            terminalIosBackspaceRepeatRunwayLength * 2,
+            suffix: 'ls ',
+          ),
+        );
+        await tester.pump();
+
+        expect(harness.terminalOutput, ['ls ']);
+        expect(
+          _terminalTextInputClient(tester).currentTextEditingValue,
+          _editingValue('ls ', selectionOffset: 'ls '.length),
+        );
+
+        await _disposeTerminalHarness(tester, harness);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
 
     testWidgets(
       'preserves leading zero-width text outside iOS backspace runway state',


### PR DESCRIPTION
## Summary
- Disable soft-keyboard autocorrect for terminal input while keeping suggestions/dictation available.
- Strip duplicated hidden iOS backspace runway sentinels so zero-width placeholder bursts do not reach the terminal as blank characters.
- Add widget regressions for the terminal keyboard config and duplicated iOS runway leak.

## Validation
- flutter test test/widget/terminal_text_input_handler_test.dart --name 'TerminalTextInputHandler'
- flutter analyze
- pre-commit checks: dart format, flutter analyze, flutter test