### PR TITLE
fix(terminal): paint full-width prompt backgrounds via XTVERSION, drop fill heuristic

### DIFF
--- a/lib/presentation/widgets/connection_preview_snippet.dart
+++ b/lib/presentation/widgets/connection_preview_snippet.dart
@@ -877,7 +877,6 @@ class _TerminalPreviewPainter extends CustomPainter {
       canvas
         ..save()
         ..clipRect(Rect.fromLTWH(0, y, size.width, lineHeight));
-      painter.paintLineTrailingBackgroundFill(canvas, Offset(0, y), line);
       for (
         var column = 0;
         column < line.length && column < visibleColumns;

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1792,7 +1792,6 @@ class MonkeyTerminalPainter extends TerminalPainter {
         i++;
       }
     }
-    paintLineTrailingBackgroundFill(canvas, offset, line);
   }
 
   /// Paints only the glyphs for [line], in a pass run after every visible
@@ -1860,145 +1859,6 @@ class MonkeyTerminalPainter extends TerminalPainter {
       ),
       Paint()..color = theme.background,
     );
-  }
-
-  void paintLineTrailingBackgroundFill(
-    Canvas canvas,
-    Offset offset,
-    BufferLine line,
-  ) {
-    final fill = resolveMonkeyTerminalTrailingBackgroundFill(line);
-    if (fill == null) {
-      return;
-    }
-
-    canvas.drawRect(
-      Rect.fromLTWH(
-        offset.dx + (fill.startColumn * cellSize.width),
-        offset.dy,
-        (line.length - fill.startColumn) * cellSize.width,
-        cellSize.height,
-      ),
-      Paint()..color = fill.color,
-    );
-  }
-
-  ({int startColumn, Color color})? resolveMonkeyTerminalTrailingBackgroundFill(
-    BufferLine line,
-  ) {
-    if (line.length == 0) {
-      return null;
-    }
-
-    final firstCell = CellData.empty();
-    final runStartColumn = _trailingBackgroundRunStartColumn(line, firstCell);
-    if (runStartColumn == null) {
-      return null;
-    }
-
-    final runBackground = _resolveCellBackgroundPaintColor(firstCell);
-    final runCell = CellData.empty();
-    var contentEndColumn = -1;
-    for (var column = runStartColumn; column < line.length; column += 1) {
-      line.getCellData(column, runCell);
-      final rightEdgeDecoration = _isRightEdgeDecorationCell(
-        line,
-        column,
-        runCell,
-      );
-      final matchesPromptBackground = _cellMatchesTrailingBackgroundRun(
-        runCell,
-        runBackground,
-      );
-      if (!matchesPromptBackground &&
-          !_isBlankTerminalBackgroundCell(runCell) &&
-          !_isNormalTextCell(runCell) &&
-          !rightEdgeDecoration) {
-        return null;
-      }
-      if ((!_isBlankCell(runCell) ||
-              (matchesPromptBackground && _isLiteralSpaceCell(runCell))) &&
-          !rightEdgeDecoration) {
-        contentEndColumn = math.max(
-          contentEndColumn,
-          column + _cellContentColumnWidth(runCell),
-        );
-      }
-    }
-
-    final fillStartColumn = contentEndColumn;
-    if (contentEndColumn < 0 || fillStartColumn >= line.length) {
-      return null;
-    }
-
-    final trailingCell = CellData.empty();
-    for (var column = fillStartColumn; column < line.length; column += 1) {
-      line.getCellData(column, trailingCell);
-      if (!_isBlankTerminalBackgroundCell(trailingCell) &&
-          !_isRightEdgeDecorationCell(line, column, trailingCell)) {
-        return null;
-      }
-    }
-
-    return (
-      startColumn: fillStartColumn,
-      color: _resolveCellBackgroundPaintColor(firstCell),
-    );
-  }
-
-  bool _cellMatchesTrailingBackgroundRun(CellData cellData, Color color) {
-    if (!_cellPaintsBackground(cellData)) {
-      return false;
-    }
-    return _resolveCellBackgroundPaintColor(cellData) == color;
-  }
-
-  bool _isNormalTextCell(CellData cellData) =>
-      !_cellPaintsBackground(cellData) && !_isBlankCell(cellData);
-
-  bool _isRightEdgeDecorationCell(
-    BufferLine line,
-    int column,
-    CellData cellData,
-  ) {
-    if (column < line.length - 2) {
-      return false;
-    }
-    final charCode = cellData.content & CellContent.codepointMask;
-    return charCode == 0x2502 || // │
-        charCode == 0x2503 || // ┃
-        charCode == 0x2551 || // ║
-        charCode == 0x2588 || // █
-        charCode == 0x258C || // ▌
-        charCode == 0x2590 || // ▐
-        charCode == 0x2595; // ▕
-  }
-
-  bool _isBlankTerminalBackgroundCell(CellData cellData) {
-    if (!_isBlankNormalCell(cellData)) {
-      return _isBlankCell(cellData) &&
-          _cellPaintsBackground(cellData) &&
-          _resolveCellBackgroundPaintColor(cellData) == theme.background;
-    }
-    return true;
-  }
-
-  int? _trailingBackgroundRunStartColumn(BufferLine line, CellData firstCell) {
-    line.getCellData(0, firstCell);
-    if (_shouldExtendTrailingBackgroundFill(firstCell)) {
-      return 0;
-    }
-
-    for (var column = 0; column < line.length; column += 1) {
-      line.getCellData(column, firstCell);
-      if (_shouldExtendTrailingBackgroundFill(firstCell)) {
-        return column;
-      }
-      if (!_isBlankNormalCell(firstCell)) {
-        return null;
-      }
-    }
-    return null;
   }
 
   @override
@@ -2288,64 +2148,6 @@ class MonkeyTerminalPainter extends TerminalPainter {
       cellData.flags & CellFlags.inverse != 0 ||
       _cellBackgroundColorType(cellData) != CellColor.normal;
 
-  bool _shouldExtendTrailingBackgroundFill(CellData firstCell) {
-    final inverse = firstCell.flags & CellFlags.inverse != 0;
-    final backgroundSourceColor = inverse
-        ? firstCell.foreground
-        : firstCell.background;
-    final backgroundType = _cellColorType(backgroundSourceColor);
-    if (backgroundType == CellColor.normal) {
-      return false;
-    }
-    // ANSI bright black is commonly used as a neutral prompt/message row
-    // background; semantic color labels should stay text-width.
-    if ((backgroundType == CellColor.named ||
-            backgroundType == CellColor.palette) &&
-        _cellColorValue(backgroundSourceColor) == 8) {
-      return true;
-    }
-    return _isNeutralTerminalColor(
-      inverse
-          ? resolveForegroundColor(firstCell.foreground)
-          : resolveBackgroundColor(firstCell.background),
-    );
-  }
-
-  bool _isBlankCell(CellData cellData) {
-    final charCode = cellData.content & CellContent.codepointMask;
-    return charCode == 0 || charCode == 0x20;
-  }
-
-  bool _isLiteralSpaceCell(CellData cellData) {
-    final charCode = cellData.content & CellContent.codepointMask;
-    return charCode == 0x20;
-  }
-
-  int _cellContentColumnWidth(CellData cellData) {
-    final width = cellData.content >> CellContent.widthShift;
-    return width > 0 ? width : 1;
-  }
-
-  bool _isBlankNormalCell(CellData cellData) {
-    // TUIs commonly clear row tails with literal spaces; render those like
-    // empty cells when deciding whether a neutral prompt background can extend.
-    final charCode = cellData.content & CellContent.codepointMask;
-    if (charCode == 0) {
-      return (cellData.flags & CellFlags.inverse) == 0 &&
-          _cellBackgroundColorType(cellData) == CellColor.normal;
-    }
-    if (charCode != 0x20) {
-      return false;
-    }
-    const visibleBlankFlags =
-        CellFlags.inverse |
-        CellFlags.underline |
-        CellFlags.overline |
-        CellFlags.strikethrough;
-    return (cellData.flags & visibleBlankFlags) == 0 &&
-        _cellBackgroundColorType(cellData) == CellColor.normal;
-  }
-
   Color _resolveCellBackgroundPaintColor(
     CellData cellData, {
     bool toneNeutralBackgrounds = true,
@@ -2402,8 +2204,6 @@ class MonkeyTerminalPainter extends TerminalPainter {
 }
 
 int _cellColorType(int cellColor) => cellColor & CellColor.typeMask;
-
-int _cellColorValue(int cellColor) => cellColor & CellColor.valueMask;
 
 int _cellBackgroundColorType(CellData cellData) =>
     _cellColorType(cellData.background);

--- a/test/unit/terminal_query_response_test.dart
+++ b/test/unit/terminal_query_response_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/xterm.dart';
+
+void main() {
+  group('terminal capability query responses', () {
+    test('XTVERSION (CSI > q) reports a kitty-family identity', () {
+      // CLIs such as the GitHub Copilot CLI gate their richer rendering (e.g.
+      // full-width prompt/composer backgrounds) on a recognized XTVERSION name.
+      // MonkeySSH implements the kitty graphics + keyboard protocols, so it
+      // answers with a kitty identity to unlock that path.
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[>q');
+
+      expect(responses, ['\x1bP>|kitty(0.32.0)\x1b\\']);
+    });
+
+    test('XTVERSION reply starts with a name Copilot CLI recognizes', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[>q');
+
+      // DCS `ESC P > | <name> ESC \`; the payload must start with "kitty".
+      final reply = responses.single;
+      expect(reply.startsWith('\x1bP>|kitty'), isTrue);
+      expect(reply.endsWith('\x1b\\'), isTrue);
+    });
+
+    test('a bare CSI q (no > prefix) does not emit an XTVERSION reply', () {
+      final responses = <String>[];
+      // Space-intermediate form (DECSCUSR cursor style) must not be treated as
+      // XTVERSION.
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[ q');
+
+      expect(responses, isEmpty);
+    });
+
+    test('primary device attributes still answer', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[c');
+
+      expect(responses, ['\x1b[?1;2c']);
+    });
+  });
+}

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -662,271 +662,14 @@ void main() {
       },
     );
 
-    test('extends left-edge highlighted rows to line end', () {
+    test('does not paint an inline code-span background past the span', () async {
+      const codeBackground = Color(0xFFD0DAD9);
+      // A neutral inline code span (Copilot-style padding spaces) followed by
+      // normal text. The span background must stay within its own cells and
+      // never bleed to the end of the row.
       final terminal = Terminal()
-        ..resize(24, 2)
-        ..write('\x1b[100m> fix contrast\x1b[49m');
-      final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
-        textStyle: const TerminalStyle(),
-        textScaler: TextScaler.noScaling,
-      );
-
-      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
-        terminal.buffer.lines[0],
-      );
-
-      expect(fill, isNotNull);
-      expect(fill!.startColumn, '> fix contrast'.length);
-      expect(
-        _contrastRatio(TerminalThemes.defaultLightTheme.foreground, fill.color),
-        greaterThanOrEqualTo(4.5),
-      );
-    });
-
-    test('extends neutral truecolor composer rows to line end', () {
-      const neutralBackground = Color(0xFF5F5F5F);
-      final terminal = Terminal()
-        ..resize(32, 2)
-        ..write('\x1b[48;2;95;95;95mAsk Codex\x1b[49m');
-      final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultDarkTheme.toXtermTheme(),
-        textStyle: const TerminalStyle(),
-        textScaler: TextScaler.noScaling,
-      );
-
-      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
-        terminal.buffer.lines[0],
-      );
-
-      expect(fill, isNotNull);
-      expect(fill!.startColumn, 'Ask Codex'.length);
-      expect(fill.color, isNot(neutralBackground));
-      expect(
-        _contrastRatio(fill.color, TerminalThemes.defaultDarkTheme.background),
-        inInclusiveRange(1.04, 1.75),
-      );
-    });
-
-    test('extends Copilot prompt rows across trailing normal spaces', () {
-      const copilotPromptStyle = '\x1b[38;2;180;180;180;48;2;32;32;32m';
-      final terminal = Terminal()
-        ..resize(48, 2)
-        ..write(
-          '$copilotPromptStyle❯\x1b[39m once everything is addressed\x1b[m     ',
-        );
-      final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultDarkTheme.toXtermTheme(),
-        textStyle: const TerminalStyle(),
-        textScaler: TextScaler.noScaling,
-      );
-
-      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
-        terminal.buffer.lines[0],
-      );
-
-      expect(fill, isNotNull);
-      expect(fill!.startColumn, '❯ once everything is addressed'.length);
-      expect(
-        _contrastRatio(fill.color, TerminalThemes.defaultDarkTheme.background),
-        inInclusiveRange(1.04, 1.75),
-      );
-    });
-
-    test('counts prompt-background spaces as prompt row content', () {
-      const promptBackground = Color(0xFFD0DAD9);
-      const promptBackgroundSequence = '\x1b[48;2;208;218;217m';
-      final terminal = Terminal()
-        ..resize(48, 2)
-        ..write('$promptBackgroundSequence❯ \x1b[m');
-      final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
-        textStyle: const TerminalStyle(),
-        textScaler: TextScaler.noScaling,
-      );
-
-      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
-        terminal.buffer.lines[0],
-      );
-
-      expect(fill, isNotNull);
-      expect(fill!.startColumn, '❯ '.length);
-      expect(fill.color, promptBackground);
-    });
-
-    test('starts Copilot prompt tail fill after full double-width glyphs', () {
-      const promptBackground = Color(0xFFD0DAD9);
-      const promptBackgroundSequence = '\x1b[48;2;208;218;217m';
-      final terminal = Terminal()
-        ..resize(48, 2)
-        ..write('$promptBackgroundSequence❯ 中\x1b[m');
-      final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
-        textStyle: const TerminalStyle(),
-        textScaler: TextScaler.noScaling,
-      );
-
-      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
-        terminal.buffer.lines[0],
-      );
-
-      expect(fill, isNotNull);
-      expect(fill!.startColumn, 4);
-      expect(fill.color, promptBackground);
-    });
-
-    test('extends inverse Copilot prompt rows on light themes', () {
-      const copilotPromptStyle = '\x1b[38;2;180;180;180;7m';
-      final terminal = Terminal()
-        ..resize(48, 2)
-        ..write('$copilotPromptStyle❯ what is the easiest way?\x1b[m     ');
-      final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
-        textStyle: const TerminalStyle(),
-        textScaler: TextScaler.noScaling,
-      );
-
-      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
-        terminal.buffer.lines[0],
-      );
-
-      expect(fill, isNotNull);
-      expect(fill!.startColumn, '❯ what is the easiest way?'.length);
-      expect(fill.color, const Color(0xFFB4B4B4));
-    });
-
-    test(
-      'paints Copilot prompt marker background through normal text rows',
-      () async {
-        const promptBackground = Color(0xFFD0DAD9);
-        const promptBackgroundSequence = '\x1b[48;2;208;218;217m';
-        const promptText = '❯ did it work?';
-        final terminal = Terminal()
-          ..resize(48, 2)
-          ..write(
-            '\x1b[2;4m\x1b[K\r'
-            '$promptBackgroundSequence❯ \x1b[mdid it work?',
-          );
-        final theme = TerminalThemes.defaultLightTheme.toXtermTheme();
-        final painter = MonkeyTerminalPainter(
-          theme: theme,
-          textStyle: const TerminalStyle(),
-          textScaler: TextScaler.noScaling,
-        );
-        final cellSize = painter.cellSize;
-        final imageWidth = (cellSize.width * terminal.viewWidth).ceil();
-        final imageHeight = cellSize.height.ceil();
-        final recorder = ui.PictureRecorder();
-        final canvas = Canvas(recorder);
-
-        painter.paintLine(canvas, Offset.zero, terminal.buffer.lines[0]);
-
-        final image = await recorder.endRecording().toImage(
-          imageWidth,
-          imageHeight,
-        );
-        final byteData = await image.toByteData();
-        expect(byteData, isNotNull);
-
-        final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
-          terminal.buffer.lines[0],
-        );
-        expect(fill, isNotNull);
-        expect(fill!.startColumn, promptText.length);
-        expect(fill.color, promptBackground);
-        expect(
-          _rawRgbaPixel(
-            byteData!,
-            imageWidth,
-            ((promptText.length + 4) * cellSize.width).round(),
-            (cellSize.height / 2).round(),
-          ),
-          promptBackground,
-        );
-      },
-    );
-
-    test(
-      'paints Copilot prompts over explicit terminal-background tails',
-      () async {
-        const promptBackground = Color(0xFFD0DAD9);
-        const promptBackgroundSequence = '\x1b[48;2;208;218;217m';
-        const terminalBackgroundSequence = '\x1b[48;2;235;243;242m';
-        const promptText = '❯ did it work';
-        final terminal = Terminal()
-          ..resize(48, 2)
-          ..write(
-            '$promptBackgroundSequence❯ \x1b[mdid it work'
-            '$terminalBackgroundSequence     \x1b[m',
-          );
-        final painter = MonkeyTerminalPainter(
-          theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
-          textStyle: const TerminalStyle(),
-          textScaler: TextScaler.noScaling,
-        );
-        final cellSize = painter.cellSize;
-        final imageWidth = (cellSize.width * terminal.viewWidth).ceil();
-        final imageHeight = cellSize.height.ceil();
-        final recorder = ui.PictureRecorder();
-        final canvas = Canvas(recorder);
-
-        painter.paintLine(canvas, Offset.zero, terminal.buffer.lines[0]);
-
-        final image = await recorder.endRecording().toImage(
-          imageWidth,
-          imageHeight,
-        );
-        final byteData = await image.toByteData();
-        expect(byteData, isNotNull);
-
-        final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
-          terminal.buffer.lines[0],
-        );
-        expect(fill, isNotNull);
-        expect(fill!.startColumn, promptText.length);
-        expect(fill.color, promptBackground);
-        expect(
-          _rawRgbaPixel(
-            byteData!,
-            imageWidth,
-            ((promptText.length + 4) * cellSize.width).round(),
-            (cellSize.height / 2).round(),
-          ),
-          promptBackground,
-        );
-      },
-    );
-
-    test('extends Copilot prompts past right-edge scrollbar glyphs', () {
-      const promptBackground = Color(0xFFD0DAD9);
-      const promptBackgroundSequence = '\x1b[48;2;208;218;217m';
-      const promptText = '❯ test';
-      final terminal = Terminal()
-        ..resize(48, 2)
-        ..write(
-          '\x1b[2;4m\x1b[K\r'
-          '$promptBackgroundSequence❯ test\x1b[m\x1b[48G│',
-        );
-      final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
-        textStyle: const TerminalStyle(),
-        textScaler: TextScaler.noScaling,
-      );
-
-      final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
-        terminal.buffer.lines[0],
-      );
-
-      expect(fill, isNotNull);
-      expect(fill!.startColumn, promptText.length);
-      expect(fill.color, promptBackground);
-    });
-
-    test('keeps right-edge scrollbar glyphs over prompt tail fills', () async {
-      const promptBackgroundSequence = '\x1b[48;2;208;218;217m';
-      final terminal = Terminal()
-        ..resize(48, 2)
-        ..write('$promptBackgroundSequence❯ test\x1b[m\x1b[48G█');
+        ..resize(40, 2)
+        ..write('\x1b[48;2;208;218;217m main \x1b[49m and more text');
       final theme = TerminalThemes.defaultLightTheme.toXtermTheme();
       final painter = MonkeyTerminalPainter(
         theme: theme,
@@ -937,7 +680,11 @@ void main() {
       final imageWidth = (cellSize.width * terminal.viewWidth).ceil();
       final imageHeight = cellSize.height.ceil();
       final recorder = ui.PictureRecorder();
-      final canvas = Canvas(recorder);
+      final canvas = Canvas(recorder)
+        ..drawRect(
+          Rect.fromLTWH(0, 0, imageWidth.toDouble(), imageHeight.toDouble()),
+          Paint()..color = theme.background,
+        );
 
       painter.paintLine(canvas, Offset.zero, terminal.buffer.lines[0]);
 
@@ -947,91 +694,69 @@ void main() {
       );
       final byteData = await image.toByteData();
       expect(byteData, isNotNull);
-      expect(
-        _rawRgbaPixel(
-          byteData!,
-          imageWidth,
-          ((terminal.viewWidth - 0.5) * cellSize.width).round(),
-          (cellSize.height / 2).round(),
-        ),
-        theme.foreground,
+
+      Color sample(int column) => _rawRgbaPixel(
+        byteData!,
+        imageWidth,
+        ((column + 0.5) * cellSize.width).round(),
+        (cellSize.height / 2).round(),
       );
+
+      // The leading padding space of the code span carries the code background.
+      expect(sample(0), codeBackground);
+      // The empty tail of the row keeps the terminal background (no bleed).
+      expect(sample(35), theme.background);
     });
 
     test(
-      'extends neutral truecolor composer rows after blank leading cells',
-      () {
+      'renders a full-width prompt background painted with real cells',
+      () async {
+        // When a CLI detects a capable terminal (via XTVERSION) it paints the
+        // prompt row background across the whole width with real bg-coloured
+        // space cells. This must render edge to edge with no help from any fill
+        // heuristic. Models the captured Copilot rich-mode prompt.
+        final promptRow = '\x1b[48;2;20;27;34m\u276F ok${' ' * 36}\x1b[m';
         final terminal = Terminal()
-          ..resize(32, 2)
-          ..write('\x1b[2C\x1b[48;2;95;95;95mAsk Codex\x1b[49m');
+          ..resize(40, 2)
+          ..write(promptRow);
+        final theme = TerminalThemes.defaultDarkTheme.toXtermTheme();
         final painter = MonkeyTerminalPainter(
-          theme: TerminalThemes.defaultDarkTheme.toXtermTheme(),
+          theme: theme,
           textStyle: const TerminalStyle(),
           textScaler: TextScaler.noScaling,
         );
+        final cellSize = painter.cellSize;
+        final imageWidth = (cellSize.width * terminal.viewWidth).ceil();
+        final imageHeight = cellSize.height.ceil();
+        final recorder = ui.PictureRecorder();
+        final canvas = Canvas(recorder)
+          ..drawRect(
+            Rect.fromLTWH(0, 0, imageWidth.toDouble(), imageHeight.toDouble()),
+            Paint()..color = theme.background,
+          );
 
-        final fill = painter.resolveMonkeyTerminalTrailingBackgroundFill(
-          terminal.buffer.lines[0],
+        painter.paintLine(canvas, Offset.zero, terminal.buffer.lines[0]);
+
+        final image = await recorder.endRecording().toImage(
+          imageWidth,
+          imageHeight,
+        );
+        final byteData = await image.toByteData();
+        expect(byteData, isNotNull);
+
+        Color sample(int column) => _rawRgbaPixel(
+          byteData!,
+          imageWidth,
+          ((column + 0.5) * cellSize.width).round(),
+          (cellSize.height / 2).round(),
         );
 
-        expect(fill, isNotNull);
-        expect(fill!.startColumn, 2 + 'Ask Codex'.length);
+        // Both an early fill cell and a far-right fill cell share the same
+        // explicit prompt background, distinct from the terminal background.
+        expect(sample(10), isNot(theme.background));
+        expect(sample(35), sample(10));
       },
     );
-
-    test('does not extend inset highlighted runs', () {
-      final terminal = Terminal()
-        ..resize(24, 2)
-        ..write('x \x1b[100mstatus\x1b[49m');
-      final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
-        textStyle: const TerminalStyle(),
-        textScaler: TextScaler.noScaling,
-      );
-
-      expect(
-        painter.resolveMonkeyTerminalTrailingBackgroundFill(
-          terminal.buffer.lines[0],
-        ),
-        isNull,
-      );
-    });
-
-    test('does not extend semantic color labels', () {
-      final terminal = Terminal()
-        ..resize(24, 2)
-        ..write('\x1b[41mERROR\x1b[49m');
-      final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
-        textStyle: const TerminalStyle(),
-        textScaler: TextScaler.noScaling,
-      );
-
-      expect(
-        painter.resolveMonkeyTerminalTrailingBackgroundFill(
-          terminal.buffer.lines[0],
-        ),
-        isNull,
-      );
-    });
-
-    test('does not extend saturated truecolor labels', () {
-      final terminal = Terminal()
-        ..resize(24, 2)
-        ..write('\x1b[48;2;168;47;69mERROR\x1b[49m');
-      final painter = MonkeyTerminalPainter(
-        theme: TerminalThemes.defaultLightTheme.toXtermTheme(),
-        textStyle: const TerminalStyle(),
-        textScaler: TextScaler.noScaling,
-      );
-
-      expect(
-        painter.resolveMonkeyTerminalTrailingBackgroundFill(
-          terminal.buffer.lines[0],
-        ),
-        isNull,
-      );
-    });
 
     test('lifts low-contrast foreground-only ANSI colors', () {
       final terminal = Terminal()

--- a/third_party/xterm/CHANGELOG.md
+++ b/third_party/xterm/CHANGELOG.md
@@ -50,6 +50,16 @@ out of scope.
   cursor alignment depending on the host's own `wcwidth`, so it is left as a
   separate, deliberate change.
 
+### MonkeySSH-local additions (preserve across kterm syncs)
+* XTVERSION reply (`CSI > q` -> `DCS > | kitty(0.32.0) ST`). MonkeySSH
+  implements the kitty graphics + keyboard protocols, so it reports a
+  kitty-family identity. CLIs such as the GitHub Copilot CLI gate their richer
+  rendering (full-width prompt/composer backgrounds, painted with real cells)
+  on a recognized XTVERSION name; without it they fall back to a tight,
+  text-width background. Upstream kterm does not answer XTVERSION yet, so keep
+  `EscapeEmitter.terminalVersion()` and the `CSI q` parser dispatch when
+  re-syncing. Consider upstreaming.
+
 
 ## [3.6.1-pre] - 2023-04-28
 * Add Termianl.onPrivateOSC callback

--- a/third_party/xterm/lib/src/core/escape/emitter.dart
+++ b/third_party/xterm/lib/src/core/escape/emitter.dart
@@ -15,6 +15,19 @@ class EscapeEmitter {
     return '\x1bP!|00000000\x1b\\';
   }
 
+  /// Response to XTVERSION (`CSI > q`): the terminal name and version.
+  ///
+  /// MonkeySSH implements the kitty graphics and keyboard protocols (plus
+  /// truecolor and styled underlines), so it reports a kitty-family identity.
+  /// Besides being accurate about the supported protocol family, this unlocks
+  /// the richer rendering path in CLIs (for example the GitHub Copilot CLI)
+  /// that gate full-width prompt/composer backgrounds on a recognized
+  /// XTVERSION name. The version predates the kitty text-sizing protocol, which
+  /// this terminal does not implement.
+  String terminalVersion() {
+    return '\x1bP>|kitty(0.32.0)\x1b\\';
+  }
+
   String operatingStatus() {
     return '\x1b[0n';
   }

--- a/third_party/xterm/lib/src/core/escape/handler.dart
+++ b/third_party/xterm/lib/src/core/escape/handler.dart
@@ -64,6 +64,8 @@ abstract class EscapeHandler {
 
   void sendTertiaryDeviceAttributes();
 
+  void sendTerminalVersion();
+
   void sendOperatingStatus();
 
   void sendCursorPosition();

--- a/third_party/xterm/lib/src/core/escape/parser.dart
+++ b/third_party/xterm/lib/src/core/escape/parser.dart
@@ -361,6 +361,7 @@ class EscapeParser {
     'l'.codeUnitAt(0): _csiHandleMode,
     'm'.codeUnitAt(0): _csiHandleSgr,
     'n'.codeUnitAt(0): _csiHandleDeviceStatusReport,
+    'q'.codeUnitAt(0): _csiHandleRequestTerminalVersion,
     'r'.codeUnitAt(0): _csiHandleSetMargins,
     't'.codeUnitAt(0): _csiWindowManipulation,
     'A'.codeUnitAt(0): _csiHandleCursorUp,
@@ -418,6 +419,18 @@ class EscapeParser {
         return handler.sendTertiaryDeviceAttributes();
       default:
         handler.sendPrimaryDeviceAttributes();
+    }
+  }
+
+  /// `ESC [ > q` Request Terminal Name and Version (XTVERSION)
+  ///
+  /// https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+  void _csiHandleRequestTerminalVersion() {
+    // Only the `>` form is XTVERSION. Other `q` finals (DECSCUSR cursor style
+    // with a space intermediate, DECSCA with a `"` intermediate) are not
+    // handled here.
+    if (_csi.prefix == Ascii.greaterThan) {
+      handler.sendTerminalVersion();
     }
   }
 

--- a/third_party/xterm/lib/src/terminal.dart
+++ b/third_party/xterm/lib/src/terminal.dart
@@ -622,6 +622,11 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
   }
 
   @override
+  void sendTerminalVersion() {
+    onOutput?.call(_emitter.terminalVersion());
+  }
+
+  @override
   void sendOperatingStatus() {
     onOutput?.call(_emitter.operatingStatus());
   }

--- a/third_party/xterm/lib/src/utils/debugger.dart
+++ b/third_party/xterm/lib/src/utils/debugger.dart
@@ -237,6 +237,11 @@ class _TerminalDebuggerHandler implements EscapeHandler {
   }
 
   @override
+  void sendTerminalVersion() {
+    onCommand('sendTerminalVersion');
+  }
+
+  @override
   void sendOperatingStatus() {
     onCommand('sendOperatingStatus');
   }


### PR DESCRIPTION
## Problem
On MonkeySSH, Copilot CLI prompt/composer backgrounds rendered tight around the text instead of spanning the row, and a painter heuristic added to compensate smeared inline code-span backgrounds to the end of the line (the reported bug).

## Root cause
Copilot (and similar CLIs) gate their rich rendering — full-width backgrounds painted with real cells — on a recognized **XTVERSION** (`CSI > q`) reply. The vendored xterm never answered XTVERSION, so Copilot fell back to a tight, text-width background. The old `paintLineTrailingBackgroundFill` heuristic faked that fill and over-fired on inline code spans in wrapped markdown.

Verified with `pyte` (a faithful terminal emulator): with no XTVERSION reply the prompt background spans only the text (cols 1–24); with a `kitty(...)` reply Copilot paints the full row (cols 1–77) with real bg-coloured space cells.

## Fix
- **Answer XTVERSION** in the vendored xterm with `kitty(0.32.0)` — accurate, since the terminal implements the kitty graphics + keyboard protocols. This unlocks Copilot's rich mode, which emits the full-width background as real cells that the faithful per-cell renderer already draws.
- **Remove the trailing-background-fill heuristic** entirely (−200 lines) and its preview-snippet call. Backgrounds now render like a standard terminal (macOS Terminal / Ghostty).

## Tests
- XTVERSION reply + prefix guard — `test/unit/terminal_query_response_test.dart`
- Inline code span no longer bleeds; full-width background via real cells renders edge to edge — `monkey_terminal_view_layout_test.dart`
- Full suite: **2442 passed**; vendored xterm core: 119 passed; `flutter analyze` clean

## Follow-ups (separate issues, not in this PR)
- #590 — answer remaining terminal capability queries (DECRQM, OSC color/palette, XTGETTCAP, DA modernization)
- #591 — re-sync vendored xterm with kterm 1.5.0 (kitty_protocol + fixes); upstream the XTVERSION reply
