### PR TITLE
fix: accept dartssh host key fingerprints

### DIFF
--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -1723,7 +1723,7 @@ class SshService {
           final trusted = _trustedHostMatchesCallback(trustedHost, fingerprint);
           rejectedTrustedHostKey = !trusted;
           if (!trusted) {
-            rejectedCallbackFingerprint = _formatLegacyFingerprintBytes(
+            rejectedCallbackFingerprint = _formatCallbackHostKeyFingerprint(
               fingerprint,
             );
           }
@@ -1948,7 +1948,7 @@ class SshService {
         username: config.username,
         onVerifyHostKey: (type, fingerprint) {
           callbackKeyType = type;
-          callbackFingerprint = _formatLegacyFingerprintBytes(fingerprint);
+          callbackFingerprint = _formatCallbackHostKeyFingerprint(fingerprint);
           return true;
         },
       );
@@ -2027,7 +2027,10 @@ class SshService {
     required SshConnectionConfig config,
   }) {
     if (callbackFingerprint != null &&
-        callbackFingerprint != presentedHostKey.md5Fingerprint) {
+        !_hostKeyFingerprintMatchesPresentedKey(
+          presentedHostKey,
+          callbackFingerprint,
+        )) {
       throw HostKeyVerificationException(
         'Failed to confirm the presented host key for '
         '${config.hostname}:${config.port}.',
@@ -2041,16 +2044,47 @@ class SshService {
   ) => sshHostTrustMatches(
     firstFingerprint: trustedHost.fingerprint,
     firstEncodedHostKey: trustedHost.hostKey,
-    secondFingerprint: _formatLegacyFingerprintBytes(fingerprint),
+    secondFingerprint: _formatCallbackHostKeyFingerprint(fingerprint),
     secondEncodedHostKey: '',
   );
 
   bool _probedHostKeyMatchesCallback(
     VerifiedHostKey presentedHostKey,
     Uint8List fingerprint,
-  ) =>
-      presentedHostKey.md5Fingerprint ==
-      _formatLegacyFingerprintBytes(fingerprint);
+  ) => _hostKeyFingerprintMatchesPresentedKey(
+    presentedHostKey,
+    _formatCallbackHostKeyFingerprint(fingerprint),
+  );
+
+  bool _hostKeyFingerprintMatchesPresentedKey(
+    VerifiedHostKey presentedHostKey,
+    String callbackFingerprint,
+  ) => sshHostTrustMatches(
+    firstFingerprint: presentedHostKey.fingerprint,
+    firstEncodedHostKey: presentedHostKey.encodedHostKey,
+    secondFingerprint: callbackFingerprint,
+    secondEncodedHostKey: '',
+  );
+
+  String _formatCallbackHostKeyFingerprint(Uint8List fingerprint) {
+    final openSshFingerprint = _tryDecodeOpenSshHostKeyFingerprint(fingerprint);
+    if (openSshFingerprint != null) {
+      return openSshFingerprint;
+    }
+    return _formatLegacyFingerprintBytes(fingerprint);
+  }
+
+  String? _tryDecodeOpenSshHostKeyFingerprint(Uint8List fingerprint) {
+    try {
+      final text = utf8.decode(fingerprint);
+      if (text.startsWith('SHA256:')) {
+        return text;
+      }
+    } on FormatException {
+      return null;
+    }
+    return null;
+  }
 
   String _formatLegacyFingerprintBytes(Uint8List fingerprint) => fingerprint
       .map((value) => value.toRadixString(16).padLeft(2, '0'))

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -5,7 +5,6 @@ import 'dart:typed_data';
 
 // ignore_for_file: public_member_api_docs
 
-import 'package:crypto/crypto.dart';
 import 'package:dartssh2/dartssh2.dart';
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:drift/native.dart';
@@ -2582,7 +2581,7 @@ void main() {
                   final bytes = await (socket as HostKeySource).hostKeyBytes;
                   final trusted = await onVerifyHostKey!(
                     'ssh-ed25519',
-                    Uint8List.fromList(md5.convert(bytes).bytes),
+                    _hostKeyCallbackFingerprint(bytes),
                   );
                   expect(trusted, isTrue);
                 });
@@ -2700,7 +2699,7 @@ void main() {
                 final bytes = await (socket as HostKeySource).hostKeyBytes;
                 final trusted = await onVerifyHostKey!(
                   'ssh-ed25519',
-                  Uint8List.fromList(md5.convert(bytes).bytes),
+                  _hostKeyCallbackFingerprint(bytes),
                 );
                 expect(trusted, isTrue);
               });
@@ -2785,7 +2784,7 @@ void main() {
                 final bytes = await (socket as HostKeySource).hostKeyBytes;
                 final trusted = await onVerifyHostKey!(
                   'ssh-ed25519',
-                  Uint8List.fromList(md5.convert(bytes).bytes),
+                  _hostKeyCallbackFingerprint(bytes),
                 );
                 if (!trusted) {
                   return Future<void>.error(
@@ -2872,7 +2871,7 @@ void main() {
                   final bytes = await (socket as HostKeySource).hostKeyBytes;
                   final trusted = await onVerifyHostKey!(
                     'ssh-ed25519',
-                    Uint8List.fromList(md5.convert(bytes).bytes),
+                    _hostKeyCallbackFingerprint(bytes),
                   );
                   if (!trusted) {
                     return Future<void>.error(
@@ -2939,7 +2938,7 @@ void main() {
                 final bytes = await (socket as HostKeySource).hostKeyBytes;
                 await onVerifyHostKey!(
                   'ssh-ed25519',
-                  Uint8List.fromList(md5.convert(bytes).bytes),
+                  _hostKeyCallbackFingerprint(bytes),
                 );
               });
               return client;
@@ -3002,7 +3001,7 @@ void main() {
                   final bytes = await hostKeyBytes;
                   await onVerifyHostKey!(
                     'ssh-ed25519',
-                    Uint8List.fromList(md5.convert(bytes).bytes),
+                    _hostKeyCallbackFingerprint(bytes),
                   );
                 });
               } else {
@@ -3010,7 +3009,7 @@ void main() {
                   final bytes = await hostKeyBytes;
                   await onVerifyHostKey!(
                     'ssh-ed25519',
-                    Uint8List.fromList(md5.convert(bytes).bytes),
+                    _hostKeyCallbackFingerprint(bytes),
                   );
                 });
               }
@@ -3118,7 +3117,7 @@ void main() {
                 final bytes = await hostKeyBytes;
                 final trusted = await onVerifyHostKey!(
                   'ssh-ed25519',
-                  Uint8List.fromList(md5.convert(bytes).bytes),
+                  _hostKeyCallbackFingerprint(bytes),
                 );
                 expect(trusted, isTrue);
               });
@@ -3174,7 +3173,7 @@ void main() {
                   final bytes = await (socket as HostKeySource).hostKeyBytes;
                   await onVerifyHostKey!(
                     'ssh-ed25519',
-                    Uint8List.fromList(md5.convert(bytes).bytes),
+                    _hostKeyCallbackFingerprint(bytes),
                   );
                   return Future<void>.error(
                     SSHAuthFailError('Authentication failed'),
@@ -3255,7 +3254,7 @@ void main() {
                   final bytes = await (socket as HostKeySource).hostKeyBytes;
                   final trusted = await onVerifyHostKey!(
                     'ssh-ed25519',
-                    Uint8List.fromList(md5.convert(bytes).bytes),
+                    _hostKeyCallbackFingerprint(bytes),
                   );
                   if (!trusted) {
                     return Future<void>.error(
@@ -3456,6 +3455,9 @@ Uint8List _ed25519HostKeyBlob(List<int> keyData) {
     ..add(keyData);
   return writer.takeBytes();
 }
+
+Uint8List _hostKeyCallbackFingerprint(List<int> hostKeyBytes) =>
+    Uint8List.fromList(utf8.encode(formatSshHostKeyFingerprint(hostKeyBytes)));
 
 Uint8List _uint32(int value) => Uint8List.fromList([
   (value >> 24) & 0xFF,


### PR DESCRIPTION
## Summary
- Accept dartssh2 2.18 OpenSSH-style SHA256 host key fingerprints in SSH host-key verification callbacks
- Preserve compatibility with legacy raw MD5 callback fingerprints
- Update SSH service tests to model the new dartssh2 callback format

## Validation
- flutter test test/domain/services/ssh_service_test.dart --name "connect"
- flutter analyze
- flutter test test/domain/services/ssh_service_test.dart
- pre-commit hook: format, analyzer, tests