### PR TITLE
ci: address Android preview follow-up feedback

### DIFF
--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -338,7 +338,6 @@ jobs:
       actions: write
       contents: read
     outputs:
-      reuse-artifacts: ${{ steps.resolve.outputs.reuse-artifacts }}
       reuse-android-artifact: ${{ steps.resolve.outputs.reuse-android-artifact }}
       reuse-ios-artifact: ${{ steps.resolve.outputs.reuse-ios-artifact }}
       preview-run-id: ${{ steps.resolve.outputs.preview-run-id }}
@@ -368,11 +367,6 @@ jobs:
               reuseIosArtifact = 'false',
               previewRunId = '',
             }) => {
-              const reuseArtifacts =
-                reuseAndroidArtifact === 'true' || reuseIosArtifact === 'true'
-                  ? 'true'
-                  : 'false';
-              core.setOutput('reuse-artifacts', reuseArtifacts);
               core.setOutput('reuse-android-artifact', reuseAndroidArtifact);
               core.setOutput('reuse-ios-artifact', reuseIosArtifact);
               core.setOutput('preview-run-id', previewRunId);

--- a/.github/workflows/preview-internal-app-sharing.yml
+++ b/.github/workflows/preview-internal-app-sharing.yml
@@ -61,14 +61,29 @@ jobs:
               run_id: workflowRun.id,
               per_page: 100,
             });
-            const aabArtifact = artifacts.find((artifact) =>
-              !artifact.expired && artifact.name.startsWith('android-unsigned-private-'),
+            const isAndroidAabArtifact = (artifact) =>
+              !artifact.expired && artifact.name.startsWith('android-unsigned-private-');
+            const isAbiLimitedAndroidAab = (artifact) =>
+              /-android-(arm|arm64|x64)$/.test(artifact.name);
+            const aabArtifact = artifacts.find(
+              (artifact) => isAndroidAabArtifact(artifact) && !isAbiLimitedAndroidAab(artifact),
+            );
+            const abiLimitedAabArtifact = artifacts.find(
+              (artifact) => isAndroidAabArtifact(artifact) && isAbiLimitedAndroidAab(artifact),
             );
             const apkArtifact = artifacts.find((artifact) =>
               !artifact.expired && artifact.name.startsWith('android-apk-private-'),
             );
 
             if (!aabArtifact) {
+              if (abiLimitedAabArtifact) {
+                core.notice(
+                  `Skipping Internal App Sharing upload because ${abiLimitedAabArtifact.name} is ABI-limited.`,
+                );
+                core.setOutput('should-upload', 'false');
+                return;
+              }
+
               core.setFailed(
                 `No reusable Android AAB artifact was found on workflow run ${workflowRun.id}.`,
               );


### PR DESCRIPTION
## Summary
- skip Play Internal App Sharing upload when the only preview AAB is ABI-limited
- keep the downloadable APK artifact as the fast arm64 preview path
- remove the unused combined `reuse-artifacts` output after per-platform reuse split

## Validation
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "workflow yaml ok"' .github/workflows/preview-internal-app-sharing.yml .github/workflows/deploy-testflight.yml\n- pre-commit checks