### PR TITLE
fix(terminal): unstick touch scroll on monkeymux mouse-mode changes

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -802,6 +802,26 @@ bool? resolveTmuxBarActiveWindowMouseReportSgr(Iterable<TmuxWindow>? windows) =>
         .firstOrNull
         ?.terminalMouseReportSgr;
 
+/// Scroll-relevant mouse-reporting signature for the active tmux window.
+///
+/// Used to detect when touch-scroll routing must be recomputed after a window
+/// metadata update that doesn't change the active window itself (for example a
+/// foreground app toggling mouse mode). Returns `null` when there is no active
+/// window so an appearing/disappearing active window is also treated as a
+/// change.
+@visibleForTesting
+({bool? reportsMouseWheel, bool? mouseReportSgr})?
+activeTmuxWindowScrollModeSignature(Iterable<TmuxWindow>? windows) {
+  final activeWindow = windows?.where((window) => window.isActive).firstOrNull;
+  if (activeWindow == null) {
+    return null;
+  }
+  return (
+    reportsMouseWheel: activeWindow.terminalReportsMouseWheel,
+    mouseReportSgr: activeWindow.terminalMouseReportSgr,
+  );
+}
+
 /// Resolves the tmux windows the bar should display, including any local
 /// optimistic selection while the tmux snapshot is still catching up.
 @visibleForTesting
@@ -4565,6 +4585,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       sessionName: sessionName,
       reason: 'tmux_window_state_changed',
     );
+  }
+
+  /// Recomputes touch-scroll routing when the active window's mouse-reporting
+  /// metadata changes. The routing getters read live from the tmux bar
+  /// snapshot, so a rebuild is enough to flip `touchScrollToTerminal` and stop
+  /// scrolling from getting stuck until the next window switch.
+  void _handleActiveWindowScrollModeChanged() {
+    if (!mounted) {
+      return;
+    }
+    setState(() {});
   }
 
   void _refreshMuxPaneContextAfterWindowStateChange(
@@ -8734,6 +8765,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       onExpandedChanged: _handleTmuxBarExpandedChanged,
       onSidebarDragOffsetChanged: _handleTmuxSidebarDragOffsetChanged,
       onWindowStateChanged: _handleTmuxWindowStateChanged,
+      onActiveWindowScrollModeChanged: _handleActiveWindowScrollModeChanged,
       onWindowLoadStalled: _recoverTmuxWindowPanel,
       onSessionEnded: _handleMuxSessionEnded,
       scopeWorkingDirectory: resolveTmuxAiSessionScopeWorkingDirectory(

--- a/lib/presentation/widgets/tmux_expandable_bar.dart
+++ b/lib/presentation/widgets/tmux_expandable_bar.dart
@@ -25,6 +25,7 @@ class _TmuxExpandableBar extends StatefulWidget {
     this.tmuxExtraFlags,
     this.scopeWorkingDirectory,
     this.onWindowStateChanged,
+    this.onActiveWindowScrollModeChanged,
     this.onWindowLoadStalled,
     this.onSessionEnded,
     super.key,
@@ -81,6 +82,13 @@ class _TmuxExpandableBar extends StatefulWidget {
     required bool activeWindowChanged,
   })?
   onWindowStateChanged;
+
+  /// Called when the active window's scroll-relevant mouse-reporting metadata
+  /// (mouse-wheel / SGR reporting) changes without the active window itself
+  /// changing — for example when the foreground app enters or leaves mouse
+  /// mode. Lets the parent recompute touch-scroll routing so scrolling doesn't
+  /// stay stuck until the next window switch.
+  final VoidCallback? onActiveWindowScrollModeChanged;
 
   final Future<void> Function(SshSession session, String sessionName)?
   onWindowLoadStalled;
@@ -449,6 +457,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   );
 
   void _applyWindows(List<TmuxWindow> windows) {
+    final previousScrollModeSignature = activeTmuxWindowScrollModeSignature(
+      _windows,
+    );
     // Detect new alerts that weren't in the previous window list.
     final newAlerts = windows.where(
       (w) =>
@@ -509,6 +520,15 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       _isLoading = false;
       _pendingSelectedWindowIndex = nextPendingSelectedWindowIndex;
     });
+
+    // Mouse-mode toggles arrive as `window_updated` events that don't change
+    // the active window or its theme identity, so they wouldn't otherwise
+    // notify the parent. Surface them explicitly so touch-scroll routing is
+    // recomputed and scrolling doesn't get stuck until the next window switch.
+    if (activeTmuxWindowScrollModeSignature(windows) !=
+        previousScrollModeSignature) {
+      widget.onActiveWindowScrollModeChanged?.call();
+    }
   }
 
   void _startPendingSelectionTimer(int windowIndex) {

--- a/test/widget/terminal_screen_scroll_policy_test.dart
+++ b/test/widget/terminal_screen_scroll_policy_test.dart
@@ -2,7 +2,21 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
+import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
+
+TmuxWindow _window({
+  required int index,
+  required bool isActive,
+  bool? reportsMouseWheel,
+  bool? mouseReportSgr,
+}) => TmuxWindow(
+  index: index,
+  name: 'w$index',
+  isActive: isActive,
+  terminalReportsMouseWheel: reportsMouseWheel,
+  terminalMouseReportSgr: mouseReportSgr,
+);
 
 void main() {
   group('terminal scroll policy helpers', () {
@@ -213,6 +227,68 @@ void main() {
         ),
         isTrue,
       );
+    });
+  });
+
+  group('active window scroll-mode signature', () {
+    test('is null when no window is active', () {
+      expect(
+        activeTmuxWindowScrollModeSignature([
+          _window(index: 0, isActive: false, reportsMouseWheel: true),
+        ]),
+        isNull,
+      );
+    });
+
+    test('captures the active window mouse-reporting state', () {
+      final signature = activeTmuxWindowScrollModeSignature([
+        _window(index: 0, isActive: true, reportsMouseWheel: true),
+        _window(index: 1, isActive: false, reportsMouseWheel: false),
+      ]);
+      expect(signature?.reportsMouseWheel, isTrue);
+      expect(signature?.mouseReportSgr, isNull);
+    });
+
+    test('changes when the active window toggles mouse mode', () {
+      final before = activeTmuxWindowScrollModeSignature([
+        _window(index: 0, isActive: true, reportsMouseWheel: false),
+      ]);
+      final after = activeTmuxWindowScrollModeSignature([
+        _window(index: 0, isActive: true, reportsMouseWheel: true),
+      ]);
+      expect(before == after, isFalse);
+    });
+
+    test('changes when the active window toggles SGR reporting', () {
+      final before = activeTmuxWindowScrollModeSignature([
+        _window(
+          index: 0,
+          isActive: true,
+          reportsMouseWheel: true,
+          mouseReportSgr: false,
+        ),
+      ]);
+      final after = activeTmuxWindowScrollModeSignature([
+        _window(
+          index: 0,
+          isActive: true,
+          reportsMouseWheel: true,
+          mouseReportSgr: true,
+        ),
+      ]);
+      expect(before == after, isFalse);
+    });
+
+    test('ignores mouse-mode changes on non-active windows', () {
+      final before = activeTmuxWindowScrollModeSignature([
+        _window(index: 0, isActive: true, reportsMouseWheel: false),
+        _window(index: 1, isActive: false, reportsMouseWheel: false),
+      ]);
+      final after = activeTmuxWindowScrollModeSignature([
+        _window(index: 0, isActive: true, reportsMouseWheel: false),
+        _window(index: 1, isActive: false, reportsMouseWheel: true),
+      ]);
+      expect(before == after, isTrue);
     });
   });
 


### PR DESCRIPTION
## Problem

Sometimes touch scrolling stops working in a monkeymux session until you switch windows.

When a monkeymux active window's foreground app toggles mouse-wheel / SGR reporting, the multiplexer emits a `window_updated` control event. `_TmuxExpandableBar` updates its internal window snapshot but only notifies the parent `TerminalScreen` when the **theme-refresh identity** (`_tmuxWindowRefreshIdentity`) changes — and that identity excludes the mouse-mode fields (`terminalReportsMouseWheel` / `terminalMouseReportSgr`).

So the parent never rebuilds, leaving `MonkeyTerminalView.touchScrollToTerminal` stale. Stuck `true`, the viewport uses `NeverScrollableScrollPhysics` and wheel events are sent to an app that no longer wants them → touch scrolling appears frozen until a window switch forces a rebuild.

## Fix

- **`tmux_expandable_bar.dart`**: add an `onActiveWindowScrollModeChanged` callback, fired from `_applyWindows` (the single window-update choke point) whenever the active window's scroll-relevant mouse-reporting signature changes. Kept decoupled from the theme-refresh path so it doesn't trigger extra remote theme refreshes.
- **`terminal_screen.dart`**: add `_handleActiveWindowScrollModeChanged` (rebuilds to recompute `touchScrollToTerminal` / `forceSgrTouchScroll`, which read live from the bar snapshot) and a `@visibleForTesting` `activeTmuxWindowScrollModeSignature` helper.

Scrolling now unsticks the moment the foreground app's mouse mode changes — no window switch needed. Handles both directions (entering and leaving mouse mode).

## Tests

- 5 new unit tests in `terminal_screen_scroll_policy_test.dart` covering the signature detection: changes on active-window mouse/SGR toggle, ignores non-active windows, null when no active window.
- `flutter analyze`: clean.
- Full `flutter test` suite: all 2525 tests pass (pre-commit hook).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>