### PR TITLE
fix: preserve keyboard when toggling extra keys

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -10084,12 +10084,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   void _toggleKeyboardToolbar() {
     final nextValue = !_showKeyboardToolbar;
+    final shouldRestoreSystemKeyboard =
+        _isMobilePlatform &&
+        (_terminalTextInputController.isKeyboardVisible ||
+            MediaQuery.viewInsetsOf(context).bottom > 0);
     unawaited(
       ref
           .read(telemetryServiceProvider)
           .logKeyboardToolbarToggled(enabled: nextValue),
     );
     setState(() => _showKeyboardToolbar = nextValue);
+    if (shouldRestoreSystemKeyboard) {
+      _restoreTerminalFocus(forceShowSystemKeyboard: true);
+    }
   }
 
   /// Restores focus to the terminal after a UI interaction.

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -6311,6 +6311,38 @@ void main() {
     );
 
     testWidgets(
+      'extra keys toggle preserves the visible mobile keyboard',
+      (tester) async {
+        await pumpScreen(tester);
+
+        await tester.tap(find.byType(MonkeyTerminalView));
+        await tester.pump();
+
+        expect(tester.testTextInput.isVisible, isTrue);
+
+        Future<void> expectKeyboardReshownAfterToggle(String tooltip) async {
+          tester.testTextInput.log.clear();
+
+          await tester.tap(find.byTooltip(tooltip));
+          await tester.pump();
+          await tester.pump();
+
+          expect(
+            tester.testTextInput.log.where(
+              (call) => call.method == 'TextInput.show',
+            ),
+            isNotEmpty,
+          );
+          expect(tester.testTextInput.isVisible, isTrue);
+        }
+
+        await expectKeyboardReshownAfterToggle('Hide extra keys');
+        await expectKeyboardReshownAfterToggle('Show extra keys');
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
       'terminal overflow menu stays above the visible mobile keyboard',
       (tester) async {
         tester.view


### PR DESCRIPTION
## Summary
- keep the system keyboard visible when toggling the extra-keys toolbar if it was already open
- cover both hiding and showing the extra-keys toolbar with a mobile IME regression test

## Validation
- flutter test test/presentation/screens/terminal_screen_test.dart --name "extra keys toggle preserves the visible mobile keyboard"
- flutter analyze