### PR TITLE
fix: harden SSH cleanup after disconnect

### DIFF
--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -916,14 +916,14 @@ Future<void> _closeMonkeyMuxExecSession(
   SSHSession execSession, {
   required SshSession ownerSession,
   required String operation,
-}) => _closeMonkeyMuxSessionStdin(
+}) => _closeMonkeyMuxSession(
   execSession,
   connectionId: ownerSession.connectionId,
   category: 'monkeymux.control',
   operation: operation,
 );
 
-Future<void> _closeMonkeyMuxSessionStdin(
+Future<void> _closeMonkeyMuxSession(
   SSHSession session, {
   required int connectionId,
   required String category,
@@ -948,6 +948,34 @@ Future<void> _closeMonkeyMuxSessionStdin(
       },
     );
   }
+
+  _closeSshSessionBestEffort(
+    session,
+    connectionId: connectionId,
+    category: category,
+    operation: operation,
+  );
+}
+
+void _closeSshSessionBestEffort(
+  SSHSession session, {
+  required int connectionId,
+  required String category,
+  required String operation,
+}) {
+  void logFailure(Object error) {
+    DiagnosticsLogService.instance.warning(
+      category,
+      'session_close_failed',
+      fields: {
+        'connectionId': connectionId,
+        'operation': operation,
+        'errorType': error.runtimeType,
+      },
+    );
+  }
+
+  runZonedGuarded(session.close, (error, _) => logFailure(error));
 }
 
 class _MonkeyMuxWindowChangeObserver {
@@ -1193,7 +1221,7 @@ class _MonkeyMuxWindowChangeObserver {
   Future<void> _closeControlSession(
     SSHSession controlSession, {
     required String operation,
-  }) => _closeMonkeyMuxSessionStdin(
+  }) => _closeMonkeyMuxSession(
     controlSession,
     connectionId: session.connectionId,
     category: 'monkeymux.watch',

--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -26,6 +26,7 @@ typedef _MonkeyMuxAgentSessionMetadata = ({
 
 const _oneShotControlResponseTimeout = Duration(seconds: 10);
 const _oneShotRunCommandResponseTimeout = Duration(seconds: 25);
+const _monkeyMuxSessionStdinCloseTimeout = Duration(milliseconds: 250);
 
 /// MonkeyMux-backed implementation of [RemoteMultiplexerService].
 final monkeyMuxServiceProvider = Provider<MonkeyMuxService>(
@@ -861,8 +862,11 @@ Future<_MonkeyMuxControlResponse> _runOneShotControlCommand(
       return response;
     }
   } finally {
-    await execSession.stdin.close();
-    execSession.close();
+    await _closeMonkeyMuxExecSession(
+      execSession,
+      ownerSession: session,
+      operation: 'one_shot_control',
+    );
   }
   throw const MonkeyMuxInstallException(
     'MonkeyMux control command closed without a response.',
@@ -899,10 +903,51 @@ Future<MonkeyMuxServerStatus?> _readRunningServerStatus(
   } on TimeoutException {
     return null;
   } finally {
-    await execSession.stdin.close();
-    execSession.close();
+    await _closeMonkeyMuxExecSession(
+      execSession,
+      ownerSession: session,
+      operation: 'server_status',
+    );
   }
   return null;
+}
+
+Future<void> _closeMonkeyMuxExecSession(
+  SSHSession execSession, {
+  required SshSession ownerSession,
+  required String operation,
+}) => _closeMonkeyMuxSessionStdin(
+  execSession,
+  connectionId: ownerSession.connectionId,
+  category: 'monkeymux.control',
+  operation: operation,
+);
+
+Future<void> _closeMonkeyMuxSessionStdin(
+  SSHSession session, {
+  required int connectionId,
+  required String category,
+  required String operation,
+}) async {
+  try {
+    await session.stdin.close().timeout(_monkeyMuxSessionStdinCloseTimeout);
+  } on TimeoutException {
+    DiagnosticsLogService.instance.warning(
+      category,
+      'stdin_close_timed_out',
+      fields: {'connectionId': connectionId, 'operation': operation},
+    );
+  } on Object catch (error) {
+    DiagnosticsLogService.instance.warning(
+      category,
+      'stdin_close_failed',
+      fields: {
+        'connectionId': connectionId,
+        'operation': operation,
+        'errorType': error.runtimeType,
+      },
+    );
+  }
 }
 
 class _MonkeyMuxWindowChangeObserver {
@@ -1012,7 +1057,7 @@ class _MonkeyMuxWindowChangeObserver {
           '${_shellQuote(sessionName)}';
       final controlSession = await session.execute(command);
       if (_disposed) {
-        controlSession.close();
+        await _closeControlSession(controlSession, operation: 'start_disposed');
         return;
       }
       _controlSession = controlSession;
@@ -1046,7 +1091,13 @@ class _MonkeyMuxWindowChangeObserver {
           ? _normalCommandQueue.removeFirst()
           : _lowCommandQueue.removeFirst();
       _pendingCommands[request.id] = request;
-      controlSession.write(utf8.encode('${jsonEncode(request.payload)}\n'));
+      try {
+        controlSession.write(utf8.encode('${jsonEncode(request.payload)}\n'));
+      } on Object catch (error, stackTrace) {
+        _pendingCommands.remove(request.id);
+        _handleError(error, stackTrace);
+        Error.throwWithStackTrace(error, stackTrace);
+      }
     }
   }
 
@@ -1134,8 +1185,20 @@ class _MonkeyMuxWindowChangeObserver {
       if (stdoutSubscription != null) stdoutSubscription.cancel(),
       if (doneSubscription != null) doneSubscription.cancel(),
     ]);
-    controlSession?.close();
+    if (controlSession != null) {
+      await _closeControlSession(controlSession, operation: 'observer_cleanup');
+    }
   }
+
+  Future<void> _closeControlSession(
+    SSHSession controlSession, {
+    required String operation,
+  }) => _closeMonkeyMuxSessionStdin(
+    controlSession,
+    connectionId: session.connectionId,
+    category: 'monkeymux.watch',
+    operation: operation,
+  );
 
   void _scheduleReconnect() {
     if (_disposed ||

--- a/lib/domain/services/ssh_session_runtime.dart
+++ b/lib/domain/services/ssh_session_runtime.dart
@@ -5,6 +5,8 @@ class _SshSessionRuntime {
 
   final SshSession _session;
 
+  static const _stdinCloseTimeout = Duration(milliseconds: 250);
+
   SSHSession? _shell;
   StreamController<String>? _shellStdoutController;
   StreamController<String>? _shellStderrController;
@@ -235,7 +237,27 @@ class _SshSessionRuntime {
     _shellStderrController = null;
     _shellDoneController = null;
 
-    _shell?.close();
+    final shell = _shell;
+    if (shell != null) {
+      try {
+        await shell.stdin.close().timeout(_stdinCloseTimeout);
+      } on TimeoutException {
+        DiagnosticsLogService.instance.warning(
+          'ssh.shell',
+          'stdin_close_timed_out',
+          fields: {'connectionId': _session.connectionId},
+        );
+      } on Object catch (error) {
+        DiagnosticsLogService.instance.warning(
+          'ssh.shell',
+          'stdin_close_failed',
+          fields: {
+            'connectionId': _session.connectionId,
+            'errorType': error.runtimeType,
+          },
+        );
+      }
+    }
     _shell = null;
     _session._resetShellRuntimeMetadata();
     _terminalWindowMetrics = null;

--- a/lib/domain/services/ssh_session_runtime.dart
+++ b/lib/domain/services/ssh_session_runtime.dart
@@ -257,6 +257,7 @@ class _SshSessionRuntime {
           },
         );
       }
+      _closeShellBestEffort(shell);
     }
     _shell = null;
     _session._resetShellRuntimeMetadata();
@@ -273,6 +274,21 @@ class _SshSessionRuntime {
       'close_complete',
       fields: {'connectionId': _session.connectionId},
     );
+  }
+
+  void _closeShellBestEffort(SSHSession shell) {
+    void logFailure(Object error) {
+      DiagnosticsLogService.instance.warning(
+        'ssh.shell',
+        'close_failed',
+        fields: {
+          'connectionId': _session.connectionId,
+          'errorType': error.runtimeType,
+        },
+      );
+    }
+
+    runZonedGuarded(shell.close, (error, _) => logFailure(error));
   }
 
   void _ensureShellStreamPipes() {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3016,6 +3016,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   Timer? _monkeyMuxPostRedrawDisplayRefreshTimer;
   final List<Timer> _monkeyMuxSettledRedrawDisplayRefreshTimers = <Timer>[];
   int _monkeyMuxSettledRedrawDisplayRefreshGeneration = 0;
+  int _monkeyMuxRefreshAndResizeGeneration = 0;
   Timer? _muxWindowRefreshProbeTimer;
   Timer? _muxWindowRefreshSafetyNetTimer;
   DateTime? _lastMuxWindowChangeAt;
@@ -6477,12 +6478,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       session,
       reason: 'window_change_replay',
     );
+    final generation = _monkeyMuxRefreshAndResizeGeneration;
     _monkeyMuxWindowRefreshFollowUpTimer?.cancel();
     _monkeyMuxWindowRefreshFollowUpTimer = Timer(
       const Duration(milliseconds: 50),
       () {
         _monkeyMuxWindowRefreshFollowUpTimer = null;
         if (!mounted ||
+            generation != _monkeyMuxRefreshAndResizeGeneration ||
             _isTerminalOutputFollowPaused ||
             _connectionId != session.connectionId) {
           return;
@@ -6576,11 +6579,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
     final connectionId = session.connectionId;
+    final generation = _monkeyMuxRefreshAndResizeGeneration;
     _monkeyMuxResizeSyncInFlight = true;
     _monkeyMuxResizeSyncThrottled = true;
     _monkeyMuxResizeSyncCooldownTimer?.cancel();
     _monkeyMuxResizeSyncCooldownTimer = Timer(minGap, () {
       _monkeyMuxResizeSyncCooldownTimer = null;
+      if (generation != _monkeyMuxRefreshAndResizeGeneration) {
+        return;
+      }
       _monkeyMuxResizeSyncThrottled = false;
       _maybeSendPendingMonkeyMuxResizeSync(session, connectionId);
     });
@@ -6592,8 +6599,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           rows: rows,
         );
       } finally {
-        _monkeyMuxResizeSyncInFlight = false;
-        _maybeSendPendingMonkeyMuxResizeSync(session, connectionId);
+        if (generation == _monkeyMuxRefreshAndResizeGeneration) {
+          _monkeyMuxResizeSyncInFlight = false;
+          _maybeSendPendingMonkeyMuxResizeSync(session, connectionId);
+        }
       }
     }());
   }
@@ -6626,12 +6635,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
     final connectionId = session.connectionId;
+    final generation = _monkeyMuxRefreshAndResizeGeneration;
     _monkeyMuxResizeRedrawFollowUpTimer?.cancel();
     _monkeyMuxResizeRedrawFollowUpTimer = Timer(
       _monkeyMuxResizeRedrawFollowUpDelay,
       () {
         _monkeyMuxResizeRedrawFollowUpTimer = null;
-        if (!mounted || _connectionId != connectionId) {
+        if (!mounted ||
+            generation != _monkeyMuxRefreshAndResizeGeneration ||
+            _connectionId != connectionId) {
           return;
         }
         unawaited(
@@ -6645,12 +6657,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   void _scheduleMonkeyMuxPostRedrawDisplayRefresh(int connectionId) {
+    final generation = _monkeyMuxRefreshAndResizeGeneration;
     _monkeyMuxPostRedrawDisplayRefreshTimer?.cancel();
     _monkeyMuxPostRedrawDisplayRefreshTimer = Timer(
       _monkeyMuxPostRedrawDisplayRefreshDelay,
       () {
         _monkeyMuxPostRedrawDisplayRefreshTimer = null;
-        if (!mounted || _connectionId != connectionId) {
+        if (!mounted ||
+            generation != _monkeyMuxRefreshAndResizeGeneration ||
+            _connectionId != connectionId) {
           return;
         }
         _refreshTerminalDisplayAfterMonkeyMuxRedraw(
@@ -6701,6 +6716,26 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _monkeyMuxSettledRedrawDisplayRefreshTimers.clear();
   }
 
+  void _cancelMonkeyMuxRefreshAndResizeState() {
+    _monkeyMuxRefreshAndResizeGeneration += 1;
+    _monkeyMuxWindowRefreshFollowUpTimer?.cancel();
+    _monkeyMuxWindowRefreshFollowUpTimer = null;
+    _monkeyMuxResizeRedrawFollowUpTimer?.cancel();
+    _monkeyMuxResizeRedrawFollowUpTimer = null;
+    _monkeyMuxResizeSyncCooldownTimer?.cancel();
+    _monkeyMuxResizeSyncCooldownTimer = null;
+    _monkeyMuxResizeSyncInFlight = false;
+    _monkeyMuxResizeSyncThrottled = false;
+    _monkeyMuxResizeSyncPending = false;
+    _monkeyMuxResizeSyncColumns = null;
+    _monkeyMuxResizeSyncRows = null;
+    _monkeyMuxPostRedrawDisplayRefreshTimer?.cancel();
+    _monkeyMuxPostRedrawDisplayRefreshTimer = null;
+    _cancelMonkeyMuxSettledRedrawDisplayRefreshes();
+    _pendingMonkeyMuxResizeSyncs.clear();
+    _lastMonkeyMuxResizeSync = null;
+  }
+
   void _refreshTerminalDisplayAfterMonkeyMuxRedraw({
     required int connectionId,
     required String reason,
@@ -6741,6 +6776,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     int? rows,
     bool refreshVisibleTerminal = false,
   }) async {
+    final generation = _monkeyMuxRefreshAndResizeGeneration;
     final isMonkeyMuxSession =
         _activeMuxBackend == RemoteMuxBackend.monkeyMux ||
         session.remoteMuxBackend == RemoteMuxBackend.monkeyMux;
@@ -6808,6 +6844,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       );
       _lastMonkeyMuxResizeSync = resizeKey;
       if (refreshVisibleTerminal) {
+        if (generation != _monkeyMuxRefreshAndResizeGeneration) {
+          return;
+        }
         _scheduleMonkeyMuxPostRedrawDisplayRefresh(session.connectionId);
         _scheduleMonkeyMuxSettledRedrawDisplayRefreshes(
           session,
@@ -7659,6 +7698,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   void _clearTmuxState() {
     _stopTmuxForegroundVerification();
+    _cancelMonkeyMuxRefreshAndResizeState();
     _cancelPendingTmuxWindowThemeRefresh();
     _tmuxDetectionGeneration += 1;
     _isTmuxActive = false;
@@ -9521,11 +9561,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _stopTmuxForegroundVerification();
     _promptOutputImeResetTimer?.cancel();
     _shellCompletionDebounceTimer?.cancel();
-    _monkeyMuxWindowRefreshFollowUpTimer?.cancel();
-    _monkeyMuxResizeRedrawFollowUpTimer?.cancel();
-    _monkeyMuxResizeSyncCooldownTimer?.cancel();
-    _monkeyMuxPostRedrawDisplayRefreshTimer?.cancel();
-    _cancelMonkeyMuxSettledRedrawDisplayRefreshes();
+    _cancelMonkeyMuxRefreshAndResizeState();
     _muxWindowRefreshProbeTimer?.cancel();
     _muxWindowRefreshSafetyNetTimer?.cancel();
     _disposeTerminalPathVerificationSftp();

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -6842,7 +6842,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           'refreshedVisibleTerminal': refreshVisibleTerminal,
         },
       );
-      _lastMonkeyMuxResizeSync = resizeKey;
+      if (generation == _monkeyMuxRefreshAndResizeGeneration) {
+        _lastMonkeyMuxResizeSync = resizeKey;
+      }
       if (refreshVisibleTerminal) {
         if (generation != _monkeyMuxRefreshAndResizeGeneration) {
           return;


### PR DESCRIPTION
## Summary

- harden MonkeyMux control cleanup by using bounded stdin shutdown instead of dartssh2 SSHSession.close
- harden interactive shell cleanup against close-after-transport-disconnect races
- invalidate MonkeyMux redraw and resize timers/in-flight state when mux state is cleared

## Validation

- flutter analyze
- flutter test test/domain/services/monkeymux_service_test.dart test/presentation/screens/terminal_screen_test.dart test/widget/monkey_terminal_view_resize_test.dart
