### PR TITLE
fix(keyboard): clear phantom keyboard inset and fix terminal keyboard button

### DIFF
--- a/lib/app/keyboard_dismiss_route_observer.dart
+++ b/lib/app/keyboard_dismiss_route_observer.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+/// Navigator observer that clears a stale soft-keyboard inset after a route
+/// transition.
+///
+/// When a route that had the on-screen keyboard open is dismissed (for example
+/// closing a modal sheet or returning from the terminal), the platform can keep
+/// reserving space for the keyboard even though the keyboard itself is no longer
+/// visible. That phantom bottom inset shrinks the revealed screen, leaving a
+/// blank gap and — on scrollable screens such as settings — making content look
+/// like it failed to render.
+///
+/// After every push/pop/replace/remove this observer asks the platform to hide
+/// the keyboard, which forces the bottom view inset to be recomputed. The hide
+/// request is skipped whenever a real input is focused, so screens that
+/// intentionally show the keyboard (an autofocused field, the terminal) are
+/// never disturbed.
+class KeyboardDismissRouteObserver extends NavigatorObserver {
+  /// Creates a [KeyboardDismissRouteObserver].
+  KeyboardDismissRouteObserver();
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    _dismissKeyboardWhenUnfocused();
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    _dismissKeyboardWhenUnfocused();
+  }
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didRemove(route, previousRoute);
+    _dismissKeyboardWhenUnfocused();
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    _dismissKeyboardWhenUnfocused();
+  }
+
+  void _dismissKeyboardWhenUnfocused() {
+    // Defer to the next frame so focus has settled on the revealed route before
+    // deciding whether the keyboard is still wanted.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final primaryFocus = FocusManager.instance.primaryFocus;
+      final hasEditableFocus =
+          primaryFocus != null &&
+          primaryFocus is! FocusScopeNode &&
+          primaryFocus.hasPrimaryFocus;
+      if (hasEditableFocus) {
+        return;
+      }
+      unawaited(SystemChannels.textInput.invokeMethod<void>('TextInput.hide'));
+    });
+  }
+}

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -23,6 +23,7 @@ import '../presentation/screens/snippet_edit_screen.dart';
 import '../presentation/screens/snippets_screen.dart';
 import '../presentation/screens/terminal_screen.dart';
 import '../presentation/screens/upgrade_screen.dart';
+import 'keyboard_dismiss_route_observer.dart';
 import 'routes.dart';
 import 'telemetry_route_observer.dart';
 
@@ -42,7 +43,10 @@ final routerProvider = Provider<GoRouter>((ref) {
   return GoRouter(
     navigatorKey: appNavigatorKey,
     initialLocation: '/',
-    observers: [TelemetryRouteObserver(telemetryService: telemetryService)],
+    observers: [
+      TelemetryRouteObserver(telemetryService: telemetryService),
+      KeyboardDismissRouteObserver(),
+    ],
     redirect: (context, state) => redirectForAuthState(
       authState: authState,
       matchedLocation: state.matchedLocation,

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -10266,7 +10266,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final isMobile =
         defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS;
-    final systemKeyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
+    // A stale platform bottom inset (keyboard space reserved while the keyboard
+    // is not actually open) must not make the toggle think the keyboard is
+    // visible; otherwise the button would run its hide branch and fail to bring
+    // the keyboard up. Require the app's own input-connection state to agree.
+    final systemKeyboardVisible =
+        MediaQuery.viewInsetsOf(context).bottom > 0 &&
+        _terminalTextInputController.isKeyboardVisible;
     if (_isAndroidPlatform) {
       _logAndroidPredictiveBackDiagnostics(context, phase: 'build');
       _queueAndroidPredictiveBackPostFrameDiagnostics(context);

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3215,6 +3215,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   late final FocusNode _nativeSelectionFocusNode;
   late FocusNode _terminalFocusNode;
   final _terminalTextInputController = TerminalTextInputHandlerController();
+  bool _keyboardVisibilityRebuildScheduled = false;
   final _toolbarController = KeyboardToolbarController();
   SSHSession? _shell;
   StreamSubscription<void>? _doneSubscription;
@@ -4072,6 +4073,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _terminal.addListener(_onTerminalStateChanged);
     _terminalController.addListener(_onSelectionChanged);
     _terminalFocusNode = FocusNode();
+    _terminalTextInputController.addListener(
+      _handleTerminalKeyboardVisibilityChanged,
+    );
     unawaited(_refreshKeyboardToolbarSnippetMenu());
     // Defer connection to avoid modifying provider state during widget build
     Future.microtask(_loadHostAndConnect);
@@ -10113,6 +10117,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _doneSubscription?.cancel();
     _shellStdoutSubscription?.cancel();
     _terminalFocusNode.dispose();
+    _terminalTextInputController
+      ..removeListener(_handleTerminalKeyboardVisibilityChanged)
+      ..dispose();
     _toolbarController.dispose();
     super.dispose();
   }
@@ -10601,6 +10608,23 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         ),
       ),
     );
+  }
+
+  // Rebuilds so the keyboard toggle button reflects the current
+  // input-connection state even when the platform bottom inset does not change
+  // (e.g. a stale inset equal to the keyboard height). Deferred to a post-frame
+  // callback so it is safe to trigger from focus/build-phase changes.
+  void _handleTerminalKeyboardVisibilityChanged() {
+    if (_keyboardVisibilityRebuildScheduled || !mounted) {
+      return;
+    }
+    _keyboardVisibilityRebuildScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _keyboardVisibilityRebuildScheduled = false;
+      if (mounted) {
+        setState(() {});
+      }
+    });
   }
 
   /// Toggles the system keyboard visibility on mobile platforms.

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -129,7 +129,11 @@ bool shouldRequestKeyboardForTerminalPointerUp({
 }
 
 /// Controls a [TerminalTextInputHandler] from an ancestor widget.
-class TerminalTextInputHandlerController {
+///
+/// Notifies listeners whenever the soft keyboard visibility ([isKeyboardVisible])
+/// changes so UI that depends on it can rebuild even when the platform bottom
+/// inset does not change.
+class TerminalTextInputHandlerController extends ChangeNotifier {
   _TerminalTextInputHandlerState? _state;
 
   // ignore: use_setters_to_change_properties
@@ -159,6 +163,10 @@ class TerminalTextInputHandlerController {
 
   /// Whether the handler currently expects the soft keyboard to be visible.
   bool get isKeyboardVisible => _state?._isInputConnectionShown ?? false;
+
+  void _notifyKeyboardVisibilityChanged() {
+    notifyListeners();
+  }
 
   /// Clears the transient IME buffer after external terminal actions.
   ///
@@ -862,7 +870,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (hasInputConnection) {
       _connection?.close();
     }
-    _isInputConnectionShown = false;
+    _setInputConnectionShown(shown: false);
   }
 
   void _suppressNextTouchKeyboardRequest() {
@@ -973,20 +981,28 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       value.selection != _initEditingState.selection ||
       !value.composing.isCollapsed;
 
+  void _setInputConnectionShown({required bool shown}) {
+    if (_isInputConnectionShown == shown) {
+      return;
+    }
+    _isInputConnectionShown = shown;
+    widget.controller?._notifyKeyboardVisibilityChanged();
+  }
+
   void _openInputConnection({bool show = true}) {
     if (!_shouldCreateInputConnection) return;
 
     if (hasInputConnection) {
       if (show) {
         _connection!.show();
-        _isInputConnectionShown = true;
+        _setInputConnectionShown(shown: true);
       }
     } else {
       _connection = TextInput.attach(this, _buildTextInputConfiguration());
-      _isInputConnectionShown = false;
+      _setInputConnectionShown(shown: false);
       if (show) {
         _connection!.show();
-        _isInputConnectionShown = true;
+        _setInputConnectionShown(shown: true);
       }
       _invalidatePendingEditingUpdates();
       _sawImeComposition = false;
@@ -1039,7 +1055,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       _connection!.close();
       _connection = null;
     }
-    _isInputConnectionShown = false;
+    _setInputConnectionShown(shown: false);
     _invalidatePendingEditingUpdates();
     _sawImeComposition = false;
     _lastProcessedUserSelectionWasValid = false;

--- a/test/app/keyboard_dismiss_route_observer_test.dart
+++ b/test/app/keyboard_dismiss_route_observer_test.dart
@@ -1,0 +1,108 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/app/keyboard_dismiss_route_observer.dart';
+
+void main() {
+  MaterialPageRoute<void> fakeRoute() =>
+      MaterialPageRoute<void>(builder: (_) => const SizedBox.shrink());
+
+  bool loggedHide(WidgetTester tester) =>
+      tester.testTextInput.log.any((call) => call.method == 'TextInput.hide');
+
+  group('KeyboardDismissRouteObserver', () {
+    testWidgets('hides the keyboard after a pop when nothing is focused', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: SizedBox.shrink())),
+      );
+      final observer = KeyboardDismissRouteObserver();
+      tester.testTextInput.log.clear();
+
+      observer.didPop(fakeRoute(), fakeRoute());
+      await tester.pump();
+
+      expect(loggedHide(tester), isTrue);
+    });
+
+    testWidgets('hides the keyboard after a push when nothing is focused', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: SizedBox.shrink())),
+      );
+      final observer = KeyboardDismissRouteObserver();
+      tester.testTextInput.log.clear();
+
+      observer.didPush(fakeRoute(), fakeRoute());
+      await tester.pump();
+
+      expect(loggedHide(tester), isTrue);
+    });
+
+    testWidgets('does not hide the keyboard while a text field is focused', (
+      tester,
+    ) async {
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TextField(focusNode: focusNode, autofocus: true),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(focusNode.hasPrimaryFocus, isTrue);
+
+      final observer = KeyboardDismissRouteObserver();
+      tester.testTextInput.log.clear();
+
+      observer
+        ..didPop(fakeRoute(), fakeRoute())
+        ..didPush(fakeRoute(), fakeRoute());
+      await tester.pump();
+
+      expect(loggedHide(tester), isFalse);
+      expect(focusNode.hasPrimaryFocus, isTrue);
+    });
+
+    testWidgets('dismisses a lingering keyboard when returning to a screen', (
+      tester,
+    ) async {
+      final observer = KeyboardDismissRouteObserver();
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorObservers: [observer],
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => Center(
+                child: ElevatedButton(
+                  onPressed: () => Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) =>
+                          const Scaffold(body: TextField(autofocus: true)),
+                    ),
+                  ),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      expect(tester.testTextInput.isVisible, isTrue);
+
+      tester.state<NavigatorState>(find.byType(Navigator)).pop();
+      await tester.pumpAndSettle();
+
+      expect(tester.testTextInput.isVisible, isFalse);
+      expect(loggedHide(tester), isTrue);
+    });
+  });
+}

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -6507,6 +6507,46 @@ void main() {
     );
 
     testWidgets(
+      'keyboard button shows the keyboard despite a stale bottom inset',
+      (tester) async {
+        // Simulate the broken state: the platform still reserves keyboard space
+        // (a stale bottom inset) while the keyboard itself is not open.
+        tester.view
+          ..physicalSize = const Size(390, 844)
+          ..devicePixelRatio = 1
+          ..viewInsets = const FakeViewPadding(bottom: 500);
+        addTearDown(() {
+          tester.view
+            ..resetPhysicalSize()
+            ..resetDevicePixelRatio()
+            ..resetViewInsets();
+        });
+
+        await pumpScreen(tester);
+
+        // The keyboard is not actually shown, so the toggle must offer to show
+        // it rather than treating the stale inset as a visible keyboard.
+        expect(tester.testTextInput.isVisible, isFalse);
+        expect(find.byTooltip('Show system keyboard'), findsOneWidget);
+        expect(find.byTooltip('Hide system keyboard'), findsNothing);
+
+        tester.testTextInput.log.clear();
+        await tester.tap(find.byTooltip('Show system keyboard'));
+        await tester.pump();
+        await tester.pump();
+
+        expect(
+          tester.testTextInput.log.where(
+            (call) => call.method == 'TextInput.show',
+          ),
+          isNotEmpty,
+        );
+        expect(tester.testTextInput.isVisible, isTrue);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
       'terminal overflow menu stays above the visible mobile keyboard',
       (tester) async {
         tester.view

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -6542,6 +6542,13 @@ void main() {
           isNotEmpty,
         );
         expect(tester.testTextInput.isVisible, isTrue);
+
+        // The toggle must reactively flip to "hide" once the keyboard is shown,
+        // even though the (stale) bottom inset never changed, so a second tap
+        // hides the keyboard instead of re-showing it.
+        await tester.pump();
+        expect(find.byTooltip('Hide system keyboard'), findsOneWidget);
+        expect(find.byTooltip('Show system keyboard'), findsNothing);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),
     );


### PR DESCRIPTION
## Problem

Sometimes the app gets into a broken UI state where space is reserved for the on-screen keyboard even though the keyboard isn't open. The blank gap shrinks scrollable screens, so content looks like it failed to render (e.g. the settings page doesn't fully load).

This happens when a route that had the keyboard open is dismissed (returning from the terminal, closing a modal sheet/dialog) and the platform keeps reporting a stale bottom view inset.

A second symptom: while in this state, the terminal's **Show system keyboard** button did nothing.

## Fix

**1. Clear the phantom inset on navigation** — new `KeyboardDismissRouteObserver`, registered in the GoRouter `observers`. After every push/pop/replace/remove it asks the platform to hide the keyboard (forcing the bottom inset to recompute), **but only when no editable field is focused**. Screens that intentionally show the keyboard (an autofocused field, the terminal) are never disturbed and focus is never stolen. It reuses the existing `TextInput.hide` idiom already used in the terminal screen.

**2. Make the terminal keyboard button robust to a stale inset** — the button derived "keyboard visible" solely from `MediaQuery.viewInsets.bottom > 0`. During the phantom state that reads `true`, so the button rendered as *Hide* and tapping it ran the hide branch — a no-op. It now treats the keyboard as visible only when both the platform inset **and** the app's own input-connection state agree, so tapping reliably brings the keyboard up.

## Tests

- `test/app/keyboard_dismiss_route_observer_test.dart` — observer hides the keyboard after push/pop when nothing is focused, does **not** hide while a text field is focused, and dismisses a lingering keyboard when returning to a screen.
- `test/presentation/screens/terminal_screen_test.dart` — new case: with a stale bottom inset, the terminal keyboard button offers to **show** the keyboard and actually shows it on tap.

`flutter analyze` clean, `dart format` applied, full test suite passes (2597 tests via pre-commit hook).
