### PR TITLE
fix: skip precheck during iOS metadata sync

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -477,6 +477,7 @@ platform :ios do
       skip_binary_upload: true,
       skip_screenshots: false,
       submit_for_review: false,
+      run_precheck_before_submit: false,
       automatic_release: false,
       force: true,
     )


### PR DESCRIPTION
## Summary
- Disable Fastlane precheck for the iOS metadata-only sync lane.
- This lets the corrected screenshot upload flow finish when using an App Store Connect API key, since precheck cannot inspect IAP with API-key auth.

## Validation
- `ruby -c ios/fastlane/Fastfile`
- `git diff --check`
