### PR TITLE
Fix Android IME Enter submitting in terminal

### DIFF
--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -1335,16 +1335,65 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
 
     final appendedText = delta.appendedText;
-    if (appendedText.isNotEmpty) {
-      widget.terminal.textInput(_applyTerminalTextInputModifiers(appendedText));
-    }
+    final newlineCount = _sendAppendedTerminalInput(appendedText);
 
     _lastSentText = currentText;
     _lastSentCursorOffset =
         delta.deleteCursorOffset -
         deletedCount +
         appendedText.characters.length;
-    return '\n'.allMatches(appendedText).length;
+    return newlineCount;
+  }
+
+  int _sendAppendedTerminalInput(String text) {
+    if (text.isEmpty) {
+      return 0;
+    }
+
+    var newlineCount = 0;
+    var segmentStart = 0;
+    var index = 0;
+    while (index < text.length) {
+      final codeUnit = text.codeUnitAt(index);
+      final newlineLength = codeUnit == 0x0D
+          ? (index + 1 < text.length && text.codeUnitAt(index + 1) == 0x0A
+                ? 2
+                : 1)
+          : codeUnit == 0x0A
+          ? 1
+          : 0;
+      if (newlineLength == 0) {
+        index++;
+        continue;
+      }
+
+      _sendTerminalTextSegment(text.substring(segmentStart, index));
+      _sendTerminalEnterFromTextInput();
+      newlineCount++;
+      index += newlineLength;
+      segmentStart = index;
+    }
+
+    _sendTerminalTextSegment(text.substring(segmentStart));
+    return newlineCount;
+  }
+
+  void _sendTerminalTextSegment(String text) {
+    if (text.isEmpty) {
+      return;
+    }
+    widget.terminal.textInput(_applyTerminalTextInputModifiers(text));
+  }
+
+  void _sendTerminalEnterFromTextInput() {
+    final modifiers = widget.resolveTerminalKeyModifiers?.call();
+    sendTerminalEnterInput(
+      widget.terminal,
+      shiftActive: modifiers?.shift ?? false,
+      altActive: modifiers?.alt ?? false,
+      ctrlActive: modifiers?.ctrl ?? false,
+    );
+    widget.consumeTerminalKeyModifiers?.call();
   }
 
   void _resetCommittedInputState({

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -1543,7 +1543,10 @@ void main() {
 
       await _commitSwipeText(tester, '$_deleteDetectionMarker next');
 
-      expect(terminalOutput.join(), 'echo hi\nnext');
+      expect(
+        terminalOutput.join(),
+        'echo hi${_terminalKeyOutput(TerminalKey.enter)}next',
+      );
 
       focusNode.dispose();
     });
@@ -4739,6 +4742,55 @@ void main() {
         focusNode.dispose();
       },
     );
+
+    testWidgets('soft-keyboard newline text sends terminal Enter', (
+      tester,
+    ) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalTextInputHandler(
+              terminal: terminal,
+              focusNode: focusNode,
+              deleteDetection: true,
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      tester.testTextInput.updateEditingValue(
+        _editingValue('echo', selectionOffset: 'echo'.length),
+      );
+      await tester.pump();
+
+      terminalOutput.clear();
+
+      tester.testTextInput.updateEditingValue(
+        _editingValue('echo\n', selectionOffset: 'echo\n'.length),
+      );
+      await tester.pump();
+
+      expect(terminalOutput.join(), _terminalKeyOutput(TerminalKey.enter));
+      expect(
+        _terminalTextInputClient(tester).currentTextEditingValue,
+        const TextEditingValue(
+          text: _deleteDetectionMarker,
+          selection: TextSelection.collapsed(
+            offset: _deleteDetectionMarker.length,
+          ),
+        ),
+      );
+
+      focusNode.dispose();
+    });
 
     testWidgets(
       'suppresses the first follow-up newline action after a committed newline update',
@@ -8253,7 +8305,10 @@ void main() {
       );
       await tester.pump();
 
-      expect(_terminalTextFromEvents(terminalOutput), 'echo hi\nnext');
+      expect(
+        _terminalTextFromEvents(terminalOutput),
+        'echo hi${_terminalKeyOutput(TerminalKey.enter)}next',
+      );
 
       focusNode.dispose();
     });


### PR DESCRIPTION
## Summary
- Route IME-committed newline text through the same terminal Enter encoder used by explicit keyboard actions.
- Preserve duplicate action suppression while handling LF, CR, and CRLF newline commits.
- Add a regression test for soft-keyboard newline text sending terminal Enter.

## Validation
- `flutter test test/widget/terminal_text_input_handler_test.dart --plain-name "soft-keyboard newline text sends terminal Enter"`
- `flutter test test/widget/terminal_text_input_handler_test.dart --name "newline"`
- `flutter analyze lib/presentation/widgets/terminal_text_input_handler.dart test/widget/terminal_text_input_handler_test.dart`
- Pre-commit checks: formatting, analyzer, full test suite (`2447` tests passed)