### PR TITLE
feat(windows): complete shell suggestions on Windows remotes

### DIFF
--- a/lib/domain/services/shell_completion_service.dart
+++ b/lib/domain/services/shell_completion_service.dart
@@ -1023,6 +1023,7 @@ String? _normalizeShellCompletionCommandName(String? commandName) {
   if (normalized.startsWith('-')) {
     normalized = normalized.substring(1);
   }
+  normalized = normalized.toLowerCase();
   if (normalized.endsWith('.exe')) {
     normalized = normalized.substring(0, normalized.length - 4);
   }
@@ -2263,7 +2264,9 @@ if($__c.CommandType -eq 'Application'){$__n=[System.IO.Path]::GetFileNameWithout
 if($__n){if(!(__flEmit 'command' $__n)){break}}
 }
 }else{
-if($__flMode -eq 'argument' -and (__flTryTabExpansion)){return}
+$__flUsePathFallback=$true
+if($__flMode -eq 'argument' -and (__flTryTabExpansion)){$__flUsePathFallback=$false}
+if($__flUsePathFallback){
 $__flPrefix=($__flToken -replace '[^/]*$','')
 $__flBase=($__flToken -replace '.*/','')
 if($__flPrefix){$__flDir=($__flPrefix -replace '/$','');if($__flDir -match '^[A-Za-z]:$'){$__flDir="$__flDir/"}}
@@ -2274,6 +2277,7 @@ foreach($__it in $__flItems){
 $__nm=$__it.Name;$__val="$__flPrefix$__nm"
 if($__it.PSIsContainer){if(!(__flEmit 'directory' $__val)){break}}
 elseif($__flMode -eq 'path'){if(!(__flEmit 'file' $__val)){break}}
+}
 }
 }''';
 

--- a/lib/domain/services/shell_completion_service.dart
+++ b/lib/domain/services/shell_completion_service.dart
@@ -1019,9 +1019,12 @@ String? _normalizeShellCompletionCommandName(String? commandName) {
   if (normalized == null || normalized.isEmpty) {
     return null;
   }
-  normalized = normalized.split('/').last;
+  normalized = normalized.replaceAll(r'\', '/').split('/').last;
   if (normalized.startsWith('-')) {
     normalized = normalized.substring(1);
+  }
+  if (normalized.endsWith('.exe')) {
+    normalized = normalized.substring(0, normalized.length - 4);
   }
   return normalized;
 }
@@ -2173,22 +2176,94 @@ String _bashCompWordsAssignment(ShellCompletionInvocation invocation) {
 
 String _shellQuote(String value) => "'${value.replaceAll("'", r"'\''")}'";
 
+/// PowerShell logic that normalizes the active Windows shell name into `cmd`,
+/// `powershell`, `pwsh`, or an empty string.
+///
+/// When a mux pane reports its foreground command, Dart assigns `$__flShell`
+/// before this script runs. For plain Windows OpenSSH sessions, that foreground
+/// command is not observable from the side channel, so this falls back to the
+/// OpenSSH `DefaultShell` registry value. Missing `DefaultShell` means OpenSSH is
+/// using its default `cmd.exe` shell.
+const _windowsShellDetectionLogic = r'''
+function __flNormalizeShellName([string]$value){
+if(!$value){return ''}
+$value=[System.IO.Path]::GetFileNameWithoutExtension($value).ToLowerInvariant()
+while($value.StartsWith('-')){$value=$value.Substring(1)}
+if($value -eq 'cmd' -or $value -eq 'powershell' -or $value -eq 'pwsh'){return $value}
+return ''
+}
+function __flResolveShellName(){
+$__flResolved=__flNormalizeShellName $__flShell
+if($__flResolved){return $__flResolved}
+try{$__flDefault=(Get-ItemProperty -Path 'HKLM:\SOFTWARE\OpenSSH' -Name DefaultShell -ErrorAction Stop).DefaultShell}catch{$__flDefault=''}
+$__flResolved=__flNormalizeShellName $__flDefault
+if($__flResolved){return $__flResolved}
+return 'cmd'
+}
+''';
+
 /// Static PowerShell logic for [buildWindowsShellCompletionScript]. Reads the
 /// `$__flMode`/`$__flToken`/`$__flCwd`/`$__flLimit` parameters assigned by the
 /// caller and appends `<kind>\t<value>` lines to `$__flOut`, matching
 /// [parseShellCompletionOutput]. Paths use forward slashes and are relative to
 /// the token, like the POSIX completion fallback.
 const _windowsCompletionLogic = r'''
+$__flShell=__flResolveShellName
 if($__flCwd){Set-Location -LiteralPath $__flCwd -ErrorAction SilentlyContinue}
+function __flEmit([string]$kind,[string]$value){
+if(!$value -or $__flEmitCount -ge $__flLimit){return $false}
+if($value.IndexOf([char]9) -ge 0 -or $value.IndexOf([char]10) -ge 0 -or $value.IndexOf([char]13) -ge 0){return $true}
+$script:__flEmitCount++
+[void]$__flOut.Append($kind);[void]$__flOut.Append([char]9);[void]$__flOut.Append($value);[void]$__flOut.Append([char]10)
+return ($__flEmitCount -lt $__flLimit)
+}
+function __flNormalizeCompletionText([string]$value){
+if(!$value){return ''}
+$value=$value.TrimEnd()
+if($value.Length -ge 2){
+$first=$value[0];$last=$value[$value.Length-1]
+if(($first -eq "'" -and $last -eq "'") -or ($first -eq '"' -and $last -eq '"')){
+$value=$value.Substring(1,$value.Length-2)
+if($first -eq "'"){$value=$value -replace "''","'"}
+else{$value=$value -replace '`(.)','$1' -replace '""','"'}
+}
+}
+return ($value -replace '\\','/')
+}
+function __flTryTabExpansion(){
+if($__flShell -eq 'cmd'){return $false}
+if(!(Get-Command TabExpansion2 -ErrorAction SilentlyContinue)){return $false}
+$__flCompletion=TabExpansion2 $__flCommandLine $__flCursorOffset
+if(!$__flCompletion -or !$__flCompletion.CompletionMatches){return $false}
+$__flAny=$false
+foreach($__m in $__flCompletion.CompletionMatches){
+if($__flEmitCount -ge $__flLimit){break}
+$__flText=__flNormalizeCompletionText ([string]$__m.CompletionText)
+if(!$__flText){$__flText=__flNormalizeCompletionText ([string]$__m.ListItemText)}
+if(!$__flText){continue}
+$__flType=[string]$__m.ResultType
+$__flKind='argument'
+if($__flType -eq 'Command'){$__flKind='command'}
+elseif($__flType -eq 'ProviderContainer'){$__flKind='directory'}
+elseif($__flType -eq 'ProviderItem'){$__flKind='file'}
+if($__flMode -eq 'argument' -and $__flKind -eq 'command'){continue}
+if($__flMode -eq 'directory' -and $__flKind -ne 'directory'){continue}
+if($__flMode -eq 'path' -and $__flKind -ne 'directory' -and $__flKind -ne 'file'){continue}
+$__flAny=$true
+if(!(__flEmit $__flKind $__flText)){break}
+}
+return $__flAny
+}
 if($__flMode -eq 'command'){
 $__flPat=[System.Management.Automation.WildcardPattern]::Escape($__flToken)+'*'
 $__flCmds=@(Get-Command -Name $__flPat -ErrorAction SilentlyContinue|Select-Object -First $__flLimit)
 foreach($__c in $__flCmds){
 $__n=$__c.Name
 if($__c.CommandType -eq 'Application'){$__n=[System.IO.Path]::GetFileNameWithoutExtension($__n)}
-if($__n){[void]$__flOut.Append('command');[void]$__flOut.Append([char]9);[void]$__flOut.Append($__n);[void]$__flOut.Append([char]10)}
+if($__n){if(!(__flEmit 'command' $__n)){break}}
 }
 }else{
+if($__flMode -eq 'argument' -and (__flTryTabExpansion)){return}
 $__flPrefix=($__flToken -replace '[^/]*$','')
 $__flBase=($__flToken -replace '.*/','')
 if($__flPrefix){$__flDir=($__flPrefix -replace '/$','');if($__flDir -match '^[A-Za-z]:$'){$__flDir="$__flDir/"}}
@@ -2197,8 +2272,8 @@ $__flPat=[System.Management.Automation.WildcardPattern]::Escape($__flBase)+'*'
 $__flItems=@(Get-ChildItem -LiteralPath $__flDir -ErrorAction SilentlyContinue|Where-Object {$_.Name -like $__flPat}|Select-Object -First $__flLimit)
 foreach($__it in $__flItems){
 $__nm=$__it.Name;$__val="$__flPrefix$__nm"
-if($__it.PSIsContainer){[void]$__flOut.Append('directory');[void]$__flOut.Append([char]9);[void]$__flOut.Append($__val);[void]$__flOut.Append([char]10)}
-elseif($__flMode -eq 'path'){[void]$__flOut.Append('file');[void]$__flOut.Append([char]9);[void]$__flOut.Append($__val);[void]$__flOut.Append([char]10)}
+if($__it.PSIsContainer){if(!(__flEmit 'directory' $__val)){break}}
+elseif($__flMode -eq 'path'){if(!(__flEmit 'file' $__val)){break}}
 }
 }''';
 
@@ -2207,12 +2282,14 @@ elseif($__flMode -eq 'path'){[void]$__flOut.Append('file');[void]$__flOut.Append
 /// [parseShellCompletionOutput] parses.
 ///
 /// Command mode lists matching commands via `Get-Command` (executable extensions
-/// stripped); directory/path modes enumerate the token's directory. Argument
-/// mode (installed shell completions) has no Windows equivalent and yields
-/// nothing so the caller falls back to static suggestions.
+/// stripped); argument mode asks PowerShell's native `TabExpansion2` completer;
+/// directory/path modes enumerate the token's directory.
 @visibleForTesting
 String buildWindowsShellCompletionScript(ShellCompletionInvocation invocation) {
   final limit = invocation.maxSuggestions * 4;
+  final shellCommand = _normalizeShellCompletionCommandName(
+    invocation.shellCommand,
+  );
   final assignments = StringBuffer()
     ..write(r'$__flMode=')
     ..write(powerShellSingleQuote(invocation.mode.name))
@@ -2223,8 +2300,18 @@ String buildWindowsShellCompletionScript(ShellCompletionInvocation invocation) {
     ..write(r'$__flCwd=')
     ..write(powerShellSingleQuote(invocation.workingDirectory?.trim() ?? ''))
     ..write(';')
+    ..write(r'$__flCommandLine=')
+    ..write(powerShellSingleQuote(invocation.commandLine))
+    ..write(';')
+    ..write('\$__flCursorOffset=${invocation.cursorOffset};')
+    ..write(r'$__flShell=')
+    ..write(powerShellSingleQuote(shellCommand ?? ''))
+    ..write(';')
+    ..write(r'$__flEmitCount=0;')
     ..write('\$__flLimit=$limit;');
-  return powerShellUtf8OutputScript('$assignments$_windowsCompletionLogic');
+  return powerShellUtf8OutputScript(
+    '$assignments$_windowsShellDetectionLogic$_windowsCompletionLogic',
+  );
 }
 
 /// Builds a PowerShell script that emits recent PowerShell command history on a
@@ -2235,18 +2322,41 @@ String buildWindowsShellCompletionScript(ShellCompletionInvocation invocation) {
 /// command so the existing parser treats it as a literal command string.
 @visibleForTesting
 String buildWindowsShellHistoryScript(ShellCompletionInvocation invocation) {
+  final shellCommand = _normalizeShellCompletionCommandName(
+    invocation.shellCommand,
+  );
   final body = StringBuffer()
+    ..write(r'$__flShell=')
+    ..write(powerShellSingleQuote(shellCommand ?? ''))
+    ..write(';')
+    ..write(_windowsShellDetectionLogic)
+    ..write(r'$__flShell=__flResolveShellName;')
     ..write(
-      r"$__flHist=Join-Path $env:APPDATA 'Microsoft\Windows\PowerShell\PSReadLine\ConsoleHost_history.txt';",
+      r'$__flHistPaths=New-Object System.Collections.Generic.List[string];',
+    )
+    ..write(
+      r'try{$__flOpt=Get-PSReadLineOption -ErrorAction Stop;if($__flOpt.HistorySavePath){$__flHistPaths.Add($__flOpt.HistorySavePath)}}catch{}',
+    )
+    ..write(r'$__flFallbacks=@(')
+    ..write(
+      r"(Join-Path $env:APPDATA 'Microsoft\Windows\PowerShell\PSReadLine\ConsoleHost_history.txt'),",
+    )
+    ..write(
+      r"(Join-Path $env:APPDATA 'Microsoft\PowerShell\PSReadLine\ConsoleHost_history.txt')",
+    )
+    ..write(');')
+    ..write(
+      r'foreach($__flFb in $__flFallbacks){if($__flFb -and !$__flHistPaths.Contains($__flFb)){$__flHistPaths.Add($__flFb)}}',
     )
     ..write(r'[void]$__flOut.Append(')
     ..write(powerShellSingleQuote('__FLUTTY_HISTORY_START__'))
     ..write(r');[void]$__flOut.Append([char]10);')
+    ..write(r"if($__flShell -ne 'cmd'){")
     ..write(
-      r'if(Test-Path -LiteralPath $__flHist -PathType Leaf){$__flLines=@(Get-Content -LiteralPath $__flHist -Tail 1200 -Encoding UTF8 -ErrorAction SilentlyContinue);',
+      r'foreach($__flHist in $__flHistPaths){if(Test-Path -LiteralPath $__flHist -PathType Leaf){$__flLines=@(Get-Content -LiteralPath $__flHist -Tail 1200 -Encoding UTF8 -ErrorAction SilentlyContinue);',
     )
     ..write(
-      r"foreach($__l in $__flLines){[void]$__flOut.Append('bash');[void]$__flOut.Append([char]9);[void]$__flOut.Append($__l);[void]$__flOut.Append([char]10)}}",
+      r"foreach($__l in $__flLines){[void]$__flOut.Append('bash');[void]$__flOut.Append([char]9);[void]$__flOut.Append($__l);[void]$__flOut.Append([char]10)}break}}}",
     )
     ..write(r'[void]$__flOut.Append(')
     ..write(powerShellSingleQuote(_shellHistoryDoneMarker))

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -269,6 +269,7 @@ const _shellCompletionTmuxContextTtl = Duration(seconds: 5);
 const _shellCompletionShellCommands = <String>{
   'ash',
   'bash',
+  'cmd',
   'csh',
   'dash',
   'elvish',
@@ -467,9 +468,12 @@ bool isShellCompletionTmuxShellCommand(String? command) {
   if (normalized == null || normalized.isEmpty) {
     return false;
   }
-  normalized = normalized.split('/').last;
+  normalized = normalized.replaceAll(r'\', '/').split('/').last;
   if (normalized.startsWith('-')) {
     normalized = normalized.substring(1);
+  }
+  if (normalized.endsWith('.exe')) {
+    normalized = normalized.substring(0, normalized.length - 4);
   }
   return _shellCompletionShellCommands.contains(normalized);
 }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -472,6 +472,7 @@ bool isShellCompletionTmuxShellCommand(String? command) {
   if (normalized.startsWith('-')) {
     normalized = normalized.substring(1);
   }
+  normalized = normalized.toLowerCase();
   if (normalized.endsWith('.exe')) {
     normalized = normalized.substring(0, normalized.length - 4);
   }

--- a/test/domain/services/shell_completion_service_test.dart
+++ b/test/domain/services/shell_completion_service_test.dart
@@ -618,6 +618,68 @@ void main() {
       },
     );
 
+    test('uses TabExpansion2 for Windows argument completions', () async {
+      final service = ShellCompletionService();
+      final client = _MockSshClient();
+      final session = _buildShellCompletionSession(
+        client,
+        connectionId: 8,
+        hostId: 100,
+      );
+      when(
+        () => client.remoteVersion,
+      ).thenReturn('SSH-2.0-OpenSSH_for_Windows_9.5');
+      when(() => client.execute(any(), pty: any(named: 'pty'))).thenAnswer((
+        invocation,
+      ) async {
+        final command = invocation.positionalArguments.first as String;
+        final script = _decodeEncodedPowerShell(command);
+        final output = script.contains('HistorySavePath')
+            ? '__FLUTTY_HISTORY_START__\n__FLUTTY_HISTORY_DONE__\n'
+            : 'argument\tcheckout\nargument\tcherry-pick\n';
+        final exec = _MockSshExecSession();
+        when(() => exec.stdout).thenAnswer(
+          (_) => Stream<Uint8List>.fromIterable([
+            Uint8List.fromList(utf8.encode(output)),
+          ]),
+        );
+        when(
+          () => exec.stderr,
+        ).thenAnswer((_) => const Stream<Uint8List>.empty());
+        when(() => exec.done).thenAnswer((_) => Future<void>.value());
+        when(exec.close).thenAnswer((_) {});
+        return exec;
+      });
+      const invocation = ShellCompletionInvocation(
+        commandLine: 'git ch',
+        cursorOffset: 6,
+        token: 'ch',
+        tokenStart: 4,
+        mode: ShellCompletionMode.argument,
+        commandName: 'git',
+        shellCommand: 'powershell.exe',
+        words: ['git', 'ch'],
+        wordIndex: 1,
+        workingDirectory: r'C:\Users\tester',
+      );
+
+      final suggestions = await service.complete(session, invocation);
+
+      expect(suggestions.map((suggestion) => suggestion.label), [
+        'git checkout',
+        'git cherry-pick',
+      ]);
+      expect(suggestions.first.replacement, 'checkout');
+      final commands = verify(
+        () => client.execute(captureAny(), pty: any(named: 'pty')),
+      ).captured.cast<String>();
+      final completionScript = commands
+          .map(_decodeEncodedPowerShell)
+          .singleWhere((script) => script.contains('TabExpansion2'));
+      expect(completionScript, contains(r"$__flShell='powershell'"));
+      expect(completionScript, contains(r'TabExpansion2 $__flCommandLine'));
+    });
+
     test(
       'service keeps in-flight history loads scoped to their connection',
       () async {

--- a/test/domain/services/windows_remote_powershell_test.dart
+++ b/test/domain/services/windows_remote_powershell_test.dart
@@ -197,7 +197,7 @@ void main() {
         tokenStart: 4,
         mode: ShellCompletionMode.argument,
         commandName: 'git',
-        shellCommand: 'pwsh.exe',
+        shellCommand: 'PWSH.EXE',
         words: ['git', 'ch'],
         wordIndex: 1,
         workingDirectory: r'C:\Users\x',
@@ -211,6 +211,7 @@ void main() {
       expect(script, contains(r'TabExpansion2 $__flCommandLine'));
       expect(script, contains(r'$__m.CompletionText'));
       expect(script, contains(r'__flEmit $__flKind $__flText'));
+      expect(script, isNot(contains('(__flTryTabExpansion)){return}')));
     });
 
     test('argument mode does not use PowerShell completers for cmd panes', () {

--- a/test/domain/services/windows_remote_powershell_test.dart
+++ b/test/domain/services/windows_remote_powershell_test.dart
@@ -186,7 +186,49 @@ void main() {
       expect(script, contains(r"$__flMode='command'"));
       expect(script, contains(r"$__flToken='gi'"));
       expect(script, contains('Get-Command -Name'));
-      expect(script, contains("Append('command')"));
+      expect(script, contains(r"__flEmit 'command' $__n"));
+    });
+
+    test('argument mode uses native PowerShell TabExpansion2', () {
+      const invocation = ShellCompletionInvocation(
+        commandLine: 'git ch',
+        cursorOffset: 6,
+        token: 'ch',
+        tokenStart: 4,
+        mode: ShellCompletionMode.argument,
+        commandName: 'git',
+        shellCommand: 'pwsh.exe',
+        words: ['git', 'ch'],
+        wordIndex: 1,
+        workingDirectory: r'C:\Users\x',
+      );
+      final script = buildWindowsShellCompletionScript(invocation);
+      expect(script, contains(r"$__flMode='argument'"));
+      expect(script, contains(r"$__flCommandLine='git ch'"));
+      expect(script, contains(r'$__flCursorOffset=6'));
+      expect(script, contains(r"$__flShell='pwsh'"));
+      expect(script, contains('Get-Command TabExpansion2'));
+      expect(script, contains(r'TabExpansion2 $__flCommandLine'));
+      expect(script, contains(r'$__m.CompletionText'));
+      expect(script, contains(r'__flEmit $__flKind $__flText'));
+    });
+
+    test('argument mode does not use PowerShell completers for cmd panes', () {
+      const invocation = ShellCompletionInvocation(
+        commandLine: 'git ch',
+        cursorOffset: 6,
+        token: 'ch',
+        tokenStart: 4,
+        mode: ShellCompletionMode.argument,
+        commandName: 'git',
+        shellCommand: 'cmd.exe',
+        words: ['git', 'ch'],
+        wordIndex: 1,
+        workingDirectory: r'C:\Users\x',
+      );
+      final script = buildWindowsShellCompletionScript(invocation);
+      expect(script, contains(r"$__flShell='cmd'"));
+      expect(script, contains(r"if($__flShell -eq 'cmd'){return $false}"));
     });
 
     test('path mode enumerates directories and files', () {
@@ -201,8 +243,8 @@ void main() {
       final script = buildWindowsShellCompletionScript(invocation);
       expect(script, contains(r"$__flMode='path'"));
       expect(script, contains('Get-ChildItem -LiteralPath'));
-      expect(script, contains("Append('directory')"));
-      expect(script, contains("Append('file')"));
+      expect(script, contains(r"__flEmit 'directory' $__val"));
+      expect(script, contains(r"__flEmit 'file' $__val"));
     });
 
     test('escapes wildcard tokens and handles drive roots', () {
@@ -278,10 +320,17 @@ void main() {
         token: '',
         tokenStart: 0,
         mode: ShellCompletionMode.command,
+        shellCommand: 'powershell.exe',
         workingDirectory: r'C:\Users\x',
       );
       final script = buildWindowsShellHistoryScript(invocation);
+      expect(script, contains(r"$__flShell='powershell'"));
+      expect(script, contains('DefaultShell'));
+      expect(script, contains(r"if($__flShell -ne 'cmd')"));
+      expect(script, contains('Get-PSReadLineOption'));
+      expect(script, contains('HistorySavePath'));
       expect(script, contains('ConsoleHost_history.txt'));
+      expect(script, contains(r'Microsoft\PowerShell\PSReadLine'));
       expect(script, contains("Append('__FLUTTY_HISTORY_START__')"));
       expect(script, contains("Append('__FLUTTY_HISTORY_DONE__')"));
       expect(script, contains("Append('bash')"));
@@ -291,6 +340,21 @@ void main() {
           r'Get-Content -LiteralPath $__flHist -Tail 1200 -Encoding UTF8',
         ),
       );
+    });
+
+    test('detects cmd shells before deciding whether to read PSReadLine', () {
+      const invocation = ShellCompletionInvocation(
+        commandLine: '',
+        cursorOffset: 0,
+        token: '',
+        tokenStart: 0,
+        mode: ShellCompletionMode.command,
+        shellCommand: 'cmd.exe',
+        workingDirectory: r'C:\Users\x',
+      );
+      final script = buildWindowsShellHistoryScript(invocation);
+      expect(script, contains(r"$__flShell='cmd'"));
+      expect(script, contains(r"if($__flShell -ne 'cmd')"));
     });
   });
 }

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -670,7 +670,7 @@ void main() {
       expect(isShellCompletionTmuxShellCommand('cmd.exe'), isTrue);
       expect(
         isShellCompletionTmuxShellCommand(
-          r'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe',
+          r'C:\Windows\System32\WindowsPowerShell\v1.0\PowerShell.EXE',
         ),
         isTrue,
       );

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -667,6 +667,13 @@ void main() {
       expect(isShellCompletionTmuxShellCommand('zsh'), isTrue);
       expect(isShellCompletionTmuxShellCommand('/bin/bash'), isTrue);
       expect(isShellCompletionTmuxShellCommand('-fish'), isTrue);
+      expect(isShellCompletionTmuxShellCommand('cmd.exe'), isTrue);
+      expect(
+        isShellCompletionTmuxShellCommand(
+          r'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe',
+        ),
+        isTrue,
+      );
       expect(isShellCompletionTmuxShellCommand('vim'), isFalse);
       expect(isShellCompletionTmuxShellCommand(null), isFalse);
     });


### PR DESCRIPTION
## Summary
- use PowerShell TabExpansion2 for Windows argument completions when the active shell is PowerShell/pwsh
- detect cmd vs PowerShell/pwsh for Windows completion/history helpers and normalize .exe shell names
- read PSReadLine history via HistorySavePath with Windows PowerShell and PowerShell 7 fallbacks

Closes #622