### PR TITLE
perf(terminal): batch drawParagraph by style-run in MonkeyTerminalPainter

### DIFF
--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1721,6 +1721,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
     FontFeature.disable('calt'),
     FontFeature.disable('dlig'),
     FontFeature.disable('hlig'),
+    FontFeature.disable('rlig'),
   ];
 
   // Cache of recorded per-line glyph pictures, keyed by a hash of the line's
@@ -1733,6 +1734,12 @@ class MonkeyTerminalPainter extends TerminalPainter {
   // cache), since those change how a given cell content renders.
   final _foregroundPictureCache = <int, Picture>{};
   static const _maxForegroundPictureCacheEntries = 512;
+
+  /// Number of foreground style-run paragraphs currently cached. A coalesced
+  /// line of N same-style cells caches a single N-glyph run paragraph here (not
+  /// N per-cell paragraphs), so tests can assert that batching actually occurs.
+  @visibleForTesting
+  int get runParagraphCacheLength => _runParagraphCache.length;
 
   @override
   set textStyle(TerminalStyle value) {
@@ -1915,10 +1922,14 @@ class MonkeyTerminalPainter extends TerminalPainter {
   /// into a single paragraph and drawn with one `drawParagraph` (a "style run"),
   /// cutting draw-call overhead on dense, freshly rendered lines — the ones that
   /// miss the per-line picture cache during high-throughput output. Runs break
-  /// on any style change and at cells that are positioned or painted specially
-  /// (Kitty placeholders, block elements, wide glyphs, concealed cells, and
-  /// undrawn blank cells), which fall back to the per-cell [paintCellForeground]
-  /// so their exact placement and special drawing are preserved.
+  /// on any style change and at cells that are positioned or painted specially,
+  /// which fall back to the per-cell [paintCellForeground] so their exact
+  /// placement and special drawing are preserved: Kitty placeholders, block
+  /// elements, wide (2-cell) and zero-width (combining-mark) glyphs, concealed
+  /// cells, undrawn blank cells, and any code point that is not
+  /// [_isBatchableForegroundCodePoint] (complex/joining scripts and glyphs that
+  /// may fall back to a non-monospace font, which would shape or advance
+  /// differently once concatenated into one paragraph).
   void _paintLineForegroundsInto(Canvas canvas, BufferLine line) {
     final cellData = CellData.empty();
     final cellWidth = cellSize.width;
@@ -1972,10 +1983,16 @@ class MonkeyTerminalPainter extends TerminalPainter {
           charCode == kittyGraphicsPlaceholderCodePoint ||
           flags & CellFlags.invisible != 0 ||
           (charCode == 0x20 && !overline && !strikethrough);
-      // Block-element glyphs are painted as rectangles, and wide (2-cell) glyphs
-      // must sit at an exact offset; neither can join a text run.
-      final paintedSpecially =
-          charWidth == 2 || _isRectPaintedBlockElement(charCode);
+      // Cells that must be drawn individually at their exact column: block
+      // elements (painted as rectangles), wide (2-cell) and zero-width
+      // (combining-mark) glyphs — which shape and advance with their neighbours
+      // inside one paragraph — and code points that are not safe to concatenate
+      // (complex/joining scripts, non-monospace fallbacks). These break the run
+      // and defer to the per-cell path, preserving the pre-batching output.
+      final drawIndividually =
+          charWidth != 1 ||
+          _isRectPaintedBlockElement(charCode) ||
+          !_isBatchableForegroundCodePoint(charCode);
 
       if (drawsNothing) {
         flushRun();
@@ -1985,7 +2002,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
         continue;
       }
 
-      if (paintedSpecially) {
+      if (drawIndividually) {
         flushRun();
         paintCellForeground(canvas, Offset(i * cellWidth, 0), cellData);
         if (charWidth == 2) {
@@ -2434,6 +2451,41 @@ class MonkeyTerminalPainter extends TerminalPainter {
       charCode == 0x2594 ||
       charCode == 0x2595 ||
       (charCode >= 0x2596 && charCode <= 0x259F);
+
+  /// Whether [charCode] may be coalesced into a batched foreground style run.
+  ///
+  /// A run concatenates several cells into a single paragraph, so only code
+  /// points that shape identically whether laid out in isolation or in sequence
+  /// — and that occupy exactly one monospace cell in standard terminal fonts —
+  /// are eligible. This deliberately excludes cursive-joining and complex
+  /// scripts (Arabic, Syriac, Indic, …), whose glyphs would connect or reorder
+  /// once concatenated (mandatory `init`/`medi`/`fina`/`isol` shaping that
+  /// [_ligatureDisablingFeatures] cannot turn off), and code points likely to
+  /// fall back to a proportional font, whose advance would drift the rest of the
+  /// run off the grid. Everything outside this set is drawn one cell at a time by
+  /// [paintCellForeground], exactly as the pre-batching path did, so their
+  /// placement and shaping are unchanged.
+  static bool _isBatchableForegroundCodePoint(int charCode) {
+    // Basic Latin (printable) — the dominant case for high-throughput output
+    // such as `tail -f`/`yes`, logs, and source code.
+    if (charCode >= 0x20 && charCode <= 0x7E) {
+      return true;
+    }
+    // Latin-1 Supplement (printable), minus the soft hyphen (a zero-width
+    // format character). This block holds no combining or cursive-joining code
+    // points, so isolated and in-run shaping match; it includes U+00A0, which
+    // decorated spaces are substituted with.
+    if (charCode >= 0xA0 && charCode <= 0xFF && charCode != 0xAD) {
+      return true;
+    }
+    // Box Drawing — borders, tables, and rules. Present at exactly one cell in
+    // terminal fonts and neither joining nor combining. (Block Elements at
+    // 0x2580+ are handled separately as rectangles.)
+    if (charCode >= 0x2500 && charCode <= 0x257F) {
+      return true;
+    }
+    return false;
+  }
 
   @visibleForTesting
   Color resolveMonkeyTerminalCellForegroundColor(CellData cellData) {

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -1702,8 +1702,26 @@ class MonkeyTerminalPainter extends TerminalPainter {
 
   List<Color> _palette;
   final _paragraphCache = ParagraphCache(10240);
+  // Paragraphs for multi-cell foreground runs (see `_paintLineForegroundsInto`),
+  // keyed by run text + resolved style. Kept separate from the per-cell
+  // `_paragraphCache` so the two key spaces can never collide.
+  final _runParagraphCache = ParagraphCache(4096);
   final _inlineUnderlineParagraphCache = ParagraphCache(1024);
   final _cursorCellData = CellData.empty();
+
+  // OpenType features that turn adjacent glyphs into a single ligature or a
+  // context-dependent alternate. A batched run concatenates several cells into
+  // one paragraph, so these must stay disabled: the per-cell path can never
+  // form a ligature (each cell is shaped alone), and letting one appear here
+  // would both change the terminal's look and collapse two grid cells into one
+  // glyph, drifting the rest of the run off the monospace grid.
+  static const _ligatureDisablingFeatures = <FontFeature>[
+    FontFeature.disable('liga'),
+    FontFeature.disable('clig'),
+    FontFeature.disable('calt'),
+    FontFeature.disable('dlig'),
+    FontFeature.disable('hlig'),
+  ];
 
   // Cache of recorded per-line glyph pictures, keyed by a hash of the line's
   // cell content. Painting a full screen of text draws one paragraph per
@@ -1724,6 +1742,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
     super.textStyle = value;
     _paragraphCache.clear();
     _inlineUnderlineParagraphCache.clear();
+    _runParagraphCache.clear();
     _foregroundPictureCache.clear();
   }
 
@@ -1735,6 +1754,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
     super.textScaler = value;
     _paragraphCache.clear();
     _inlineUnderlineParagraphCache.clear();
+    _runParagraphCache.clear();
     _foregroundPictureCache.clear();
   }
 
@@ -1747,6 +1767,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
     _palette = _buildMonkeyTerminalPalette(value);
     _paragraphCache.clear();
     _inlineUnderlineParagraphCache.clear();
+    _runParagraphCache.clear();
     _foregroundPictureCache.clear();
   }
 
@@ -1755,6 +1776,7 @@ class MonkeyTerminalPainter extends TerminalPainter {
     super.clearFontCache();
     _paragraphCache.clear();
     _inlineUnderlineParagraphCache.clear();
+    _runParagraphCache.clear();
     _foregroundPictureCache.clear();
   }
 
@@ -1888,17 +1910,182 @@ class MonkeyTerminalPainter extends TerminalPainter {
 
   /// Draws [line]'s glyphs at the origin (each cell at `x = column * cellWidth`),
   /// for recording into a cached [Picture]. See [paintLineForegrounds].
+  ///
+  /// Consecutive width-1 text cells that share a foreground style are coalesced
+  /// into a single paragraph and drawn with one `drawParagraph` (a "style run"),
+  /// cutting draw-call overhead on dense, freshly rendered lines — the ones that
+  /// miss the per-line picture cache during high-throughput output. Runs break
+  /// on any style change and at cells that are positioned or painted specially
+  /// (Kitty placeholders, block elements, wide glyphs, concealed cells, and
+  /// undrawn blank cells), which fall back to the per-cell [paintCellForeground]
+  /// so their exact placement and special drawing are preserved.
   void _paintLineForegroundsInto(Canvas canvas, BufferLine line) {
     final cellData = CellData.empty();
     final cellWidth = cellSize.width;
-    for (var i = 0; i < line.length; i++) {
-      line.getCellData(i, cellData);
-      final charWidth = cellData.content >> CellContent.widthShift;
-      paintCellForeground(canvas, Offset(i * cellWidth, 0), cellData);
-      if (charWidth == 2) {
-        i++;
+    final length = line.length;
+
+    // Accumulated style run: a maximal sequence of consecutive width-1 text
+    // cells sharing one foreground style, starting at column [runStartColumn].
+    var runStartColumn = -1;
+    final runCharCodes = <int>[];
+    var runColor = const Color(0x00000000);
+    var runBold = false;
+    var runItalic = false;
+    var runOverline = false;
+    var runStrikethrough = false;
+    Color? runDecorationColor;
+
+    void flushRun() {
+      if (runStartColumn < 0) {
+        return;
       }
+      _flushForegroundRun(
+        canvas,
+        Offset(runStartColumn * cellWidth, 0),
+        runCharCodes,
+        color: runColor,
+        bold: runBold,
+        italic: runItalic,
+        overline: runOverline,
+        strikethrough: runStrikethrough,
+        decorationColor: runDecorationColor,
+      );
+      runStartColumn = -1;
+      runCharCodes.clear();
     }
+
+    for (var i = 0; i < length; i++) {
+      line.getCellData(i, cellData);
+      final content = cellData.content;
+      final charWidth = content >> CellContent.widthShift;
+      final charCode = content & CellContent.codepointMask;
+      final flags = cellData.flags;
+
+      final overline = flags & CellFlags.overline != 0;
+      final strikethrough = flags & CellFlags.strikethrough != 0;
+      // Cells that draw nothing in the foreground pass: an empty cell, a Kitty
+      // graphics placeholder, a concealed (SGR 8) cell, or a plain space whose
+      // background/underline are handled by the other passes. Each ends the run
+      // but is otherwise skipped, matching [paintCellForeground]'s early returns.
+      final drawsNothing =
+          charCode == 0 ||
+          charCode == kittyGraphicsPlaceholderCodePoint ||
+          flags & CellFlags.invisible != 0 ||
+          (charCode == 0x20 && !overline && !strikethrough);
+      // Block-element glyphs are painted as rectangles, and wide (2-cell) glyphs
+      // must sit at an exact offset; neither can join a text run.
+      final paintedSpecially =
+          charWidth == 2 || _isRectPaintedBlockElement(charCode);
+
+      if (drawsNothing) {
+        flushRun();
+        if (charWidth == 2) {
+          i++;
+        }
+        continue;
+      }
+
+      if (paintedSpecially) {
+        flushRun();
+        paintCellForeground(canvas, Offset(i * cellWidth, 0), cellData);
+        if (charWidth == 2) {
+          i++;
+        }
+        continue;
+      }
+
+      final color = resolveMonkeyTerminalCellForegroundColor(cellData);
+      final bold = flags & CellFlags.bold != 0;
+      final italic = flags & CellFlags.italic != 0;
+      // The decoration color only affects the paragraph when an overline or
+      // strikethrough is drawn; keep it null otherwise so cells that differ only
+      // in an unused underline color still coalesce.
+      final decorationColor = (overline || strikethrough)
+          ? (cellData.underlineColor != 0
+                ? resolveForegroundColor(cellData.underlineColor)
+                : null)
+          : null;
+      // Flutter will not draw an overline/strikethrough beneath a lone space, so
+      // a decorated space is shaped as U+00A0 (same monospace advance) exactly
+      // as the per-cell path does.
+      final drawCharCode = (overline || strikethrough) && charCode == 0x20
+          ? 0xA0
+          : charCode;
+
+      final continuesRun =
+          runStartColumn >= 0 &&
+          color == runColor &&
+          bold == runBold &&
+          italic == runItalic &&
+          overline == runOverline &&
+          strikethrough == runStrikethrough &&
+          decorationColor == runDecorationColor;
+      if (!continuesRun) {
+        flushRun();
+        runStartColumn = i;
+        runColor = color;
+        runBold = bold;
+        runItalic = italic;
+        runOverline = overline;
+        runStrikethrough = strikethrough;
+        runDecorationColor = decorationColor;
+      }
+      runCharCodes.add(drawCharCode);
+    }
+    flushRun();
+  }
+
+  /// Lays out (with caching) and draws one foreground style run: the glyphs in
+  /// [charCodes] sharing the given style, at [offset]. Ligatures and contextual
+  /// alternates are disabled so the run stays one glyph per cell, aligned to the
+  /// monospace grid exactly as the per-cell path renders it.
+  void _flushForegroundRun(
+    Canvas canvas,
+    Offset offset,
+    List<int> charCodes, {
+    required Color color,
+    required bool bold,
+    required bool italic,
+    required bool overline,
+    required bool strikethrough,
+    required Color? decorationColor,
+  }) {
+    if (charCodes.isEmpty) {
+      return;
+    }
+    final text = String.fromCharCodes(charCodes);
+    final cacheKey = Object.hash(
+      text,
+      color,
+      bold,
+      italic,
+      overline,
+      strikethrough,
+      decorationColor,
+      textScaler,
+    );
+    var paragraph = _runParagraphCache.getLayoutFromCache(cacheKey);
+    if (paragraph == null) {
+      final style = textStyle
+          .toTextStyle(
+            color: color,
+            bold: bold,
+            italic: italic,
+            // The underline is drawn manually in the underline pass so wavy/
+            // dotted/dashed/double styles render and connect across cells.
+            overline: overline,
+            strikethrough: strikethrough,
+            decorationColor: decorationColor,
+          )
+          .copyWith(fontFeatures: _ligatureDisablingFeatures);
+      paragraph = _runParagraphCache.performAndCacheLayout(
+        text,
+        style,
+        textScaler,
+        cacheKey,
+      );
+    }
+    canvas.drawParagraph(paragraph, offset);
   }
 
   /// A content hash of [line]'s cells, used to key the foreground picture cache.

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -414,6 +414,103 @@ void main() {
       );
     });
 
+    test(
+      'coalesces consecutive same-style cells into one run paragraph',
+      () async {
+        final theme = TerminalThemes.defaultDarkTheme.toXtermTheme();
+        final painter = MonkeyTerminalPainter(
+          theme: theme,
+          textStyle: const TerminalStyle(fontSize: 20),
+          textScaler: TextScaler.noScaling,
+        );
+        // Four distinct glyphs sharing one style: batching must cache a single
+        // 4-glyph run paragraph, not one paragraph per cell. (Without coalescing
+        // these would be four separate length-1 runs, i.e. four cache entries.)
+        final terminal = Terminal()
+          ..resize(8, 1)
+          ..write('\x1b[37mABCD');
+        expect(
+          painter.runParagraphCacheLength,
+          0,
+          reason: 'a fresh painter has cached no runs yet',
+        );
+
+        final recorder = ui.PictureRecorder();
+        painter.paintLineForegrounds(
+          Canvas(recorder),
+          Offset.zero,
+          terminal.buffer.lines[0],
+        );
+        recorder.endRecording();
+
+        expect(
+          painter.runParagraphCacheLength,
+          1,
+          reason: 'four same-style cells coalesce into one run paragraph',
+        );
+      },
+    );
+
+    test('style-run batching falls back to per-cell for combining marks, '
+        'complex scripts, and emoji', () async {
+      final theme = TerminalThemes.defaultDarkTheme.toXtermTheme();
+      final painter = MonkeyTerminalPainter(
+        theme: theme,
+        textStyle: const TerminalStyle(fontSize: 20),
+        textScaler: TextScaler.noScaling,
+      );
+      const columns = 32;
+      // Cells that must NOT be coalesced into a run: a combining mark (width
+      // 0, which would shape with its neighbour and desync the grid), a
+      // cursive-joining script (Arabic, which would connect when concatenated
+      // but is drawn isolated per cell), and an emoji (wide, non-monospace
+      // fallback). All must fall back to the per-cell path unchanged.
+      final terminal = Terminal()
+        ..resize(columns, 2)
+        ..write('\x1b[37mabc e\u0301f \u0627\u0644\u0645 \u{1F600} xyz');
+      final line = terminal.buffer.lines[0];
+
+      final width = (painter.cellSize.width * columns).ceil();
+      final height = painter.cellSize.height.ceil();
+
+      Future<ByteData> render(void Function(Canvas) paint) async {
+        final recorder = ui.PictureRecorder();
+        final canvas = Canvas(recorder)
+          ..drawRect(
+            Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()),
+            Paint()..color = theme.background,
+          );
+        paint(canvas);
+        final image = await recorder.endRecording().toImage(width, height);
+        return (await image.toByteData())!;
+      }
+
+      // Reference: every cell drawn individually (the pre-batching path).
+      final reference = await render((canvas) {
+        final cellData = CellData.empty();
+        final cellWidth = painter.cellSize.width;
+        for (var i = 0; i < line.length; i++) {
+          line.getCellData(i, cellData);
+          painter.paintCellForeground(
+            canvas,
+            Offset(i * cellWidth, 0),
+            cellData,
+          );
+        }
+      });
+
+      final batched = await render(
+        (canvas) => painter.paintLineForegrounds(canvas, Offset.zero, line),
+      );
+
+      expect(
+        batched.buffer.asUint8List(),
+        reference.buffer.asUint8List(),
+        reason:
+            'non-batchable cells must render identically to the per-cell path',
+      );
+    });
+
     test('colored underline (SGR 58) tints the underline', () async {
       final theme = TerminalThemes.defaultDarkTheme.toXtermTheme();
 

--- a/test/widget/monkey_terminal_view_layout_test.dart
+++ b/test/widget/monkey_terminal_view_layout_test.dart
@@ -345,6 +345,75 @@ void main() {
       },
     );
 
+    test('style-run batching matches per-cell foreground rendering', () async {
+      final theme = TerminalThemes.defaultDarkTheme.toXtermTheme();
+      final painter = MonkeyTerminalPainter(
+        theme: theme,
+        textStyle: const TerminalStyle(fontSize: 20),
+        textScaler: TextScaler.noScaling,
+      );
+      const columns = 24;
+      // A line that forces several run breaks: a colored run, a bold color
+      // change, an undrawn gap space, a decorated (SGR 4/58) cell, and a wide
+      // (2-cell) glyph. Batched output must equal the per-cell reference.
+      final terminal = Terminal()
+        ..resize(columns, 2)
+        ..write(
+          '\x1b[37mhello \x1b[1;32mWorld\x1b[0m '
+          '\x1b[4;58:2::255:0:0mx\x1b[0m \x1b[53mA B\x1b[0m \u4e2d\u6587',
+        );
+      final line = terminal.buffer.lines[0];
+
+      final width = (painter.cellSize.width * columns).ceil();
+      final height = painter.cellSize.height.ceil();
+
+      Future<ByteData> render(void Function(Canvas) paint) async {
+        final recorder = ui.PictureRecorder();
+        final canvas = Canvas(recorder)
+          ..drawRect(
+            Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()),
+            Paint()..color = theme.background,
+          );
+        paint(canvas);
+        final image = await recorder.endRecording().toImage(width, height);
+        return (await image.toByteData())!;
+      }
+
+      // Reference: draw every cell individually, the pre-batching behaviour.
+      // Wide-glyph spacer cells are empty, so paintCellForeground draws
+      // nothing for them and the wide glyph is drawn once at its own column.
+      final reference = await render((canvas) {
+        final cellData = CellData.empty();
+        final cellWidth = painter.cellSize.width;
+        for (var i = 0; i < line.length; i++) {
+          line.getCellData(i, cellData);
+          painter.paintCellForeground(
+            canvas,
+            Offset(i * cellWidth, 0),
+            cellData,
+          );
+        }
+      });
+
+      // Batched: the production foreground pass with style-run coalescing.
+      final batched = await render(
+        (canvas) => painter.paintLineForegrounds(canvas, Offset.zero, line),
+      );
+
+      final referenceBytes = reference.buffer.asUint8List();
+      final batchedBytes = batched.buffer.asUint8List();
+      expect(
+        referenceBytes.any((byte) => byte != 0),
+        isTrue,
+        reason: 'the reference must actually draw glyphs',
+      );
+      expect(
+        batchedBytes,
+        referenceBytes,
+        reason: 'style-run batching must be pixel-identical to per-cell',
+      );
+    });
+
     test('colored underline (SGR 58) tints the underline', () async {
       final theme = TerminalThemes.defaultDarkTheme.toXtermTheme();
 


### PR DESCRIPTION
Closes #595.

## What

Ports the upstream kterm 1.4.2 "style run" batching into `MonkeyTerminalPainter`, where it actually runs (the app fully overrides `paintLine` and never reaches the vendored painter's batching). Consecutive width-1 text cells that share a foreground style are now coalesced into a single paragraph and drawn with one `drawParagraph`, cutting per-cell draw-call overhead on dense, freshly rendered lines — the ones that miss the per-line foreground picture cache during high-throughput output (`tail -f`, `yes`).

This goes a step beyond upstream: upstream keys run-grouping on `CellData.getHash()` (so it only merges *identical* cells), whereas this merges any consecutive cells that share a *style*, which is the win the issue asks for.

## Correctness (the "needs care" items from #595)

- **Runs break on any style change**: resolved foreground color, bold, italic, overline, strikethrough, and decoration (underline) color.
- **Runs break at specially-handled cells**, which fall back to the per-cell `paintCellForeground` for exact placement/drawing:
  - Kitty Unicode placeholders (`0x10EEEE`)
  - block-element glyphs (drawn as rects)
  - wide (2-cell) glyphs
  - concealed (SGR 8) cells and undrawn blank cells
- **Ligatures and contextual alternates are disabled** (`liga/clig/calt/dlig/hlig`) in run paragraphs, so a batched run stays one glyph per cell aligned to the monospace grid — exactly what the per-cell path renders today (which can never form a ligature). This avoids both a visual change and grid drift.
- **Background and underline passes are untouched** (`paintLineBackgrounds` / `paintLineCellUnderlines`), so wavy/dotted/dashed/double underlines still connect across cells.
- Decorated spaces are shaped as U+00A0 within a run, matching the per-cell path.
- A new run-keyed paragraph cache (kept separate from the per-cell cache) is cleared alongside the others on font/theme/scale changes.

## Tests

- New test asserts the batched foreground pass is **pixel-identical** to the per-cell path across a line with color changes, a bold span, blank gaps, an overlined span with an internal (U+00A0-substituted) space, an SGR 58 decorated cell, and wide CJK glyphs.
- Existing painter tests (conceal, colored/styled underlines, block cells, picture cache, full-width prompt) are unchanged and green.
- Full suite (2602 tests) passes via the pre-commit hook.
