### PR TITLE
fix(preview): render terminal images in connection/host previews

### DIFF
--- a/lib/domain/models/terminal_preview.dart
+++ b/lib/domain/models/terminal_preview.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/foundation.dart';
 import 'package:xterm/xterm.dart';
 
@@ -5,7 +7,11 @@ import 'package:xterm/xterm.dart';
 @immutable
 class TerminalPreviewSnapshot {
   /// Creates a [TerminalPreviewSnapshot].
-  const TerminalPreviewSnapshot({required this.lines, required this.plainText});
+  const TerminalPreviewSnapshot({
+    required this.lines,
+    required this.plainText,
+    this.images = const [],
+  });
 
   /// Preview rows in display order.
   final List<TerminalPreviewLine> lines;
@@ -13,15 +19,115 @@ class TerminalPreviewSnapshot {
   /// Plain-text fallback matching the rendered preview rows.
   final String plainText;
 
+  /// Terminal-graphics images (Kitty protocol) composited over [lines], resolved
+  /// into cell-space geometry relative to the first preview row. Empty when the
+  /// captured rows contain no images.
+  final List<TerminalPreviewImage> images;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is TerminalPreviewSnapshot &&
           plainText == other.plainText &&
-          listEquals(lines, other.lines);
+          listEquals(lines, other.lines) &&
+          listEquals(images, other.images);
 
   @override
-  int get hashCode => Object.hash(plainText, Object.hashAll(lines));
+  int get hashCode =>
+      Object.hash(plainText, Object.hashAll(lines), Object.hashAll(images));
+}
+
+/// A single terminal-graphics image draw captured for a connection preview.
+///
+/// Geometry is expressed in *cells* relative to the preview's first visible row
+/// (row `0` is the top preview line, column `0` is the leftmost cell), so the
+/// preview painter can scale it to its own cell size — the preview is a scaled
+/// thumbnail of the live terminal. Mirrors the compositing in
+/// `monkey_terminal_view.dart` (`_paintGraphics` / `_paintKittyPlaceholderGraphics`).
+@immutable
+class TerminalPreviewImage {
+  /// Creates a [TerminalPreviewImage].
+  const TerminalPreviewImage({
+    required this.image,
+    required this.src,
+    required this.col,
+    required this.row,
+    required this.colSpan,
+    required this.rowSpan,
+    this.xOffset = 0,
+    this.yOffset = 0,
+    this.z = 0,
+    this.order = 0,
+    this.fitToWidth = false,
+  });
+
+  /// The decoded image to composite.
+  final ui.Image image;
+
+  /// Source rectangle within [image], in image pixels.
+  final ui.Rect src;
+
+  /// Left cell column of the destination (0 = leftmost preview cell).
+  final int col;
+
+  /// Top cell row of the destination, relative to the first preview row. May be
+  /// negative when a placement starts above the captured rows.
+  final int row;
+
+  /// Number of cell columns the destination spans. When [fitToWidth] is true
+  /// this is the maximum available width used to fit the image.
+  final int colSpan;
+
+  /// Number of cell rows the destination spans. Ignored when [fitToWidth] is
+  /// true (the height is derived from the fitted width).
+  final int rowSpan;
+
+  /// Horizontal pixel offset within the top-left cell (Kitty `X=`).
+  final double xOffset;
+
+  /// Vertical pixel offset within the top-left cell (Kitty `Y=`).
+  final double yOffset;
+
+  /// Z-index. Negative values are drawn behind the terminal text.
+  final int z;
+
+  /// Stable ordering key (placement id / write order) for equal z-indices.
+  final int order;
+
+  /// Whether the image should be scaled to fit [colSpan] columns preserving its
+  /// aspect ratio (Kitty auto-sized placement with no explicit `c=`/`r=`).
+  final bool fitToWidth;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TerminalPreviewImage &&
+          identical(image, other.image) &&
+          src == other.src &&
+          col == other.col &&
+          row == other.row &&
+          colSpan == other.colSpan &&
+          rowSpan == other.rowSpan &&
+          xOffset == other.xOffset &&
+          yOffset == other.yOffset &&
+          z == other.z &&
+          order == other.order &&
+          fitToWidth == other.fitToWidth;
+
+  @override
+  int get hashCode => Object.hash(
+    identityHashCode(image),
+    src,
+    col,
+    row,
+    colSpan,
+    rowSpan,
+    xOffset,
+    yOffset,
+    z,
+    order,
+    fitToWidth,
+  );
 }
 
 /// One terminal display row in a [TerminalPreviewSnapshot].

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -28,6 +28,7 @@ import 'ssh_exec_queue.dart';
 import 'telemetry_service.dart';
 import 'terminal_hyperlink_tracker.dart';
 import 'terminal_notification.dart';
+import 'terminal_preview_graphics.dart';
 import 'wifi_network_service.dart';
 
 part 'ssh_session_runtime.dart';
@@ -3090,6 +3091,11 @@ class SshSession {
     return TerminalPreviewSnapshot(
       lines: List.unmodifiable(previewLines),
       plainText: previewLines.map((line) => line.text).join('\n'),
+      images: buildTerminalPreviewImages(
+        terminal,
+        startRow: visibleRange.start,
+        endRow: visibleRange.end,
+      ),
     );
   }
 

--- a/lib/domain/services/terminal_preview_graphics.dart
+++ b/lib/domain/services/terminal_preview_graphics.dart
@@ -1,0 +1,454 @@
+import 'dart:math' as math;
+import 'dart:ui' show Image, Rect;
+
+import 'package:xterm/xterm.dart';
+
+import '../models/terminal_preview.dart';
+
+/// Minimum fraction of a Kitty Unicode-placeholder instance's bounding box that
+/// must contain live cells before it is treated as a real image (rather than a
+/// scattered torn remnant). Kept in sync with `monkey_terminal_view.dart`.
+const double _kittyPlaceholderRenderThreshold = 0.85;
+
+/// Resolves the Kitty-graphics images that intersect the captured preview rows
+/// ([startRow]..[endRow], inclusive absolute buffer rows) into cell-space draws.
+///
+/// The result mirrors the compositing done live in `monkey_terminal_view.dart`
+/// (`_paintGraphics` + `_paintKittyPlaceholderGraphics`), but expressed in cells
+/// relative to [startRow] so the connection-preview painter can scale it to its
+/// own (smaller) cell size. Classic placements come first (sorted by z-index,
+/// then placement id) followed by Unicode-placeholder strips, so a single
+/// stable pass draws z<0 below the text and the rest above it.
+List<TerminalPreviewImage> buildTerminalPreviewImages(
+  Terminal terminal, {
+  required int startRow,
+  required int endRow,
+}) {
+  final graphics = terminal.graphics;
+  if (!graphics.hasPlacements && graphics.imageCount == 0) {
+    return const [];
+  }
+
+  final images = <TerminalPreviewImage>[
+    ..._resolveClassicPlacements(terminal, startRow: startRow, endRow: endRow),
+    ..._resolvePlaceholderStrips(terminal, startRow: startRow, endRow: endRow),
+  ];
+  return images;
+}
+
+/// Resolves classic (`a=p`/`a=T`) Kitty placements overlapping the preview rows.
+List<TerminalPreviewImage> _resolveClassicPlacements(
+  Terminal terminal, {
+  required int startRow,
+  required int endRow,
+}) {
+  final graphics = terminal.graphics;
+  final viewWidth = terminal.viewWidth;
+  if (viewWidth <= 0) {
+    return const [];
+  }
+
+  final resolved = <TerminalPreviewImage>[];
+  for (final placement in graphics.placements) {
+    if (!placement.attached) {
+      continue;
+    }
+    final stored = graphics.imageById(placement.imageId);
+    if (stored == null) {
+      continue;
+    }
+    final image = stored.image;
+    final imageWidth = image.width.toDouble();
+    final imageHeight = image.height.toDouble();
+
+    // Source rectangle: the optional crop (x=,y=,w=,h=), clamped to the image.
+    final srcLeft = placement.srcX.toDouble().clamp(0.0, imageWidth);
+    final srcTop = placement.srcY.toDouble().clamp(0.0, imageHeight);
+    final srcWidth =
+        (placement.srcWidth > 0
+                ? placement.srcWidth.toDouble()
+                : imageWidth - srcLeft)
+            .clamp(0.0, imageWidth - srcLeft);
+    final srcHeight =
+        (placement.srcHeight > 0
+                ? placement.srcHeight.toDouble()
+                : imageHeight - srcTop)
+            .clamp(0.0, imageHeight - srcTop);
+    if (srcWidth <= 0 || srcHeight <= 0) {
+      continue;
+    }
+
+    final bool fitToWidth;
+    final int colSpan;
+    final int rowSpan;
+    if (placement.cols > 0 && placement.rows > 0) {
+      fitToWidth = false;
+      colSpan = placement.cols;
+      rowSpan = placement.rows;
+    } else {
+      // No explicit cell span: the painter fits the source width within the
+      // available columns (mirrors the live view's pixel fit, resolution-free).
+      fitToWidth = true;
+      colSpan = (viewWidth - placement.col).clamp(1, viewWidth);
+      // Approximate the covered rows only to cull placements that cannot reach
+      // the captured window; the painter derives the real height when drawing.
+      rowSpan = math.max(1, (srcHeight / srcWidth * colSpan).ceil());
+    }
+
+    // Skip placements entirely outside the captured rows.
+    if (placement.row > endRow || placement.row + rowSpan < startRow) {
+      continue;
+    }
+
+    resolved.add(
+      TerminalPreviewImage(
+        image: image,
+        src: Rect.fromLTWH(srcLeft, srcTop, srcWidth, srcHeight),
+        col: placement.col,
+        row: placement.row - startRow,
+        colSpan: colSpan,
+        rowSpan: rowSpan,
+        xOffset: placement.xOffset.toDouble(),
+        yOffset: placement.yOffset.toDouble(),
+        z: placement.z,
+        order: placement.placementId,
+        fitToWidth: fitToWidth,
+      ),
+    );
+  }
+
+  resolved.sort((a, b) {
+    final byZ = a.z.compareTo(b.z);
+    return byZ != 0 ? byZ : a.order.compareTo(b.order);
+  });
+  return resolved;
+}
+
+/// A live Kitty Unicode-placeholder cell resolved for the preview.
+class _PreviewPlaceholderCell {
+  const _PreviewPlaceholderCell({
+    required this.imageKey,
+    required this.imageId,
+    required this.bitWidth,
+    required this.cellRow,
+    required this.cellCol,
+    required this.imgRow,
+    required this.imgCol,
+  });
+
+  final String imageKey;
+  final int imageId;
+  final int bitWidth;
+  final int cellRow;
+  final int cellCol;
+  final int imgRow;
+  final int imgCol;
+}
+
+/// Resolves Kitty Unicode-placeholder images into per-row cell strips.
+///
+/// Ports the density- and recency-gated grouping from
+/// `monkey_terminal_view.dart` so partial/ghost placements are handled the same
+/// way in the preview as in the live terminal.
+List<TerminalPreviewImage> _resolvePlaceholderStrips(
+  Terminal terminal, {
+  required int startRow,
+  required int endRow,
+}) {
+  final graphics = terminal.graphics..pruneDetachedPlaceholders();
+  final placeholders = graphics.placeholders;
+  if (placeholders.isEmpty) {
+    return const [];
+  }
+
+  final buffer = terminal.buffer;
+  final lineCount = buffer.lines.length;
+
+  bool cellIsLivePlaceholder(int cellRow, int cellCol) {
+    if (cellRow < 0 || cellRow >= lineCount) {
+      return false;
+    }
+    final line = buffer.lines[cellRow];
+    if (cellCol < 0 || cellCol >= line.length) {
+      return false;
+    }
+    return line.getCodePoint(cellCol) == kittyGraphicsPlaceholderCodePoint;
+  }
+
+  // Pass 1: group live placeholder cells into display instances and keep the
+  // ones dense/recent enough to be a real image (not a torn remnant or ghost).
+  final gridCols = <String, int>{};
+  final gridRows = <String, int>{};
+  final instanceCellCount = <String, int>{};
+  final instanceRowBounds = <String, List<int>>{};
+  final instanceColBounds = <String, List<int>>{};
+  final instanceRecency = <String, int>{};
+  final instanceImageKey = <String, String>{};
+
+  String instanceKeyFor(TerminalImagePlaceholder p, String imageKey) {
+    final offsetRow = p.cellRow - p.row;
+    final offsetCol = p.cellCol - p.col;
+    return '$imageKey@$offsetRow,$offsetCol';
+  }
+
+  for (var index = 0; index < placeholders.length; index++) {
+    final placeholder = placeholders[index];
+    if (!placeholder.attached) {
+      continue;
+    }
+    final key = '${placeholder.imageIdBitWidth}:${placeholder.imageId}';
+    final virtualPlacement = graphics.virtualPlacementById(placeholder.imageId);
+    final cols = (virtualPlacement?.cols ?? 0) > 0
+        ? virtualPlacement!.cols
+        : math.max(gridCols[key] ?? 1, placeholder.col + 1);
+    final rows = (virtualPlacement?.rows ?? 0) > 0
+        ? virtualPlacement!.rows
+        : math.max(gridRows[key] ?? 1, placeholder.row + 1);
+    gridCols[key] = cols;
+    gridRows[key] = rows;
+
+    if (!cellIsLivePlaceholder(placeholder.cellRow, placeholder.cellCol)) {
+      continue;
+    }
+    final instanceKey = instanceKeyFor(placeholder, key);
+    instanceImageKey[instanceKey] = key;
+    instanceCellCount[instanceKey] = (instanceCellCount[instanceKey] ?? 0) + 1;
+    instanceRecency[instanceKey] = index;
+    final rowBounds = instanceRowBounds[instanceKey] ??= <int>[
+      placeholder.row,
+      placeholder.row,
+    ];
+    rowBounds[0] = math.min(rowBounds[0], placeholder.row);
+    rowBounds[1] = math.max(rowBounds[1], placeholder.row);
+    final colBounds = instanceColBounds[instanceKey] ??= <int>[
+      placeholder.col,
+      placeholder.col,
+    ];
+    colBounds[0] = math.min(colBounds[0], placeholder.col);
+    colBounds[1] = math.max(colBounds[1], placeholder.col);
+  }
+
+  final denseInstances = <String>[];
+  for (final entry in instanceCellCount.entries) {
+    final rowBounds = instanceRowBounds[entry.key];
+    final colBounds = instanceColBounds[entry.key];
+    if (rowBounds == null || colBounds == null) {
+      continue;
+    }
+    final boxRows = rowBounds[1] - rowBounds[0] + 1;
+    final boxCols = colBounds[1] - colBounds[0] + 1;
+    final boxArea = boxRows * boxCols;
+    if (boxArea <= 0) {
+      continue;
+    }
+    if (entry.value >= boxArea * _kittyPlaceholderRenderThreshold) {
+      denseInstances.add(entry.key);
+    }
+  }
+  if (denseInstances.isEmpty) {
+    return const [];
+  }
+
+  // Among dense instances of the same image id, keep only the most recent one.
+  final newestInstanceForImage = <String, String>{};
+  for (final instanceKey in denseInstances) {
+    final imageKey = instanceImageKey[instanceKey]!;
+    final current = newestInstanceForImage[imageKey];
+    if (current == null ||
+        instanceRecency[instanceKey]! > instanceRecency[current]!) {
+      newestInstanceForImage[imageKey] = instanceKey;
+    }
+  }
+  final renderableInstances = newestInstanceForImage.values.toSet();
+  if (renderableInstances.isEmpty) {
+    return const [];
+  }
+
+  // Pass 2: collect the captured cells belonging to a renderable instance.
+  final cellByPosition = <int, _PreviewPlaceholderCell>{};
+  for (final placeholder in placeholders) {
+    if (!placeholder.attached) {
+      continue;
+    }
+    final key = '${placeholder.imageIdBitWidth}:${placeholder.imageId}';
+    if (!renderableInstances.contains(instanceKeyFor(placeholder, key))) {
+      continue;
+    }
+    final cellRow = placeholder.cellRow;
+    if (cellRow < startRow || cellRow > endRow) {
+      continue;
+    }
+    final cellCol = placeholder.cellCol;
+    if (!cellIsLivePlaceholder(cellRow, cellCol)) {
+      continue;
+    }
+    cellByPosition[cellRow * _kittyGridStride +
+        cellCol] = _PreviewPlaceholderCell(
+      imageKey: key,
+      imageId: placeholder.imageId,
+      bitWidth: placeholder.imageIdBitWidth,
+      cellRow: cellRow,
+      cellCol: cellCol,
+      imgRow: placeholder.row,
+      imgCol: placeholder.col,
+    );
+  }
+  final visible = cellByPosition.values.toList();
+  if (visible.isEmpty) {
+    return const [];
+  }
+
+  // Merge contiguous cells in the same screen row into one horizontal run per
+  // image, then stack vertically-adjacent runs so a solid image is drawn as a
+  // single rectangle (no per-row sampling seams).
+  visible.sort((a, b) {
+    final byImage = a.imageKey.compareTo(b.imageKey);
+    if (byImage != 0) return byImage;
+    if (a.cellRow != b.cellRow) return a.cellRow - b.cellRow;
+    return a.cellCol - b.cellCol;
+  });
+
+  final imageCache = <String, TerminalImage?>{};
+  final runs = <_PreviewPlaceholderRun>[];
+  var i = 0;
+  while (i < visible.length) {
+    final start = visible[i];
+    var end = i;
+    while (end + 1 < visible.length) {
+      final cur = visible[end];
+      final next = visible[end + 1];
+      if (next.imageKey == cur.imageKey &&
+          next.cellRow == cur.cellRow &&
+          next.cellCol == cur.cellCol + 1 &&
+          next.imgRow == cur.imgRow &&
+          next.imgCol == cur.imgCol + 1) {
+        end++;
+      } else {
+        break;
+      }
+    }
+    final last = visible[end];
+    i = end + 1;
+
+    final stored = imageCache.putIfAbsent(
+      start.imageKey,
+      () => graphics.imageByPlaceholderColorId(
+        start.imageId,
+        bitWidth: start.bitWidth,
+      ),
+    );
+    if (stored == null) {
+      continue;
+    }
+    final cols = gridCols[start.imageKey] ?? 1;
+    final rows = gridRows[start.imageKey] ?? 1;
+    if (cols <= 0 || rows <= 0) {
+      continue;
+    }
+
+    runs.add(
+      _PreviewPlaceholderRun(
+        imageKey: start.imageKey,
+        image: stored.image,
+        srcCellWidth: stored.image.width / cols,
+        srcCellHeight: stored.image.height / rows,
+        cellRow: start.cellRow,
+        cellCol: start.cellCol,
+        colSpan: last.cellCol - start.cellCol + 1,
+        imgRow: start.imgRow,
+        imgCol: start.imgCol,
+      ),
+    );
+  }
+  if (runs.isEmpty) {
+    return const [];
+  }
+
+  // Stack runs that share the same columns and image columns into rectangles,
+  // extending downward while screen rows and image rows stay contiguous.
+  runs.sort((a, b) {
+    final byImage = a.imageKey.compareTo(b.imageKey);
+    if (byImage != 0) return byImage;
+    if (a.cellCol != b.cellCol) return a.cellCol - b.cellCol;
+    return a.cellRow - b.cellRow;
+  });
+
+  final strips = <TerminalPreviewImage>[];
+  var order = 0;
+  var r = 0;
+  while (r < runs.length) {
+    final start = runs[r];
+    var end = r;
+    while (end + 1 < runs.length) {
+      final cur = runs[end];
+      final next = runs[end + 1];
+      if (identical(next.image, cur.image) &&
+          next.imageKey == cur.imageKey &&
+          next.cellCol == cur.cellCol &&
+          next.colSpan == cur.colSpan &&
+          next.imgCol == cur.imgCol &&
+          next.cellRow == cur.cellRow + 1 &&
+          next.imgRow == cur.imgRow + 1) {
+        end++;
+      } else {
+        break;
+      }
+    }
+    final last = runs[end];
+    final rowSpan = last.cellRow - start.cellRow + 1;
+    r = end + 1;
+
+    final src = Rect.fromLTWH(
+      start.imgCol * start.srcCellWidth,
+      start.imgRow * start.srcCellHeight,
+      start.colSpan * start.srcCellWidth,
+      rowSpan * start.srcCellHeight,
+    );
+    if (src.width <= 0 || src.height <= 0) {
+      continue;
+    }
+
+    strips.add(
+      TerminalPreviewImage(
+        image: start.image,
+        src: src,
+        col: start.cellCol,
+        row: start.cellRow - startRow,
+        colSpan: start.colSpan,
+        rowSpan: rowSpan,
+        order: order++,
+      ),
+    );
+  }
+  return strips;
+}
+
+/// A single horizontal run of Kitty Unicode-placeholder cells before vertical
+/// runs are stacked into rectangles.
+class _PreviewPlaceholderRun {
+  const _PreviewPlaceholderRun({
+    required this.imageKey,
+    required this.image,
+    required this.srcCellWidth,
+    required this.srcCellHeight,
+    required this.cellRow,
+    required this.cellCol,
+    required this.colSpan,
+    required this.imgRow,
+    required this.imgCol,
+  });
+
+  final String imageKey;
+  final Image image;
+  final double srcCellWidth;
+  final double srcCellHeight;
+  final int cellRow;
+  final int cellCol;
+  final int colSpan;
+  final int imgRow;
+  final int imgCol;
+}
+
+/// Stride used to pack (row, col) into a single map key. Kept in sync with
+/// `monkey_terminal_view.dart`.
+const int _kittyGridStride = 100003;

--- a/lib/presentation/widgets/connection_preview_snippet.dart
+++ b/lib/presentation/widgets/connection_preview_snippet.dart
@@ -835,6 +835,16 @@ class _TerminalPreviewPainter extends CustomPainter {
       ..clipRect(Offset.zero & size)
       ..drawRect(Offset.zero & size, Paint()..color = painter.theme.background);
 
+    // Kitty images with a negative z-index sit behind the terminal text.
+    _paintImages(
+      canvas,
+      size,
+      cellWidth: cellWidth,
+      lineHeight: lineHeight,
+      startRow: startRow,
+      belowText: true,
+    );
+
     for (var visibleIndex = 0; visibleIndex < lineCount; visibleIndex++) {
       final row = startRow + visibleIndex;
       final line = preview.lines[row].cells;
@@ -860,7 +870,81 @@ class _TerminalPreviewPainter extends CustomPainter {
       }
       canvas.restore();
     }
+
+    // Non-negative z-index placements and Unicode-placeholder strips draw on top.
+    _paintImages(
+      canvas,
+      size,
+      cellWidth: cellWidth,
+      lineHeight: lineHeight,
+      startRow: startRow,
+      belowText: false,
+    );
     canvas.restore();
+  }
+
+  /// Composites the snapshot's captured Kitty-graphics images, scaling their
+  /// cell-space geometry to the preview's cell metrics. Mirrors the live
+  /// terminal compositing in `monkey_terminal_view.dart`; failures are swallowed
+  /// so an optional preview adornment never crashes the card.
+  void _paintImages(
+    Canvas canvas,
+    Size size, {
+    required double cellWidth,
+    required double lineHeight,
+    required int startRow,
+    required bool belowText,
+  }) {
+    if (preview.images.isEmpty ||
+        !cellWidth.isFinite ||
+        !lineHeight.isFinite ||
+        cellWidth <= 0 ||
+        lineHeight <= 0) {
+      return;
+    }
+    final paint = Paint()..filterQuality = FilterQuality.medium;
+    for (final image in preview.images) {
+      if (belowText ? image.z >= 0 : image.z < 0) {
+        continue;
+      }
+      final double dstWidth;
+      final double dstHeight;
+      if (image.fitToWidth) {
+        final maxWidth = image.colSpan * cellWidth;
+        final scale = image.src.width > maxWidth
+            ? maxWidth / image.src.width
+            : 1.0;
+        dstWidth = image.src.width * scale;
+        dstHeight = image.src.height * scale;
+      } else {
+        dstWidth = image.colSpan * cellWidth;
+        dstHeight = image.rowSpan * lineHeight;
+      }
+      final x = image.col * cellWidth + image.xOffset;
+      final y = (image.row - startRow) * lineHeight + image.yOffset;
+      if (!dstWidth.isFinite ||
+          !dstHeight.isFinite ||
+          dstWidth <= 0 ||
+          dstHeight <= 0 ||
+          !x.isFinite ||
+          !y.isFinite ||
+          y >= size.height ||
+          y + dstHeight <= 0 ||
+          x >= size.width ||
+          x + dstWidth <= 0) {
+        continue;
+      }
+      try {
+        canvas.drawImageRect(
+          image.image,
+          image.src,
+          Rect.fromLTWH(x, y, dstWidth, dstHeight),
+          paint,
+        );
+      } on Object catch (_) {
+        // Preview image compositing is optional adornment; never crash the card.
+      }
+    }
   }
 
   @override

--- a/test/domain/services/terminal_preview_graphics_test.dart
+++ b/test/domain/services/terminal_preview_graphics_test.dart
@@ -1,0 +1,147 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/services/ssh_service.dart';
+import 'package:xterm/xterm.dart';
+
+/// Kitty row/column placeholder diacritics (row/column order), enough to drive
+/// small placeholder grids in tests.
+const _kittyDiacritics = <int>[
+  0x0305,
+  0x030D,
+  0x030E,
+  0x0310,
+  0x0312,
+  0x033D,
+  0x033E,
+  0x033F,
+  0x0346,
+  0x034A,
+  0x034B,
+  0x034C,
+  0x0350,
+  0x0351,
+  0x0352,
+  0x0357,
+  0x035B,
+  0x0363,
+  0x0364,
+  0x0365,
+  0x0366,
+  0x0367,
+  0x0368,
+  0x0369,
+];
+
+ui.Image _solidImage(ui.Color color, int width, int height) {
+  final recorder = ui.PictureRecorder();
+  ui.Canvas(recorder).drawRect(
+    ui.Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()),
+    ui.Paint()..color = color,
+  );
+  return recorder.endRecording().toImageSync(width, height);
+}
+
+/// Emits the Kitty Unicode-placeholder cells for [imageId] across [cols]x[rows]
+/// cells, exactly as a kitty-aware client does.
+String _placeholderGrid(int imageId, {required int cols, required int rows}) {
+  final placeholder = String.fromCharCode(kittyGraphicsPlaceholderCodePoint);
+  final r = (imageId >> 16) & 0xFF;
+  final g = (imageId >> 8) & 0xFF;
+  final b = imageId & 0xFF;
+  final buffer = StringBuffer();
+  for (var row = 0; row < rows; row++) {
+    buffer.write('\x1b[38;2;$r;$g;${b}m');
+    for (var col = 0; col < cols; col++) {
+      buffer
+        ..write(placeholder)
+        ..writeCharCode(_kittyDiacritics[row])
+        ..writeCharCode(_kittyDiacritics[col]);
+    }
+    buffer.write('\x1b[39m');
+    if (row < rows - 1) buffer.write('\r\n');
+  }
+  return buffer.toString();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('terminal preview image capture', () {
+    test('has no images for a plain terminal', () {
+      final terminal = Terminal(maxLines: 100)..write('plain output');
+
+      final snapshot = SshSession.buildTerminalPreviewSnapshot(terminal)!;
+
+      expect(snapshot.images, isEmpty);
+    });
+
+    test('captures a Unicode-placeholder image as a single merged rect', () {
+      final terminal = Terminal(maxLines: 100)..resize(40, 12);
+      terminal.graphics.storeImageWithId(
+        42,
+        _solidImage(const ui.Color(0xFFFF0000), 32, 32),
+      );
+      terminal
+        ..write('before\r\n')
+        ..write(_placeholderGrid(42, cols: 8, rows: 4))
+        ..write('\r\nafter');
+
+      final snapshot = SshSession.buildTerminalPreviewSnapshot(terminal)!;
+
+      // A solid 8x4 grid collapses into one rectangle covering all cells.
+      expect(snapshot.images, hasLength(1));
+      final image = snapshot.images.single;
+      expect(image.col, 0);
+      expect(image.row, 1, reason: 'image starts on the row after "before"');
+      expect(image.colSpan, 8);
+      expect(image.rowSpan, 4);
+      expect(image.fitToWidth, isFalse);
+      expect(image.src, const ui.Rect.fromLTWH(0, 0, 32, 32));
+    });
+
+    test('captures a classic placement with an explicit cell span', () {
+      final terminal = Terminal(maxLines: 100)
+        ..resize(40, 12)
+        ..write('row0\r\nrow1\r\nimg:');
+      terminal.graphics.storeImageWithId(
+        1,
+        _solidImage(const ui.Color(0xFF0000FF), 24, 24),
+      );
+      terminal.graphics.placeImage(
+        1,
+        terminal.buffer.createAnchorFromCursor(),
+        cols: 6,
+        rows: 2,
+      );
+
+      final snapshot = SshSession.buildTerminalPreviewSnapshot(terminal)!;
+
+      final placement = snapshot.images.singleWhere((i) => !i.fitToWidth);
+      expect(placement.colSpan, 6);
+      expect(placement.rowSpan, 2);
+    });
+
+    test(
+      'drops the previous placeholder ghost, keeping the newest instance',
+      () {
+        final terminal = Terminal(maxLines: 100)..resize(40, 12);
+        terminal.graphics.storeImageWithId(
+          7,
+          _solidImage(const ui.Color(0xFF00FF00), 32, 32),
+        );
+        // Draw the image, clear the screen, then redraw it lower down.
+        terminal
+          ..write(_placeholderGrid(7, cols: 8, rows: 4))
+          ..write('\x1b[H\x1b[2J')
+          ..write('\r\n\r\n')
+          ..write(_placeholderGrid(7, cols: 8, rows: 4));
+
+        final snapshot = SshSession.buildTerminalPreviewSnapshot(terminal)!;
+
+        // Only the most recent placement survives (no lingering ghost copy).
+        expect(snapshot.images, hasLength(1));
+      },
+    );
+  });
+}

--- a/test/widget/connection_preview_snippet_test.dart
+++ b/test/widget/connection_preview_snippet_test.dart
@@ -1,8 +1,12 @@
 // ignore_for_file: public_member_api_docs
 
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:monkeyssh/domain/models/terminal_preview.dart';
 import 'package:monkeyssh/domain/models/terminal_themes.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
@@ -535,6 +539,73 @@ void main() {
       expect(decoration?.color, testTheme.background);
     },
   );
+
+  testWidgets('composites captured terminal images into the preview', (
+    tester,
+  ) async {
+    final boundaryKey = GlobalKey();
+    late TerminalPreviewSnapshot snapshot;
+    await tester.runAsync(() async {
+      final terminal = Terminal(maxLines: 100)..resize(40, 12);
+      terminal.graphics.storeImageWithId(
+        9,
+        _solidImage(const Color(0xFFFF0000), 32, 32),
+      );
+      terminal
+        ..write('agent output\r\n')
+        ..write(_placeholderGrid(9, cols: 8, rows: 4));
+      snapshot = SshSession.buildTerminalPreviewSnapshot(terminal)!;
+    });
+    expect(snapshot.images, isNotEmpty);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 360,
+            child: RepaintBoundary(
+              key: boundaryKey,
+              child: ConnectionPreviewStack(
+                entries: [
+                  ConnectionPreviewStackEntry(
+                    title: 'Connection #1',
+                    body: snapshot.plainText,
+                    previewSnapshot: snapshot,
+                    terminalTheme: TerminalThemes.defaultDarkTheme,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    var hasRed = false;
+    await tester.runAsync(() async {
+      final boundary =
+          boundaryKey.currentContext!.findRenderObject()!
+              as RenderRepaintBoundary;
+      final shot = await boundary.toImage();
+      final data = (await shot.toByteData())!;
+      for (var i = 0; i + 4 <= data.lengthInBytes; i += 4) {
+        final r = data.getUint8(i);
+        final g = data.getUint8(i + 1);
+        final b = data.getUint8(i + 2);
+        if (r > 150 && g < 90 && b < 90) {
+          hasRed = true;
+          break;
+        }
+      }
+    });
+
+    expect(
+      hasRed,
+      isTrue,
+      reason: 'the captured image should be composited into the preview card',
+    );
+  });
 }
 
 List<BoxDecoration> _boxDecorationsWithColor(
@@ -546,3 +617,60 @@ List<BoxDecoration> _boxDecorationsWithColor(
     .whereType<BoxDecoration>()
     .where((decoration) => decoration.color == color)
     .toList(growable: false);
+
+/// Kitty row/column placeholder diacritics (row/column order).
+const _kittyDiacritics = <int>[
+  0x0305,
+  0x030D,
+  0x030E,
+  0x0310,
+  0x0312,
+  0x033D,
+  0x033E,
+  0x033F,
+  0x0346,
+  0x034A,
+  0x034B,
+  0x034C,
+  0x0350,
+  0x0351,
+  0x0352,
+  0x0357,
+  0x035B,
+  0x0363,
+  0x0364,
+  0x0365,
+  0x0366,
+  0x0367,
+  0x0368,
+  0x0369,
+];
+
+ui.Image _solidImage(Color color, int width, int height) {
+  final recorder = ui.PictureRecorder();
+  ui.Canvas(recorder).drawRect(
+    Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()),
+    Paint()..color = color,
+  );
+  return recorder.endRecording().toImageSync(width, height);
+}
+
+String _placeholderGrid(int imageId, {required int cols, required int rows}) {
+  final placeholder = String.fromCharCode(kittyGraphicsPlaceholderCodePoint);
+  final r = (imageId >> 16) & 0xFF;
+  final g = (imageId >> 8) & 0xFF;
+  final b = imageId & 0xFF;
+  final buffer = StringBuffer();
+  for (var row = 0; row < rows; row++) {
+    buffer.write('\x1b[38;2;$r;$g;${b}m');
+    for (var col = 0; col < cols; col++) {
+      buffer
+        ..write(placeholder)
+        ..writeCharCode(_kittyDiacritics[row])
+        ..writeCharCode(_kittyDiacritics[col]);
+    }
+    buffer.write('\x1b[39m');
+    if (row < rows - 1) buffer.write('\r\n');
+  }
+  return buffer.toString();
+}


### PR DESCRIPTION
## Problem

Kitty-graphics images never appeared in the connection/host **preview cards**. On the Hosts page and the connection stack, an active session that had rendered an image (an agent CLI showing a generated picture, `icat`/`imgcat`, etc.) showed the surrounding text but a **blank gap** where the image belonged.

**Root cause:** `TerminalPreviewSnapshot` only copied text `BufferLine` cells. Terminal images live elsewhere — classic Kitty placements in `terminal.graphics` (never in the buffer) and Unicode-placeholder cells whose glyph the painter deliberately skips. Neither the images nor placements were captured, so the styled preview painter had nothing to draw.

## Fix

Capture resolved, **cell-space** image draws into the snapshot and composite them in the preview painter, mirroring the live terminal's compositing **without touching that battle-tested render path**.

- **`terminal_preview.dart`** — new `TerminalPreviewImage` (image + src rect + cell geometry) and `TerminalPreviewSnapshot.images`, value-equal so the 150 ms refresh ticks don't spuriously rebuild rows.
- **`terminal_preview_graphics.dart`** *(new)* — `buildTerminalPreviewImages` resolves classic placements and Unicode-placeholder images into cell-space draws relative to the first preview row. Reuses the same **0.85 density + recency gating** as `monkey_terminal_view.dart` (drops torn remnants and re-draw ghosts), and merges contiguous runs into **seam-free rectangles**.
- **`ssh_service.dart`** — `buildTerminalPreviewSnapshot` captures images over the visible range.
- **`connection_preview_snippet.dart`** — `_TerminalPreviewPainter` composites images (z<0 below text, z≥0 + placeholders above), scaled to the preview cell size, clipped, and guarded with try/catch so a bad draw never crashes a card.

## Behavior

Before: preview shows text with a blank region where an image was rendered.
After: the image is composited into the card as a crisp, scaled thumbnail.

## Testing

- New resolver unit tests: placeholder capture + single-rect merge geometry, classic placement span, and ghost dismissal (recency).
- New widget test: asserts composited image pixels land in the rendered preview card.
- `flutter analyze` clean; full pre-commit suite (2525 tests) passes.

## Notes

The preview resolver intentionally parallels the live-view compositor rather than sharing it, to avoid risk to the primary terminal render path. Keep the two placeholder density/recency heuristics in sync when either changes.