### PR TITLE
ci: publish Internal App Sharing link for arm64-only previews

### DIFF
--- a/.github/workflows/preview-internal-app-sharing.yml
+++ b/.github/workflows/preview-internal-app-sharing.yml
@@ -65,25 +65,20 @@ jobs:
               !artifact.expired && artifact.name.startsWith('android-unsigned-private-');
             const isAbiLimitedAndroidAab = (artifact) =>
               /-android-(arm|arm64|x64)$/.test(artifact.name);
-            const aabArtifact = artifacts.find(
-              (artifact) => isAndroidAabArtifact(artifact) && !isAbiLimitedAndroidAab(artifact),
-            );
-            const abiLimitedAabArtifact = artifacts.find(
-              (artifact) => isAndroidAabArtifact(artifact) && isAbiLimitedAndroidAab(artifact),
-            );
+            const androidAabArtifacts = artifacts.filter(isAndroidAabArtifact);
+            // Prefer a full (all-ABI) AAB when one is present, but fall back to
+            // an ABI-limited preview AAB. Fast PR previews build arm64-only, so
+            // without this fallback the Internal App Sharing link would never be
+            // published; an arm64 bundle still installs on real arm64 test
+            // devices via the sharing link.
+            const aabArtifact =
+              androidAabArtifacts.find((artifact) => !isAbiLimitedAndroidAab(artifact)) ??
+              androidAabArtifacts[0];
             const apkArtifact = artifacts.find((artifact) =>
               !artifact.expired && artifact.name.startsWith('android-apk-private-'),
             );
 
             if (!aabArtifact) {
-              if (abiLimitedAabArtifact) {
-                core.notice(
-                  `Skipping Internal App Sharing upload because ${abiLimitedAabArtifact.name} is ABI-limited.`,
-                );
-                core.setOutput('should-upload', 'false');
-                return;
-              }
-
               core.setFailed(
                 `No reusable Android AAB artifact was found on workflow run ${workflowRun.id}.`,
               );


### PR DESCRIPTION
## Problem

PR preview comments stopped showing the **Android Internal App Sharing install link**.

## Root cause

Two recent CI changes combined into a regression:

1. `afb1cb0b` ("speed up Android preview builds") switched PR previews to build an **arm64-only** AAB via `android-target-platform: android-arm64`. That names the artifact `android-unsigned-private-<name>-<number>-android-arm64`.
2. `de279967` ("skip ABI-limited previews for app sharing") then made `preview-internal-app-sharing.yml` **skip** any AAB whose name matches `-android-(arm|arm64|x64)$`.

Since previews now *always* produce an arm64-only AAB, the upload was always skipped and no link was ever posted.

## Fix

Prefer a full (all-ABI) AAB when one is present, but **fall back to the ABI-limited preview AAB** instead of skipping. An arm64 bundle installs fine on real arm64 test devices through the sharing link — this restores the pre-regression behavior while keeping fast previews.

## Validation

- Workflow YAML parses; both embedded `github-script` blocks pass `node --check`.
- Simulated the selection logic:
  - arm64-only preview → arm64 AAB selected (link published) ✅
  - full + arm64 present → full AAB preferred ✅
  - full only → full AAB ✅
  - no AAB → `setFailed` (unchanged) ✅
  - expired arm64 → ignored ✅