### PR TITLE
Fix App Store subscription review compliance

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -172,6 +172,8 @@ ios/fastlane/
 │   │   ├── release_notes.txt
 │   │   ├── privacy_url.txt
 │   │   └── support_url.txt
+│   ├── review_information/
+│   │   └── notes.txt
 │   ├── copyright.txt
 │   └── primary_category.txt
 └── metadata-production/     # MonkeySSH (production app)

--- a/ios/fastlane/metadata-private/en-US/description.txt
+++ b/ios/fastlane/metadata-private/en-US/description.txt
@@ -12,3 +12,6 @@ Built for modern remote development:
 - Optional analytics and crash reports that are off by default and exclude commands, terminal output, paths, hostnames, usernames, clipboard contents, and credentials.
 
 This beta listing is used for preview and internal testing builds before changes reach the public MonkeySSH app.
+
+Terms of Use (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+Privacy Policy: https://github.com/depollsoft/MonkeySSH/blob/main/docs/privacy-policy.md

--- a/ios/fastlane/metadata-private/review_information/notes.txt
+++ b/ios/fastlane/metadata-private/review_information/notes.txt
@@ -1,0 +1,10 @@
+MonkeySSH Pro is available from Settings > MonkeySSH Pro and from Pro-gated feature prompts.
+
+The purchase flow shows the subscription title, monthly/annual renewal lengths, App Store-loaded prices, and functional links to:
+- Terms of Use (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+- Privacy Policy: https://github.com/depollsoft/MonkeySSH/blob/main/docs/privacy-policy.md
+
+The private beta app queries only the private App Store product IDs:
+- monkeyssh_pro_monthly
+- monkeyssh_pro_annual
+- monkeyssh_pro_lifetime

--- a/ios/fastlane/metadata-production/en-US/description.txt
+++ b/ios/fastlane/metadata-production/en-US/description.txt
@@ -12,3 +12,6 @@ Built for modern remote development:
 - Optional analytics and crash reports that are off by default and exclude commands, terminal output, paths, hostnames, usernames, clipboard contents, and credentials.
 
 MonkeySSH keeps SSH practical on mobile while adding the workflow shortcuts remote developers need when they are away from a laptop.
+
+Terms of Use (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+Privacy Policy: https://github.com/depollsoft/MonkeySSH/blob/main/docs/privacy-policy.md

--- a/ios/fastlane/metadata-production/review_information/notes.txt
+++ b/ios/fastlane/metadata-production/review_information/notes.txt
@@ -1,0 +1,10 @@
+MonkeySSH Pro is available from Settings > MonkeySSH Pro and from Pro-gated feature prompts.
+
+The purchase flow shows the subscription title, monthly/annual renewal lengths, App Store-loaded prices, and functional links to:
+- Terms of Use (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+- Privacy Policy: https://github.com/depollsoft/MonkeySSH/blob/main/docs/privacy-policy.md
+
+The production app queries only the production App Store product IDs:
+- monkeyssh_pro_monthly_prod
+- monkeyssh_pro_annual_prod
+- monkeyssh_pro_lifetime_prod

--- a/lib/domain/models/monetization.dart
+++ b/lib/domain/models/monetization.dart
@@ -57,22 +57,43 @@ abstract final class MonetizationProductIds {
   static const allLifetime = <String>{androidProLifetime, iosProLifetimeProd};
 
   /// Product identifiers to query on the current platform.
-  static Set<String> forPlatform(TargetPlatform platform) => switch (platform) {
+  static Set<String> forPlatform(
+    TargetPlatform platform, {
+    String? packageName,
+  }) => switch (platform) {
     TargetPlatform.android => const {androidPro, androidProLifetime},
-    TargetPlatform.iOS || TargetPlatform.macOS => const {
-      iosMonthly,
-      iosAnnual,
-      iosMonthlyProd,
-      iosAnnualProd,
-      iosProLifetime,
-      iosProLifetimeProd,
-    },
+    TargetPlatform.iOS ||
+    TargetPlatform.macOS => _forApplePackageName(packageName),
     _ => const {},
   };
 
   /// Whether [productId] identifies a lifetime (one-time) product.
   static bool isLifetime(String? productId) =>
       productId != null && allLifetime.contains(productId);
+
+  static Set<String> _forApplePackageName(String? packageName) {
+    final normalizedPackageName = packageName?.trim();
+    return switch (normalizedPackageName) {
+      'xyz.depollsoft.monkeyssh.private' => const {
+        iosMonthly,
+        iosAnnual,
+        iosProLifetime,
+      },
+      'xyz.depollsoft.monkeyssh' => const {
+        iosMonthlyProd,
+        iosAnnualProd,
+        iosProLifetimeProd,
+      },
+      _ => const {
+        iosMonthly,
+        iosAnnual,
+        iosMonthlyProd,
+        iosAnnualProd,
+        iosProLifetime,
+        iosProLifetimeProd,
+      },
+    };
+  }
 }
 
 /// Premium features controlled by MonkeySSH Pro.

--- a/lib/domain/services/monetization_service.dart
+++ b/lib/domain/services/monetization_service.dart
@@ -9,6 +9,7 @@ import 'package:in_app_purchase_android/in_app_purchase_android.dart';
 import 'package:in_app_purchase_storekit/in_app_purchase_storekit.dart';
 import 'package:in_app_purchase_storekit/store_kit_2_wrappers.dart';
 import 'package:in_app_purchase_storekit/store_kit_wrappers.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 import '../models/monetization.dart';
 import 'settings_service.dart';
@@ -29,11 +30,13 @@ class MonetizationService {
     bool? allowDebugUnlock,
     Duration purchaseTimeout = const Duration(seconds: 60),
     Duration restoreTimeout = const Duration(seconds: 45),
+    Future<String> Function()? packageNameLoader,
   }) : _inAppPurchase = inAppPurchase ?? InAppPurchase.instance,
        _androidPlatformAddition = androidPlatformAddition,
        _allowDebugUnlock = allowDebugUnlock ?? kDebugMode,
        _purchaseTimeout = purchaseTimeout,
-       _restoreTimeout = restoreTimeout;
+       _restoreTimeout = restoreTimeout,
+       _packageNameLoader = packageNameLoader ?? _loadPackageName;
 
   final SettingsService _settings;
   final InAppPurchase _inAppPurchase;
@@ -41,6 +44,7 @@ class MonetizationService {
   final bool _allowDebugUnlock;
   final Duration _purchaseTimeout;
   final Duration _restoreTimeout;
+  final Future<String> Function() _packageNameLoader;
   final _controller = StreamController<MonetizationState>.broadcast();
   final _purchaseOptionsByOfferId = <String, _MonetizationPurchaseOption>{};
 
@@ -180,7 +184,7 @@ class MonetizationService {
     }
 
     final response = await _inAppPurchase.queryProductDetails(
-      MonetizationProductIds.forPlatform(defaultTargetPlatform),
+      await _productIdsForCurrentStorefront(),
     );
     final catalog = _buildMonetizationCatalog(response.productDetails);
     _purchaseOptionsByOfferId
@@ -196,6 +200,17 @@ class MonetizationService {
             ? null
             : 'Could not load purchase options. Try again.',
       ),
+    );
+  }
+
+  Future<Set<String>> _productIdsForCurrentStorefront() async {
+    final packageName = switch (defaultTargetPlatform) {
+      TargetPlatform.iOS || TargetPlatform.macOS => await _packageNameLoader(),
+      _ => null,
+    };
+    return MonetizationProductIds.forPlatform(
+      defaultTargetPlatform,
+      packageName: packageName,
     );
   }
 
@@ -738,6 +753,11 @@ final monetizationServiceProvider = Provider<MonetizationService>((ref) {
   unawaited(service.initialize());
   return service;
 });
+
+Future<String> _loadPackageName() async {
+  final packageInfo = await PackageInfo.fromPlatform();
+  return packageInfo.packageName;
+}
 
 /// Stream provider for the latest [MonetizationState].
 final monetizationStateProvider = StreamProvider<MonetizationState>((ref) {

--- a/lib/presentation/screens/upgrade_screen.dart
+++ b/lib/presentation/screens/upgrade_screen.dart
@@ -10,6 +10,13 @@ import '../../domain/services/monetization_service.dart';
 import '../../domain/services/telemetry_service.dart';
 import '../widgets/premium_badge.dart';
 
+final _privacyPolicyUri = Uri.parse(
+  'https://github.com/depollsoft/MonkeySSH/blob/main/docs/privacy-policy.md',
+);
+final _termsOfUseUri = Uri.parse(
+  'https://www.apple.com/legal/internet-services/itunes/dev/stdeula/',
+);
+
 /// Upgrade screen for MonkeySSH Pro.
 class UpgradeScreen extends ConsumerStatefulWidget {
   /// Creates a new [UpgradeScreen].
@@ -238,6 +245,14 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
     }
   }
 
+  Future<void> _openLegalUrl(Uri url, String label) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final didOpen = await launchUrl(url, mode: LaunchMode.externalApplication);
+    if (!didOpen && mounted) {
+      messenger.showSnackBar(SnackBar(content: Text('Could not open $label.')));
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -315,6 +330,13 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
             const SizedBox(height: 20),
             _UpgradeProgressBanner(message: message),
           ],
+          const SizedBox(height: 20),
+          _SubscriptionLegalCard(
+            onOpenPrivacyPolicy: () =>
+                _openLegalUrl(_privacyPolicyUri, 'the privacy policy'),
+            onOpenTermsOfUse: () =>
+                _openLegalUrl(_termsOfUseUri, 'the Terms of Use'),
+          ),
           if (isLifetimeUnlocked) ...[
             const SizedBox(height: 20),
             _UpgradeBanner(
@@ -484,6 +506,60 @@ class _UpgradeScreenState extends ConsumerState<UpgradeScreen> {
             ),
           ],
         ],
+      ),
+    );
+  }
+}
+
+class _SubscriptionLegalCard extends StatelessWidget {
+  const _SubscriptionLegalCard({
+    required this.onOpenPrivacyPolicy,
+    required this.onOpenTermsOfUse,
+  });
+
+  final VoidCallback onOpenPrivacyPolicy;
+  final VoidCallback onOpenTermsOfUse;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Subscription details', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(
+              'MonkeySSH Pro subscriptions are auto-renewable. Monthly plans '
+              'renew every month and annual plans renew every year. Prices are '
+              'shown on the plan cards below and load from your storefront.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                TextButton.icon(
+                  onPressed: onOpenPrivacyPolicy,
+                  icon: const Icon(Icons.privacy_tip_outlined),
+                  label: const Text('Privacy Policy'),
+                ),
+                TextButton.icon(
+                  onPressed: onOpenTermsOfUse,
+                  icon: const Icon(Icons.description_outlined),
+                  label: const Text('Terms of Use (EULA)'),
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/scripts/validate_app_store_metadata.py
+++ b/scripts/validate_app_store_metadata.py
@@ -21,6 +21,9 @@ ROOT_TEXT_LIMITS = {
     'primary_category.txt': 64,
     'copyright.txt': 64,
 }
+REVIEW_INFORMATION_TEXT_LIMITS = {
+    'notes.txt': 4000,
+}
 
 
 def _parse_args() -> argparse.Namespace:
@@ -70,6 +73,10 @@ def _validate_variant(variant: str) -> None:
 
     for file_name, max_length in ROOT_TEXT_LIMITS.items():
         _validate_text_file(metadata_dir / file_name, max_length)
+
+    review_information_dir = metadata_dir / 'review_information'
+    for file_name, max_length in REVIEW_INFORMATION_TEXT_LIMITS.items():
+        _validate_text_file(review_information_dir / file_name, max_length)
 
 
 def main() -> None:

--- a/test/domain/services/monetization_service_test.dart
+++ b/test/domain/services/monetization_service_test.dart
@@ -15,6 +15,7 @@ import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/domain/models/monetization.dart';
 import 'package:monkeyssh/domain/services/monetization_service.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 class MockInAppPurchase extends Mock implements InAppPurchase {}
 
@@ -29,70 +30,80 @@ class MockInAppPurchaseAndroidPlatformAddition extends Mock
 class _FakePurchaseParam extends Fake implements PurchaseParam {}
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   setUpAll(() {
     registerFallbackValue(_FakePurchaseParam());
   });
 
-  test(
-    'queries both preview and prod App Store product IDs on Apple platforms',
-    () {
-      expect(
-        MonetizationProductIds.forPlatform(TargetPlatform.iOS),
-        unorderedEquals([
-          MonetizationProductIds.iosMonthly,
-          MonetizationProductIds.iosAnnual,
-          MonetizationProductIds.iosMonthlyProd,
-          MonetizationProductIds.iosAnnualProd,
-          MonetizationProductIds.iosProLifetime,
-          MonetizationProductIds.iosProLifetimeProd,
-        ]),
-      );
-      expect(
-        MonetizationProductIds.forPlatform(TargetPlatform.macOS),
-        unorderedEquals([
-          MonetizationProductIds.iosMonthly,
-          MonetizationProductIds.iosAnnual,
-          MonetizationProductIds.iosMonthlyProd,
-          MonetizationProductIds.iosAnnualProd,
-          MonetizationProductIds.iosProLifetime,
-          MonetizationProductIds.iosProLifetimeProd,
-        ]),
-      );
-      expect(
-        MonetizationProductIds.forPlatform(TargetPlatform.android),
-        unorderedEquals([
-          MonetizationProductIds.androidPro,
-          MonetizationProductIds.androidProLifetime,
-        ]),
-      );
-      expect(
-        MonetizationProductIds.allKnown,
-        containsAll({
-          MonetizationProductIds.iosMonthlyProd,
-          MonetizationProductIds.iosAnnualProd,
-          MonetizationProductIds.iosProLifetimeProd,
-          MonetizationProductIds.androidProLifetime,
-        }),
-      );
-      expect(
-        MonetizationProductIds.isLifetime(
-          MonetizationProductIds.androidProLifetime,
-        ),
-        isTrue,
-      );
-      expect(
-        MonetizationProductIds.isLifetime(
-          MonetizationProductIds.iosProLifetimeProd,
-        ),
-        isTrue,
-      );
-      expect(
-        MonetizationProductIds.isLifetime(MonetizationProductIds.androidPro),
-        isFalse,
-      );
-      expect(MonetizationProductIds.isLifetime(null), isFalse);
-    },
-  );
+  test('queries the App Store product IDs for the current Apple bundle', () {
+    expect(
+      MonetizationProductIds.forPlatform(
+        TargetPlatform.iOS,
+        packageName: 'xyz.depollsoft.monkeyssh.private',
+      ),
+      unorderedEquals([
+        MonetizationProductIds.iosMonthly,
+        MonetizationProductIds.iosAnnual,
+        MonetizationProductIds.iosProLifetime,
+      ]),
+    );
+    expect(
+      MonetizationProductIds.forPlatform(
+        TargetPlatform.iOS,
+        packageName: 'xyz.depollsoft.monkeyssh',
+      ),
+      unorderedEquals([
+        MonetizationProductIds.iosMonthlyProd,
+        MonetizationProductIds.iosAnnualProd,
+        MonetizationProductIds.iosProLifetimeProd,
+      ]),
+    );
+    expect(
+      MonetizationProductIds.forPlatform(TargetPlatform.android),
+      unorderedEquals([
+        MonetizationProductIds.androidPro,
+        MonetizationProductIds.androidProLifetime,
+      ]),
+    );
+    expect(
+      MonetizationProductIds.allKnown,
+      containsAll({
+        MonetizationProductIds.iosMonthlyProd,
+        MonetizationProductIds.iosAnnualProd,
+        MonetizationProductIds.iosProLifetimeProd,
+        MonetizationProductIds.androidProLifetime,
+      }),
+    );
+    expect(
+      MonetizationProductIds.forPlatform(TargetPlatform.macOS),
+      containsAll({
+        MonetizationProductIds.iosMonthly,
+        MonetizationProductIds.iosAnnual,
+        MonetizationProductIds.iosMonthlyProd,
+        MonetizationProductIds.iosAnnualProd,
+        MonetizationProductIds.iosProLifetime,
+        MonetizationProductIds.iosProLifetimeProd,
+      }),
+    );
+    expect(
+      MonetizationProductIds.isLifetime(
+        MonetizationProductIds.androidProLifetime,
+      ),
+      isTrue,
+    );
+    expect(
+      MonetizationProductIds.isLifetime(
+        MonetizationProductIds.iosProLifetimeProd,
+      ),
+      isTrue,
+    );
+    expect(
+      MonetizationProductIds.isLifetime(MonetizationProductIds.androidPro),
+      isFalse,
+    );
+    expect(MonetizationProductIds.isLifetime(null), isFalse);
+  });
 
   group('buildMonetizationOffers', () {
     test('deduplicates Google Play base plans and keeps trial offers', () {
@@ -362,6 +373,13 @@ void main() {
       inAppPurchase = MockInAppPurchase();
       androidPlatformAddition = MockInAppPurchaseAndroidPlatformAddition();
       purchaseController = StreamController<List<PurchaseDetails>>.broadcast();
+      PackageInfo.setMockInitialValues(
+        appName: 'MonkeySSH',
+        packageName: 'xyz.depollsoft.monkeyssh',
+        version: '0.1.1',
+        buildNumber: '1',
+        buildSignature: '',
+      );
 
       when(
         () => inAppPurchase.purchaseStream,
@@ -472,6 +490,81 @@ void main() {
         );
       },
     );
+
+    test(
+      'production App Store builds query only production product IDs',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+        when(() => inAppPurchase.isAvailable()).thenAnswer((_) async => true);
+        when(() => inAppPurchase.queryProductDetails(any())).thenAnswer(
+          (_) async => ProductDetailsResponse(
+            productDetails: const [],
+            notFoundIDs: const [],
+          ),
+        );
+
+        final service = MonetizationService(
+          settings,
+          inAppPurchase: inAppPurchase,
+          allowDebugUnlock: false,
+          packageNameLoader: () async => 'xyz.depollsoft.monkeyssh',
+        );
+        addTearDown(service.dispose);
+
+        await service.initialize();
+
+        final queriedProductIds =
+            verify(
+                  () => inAppPurchase.queryProductDetails(captureAny()),
+                ).captured.single
+                as Set<String>;
+        expect(
+          queriedProductIds,
+          unorderedEquals([
+            MonetizationProductIds.iosMonthlyProd,
+            MonetizationProductIds.iosAnnualProd,
+            MonetizationProductIds.iosProLifetimeProd,
+          ]),
+        );
+      },
+    );
+
+    test('private App Store builds query only private product IDs', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      when(() => inAppPurchase.isAvailable()).thenAnswer((_) async => true);
+      when(() => inAppPurchase.queryProductDetails(any())).thenAnswer(
+        (_) async => ProductDetailsResponse(
+          productDetails: const [],
+          notFoundIDs: const [],
+        ),
+      );
+
+      final service = MonetizationService(
+        settings,
+        inAppPurchase: inAppPurchase,
+        allowDebugUnlock: false,
+        packageNameLoader: () async => 'xyz.depollsoft.monkeyssh.private',
+      );
+      addTearDown(service.dispose);
+
+      await service.initialize();
+
+      final queriedProductIds =
+          verify(
+                () => inAppPurchase.queryProductDetails(captureAny()),
+              ).captured.single
+              as Set<String>;
+      expect(
+        queriedProductIds,
+        unorderedEquals([
+          MonetizationProductIds.iosMonthly,
+          MonetizationProductIds.iosAnnual,
+          MonetizationProductIds.iosProLifetime,
+        ]),
+      );
+    });
 
     test(
       'concurrent initialize calls wait for the same in-flight work',

--- a/test/widget/upgrade_screen_test.dart
+++ b/test/widget/upgrade_screen_test.dart
@@ -38,7 +38,6 @@ void main() {
 
     when(() => service.currentState).thenReturn(state);
     _stubRestorePurchases(service);
-
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
@@ -66,6 +65,54 @@ void main() {
       find.text('Auto-connect automation is part of MonkeySSH Pro'),
       findsNothing,
     );
+  });
+
+  testWidgets('shows subscription legal details and policy links', (
+    tester,
+  ) async {
+    final service = _MockMonetizationService();
+    const state = MonetizationState(
+      billingAvailability: MonetizationBillingAvailability.available,
+      entitlements: MonetizationEntitlements.free(),
+      offers: [
+        MonetizationOffer(
+          id: 'monthly',
+          productId: 'monkeyssh_pro_monthly',
+          billingPeriod: MonetizationBillingPeriod.monthly,
+          planLabel: 'Monthly',
+          priceLabel: r'$5.00',
+          displayPriceLabel: r'$5.00 / month',
+          rawPrice: 5,
+          currencyCode: 'USD',
+          currencySymbol: r'$',
+        ),
+      ],
+      debugUnlockAvailable: false,
+      debugUnlocked: false,
+    );
+
+    when(() => service.currentState).thenReturn(state);
+    when(
+      () => service.purchaseOffer(any()),
+    ).thenAnswer(_cancelledPurchaseResult);
+    _stubRestorePurchases(service);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          monetizationServiceProvider.overrideWithValue(service),
+          monetizationStateProvider.overrideWith((ref) => Stream.value(state)),
+        ],
+        child: const MaterialApp(home: UpgradeScreen()),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Subscription details'), findsOneWidget);
+    expect(find.textContaining('auto-renewable'), findsOneWidget);
+    expect(find.textContaining('renew every month'), findsOneWidget);
+    expect(find.text('Privacy Policy'), findsOneWidget);
+    expect(find.text('Terms of Use (EULA)'), findsOneWidget);
   });
 
   testWidgets('plan cards stay legible in dark mode', (tester) async {
@@ -126,11 +173,12 @@ void main() {
       ),
     );
     await tester.pump();
-    final annualSavingsBanner = tester.widget<Text>(
-      find.text(
-        'Annual is the best value - save about 17% compared with paying monthly.',
-      ),
+    final annualSavingsFinder = find.text(
+      'Annual is the best value - save about 17% compared with paying monthly.',
     );
+    await tester.scrollUntilVisible(annualSavingsFinder, 300);
+    await tester.pumpAndSettle();
+    final annualSavingsBanner = tester.widget<Text>(annualSavingsFinder);
     await tester.scrollUntilVisible(find.text('Monthly'), 300);
     await tester.pumpAndSettle();
 
@@ -227,7 +275,6 @@ void main() {
       () => service.purchaseOffer(any()),
     ).thenAnswer(_cancelledPurchaseResult);
     _stubRestorePurchases(service);
-
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
@@ -294,11 +341,12 @@ void main() {
       ),
     );
     await tester.pump();
-    final annualSavingsBanner = tester.widget<Text>(
-      find.text(
-        'Annual is the best value - save about 17% compared with paying monthly.',
-      ),
+    final annualSavingsFinder = find.text(
+      'Annual is the best value - save about 17% compared with paying monthly.',
     );
+    await tester.scrollUntilVisible(annualSavingsFinder, 300);
+    await tester.pumpAndSettle();
+    final annualSavingsBanner = tester.widget<Text>(annualSavingsFinder);
     await tester.scrollUntilVisible(find.text('Best value - Save 17%'), 300);
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary
- Restrict Apple IAP catalog queries by bundle ID so production and private builds no longer query each other's App Store products.
- Add subscription renewal copy plus functional Privacy Policy and Terms of Use (EULA) links to the MonkeySSH Pro upgrade flow.
- Add App Store description legal links, Fastlane App Review notes, and metadata validation for review notes.

## Validation
- python3 scripts/validate_app_store_metadata.py
- flutter test test/domain/services/monetization_service_test.dart test/widget/upgrade_screen_test.dart
- flutter analyze
- pre-commit hook: dart format, flutter analyze, flutter test (2449 tests passed)