### PR TITLE
ci: speed up Android preview builds

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -55,6 +55,11 @@ on:
         type: boolean
         default: true
         description: 'Whether to run the Android build job'
+      android-runner:
+        required: false
+        type: string
+        default: 'ubicloud-standard-4'
+        description: 'Runner label for the Android build job'
       build-ios:
         required: false
         type: boolean
@@ -205,7 +210,7 @@ jobs:
   build-android:
     name: Build & Deploy Android (${{ inputs.flavor }})
     if: inputs.build-android
-    runs-on: ubicloud-standard-4
+    runs-on: ${{ inputs.android-runner }}
     env:
       FLUTTY_PR_NUMBER: ${{ inputs.pr-number }}
       FLUTTY_PR_TITLE: ${{ inputs.pr-title }}

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -276,6 +276,15 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
           add-job-summary: on-failure
 
+      - name: Configure CI Gradle properties
+        if: inputs.android-reuse-aab-artifact-name == ''
+        run: |
+          mkdir -p ~/.gradle
+          {
+            echo 'org.gradle.daemon=false'
+            echo 'org.gradle.vfs.watch=false'
+          } >> ~/.gradle/gradle.properties
+
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         if: inputs.android-reuse-aab-artifact-name == ''
         with:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -70,6 +70,11 @@ on:
         type: boolean
         default: true
         description: 'Whether to derive and upload a universal Android APK artifact from the preview AAB when deploy-android-to == none'
+      android-target-platform:
+        required: false
+        type: string
+        default: ''
+        description: 'Optional Flutter Android target platform override, e.g. android-arm64 for fast preview builds'
       build-ios-unsigned-ipa:
         required: false
         type: boolean
@@ -258,15 +263,13 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        if: inputs.android-reuse-aab-artifact-name == ''
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('android/build.gradle*', 'android/app/build.gradle*', 'android/gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: gradle-${{ runner.os }}-
+          cache: 'gradle'
+          cache-dependency-path: |
+            android/*.gradle*
+            android/**/*.gradle*
+            android/gradle.properties
+            android/gradle/wrapper/gradle-wrapper.properties
+            pubspec.lock
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         if: inputs.android-reuse-aab-artifact-name == ''
@@ -302,7 +305,8 @@ jobs:
           printf '%s' "$GOOGLE_SERVICES_JSON" > "android/app/src/${{ inputs.flavor }}/google-services.json"
           echo "FLUTTY_FIREBASE_ENABLED=true" >> "$GITHUB_ENV"
 
-      - name: Install Android CMake
+      - name: Resolve Android SDK path
+        id: android-sdk
         if: inputs.android-reuse-aab-artifact-name == ''
         run: |
           set -euo pipefail
@@ -310,6 +314,23 @@ jobs:
           if [ -z "$ANDROID_SDK" ]; then
             echo "::error title=Missing Android SDK::ANDROID_HOME or ANDROID_SDK_ROOT must be set."
             exit 1
+          fi
+          echo "path=$ANDROID_SDK" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        if: inputs.android-reuse-aab-artifact-name == ''
+        with:
+          path: ${{ steps.android-sdk.outputs.path }}/cmake/3.22.1
+          key: android-cmake-${{ runner.os }}-3.22.1
+
+      - name: Install Android CMake
+        if: inputs.android-reuse-aab-artifact-name == ''
+        env:
+          ANDROID_SDK: ${{ steps.android-sdk.outputs.path }}
+        run: |
+          set -euo pipefail
+          if [ -x "$ANDROID_SDK/cmake/3.22.1/bin/cmake" ]; then
+            exit 0
           fi
           SDKMANAGER="$ANDROID_SDK/cmdline-tools/latest/bin/sdkmanager"
           if [ ! -x "$SDKMANAGER" ]; then
@@ -381,10 +402,17 @@ jobs:
 
       - name: Build signed AAB
         if: inputs.deploy-android-to != 'none' && inputs.android-reuse-aab-artifact-name == ''
+        env:
+          ANDROID_TARGET_PLATFORM: ${{ inputs.android-target-platform }}
         run: |
+          EXTRA_ANDROID_FLAGS=()
+          if [ -n "$ANDROID_TARGET_PLATFORM" ]; then
+            EXTRA_ANDROID_FLAGS+=(--target-platform="$ANDROID_TARGET_PLATFORM")
+          fi
           flutter build appbundle \
             --flavor ${{ inputs.flavor }} \
             --release \
+            "${EXTRA_ANDROID_FLAGS[@]}" \
             --build-name=${{ inputs.build-name }} \
             --build-number=${{ inputs.build-number }} \
             --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
@@ -409,12 +437,18 @@ jobs:
       - name: Build unsigned AAB
         if: inputs.build-android-unsigned-aab && inputs.android-reuse-aab-artifact-name == '' && inputs.deploy-android-to == 'none'
         env:
+          ANDROID_TARGET_PLATFORM: ${{ inputs.android-target-platform }}
           FLUTTY_ALLOW_UNSIGNED_RELEASE: 'true'
         run: |
+          EXTRA_ANDROID_FLAGS=()
+          if [ -n "$ANDROID_TARGET_PLATFORM" ]; then
+            EXTRA_ANDROID_FLAGS+=(--target-platform="$ANDROID_TARGET_PLATFORM")
+          fi
           flutter build appbundle \
             --flavor ${{ inputs.flavor }} \
             --release \
             --no-tree-shake-icons \
+            "${EXTRA_ANDROID_FLAGS[@]}" \
             --build-name=${{ inputs.build-name }} \
             --build-number=${{ inputs.build-number }} \
             --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
@@ -424,11 +458,18 @@ jobs:
 
       - name: Build debug AAB for preview artifacts
         if: inputs.build-android-apk && inputs.deploy-android-to == 'none' && !inputs.build-android-unsigned-aab
+        env:
+          ANDROID_TARGET_PLATFORM: ${{ inputs.android-target-platform }}
         run: |
+          EXTRA_ANDROID_FLAGS=()
+          if [ -n "$ANDROID_TARGET_PLATFORM" ]; then
+            EXTRA_ANDROID_FLAGS+=(--target-platform="$ANDROID_TARGET_PLATFORM")
+          fi
           flutter build appbundle \
             --flavor ${{ inputs.flavor }} \
             --debug \
             --no-tree-shake-icons \
+            "${EXTRA_ANDROID_FLAGS[@]}" \
             --build-name=${{ inputs.build-name }} \
             --build-number=${{ inputs.build-number }} \
             --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -79,7 +79,7 @@ on:
         required: false
         type: string
         default: ''
-        description: 'Optional Flutter Android target platform override, e.g. android-arm64 for fast preview builds'
+        description: 'Optional Flutter Android target platform override, e.g. android-arm64 for fast non-deploy preview builds'
       build-ios-unsigned-ipa:
         required: false
         type: boolean
@@ -621,7 +621,7 @@ jobs:
         if: inputs.build-android-unsigned-aab && inputs.android-reuse-aab-artifact-name == '' && inputs.deploy-android-to == 'none'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: android-unsigned-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}
+          name: android-unsigned-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}${{ inputs.android-target-platform != '' && format('-{0}', inputs.android-target-platform) || '' }}
           path: build/app/outputs/bundle/${{ inputs.flavor }}Release/app-${{ inputs.flavor }}-release.aab
 
       - name: Upload APK artifact

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -263,13 +263,13 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
-          cache-dependency-path: |
-            android/*.gradle*
-            android/**/*.gradle*
-            android/gradle.properties
-            android/gradle/wrapper/gradle-wrapper.properties
-            pubspec.lock
+
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        if: inputs.android-reuse-aab-artifact-name == ''
+        with:
+          cache-cleanup: always
+          cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          add-job-summary: on-failure
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         if: inputs.android-reuse-aab-artifact-name == ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,14 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
           add-job-summary: on-failure
 
+      - name: Configure CI Gradle properties
+        run: |
+          mkdir -p ~/.gradle
+          {
+            echo 'org.gradle.daemon=false'
+            echo 'org.gradle.vfs.watch=false'
+          } >> ~/.gradle/gradle.properties
+
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
   # ---------------------------------------------------------------------------
   build-android:
     name: Build Android
-    needs: [changes, check]
+    needs: changes
     if: needs.changes.outputs.android == 'true'
     runs-on: ubicloud-standard-4
     timeout-minutes: 15
@@ -192,15 +192,13 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ~/.gradle/configuration-cache
-          key: gradle-${{ runner.os }}-${{ hashFiles('android/build.gradle*', 'android/app/build.gradle*', 'android/gradle/wrapper/gradle-wrapper.properties', 'pubspec.lock') }}
-          restore-keys: gradle-${{ runner.os }}-
+          cache: 'gradle'
+          cache-dependency-path: |
+            android/*.gradle*
+            android/**/*.gradle*
+            android/gradle.properties
+            android/gradle/wrapper/gradle-wrapper.properties
+            pubspec.lock
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
@@ -263,7 +261,7 @@ jobs:
 
   build-ios:
     name: Build iOS
-    needs: [changes, check]
+    needs: changes
     if: needs.changes.outputs.ios == 'true'
     runs-on: macos-26
     env:
@@ -339,7 +337,7 @@ jobs:
 
   build-macos:
     name: Build macOS
-    needs: [changes, check]
+    needs: changes
     if: needs.changes.outputs.macos == 'true'
     runs-on: macos-26
     timeout-minutes: 15
@@ -389,7 +387,7 @@ jobs:
 
   build-windows:
     name: Build Windows
-    needs: [changes, check]
+    needs: changes
     if: needs.changes.outputs.windows == 'true'
     runs-on: windows-2025
     timeout-minutes: 15
@@ -420,7 +418,7 @@ jobs:
 
   build-linux:
     name: Build Linux
-    needs: [changes, check]
+    needs: changes
     if: needs.changes.outputs.linux == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,13 +192,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
-          cache-dependency-path: |
-            android/*.gradle*
-            android/**/*.gradle*
-            android/gradle.properties
-            android/gradle/wrapper/gradle-wrapper.properties
-            pubspec.lock
+
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-cleanup: always
+          cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          add-job-summary: on-failure
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:

--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -339,6 +339,8 @@ jobs:
       contents: read
     outputs:
       reuse-artifacts: ${{ steps.resolve.outputs.reuse-artifacts }}
+      reuse-android-artifact: ${{ steps.resolve.outputs.reuse-android-artifact }}
+      reuse-ios-artifact: ${{ steps.resolve.outputs.reuse-ios-artifact }}
       preview-run-id: ${{ steps.resolve.outputs.preview-run-id }}
     steps:
       - name: Find or start reusable artifact build
@@ -355,19 +357,24 @@ jobs:
             const rebuildRequired =
               '${{ needs.finalize-version.outputs.rebuild-required }}' === 'true';
             const workflowId = 'preview.yml';
-            const requiredArtifactNames = [
-              `android-unsigned-private-${buildName}-${buildNumber}`,
-              `ios-unsigned-private-${buildName}-${buildNumber}.ipa`,
-            ];
+            const androidArtifactName = `android-unsigned-private-${buildName}-${buildNumber}`;
+            const iosArtifactName = `ios-unsigned-private-${buildName}-${buildNumber}.ipa`;
             const waitStatuses = new Set(['queued', 'in_progress', 'requested', 'waiting']);
             const maxWaitAttempts = 40;
             const waitDelayMs = 30_000;
 
             const setOutputs = ({
-              reuseArtifacts = 'false',
+              reuseAndroidArtifact = 'false',
+              reuseIosArtifact = 'false',
               previewRunId = '',
             }) => {
+              const reuseArtifacts =
+                reuseAndroidArtifact === 'true' || reuseIosArtifact === 'true'
+                  ? 'true'
+                  : 'false';
               core.setOutput('reuse-artifacts', reuseArtifacts);
+              core.setOutput('reuse-android-artifact', reuseAndroidArtifact);
+              core.setOutput('reuse-ios-artifact', reuseIosArtifact);
               core.setOutput('preview-run-id', previewRunId);
             };
 
@@ -465,20 +472,28 @@ jobs:
             const availableArtifactNames = new Set(
               artifacts.filter((artifact) => !artifact.expired).map((artifact) => artifact.name),
             );
-            const missingArtifactNames = requiredArtifactNames.filter(
-              (artifactName) => !availableArtifactNames.has(artifactName),
-            );
+            const hasAndroidArtifact = availableArtifactNames.has(androidArtifactName);
+            const hasIosArtifact = availableArtifactNames.has(iosArtifactName);
 
-            if (missingArtifactNames.length > 0) {
+            if (!hasAndroidArtifact) {
               core.notice(
-                 `Preview workflow run ${finishedRun.id} is missing reusable artifacts (${missingArtifactNames.join(', ')}); deploy will build fresh artifacts.`,
-               );
+                `Preview workflow run ${finishedRun.id} is missing reusable full-ABI Android artifact ${androidArtifactName}; deploy will build Android from source.`,
+              );
+            }
+            if (!hasIosArtifact) {
+              core.notice(
+                `Preview workflow run ${finishedRun.id} is missing reusable iOS artifact ${iosArtifactName}; deploy will build iOS from source.`,
+              );
+            }
+
+            if (!hasAndroidArtifact && !hasIosArtifact) {
               setOutputs({});
               return;
             }
 
             setOutputs({
-              reuseArtifacts: 'true',
+              reuseAndroidArtifact: hasAndroidArtifact ? 'true' : 'false',
+              reuseIosArtifact: hasIosArtifact ? 'true' : 'false',
               previewRunId: String(finishedRun.id),
             });
 
@@ -577,11 +592,19 @@ jobs:
               '${{ needs.finalize-version.outputs.rebuild-required }}' === 'true';
             const rebuildNote =
               ${{ toJSON(needs.finalize-version.outputs.rebuild-note) }};
+            const reuseAndroidArtifact =
+              '${{ needs.resolve-preview-artifacts.outputs.reuse-android-artifact }}' === 'true';
+            const reuseIosArtifact =
+              '${{ needs.resolve-preview-artifacts.outputs.reuse-ios-artifact }}' === 'true';
             const artifactDetails =
               rebuildRequired
                 ? `| **Artifacts** | Rebuilding deploy artifacts in this run because requested preview build \`${{ needs.finalize-version.outputs.requested-build-number }}\` is not newer than the highest recent private deploy build \`${{ needs.finalize-version.outputs.previous-private-deploy-build-number }}\` |`
-                : '${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts }}' === 'true'
-                ? `| **Artifacts** | Reusing unsigned preview intermediates from run #${{ needs.resolve-preview-artifacts.outputs.preview-run-id }} |`
+                : reuseAndroidArtifact && reuseIosArtifact
+                ? `| **Artifacts** | Reusing unsigned Android and iOS preview intermediates from run #${{ needs.resolve-preview-artifacts.outputs.preview-run-id }} |`
+                : reuseAndroidArtifact
+                ? `| **Artifacts** | Reusing unsigned Android preview intermediate from run #${{ needs.resolve-preview-artifacts.outputs.preview-run-id }}; building iOS from source |`
+                : reuseIosArtifact
+                ? `| **Artifacts** | Reusing unsigned iOS preview intermediate from run #${{ needs.resolve-preview-artifacts.outputs.preview-run-id }}; building Android from source |`
                 : '| **Artifacts** | Preview intermediates unavailable, so this run is building deploy artifacts from source |';
 
             const body = [
@@ -663,14 +686,14 @@ jobs:
       source-ref: ${{ needs.validate-pr.outputs.deploy-sha }}
       deploy-ios-to: testflight
       deploy-android-to: internal
-      android-reuse-run-id: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.resolve-preview-artifacts.outputs.preview-run-id || '' }}
-      android-reuse-aab-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('android-unsigned-{0}-{1}-{2}', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
-      android-reuse-aab-is-unsigned: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' }}
-      android-reuse-source-sha: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.validate-pr.outputs.deploy-sha || '' }}
-      ios-reuse-run-id: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.resolve-preview-artifacts.outputs.preview-run-id || '' }}
-      ios-reuse-ipa-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('ios-unsigned-{0}-{1}-{2}.ipa', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
-      ios-reuse-ipa-is-unsigned: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' }}
-      ios-reuse-source-sha: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.validate-pr.outputs.deploy-sha || '' }}
+      android-reuse-run-id: ${{ needs.resolve-preview-artifacts.outputs.reuse-android-artifact == 'true' && needs.resolve-preview-artifacts.outputs.preview-run-id || '' }}
+      android-reuse-aab-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-android-artifact == 'true' && format('android-unsigned-{0}-{1}-{2}', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
+      android-reuse-aab-is-unsigned: ${{ needs.resolve-preview-artifacts.outputs.reuse-android-artifact == 'true' }}
+      android-reuse-source-sha: ${{ needs.resolve-preview-artifacts.outputs.reuse-android-artifact == 'true' && needs.validate-pr.outputs.deploy-sha || '' }}
+      ios-reuse-run-id: ${{ needs.resolve-preview-artifacts.outputs.reuse-ios-artifact == 'true' && needs.resolve-preview-artifacts.outputs.preview-run-id || '' }}
+      ios-reuse-ipa-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-ios-artifact == 'true' && format('ios-unsigned-{0}-{1}-{2}.ipa', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
+      ios-reuse-ipa-is-unsigned: ${{ needs.resolve-preview-artifacts.outputs.reuse-ios-artifact == 'true' }}
+      ios-reuse-source-sha: ${{ needs.resolve-preview-artifacts.outputs.reuse-ios-artifact == 'true' && needs.validate-pr.outputs.deploy-sha || '' }}
       update-pr-deploy-comment: true
     secrets:
       ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
@@ -824,11 +847,19 @@ jobs:
               '${{ needs.finalize-version.outputs.rebuild-required }}' === 'true';
             const rebuildNote =
               ${{ toJSON(needs.finalize-version.outputs.rebuild-note) }};
+            const reuseAndroidArtifact =
+              '${{ needs.resolve-preview-artifacts.outputs.reuse-android-artifact }}' === 'true';
+            const reuseIosArtifact =
+              '${{ needs.resolve-preview-artifacts.outputs.reuse-ios-artifact }}' === 'true';
             const artifactDetails =
               rebuildRequired
                 ? `| **Artifacts** | Built fresh deploy artifacts in this run because requested preview build \`${{ needs.finalize-version.outputs.requested-build-number }}\` was not newer than the highest recent private deploy build \`${{ needs.finalize-version.outputs.previous-private-deploy-build-number }}\` |`
-                : '${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts }}' === 'true'
-                ? `| **Artifacts** | Reused unsigned preview intermediates from run #${{ needs.resolve-preview-artifacts.outputs.preview-run-id }} |`
+                : reuseAndroidArtifact && reuseIosArtifact
+                ? `| **Artifacts** | Reused unsigned Android and iOS preview intermediates from run #${{ needs.resolve-preview-artifacts.outputs.preview-run-id }} |`
+                : reuseAndroidArtifact
+                ? `| **Artifacts** | Reused unsigned Android preview intermediate from run #${{ needs.resolve-preview-artifacts.outputs.preview-run-id }}; built iOS from source |`
+                : reuseIosArtifact
+                ? `| **Artifacts** | Reused unsigned iOS preview intermediate from run #${{ needs.resolve-preview-artifacts.outputs.preview-run-id }}; built Android from source |`
                 : '| **Artifacts** | Built fresh deploy artifacts in this run because matching preview intermediates were unavailable |';
 
             const syncRequestCommentReaction = async (targetReaction) => {

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -147,6 +147,7 @@ jobs:
       build-ios: false
       build-android: true
       build-android-unsigned-aab: true
+      android-target-platform: android-arm64
     secrets:
       FIREBASE_ANDROID_PRIVATE_GOOGLE_SERVICES_JSON: ${{ secrets.FIREBASE_ANDROID_PRIVATE_GOOGLE_SERVICES_JSON }}
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -146,6 +146,7 @@ jobs:
       deploy-android-to: none
       build-ios: false
       build-android: true
+      android-runner: ubicloud-standard-8
       build-android-unsigned-aab: true
       android-target-platform: android-arm64
     secrets:

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,8 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
-org.gradle.daemon=false
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.vfs.watch=false
 android.useAndroidX=true
 android.newDsl=false
 android.builtInKotlin=false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,8 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.daemon=false
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.vfs.watch=false
 android.useAndroidX=true
 android.newDsl=false
 android.builtInKotlin=false


### PR DESCRIPTION
## Summary
- use `gradle/actions/setup-gradle` for Android Gradle User Home caching
- cache Android CMake and skip reinstall when restored
- build PR preview Android artifacts on `ubicloud-standard-8` and limit preview compilation to `android-arm64`
- keep ABI-limited preview AABs out of `/deploy` reuse by suffixing their artifact names, so Play Internal deploys rebuild full-ABI bundles
- let platform CI builds run in parallel with analyze/format
- scope Gradle daemon/VFS watch overrides to CI instead of project `gradle.properties`

## Validation
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "workflow yaml ok"' .github/workflows/build-deploy.yml .github/workflows/preview.yml .github/workflows/ci.yml\n- pre-commit checks\n\n## Benchmark\n- Recent Android Preview average before this PR: ~5m20s\n- Warm `setup-gradle` run on `ubicloud-standard-4`: 3m54s\n- `ubicloud-standard-8` run: 2m59s