### PR TITLE
feat(windows): advertise terminal capabilities

### DIFF
--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -31,6 +31,7 @@ import 'terminal_hyperlink_tracker.dart';
 import 'terminal_notification.dart';
 import 'terminal_preview_graphics.dart';
 import 'wifi_network_service.dart';
+import 'windows_remote_powershell.dart';
 
 part 'ssh_session_runtime.dart';
 

--- a/lib/domain/services/ssh_session_runtime.dart
+++ b/lib/domain/services/ssh_session_runtime.dart
@@ -1,5 +1,7 @@
 part of 'ssh_service.dart';
 
+enum _WindowsShellKind { cmd, powershell, pwsh }
+
 class _SshSessionRuntime {
   _SshSessionRuntime(this._session);
 
@@ -94,16 +96,38 @@ class _SshSessionRuntime {
   static const _monkeyMuxActiveWindowReplayMarker =
       '\x1b\\\x1b[?1000l\x1b[?1002l\x1b[?1003l';
   // SSH pty negotiation sets TERM but cannot advertise COLORTERM or terminal
-  // app hints. Launch the user's login shell with those hints instead of
-  // relying on server-gated env requests that OpenSSH commonly rejects by
-  // default. Keep TERM itself unchanged: xterm-kitty terminfo is often absent
-  // on remote hosts, while TERM_PROGRAM/KITTY_WINDOW_ID are enough for image
-  // capable CLIs to choose Kitty graphics sequences. FORCE_HYPERLINK=1 makes
-  // OSC 8 capable CLIs (Copilot, gh, ...) emit hyperlinks even though their
-  // capability probes don't recognize this TERM/TERM_PROGRAM combination;
-  // MonkeySSH renders and opens OSC 8 links, so advertising support is safe.
+  // app hints. POSIX remotes get a login-shell bootstrap; Windows remotes first
+  // try SSH env requests and then shell-specific prefixes because OpenSSH
+  // commonly rejects env requests unless AcceptEnv is configured. Keep TERM
+  // itself unchanged: xterm-kitty terminfo is often absent on remote hosts,
+  // while TERM_PROGRAM/KITTY_WINDOW_ID are enough for image capable CLIs to
+  // choose Kitty graphics sequences. FORCE_HYPERLINK=1 makes OSC 8 capable CLIs
+  // (Copilot, gh, ...) emit hyperlinks even though their capability probes don't
+  // recognize this TERM/TERM_PROGRAM combination; MonkeySSH renders and opens
+  // OSC 8 links, so advertising support is safe.
+  static const _terminalCapabilityEnvironment = {
+    'COLORTERM': 'truecolor',
+    'TERM_PROGRAM': 'kitty',
+    'KITTY_WINDOW_ID': '1',
+    'FORCE_HYPERLINK': '1',
+  };
   static const _trueColorLoginShellCommand =
       r"""exec env COLORTERM=truecolor TERM_PROGRAM=kitty KITTY_WINDOW_ID=1 FORCE_HYPERLINK=1 /bin/sh -lc 'if [ -n "$SHELL" ]; then exec "$SHELL" -l; else exec /bin/sh; fi'""";
+  static const _windowsShellDetectionTimeout = Duration(seconds: 2);
+  static const _windowsShellDetectionCommand = r'''
+$ErrorActionPreference='SilentlyContinue'
+function __flNormalizeShellName([string]$value){
+if(!$value){return ''}
+$value=[System.IO.Path]::GetFileNameWithoutExtension($value).ToLowerInvariant()
+while($value.StartsWith('-')){$value=$value.Substring(1)}
+if($value -eq 'cmd' -or $value -eq 'powershell' -or $value -eq 'pwsh'){$value}else{''}
+}
+$__flDefault=''
+try{$__flDefault=(Get-ItemProperty -Path 'HKLM:\SOFTWARE\OpenSSH' -Name DefaultShell -ErrorAction Stop).DefaultShell}catch{}
+$__flResolved=__flNormalizeShellName $__flDefault
+if(!$__flResolved){$__flResolved='cmd'}
+[Console]::Out.Write($__flResolved)
+''';
 
   /// UTF-8 decoder that tolerates malformed bytes by emitting U+FFFD instead
   /// of throwing a [FormatException]. The shell stream carries raw terminal
@@ -229,21 +253,8 @@ class _SshSessionRuntime {
       return _session.client.execute(command, pty: ptyConfig);
     }
 
-    // Windows OpenSSH runs the interactive shell through cmd.exe/PowerShell,
-    // which cannot execute the POSIX login-shell bootstrap
-    // ("exec env ... /bin/sh -lc ..."). Running it fails with
-    // "'exec' is not recognized as an internal or external command" and closes
-    // the connection, so request a plain interactive shell instead.
     if (_session.remoteIsWindows) {
-      DiagnosticsLogService.instance.info(
-        'ssh.shell',
-        'windows_plain_shell',
-        fields: {
-          'connectionId': _session.connectionId,
-          'hostId': _session.hostId,
-        },
-      );
-      return _session.client.shell(pty: ptyConfig);
+      return _openWindowsCapabilityShell(ptyConfig);
     }
 
     try {
@@ -262,6 +273,132 @@ class _SshSessionRuntime {
       );
       return _session.client.shell(pty: ptyConfig);
     }
+  }
+
+  Future<SSHSession> _openWindowsCapabilityShell(SSHPtyConfig ptyConfig) async {
+    try {
+      final shell = await _session.client.shell(
+        pty: ptyConfig,
+        environment: _terminalCapabilityEnvironment,
+      );
+      DiagnosticsLogService.instance.info(
+        'ssh.shell',
+        'windows_env_shell',
+        fields: {
+          'connectionId': _session.connectionId,
+          'hostId': _session.hostId,
+        },
+      );
+      return shell;
+    } on SSHChannelRequestError {
+      DiagnosticsLogService.instance.warning(
+        'ssh.shell',
+        'windows_env_rejected',
+        fields: {
+          'connectionId': _session.connectionId,
+          'hostId': _session.hostId,
+        },
+      );
+    }
+
+    final shellKind = await _detectWindowsShellKind();
+    final command = _windowsCapabilityShellCommand(shellKind);
+    try {
+      final shell = await _session.client.execute(command, pty: ptyConfig);
+      DiagnosticsLogService.instance.info(
+        'ssh.shell',
+        'windows_prefixed_shell',
+        fields: {
+          'connectionId': _session.connectionId,
+          'hostId': _session.hostId,
+          'shellKind': shellKind.name,
+        },
+      );
+      return shell;
+    } on SSHChannelRequestError {
+      DiagnosticsLogService.instance.warning(
+        'ssh.shell',
+        'windows_prefixed_shell_rejected',
+        fields: {
+          'connectionId': _session.connectionId,
+          'hostId': _session.hostId,
+          'shellKind': shellKind.name,
+        },
+      );
+      return _session.client.shell(pty: ptyConfig);
+    }
+  }
+
+  Future<_WindowsShellKind> _detectWindowsShellKind() async {
+    final command = buildWindowsPowerShellCommand(
+      _windowsShellDetectionCommand,
+    );
+    SSHSession? detectionSession;
+    try {
+      detectionSession = await _session.client.execute(command);
+      final output = await _shellStreamDecoder
+          .bind(detectionSession.stdout)
+          .join()
+          .timeout(_windowsShellDetectionTimeout);
+      return _parseWindowsShellKind(output);
+    } on SSHChannelRequestError {
+      DiagnosticsLogService.instance.warning(
+        'ssh.shell',
+        'windows_shell_detection_rejected',
+        fields: {
+          'connectionId': _session.connectionId,
+          'hostId': _session.hostId,
+        },
+      );
+      return _WindowsShellKind.cmd;
+    } on TimeoutException {
+      DiagnosticsLogService.instance.warning(
+        'ssh.shell',
+        'windows_shell_detection_timed_out',
+        fields: {
+          'connectionId': _session.connectionId,
+          'hostId': _session.hostId,
+        },
+      );
+      return _WindowsShellKind.cmd;
+    } finally {
+      detectionSession?.close();
+    }
+  }
+
+  _WindowsShellKind _parseWindowsShellKind(String output) {
+    final normalized = output.trim().toLowerCase();
+    return switch (normalized) {
+      'powershell' => _WindowsShellKind.powershell,
+      'pwsh' => _WindowsShellKind.pwsh,
+      _ => _WindowsShellKind.cmd,
+    };
+  }
+
+  String _windowsCapabilityShellCommand(_WindowsShellKind shellKind) {
+    switch (shellKind) {
+      case _WindowsShellKind.cmd:
+        return 'cmd.exe /d /k "set COLORTERM=truecolor&& '
+            'set TERM_PROGRAM=kitty&& '
+            'set KITTY_WINDOW_ID=1&& '
+            'set FORCE_HYPERLINK=1"';
+      case _WindowsShellKind.powershell:
+        return _windowsPowerShellCapabilityShellCommand('powershell.exe');
+      case _WindowsShellKind.pwsh:
+        return _windowsPowerShellCapabilityShellCommand('pwsh.exe');
+    }
+  }
+
+  String _windowsPowerShellCapabilityShellCommand(String executable) {
+    final script = _terminalCapabilityEnvironment.entries
+        .map(
+          (entry) =>
+              r'$env:'
+              '${entry.key}=${powerShellSingleQuote(entry.value)}',
+        )
+        .join(';');
+    return '$executable -NoLogo -NoExit '
+        '-EncodedCommand ${encodePowerShellCommand(script)}';
   }
 
   /// Close only the interactive shell channel while keeping the SSH client.

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -116,6 +116,27 @@ class _MockExecSession extends Mock implements SSHSession {}
 
 class _MockSftpClient extends Mock implements SftpClient {}
 
+void _stubSessionStreams(_MockExecSession session, {String stdout = ''}) {
+  when(() => session.stdout).thenAnswer(
+    (_) => Stream<Uint8List>.fromIterable([
+      Uint8List.fromList(utf8.encode(stdout)),
+    ]),
+  );
+  when(() => session.stderr).thenAnswer((_) => const Stream.empty());
+  when(() => session.done).thenAnswer((_) => Future<void>.value());
+  when(session.close).thenAnswer((_) {});
+}
+
+String _decodePowerShellScriptFromCommand(String command) {
+  final encoded = command.split('-EncodedCommand ').last;
+  final bytes = base64.decode(encoded);
+  final buffer = StringBuffer();
+  for (var i = 0; i + 1 < bytes.length; i += 2) {
+    buffer.writeCharCode(bytes[i] | (bytes[i + 1] << 8));
+  }
+  return buffer.toString();
+}
+
 class _FakeHostKeySocket implements SSHSocket, HostKeySource {
   _FakeHostKeySocket(this._hostKeyBytes);
 
@@ -1382,10 +1403,59 @@ void main() {
       },
     );
 
+    test('requests terminal capability env on Windows remotes', () async {
+      final client = _MockSshClient();
+      final shell = _MockExecSession();
+      final session = SshSession(
+        connectionId: 1,
+        hostId: 2,
+        client: client,
+        config: const SshConnectionConfig(
+          hostname: 'example.com',
+          port: 22,
+          username: 'tester',
+        ),
+      );
+      const pty = SSHPtyConfig(width: 120, height: 30);
+      const terminalCapabilityEnvironment = {
+        'COLORTERM': 'truecolor',
+        'TERM_PROGRAM': 'kitty',
+        'KITTY_WINDOW_ID': '1',
+        'FORCE_HYPERLINK': '1',
+      };
+
+      when(
+        () => client.remoteVersion,
+      ).thenReturn('SSH-2.0-OpenSSH_for_Windows_9.5');
+      when(
+        () => client.shell(
+          pty: any(named: 'pty'),
+          environment: any(named: 'environment'),
+        ),
+      ).thenAnswer((_) async => shell);
+      _stubSessionStreams(shell);
+
+      expect(session.remoteIsWindows, isTrue);
+
+      final result = await session.getShell(pty: pty);
+
+      expect(result, same(shell));
+      final capturedShellArgs = verify(
+        () => client.shell(
+          pty: captureAny(named: 'pty'),
+          environment: captureAny(named: 'environment'),
+        ),
+      ).captured;
+      expect(capturedShellArgs, [pty, terminalCapabilityEnvironment]);
+      verifyNever(() => client.execute(any(), pty: any(named: 'pty')));
+      await session.closeShell(waitForStreams: false);
+    });
+
     test(
-      'requests a plain shell without the bootstrap on Windows remotes',
+      'falls back to a cmd capability prefix when Windows env is rejected',
       () async {
         final client = _MockSshClient();
+        final detection = _MockExecSession();
         final shell = _MockExecSession();
         final session = SshSession(
           connectionId: 1,
@@ -1403,19 +1473,94 @@ void main() {
           () => client.remoteVersion,
         ).thenReturn('SSH-2.0-OpenSSH_for_Windows_9.5');
         when(
-          () => client.shell(pty: any(named: 'pty')),
-        ).thenAnswer((_) async => shell);
-        when(() => shell.stdout).thenAnswer((_) => const Stream.empty());
-        when(() => shell.stderr).thenAnswer((_) => const Stream.empty());
-        when(() => shell.done).thenAnswer((_) => Future<void>.value());
-
-        expect(session.remoteIsWindows, isTrue);
+          () => client.shell(
+            pty: any(named: 'pty'),
+            environment: any(named: 'environment'),
+          ),
+        ).thenThrow(SSHChannelRequestError('env rejected'));
+        when(() => client.execute(any(), pty: any(named: 'pty'))).thenAnswer((
+          invocation,
+        ) async {
+          if (invocation.namedArguments[#pty] == null) {
+            return detection;
+          }
+          return shell;
+        });
+        _stubSessionStreams(detection, stdout: 'cmd');
+        _stubSessionStreams(shell);
 
         final result = await session.getShell(pty: pty);
 
         expect(result, same(shell));
-        verify(() => client.shell(pty: pty)).called(1);
-        verifyNever(() => client.execute(any(), pty: any(named: 'pty')));
+        final commands = verify(
+          () => client.execute(captureAny(), pty: any(named: 'pty')),
+        ).captured.cast<String>();
+        expect(
+          commands.last,
+          'cmd.exe /d /k "set COLORTERM=truecolor&& '
+          'set TERM_PROGRAM=kitty&& '
+          'set KITTY_WINDOW_ID=1&& '
+          'set FORCE_HYPERLINK=1"',
+        );
+        await session.closeShell(waitForStreams: false);
+      },
+    );
+
+    test(
+      'falls back to a PowerShell capability prefix for PowerShell remotes',
+      () async {
+        final client = _MockSshClient();
+        final detection = _MockExecSession();
+        final shell = _MockExecSession();
+        final session = SshSession(
+          connectionId: 1,
+          hostId: 2,
+          client: client,
+          config: const SshConnectionConfig(
+            hostname: 'example.com',
+            port: 22,
+            username: 'tester',
+          ),
+        );
+        const pty = SSHPtyConfig(width: 120, height: 30);
+
+        when(
+          () => client.remoteVersion,
+        ).thenReturn('SSH-2.0-OpenSSH_for_Windows_9.5');
+        when(
+          () => client.shell(
+            pty: any(named: 'pty'),
+            environment: any(named: 'environment'),
+          ),
+        ).thenThrow(SSHChannelRequestError('env rejected'));
+        when(() => client.execute(any(), pty: any(named: 'pty'))).thenAnswer((
+          invocation,
+        ) async {
+          if (invocation.namedArguments[#pty] == null) {
+            return detection;
+          }
+          return shell;
+        });
+        _stubSessionStreams(detection, stdout: 'powershell');
+        _stubSessionStreams(shell);
+
+        final result = await session.getShell(pty: pty);
+
+        expect(result, same(shell));
+        final commands = verify(
+          () => client.execute(captureAny(), pty: any(named: 'pty')),
+        ).captured.cast<String>();
+        expect(
+          commands.last,
+          startsWith('powershell.exe -NoLogo -NoExit -EncodedCommand '),
+        );
+        expect(
+          _decodePowerShellScriptFromCommand(commands.last),
+          contains(
+            r"$env:COLORTERM='truecolor';$env:TERM_PROGRAM='kitty';"
+            r"$env:KITTY_WINDOW_ID='1';$env:FORCE_HYPERLINK='1'",
+          ),
+        );
         await session.closeShell(waitForStreams: false);
       },
     );


### PR DESCRIPTION
## Summary
- advertise truecolor, Kitty terminal hints, and forced hyperlinks on Windows interactive shells
- fall back from SSH env requests to cmd/PowerShell-specific shell prefixes when needed
- cover Windows env and fallback launch paths in SSH service tests

Closes #625

## Tests
- flutter analyze
- flutter test test/domain/services/ssh_service_test.dart --name "truecolor login bootstrap|truecolor bootstrap is rejected|terminal capability env|capability prefix"