### PR TITLE
fix(host-edit): retain window config when switching startup modes

### DIFF
--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -1605,6 +1605,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   }
 
   Future<void> _handleStartupModeSelection(HostStartupMode value) async {
+    final previousMode = _selectedStartupMode;
     if (value == HostStartupMode.agent) {
       final hasAccess = await requireMonetizationFeatureAccess(
         context: context,
@@ -1636,6 +1637,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
 
     setState(() {
       _selectedStartupMode = value;
+      _carryWindowConfigAcrossModeChange(previousMode, value);
       switch (value) {
         case HostStartupMode.none:
         case HostStartupMode.muxAuto:
@@ -1653,6 +1655,65 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     _updateDirtyState();
     if (value == HostStartupMode.agent) {
       _syncAutoConnectCommandFromPreset();
+    }
+  }
+
+  /// Carries shared remote-window configuration across a startup-mode change so
+  /// the session name, working directory, and tmux options a user enters for a
+  /// MonkeyMux/tmux startup are retained when switching to (or from) a coding
+  /// agent that reuses the same window backend. Only blank destination fields
+  /// are seeded, so text already entered in the target mode is never
+  /// overwritten.
+  void _carryWindowConfigAcrossModeChange(
+    HostStartupMode from,
+    HostStartupMode to,
+  ) {
+    if (from.usesRemoteMultiplexer && to == HostStartupMode.agent) {
+      final agentUnconfigured = _agentTmuxSessionController.text.trim().isEmpty;
+      _seedControllerIfEmpty(
+        _agentTmuxSessionController,
+        _tmuxSessionController.text,
+      );
+      _seedControllerIfEmpty(
+        _agentWorkingDirectoryController,
+        _tmuxWorkingDirectoryController.text,
+      );
+      _seedControllerIfEmpty(
+        _agentTmuxExtraFlagsController,
+        _tmuxExtraFlagsController.text,
+      );
+      if (agentUnconfigured) {
+        _selectedAgentMuxBackend =
+            from.remoteMuxBackend == RemoteMuxBackend.tmux
+            ? RemoteMuxBackend.tmux
+            : RemoteMuxBackend.monkeyMux;
+        _disableAgentTmuxStatusBar = _disableTmuxStatusBar;
+      }
+    } else if (from == HostStartupMode.agent && to.usesRemoteMultiplexer) {
+      final muxUnconfigured = _tmuxSessionController.text.trim().isEmpty;
+      _seedControllerIfEmpty(
+        _tmuxSessionController,
+        _agentTmuxSessionController.text,
+      );
+      _seedControllerIfEmpty(
+        _tmuxWorkingDirectoryController,
+        _agentWorkingDirectoryController.text,
+      );
+      _seedControllerIfEmpty(
+        _tmuxExtraFlagsController,
+        _agentTmuxExtraFlagsController.text,
+      );
+      if (muxUnconfigured) {
+        _disableTmuxStatusBar = _disableAgentTmuxStatusBar;
+      }
+    }
+  }
+
+  /// Copies [value] into [controller] only when the controller is currently
+  /// blank, preserving any text the user already entered in the destination.
+  void _seedControllerIfEmpty(TextEditingController controller, String value) {
+    if (controller.text.trim().isEmpty && value.trim().isNotEmpty) {
+      controller.text = value;
     }
   }
 

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -313,6 +313,33 @@ bool _textFieldHasFocus(WidgetTester tester, Key fieldKey) {
   return editableText.focusNode.hasFocus;
 }
 
+String _fieldText(WidgetTester tester, Key fieldKey) {
+  final editableText = tester.widget<EditableText>(
+    find.descendant(
+      of: find.byKey(fieldKey),
+      matching: find.byType(EditableText),
+    ),
+  );
+  return editableText.controller.text;
+}
+
+/// Opens the startup-mode dropdown from any current selection and taps [label].
+Future<void> _switchStartupMode(WidgetTester tester, String label) async {
+  final startupModeField = find.byKey(const Key('host-startup-mode-field'));
+  await tester.scrollUntilVisible(
+    startupModeField,
+    200,
+    scrollable: find.byType(Scrollable).first,
+  );
+  await tester.ensureVisible(startupModeField);
+  await tester.tap(startupModeField);
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 300));
+  await tester.tap(find.text(label).last, warnIfMissed: false);
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 300));
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(const AgentLaunchPreset(tool: AgentLaunchTool.codex));
@@ -416,6 +443,107 @@ void main() {
       expect(find.text('MonkeyMux'), findsOneWidget);
       expect(find.text('tmux'), findsOneWidget);
       expect(find.text('Automatic windows'), findsNothing);
+    });
+
+    testWidgets('retains tmux session config when switching to coding agent', (
+      tester,
+    ) async {
+      await _pumpHostCreateScreen(tester, hasPro: true);
+      await _fillRequiredHostFields(tester);
+      await _switchStartupMode(tester, 'tmux');
+
+      await tester.enterText(
+        find.byKey(const Key('host-tmux-session-field')),
+        'workspace',
+      );
+      await tester.enterText(
+        find.byKey(const Key('host-tmux-working-directory-field')),
+        '~/src/app',
+      );
+      await tester.enterText(
+        find.byKey(const Key('host-tmux-extra-flags-field')),
+        '-x 160',
+      );
+      await tester.pump();
+
+      await _switchStartupMode(tester, 'Launch coding agent');
+
+      expect(
+        _fieldText(tester, const Key('host-agent-tmux-session-field')),
+        'workspace',
+      );
+      expect(
+        _fieldText(tester, const Key('host-agent-working-directory-field')),
+        '~/src/app',
+      );
+      // The agent tmux flags field only renders when the carried-over tmux
+      // backend is applied, so its presence and value confirm both.
+      expect(
+        find.byKey(const Key('host-agent-tmux-extra-flags-field')),
+        findsOneWidget,
+      );
+      expect(
+        _fieldText(tester, const Key('host-agent-tmux-extra-flags-field')),
+        '-x 160',
+      );
+    });
+
+    testWidgets(
+      'retains coding agent session config when switching to tmux startup',
+      (tester) async {
+        await _pumpHostCreateScreen(tester, hasPro: true);
+        await _fillRequiredHostFields(tester);
+        await _switchStartupMode(tester, 'Launch coding agent');
+
+        await tester.enterText(
+          find.byKey(const Key('host-agent-tmux-session-field')),
+          'agent-workspace',
+        );
+        await tester.enterText(
+          find.byKey(const Key('host-agent-working-directory-field')),
+          '~/src/agent',
+        );
+        await tester.pump();
+
+        await _switchStartupMode(tester, 'tmux');
+
+        expect(
+          _fieldText(tester, const Key('host-tmux-session-field')),
+          'agent-workspace',
+        );
+        expect(
+          _fieldText(tester, const Key('host-tmux-working-directory-field')),
+          '~/src/agent',
+        );
+      },
+    );
+
+    testWidgets('does not overwrite existing coding agent values on switch', (
+      tester,
+    ) async {
+      await _pumpHostCreateScreen(tester, hasPro: true);
+      await _fillRequiredHostFields(tester);
+
+      await _switchStartupMode(tester, 'Launch coding agent');
+      await tester.enterText(
+        find.byKey(const Key('host-agent-tmux-session-field')),
+        'agent-session',
+      );
+      await tester.pump();
+
+      await _switchStartupMode(tester, 'tmux');
+      await tester.enterText(
+        find.byKey(const Key('host-tmux-session-field')),
+        'tmux-session',
+      );
+      await tester.pump();
+
+      await _switchStartupMode(tester, 'Launch coding agent');
+
+      expect(
+        _fieldText(tester, const Key('host-agent-tmux-session-field')),
+        'agent-session',
+      );
     });
 
     testWidgets('scrolls to missing tmux session when saving tmux startup', (


### PR DESCRIPTION
## Problem

When configuring a host, switching the **startup mode** between MonkeyMux/tmux and **Launch coding agent** erased the values already entered (session name, working directory, tmux flags). The two sections are backed by separate text controllers that were only populated on load, so the fields appeared blank after every switch and had to be re-typed.

## Fix

Added `_carryWindowConfigAcrossModeChange` (invoked from `_handleStartupModeSelection`) that carries the shared window configuration across a mode switch:

- **MonkeyMux/tmux → agent**: seeds the agent session, working directory, and tmux flags; aligns the agent window backend and hide-status-bar toggle to the source mux mode.
- **agent → MonkeyMux/tmux**: seeds the tmux session, working directory, flags, and hide-status-bar toggle.

Only **blank** destination fields are seeded (`_seedControllerIfEmpty`), so anything already entered in the target mode is never overwritten — safe even if a legacy host loads both representations with different values.

## Testing

- `flutter analyze` — no issues
- `flutter test test/widget/host_edit_screen_test.dart` — all pass, including 3 new tests:
  - retains tmux config when switching to the coding agent
  - retains agent config when switching to tmux startup
  - does not overwrite existing agent values on switch
- Full pre-commit suite (2523 tests) passed.
