### PR TITLE
fix: extend Copilot prompt backgrounds

### DIFF
--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1901,16 +1901,22 @@ class MonkeyTerminalPainter extends TerminalPainter {
     var lastContentColumn = -1;
     for (var column = runStartColumn; column < line.length; column += 1) {
       line.getCellData(column, runCell);
+      final rightEdgeDecoration = _isRightEdgeDecorationCell(
+        line,
+        column,
+        runCell,
+      );
       final matchesPromptBackground = _cellMatchesTrailingBackgroundRun(
         runCell,
         runBackground,
       );
       if (!matchesPromptBackground &&
           !_isBlankTerminalBackgroundCell(runCell) &&
-          !_isNormalTextCell(runCell)) {
+          !_isNormalTextCell(runCell) &&
+          !rightEdgeDecoration) {
         return null;
       }
-      if (!_isBlankCell(runCell)) {
+      if (!_isBlankCell(runCell) && !rightEdgeDecoration) {
         lastContentColumn = column;
       }
     }
@@ -1923,7 +1929,8 @@ class MonkeyTerminalPainter extends TerminalPainter {
     final trailingCell = CellData.empty();
     for (var column = fillStartColumn; column < line.length; column += 1) {
       line.getCellData(column, trailingCell);
-      if (!_isBlankTerminalBackgroundCell(trailingCell)) {
+      if (!_isBlankTerminalBackgroundCell(trailingCell) &&
+          !_isRightEdgeDecorationCell(line, column, trailingCell)) {
         return null;
       }
     }
@@ -1943,6 +1950,34 @@ class MonkeyTerminalPainter extends TerminalPainter {
 
   bool _isNormalTextCell(CellData cellData) =>
       !_cellPaintsBackground(cellData) && !_isBlankCell(cellData);
+
+  bool _isNormalPromptPrefixCell(CellData cellData) {
+    if (_cellPaintsBackground(cellData)) {
+      return false;
+    }
+    final charCode = cellData.content & CellContent.codepointMask;
+    return charCode == 0x276F || // ❯
+        charCode == 0x203A || // ›
+        charCode == 0x003E; // >
+  }
+
+  bool _isRightEdgeDecorationCell(
+    BufferLine line,
+    int column,
+    CellData cellData,
+  ) {
+    if (column < line.length - 2) {
+      return false;
+    }
+    final charCode = cellData.content & CellContent.codepointMask;
+    return charCode == 0x2502 || // │
+        charCode == 0x2503 || // ┃
+        charCode == 0x2551 || // ║
+        charCode == 0x2588 || // █
+        charCode == 0x258C || // ▌
+        charCode == 0x2590 || // ▐
+        charCode == 0x2595; // ▕
+  }
 
   bool _isBlankTerminalBackgroundCell(CellData cellData) {
     if (!_isBlankNormalCell(cellData)) {
@@ -1964,7 +1999,8 @@ class MonkeyTerminalPainter extends TerminalPainter {
       if (_shouldExtendTrailingBackgroundFill(firstCell)) {
         return column;
       }
-      if (!_isBlankNormalCell(firstCell)) {
+      if (!_isBlankNormalCell(firstCell) &&
+          !_isNormalPromptPrefixCell(firstCell)) {
         return null;
       }
     }

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1906,7 +1906,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
         runBackground,
       );
       if (!matchesPromptBackground &&
-          !_isBlankNormalCell(runCell) &&
+          !_isBlankTerminalBackgroundCell(runCell) &&
           !_isNormalTextCell(runCell)) {
         return null;
       }
@@ -1923,7 +1923,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
     final trailingCell = CellData.empty();
     for (var column = fillStartColumn; column < line.length; column += 1) {
       line.getCellData(column, trailingCell);
-      if (!_isBlankNormalCell(trailingCell)) {
+      if (!_isBlankTerminalBackgroundCell(trailingCell)) {
         return null;
       }
     }
@@ -1943,6 +1943,15 @@ class MonkeyTerminalPainter extends TerminalPainter {
 
   bool _isNormalTextCell(CellData cellData) =>
       !_cellPaintsBackground(cellData) && !_isBlankCell(cellData);
+
+  bool _isBlankTerminalBackgroundCell(CellData cellData) {
+    if (!_isBlankNormalCell(cellData)) {
+      return _isBlankCell(cellData) &&
+          _cellPaintsBackground(cellData) &&
+          _resolveCellBackgroundPaintColor(cellData) == theme.background;
+    }
+    return true;
+  }
 
   int? _trailingBackgroundRunStartColumn(BufferLine line, CellData firstCell) {
     line.getCellData(0, firstCell);

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1768,8 +1768,8 @@ class MonkeyTerminalPainter extends TerminalPainter {
   @override
   void paintLine(Canvas canvas, Offset offset, BufferLine line) {
     paintLineBackground(canvas, offset, line);
-    paintLineTrailingBackgroundFill(canvas, offset, line);
     super.paintLine(canvas, offset, line);
+    paintLineTrailingBackgroundFill(canvas, offset, line);
   }
 
   /// Paints only the backgrounds (line fill, trailing run, and each cell's own
@@ -1782,7 +1782,6 @@ class MonkeyTerminalPainter extends TerminalPainter {
   /// behind the next row's background.
   void paintLineBackgrounds(Canvas canvas, Offset offset, BufferLine line) {
     paintLineBackground(canvas, offset, line);
-    paintLineTrailingBackgroundFill(canvas, offset, line);
     final cellData = CellData.empty();
     final cellWidth = cellSize.width;
     for (var i = 0; i < line.length; i++) {
@@ -1793,6 +1792,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
         i++;
       }
     }
+    paintLineTrailingBackgroundFill(canvas, offset, line);
   }
 
   /// Paints only the glyphs for [line], in a pass run after every visible

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1910,9 +1910,10 @@ class MonkeyTerminalPainter extends TerminalPainter {
       return null;
     }
 
+    final trailingCell = CellData.empty();
     for (var column = fillStartColumn; column < line.length; column += 1) {
-      if (line.getCodePoint(column) != 0 ||
-          _cellColorType(line.getBackground(column)) != CellColor.normal) {
+      line.getCellData(column, trailingCell);
+      if (!_isBlankNormalCell(trailingCell)) {
         return null;
       }
     }
@@ -1934,12 +1935,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
       if (_shouldExtendTrailingBackgroundFill(firstCell)) {
         return column;
       }
-      final charCode = firstCell.content & CellContent.codepointMask;
-      final isBlankNormalCell =
-          charCode == 0 &&
-          (firstCell.flags & CellFlags.inverse) == 0 &&
-          _cellBackgroundColorType(firstCell) == CellColor.normal;
-      if (!isBlankNormalCell) {
+      if (!_isBlankNormalCell(firstCell)) {
         return null;
       }
     }
@@ -2251,6 +2247,23 @@ class MonkeyTerminalPainter extends TerminalPainter {
     return _isNeutralTerminalColor(
       resolveBackgroundColor(firstCell.background),
     );
+  }
+
+  bool _isBlankNormalCell(CellData cellData) {
+    final charCode = cellData.content & CellContent.codepointMask;
+    // TUIs commonly clear row tails with literal spaces; render those like
+    // empty cells when deciding whether a neutral prompt background can extend.
+    final visibleBlank = charCode == 0 || charCode == 0x20;
+    if (!visibleBlank) {
+      return false;
+    }
+    const visibleBlankFlags =
+        CellFlags.inverse |
+        CellFlags.underline |
+        CellFlags.overline |
+        CellFlags.strikethrough;
+    return (cellData.flags & visibleBlankFlags) == 0 &&
+        _cellBackgroundColorType(cellData) == CellColor.normal;
   }
 
   Color _resolveCellBackgroundPaintColor(

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1767,9 +1767,9 @@ class MonkeyTerminalPainter extends TerminalPainter {
 
   @override
   void paintLine(Canvas canvas, Offset offset, BufferLine line) {
-    paintLineBackground(canvas, offset, line);
-    super.paintLine(canvas, offset, line);
-    paintLineTrailingBackgroundFill(canvas, offset, line);
+    paintLineBackgrounds(canvas, offset, line);
+    paintLineForegrounds(canvas, offset, line);
+    paintLineCellUnderlines(canvas, offset, line);
   }
 
   /// Paints only the backgrounds (line fill, trailing run, and each cell's own
@@ -1898,7 +1898,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
 
     final runBackground = _resolveCellBackgroundPaintColor(firstCell);
     final runCell = CellData.empty();
-    var lastContentColumn = -1;
+    var contentEndColumn = -1;
     for (var column = runStartColumn; column < line.length; column += 1) {
       line.getCellData(column, runCell);
       final rightEdgeDecoration = _isRightEdgeDecorationCell(
@@ -1916,13 +1916,18 @@ class MonkeyTerminalPainter extends TerminalPainter {
           !rightEdgeDecoration) {
         return null;
       }
-      if (!_isBlankCell(runCell) && !rightEdgeDecoration) {
-        lastContentColumn = column;
+      if ((!_isBlankCell(runCell) ||
+              (matchesPromptBackground && _isLiteralSpaceCell(runCell))) &&
+          !rightEdgeDecoration) {
+        contentEndColumn = math.max(
+          contentEndColumn,
+          column + _cellContentColumnWidth(runCell),
+        );
       }
     }
 
-    final fillStartColumn = lastContentColumn + 1;
-    if (lastContentColumn < runStartColumn || fillStartColumn >= line.length) {
+    final fillStartColumn = contentEndColumn;
+    if (contentEndColumn < 0 || fillStartColumn >= line.length) {
       return null;
     }
 
@@ -2309,6 +2314,16 @@ class MonkeyTerminalPainter extends TerminalPainter {
   bool _isBlankCell(CellData cellData) {
     final charCode = cellData.content & CellContent.codepointMask;
     return charCode == 0 || charCode == 0x20;
+  }
+
+  bool _isLiteralSpaceCell(CellData cellData) {
+    final charCode = cellData.content & CellContent.codepointMask;
+    return charCode == 0x20;
+  }
+
+  int _cellContentColumnWidth(CellData cellData) {
+    final width = cellData.content >> CellContent.widthShift;
+    return width > 0 ? width : 1;
   }
 
   bool _isBlankNormalCell(CellData cellData) {

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1896,14 +1896,17 @@ class MonkeyTerminalPainter extends TerminalPainter {
       return null;
     }
 
-    final background = firstCell.background;
+    final runBackground = _resolveCellBackgroundPaintColor(firstCell);
     var fillStartColumn = runStartColumn;
     var hasHighlightedContent = false;
+    final runCell = CellData.empty();
     for (; fillStartColumn < line.length; fillStartColumn += 1) {
-      if (line.getBackground(fillStartColumn) != background) {
+      line.getCellData(fillStartColumn, runCell);
+      if (!_cellMatchesTrailingBackgroundRun(runCell, runBackground)) {
         break;
       }
-      hasHighlightedContent |= line.getCodePoint(fillStartColumn) != 0;
+      hasHighlightedContent |=
+          (runCell.content & CellContent.codepointMask) != 0;
     }
 
     if (!hasHighlightedContent || fillStartColumn >= line.length) {
@@ -1922,6 +1925,13 @@ class MonkeyTerminalPainter extends TerminalPainter {
       startColumn: fillStartColumn,
       color: _resolveCellBackgroundPaintColor(firstCell),
     );
+  }
+
+  bool _cellMatchesTrailingBackgroundRun(CellData cellData, Color color) {
+    if (!_cellPaintsBackground(cellData)) {
+      return false;
+    }
+    return _resolveCellBackgroundPaintColor(cellData) == color;
   }
 
   int? _trailingBackgroundRunStartColumn(BufferLine line, CellData firstCell) {
@@ -2230,10 +2240,11 @@ class MonkeyTerminalPainter extends TerminalPainter {
       _cellBackgroundColorType(cellData) != CellColor.normal;
 
   bool _shouldExtendTrailingBackgroundFill(CellData firstCell) {
-    if (firstCell.flags & CellFlags.inverse != 0) {
-      return false;
-    }
-    final backgroundType = _cellBackgroundColorType(firstCell);
+    final inverse = firstCell.flags & CellFlags.inverse != 0;
+    final backgroundSourceColor = inverse
+        ? firstCell.foreground
+        : firstCell.background;
+    final backgroundType = _cellColorType(backgroundSourceColor);
     if (backgroundType == CellColor.normal) {
       return false;
     }
@@ -2241,11 +2252,13 @@ class MonkeyTerminalPainter extends TerminalPainter {
     // background; semantic color labels should stay text-width.
     if ((backgroundType == CellColor.named ||
             backgroundType == CellColor.palette) &&
-        _cellColorValue(firstCell.background) == 8) {
+        _cellColorValue(backgroundSourceColor) == 8) {
       return true;
     }
     return _isNeutralTerminalColor(
-      resolveBackgroundColor(firstCell.background),
+      inverse
+          ? resolveForegroundColor(firstCell.foreground)
+          : resolveBackgroundColor(firstCell.background),
     );
   }
 

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1951,16 +1951,6 @@ class MonkeyTerminalPainter extends TerminalPainter {
   bool _isNormalTextCell(CellData cellData) =>
       !_cellPaintsBackground(cellData) && !_isBlankCell(cellData);
 
-  bool _isNormalPromptPrefixCell(CellData cellData) {
-    if (_cellPaintsBackground(cellData)) {
-      return false;
-    }
-    final charCode = cellData.content & CellContent.codepointMask;
-    return charCode == 0x276F || // ❯
-        charCode == 0x203A || // ›
-        charCode == 0x003E; // >
-  }
-
   bool _isRightEdgeDecorationCell(
     BufferLine line,
     int column,
@@ -1999,8 +1989,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
       if (_shouldExtendTrailingBackgroundFill(firstCell)) {
         return column;
       }
-      if (!_isBlankNormalCell(firstCell) &&
-          !_isNormalPromptPrefixCell(firstCell)) {
+      if (!_isBlankNormalCell(firstCell)) {
         return null;
       }
     }
@@ -2325,7 +2314,12 @@ class MonkeyTerminalPainter extends TerminalPainter {
   bool _isBlankNormalCell(CellData cellData) {
     // TUIs commonly clear row tails with literal spaces; render those like
     // empty cells when deciding whether a neutral prompt background can extend.
-    if (!_isBlankCell(cellData)) {
+    final charCode = cellData.content & CellContent.codepointMask;
+    if (charCode == 0) {
+      return (cellData.flags & CellFlags.inverse) == 0 &&
+          _cellBackgroundColorType(cellData) == CellColor.normal;
+    }
+    if (charCode != 0x20) {
       return false;
     }
     const visibleBlankFlags =

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1897,19 +1897,26 @@ class MonkeyTerminalPainter extends TerminalPainter {
     }
 
     final runBackground = _resolveCellBackgroundPaintColor(firstCell);
-    var fillStartColumn = runStartColumn;
-    var hasHighlightedContent = false;
     final runCell = CellData.empty();
-    for (; fillStartColumn < line.length; fillStartColumn += 1) {
-      line.getCellData(fillStartColumn, runCell);
-      if (!_cellMatchesTrailingBackgroundRun(runCell, runBackground)) {
-        break;
+    var lastContentColumn = -1;
+    for (var column = runStartColumn; column < line.length; column += 1) {
+      line.getCellData(column, runCell);
+      final matchesPromptBackground = _cellMatchesTrailingBackgroundRun(
+        runCell,
+        runBackground,
+      );
+      if (!matchesPromptBackground &&
+          !_isBlankNormalCell(runCell) &&
+          !_isNormalTextCell(runCell)) {
+        return null;
       }
-      hasHighlightedContent |=
-          (runCell.content & CellContent.codepointMask) != 0;
+      if (!_isBlankCell(runCell)) {
+        lastContentColumn = column;
+      }
     }
 
-    if (!hasHighlightedContent || fillStartColumn >= line.length) {
+    final fillStartColumn = lastContentColumn + 1;
+    if (lastContentColumn < runStartColumn || fillStartColumn >= line.length) {
       return null;
     }
 
@@ -1933,6 +1940,9 @@ class MonkeyTerminalPainter extends TerminalPainter {
     }
     return _resolveCellBackgroundPaintColor(cellData) == color;
   }
+
+  bool _isNormalTextCell(CellData cellData) =>
+      !_cellPaintsBackground(cellData) && !_isBlankCell(cellData);
 
   int? _trailingBackgroundRunStartColumn(BufferLine line, CellData firstCell) {
     line.getCellData(0, firstCell);
@@ -2262,12 +2272,15 @@ class MonkeyTerminalPainter extends TerminalPainter {
     );
   }
 
-  bool _isBlankNormalCell(CellData cellData) {
+  bool _isBlankCell(CellData cellData) {
     final charCode = cellData.content & CellContent.codepointMask;
+    return charCode == 0 || charCode == 0x20;
+  }
+
+  bool _isBlankNormalCell(CellData cellData) {
     // TUIs commonly clear row tails with literal spaces; render those like
     // empty cells when deciding whether a neutral prompt background can extend.
-    final visibleBlank = charCode == 0 || charCode == 0x20;
-    if (!visibleBlank) {
+    if (!_isBlankCell(cellData)) {
       return false;
     }
     const visibleBlankFlags =

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -852,6 +852,28 @@ void main() {
       },
     );
 
+    test('extends Copilot prompts past right-edge scrollbar glyphs', () {
+      const promptBackground = Color(0xFFD0DAD9);
+      const promptBackgroundSequence = '\x1b[48;2;208;218;217m';
+      const promptText = '❯ test';
+      final terminal = Terminal()
+        ..resize(48, 2)
+        ..write('❯ ${promptBackgroundSequence}test\x1b[m\x1b[48G│');
+      final painter = MonkeyTerminalPainter(
+        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
+        textStyle: const TerminalStyle(),
+        textScaler: TextScaler.noScaling,
+      );
+
+      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
+        terminal.buffer.lines[0],
+      );
+
+      expect(fill, isNotNull);
+      expect(fill!.startColumn, promptText.length);
+      expect(fill.color, promptBackground);
+    });
+
     test(
       'extends neutral truecolor composer rows after blank leading cells',
       () {

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -708,6 +708,31 @@ void main() {
       );
     });
 
+    test('extends Copilot prompt rows across trailing normal spaces', () {
+      const copilotPromptStyle = '\x1b[38;2;180;180;180;48;2;32;32;32m';
+      final terminal = Terminal()
+        ..resize(48, 2)
+        ..write(
+          '$copilotPromptStyle❯\x1b[39m once everything is addressed\x1b[m     ',
+        );
+      final painter = MonkeyTerminalPainter(
+        theme: TerminalThemes.defaultDarkTheme.toXtermTheme(),
+        textStyle: const TerminalStyle(),
+        textScaler: TextScaler.noScaling,
+      );
+
+      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
+        terminal.buffer.lines[0],
+      );
+
+      expect(fill, isNotNull);
+      expect(fill!.startColumn, '❯ once everything is addressed'.length);
+      expect(
+        _contrastRatio(fill.color, TerminalThemes.defaultDarkTheme.background),
+        inInclusiveRange(1.04, 1.75),
+      );
+    });
+
     test(
       'extends neutral truecolor composer rows after blank leading cells',
       () {

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -801,6 +801,32 @@ void main() {
       },
     );
 
+    test('extends Copilot prompts over explicit terminal-background tails', () {
+      const promptBackground = Color(0xFFD0DAD9);
+      const promptBackgroundSequence = '\x1b[48;2;208;218;217m';
+      const terminalBackgroundSequence = '\x1b[48;2;235;243;242m';
+      const promptText = '❯ did it work';
+      final terminal = Terminal()
+        ..resize(48, 2)
+        ..write(
+          '$promptBackgroundSequence❯ \x1b[mdid it work'
+          '$terminalBackgroundSequence     \x1b[m',
+        );
+      final painter = MonkeyTerminalPainter(
+        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
+        textStyle: const TerminalStyle(),
+        textScaler: TextScaler.noScaling,
+      );
+
+      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
+        terminal.buffer.lines[0],
+      );
+
+      expect(fill, isNotNull);
+      expect(fill!.startColumn, promptText.length);
+      expect(fill.color, promptBackground);
+    });
+
     test(
       'extends neutral truecolor composer rows after blank leading cells',
       () {

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -761,7 +761,10 @@ void main() {
         const promptText = '❯ did it work?';
         final terminal = Terminal()
           ..resize(48, 2)
-          ..write('$promptBackgroundSequence❯ \x1b[mdid it work?');
+          ..write(
+            '\x1b[2;4m\x1b[K\r'
+            '$promptBackgroundSequence❯ \x1b[mdid it work?',
+          );
         final theme = TerminalThemes.defaultLightTheme.toXtermTheme();
         final painter = MonkeyTerminalPainter(
           theme: theme,
@@ -858,7 +861,10 @@ void main() {
       const promptText = '❯ test';
       final terminal = Terminal()
         ..resize(48, 2)
-        ..write('❯ ${promptBackgroundSequence}test\x1b[m\x1b[48G│');
+        ..write(
+          '\x1b[2;4m\x1b[K\r'
+          '$promptBackgroundSequence❯ test\x1b[m\x1b[48G│',
+        );
       final painter = MonkeyTerminalPainter(
         theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
         textStyle: const TerminalStyle(),

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -754,6 +754,54 @@ void main() {
     });
 
     test(
+      'paints Copilot prompt marker background through normal text rows',
+      () async {
+        const promptBackground = Color(0xFFD0DAD9);
+        const promptBackgroundSequence = '\x1b[48;2;208;218;217m';
+        const promptText = '❯ did it work?';
+        final terminal = Terminal()
+          ..resize(48, 2)
+          ..write('$promptBackgroundSequence❯ \x1b[mdid it work?');
+        final theme = TerminalThemes.defaultLightTheme.toXtermTheme();
+        final painter = MonkeyTerminalPainter(
+          theme: theme,
+          textStyle: const TerminalStyle(),
+          textScaler: TextScaler.noScaling,
+        );
+        final cellSize = painter.cellSize;
+        final imageWidth = (cellSize.width * terminal.viewWidth).ceil();
+        final imageHeight = cellSize.height.ceil();
+        final recorder = ui.PictureRecorder();
+        final canvas = Canvas(recorder);
+
+        painter.paintLine(canvas, Offset.zero, terminal.buffer.lines[0]);
+
+        final image = await recorder.endRecording().toImage(
+          imageWidth,
+          imageHeight,
+        );
+        final byteData = await image.toByteData();
+        expect(byteData, isNotNull);
+
+        final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
+          terminal.buffer.lines[0],
+        );
+        expect(fill, isNotNull);
+        expect(fill!.startColumn, promptText.length);
+        expect(fill.color, promptBackground);
+        expect(
+          _rawRgbaPixel(
+            byteData!,
+            imageWidth,
+            ((promptText.length + 4) * cellSize.width).round(),
+            (cellSize.height / 2).round(),
+          ),
+          promptBackground,
+        );
+      },
+    );
+
+    test(
       'extends neutral truecolor composer rows after blank leading cells',
       () {
         final terminal = Terminal()

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -801,31 +801,56 @@ void main() {
       },
     );
 
-    test('extends Copilot prompts over explicit terminal-background tails', () {
-      const promptBackground = Color(0xFFD0DAD9);
-      const promptBackgroundSequence = '\x1b[48;2;208;218;217m';
-      const terminalBackgroundSequence = '\x1b[48;2;235;243;242m';
-      const promptText = '❯ did it work';
-      final terminal = Terminal()
-        ..resize(48, 2)
-        ..write(
-          '$promptBackgroundSequence❯ \x1b[mdid it work'
-          '$terminalBackgroundSequence     \x1b[m',
+    test(
+      'paints Copilot prompts over explicit terminal-background tails',
+      () async {
+        const promptBackground = Color(0xFFD0DAD9);
+        const promptBackgroundSequence = '\x1b[48;2;208;218;217m';
+        const terminalBackgroundSequence = '\x1b[48;2;235;243;242m';
+        const promptText = '❯ did it work';
+        final terminal = Terminal()
+          ..resize(48, 2)
+          ..write(
+            '$promptBackgroundSequence❯ \x1b[mdid it work'
+            '$terminalBackgroundSequence     \x1b[m',
+          );
+        final painter = MonkeyTerminalPainter(
+          theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
+          textStyle: const TerminalStyle(),
+          textScaler: TextScaler.noScaling,
         );
-      final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
-        textStyle: const TerminalStyle(),
-        textScaler: TextScaler.noScaling,
-      );
+        final cellSize = painter.cellSize;
+        final imageWidth = (cellSize.width * terminal.viewWidth).ceil();
+        final imageHeight = cellSize.height.ceil();
+        final recorder = ui.PictureRecorder();
+        final canvas = Canvas(recorder);
 
-      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
-        terminal.buffer.lines[0],
-      );
+        painter.paintLine(canvas, Offset.zero, terminal.buffer.lines[0]);
 
-      expect(fill, isNotNull);
-      expect(fill!.startColumn, promptText.length);
-      expect(fill.color, promptBackground);
-    });
+        final image = await recorder.endRecording().toImage(
+          imageWidth,
+          imageHeight,
+        );
+        final byteData = await image.toByteData();
+        expect(byteData, isNotNull);
+
+        final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
+          terminal.buffer.lines[0],
+        );
+        expect(fill, isNotNull);
+        expect(fill!.startColumn, promptText.length);
+        expect(fill.color, promptBackground);
+        expect(
+          _rawRgbaPixel(
+            byteData!,
+            imageWidth,
+            ((promptText.length + 4) * cellSize.width).round(),
+            (cellSize.height / 2).round(),
+          ),
+          promptBackground,
+        );
+      },
+    );
 
     test(
       'extends neutral truecolor composer rows after blank leading cells',

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -733,6 +733,48 @@ void main() {
       );
     });
 
+    test('counts prompt-background spaces as prompt row content', () {
+      const promptBackground = Color(0xFFD0DAD9);
+      const promptBackgroundSequence = '\x1b[48;2;208;218;217m';
+      final terminal = Terminal()
+        ..resize(48, 2)
+        ..write('$promptBackgroundSequence❯ \x1b[m');
+      final painter = MonkeyTerminalPainter(
+        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
+        textStyle: const TerminalStyle(),
+        textScaler: TextScaler.noScaling,
+      );
+
+      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
+        terminal.buffer.lines[0],
+      );
+
+      expect(fill, isNotNull);
+      expect(fill!.startColumn, '❯ '.length);
+      expect(fill.color, promptBackground);
+    });
+
+    test('starts Copilot prompt tail fill after full double-width glyphs', () {
+      const promptBackground = Color(0xFFD0DAD9);
+      const promptBackgroundSequence = '\x1b[48;2;208;218;217m';
+      final terminal = Terminal()
+        ..resize(48, 2)
+        ..write('$promptBackgroundSequence❯ 中\x1b[m');
+      final painter = MonkeyTerminalPainter(
+        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
+        textStyle: const TerminalStyle(),
+        textScaler: TextScaler.noScaling,
+      );
+
+      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
+        terminal.buffer.lines[0],
+      );
+
+      expect(fill, isNotNull);
+      expect(fill!.startColumn, 4);
+      expect(fill.color, promptBackground);
+    });
+
     test('extends inverse Copilot prompt rows on light themes', () {
       const copilotPromptStyle = '\x1b[38;2;180;180;180;7m';
       final terminal = Terminal()
@@ -878,6 +920,42 @@ void main() {
       expect(fill, isNotNull);
       expect(fill!.startColumn, promptText.length);
       expect(fill.color, promptBackground);
+    });
+
+    test('keeps right-edge scrollbar glyphs over prompt tail fills', () async {
+      const promptBackgroundSequence = '\x1b[48;2;208;218;217m';
+      final terminal = Terminal()
+        ..resize(48, 2)
+        ..write('$promptBackgroundSequence❯ test\x1b[m\x1b[48G█');
+      final theme = TerminalThemes.defaultLightTheme.toXtermTheme();
+      final painter = MonkeyTerminalPainter(
+        theme: theme,
+        textStyle: const TerminalStyle(),
+        textScaler: TextScaler.noScaling,
+      );
+      final cellSize = painter.cellSize;
+      final imageWidth = (cellSize.width * terminal.viewWidth).ceil();
+      final imageHeight = cellSize.height.ceil();
+      final recorder = ui.PictureRecorder();
+      final canvas = Canvas(recorder);
+
+      painter.paintLine(canvas, Offset.zero, terminal.buffer.lines[0]);
+
+      final image = await recorder.endRecording().toImage(
+        imageWidth,
+        imageHeight,
+      );
+      final byteData = await image.toByteData();
+      expect(byteData, isNotNull);
+      expect(
+        _rawRgbaPixel(
+          byteData!,
+          imageWidth,
+          ((terminal.viewWidth - 0.5) * cellSize.width).round(),
+          (cellSize.height / 2).round(),
+        ),
+        theme.foreground,
+      );
     });
 
     test(

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -733,6 +733,26 @@ void main() {
       );
     });
 
+    test('extends inverse Copilot prompt rows on light themes', () {
+      const copilotPromptStyle = '\x1b[38;2;180;180;180;7m';
+      final terminal = Terminal()
+        ..resize(48, 2)
+        ..write('$copilotPromptStyle❯ what is the easiest way?\x1b[m     ');
+      final painter = MonkeyTerminalPainter(
+        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
+        textStyle: const TerminalStyle(),
+        textScaler: TextScaler.noScaling,
+      );
+
+      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
+        terminal.buffer.lines[0],
+      );
+
+      expect(fill, isNotNull);
+      expect(fill!.startColumn, '❯ what is the easiest way?'.length);
+      expect(fill.color, const Color(0xFFB4B4B4));
+    });
+
     test(
       'extends neutral truecolor composer rows after blank leading cells',
       () {


### PR DESCRIPTION
## Summary
- Treat normal literal space cells as blank when extending neutral terminal prompt backgrounds.
- This lets submitted Copilot prompt rows keep the prompt background through the row tail after the CLI clears with spaces.
- Add a regression test using Copilot-style ANSI truecolor prompt output.

## Validation
- dart format lib/presentation/widgets/monkey_terminal_view.dart test/widget/monkey_terminal_view_layout_test.dart
- flutter test test/widget/monkey_terminal_view_layout_test.dart
- flutter analyze