### PR TITLE
fix(windows): paste uploaded paths with native separators

### DIFF
--- a/lib/domain/services/monkeymux_installer_service.dart
+++ b/lib/domain/services/monkeymux_installer_service.dart
@@ -320,7 +320,7 @@ class MonkeyMuxInstallerService {
       // SFTP presents Windows paths as `/C:/...`; the shell (attach/control
       // commands, certutil) needs the native `C:\...` form.
       final executablePath = isWindows
-          ? _sftpPathToWindowsPath(executableSftpPath)
+          ? sftpPathToWindowsShellPath(executableSftpPath)
           : executableSftpPath;
       if (await _remoteShaMatches(
         session,
@@ -394,7 +394,7 @@ class MonkeyMuxInstallerService {
         '${DateTime.now().microsecondsSinceEpoch}.tmp',
       );
       final temporaryCommandPath = isWindows
-          ? _sftpPathToWindowsPath(temporaryExecutablePath)
+          ? sftpPathToWindowsShellPath(temporaryExecutablePath)
           : temporaryExecutablePath;
       var movedTemporaryExecutable = false;
       try {
@@ -612,16 +612,6 @@ class MonkeyMuxInstallerService {
   }
 
   bool _isWindowsPlatform(String platform) => platform.startsWith('windows-');
-
-  /// Converts a Windows OpenSSH SFTP path (for example `/C:/Users/me/x.exe`)
-  /// into the native form a Windows shell expects (`C:\Users\me\x.exe`).
-  String _sftpPathToWindowsPath(String sftpPath) {
-    var normalized = sftpPath;
-    if (normalized.startsWith('/')) {
-      normalized = normalized.substring(1);
-    }
-    return normalized.replaceAll('/', r'\');
-  }
 
   /// Extracts the SHA-256 digest from `certutil -hashfile` output, tolerating
   /// the byte-spaced formatting older certutil versions emit.

--- a/lib/domain/services/remote_file_service.dart
+++ b/lib/domain/services/remote_file_service.dart
@@ -8,6 +8,10 @@ import 'package:path/path.dart' as path;
 /// Display path for files pasted directly into a terminal session.
 const remoteClipboardUploadDirectoryDisplay = '~/.cache/monkeyssh/uploads';
 
+/// Windows display path for files pasted directly into a terminal session.
+const remoteClipboardWindowsUploadDirectoryDisplay =
+    r'%USERPROFILE%\.cache\monkeyssh\uploads';
+
 /// Private directory permissions for terminal upload staging directories.
 final remoteUploadDirectoryMode = SftpFileMode(
   groupRead: false,
@@ -29,22 +33,72 @@ final remoteUploadFileMode = SftpFileMode(
   otherExecute: false,
 );
 
+/// Remote path syntax to use when building paths.
+enum RemotePathStyle {
+  /// SFTP/POSIX path syntax using `/` separators.
+  sftp,
+
+  /// Windows shell path syntax using `\` separators.
+  windows,
+}
+
+/// Returns the user-facing terminal upload directory display path.
+String remoteClipboardUploadDirectoryDisplayFor({required bool windows}) =>
+    windows
+    ? remoteClipboardWindowsUploadDirectoryDisplay
+    : remoteClipboardUploadDirectoryDisplay;
+
 /// Builds the remote directory for files pasted directly into a terminal.
-String buildRemoteClipboardUploadDirectory(String homeDirectory) =>
-    joinRemotePath(homeDirectory, '.cache/monkeyssh/uploads');
+String buildRemoteClipboardUploadDirectory(
+  String homeDirectory, {
+  RemotePathStyle style = RemotePathStyle.sftp,
+}) => joinRemotePath(homeDirectory, '.cache/monkeyssh/uploads', style: style);
 
 /// Builds the app-owned parent directory for terminal uploads.
-String buildRemoteClipboardUploadParentDirectory(String homeDirectory) =>
-    joinRemotePath(homeDirectory, '.cache/monkeyssh');
+String buildRemoteClipboardUploadParentDirectory(
+  String homeDirectory, {
+  RemotePathStyle style = RemotePathStyle.sftp,
+}) => joinRemotePath(homeDirectory, '.cache/monkeyssh', style: style);
 
 /// Joins a remote directory and child name into a normalized absolute path.
-String joinRemotePath(String directory, String name) {
+String joinRemotePath(
+  String directory,
+  String name, {
+  RemotePathStyle style = RemotePathStyle.sftp,
+}) {
+  if (style == RemotePathStyle.windows) {
+    return _joinWindowsRemotePath(directory, name);
+  }
   final cleanName = name.replaceFirst(RegExp('^/+'), '');
   final baseDirectory = directory.isEmpty ? '/' : directory;
   final joined = path.posix.join(baseDirectory, cleanName);
   final normalized = path.posix.normalize(joined);
   return normalized.startsWith('/') ? normalized : '/$normalized';
 }
+
+String _joinWindowsRemotePath(String directory, String name) {
+  final cleanName = name.replaceFirst(RegExp(r'^[\\/]+'), '');
+  final baseDirectory = directory.isEmpty
+      ? r'\'
+      : sftpPathToWindowsShellPath(directory);
+  return path.windows.normalize(path.windows.join(baseDirectory, cleanName));
+}
+
+/// Converts a Windows OpenSSH SFTP path into a native Windows shell path.
+///
+/// OpenSSH SFTP reports drive paths as `/C:/Users/...`; cmd.exe and PowerShell
+/// expect `C:\Users\...`.
+String sftpPathToWindowsShellPath(String sftpPath) {
+  var normalized = sftpPath.trim();
+  if (RegExp(r'^/[A-Za-z]:($|/)').hasMatch(normalized)) {
+    normalized = normalized.substring(1);
+  }
+  return normalized.replaceAll('/', r'\');
+}
+
+/// Converts an SFTP path into the path syntax expected by the remote shell.
+String remoteShellPathForSftpPath(String sftpPath, {required bool windows}) =>
+    windows ? sftpPathToWindowsShellPath(sftpPath) : sftpPath;
 
 /// Normalizes an absolute remote path by collapsing `.`, `..`, and extra `/`.
 String? normalizeSftpAbsolutePath(String? path) {
@@ -171,6 +225,14 @@ bool looksLikeBinaryContent(Uint8List bytes) {
 /// Escapes a path so it can be pasted directly into a POSIX shell.
 String shellEscapePosix(String value) => "'${value.replaceAll("'", r"'\''")}'";
 
+/// Escapes a path so it can be pasted directly into a Windows shell.
+String shellEscapeWindows(String value) {
+  if (value.isEmpty) {
+    return '""';
+  }
+  return '"${value.replaceAll('"', '')}"';
+}
+
 /// Bracketed-paste introducer and terminator (`CSI 200~` / `CSI 201~`).
 const _bracketedPasteStart = '\x1b[200~';
 const _bracketedPasteEnd = '\x1b[201~';
@@ -179,8 +241,15 @@ const _bracketedPasteEnd = '\x1b[201~';
 /// strict upload-filename allowlist). Uploaded filenames are sanitized, but the
 /// directory prefix derives from the remote home directory, which a hostile or
 /// misconfigured server could fill with spaces or shell metacharacters.
-bool _isUnquotedSafeAttachmentPath(String path) =>
-    RegExp(r'^[A-Za-z0-9._/-]+$').hasMatch(path);
+bool _isUnquotedSafeAttachmentPath(String path, {required bool windows}) {
+  final safePathPattern = windows
+      ? RegExp(r'^[A-Za-z0-9._/\\:-]+$')
+      : RegExp(r'^[A-Za-z0-9._/-]+$');
+  return safePathPattern.hasMatch(path);
+}
+
+String _shellEscapeAttachmentPath(String path, {required bool windows}) =>
+    windows ? shellEscapeWindows(path) : shellEscapePosix(path);
 
 /// Builds the terminal-input segments that reference uploaded [remotePaths]
 /// after a paste upload.
@@ -206,6 +275,7 @@ bool _isUnquotedSafeAttachmentPath(String path) =>
 List<String> buildTerminalAttachmentPasteSegments(
   Iterable<String> remotePaths, {
   required bool bracketedPasteMode,
+  bool windows = false,
 }) {
   final paths = remotePaths
       .where((remotePath) => remotePath.isNotEmpty)
@@ -214,9 +284,15 @@ List<String> buildTerminalAttachmentPasteSegments(
     return const [];
   }
   final canRenderChips =
-      bracketedPasteMode && paths.every(_isUnquotedSafeAttachmentPath);
+      bracketedPasteMode &&
+      paths.every(
+        (remotePath) =>
+            _isUnquotedSafeAttachmentPath(remotePath, windows: windows),
+      );
   if (!canRenderChips) {
-    return ['${paths.map(shellEscapePosix).join(' ')} '];
+    return [
+      '${paths.map((path) => _shellEscapeAttachmentPath(path, windows: windows)).join(' ')} ',
+    ];
   }
   return [
     for (final remotePath in paths)
@@ -312,6 +388,7 @@ class RemoteFileService {
     required SftpClient sftp,
     required String remotePath,
     required Stream<List<int>> stream,
+    bool applyPrivateMode = true,
   }) async {
     final remoteFile = await sftp.open(
       remotePath,
@@ -325,7 +402,9 @@ class RemoteFileService {
     } finally {
       await remoteFile.close();
     }
-    await sftp.setStat(remotePath, SftpFileAttrs(mode: remoteUploadFileMode));
+    if (applyPrivateMode) {
+      await sftp.setStat(remotePath, SftpFileAttrs(mode: remoteUploadFileMode));
+    }
   }
 
   /// Uploads raw bytes into a remote file path.
@@ -333,10 +412,12 @@ class RemoteFileService {
     required SftpClient sftp,
     required String remotePath,
     required Uint8List bytes,
+    bool applyPrivateMode = true,
   }) => uploadStream(
     sftp: sftp,
     remotePath: remotePath,
     stream: Stream<List<int>>.value(bytes),
+    applyPrivateMode: applyPrivateMode,
   );
 
   Stream<Uint8List> _normalizeByteStream(Stream<List<int>> stream) => stream

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -290,6 +290,23 @@ const _shellCompletionShellCommands = <String>{
   'zsh',
 };
 
+class _ClipboardUploadTarget {
+  const _ClipboardUploadTarget({
+    required this.sftpDirectory,
+    required this.windows,
+  });
+
+  final String sftpDirectory;
+  final bool windows;
+
+  SftpFileMode? get directoryMode => windows ? null : remoteUploadDirectoryMode;
+
+  bool get applyPrivateFileMode => !windows;
+
+  String terminalPathForSftpPath(String sftpPath) =>
+      remoteShellPathForSftpPath(sftpPath, windows: windows);
+}
+
 /// Resolves the retry schedule used for tmux detection after connect.
 @visibleForTesting
 List<Duration> resolveTmuxDetectionRetrySchedule({bool skipDelay = false}) =>
@@ -3880,6 +3897,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   String? get _workingDirectoryPath =>
       _liveWorkingDirectoryPath ?? _tmuxWorkingDirectory;
+
+  String get _clipboardUploadDirectoryDisplay =>
+      remoteClipboardUploadDirectoryDisplayFor(
+        windows: _activeSession()?.remoteIsWindows ?? false,
+      );
 
   TerminalShellStatus? get _shellStatus => _observedSession?.shellStatus;
 
@@ -14472,7 +14494,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     Future<T> Function(
       SftpClient sftp,
       RemoteFileService remoteFileService,
-      String uploadDirectory,
+      _ClipboardUploadTarget uploadTarget,
     )
     action, {
     String? uploadBaseDirectory,
@@ -14495,17 +14517,21 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       final uploadDirectory = buildRemoteClipboardUploadDirectory(
         homeDirectory,
       );
+      final uploadTarget = _ClipboardUploadTarget(
+        sftpDirectory: uploadDirectory,
+        windows: session.remoteIsWindows,
+      );
       await remoteFileService.ensureDirectoryExists(
         sftp,
         appUploadParentDirectory,
-        mode: remoteUploadDirectoryMode,
+        mode: uploadTarget.directoryMode,
       );
       await remoteFileService.ensureDirectoryExists(
         sftp,
         uploadDirectory,
-        mode: remoteUploadDirectoryMode,
+        mode: uploadTarget.directoryMode,
       );
-      return await action(sftp, remoteFileService, uploadDirectory);
+      return await action(sftp, remoteFileService, uploadTarget);
     } on TimeoutException {
       session.discardSftpClient(sftp);
       rethrow;
@@ -14605,10 +14631,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   /// attachment. The pre-built segments are written straight to the session
   /// input via [Terminal.onOutput]; they must not go through [Terminal.paste],
   /// which would strip the bracketed-paste markers.
-  Future<void> _insertUploadedFileReferences(List<String> remotePaths) async {
+  Future<void> _insertUploadedFileReferences(
+    List<String> remotePaths, {
+    required bool windows,
+  }) async {
     final segments = buildTerminalAttachmentPasteSegments(
       remotePaths,
       bracketedPasteMode: _terminal.bracketedPasteMode,
+      windows: windows,
     );
     for (var i = 0; i < segments.length; i++) {
       if (!mounted) {
@@ -14625,7 +14655,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final shouldUpload = await _confirmClipboardUpload(
       title: 'Upload clipboard files?',
       message:
-          'This will upload ${clipboardFiles.length} clipboard file${clipboardFiles.length == 1 ? '' : 's'} to $remoteClipboardUploadDirectoryDisplay on the connected host and paste their remote paths into the terminal.',
+          'This will upload ${clipboardFiles.length} clipboard file${clipboardFiles.length == 1 ? '' : 's'} to $_clipboardUploadDirectoryDisplay on the connected host and paste their remote paths into the terminal.',
       confirmLabel: 'Upload and paste',
       details: [
         for (var index = 0; index < clipboardFiles.length; index++)
@@ -14643,7 +14673,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final remotePaths = await _withClipboardSftp((
       sftp,
       remoteFileService,
-      uploadDirectory,
+      uploadTarget,
     ) async {
       final remotePaths = <String>[];
       for (var index = 0; index < clipboardFiles.length; index++) {
@@ -14663,7 +14693,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           );
           sourceName = clipboardFile.name;
           remotePath = joinRemotePath(
-            uploadDirectory,
+            uploadTarget.sftpDirectory,
             buildClipboardUploadFileName(
               sourceName,
               timestamp,
@@ -14674,11 +14704,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             sftp: sftp,
             remotePath: remotePath,
             bytes: clipboardFile.bytes,
+            applyPrivateMode: uploadTarget.applyPrivateFileMode,
           );
         } else {
           sourceName = path.basename(localPath);
           remotePath = joinRemotePath(
-            uploadDirectory,
+            uploadTarget.sftpDirectory,
             buildClipboardUploadFileName(
               sourceName,
               timestamp,
@@ -14689,15 +14720,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             sftp: sftp,
             remotePath: remotePath,
             stream: File(localPath).openRead(),
+            applyPrivateMode: uploadTarget.applyPrivateFileMode,
           );
         }
-        remotePaths.add(remotePath);
+        remotePaths.add(uploadTarget.terminalPathForSftpPath(remotePath));
       }
-      return remotePaths;
+      return (paths: remotePaths, windows: uploadTarget.windows);
     });
 
     _followLiveOutput();
-    await _insertUploadedFileReferences(remotePaths);
+    await _insertUploadedFileReferences(
+      remotePaths.paths,
+      windows: remotePaths.windows,
+    );
     if (!mounted) {
       return;
     }
@@ -14712,7 +14747,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _terminalController.clearSelection();
     _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
     _showClipboardMessage(
-      'Uploaded ${remotePaths.length} file${remotePaths.length == 1 ? '' : 's'} to $remoteClipboardUploadDirectoryDisplay',
+      'Uploaded ${remotePaths.paths.length} file${remotePaths.paths.length == 1 ? '' : 's'} to $_clipboardUploadDirectoryDisplay',
     );
   }
 
@@ -14754,7 +14789,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       final shouldUpload = await _confirmClipboardUpload(
         title: 'Upload clipboard image?',
         message:
-            'This will upload the clipboard image to $remoteClipboardUploadDirectoryDisplay on the connected host and paste its remote path into the terminal.',
+            'This will upload the clipboard image to $_clipboardUploadDirectoryDisplay on the connected host and paste its remote path into the terminal.',
         confirmLabel: 'Upload and paste',
         details: const ['release-checklist.png'],
         autoConfirmAfter: autoConfirmAfter,
@@ -14768,21 +14803,27 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final remotePath = await _withClipboardSftp((
       sftp,
       remoteFileService,
-      uploadDirectory,
+      uploadTarget,
     ) async {
       final remotePath = joinRemotePath(
-        uploadDirectory,
+        uploadTarget.sftpDirectory,
         buildClipboardImageFileName(DateTime.now()),
       );
       await remoteFileService.uploadBytes(
         sftp: sftp,
         remotePath: remotePath,
         bytes: imageBytes,
+        applyPrivateMode: uploadTarget.applyPrivateFileMode,
       );
-      return remotePath;
+      return (
+        path: uploadTarget.terminalPathForSftpPath(remotePath),
+        windows: uploadTarget.windows,
+      );
     }, uploadBaseDirectory: uploadBaseDirectory);
     _followLiveOutput();
-    await _insertUploadedFileReferences([remotePath]);
+    await _insertUploadedFileReferences([
+      remotePath.path,
+    ], windows: remotePath.windows);
     if (!mounted) {
       return;
     }
@@ -14798,7 +14839,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _restoreTerminalFocus(
       showSystemKeyboard: showKeyboardAfterPaste && _isMobilePlatform,
     );
-    _showClipboardMessage('Uploaded clipboard image to $remotePath');
+    _showClipboardMessage('Uploaded clipboard image to ${remotePath.path}');
   }
 
   Future<void> _pasteSelectedFiles(
@@ -14815,7 +14856,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final shouldUpload = await _confirmClipboardUpload(
       title: 'Upload selected $itemLabel?',
       message:
-          'This will upload ${selectedFiles.length == 1 ? 'the selected $itemLabelSingular' : '${selectedFiles.length} selected $itemLabelPlural'} to $remoteClipboardUploadDirectoryDisplay on the connected host and paste ${selectedFiles.length == 1 ? 'its remote path' : 'their remote paths'} into the terminal.',
+          'This will upload ${selectedFiles.length == 1 ? 'the selected $itemLabelSingular' : '${selectedFiles.length} selected $itemLabelPlural'} to $_clipboardUploadDirectoryDisplay on the connected host and paste ${selectedFiles.length == 1 ? 'its remote path' : 'their remote paths'} into the terminal.',
       confirmLabel: 'Upload and paste',
       details: [
         for (var index = 0; index < selectedFiles.length; index++)
@@ -14834,7 +14875,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final remotePaths = await _withClipboardSftp((
       sftp,
       remoteFileService,
-      uploadDirectory,
+      uploadTarget,
     ) async {
       final remotePaths = <String>[];
       for (var index = 0; index < selectedFiles.length; index++) {
@@ -14844,7 +14885,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           index: index,
         );
         final remotePath = joinRemotePath(
-          uploadDirectory,
+          uploadTarget.sftpDirectory,
           buildClipboardUploadFileName(sourceName, timestamp, sequence: index),
         );
         final readStream = resolvePickedTerminalUploadReadStream(file);
@@ -14853,6 +14894,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             sftp: sftp,
             remotePath: remotePath,
             stream: readStream,
+            applyPrivateMode: uploadTarget.applyPrivateFileMode,
           );
         } else {
           final Uint8List bytes;
@@ -14865,15 +14907,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             sftp: sftp,
             remotePath: remotePath,
             bytes: bytes,
+            applyPrivateMode: uploadTarget.applyPrivateFileMode,
           );
         }
-        remotePaths.add(remotePath);
+        remotePaths.add(uploadTarget.terminalPathForSftpPath(remotePath));
       }
-      return remotePaths;
+      return (paths: remotePaths, windows: uploadTarget.windows);
     });
 
     _followLiveOutput();
-    await _insertUploadedFileReferences(remotePaths);
+    await _insertUploadedFileReferences(
+      remotePaths.paths,
+      windows: remotePaths.windows,
+    );
     if (!mounted) {
       return;
     }
@@ -14885,7 +14931,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _terminalController.clearSelection();
     _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
     _showClipboardMessage(
-      'Uploaded ${selectedFiles.length == 1 ? 'selected $itemLabelSingular' : '${remotePaths.length} $itemLabelPlural'} to $remoteClipboardUploadDirectoryDisplay',
+      'Uploaded ${selectedFiles.length == 1 ? 'selected $itemLabelSingular' : '${remotePaths.paths.length} $itemLabelPlural'} to $_clipboardUploadDirectoryDisplay',
     );
   }
 

--- a/test/domain/services/monkeymux_installer_service_test.dart
+++ b/test/domain/services/monkeymux_installer_service_test.dart
@@ -57,6 +57,7 @@ class _FakeRemoteFileService extends RemoteFileService {
     required SftpClient sftp,
     required String remotePath,
     required Uint8List bytes,
+    bool applyPrivateMode = true,
   }) async {
     uploaded = true;
     uploadCount++;

--- a/test/domain/services/remote_file_service_test.dart
+++ b/test/domain/services/remote_file_service_test.dart
@@ -22,6 +22,24 @@ void main() {
       expect(joinRemotePath('', 'example.txt'), '/example.txt');
     });
 
+    test('joins Windows remote paths for terminal insertion', () {
+      expect(
+        joinRemotePath(
+          '/C:/Users/proof',
+          '.cache/monkeyssh/uploads',
+          style: RemotePathStyle.windows,
+        ),
+        r'C:\Users\proof\.cache\monkeyssh\uploads',
+      );
+      expect(
+        buildRemoteClipboardUploadDirectory(
+          r'C:\Users\proof',
+          style: RemotePathStyle.windows,
+        ),
+        r'C:\Users\proof\.cache\monkeyssh\uploads',
+      );
+    });
+
     test(
       'tolerates concurrent mkdir races when ensuring directories',
       () async {
@@ -112,6 +130,26 @@ void main() {
 
     test('escapes uploaded paths for terminal insertion', () {
       expect(shellEscapePosix("/tmp/it's.txt"), r"'/tmp/it'\''s.txt'");
+      expect(
+        shellEscapeWindows(r'C:\Users\John Smith\image.png'),
+        r'"C:\Users\John Smith\image.png"',
+      );
+    });
+
+    test('converts Windows SFTP paths for terminal insertion', () {
+      expect(
+        sftpPathToWindowsShellPath(
+          '/C:/Users/proof/.cache/monkeyssh/uploads/image.png',
+        ),
+        r'C:\Users\proof\.cache\monkeyssh\uploads\image.png',
+      );
+      expect(
+        remoteShellPathForSftpPath(
+          '/C:/Users/proof/.cache/monkeyssh/uploads/image.png',
+          windows: true,
+        ),
+        r'C:\Users\proof\.cache\monkeyssh\uploads\image.png',
+      );
     });
 
     test(
@@ -139,6 +177,28 @@ void main() {
           '/tmp/b.png',
         ], bracketedPasteMode: false),
         ["'/tmp/a.png' '/tmp/b.png' "],
+      );
+    });
+
+    test('uses native Windows paths for terminal attachment pastes', () {
+      const start = '\x1b[200~';
+      const end = '\x1b[201~';
+
+      expect(
+        buildTerminalAttachmentPasteSegments(
+          [r'C:\Users\proof\.cache\monkeyssh\uploads\a.png'],
+          bracketedPasteMode: true,
+          windows: true,
+        ),
+        ['$start${r'C:\Users\proof\.cache\monkeyssh\uploads\a.png'}$end '],
+      );
+      expect(
+        buildTerminalAttachmentPasteSegments(
+          [r'C:\Users\John Smith\.cache\monkeyssh\uploads\a.png'],
+          bracketedPasteMode: true,
+          windows: true,
+        ),
+        [r'"C:\Users\John Smith\.cache\monkeyssh\uploads\a.png" '],
       );
     });
 


### PR DESCRIPTION
## Summary
- convert Windows OpenSSH SFTP upload paths to native Windows paths before inserting them into the terminal
- use Windows-safe quoting for pasted upload paths and Windows upload directory copy
- skip POSIX file/directory mode updates for Windows SFTP uploads

Fixes #624

## Tests
- flutter test test/domain/services/remote_file_service_test.dart
- flutter test test/domain/services/monkeymux_installer_service_test.dart
- flutter analyze