### PR TITLE
fix(monkeymux): restore push notifications for prompts/alerts

### DIFF
--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -1408,8 +1408,11 @@ TmuxWindow? _windowFromJson(Object? value) {
   final terminalMouseReportSgr =
       (value['terminalMouseReportSgr'] as bool? ?? false) ||
       _privateModeEnabled(privateModes, '1006');
-  // MonkeyMux activity is tracked via idle metadata; tmux alert flags would
-  // turn ordinary background output into noisy system notifications.
+  // The MonkeyMux server only raises the `#` alert flag when a background
+  // window emits a terminal bell (agents ring the bell when they need input),
+  // and clears it as soon as the window is selected. Parsing it restores the
+  // alert badge and the push notification for prompts/alerts without turning
+  // ordinary background output into noisy notifications.
   return TmuxWindow(
     index: index is int ? index : 0,
     id: value['id'] as String?,
@@ -1418,6 +1421,7 @@ TmuxWindow? _windowFromJson(Object? value) {
     currentCommand: _nonEmpty(value['currentCommand'] as String?),
     currentPath: _nonEmpty(value['currentPath'] as String?),
     panePid: value['panePid'] as int?,
+    flags: _nonEmpty(value['flags'] as String?),
     paneTitle: _nonEmpty(value['paneTitle'] as String?),
     agentTool: _agentToolFromMonkeyMuxMetadata(value['agentTool'] as String?),
     terminalReportsMouseWheel: terminalReportsMouseWheel,

--- a/test/domain/services/monkeymux_service_test.dart
+++ b/test/domain/services/monkeymux_service_test.dart
@@ -160,6 +160,35 @@ void main() {
       expect(window!.terminalReportsMouseWheel, isTrue);
       expect(window.terminalMouseReportSgr, isTrue);
     });
+
+    test('surfaces the alert flag so prompts trigger push notifications', () {
+      final window = parseMonkeyMuxWindowSnapshotForTesting({
+        'id': '@2',
+        'index': 1,
+        'name': 'Claude Code',
+        'active': false,
+        'currentCommand': 'claude',
+        'panePid': 4321,
+        'flags': '#',
+      });
+
+      expect(window, isNotNull);
+      expect(window!.flags, '#');
+      expect(window.hasAlert, isTrue);
+    });
+
+    test('leaves windows without an alert flag un-alerted', () {
+      final window = parseMonkeyMuxWindowSnapshotForTesting({
+        'id': '@3',
+        'index': 2,
+        'name': 'shell',
+        'active': false,
+        'currentCommand': 'zsh',
+      });
+
+      expect(window, isNotNull);
+      expect(window!.hasAlert, isFalse);
+    });
   });
 
   group('MonkeyMux agent metadata', () {


### PR DESCRIPTION
## Problem

Prompts/alerts coming from a **MonkeyMux** background window stopped firing local push notifications. When a coding agent (Claude Code, Codex, Copilot CLI, etc.) running in an inactive window needs input, it rings the terminal bell, but nothing reached the notification tray.

## Root cause

tmux/MonkeyMux push notifications are driven entirely by `TmuxWindow.hasAlert`:

```dart
bool get hasAlert => flags != null && (flags!.contains('#') || flags!.contains('!'));
```

`tmux_expandable_bar.dart` fires `showTmuxAlert(...)` only for windows where `hasAlert && !isActive`. Idle metadata drives the UI status label (`running`/`waiting`) but never a notification.

Commit `508def93` ("reduce MonkeyMux switch alert churn") fixed the real churn **on the server** — since MonkeyMux `0.1.8` the server only raises the `#` alert flag when an *inactive* window emits a terminal bell, and clears it the moment the window is selected. In the same commit the client-side `flags` parse was **also** removed from `_windowFromJson`, so MonkeyMux windows could never report `hasAlert`. That extra change was redundant with the server fix and silently disabled every MonkeyMux prompt/alert notification.

## Fix

Restore `flags` parsing for MonkeyMux window snapshots so a background bell once again lights the alert badge and fires the push notification. The server already guarantees the flag is only set on a genuine bell and cleared on select (current bundled server is `0.1.79`), so this does not reintroduce noise from ordinary background output.

## Tests

- Added a regression test asserting a snapshot with `flags: '#'` yields `hasAlert == true`.
- Added a test asserting a snapshot without the flag stays un-alerted.
- Full suite green via the pre-commit hook (2537 tests).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>