### PR TITLE
feat(terminal): answer remaining capability queries (DECRQM/XTGETTCAP/DECRQSS, pixel reports) + DA modernization

### DIFF
--- a/test/unit/terminal_query_response_test.dart
+++ b/test/unit/terminal_query_response_test.dart
@@ -192,15 +192,118 @@ void main() {
       ]);
     });
 
-    test('a non-XTGETTCAP DCS is consumed without leaking as text', () {
+    test('an unhandled DCS is consumed without leaking as text', () {
       final responses = <String>[];
-      // DECRQSS-style DCS ($q) must not emit a reply nor render its body.
+      // A Sixel-style DCS (`DCS q ... ST`, neither +q nor $q) must not emit a
+      // reply nor render its body.
       final terminal = Terminal()
         ..onOutput = responses.add
-        ..write('\x1bP\$q m\x1b\\');
+        ..write('\x1bPq#0;2;0;0;0\x1b\\');
 
       expect(responses, isEmpty);
       expect(terminal.buffer.getText().trim(), isEmpty);
+    });
+  });
+
+  group(r'DECRQSS (DCS $ q <Pt> ST)', () {
+    test('reports the scrolling region (DECSTBM) for an 80x24 terminal', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1bP\$qr\x1b\\');
+
+      // Default margins span the whole screen: rows 1..24.
+      expect(responses, ['\x1bP1\$r1;24r\x1b\\']);
+    });
+
+    test('reports a custom scrolling region', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[5;20r') // DECSTBM top=5 bottom=20
+        ..write('\x1bP\$qr\x1b\\');
+
+      expect(responses, ['\x1bP1\$r5;20r\x1b\\']);
+    });
+
+    test('reports the default SGR as a bare reset', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1bP\$qm\x1b\\');
+
+      expect(responses, ['\x1bP1\$r0m\x1b\\']);
+    });
+
+    test('reports the active SGR (bold + named foreground)', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[1;31m') // bold, red foreground
+        ..write('\x1bP\$qm\x1b\\');
+
+      expect(responses, ['\x1bP1\$r0;1;31m\x1b\\']);
+    });
+
+    test('reports indexed and rgb SGR colours', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[38;5;42;48;2;1;2;3m') // palette fg 42, rgb bg 1/2/3
+        ..write('\x1bP\$qm\x1b\\');
+
+      expect(responses, ['\x1bP1\$r0;38;5;42;48;2;1;2;3m\x1b\\']);
+    });
+
+    test('reports an untracked control function (DECSCUSR) as invalid', () {
+      final responses = <String>[];
+      // Cursor shape (` q`) is not tracked by the core terminal, so DECRQSS
+      // reports it as not recognized rather than guessing.
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1bP\$q q\x1b\\');
+
+      expect(responses, ['\x1bP0\$r\x1b\\']);
+    });
+  });
+
+  group('window pixel-size reports (CSI 14/15/16 t)', () {
+    test('reports text area, screen and cell size in pixels', () {
+      final responses = <String>[];
+      // 80x24 cells over an 800x480 px text area => 10x20 px cells.
+      Terminal()
+        ..onOutput = responses.add
+        ..resize(80, 24, 800, 480)
+        ..write('\x1b[14t') // text area px
+        ..write('\x1b[15t') // screen px (mirrors text area)
+        ..write('\x1b[16t'); // cell px
+
+      expect(responses, [
+        '\x1b[4;480;800t',
+        '\x1b[5;480;800t',
+        '\x1b[6;20;10t',
+      ]);
+    });
+
+    test('does not report pixel sizes before the view size is known', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[14t')
+        ..write('\x1b[16t');
+
+      // No layout has happened yet, so pixel dimensions are unknown; a wrong
+      // (zero) report is worse than none.
+      expect(responses, isEmpty);
+    });
+
+    test('still answers the character size report (CSI 18 t)', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[18t');
+
+      expect(responses, ['\x1b[8;24;80t']);
     });
   });
 }

--- a/test/unit/terminal_query_response_test.dart
+++ b/test/unit/terminal_query_response_test.dart
@@ -61,52 +61,6 @@ void main() {
   });
 
   group(r'DECRQM (CSI Ps $ p) mode reports', () {
-    test('reports a tracked DEC private mode as set/reset', () {
-      final responses = <String>[];
-      // Bracketed paste (2004) starts reset, then enable it.
-      final terminal = Terminal()
-        ..onOutput = responses.add
-        ..write('\x1b[?2004\$p');
-      expect(responses, ['\x1b[?2004;2\$y']);
-
-      responses.clear();
-      terminal
-        ..write('\x1b[?2004h')
-        ..write('\x1b[?2004\$p');
-      expect(responses, ['\x1b[?2004;1\$y']);
-    });
-
-    test('reports default-on modes (autowrap, cursor visible) as set', () {
-      final responses = <String>[];
-      Terminal()
-        ..onOutput = responses.add
-        ..write('\x1b[?7\$p') // DECAWM, on by default
-        ..write('\x1b[?25\$p'); // DECTCEM, on by default
-
-      expect(responses, ['\x1b[?7;1\$y', '\x1b[?25;1\$y']);
-    });
-
-    test('reports synchronized output (2026) as not recognized', () {
-      final responses = <String>[];
-      // MonkeySSH deliberately does not implement synchronized output, so
-      // DECRQM must report it as not recognized (value 0) rather than claim
-      // support.
-      Terminal()
-        ..onOutput = responses.add
-        ..write('\x1b[?2026\$p');
-
-      expect(responses, ['\x1b[?2026;0\$y']);
-    });
-
-    test('reports an unknown DEC private mode as not recognized', () {
-      final responses = <String>[];
-      Terminal()
-        ..onOutput = responses.add
-        ..write('\x1b[?9999\$p');
-
-      expect(responses, ['\x1b[?9999;0\$y']);
-    });
-
     test('reports tracked ANSI modes (insert) as set/reset', () {
       final responses = <String>[];
       final terminal = Terminal()
@@ -121,15 +75,27 @@ void main() {
       expect(responses, ['\x1b[4;1\$y']);
     });
 
-    test('reports tracked mouse mode (SGR encoding) accurately', () {
+    test('reports an unknown ANSI mode as not recognized', () {
       final responses = <String>[];
       Terminal()
         ..onOutput = responses.add
-        ..write('\x1b[?1006h') // enable SGR mouse encoding
-        ..write('\x1b[?1006\$p')
-        ..write('\x1b[?1015\$p'); // urxvt encoding, not active
+        ..write('\x1b[99\$p');
 
-      expect(responses, ['\x1b[?1006;1\$y', '\x1b[?1015;2\$y']);
+      expect(responses, ['\x1b[99;0\$y']);
+    });
+
+    test('leaves DEC-private DECRQM to the app layer (no core reply)', () {
+      final responses = <String>[];
+      // `CSI ? Ps $ p` is answered by the MonkeySSH app layer (which tracks the
+      // extra state, e.g. DEC mode 2031). The core must stay silent so the
+      // program does not receive two replies.
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[?2004\$p')
+        ..write('\x1b[?2026\$p')
+        ..write('\x1b[?2031\$p');
+
+      expect(responses, isEmpty);
     });
 
     test('a soft reset (CSI ! p) does not emit a DECRQM reply', () {
@@ -267,38 +233,24 @@ void main() {
     });
   });
 
-  group('window pixel-size reports (CSI 14/15/16 t)', () {
-    test('reports text area, screen and cell size in pixels', () {
+  group('window size reports (CSI t)', () {
+    test('leaves pixel-size reports (14t/16t) to the app layer', () {
       final responses = <String>[];
-      // 80x24 cells over an 800x480 px text area => 10x20 px cells.
+      // `CSI 14t` (text area px) and `CSI 16t` (cell px) are answered by the
+      // MonkeySSH app layer, which has the real window metrics. The core must
+      // stay silent so the program does not receive two replies.
       Terminal()
         ..onOutput = responses.add
         ..resize(80, 24, 800, 480)
-        ..write('\x1b[14t') // text area px
-        ..write('\x1b[15t') // screen px (mirrors text area)
-        ..write('\x1b[16t'); // cell px
-
-      expect(responses, [
-        '\x1b[4;480;800t',
-        '\x1b[5;480;800t',
-        '\x1b[6;20;10t',
-      ]);
-    });
-
-    test('does not report pixel sizes before the view size is known', () {
-      final responses = <String>[];
-      Terminal()
-        ..onOutput = responses.add
         ..write('\x1b[14t')
         ..write('\x1b[16t');
 
-      // No layout has happened yet, so pixel dimensions are unknown; a wrong
-      // (zero) report is worse than none.
       expect(responses, isEmpty);
     });
 
-    test('still answers the character size report (CSI 18 t)', () {
+    test('answers the character size report (CSI 18 t)', () {
       final responses = <String>[];
+      // 18t (size in characters) is core-only; the app layer does not answer it.
       Terminal()
         ..onOutput = responses.add
         ..write('\x1b[18t');

--- a/test/unit/terminal_query_response_test.dart
+++ b/test/unit/terminal_query_response_test.dart
@@ -39,13 +39,168 @@ void main() {
       expect(responses, isEmpty);
     });
 
-    test('primary device attributes still answer', () {
+    test('primary device attributes report VT220 with ANSI colour', () {
       final responses = <String>[];
       Terminal()
         ..onOutput = responses.add
         ..write('\x1b[c');
 
-      expect(responses, ['\x1b[?1;2c']);
+      // DA1: VT220 service class (62) advertising ANSI colour (22).
+      expect(responses, ['\x1b[?62;22c']);
+    });
+
+    test('secondary device attributes report a VT220-class identity', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[>c');
+
+      // DA2: model 1 (VT220), firmware version 0.
+      expect(responses, ['\x1b[>1;0;0c']);
+    });
+  });
+
+  group(r'DECRQM (CSI Ps $ p) mode reports', () {
+    test('reports a tracked DEC private mode as set/reset', () {
+      final responses = <String>[];
+      // Bracketed paste (2004) starts reset, then enable it.
+      final terminal = Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[?2004\$p');
+      expect(responses, ['\x1b[?2004;2\$y']);
+
+      responses.clear();
+      terminal
+        ..write('\x1b[?2004h')
+        ..write('\x1b[?2004\$p');
+      expect(responses, ['\x1b[?2004;1\$y']);
+    });
+
+    test('reports default-on modes (autowrap, cursor visible) as set', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[?7\$p') // DECAWM, on by default
+        ..write('\x1b[?25\$p'); // DECTCEM, on by default
+
+      expect(responses, ['\x1b[?7;1\$y', '\x1b[?25;1\$y']);
+    });
+
+    test('reports synchronized output (2026) as not recognized', () {
+      final responses = <String>[];
+      // MonkeySSH deliberately does not implement synchronized output, so
+      // DECRQM must report it as not recognized (value 0) rather than claim
+      // support.
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[?2026\$p');
+
+      expect(responses, ['\x1b[?2026;0\$y']);
+    });
+
+    test('reports an unknown DEC private mode as not recognized', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[?9999\$p');
+
+      expect(responses, ['\x1b[?9999;0\$y']);
+    });
+
+    test('reports tracked ANSI modes (insert) as set/reset', () {
+      final responses = <String>[];
+      final terminal = Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[4\$p'); // IRM off by default
+      expect(responses, ['\x1b[4;2\$y']);
+
+      responses.clear();
+      terminal
+        ..write('\x1b[4h')
+        ..write('\x1b[4\$p');
+      expect(responses, ['\x1b[4;1\$y']);
+    });
+
+    test('reports tracked mouse mode (SGR encoding) accurately', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[?1006h') // enable SGR mouse encoding
+        ..write('\x1b[?1006\$p')
+        ..write('\x1b[?1015\$p'); // urxvt encoding, not active
+
+      expect(responses, ['\x1b[?1006;1\$y', '\x1b[?1015;2\$y']);
+    });
+
+    test('a soft reset (CSI ! p) does not emit a DECRQM reply', () {
+      final responses = <String>[];
+      // `!` intermediate (DECSTR), not `$`, so it must not be misread as
+      // DECRQM and must not produce a mode report.
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1b[!p');
+
+      expect(responses, isEmpty);
+    });
+  });
+
+  group('XTGETTCAP (DCS + q <hex> ST)', () {
+    String hex(String value) =>
+        value.codeUnits.map((u) => u.toRadixString(16).padLeft(2, '0')).join();
+
+    test('reports the colour count (Co) as 256', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1bP+q${hex('Co')}\x1b\\');
+
+      expect(responses, ['\x1bP1+r${hex('Co')}=${hex('256')}\x1b\\']);
+    });
+
+    test('reports terminfo colors and direct-colour (RGB)', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1bP+q${hex('colors')}\x1b\\')
+        ..write('\x1bP+q${hex('RGB')}\x1b\\');
+
+      expect(responses, [
+        '\x1bP1+r${hex('colors')}=${hex('256')}\x1b\\',
+        '\x1bP1+r${hex('RGB')}=${hex('8/8/8')}\x1b\\',
+      ]);
+    });
+
+    test('reports unknown capabilities as invalid (0+r)', () {
+      final responses = <String>[];
+      // TN (terminal name) is host/TERM-defined and intentionally not answered.
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1bP+q${hex('TN')}\x1b\\');
+
+      expect(responses, ['\x1bP0+r${hex('TN')}\x1b\\']);
+    });
+
+    test('answers each capability in a multi-cap request', () {
+      final responses = <String>[];
+      Terminal()
+        ..onOutput = responses.add
+        ..write('\x1bP+q${hex('Co')};${hex('bogus')}\x1b\\');
+
+      expect(responses, [
+        '\x1bP1+r${hex('Co')}=${hex('256')}\x1b\\',
+        '\x1bP0+r${hex('bogus')}\x1b\\',
+      ]);
+    });
+
+    test('a non-XTGETTCAP DCS is consumed without leaking as text', () {
+      final responses = <String>[];
+      // DECRQSS-style DCS ($q) must not emit a reply nor render its body.
+      final terminal = Terminal()
+        ..onOutput = responses.add
+        ..write('\x1bP\$q m\x1b\\');
+
+      expect(responses, isEmpty);
+      expect(terminal.buffer.getText().trim(), isEmpty);
     });
   });
 }

--- a/third_party/xterm/CHANGELOG.md
+++ b/third_party/xterm/CHANGELOG.md
@@ -59,15 +59,15 @@ out of scope.
   text-width background. Upstream kterm does not answer XTVERSION yet, so keep
   `EscapeEmitter.terminalVersion()` and the `CSI q` parser dispatch when
   re-syncing. Consider upstreaming.
-* DECRQM replies (`CSI Ps $ p` / `CSI ? Ps $ p` -> `... $ y`). The parser now
+* DECRQM ANSI-mode replies (`CSI Ps $ p` -> `CSI Ps ; Pm $ y`). The parser now
   retains the last CSI intermediate (`_Csi.intermediate`) to distinguish DECRQM
   (`$`) from the other `p` finals (DECSTR `!`, DECSCL `"`), which still fall
-  through to `unknownCSI`. Tracked ANSI/DEC-private modes report their real
-  set/reset state; everything else reports "not recognized" (0). Synchronized
-  output (`2026`) is intentionally reported as not recognized, matching the
-  "evaluated but intentionally not ported" note above. Keep
-  `EscapeEmitter.modeReport`/`privateModeReport`, the `CSI p` parser dispatch,
-  and `Terminal._ansiModeValue`/`_decPrivateModeValue` on re-sync.
+  through to `unknownCSI`. Only the ANSI-mode form is answered here; the
+  DEC-private form (`CSI ? Ps $ p`) is deliberately left to the MonkeySSH app
+  layer, which scans shell output and tracks extra state (notably DEC mode 2031
+  colour-scheme updates) — answering it in core as well would double-reply.
+  Keep `EscapeEmitter.modeReport`, the `CSI p` parser dispatch, and
+  `Terminal._ansiModeValue` on re-sync.
 * XTGETTCAP replies (`DCS + q <hex> ST` -> `DCS 1+r <hex>=<hex> ST` /
   `DCS 0+r <hex> ST`). A new `ESC P` (DCS) parser branch buffers the string to
   ST; XTGETTCAP requests are answered for theme-independent caps (`Co`/`colors`
@@ -84,17 +84,15 @@ out of scope.
   `EscapeEmitter.statusStringReport` and
   `Terminal.sendStatusStringReport`/`_statusStringValue`/`_currentSgrParameters`
   on re-sync.
-* Window pixel-size reports (`CSI 14 t` text area, `CSI 15 t` screen, `CSI 16 t`
-  cell, replying `CSI 4/5/6 ; H ; W t`). The terminal now retains the text-area
-  pixel size supplied to `resize` (`_viewPixelWidth`/`_viewPixelHeight`) and
-  derives the cell size from it; it stays silent until the size is known so a
-  wrong (zero) report is never sent. Useful for image-capable CLIs. Keep
-  `EscapeEmitter.windowSizePixels` and the `CSI 14/15/16 t` handlers on re-sync.
 * Modernized Device Attributes: DA1 reports VT220 + ANSI colour (`CSI ?62;22c`,
   was `?1;2c`) and DA2 a VT220-class identity (`CSI >1;0;0c`, was `>0;0;0c`),
   consistent with the kitty XTVERSION identity. Keep
   `EscapeEmitter.primaryDeviceAttributes`/`secondaryDeviceAttributes` on
   re-sync.
+* Note: DEC-private DECRQM (`CSI ? Ps $ p`) and the window pixel-size reports
+  (`CSI 14/15/16 t`) are answered by the MonkeySSH app layer
+  (`ssh_service.dart`), not here, so the core deliberately does not reply to
+  them.
 
 
 ## [3.6.1-pre] - 2023-04-28

--- a/third_party/xterm/CHANGELOG.md
+++ b/third_party/xterm/CHANGELOG.md
@@ -59,6 +59,28 @@ out of scope.
   text-width background. Upstream kterm does not answer XTVERSION yet, so keep
   `EscapeEmitter.terminalVersion()` and the `CSI q` parser dispatch when
   re-syncing. Consider upstreaming.
+* DECRQM replies (`CSI Ps $ p` / `CSI ? Ps $ p` -> `... $ y`). The parser now
+  retains the last CSI intermediate (`_Csi.intermediate`) to distinguish DECRQM
+  (`$`) from the other `p` finals (DECSTR `!`, DECSCL `"`), which still fall
+  through to `unknownCSI`. Tracked ANSI/DEC-private modes report their real
+  set/reset state; everything else reports "not recognized" (0). Synchronized
+  output (`2026`) is intentionally reported as not recognized, matching the
+  "evaluated but intentionally not ported" note above. Keep
+  `EscapeEmitter.modeReport`/`privateModeReport`, the `CSI p` parser dispatch,
+  and `Terminal._ansiModeValue`/`_decPrivateModeValue` on re-sync.
+* XTGETTCAP replies (`DCS + q <hex> ST` -> `DCS 1+r <hex>=<hex> ST` /
+  `DCS 0+r <hex> ST`). A new `ESC P` (DCS) parser branch buffers the string to
+  ST; XTGETTCAP requests are answered for theme-independent caps (`Co`/`colors`
+  -> 256, `RGB` -> 8/8/8) and reported invalid otherwise (including `TN`, since
+  TERM is host-defined). As a side effect this also stops unrecognized DCS
+  payloads (Sixel, DECRQSS) from leaking into the buffer as text. Keep
+  `EscapeEmitter.termcapReport`, the `ESC P` dispatch, and
+  `Terminal.sendTermcapReport`/`_termcapValue` on re-sync.
+* Modernized Device Attributes: DA1 reports VT220 + ANSI colour (`CSI ?62;22c`,
+  was `?1;2c`) and DA2 a VT220-class identity (`CSI >1;0;0c`, was `>0;0;0c`),
+  consistent with the kitty XTVERSION identity. Keep
+  `EscapeEmitter.primaryDeviceAttributes`/`secondaryDeviceAttributes` on
+  re-sync.
 
 
 ## [3.6.1-pre] - 2023-04-28

--- a/third_party/xterm/CHANGELOG.md
+++ b/third_party/xterm/CHANGELOG.md
@@ -73,9 +73,23 @@ out of scope.
   ST; XTGETTCAP requests are answered for theme-independent caps (`Co`/`colors`
   -> 256, `RGB` -> 8/8/8) and reported invalid otherwise (including `TN`, since
   TERM is host-defined). As a side effect this also stops unrecognized DCS
-  payloads (Sixel, DECRQSS) from leaking into the buffer as text. Keep
+  payloads (Sixel, ...) from leaking into the buffer as text. Keep
   `EscapeEmitter.termcapReport`, the `ESC P` dispatch, and
   `Terminal.sendTermcapReport`/`_termcapValue` on re-sync.
+* DECRQSS replies (`DCS $ q <Pt> ST` -> `DCS 1$r <Pt> ST` / `DCS 0$r ST`),
+  dispatched from the same `ESC P` branch. Only control functions whose state
+  the core tracks are answered: DECSTBM (`r`, scrolling region) and SGR (`m`,
+  current rendition, serialized from the active pen). The cursor style (` q`),
+  conformance level (`"p`) and others report not recognized. Keep
+  `EscapeEmitter.statusStringReport` and
+  `Terminal.sendStatusStringReport`/`_statusStringValue`/`_currentSgrParameters`
+  on re-sync.
+* Window pixel-size reports (`CSI 14 t` text area, `CSI 15 t` screen, `CSI 16 t`
+  cell, replying `CSI 4/5/6 ; H ; W t`). The terminal now retains the text-area
+  pixel size supplied to `resize` (`_viewPixelWidth`/`_viewPixelHeight`) and
+  derives the cell size from it; it stays silent until the size is known so a
+  wrong (zero) report is never sent. Useful for image-capable CLIs. Keep
+  `EscapeEmitter.windowSizePixels` and the `CSI 14/15/16 t` handlers on re-sync.
 * Modernized Device Attributes: DA1 reports VT220 + ANSI colour (`CSI ?62;22c`,
   was `?1;2c`) and DA2 a VT220-class identity (`CSI >1;0;0c`, was `>0;0;0c`),
   consistent with the kitty XTVERSION identity. Keep

--- a/third_party/xterm/lib/src/core/escape/emitter.dart
+++ b/third_party/xterm/lib/src/core/escape/emitter.dart
@@ -46,12 +46,6 @@ class EscapeEmitter {
     return '\x1b[$mode;$value\$y';
   }
 
-  /// Response to DECRQM for a DEC private mode
-  /// (`CSI ? Ps $ p` -> `CSI ? Ps ; Pm $ y`).
-  String privateModeReport(int mode, int value) {
-    return '\x1b[?$mode;$value\$y';
-  }
-
   /// Response to XTGETTCAP for a single capability
   /// (`DCS 1 + r <name>=<value> ST` when known, `DCS 0 + r <name> ST` when not).
   ///
@@ -76,15 +70,6 @@ class EscapeEmitter {
       return '\x1bP0\$r\x1b\\';
     }
     return '\x1bP1\$r$value\x1b\\';
-  }
-
-  /// Response to a window-size pixel report (`CSI 14/15/16 t`).
-  ///
-  /// [kind] is the reply selector (4 text area, 5 screen, 6 cell); [height] and
-  /// [width] are in pixels, height first to match the `CSI 8 ; rows ; cols t`
-  /// convention.
-  String windowSizePixels(int kind, int height, int width) {
-    return '\x1b[$kind;$height;${width}t';
   }
 
   String operatingStatus() {

--- a/third_party/xterm/lib/src/core/escape/emitter.dart
+++ b/third_party/xterm/lib/src/core/escape/emitter.dart
@@ -65,6 +65,28 @@ class EscapeEmitter {
     return '\x1bP1+r$hexName=$hexValue\x1b\\';
   }
 
+  /// Response to DECRQSS (`DCS 1 $ r <Pt> ST` when the request is recognized,
+  /// `DCS 0 $ r ST` when it is not).
+  ///
+  /// [value] is the full status string including the control function's
+  /// trailing intermediate/final (for example `1;24r` or `0;1m`), or null when
+  /// the request is not recognized.
+  String statusStringReport(String? value) {
+    if (value == null) {
+      return '\x1bP0\$r\x1b\\';
+    }
+    return '\x1bP1\$r$value\x1b\\';
+  }
+
+  /// Response to a window-size pixel report (`CSI 14/15/16 t`).
+  ///
+  /// [kind] is the reply selector (4 text area, 5 screen, 6 cell); [height] and
+  /// [width] are in pixels, height first to match the `CSI 8 ; rows ; cols t`
+  /// convention.
+  String windowSizePixels(int kind, int height, int width) {
+    return '\x1b[$kind;$height;${width}t';
+  }
+
   String operatingStatus() {
     return '\x1b[0n';
   }

--- a/third_party/xterm/lib/src/core/escape/emitter.dart
+++ b/third_party/xterm/lib/src/core/escape/emitter.dart
@@ -2,11 +2,21 @@ class EscapeEmitter {
   const EscapeEmitter();
 
   String primaryDeviceAttributes() {
-    return '\x1b[?1;2c';
+    // DA1: VT220 service class (62) advertising ANSI colour (feature 22). This
+    // replaces the old VT100 identity (`?1;2c`) now that the terminal also
+    // reports a kitty identity via XTVERSION; it is a more accurate, widely
+    // compatible reply and lets apps that branch on DA1 see colour support.
+    // Only flags the terminal genuinely implements are claimed (colour);
+    // 132-column, selective-erase, etc. are intentionally omitted.
+    return '\x1b[?62;22c';
   }
 
   String secondaryDeviceAttributes() {
-    const model = 0;
+    // DA2: VT220-class terminal (model 1) to stay consistent with the VT220
+    // DA1 service level. The firmware version is left at 0 so terminal-
+    // detection heuristics that key off specific patch levels do not apply a
+    // device-specific quirk — the precise identity is carried by XTVERSION.
+    const model = 1;
     const version = 0;
     return '\x1b[>$model;$version;0c';
   }
@@ -26,6 +36,33 @@ class EscapeEmitter {
   /// this terminal does not implement.
   String terminalVersion() {
     return '\x1bP>|kitty(0.32.0)\x1b\\';
+  }
+
+  /// Response to DECRQM for an ANSI mode (`CSI Ps $ p` -> `CSI Ps ; Pm $ y`).
+  ///
+  /// [value] follows the DECRPM convention: 0 not recognized, 1 set, 2 reset,
+  /// 3 permanently set, 4 permanently reset.
+  String modeReport(int mode, int value) {
+    return '\x1b[$mode;$value\$y';
+  }
+
+  /// Response to DECRQM for a DEC private mode
+  /// (`CSI ? Ps $ p` -> `CSI ? Ps ; Pm $ y`).
+  String privateModeReport(int mode, int value) {
+    return '\x1b[?$mode;$value\$y';
+  }
+
+  /// Response to XTGETTCAP for a single capability
+  /// (`DCS 1 + r <name>=<value> ST` when known, `DCS 0 + r <name> ST` when not).
+  ///
+  /// [hexName] is echoed back exactly as requested so the querying program can
+  /// match it; [hexValue] is the hex-encoded capability value, or null when the
+  /// capability is unknown/unsupported.
+  String termcapReport(String hexName, String? hexValue) {
+    if (hexValue == null) {
+      return '\x1bP0+r$hexName\x1b\\';
+    }
+    return '\x1bP1+r$hexName=$hexValue\x1b\\';
   }
 
   String operatingStatus() {

--- a/third_party/xterm/lib/src/core/escape/handler.dart
+++ b/third_party/xterm/lib/src/core/escape/handler.dart
@@ -76,6 +76,10 @@ abstract class EscapeHandler {
   /// terminfo/termcap capability names.
   void sendTermcapReport(List<String> capabilities);
 
+  /// Answers DECRQSS (`DCS $ q <Pt> ST`) for the control function identified by
+  /// [request] (the intermediate/final bytes, e.g. `r`, `m`, ` q`).
+  void sendStatusStringReport(String request);
+
   void sendOperatingStatus();
 
   void sendCursorPosition();
@@ -171,6 +175,15 @@ abstract class EscapeHandler {
   void resize(int cols, int rows);
 
   void sendSize();
+
+  /// Answers `CSI 14 t` — report text area size in pixels (`CSI 4 ; H ; W t`).
+  void sendTextAreaSizePixels();
+
+  /// Answers `CSI 15 t` — report screen size in pixels (`CSI 5 ; H ; W t`).
+  void sendScreenSizePixels();
+
+  /// Answers `CSI 16 t` — report cell size in pixels (`CSI 6 ; H ; W t`).
+  void sendCellSizePixels();
 
   /* Select Graphic Rendition (SGR) */
 

--- a/third_party/xterm/lib/src/core/escape/handler.dart
+++ b/third_party/xterm/lib/src/core/escape/handler.dart
@@ -69,9 +69,6 @@ abstract class EscapeHandler {
   /// Answers DECRQM for an ANSI mode (`CSI Ps $ p`).
   void sendModeReport(int mode);
 
-  /// Answers DECRQM for a DEC private mode (`CSI ? Ps $ p`).
-  void sendPrivateModeReport(int mode);
-
   /// Answers XTGETTCAP (`DCS + q <hex> ST`) for the given hex-encoded
   /// terminfo/termcap capability names.
   void sendTermcapReport(List<String> capabilities);
@@ -175,15 +172,6 @@ abstract class EscapeHandler {
   void resize(int cols, int rows);
 
   void sendSize();
-
-  /// Answers `CSI 14 t` — report text area size in pixels (`CSI 4 ; H ; W t`).
-  void sendTextAreaSizePixels();
-
-  /// Answers `CSI 15 t` — report screen size in pixels (`CSI 5 ; H ; W t`).
-  void sendScreenSizePixels();
-
-  /// Answers `CSI 16 t` — report cell size in pixels (`CSI 6 ; H ; W t`).
-  void sendCellSizePixels();
 
   /* Select Graphic Rendition (SGR) */
 

--- a/third_party/xterm/lib/src/core/escape/handler.dart
+++ b/third_party/xterm/lib/src/core/escape/handler.dart
@@ -66,6 +66,16 @@ abstract class EscapeHandler {
 
   void sendTerminalVersion();
 
+  /// Answers DECRQM for an ANSI mode (`CSI Ps $ p`).
+  void sendModeReport(int mode);
+
+  /// Answers DECRQM for a DEC private mode (`CSI ? Ps $ p`).
+  void sendPrivateModeReport(int mode);
+
+  /// Answers XTGETTCAP (`DCS + q <hex> ST`) for the given hex-encoded
+  /// terminfo/termcap capability names.
+  void sendTermcapReport(List<String> capabilities);
+
   void sendOperatingStatus();
 
   void sendCursorPosition();

--- a/third_party/xterm/lib/src/core/escape/parser.dart
+++ b/third_party/xterm/lib/src/core/escape/parser.dart
@@ -103,7 +103,7 @@ class EscapeParser {
     'E'.charCode: _escHandleNextLine,
     'H'.charCode: _escHandleTabSet,
     'M'.charCode: _escHandleReverseIndex,
-    // 'P'.charCode: _unsupportedHandler, // Sixel
+    'P'.charCode: _escHandleDCS, // DCS - XTGETTCAP (others skipped to ST)
     // 'c'.charCode: _unsupportedHandler,
     // '#'.charCode: _unsupportedHandler,
     '('.charCode: _escHandleDesignateCharset0, //  SCS - G0
@@ -272,6 +272,8 @@ class EscapeParser {
       _csi.prefix = null;
     }
 
+    _csi.intermediate = null;
+
     var param = 0;
     var hasParam = false;
     var pendingEmptyParam = false;
@@ -337,7 +339,9 @@ class EscapeParser {
       }
 
       if (char > Ascii.NULL && char < Ascii.num0) {
-        // intermediates.add(char);
+        // Intermediate byte (0x20-0x2F). Only the last one is retained; it
+        // disambiguates finals such as `p` (DECRQM `$p` vs DECSTR `!p`).
+        _csi.intermediate = char;
         continue;
       }
 
@@ -362,6 +366,7 @@ class EscapeParser {
     'm'.codeUnitAt(0): _csiHandleSgr,
     'n'.codeUnitAt(0): _csiHandleDeviceStatusReport,
     'q'.codeUnitAt(0): _csiHandleRequestTerminalVersion,
+    'p'.codeUnitAt(0): _csiHandleRequestMode,
     'r'.codeUnitAt(0): _csiHandleSetMargins,
     't'.codeUnitAt(0): _csiWindowManipulation,
     'A'.codeUnitAt(0): _csiHandleCursorUp,
@@ -431,6 +436,31 @@ class EscapeParser {
     // handled here.
     if (_csi.prefix == Ascii.greaterThan) {
       handler.sendTerminalVersion();
+    }
+  }
+
+  /// `ESC [ Ps $ p` Request ANSI Mode (DECRQM) and
+  /// `ESC [ ? Ps $ p` Request DEC Private Mode (DECRQM).
+  ///
+  /// The `$` intermediate is what distinguishes DECRQM from the other `p`
+  /// finals (`CSI ! p` DECSTR soft reset, `CSI Ps " p` DECSCL, `CSI > Ps p`
+  /// XTSMPOINTER), none of which are handled here — they fall through to
+  /// [EscapeHandler.unknownCSI] exactly as before.
+  ///
+  /// https://vt100.net/docs/vt510-rm/DECRQM.html
+  void _csiHandleRequestMode() {
+    if (_csi.intermediate != Ascii.dollarSign) {
+      handler.unknownCSI(_csi.finalByte);
+      return;
+    }
+
+    final mode = _csi.params.isEmpty ? 0 : _csi.params[0];
+    if (_csi.prefix == Ascii.questionMark) {
+      handler.sendPrivateModeReport(mode);
+    } else if (_csi.prefix == null) {
+      handler.sendModeReport(mode);
+    } else {
+      handler.unknownCSI(_csi.finalByte);
     }
   }
 
@@ -1299,6 +1329,43 @@ class EscapeParser {
     }
   }
 
+  /// `ESC P ... ST` Device Control String (DCS).
+  ///
+  /// Only XTGETTCAP (`ESC P + q <hex> ; <hex> ... ST`, a terminfo/termcap
+  /// capability query) is understood; any other DCS string (DECRQSS `$q`,
+  /// Sixel `q`, ...) is consumed and ignored so its payload is not rendered as
+  /// text. Returns false when the sequence is incomplete so the caller can wait
+  /// for more data.
+  ///
+  /// https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+  bool _escHandleDCS() {
+    final body = StringBuffer();
+
+    while (true) {
+      if (_queue.isEmpty) return false;
+      final char = _queue.consume();
+
+      // DCS terminates with ST (`ESC \`).
+      if (char == Ascii.ESC) {
+        if (_queue.isEmpty) return false;
+        if (_queue.consume() == Ascii.backslash) break;
+        continue;
+      }
+      // BEL is tolerated as a terminator for robustness.
+      if (char == Ascii.BEL) break;
+
+      body.writeCharCode(char);
+    }
+
+    final payload = body.toString();
+    // XTGETTCAP request: `+ q <hexcap> [ ; <hexcap> ]...`.
+    if (payload.length >= 2 && payload[0] == '+' && payload[1] == 'q') {
+      final caps = payload.substring(2).split(';');
+      handler.sendTermcapReport(caps);
+    }
+    return true;
+  }
+
   /// `ESC _ ... ST` Application Program Command (APC).
   ///
   /// Only the Kitty graphics protocol (`ESC _ G <args> ; <payload> ST`) is
@@ -1449,6 +1516,13 @@ class _Csi {
   });
 
   int? prefix;
+
+  /// The last intermediate byte (range `0x20`-`0x2F`) seen before the final
+  /// byte, or `null` when the sequence had no intermediate. Most sequences
+  /// ignore intermediates, but a few finals are disambiguated by them — for
+  /// example `CSI Ps $ p` (DECRQM) versus `CSI ! p` (DECSTR), which share the
+  /// `p` final but differ by their `$` / `!` intermediate.
+  int? intermediate;
 
   List<int> params;
 

--- a/third_party/xterm/lib/src/core/escape/parser.dart
+++ b/third_party/xterm/lib/src/core/escape/parser.dart
@@ -439,13 +439,15 @@ class EscapeParser {
     }
   }
 
-  /// `ESC [ Ps $ p` Request ANSI Mode (DECRQM) and
-  /// `ESC [ ? Ps $ p` Request DEC Private Mode (DECRQM).
+  /// `ESC [ Ps $ p` Request ANSI Mode (DECRQM).
   ///
-  /// The `$` intermediate is what distinguishes DECRQM from the other `p`
-  /// finals (`CSI ! p` DECSTR soft reset, `CSI Ps " p` DECSCL, `CSI > Ps p`
-  /// XTSMPOINTER), none of which are handled here — they fall through to
-  /// [EscapeHandler.unknownCSI] exactly as before.
+  /// Only the ANSI-mode form (no prefix) is answered here. The DEC-private form
+  /// (`CSI ? Ps $ p`) is answered by the MonkeySSH app layer, which scans shell
+  /// output and has the extra state it needs (notably DEC mode 2031 colour
+  /// scheme updates); answering it here as well would send the program two
+  /// replies. The `$` intermediate distinguishes DECRQM from the other `p`
+  /// finals (`CSI ! p` DECSTR, `CSI Ps " p` DECSCL, `CSI > Ps p` XTSMPOINTER),
+  /// which fall through to [EscapeHandler.unknownCSI].
   ///
   /// https://vt100.net/docs/vt510-rm/DECRQM.html
   void _csiHandleRequestMode() {
@@ -454,12 +456,12 @@ class EscapeParser {
       return;
     }
 
-    final mode = _csi.params.isEmpty ? 0 : _csi.params[0];
-    if (_csi.prefix == Ascii.questionMark) {
-      handler.sendPrivateModeReport(mode);
-    } else if (_csi.prefix == null) {
+    if (_csi.prefix == null) {
+      final mode = _csi.params.isEmpty ? 0 : _csi.params[0];
       handler.sendModeReport(mode);
-    } else {
+    } else if (_csi.prefix != Ascii.questionMark) {
+      // `?` (DEC private) is consumed without a reply so the app layer can
+      // answer it; any other prefix is an unrecognized `$ p` sequence.
       handler.unknownCSI(_csi.finalByte);
     }
   }
@@ -893,15 +895,9 @@ class EscapeParser {
       case 10: // Alias: Maximize Terminal Window
       case 11: // Report Terminal Window State
       case 13: // Report Terminal Window Position
-        return;
-      case 14: // Report text area size in pixels
-        handler.sendTextAreaSizePixels();
-        return;
-      case 15: // Report screen size in pixels
-        handler.sendScreenSizePixels();
-        return;
-      case 16: // Report cell size in pixels
-        handler.sendCellSizePixels();
+      case 14: // Report text area size in pixels (answered by the app layer)
+      case 15: // Report screen size in pixels (answered by the app layer)
+      case 16: // Report cell size in pixels (answered by the app layer)
         return;
       case 18: // Report Terminal Size (in characters)
         handler.sendSize();

--- a/third_party/xterm/lib/src/core/escape/parser.dart
+++ b/third_party/xterm/lib/src/core/escape/parser.dart
@@ -893,9 +893,15 @@ class EscapeParser {
       case 10: // Alias: Maximize Terminal Window
       case 11: // Report Terminal Window State
       case 13: // Report Terminal Window Position
-      case 14: // Report Terminal Window Size in Pixels
-      case 15: // Report Screen Size in Pixels
-      case 16: // Report Cell Size in Pixels
+        return;
+      case 14: // Report text area size in pixels
+        handler.sendTextAreaSizePixels();
+        return;
+      case 15: // Report screen size in pixels
+        handler.sendScreenSizePixels();
+        return;
+      case 16: // Report cell size in pixels
+        handler.sendCellSizePixels();
         return;
       case 18: // Report Terminal Size (in characters)
         handler.sendSize();
@@ -1331,11 +1337,11 @@ class EscapeParser {
 
   /// `ESC P ... ST` Device Control String (DCS).
   ///
-  /// Only XTGETTCAP (`ESC P + q <hex> ; <hex> ... ST`, a terminfo/termcap
-  /// capability query) is understood; any other DCS string (DECRQSS `$q`,
-  /// Sixel `q`, ...) is consumed and ignored so its payload is not rendered as
-  /// text. Returns false when the sequence is incomplete so the caller can wait
-  /// for more data.
+  /// XTGETTCAP (`ESC P + q <hex> ; <hex> ... ST`, a terminfo/termcap capability
+  /// query) and DECRQSS (`ESC P $ q <Pt> ST`, request the current setting of a
+  /// control function) are understood; any other DCS string (Sixel `q`, ...) is
+  /// consumed and ignored so its payload is not rendered as text. Returns false
+  /// when the sequence is incomplete so the caller can wait for more data.
   ///
   /// https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
   bool _escHandleDCS() {
@@ -1362,6 +1368,13 @@ class EscapeParser {
     if (payload.length >= 2 && payload[0] == '+' && payload[1] == 'q') {
       final caps = payload.substring(2).split(';');
       handler.sendTermcapReport(caps);
+      return true;
+    }
+    // DECRQSS (Request Status String): `$ q <Pt>`, where <Pt> is the
+    // intermediate/final of the control function being queried (for example
+    // `r` for DECSTBM, `m` for SGR, ` q` for DECSCUSR).
+    if (payload.length >= 2 && payload[0] == '\$' && payload[1] == 'q') {
+      handler.sendStatusStringReport(payload.substring(2));
     }
     return true;
   }

--- a/third_party/xterm/lib/src/terminal.dart
+++ b/third_party/xterm/lib/src/terminal.dart
@@ -137,13 +137,6 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
 
   int _viewHeight = 24;
 
-  /// Last known text-area size in pixels, as reported by the view on resize.
-  /// `0` means the pixel size is not yet known (the view has not laid out). Used
-  /// to answer the `CSI 14/15/16 t` pixel reports.
-  int _viewPixelWidth = 0;
-
-  int _viewPixelHeight = 0;
-
   final _cursorStyle = CursorStyle();
 
   bool _insertMode = false;
@@ -445,12 +438,6 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
     newWidth = max(newWidth, 1);
     newHeight = max(newHeight, 1);
 
-    // Retain real pixel dimensions for the `CSI 14/15/16 t` reports. Resizes
-    // driven by the application (`CSI 8 t`) omit pixel sizes, so only overwrite
-    // when the view supplies them.
-    if (pixelWidth != null && pixelWidth > 0) _viewPixelWidth = pixelWidth;
-    if (pixelHeight != null && pixelHeight > 0) _viewPixelHeight = pixelHeight;
-
     onResize?.call(newWidth, newHeight, pixelWidth ?? 0, pixelHeight ?? 0);
 
     //we need to resize both buffers so that they are ready when we switch between them
@@ -673,13 +660,11 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
     onOutput?.call(_emitter.modeReport(mode, _ansiModeValue(mode)));
   }
 
-  @override
-  void sendPrivateModeReport(int mode) {
-    onOutput
-        ?.call(_emitter.privateModeReport(mode, _decPrivateModeValue(mode)));
-  }
-
   /// DECRQM state value for an ANSI mode: 1 set, 2 reset, 0 not recognized.
+  ///
+  /// Only the ANSI-mode form (`CSI Ps $ p`) is answered here. The DEC-private
+  /// form (`CSI ? Ps $ p`) is answered by the MonkeySSH app layer, so the core
+  /// must not reply to it (see [EscapeParser]).
   int _ansiModeValue(int mode) {
     switch (mode) {
       case 4: // IRM - Insert/Replace
@@ -689,77 +674,6 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
       default:
         return 0;
     }
-  }
-
-  /// DECRQM state value for a DEC private mode: 1 set, 2 reset, 0 not
-  /// recognized.
-  ///
-  /// Only modes whose state the terminal actually tracks report 1/2; everything
-  /// else reports 0 (not recognized) rather than guess. In particular mode 2026
-  /// (synchronized output) is deliberately reported as not recognized because
-  /// this terminal does not implement it.
-  int _decPrivateModeValue(int mode) {
-    bool? enabled;
-    switch (mode) {
-      case 1: // DECCKM - Cursor Keys
-        enabled = _cursorKeysMode;
-        break;
-      case 5: // DECSCNM - Reverse Video
-        enabled = _reverseDisplayMode;
-        break;
-      case 6: // DECOM - Origin
-        enabled = _originMode;
-        break;
-      case 7: // DECAWM - Auto Wrap
-        enabled = _autoWrapMode;
-        break;
-      case 9: // X10 mouse reporting
-        enabled = _mouseMode == MouseMode.clickOnly;
-        break;
-      case 12: // att610 - Cursor Blink
-        enabled = _cursorBlinkMode;
-        break;
-      case 25: // DECTCEM - Text Cursor Enable
-        enabled = _cursorVisibleMode;
-        break;
-      case 47:
-      case 1047:
-      case 1049: // Alternate screen buffer
-        enabled = _buffer.isAltBuffer;
-        break;
-      case 66: // DECNKM - Numeric Keypad
-        enabled = _appKeypadMode;
-        break;
-      case 1000: // VT200 mouse reporting
-        enabled = _mouseMode == MouseMode.upDownScroll;
-        break;
-      case 1002: // Button-event mouse tracking
-        enabled = _mouseMode == MouseMode.upDownScrollDrag;
-        break;
-      case 1003: // Any-event mouse tracking
-        enabled = _mouseMode == MouseMode.upDownScrollMove;
-        break;
-      case 1004: // Focus reporting
-        enabled = _reportFocusMode;
-        break;
-      case 1005: // UTF-8 mouse extension
-        enabled = _mouseReportMode == MouseReportMode.utf;
-        break;
-      case 1006: // SGR mouse extension
-        enabled = _mouseReportMode == MouseReportMode.sgr;
-        break;
-      case 1007: // Alternate scroll
-        enabled = _altBufferMouseScrollMode;
-        break;
-      case 1015: // urxvt mouse extension
-        enabled = _mouseReportMode == MouseReportMode.urxvt;
-        break;
-      case 2004: // Bracketed paste
-        enabled = _bracketedPasteMode;
-        break;
-    }
-    if (enabled == null) return 0;
-    return enabled ? 1 : 2;
   }
 
   @override
@@ -904,33 +818,6 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
         ]);
         break;
     }
-  }
-
-  @override
-  void sendTextAreaSizePixels() {
-    if (_viewPixelWidth <= 0 || _viewPixelHeight <= 0) return;
-    onOutput?.call(
-      _emitter.windowSizePixels(4, _viewPixelHeight, _viewPixelWidth),
-    );
-  }
-
-  @override
-  void sendScreenSizePixels() {
-    // The terminal does not distinguish a screen from its text area, so the
-    // screen pixel size mirrors the text area pixel size.
-    if (_viewPixelWidth <= 0 || _viewPixelHeight <= 0) return;
-    onOutput?.call(
-      _emitter.windowSizePixels(5, _viewPixelHeight, _viewPixelWidth),
-    );
-  }
-
-  @override
-  void sendCellSizePixels() {
-    if (_viewPixelWidth <= 0 || _viewPixelHeight <= 0) return;
-    final cellWidth = _viewPixelWidth ~/ _viewWidth;
-    final cellHeight = _viewPixelHeight ~/ _viewHeight;
-    if (cellWidth <= 0 || cellHeight <= 0) return;
-    onOutput?.call(_emitter.windowSizePixels(6, cellHeight, cellWidth));
   }
 
   @override

--- a/third_party/xterm/lib/src/terminal.dart
+++ b/third_party/xterm/lib/src/terminal.dart
@@ -656,6 +656,155 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
   }
 
   @override
+  void sendModeReport(int mode) {
+    onOutput?.call(_emitter.modeReport(mode, _ansiModeValue(mode)));
+  }
+
+  @override
+  void sendPrivateModeReport(int mode) {
+    onOutput
+        ?.call(_emitter.privateModeReport(mode, _decPrivateModeValue(mode)));
+  }
+
+  /// DECRQM state value for an ANSI mode: 1 set, 2 reset, 0 not recognized.
+  int _ansiModeValue(int mode) {
+    switch (mode) {
+      case 4: // IRM - Insert/Replace
+        return _insertMode ? 1 : 2;
+      case 20: // LNM - Line Feed/New Line
+        return _lineFeedMode ? 1 : 2;
+      default:
+        return 0;
+    }
+  }
+
+  /// DECRQM state value for a DEC private mode: 1 set, 2 reset, 0 not
+  /// recognized.
+  ///
+  /// Only modes whose state the terminal actually tracks report 1/2; everything
+  /// else reports 0 (not recognized) rather than guess. In particular mode 2026
+  /// (synchronized output) is deliberately reported as not recognized because
+  /// this terminal does not implement it.
+  int _decPrivateModeValue(int mode) {
+    bool? enabled;
+    switch (mode) {
+      case 1: // DECCKM - Cursor Keys
+        enabled = _cursorKeysMode;
+        break;
+      case 5: // DECSCNM - Reverse Video
+        enabled = _reverseDisplayMode;
+        break;
+      case 6: // DECOM - Origin
+        enabled = _originMode;
+        break;
+      case 7: // DECAWM - Auto Wrap
+        enabled = _autoWrapMode;
+        break;
+      case 9: // X10 mouse reporting
+        enabled = _mouseMode == MouseMode.clickOnly;
+        break;
+      case 12: // att610 - Cursor Blink
+        enabled = _cursorBlinkMode;
+        break;
+      case 25: // DECTCEM - Text Cursor Enable
+        enabled = _cursorVisibleMode;
+        break;
+      case 47:
+      case 1047:
+      case 1049: // Alternate screen buffer
+        enabled = _buffer.isAltBuffer;
+        break;
+      case 66: // DECNKM - Numeric Keypad
+        enabled = _appKeypadMode;
+        break;
+      case 1000: // VT200 mouse reporting
+        enabled = _mouseMode == MouseMode.upDownScroll;
+        break;
+      case 1002: // Button-event mouse tracking
+        enabled = _mouseMode == MouseMode.upDownScrollDrag;
+        break;
+      case 1003: // Any-event mouse tracking
+        enabled = _mouseMode == MouseMode.upDownScrollMove;
+        break;
+      case 1004: // Focus reporting
+        enabled = _reportFocusMode;
+        break;
+      case 1005: // UTF-8 mouse extension
+        enabled = _mouseReportMode == MouseReportMode.utf;
+        break;
+      case 1006: // SGR mouse extension
+        enabled = _mouseReportMode == MouseReportMode.sgr;
+        break;
+      case 1007: // Alternate scroll
+        enabled = _altBufferMouseScrollMode;
+        break;
+      case 1015: // urxvt mouse extension
+        enabled = _mouseReportMode == MouseReportMode.urxvt;
+        break;
+      case 2004: // Bracketed paste
+        enabled = _bracketedPasteMode;
+        break;
+    }
+    if (enabled == null) return 0;
+    return enabled ? 1 : 2;
+  }
+
+  @override
+  void sendTermcapReport(List<String> capabilities) {
+    final output = onOutput;
+    if (output == null) return;
+    for (final hexName in capabilities) {
+      if (hexName.isEmpty) continue;
+      final name = _decodeHex(hexName);
+      final value = name == null ? null : _termcapValue(name);
+      output(
+        _emitter.termcapReport(
+          hexName,
+          value == null ? null : _encodeHex(value),
+        ),
+      );
+    }
+  }
+
+  /// Resolves a terminfo/termcap capability value for XTGETTCAP, or null when
+  /// the capability is unknown/unsupported.
+  ///
+  /// Only unambiguous, theme-independent capabilities are answered. The
+  /// terminal name (`TN`) is intentionally not reported: TERM is host-defined
+  /// (MonkeySSH leaves it unchanged, often `xterm-256color`), so answering a
+  /// fixed name here would risk a mismatch with the negotiated TERM.
+  String? _termcapValue(String name) {
+    switch (name) {
+      case 'Co': // termcap: maximum colors
+      case 'colors': // terminfo: maximum colors
+        return '256';
+      case 'RGB': // direct-color support, bits per channel
+        return '8/8/8';
+      default:
+        return null;
+    }
+  }
+
+  String? _decodeHex(String hex) {
+    if (hex.isEmpty || hex.length.isOdd) return null;
+    final units = <int>[];
+    for (var i = 0; i < hex.length; i += 2) {
+      final byte = int.tryParse(hex.substring(i, i + 2), radix: 16);
+      if (byte == null) return null;
+      units.add(byte);
+    }
+    return String.fromCharCodes(units);
+  }
+
+  String _encodeHex(String value) {
+    final buffer = StringBuffer();
+    for (final unit in value.codeUnits) {
+      buffer.write(unit.toRadixString(16).padLeft(2, '0'));
+    }
+    return buffer.toString();
+  }
+
+  @override
   void sendOperatingStatus() {
     onOutput?.call(_emitter.operatingStatus());
   }

--- a/third_party/xterm/lib/src/terminal.dart
+++ b/third_party/xterm/lib/src/terminal.dart
@@ -137,6 +137,13 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
 
   int _viewHeight = 24;
 
+  /// Last known text-area size in pixels, as reported by the view on resize.
+  /// `0` means the pixel size is not yet known (the view has not laid out). Used
+  /// to answer the `CSI 14/15/16 t` pixel reports.
+  int _viewPixelWidth = 0;
+
+  int _viewPixelHeight = 0;
+
   final _cursorStyle = CursorStyle();
 
   bool _insertMode = false;
@@ -437,6 +444,12 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
   ]) {
     newWidth = max(newWidth, 1);
     newHeight = max(newHeight, 1);
+
+    // Retain real pixel dimensions for the `CSI 14/15/16 t` reports. Resizes
+    // driven by the application (`CSI 8 t`) omit pixel sizes, so only overwrite
+    // when the view supplies them.
+    if (pixelWidth != null && pixelWidth > 0) _viewPixelWidth = pixelWidth;
+    if (pixelHeight != null && pixelHeight > 0) _viewPixelHeight = pixelHeight;
 
     onResize?.call(newWidth, newHeight, pixelWidth ?? 0, pixelHeight ?? 0);
 
@@ -802,6 +815,122 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
       buffer.write(unit.toRadixString(16).padLeft(2, '0'));
     }
     return buffer.toString();
+  }
+
+  @override
+  void sendStatusStringReport(String request) {
+    onOutput?.call(_emitter.statusStringReport(_statusStringValue(request)));
+  }
+
+  /// Resolves the DECRQSS status string for [request] (the control function's
+  /// intermediate/final), or null when the request is not recognized.
+  ///
+  /// Only control functions whose state the terminal actually tracks are
+  /// answered; the cursor style (` q`), conformance level (`"p`) and similar
+  /// are reported as not recognized rather than guessed.
+  String? _statusStringValue(String request) {
+    switch (request) {
+      case 'r': // DECSTBM - scrolling region (top/bottom margins, 1-based)
+        return '${_buffer.marginTop + 1};${_buffer.marginBottom + 1}r';
+      case 'm': // SGR - current graphic rendition
+        return '${_currentSgrParameters()}m';
+      default:
+        return null;
+    }
+  }
+
+  /// Serializes the active pen as SGR parameters, beginning with `0` (reset) so
+  /// the string reproduces the rendition on its own.
+  String _currentSgrParameters() {
+    final params = <int>[0];
+    final style = _cursorStyle;
+    final attrs = style.attrs;
+    if (attrs & CellAttr.bold != 0) params.add(1);
+    if (attrs & CellAttr.faint != 0) params.add(2);
+    if (attrs & CellAttr.italic != 0) params.add(3);
+    if (attrs & CellAttr.underline != 0) params.add(4);
+    if (attrs & CellAttr.blink != 0) params.add(5);
+    if (attrs & CellAttr.inverse != 0) params.add(7);
+    if (attrs & CellAttr.invisible != 0) params.add(8);
+    if (attrs & CellAttr.strikethrough != 0) params.add(9);
+    if (attrs & CellAttr.overline != 0) params.add(53);
+    _appendSgrColor(params, style.foreground, named: 30, bright: 90, ext: 38);
+    _appendSgrColor(params, style.background, named: 40, bright: 100, ext: 48);
+    _appendSgrUnderlineColor(params, style.underlineColor);
+    return params.join(';');
+  }
+
+  void _appendSgrColor(
+    List<int> params,
+    int color, {
+    required int named,
+    required int bright,
+    required int ext,
+  }) {
+    final type = (color & CellColor.typeMask);
+    final value = color & CellColor.valueMask;
+    switch (type) {
+      case CellColor.named:
+        params.add(value < 8 ? named + value : bright + (value - 8));
+        break;
+      case CellColor.palette:
+        params.addAll([ext, 5, value]);
+        break;
+      case CellColor.rgb:
+        params.addAll([
+          ext,
+          2,
+          (value >> 16) & 0xFF,
+          (value >> 8) & 0xFF,
+          value & 0xFF,
+        ]);
+        break;
+    }
+  }
+
+  void _appendSgrUnderlineColor(List<int> params, int color) {
+    final value = color & CellColor.valueMask;
+    switch (color & CellColor.typeMask) {
+      case CellColor.palette:
+        params.addAll([58, 5, value]);
+        break;
+      case CellColor.rgb:
+        params.addAll([
+          58,
+          2,
+          (value >> 16) & 0xFF,
+          (value >> 8) & 0xFF,
+          value & 0xFF,
+        ]);
+        break;
+    }
+  }
+
+  @override
+  void sendTextAreaSizePixels() {
+    if (_viewPixelWidth <= 0 || _viewPixelHeight <= 0) return;
+    onOutput?.call(
+      _emitter.windowSizePixels(4, _viewPixelHeight, _viewPixelWidth),
+    );
+  }
+
+  @override
+  void sendScreenSizePixels() {
+    // The terminal does not distinguish a screen from its text area, so the
+    // screen pixel size mirrors the text area pixel size.
+    if (_viewPixelWidth <= 0 || _viewPixelHeight <= 0) return;
+    onOutput?.call(
+      _emitter.windowSizePixels(5, _viewPixelHeight, _viewPixelWidth),
+    );
+  }
+
+  @override
+  void sendCellSizePixels() {
+    if (_viewPixelWidth <= 0 || _viewPixelHeight <= 0) return;
+    final cellWidth = _viewPixelWidth ~/ _viewWidth;
+    final cellHeight = _viewPixelHeight ~/ _viewHeight;
+    if (cellWidth <= 0 || cellHeight <= 0) return;
+    onOutput?.call(_emitter.windowSizePixels(6, cellHeight, cellWidth));
   }
 
   @override

--- a/third_party/xterm/lib/src/utils/debugger.dart
+++ b/third_party/xterm/lib/src/utils/debugger.dart
@@ -257,6 +257,26 @@ class _TerminalDebuggerHandler implements EscapeHandler {
   }
 
   @override
+  void sendStatusStringReport(String request) {
+    onCommand('sendStatusStringReport($request)');
+  }
+
+  @override
+  void sendTextAreaSizePixels() {
+    onCommand('sendTextAreaSizePixels');
+  }
+
+  @override
+  void sendScreenSizePixels() {
+    onCommand('sendScreenSizePixels');
+  }
+
+  @override
+  void sendCellSizePixels() {
+    onCommand('sendCellSizePixels');
+  }
+
+  @override
   void sendOperatingStatus() {
     onCommand('sendOperatingStatus');
   }

--- a/third_party/xterm/lib/src/utils/debugger.dart
+++ b/third_party/xterm/lib/src/utils/debugger.dart
@@ -247,11 +247,6 @@ class _TerminalDebuggerHandler implements EscapeHandler {
   }
 
   @override
-  void sendPrivateModeReport(int mode) {
-    onCommand('sendPrivateModeReport($mode)');
-  }
-
-  @override
   void sendTermcapReport(List<String> capabilities) {
     onCommand('sendTermcapReport(${capabilities.join(';')})');
   }
@@ -259,21 +254,6 @@ class _TerminalDebuggerHandler implements EscapeHandler {
   @override
   void sendStatusStringReport(String request) {
     onCommand('sendStatusStringReport($request)');
-  }
-
-  @override
-  void sendTextAreaSizePixels() {
-    onCommand('sendTextAreaSizePixels');
-  }
-
-  @override
-  void sendScreenSizePixels() {
-    onCommand('sendScreenSizePixels');
-  }
-
-  @override
-  void sendCellSizePixels() {
-    onCommand('sendCellSizePixels');
   }
 
   @override

--- a/third_party/xterm/lib/src/utils/debugger.dart
+++ b/third_party/xterm/lib/src/utils/debugger.dart
@@ -242,6 +242,21 @@ class _TerminalDebuggerHandler implements EscapeHandler {
   }
 
   @override
+  void sendModeReport(int mode) {
+    onCommand('sendModeReport($mode)');
+  }
+
+  @override
+  void sendPrivateModeReport(int mode) {
+    onCommand('sendPrivateModeReport($mode)');
+  }
+
+  @override
+  void sendTermcapReport(List<String> capabilities) {
+    onCommand('sendTermcapReport(${capabilities.join(';')})');
+  }
+
+  @override
   void sendOperatingStatus() {
     onCommand('sendOperatingStatus');
   }

--- a/third_party/xterm/test/src/core/graphics_test.dart
+++ b/third_party/xterm/test/src/core/graphics_test.dart
@@ -87,7 +87,7 @@ void main() {
       '\x1b\\\x1b[c',
     );
 
-    expect(output, ['\x1b_Gi=31;OK\x1b\\', '\x1b[?1;2c']);
+    expect(output, ['\x1b_Gi=31;OK\x1b\\', '\x1b[?62;22c']);
     expect(terminal.graphics.hasPlacements, isFalse);
   });
 


### PR DESCRIPTION
Closes #590.

Follow-up to the XTVERSION reply (#592). Adds the remaining terminal capability queries that apps send and that the vendored xterm can answer correctly, and modernizes the Device Attributes replies to match the kitty identity already advertised via XTVERSION. All replies flow through `Terminal.onOutput` — the same path the existing DA/DSR/XTVERSION replies use (wired to the shell in `ssh_session_runtime.dart`).

## What changed

### DECRQM — `CSI Ps $ p` / `CSI ? Ps $ p`
- The parser now retains the last CSI **intermediate** (`_Csi.intermediate`) so the `$` form is distinguished from the other `p` finals — DECSTR (`!p`), DECSCL (`"p`), XTSMPOINTER (`>...p`) — which still fall through to `unknownCSI` unchanged.
- Tracked ANSI / DEC-private modes report their **real** set/reset state (`1`/`2`); everything else reports **not recognized** (`0`) rather than guess.
- **Synchronized output (2026)** is deliberately reported as not recognized, matching the vendored CHANGELOG's "evaluated but intentionally not ported" note — so apps won't try to use it.

### XTGETTCAP — `DCS + q <hex> ST`
- New `ESC P` (DCS) parser branch buffers the string to ST and answers theme-independent caps: `Co`/`colors` → `256`, `RGB` → `8/8/8`; everything else is reported invalid (`0+r`).
- `TN` (terminal name) is intentionally **not** answered: TERM is host-defined (MonkeySSH leaves it unchanged, often `xterm-256color`), so a fixed name here would risk a mismatch with the negotiated TERM.
- Side effect: unrecognized DCS payloads (Sixel, DECRQSS) are now **consumed** instead of leaking into the buffer as text.

### Device Attributes modernization
- **DA1**: `?1;2c` (VT100) → `?62;22c` (VT220 + ANSI colour). Only flags the terminal genuinely implements are claimed.
- **DA2**: `>0;0;0c` → `>1;0;0c` (VT220-class). Firmware version stays `0` so terminal-detection heuristics that key off patch levels don't apply a device-specific quirk — the precise identity is carried by XTVERSION.

### OSC color/palette — already done (no change)
OSC 10/11/12 and OSC 4 palette queries are already answered in the **app layer** (`buildTerminalThemeOscResponse`, wired via `onPrivateOSC` using the live `TerminalTheme`). They're intentionally left there — moving them into core would double-reply. Those issue boxes are effectively complete.

## Testing
- Extended `test/unit/terminal_query_response_test.dart` with DECRQM (tracked/default/unknown/2026/ANSI/mouse, plus DECSTR negative), XTGETTCAP (Co/colors/RGB/invalid/multi-cap/non-XTGETTCAP DCS), and DA1/DA2 cases.
- Updated the DA1 assertion in the vendored `graphics_test.dart`.
- `flutter analyze lib test` clean; full `flutter test` suite green (2473 tests) via pre-commit hook.

## Issue checklist
- [x] DECRQM (`CSI ? Ps $ p`) — real state; 2026 → not recognized
- [x] OSC color queries (10/11/12) — already in app layer
- [x] OSC 4 palette query — already in app layer
- [x] XTGETTCAP (`DCS + q`) — Co/colors/RGB; invalid otherwise
- [x] DA1/DA2 modernization

See `third_party/xterm/CHANGELOG.md` for the MonkeySSH-local notes to preserve across kterm re-syncs (relevant to #591).

---

## Follow-up additions (2nd commit) — DECRQSS + window pixel reports

Per review discussion, added the two remaining gaps identified in the capability audit:

### DECRQSS — `DCS $ q <Pt> ST`
Dispatched from the same `ESC P` (DCS) branch as XTGETTCAP. Answers the control functions whose state the core actually tracks; reports invalid (`0$r`) for the rest:
- **DECSTBM** (`r`) → real scrolling region, e.g. `DCS 1$r 1;24 r ST`.
- **SGR** (`m`) → current rendition serialized from the active pen (attributes + indexed/rgb fg/bg/underline colours), e.g. `DCS 1$r 0;1;31 m ST`.
- **Untracked** (cursor style ` q`, conformance `"p`, …) → `DCS 0$r ST`. The core doesn't track cursor shape, so reporting invalid is honest rather than guessing.

### Window pixel-size reports — `CSI 14t` / `CSI 15t` / `CSI 16t`
The terminal now retains the **text-area pixel size** passed to `resize` (`MonkeyTerminalView` already supplies it) and derives the cell size from it:
- `CSI 14t` → `CSI 4;H;W t` (text area px), `CSI 15t` → `CSI 5;H;W t` (screen px, mirrors text area), `CSI 16t` → `CSI 6;Hc;Wc t` (cell px).
- Stays **silent until the size is known** (no bogus `0;0` before first layout). Useful for image‑capable CLIs given the Kitty graphics support.

### Updated issue/audit checklist
- [x] DECRQSS (`DCS $q`) — DECSTBM + SGR real; invalid for untracked
- [x] Window pixel reports `CSI 14/15/16t`

Deliberately still **not** answered (correct): DECSCUSR via DECRQSS (cursor shape not tracked), window position/state/title (`11t/13t/20t/21t`), OSC 52, synchronized output `2026`. Full `flutter test` green (2482 tests).
