### PR TITLE
fix(ci): allowlist OpenSSH private-key format marker in gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,17 +4,20 @@ title = 'Flutty gitleaks configuration'
 useDefault = true
 
 [allowlist]
-description = 'Ignore known false positives in generated Podfile checksums and encryption-key identifier strings.'
+description = 'Ignore known false positives: generated Podfile checksums, encryption-key identifier strings, and the OpenSSH private-key format marker documented and asserted in the in-app key generator and its test.'
 condition = 'AND'
 paths = [
   '''(?:^|/)(?:ios|macos)/Podfile\.lock$''',
   '''(?:^|/)lib/data/security/secret_encryption_service\.dart$''',
   '''(?:^|/)test/unit/secret_encryption_service_test\.dart$''',
   '''(?:^|/)test/data/repositories/ssh_key_repository_test\.dart$''',
+  '''(?:^|/)lib/domain/services/openssh_key_generator\.dart$''',
+  '''(?:^|/)test/domain/services/openssh_key_generator_test\.dart$''',
 ]
 regexTarget = 'line'
 regexes = [
   '''^PODFILE CHECKSUM: [0-9a-f]{40}$''',
   '''flutty_db_(?:encryption|secret)_key_v1''',
   '''privateKey: 'fixture-(?:open-ssh|rsa|ec)-material(?:-[0-9]+)?\.\.\.',''',
+  '''-----BEGIN OPENSSH PRIVATE KEY-----''',
 ]


### PR DESCRIPTION
## Problem

The **Security** workflow's *Secret Scan* (gitleaks `v8.30.1`) went red on `main` right after #614 merged. The default `private-key` rule matched the literal `-----BEGIN OPENSSH PRIVATE KEY-----` **format marker** in two places — no real key material is present:

| File | Line | What it is |
|------|------|-----------|
| `lib/domain/services/openssh_key_generator.dart` | 25 | dartdoc line documenting the output PEM format |
| `test/domain/services/openssh_key_generator_test.dart` | 62 | `startsWith(...)` / `endsWith(...)` assertion on the generated header |

Both are genuine false positives.

## Fix

Extend the existing AND-scoped allowlist in `.gitleaks.toml` (path **and** line-regex) to cover these two files and the OpenSSH header marker. No source or test code changes — the marker legitimately belongs in a docstring and a header assertion.

## Verification

Reproduced the exact failure and confirmed the fix locally with gitleaks `v8.30.1` across every scan mode the workflow uses:

- **push-range** (`--no-merges <before>..<after>`, the mode that failed on `main`): `2 → 0` leaks ✅
- **pull_request** (`dir` working-tree scan, the mode this PR triggers): `0` leaks ✅
- **full-history** (`--no-merges --all`, weekly schedule): the two `openssh_key_generator` findings are gone ✅

> Note: the weekly full-history scan still reports pre-existing historical leaks (committed dartssh2 test-key fixtures, old file revisions, historical Podfile checksums) that predate this change and are out of scope here — this PR reduces that count, it doesn't add to it.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>