### PR TITLE
fix(terminal): don't drop replay tail when closing a live shell (follow-up to #599)

### DIFF
--- a/lib/domain/services/ssh_session_runtime.dart
+++ b/lib/domain/services/ssh_session_runtime.dart
@@ -680,8 +680,19 @@ class _SshSessionRuntime {
 
     final shell = _pendingShellOutputShell;
     final terminal = _pendingShellOutputTerminal;
-    if (shell == null || terminal == null || !identical(_shell, shell)) {
+    if (shell != null && !identical(_shell, shell)) {
+      // Pending output belongs to a stale shell (e.g. gathered before a
+      // reconnect swapped `_shell`): discard it, and the parse backlog, so old
+      // bytes never render into the new shell.
       _clearPendingShellOutput();
+      return;
+    }
+    if (shell == null || terminal == null) {
+      // No raw output is queued to flush. Leave any in-flight parse backlog
+      // intact for the pump/drain: it belongs to the current shell, and wiping
+      // it here (as `_clearPendingShellOutput` does) would drop the tail of a
+      // large replay that `closeShell` then expects `_drainTerminalParseBacklogNow`
+      // to render.
       return;
     }
 

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -3433,6 +3433,14 @@ func (s *muxServer) selectWindow(windowID string) error {
 // placeholder cells already on screen then resolve on the next repaint without
 // drawing or moving the cursor. Only the active window is served: the attach
 // connection is viewing it, and requested ids are scoped to what it just drew.
+//
+// The request carries no window id and resolves against whichever window is
+// active when the server processes it. This is deliberate and safe if a window
+// switch races the request: the ids are looked up in the now-active window's
+// retained cache, so ids it does not hold are simply skipped (a no-op), and the
+// client resets its per-visit request set on every window change and re-requests
+// whatever the new window is still missing. The worst case is a redundant or
+// skipped transmission, never a wrong-window image persisting on screen.
 func (s *muxServer) replayRequestedImages(ids []string) {
 	if len(ids) == 0 {
 		return


### PR DESCRIPTION
Fast-follow to #599 addressing the final code-review finding (Sonnet 5), which landed after #599 had already merged through the merge queue.

**Fix:** `closeShell`'s `_flushPendingShellOutput(drainAll: true)` could hit the early-return branch once the raw output queue had already drained into the parse backlog (`_pendingShellOutputShell` is nulled when the queue empties). That branch called `_clearPendingShellOutput`, wiping `_terminalParseBacklog`, so the immediately-following `_drainTerminalParseBacklogNow` had nothing left to render — silently dropping the tail of an in-flight replay on close/reconnect.

Now it only discards on a genuinely **stale** shell (mismatch with the current `_shell`); when there is simply no pending raw output, it returns without touching the live parse backlog so the pump/drain can render it.

Also documents why `request_images` serving the active window is safe if a window switch races the request (mismatched ids are skipped; the client re-requests on switch) — the review's other note — without changing the unreleased protocol.

Full suite (2540) green locally via the pre-commit hook.
