### PR TITLE
Fix: Add AD_ID permission to Android manifest for Play Console compliance

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
          before WifiManager will return the actual SSID. -->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <!-- Required for Firebase Analytics advertising ID collection (Android 13+) -->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
     <application
         android:enableOnBackInvokedCallback="true"
         android:label="@string/app_name"


### PR DESCRIPTION
## Summary

Adds the `com.google.android.gms.permission.AD_ID` permission to the Android manifest to resolve the Play Console error about missing advertising ID permission.

## Problem

The Play Console shows an error:
> Your advertising ID declaration in Play Console says that your app uses advertising ID. A manifest file in one of your active artifacts doesn't include the com.google.android.gms.permission.AD_ID permission.

This is required for Android 13+ (API level 33+) when using Firebase Analytics or other services that collect advertising identifiers.

## Solution

Added the AD_ID permission to `android/app/src/main/AndroidManifest.xml` with appropriate documentation.

## Validation

- ✅ `flutter analyze --fatal-warnings` passed with no issues
- ✅ Pre-commit checks passed
- Permission is only declared, not automatically granted - users still have control over ad tracking

## References

- [Android 13 Ad ID permission documentation](https://developer.android.com/training/basics/intents/package-visibility-use-cases#ad-id)
- Play Console error screenshot in task description