### PR TITLE
fix: bracket uploaded paths for active agents

### DIFF
--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -117,6 +117,7 @@ class TmuxWindow {
     this.activeAgentSessionConfidence,
     this.terminalReportsMouseWheel,
     this.terminalMouseReportSgr,
+    this.terminalBracketedPasteMode,
     int? idleSeconds,
     this.lastActivityEpochSeconds,
   }) : _snapshotIdleSeconds = idleSeconds;
@@ -215,6 +216,9 @@ class TmuxWindow {
   /// Whether the foreground application requested SGR mouse reporting.
   final bool? terminalMouseReportSgr;
 
+  /// Whether the foreground application requested bracketed paste mode.
+  final bool? terminalBracketedPasteMode;
+
   /// tmux's `window_activity` epoch seconds, if available.
   final int? lastActivityEpochSeconds;
 
@@ -270,6 +274,7 @@ class TmuxWindow {
     AgentSessionConfidence? activeAgentSessionConfidence,
     bool? terminalReportsMouseWheel,
     bool? terminalMouseReportSgr,
+    bool? terminalBracketedPasteMode,
     bool clearActiveAgentSessionMetadata = false,
     int? lastActivityEpochSeconds,
   }) => TmuxWindow(
@@ -297,6 +302,8 @@ class TmuxWindow {
         terminalReportsMouseWheel ?? this.terminalReportsMouseWheel,
     terminalMouseReportSgr:
         terminalMouseReportSgr ?? this.terminalMouseReportSgr,
+    terminalBracketedPasteMode:
+        terminalBracketedPasteMode ?? this.terminalBracketedPasteMode,
     idleSeconds: _snapshotIdleSeconds,
     lastActivityEpochSeconds:
         lastActivityEpochSeconds ?? this.lastActivityEpochSeconds,
@@ -588,6 +595,7 @@ class TmuxWindow {
           activeAgentSessionConfidence == other.activeAgentSessionConfidence &&
           terminalReportsMouseWheel == other.terminalReportsMouseWheel &&
           terminalMouseReportSgr == other.terminalMouseReportSgr &&
+          terminalBracketedPasteMode == other.terminalBracketedPasteMode &&
           lastActivityEpochSeconds == other.lastActivityEpochSeconds &&
           _snapshotIdleSeconds == other._snapshotIdleSeconds;
 
@@ -609,6 +617,7 @@ class TmuxWindow {
     activeAgentSessionConfidence,
     terminalReportsMouseWheel,
     terminalMouseReportSgr,
+    terminalBracketedPasteMode,
     lastActivityEpochSeconds,
     _snapshotIdleSeconds,
   );

--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -1462,6 +1462,9 @@ TmuxWindow? _windowFromJson(Object? value) {
   final terminalMouseReportSgr =
       (value['terminalMouseReportSgr'] as bool? ?? false) ||
       _privateModeEnabled(privateModes, '1006');
+  final terminalBracketedPasteMode =
+      (value['terminalBracketedPasteMode'] as bool? ?? false) ||
+      _privateModeEnabled(privateModes, '2004');
   // The MonkeyMux server only raises the `#` alert flag when a background
   // window emits a terminal bell (agents ring the bell when they need input),
   // and clears it as soon as the window is selected. Parsing it restores the
@@ -1480,6 +1483,7 @@ TmuxWindow? _windowFromJson(Object? value) {
     agentTool: _agentToolFromMonkeyMuxMetadata(value['agentTool'] as String?),
     terminalReportsMouseWheel: terminalReportsMouseWheel,
     terminalMouseReportSgr: terminalMouseReportSgr,
+    terminalBracketedPasteMode: terminalBracketedPasteMode,
     lastActivityEpochSeconds: value['lastActivityEpochSeconds'] as int?,
   );
 }

--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -1462,9 +1462,11 @@ TmuxWindow? _windowFromJson(Object? value) {
   final terminalMouseReportSgr =
       (value['terminalMouseReportSgr'] as bool? ?? false) ||
       _privateModeEnabled(privateModes, '1006');
-  final terminalBracketedPasteMode =
-      (value['terminalBracketedPasteMode'] as bool? ?? false) ||
-      _privateModeEnabled(privateModes, '2004');
+  final explicitTerminalBracketedPasteMode =
+      value['terminalBracketedPasteMode'];
+  final terminalBracketedPasteMode = explicitTerminalBracketedPasteMode is bool
+      ? explicitTerminalBracketedPasteMode
+      : _privateModeValue(privateModes, '2004');
   // The MonkeyMux server only raises the `#` alert flag when a background
   // window emits a terminal bell (agents ring the bell when they need input),
   // and clears it as soon as the window is selected. Parsing it restores the
@@ -1504,6 +1506,9 @@ Map<String, bool> _privateModesFromJson(Object? value) {
 
 bool _privateModeEnabled(Map<String, bool> privateModes, String mode) =>
     privateModes[mode] ?? false;
+
+bool? _privateModeValue(Map<String, bool> privateModes, String mode) =>
+    privateModes.containsKey(mode) ? privateModes[mode] : null;
 
 Set<int> _monkeyMuxAgentPanePids(Iterable<TmuxWindow> windows) => windows
     .where(

--- a/lib/domain/services/remote_file_service.dart
+++ b/lib/domain/services/remote_file_service.dart
@@ -355,7 +355,7 @@ String _shellEscapeAttachmentPath(String path, {required bool windows}) =>
 /// Builds the terminal-input segments that reference uploaded [remotePaths]
 /// after a paste upload.
 ///
-/// When [bracketedPasteMode] is enabled *and* every path is safe to paste
+/// When [useBracketedPaste] is true *and* every path is safe to paste
 /// unquoted, each path is returned as its own bracketed-paste segment
 /// (`CSI 200~ <path> CSI 201~ ` with a trailing space). The caller must write
 /// these segments sequentially with a short delay between them: an agent CLI
@@ -364,19 +364,19 @@ String _shellEscapeAttachmentPath(String path, {required bool windows}) =>
 /// distinct reads. The trailing space also keeps the paths usable as distinct
 /// shell arguments.
 ///
-/// Otherwise — bracketed paste mode is off, or a path contains characters that
-/// would be unsafe unquoted (e.g. a remote home directory with spaces or shell
-/// metacharacters) — the paths are shell-escaped for the current remote shell
-/// and returned as a single segment. That form shows no preview (a path with
-/// spaces would not produce a chip anyway) but keeps the inserted text quoted
-/// for the active remote shell.
+/// Otherwise — when bracketed paste is not requested, or when a path contains
+/// characters that would be unsafe unquoted (e.g. a remote home directory with
+/// spaces or shell metacharacters) — the paths are shell-escaped for the current
+/// remote shell and returned as a single segment. That form shows no preview (a
+/// path with spaces would not produce a chip anyway) but keeps the inserted text
+/// quoted for the active remote shell.
 ///
 /// Segments must be written straight to the session input sink (e.g.
 /// `Terminal.onOutput`), not through `Terminal.paste`, which would strip the
 /// bracketed-paste control sequences.
 List<String> buildTerminalAttachmentPasteSegments(
   Iterable<String> remotePaths, {
-  required bool bracketedPasteMode,
+  required bool useBracketedPaste,
   bool windows = false,
 }) {
   final paths = remotePaths
@@ -386,7 +386,7 @@ List<String> buildTerminalAttachmentPasteSegments(
     return const [];
   }
   final canRenderChips =
-      bracketedPasteMode &&
+      useBracketedPaste &&
       paths.every(
         (remotePath) =>
             _isUnquotedSafeAttachmentPath(remotePath, windows: windows),

--- a/lib/domain/services/remote_file_service.dart
+++ b/lib/domain/services/remote_file_service.dart
@@ -355,7 +355,7 @@ String _shellEscapeAttachmentPath(String path, {required bool windows}) =>
 /// Builds the terminal-input segments that reference uploaded [remotePaths]
 /// after a paste upload.
 ///
-/// When [useBracketedPaste] is true *and* every path is safe to paste
+/// When [bracketedPasteMode] is true *and* every path is safe to paste
 /// unquoted, each path is returned as its own bracketed-paste segment
 /// (`CSI 200~ <path> CSI 201~ ` with a trailing space). The caller must write
 /// these segments sequentially with a short delay between them: an agent CLI
@@ -376,7 +376,7 @@ String _shellEscapeAttachmentPath(String path, {required bool windows}) =>
 /// bracketed-paste control sequences.
 List<String> buildTerminalAttachmentPasteSegments(
   Iterable<String> remotePaths, {
-  required bool useBracketedPaste,
+  required bool bracketedPasteMode,
   bool windows = false,
 }) {
   final paths = remotePaths
@@ -386,7 +386,7 @@ List<String> buildTerminalAttachmentPasteSegments(
     return const [];
   }
   final canRenderChips =
-      useBracketedPaste &&
+      bracketedPasteMode &&
       paths.every(
         (remotePath) =>
             _isUnquotedSafeAttachmentPath(remotePath, windows: windows),

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -812,6 +812,15 @@ AgentLaunchTool? resolveTmuxBarActiveWindowTool(
     .firstOrNull
     ?.foregroundAgentTool;
 
+/// Resolves bracketed paste mode state tracked for the active mux window.
+@visibleForTesting
+bool? resolveTmuxBarActiveWindowBracketedPasteMode(
+  Iterable<TmuxWindow>? windows,
+) => windows
+    ?.where((window) => window.isActive)
+    .firstOrNull
+    ?.terminalBracketedPasteMode;
+
 String _telemetryMuxBackendName(RemoteMuxBackend backend) => switch (backend) {
   RemoteMuxBackend.auto => 'auto',
   RemoteMuxBackend.tmux => 'tmux',
@@ -1335,39 +1344,6 @@ bool shouldUsePhotoLibraryPickerForTerminalMedia({
 }) =>
     !isWeb &&
     (platform == TargetPlatform.android || platform == TargetPlatform.iOS);
-
-/// Whether uploaded file references should be framed as bracketed-paste input.
-@visibleForTesting
-bool shouldUseBracketedPasteForUploadedReferences({
-  required bool bracketedPasteMode,
-  required bool isAgentToolActive,
-  String? terminalIconName,
-  String? terminalWindowTitle,
-}) =>
-    bracketedPasteMode ||
-    isAgentToolActive ||
-    _terminalMetadataValueIndicatesAgentTool(terminalIconName) ||
-    _terminalMetadataValueIndicatesAgentTool(terminalWindowTitle);
-
-bool _terminalMetadataValueIndicatesAgentTool(String? value) {
-  final normalized = value?.trim();
-  if (normalized == null || normalized.isEmpty) {
-    return false;
-  }
-  if (agentLaunchToolForCommandName(normalized) != null) {
-    return true;
-  }
-  final lowered = normalized.toLowerCase();
-  for (final tool in AgentLaunchTool.values) {
-    final label = tool.label.toLowerCase();
-    if (lowered == label ||
-        lowered.startsWith('$label ') ||
-        lowered.startsWith('$label:')) {
-      return true;
-    }
-  }
-  return false;
-}
 
 /// Returns an Android image picker implementation configured for Photo Picker.
 @visibleForTesting
@@ -2691,6 +2667,15 @@ bool terminalReportsMouseWheelForScroll({
 }) =>
     localTerminalReportsMouseWheel || (activeWindowReportsMouseWheel ?? false);
 
+/// Resolves effective bracketed paste state for uploaded terminal references.
+@visibleForTesting
+bool terminalBracketedPasteModeForUploads({
+  required bool localTerminalBracketedPasteMode,
+  bool? activeWindowBracketedPasteMode,
+}) =>
+    localTerminalBracketedPasteMode ||
+    (activeWindowBracketedPasteMode ?? false);
+
 /// Whether the active terminal context is a known agent tool for scroll policy.
 @visibleForTesting
 bool isAgentToolActiveForTerminalScroll({
@@ -3692,6 +3677,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   bool? get _activeWindowMouseReportSgr =>
       resolveTmuxBarActiveWindowMouseReportSgr(_currentTmuxWindowsSnapshot);
+
+  bool? get _activeWindowBracketedPasteMode =>
+      resolveTmuxBarActiveWindowBracketedPasteMode(_currentTmuxWindowsSnapshot);
 
   bool get _terminalReportsMouseWheelForScroll =>
       terminalReportsMouseWheelForScroll(
@@ -14679,11 +14667,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     List<String> remotePaths, {
     required bool windows,
   }) async {
-    final useBracketedPaste = shouldUseBracketedPasteForUploadedReferences(
-      bracketedPasteMode: _terminal.bracketedPasteMode,
-      isAgentToolActive: _isAgentToolActive,
-      terminalIconName: _iconName,
-      terminalWindowTitle: _windowTitle,
+    final useBracketedPaste = terminalBracketedPasteModeForUploads(
+      localTerminalBracketedPasteMode: _terminal.bracketedPasteMode,
+      activeWindowBracketedPasteMode: _activeWindowBracketedPasteMode,
     );
     final segments = buildTerminalAttachmentPasteSegments(
       remotePaths,

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -821,6 +821,20 @@ bool? resolveTmuxBarActiveWindowBracketedPasteMode(
     .firstOrNull
     ?.terminalBracketedPasteMode;
 
+/// Applies active mux-window bracketed-paste state to the local terminal.
+@visibleForTesting
+bool inheritTerminalBracketedPasteModeFromMuxWindow({
+  required Terminal terminal,
+  required bool? activeWindowBracketedPasteMode,
+}) {
+  if (activeWindowBracketedPasteMode == null ||
+      terminal.bracketedPasteMode == activeWindowBracketedPasteMode) {
+    return false;
+  }
+  terminal.setBracketedPasteMode(activeWindowBracketedPasteMode);
+  return true;
+}
+
 String _telemetryMuxBackendName(RemoteMuxBackend backend) => switch (backend) {
   RemoteMuxBackend.auto => 'auto',
   RemoteMuxBackend.tmux => 'tmux',
@@ -844,16 +858,16 @@ bool? resolveTmuxBarActiveWindowMouseReportSgr(Iterable<TmuxWindow>? windows) =>
         .firstOrNull
         ?.terminalMouseReportSgr;
 
-/// Scroll-relevant mouse-reporting signature for the active tmux window.
+/// Terminal mode signature for the active tmux window.
 ///
-/// Used to detect when touch-scroll routing must be recomputed after a window
+/// Used to detect when local terminal state must be updated after a window
 /// metadata update that doesn't change the active window itself (for example a
-/// foreground app toggling mouse mode). Returns `null` when there is no active
-/// window so an appearing/disappearing active window is also treated as a
-/// change.
+/// foreground app toggling mouse or bracketed-paste mode). Returns `null` when
+/// there is no active window so an appearing/disappearing active window is also
+/// treated as a change.
 @visibleForTesting
-({bool? reportsMouseWheel, bool? mouseReportSgr})?
-activeTmuxWindowScrollModeSignature(Iterable<TmuxWindow>? windows) {
+({bool? reportsMouseWheel, bool? mouseReportSgr, bool? bracketedPasteMode})?
+activeTmuxWindowTerminalModeSignature(Iterable<TmuxWindow>? windows) {
   final activeWindow = windows?.where((window) => window.isActive).firstOrNull;
   if (activeWindow == null) {
     return null;
@@ -861,6 +875,7 @@ activeTmuxWindowScrollModeSignature(Iterable<TmuxWindow>? windows) {
   return (
     reportsMouseWheel: activeWindow.terminalReportsMouseWheel,
     mouseReportSgr: activeWindow.terminalMouseReportSgr,
+    bracketedPasteMode: activeWindow.terminalBracketedPasteMode,
   );
 }
 
@@ -2667,15 +2682,6 @@ bool terminalReportsMouseWheelForScroll({
 }) =>
     localTerminalReportsMouseWheel || (activeWindowReportsMouseWheel ?? false);
 
-/// Resolves effective bracketed paste state for uploaded terminal references.
-@visibleForTesting
-bool terminalBracketedPasteModeForUploads({
-  required bool localTerminalBracketedPasteMode,
-  bool? activeWindowBracketedPasteMode,
-}) =>
-    localTerminalBracketedPasteMode ||
-    (activeWindowBracketedPasteMode ?? false);
-
 /// Whether the active terminal context is a known agent tool for scroll policy.
 @visibleForTesting
 bool isAgentToolActiveForTerminalScroll({
@@ -3677,9 +3683,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   bool? get _activeWindowMouseReportSgr =>
       resolveTmuxBarActiveWindowMouseReportSgr(_currentTmuxWindowsSnapshot);
-
-  bool? get _activeWindowBracketedPasteMode =>
-      resolveTmuxBarActiveWindowBracketedPasteMode(_currentTmuxWindowsSnapshot);
 
   bool get _terminalReportsMouseWheelForScroll =>
       terminalReportsMouseWheelForScroll(
@@ -4697,6 +4700,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     required bool activeWindowChanged,
   }) {
     if (_activeMuxBackend == RemoteMuxBackend.monkeyMux) {
+      _syncTerminalModesFromActiveMuxWindow();
       if (activeWindowChanged) {
         _prepareTerminalForMuxWindowChange();
         _refreshTerminalAfterMonkeyMuxWindowChange(session);
@@ -4728,15 +4732,27 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
   }
 
-  /// Recomputes touch-scroll routing when the active window's mouse-reporting
-  /// metadata changes. The routing getters read live from the tmux bar
-  /// snapshot, so a rebuild is enough to flip `touchScrollToTerminal` and stop
-  /// scrolling from getting stuck until the next window switch.
-  void _handleActiveWindowScrollModeChanged() {
+  /// Syncs local terminal mode state when the active mux window's terminal-mode
+  /// metadata changes without a full active-window switch.
+  void _handleActiveWindowTerminalModeChanged() {
     if (!mounted) {
       return;
     }
+    _syncTerminalModesFromActiveMuxWindow();
     setState(() {});
+  }
+
+  void _syncTerminalModesFromActiveMuxWindow() {
+    if (_activeMuxBackend != RemoteMuxBackend.monkeyMux) {
+      return;
+    }
+    inheritTerminalBracketedPasteModeFromMuxWindow(
+      terminal: _terminal,
+      activeWindowBracketedPasteMode:
+          resolveTmuxBarActiveWindowBracketedPasteMode(
+            _currentTmuxWindowsSnapshot,
+          ),
+    );
   }
 
   void _refreshMuxPaneContextAfterWindowStateChange(
@@ -9039,7 +9055,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       onExpandedChanged: _handleTmuxBarExpandedChanged,
       onSidebarDragOffsetChanged: _handleTmuxSidebarDragOffsetChanged,
       onWindowStateChanged: _handleTmuxWindowStateChanged,
-      onActiveWindowScrollModeChanged: _handleActiveWindowScrollModeChanged,
+      onActiveWindowTerminalModeChanged: _handleActiveWindowTerminalModeChanged,
       onWindowLoadStalled: _recoverTmuxWindowPanel,
       onSessionEnded: _handleMuxSessionEnded,
       scopeWorkingDirectory: resolveTmuxAiSessionScopeWorkingDirectory(
@@ -14667,13 +14683,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     List<String> remotePaths, {
     required bool windows,
   }) async {
-    final useBracketedPaste = terminalBracketedPasteModeForUploads(
-      localTerminalBracketedPasteMode: _terminal.bracketedPasteMode,
-      activeWindowBracketedPasteMode: _activeWindowBracketedPasteMode,
-    );
     final segments = buildTerminalAttachmentPasteSegments(
       remotePaths,
-      useBracketedPaste: useBracketedPaste,
+      bracketedPasteMode: _terminal.bracketedPasteMode,
       windows: windows,
     );
     for (var i = 0; i < segments.length; i++) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1336,6 +1336,39 @@ bool shouldUsePhotoLibraryPickerForTerminalMedia({
     !isWeb &&
     (platform == TargetPlatform.android || platform == TargetPlatform.iOS);
 
+/// Whether uploaded file references should be framed as bracketed-paste input.
+@visibleForTesting
+bool shouldUseBracketedPasteForUploadedReferences({
+  required bool bracketedPasteMode,
+  required bool isAgentToolActive,
+  String? terminalIconName,
+  String? terminalWindowTitle,
+}) =>
+    bracketedPasteMode ||
+    isAgentToolActive ||
+    _terminalMetadataValueIndicatesAgentTool(terminalIconName) ||
+    _terminalMetadataValueIndicatesAgentTool(terminalWindowTitle);
+
+bool _terminalMetadataValueIndicatesAgentTool(String? value) {
+  final normalized = value?.trim();
+  if (normalized == null || normalized.isEmpty) {
+    return false;
+  }
+  if (agentLaunchToolForCommandName(normalized) != null) {
+    return true;
+  }
+  final lowered = normalized.toLowerCase();
+  for (final tool in AgentLaunchTool.values) {
+    final label = tool.label.toLowerCase();
+    if (lowered == label ||
+        lowered.startsWith('$label ') ||
+        lowered.startsWith('$label:')) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /// Returns an Android image picker implementation configured for Photo Picker.
 @visibleForTesting
 ImagePickerAndroid enableAndroidPhotoPickerForTerminalMedia(
@@ -14646,9 +14679,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     List<String> remotePaths, {
     required bool windows,
   }) async {
+    final useBracketedPaste = shouldUseBracketedPasteForUploadedReferences(
+      bracketedPasteMode: _terminal.bracketedPasteMode,
+      isAgentToolActive: _isAgentToolActive,
+      terminalIconName: _iconName,
+      terminalWindowTitle: _windowTitle,
+    );
     final segments = buildTerminalAttachmentPasteSegments(
       remotePaths,
-      bracketedPasteMode: _terminal.bracketedPasteMode,
+      useBracketedPaste: useBracketedPaste,
       windows: windows,
     );
     for (var i = 0; i < segments.length; i++) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -14683,6 +14683,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     List<String> remotePaths, {
     required bool windows,
   }) async {
+    _syncTerminalModesFromActiveMuxWindow();
     final segments = buildTerminalAttachmentPasteSegments(
       remotePaths,
       bracketedPasteMode: _terminal.bracketedPasteMode,

--- a/lib/presentation/widgets/tmux_expandable_bar.dart
+++ b/lib/presentation/widgets/tmux_expandable_bar.dart
@@ -25,7 +25,7 @@ class _TmuxExpandableBar extends StatefulWidget {
     this.tmuxExtraFlags,
     this.scopeWorkingDirectory,
     this.onWindowStateChanged,
-    this.onActiveWindowScrollModeChanged,
+    this.onActiveWindowTerminalModeChanged,
     this.onWindowLoadStalled,
     this.onSessionEnded,
     super.key,
@@ -83,12 +83,11 @@ class _TmuxExpandableBar extends StatefulWidget {
   })?
   onWindowStateChanged;
 
-  /// Called when the active window's scroll-relevant mouse-reporting metadata
-  /// (mouse-wheel / SGR reporting) changes without the active window itself
-  /// changing — for example when the foreground app enters or leaves mouse
-  /// mode. Lets the parent recompute touch-scroll routing so scrolling doesn't
-  /// stay stuck until the next window switch.
-  final VoidCallback? onActiveWindowScrollModeChanged;
+  /// Called when the active window's terminal-mode metadata changes without the
+  /// active window itself changing — for example when the foreground app enters
+  /// or leaves mouse or bracketed-paste mode. Lets the parent inherit the active
+  /// mux window's local terminal modes without waiting for a window switch.
+  final VoidCallback? onActiveWindowTerminalModeChanged;
 
   final Future<void> Function(SshSession session, String sessionName)?
   onWindowLoadStalled;
@@ -457,7 +456,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
   );
 
   void _applyWindows(List<TmuxWindow> windows) {
-    final previousScrollModeSignature = activeTmuxWindowScrollModeSignature(
+    final previousTerminalModeSignature = activeTmuxWindowTerminalModeSignature(
       _windows,
     );
     // Detect new alerts that weren't in the previous window list.
@@ -521,13 +520,13 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
       _pendingSelectedWindowIndex = nextPendingSelectedWindowIndex;
     });
 
-    // Mouse-mode toggles arrive as `window_updated` events that don't change
+    // Terminal-mode toggles arrive as `window_updated` events that don't change
     // the active window or its theme identity, so they wouldn't otherwise
-    // notify the parent. Surface them explicitly so touch-scroll routing is
-    // recomputed and scrolling doesn't get stuck until the next window switch.
-    if (activeTmuxWindowScrollModeSignature(windows) !=
-        previousScrollModeSignature) {
-      widget.onActiveWindowScrollModeChanged?.call();
+    // notify the parent. Surface them explicitly so local mode state stays in
+    // sync and touch-scroll routing doesn't get stuck until the next switch.
+    if (activeTmuxWindowTerminalModeSignature(windows) !=
+        previousTerminalModeSignature) {
+      widget.onActiveWindowTerminalModeChanged?.call();
     }
   }
 

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -338,6 +338,7 @@ type windowSnapshot struct {
 	LastActivityEpochSeconds  int64           `json:"lastActivityEpochSeconds,omitempty"`
 	TerminalReportsMouseWheel bool            `json:"terminalReportsMouseWheel,omitempty"`
 	TerminalMouseReportSgr    bool            `json:"terminalMouseReportSgr,omitempty"`
+	TerminalBracketedPaste    bool            `json:"terminalBracketedPasteMode,omitempty"`
 	PrivateModes              map[string]bool `json:"privateModes,omitempty"`
 }
 
@@ -979,6 +980,9 @@ func privateModesFromWindowSnapshot(window windowSnapshot) map[string]bool {
 	}
 	if window.TerminalMouseReportSgr {
 		modes["1006"] = true
+	}
+	if window.TerminalBracketedPaste {
+		modes["2004"] = true
 	}
 	if len(modes) == 0 {
 		return nil
@@ -3572,6 +3576,7 @@ func (s *muxServer) snapshotLocked(window *muxWindow) windowSnapshot {
 		LastActivityEpochSeconds:  window.lastActivity.Unix(),
 		TerminalReportsMouseWheel: window.reportsMouseWheelLocked(),
 		TerminalMouseReportSgr:    window.mouseTrackingActiveLocked() && window.privateModes["1006"],
+		TerminalBracketedPaste:    window.privateModes["2004"],
 		PrivateModes:              copyPrivateModes(window.privateModes),
 	}
 }

--- a/remote/monkeymux/main_test.go
+++ b/remote/monkeymux/main_test.go
@@ -2658,7 +2658,7 @@ func TestWindowSnapshotReportsTerminalMouseModes(t *testing.T) {
 		id:           "@1",
 		index:        0,
 		name:         "Mouse app",
-		privateModes: map[string]bool{"1002": true, "1006": true},
+		privateModes: map[string]bool{"1002": true, "1006": true, "2004": true},
 		lastActivity: time.Now(),
 	}
 
@@ -2670,11 +2670,17 @@ func TestWindowSnapshotReportsTerminalMouseModes(t *testing.T) {
 	if !snapshot.TerminalMouseReportSgr {
 		t.Fatal("snapshot did not report SGR mouse mode")
 	}
+	if !snapshot.TerminalBracketedPaste {
+		t.Fatal("snapshot did not report bracketed paste mode")
+	}
 	if !snapshot.PrivateModes["1002"] {
 		t.Fatalf("snapshot private modes = %#v, want SGR drag mode", snapshot.PrivateModes)
 	}
 	if !snapshot.PrivateModes["1006"] {
 		t.Fatalf("snapshot private modes = %#v, want SGR report mode", snapshot.PrivateModes)
+	}
+	if !snapshot.PrivateModes["2004"] {
+		t.Fatalf("snapshot private modes = %#v, want bracketed paste mode", snapshot.PrivateModes)
 	}
 }
 
@@ -2755,9 +2761,10 @@ func TestRestoreFromSnapshotPreservesMouseDragMode(t *testing.T) {
 			ID:                        "@1",
 			Index:                     0,
 			Name:                      "Mouse app",
-			PrivateModes:              map[string]bool{"1002": true, "1006": true},
+			PrivateModes:              map[string]bool{"1002": true, "1006": true, "2004": true},
 			TerminalReportsMouseWheel: true,
 			TerminalMouseReportSgr:    true,
+			TerminalBracketedPaste:    true,
 		},
 	})
 
@@ -2771,6 +2778,9 @@ func TestRestoreFromSnapshotPreservesMouseDragMode(t *testing.T) {
 	if !modes["1006"] {
 		t.Fatalf("restore private modes = %#v, want SGR report mode", modes)
 	}
+	if !modes["2004"] {
+		t.Fatalf("restore private modes = %#v, want bracketed paste mode", modes)
+	}
 }
 
 func TestRestoreFromLegacySnapshotPrefersSgrMouseDrag(t *testing.T) {
@@ -2781,6 +2791,7 @@ func TestRestoreFromLegacySnapshotPrefersSgrMouseDrag(t *testing.T) {
 			Name:                      "Mouse app",
 			TerminalReportsMouseWheel: true,
 			TerminalMouseReportSgr:    true,
+			TerminalBracketedPaste:    true,
 		},
 	})
 
@@ -2793,6 +2804,9 @@ func TestRestoreFromLegacySnapshotPrefersSgrMouseDrag(t *testing.T) {
 	}
 	if !modes["1006"] {
 		t.Fatalf("restore private modes = %#v, want SGR report mode", modes)
+	}
+	if !modes["2004"] {
+		t.Fatalf("restore private modes = %#v, want bracketed paste mode", modes)
 	}
 }
 

--- a/test/domain/services/monkeymux_service_test.dart
+++ b/test/domain/services/monkeymux_service_test.dart
@@ -196,6 +196,35 @@ void main() {
       expect(window.terminalBracketedPasteMode, isTrue);
     });
 
+    test(
+      'leaves bracketed paste mode unknown when helper omits mode metadata',
+      () {
+        final window = parseMonkeyMuxWindowSnapshotForTesting({
+          'id': '@1',
+          'index': 0,
+          'name': 'Shell',
+          'active': true,
+        });
+
+        expect(window, isNotNull);
+        expect(window!.terminalBracketedPasteMode, isNull);
+      },
+    );
+
+    test('uses explicit helper bracketed paste mode when present', () {
+      final window = parseMonkeyMuxWindowSnapshotForTesting({
+        'id': '@1',
+        'index': 0,
+        'name': 'Shell',
+        'active': true,
+        'terminalBracketedPasteMode': false,
+        'privateModes': {'2004': true},
+      });
+
+      expect(window, isNotNull);
+      expect(window!.terminalBracketedPasteMode, isFalse);
+    });
+
     test('surfaces the alert flag so prompts trigger push notifications', () {
       final window = parseMonkeyMuxWindowSnapshotForTesting({
         'id': '@2',

--- a/test/domain/services/monkeymux_service_test.dart
+++ b/test/domain/services/monkeymux_service_test.dart
@@ -172,11 +172,13 @@ void main() {
         'active': true,
         'terminalReportsMouseWheel': true,
         'terminalMouseReportSgr': true,
+        'terminalBracketedPasteMode': true,
       });
 
       expect(window, isNotNull);
       expect(window!.terminalReportsMouseWheel, isTrue);
       expect(window.terminalMouseReportSgr, isTrue);
+      expect(window.terminalBracketedPasteMode, isTrue);
     });
 
     test('maps helper private mode metadata onto tmux windows', () {

--- a/test/domain/services/monkeymux_service_test.dart
+++ b/test/domain/services/monkeymux_service_test.dart
@@ -185,12 +185,13 @@ void main() {
         'index': 0,
         'name': 'Mouse app',
         'active': true,
-        'privateModes': {'1002': true, '1006': true},
+        'privateModes': {'1002': true, '1006': true, '2004': true},
       });
 
       expect(window, isNotNull);
       expect(window!.terminalReportsMouseWheel, isTrue);
       expect(window.terminalMouseReportSgr, isTrue);
+      expect(window.terminalBracketedPasteMode, isTrue);
     });
 
     test('surfaces the alert flag so prompts trigger push notifications', () {

--- a/test/domain/services/remote_file_service_test.dart
+++ b/test/domain/services/remote_file_service_test.dart
@@ -203,7 +203,7 @@ void main() {
           buildTerminalAttachmentPasteSegments([
             '/home/u/.cache/monkeyssh/uploads/a.png',
             '/home/u/b.png',
-          ], bracketedPasteMode: true),
+          ], useBracketedPaste: true),
           [
             '$start/home/u/.cache/monkeyssh/uploads/a.png$end ',
             '$start/home/u/b.png$end ',
@@ -217,7 +217,7 @@ void main() {
         buildTerminalAttachmentPasteSegments([
           '/tmp/a.png',
           '/tmp/b.png',
-        ], bracketedPasteMode: false),
+        ], useBracketedPaste: false),
         ["'/tmp/a.png' '/tmp/b.png' "],
       );
     });
@@ -229,7 +229,7 @@ void main() {
       expect(
         buildTerminalAttachmentPasteSegments(
           [r'C:\Users\proof\.cache\monkeyssh\uploads\a.png'],
-          bracketedPasteMode: true,
+          useBracketedPaste: true,
           windows: true,
         ),
         ['$start${r'C:\Users\proof\.cache\monkeyssh\uploads\a.png'}$end '],
@@ -237,7 +237,7 @@ void main() {
       expect(
         buildTerminalAttachmentPasteSegments(
           [r'C:\Users\John Smith\.cache\monkeyssh\uploads\a.png'],
-          bracketedPasteMode: true,
+          useBracketedPaste: true,
           windows: true,
         ),
         [r'"C:\Users\John Smith\.cache\monkeyssh\uploads\a.png" '],
@@ -251,29 +251,26 @@ void main() {
       expect(
         buildTerminalAttachmentPasteSegments([
           '/home/john smith/.cache/monkeyssh/uploads/a.png',
-        ], bracketedPasteMode: true),
+        ], useBracketedPaste: true),
         ["'/home/john smith/.cache/monkeyssh/uploads/a.png' "],
       );
       expect(
         buildTerminalAttachmentPasteSegments([
           r'/home/u/$(reboot)/a.png',
-        ], bracketedPasteMode: true),
+        ], useBracketedPaste: true),
         [r"'/home/u/$(reboot)/a.png' "],
       );
     });
 
     test('returns no segments when there are no paths', () {
       expect(
-        buildTerminalAttachmentPasteSegments(
-          const [],
-          bracketedPasteMode: true,
-        ),
+        buildTerminalAttachmentPasteSegments(const [], useBracketedPaste: true),
         isEmpty,
       );
       expect(
         buildTerminalAttachmentPasteSegments(const [
           '',
-        ], bracketedPasteMode: true),
+        ], useBracketedPaste: true),
         isEmpty,
       );
     });

--- a/test/domain/services/remote_file_service_test.dart
+++ b/test/domain/services/remote_file_service_test.dart
@@ -203,7 +203,7 @@ void main() {
           buildTerminalAttachmentPasteSegments([
             '/home/u/.cache/monkeyssh/uploads/a.png',
             '/home/u/b.png',
-          ], useBracketedPaste: true),
+          ], bracketedPasteMode: true),
           [
             '$start/home/u/.cache/monkeyssh/uploads/a.png$end ',
             '$start/home/u/b.png$end ',
@@ -217,7 +217,7 @@ void main() {
         buildTerminalAttachmentPasteSegments([
           '/tmp/a.png',
           '/tmp/b.png',
-        ], useBracketedPaste: false),
+        ], bracketedPasteMode: false),
         ["'/tmp/a.png' '/tmp/b.png' "],
       );
     });
@@ -229,7 +229,7 @@ void main() {
       expect(
         buildTerminalAttachmentPasteSegments(
           [r'C:\Users\proof\.cache\monkeyssh\uploads\a.png'],
-          useBracketedPaste: true,
+          bracketedPasteMode: true,
           windows: true,
         ),
         ['$start${r'C:\Users\proof\.cache\monkeyssh\uploads\a.png'}$end '],
@@ -237,7 +237,7 @@ void main() {
       expect(
         buildTerminalAttachmentPasteSegments(
           [r'C:\Users\John Smith\.cache\monkeyssh\uploads\a.png'],
-          useBracketedPaste: true,
+          bracketedPasteMode: true,
           windows: true,
         ),
         [r'"C:\Users\John Smith\.cache\monkeyssh\uploads\a.png" '],
@@ -251,26 +251,29 @@ void main() {
       expect(
         buildTerminalAttachmentPasteSegments([
           '/home/john smith/.cache/monkeyssh/uploads/a.png',
-        ], useBracketedPaste: true),
+        ], bracketedPasteMode: true),
         ["'/home/john smith/.cache/monkeyssh/uploads/a.png' "],
       );
       expect(
         buildTerminalAttachmentPasteSegments([
           r'/home/u/$(reboot)/a.png',
-        ], useBracketedPaste: true),
+        ], bracketedPasteMode: true),
         [r"'/home/u/$(reboot)/a.png' "],
       );
     });
 
     test('returns no segments when there are no paths', () {
       expect(
-        buildTerminalAttachmentPasteSegments(const [], useBracketedPaste: true),
+        buildTerminalAttachmentPasteSegments(
+          const [],
+          bracketedPasteMode: true,
+        ),
         isEmpty,
       );
       expect(
         buildTerminalAttachmentPasteSegments(const [
           '',
-        ], useBracketedPaste: true),
+        ], bracketedPasteMode: true),
         isEmpty,
       );
     });

--- a/test/widget/terminal_screen_scroll_policy_test.dart
+++ b/test/widget/terminal_screen_scroll_policy_test.dart
@@ -10,12 +10,14 @@ TmuxWindow _window({
   required bool isActive,
   bool? reportsMouseWheel,
   bool? mouseReportSgr,
+  bool? bracketedPasteMode,
 }) => TmuxWindow(
   index: index,
   name: 'w$index',
   isActive: isActive,
   terminalReportsMouseWheel: reportsMouseWheel,
   terminalMouseReportSgr: mouseReportSgr,
+  terminalBracketedPasteMode: bracketedPasteMode,
 );
 
 void main() {
@@ -230,37 +232,43 @@ void main() {
     });
   });
 
-  group('active window scroll-mode signature', () {
+  group('active window terminal-mode signature', () {
     test('is null when no window is active', () {
       expect(
-        activeTmuxWindowScrollModeSignature([
+        activeTmuxWindowTerminalModeSignature([
           _window(index: 0, isActive: false, reportsMouseWheel: true),
         ]),
         isNull,
       );
     });
 
-    test('captures the active window mouse-reporting state', () {
-      final signature = activeTmuxWindowScrollModeSignature([
-        _window(index: 0, isActive: true, reportsMouseWheel: true),
+    test('captures the active window terminal mode state', () {
+      final signature = activeTmuxWindowTerminalModeSignature([
+        _window(
+          index: 0,
+          isActive: true,
+          reportsMouseWheel: true,
+          bracketedPasteMode: true,
+        ),
         _window(index: 1, isActive: false, reportsMouseWheel: false),
       ]);
       expect(signature?.reportsMouseWheel, isTrue);
       expect(signature?.mouseReportSgr, isNull);
+      expect(signature?.bracketedPasteMode, isTrue);
     });
 
     test('changes when the active window toggles mouse mode', () {
-      final before = activeTmuxWindowScrollModeSignature([
+      final before = activeTmuxWindowTerminalModeSignature([
         _window(index: 0, isActive: true, reportsMouseWheel: false),
       ]);
-      final after = activeTmuxWindowScrollModeSignature([
+      final after = activeTmuxWindowTerminalModeSignature([
         _window(index: 0, isActive: true, reportsMouseWheel: true),
       ]);
       expect(before == after, isFalse);
     });
 
     test('changes when the active window toggles SGR reporting', () {
-      final before = activeTmuxWindowScrollModeSignature([
+      final before = activeTmuxWindowTerminalModeSignature([
         _window(
           index: 0,
           isActive: true,
@@ -268,7 +276,7 @@ void main() {
           mouseReportSgr: false,
         ),
       ]);
-      final after = activeTmuxWindowScrollModeSignature([
+      final after = activeTmuxWindowTerminalModeSignature([
         _window(
           index: 0,
           isActive: true,
@@ -279,14 +287,29 @@ void main() {
       expect(before == after, isFalse);
     });
 
+    test('changes when the active window toggles bracketed paste', () {
+      final before = activeTmuxWindowTerminalModeSignature([
+        _window(index: 0, isActive: true, bracketedPasteMode: false),
+      ]);
+      final after = activeTmuxWindowTerminalModeSignature([
+        _window(index: 0, isActive: true, bracketedPasteMode: true),
+      ]);
+      expect(before == after, isFalse);
+    });
+
     test('ignores mouse-mode changes on non-active windows', () {
-      final before = activeTmuxWindowScrollModeSignature([
+      final before = activeTmuxWindowTerminalModeSignature([
         _window(index: 0, isActive: true, reportsMouseWheel: false),
         _window(index: 1, isActive: false, reportsMouseWheel: false),
       ]);
-      final after = activeTmuxWindowScrollModeSignature([
+      final after = activeTmuxWindowTerminalModeSignature([
         _window(index: 0, isActive: true, reportsMouseWheel: false),
-        _window(index: 1, isActive: false, reportsMouseWheel: true),
+        _window(
+          index: 1,
+          isActive: false,
+          reportsMouseWheel: true,
+          bracketedPasteMode: true,
+        ),
       ]);
       expect(before == after, isTrue);
     });

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -378,30 +378,6 @@ void main() {
     });
   });
 
-  group('terminalBracketedPasteModeForUploads', () {
-    test('uses local or mux window bracketed paste mode', () {
-      expect(
-        terminalBracketedPasteModeForUploads(
-          localTerminalBracketedPasteMode: false,
-        ),
-        isFalse,
-      );
-      expect(
-        terminalBracketedPasteModeForUploads(
-          localTerminalBracketedPasteMode: true,
-        ),
-        isTrue,
-      );
-      expect(
-        terminalBracketedPasteModeForUploads(
-          localTerminalBracketedPasteMode: false,
-          activeWindowBracketedPasteMode: true,
-        ),
-        isTrue,
-      );
-    });
-  });
-
   group('resolveTmuxBarActiveWindowBracketedPasteMode', () {
     test('reads bracketed paste mode from the active mux window', () {
       final windows = [
@@ -429,6 +405,43 @@ void main() {
         ]),
         isNull,
       );
+    });
+  });
+
+  group('inheritTerminalBracketedPasteModeFromMuxWindow', () {
+    test('applies known active mux window bracketed paste mode locally', () {
+      final terminal = Terminal();
+
+      expect(terminal.bracketedPasteMode, isFalse);
+      expect(
+        inheritTerminalBracketedPasteModeFromMuxWindow(
+          terminal: terminal,
+          activeWindowBracketedPasteMode: true,
+        ),
+        isTrue,
+      );
+      expect(terminal.bracketedPasteMode, isTrue);
+      expect(
+        inheritTerminalBracketedPasteModeFromMuxWindow(
+          terminal: terminal,
+          activeWindowBracketedPasteMode: false,
+        ),
+        isTrue,
+      );
+      expect(terminal.bracketedPasteMode, isFalse);
+    });
+
+    test('leaves local mode alone when mux window mode is unknown', () {
+      final terminal = Terminal()..setBracketedPasteMode(true);
+
+      expect(
+        inheritTerminalBracketedPasteModeFromMuxWindow(
+          terminal: terminal,
+          activeWindowBracketedPasteMode: null,
+        ),
+        isFalse,
+      );
+      expect(terminal.bracketedPasteMode, isTrue);
     });
   });
 

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker_android/image_picker_android.dart';
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
+import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:xterm/xterm.dart';
 
@@ -377,44 +378,56 @@ void main() {
     });
   });
 
-  group('shouldUseBracketedPasteForUploadedReferences', () {
-    test('uses bracketed paste when a known agent is active or titled', () {
+  group('terminalBracketedPasteModeForUploads', () {
+    test('uses local or mux window bracketed paste mode', () {
       expect(
-        shouldUseBracketedPasteForUploadedReferences(
-          bracketedPasteMode: false,
-          isAgentToolActive: true,
-        ),
-        isTrue,
-      );
-      expect(
-        shouldUseBracketedPasteForUploadedReferences(
-          bracketedPasteMode: false,
-          isAgentToolActive: false,
+        terminalBracketedPasteModeForUploads(
+          localTerminalBracketedPasteMode: false,
         ),
         isFalse,
       );
       expect(
-        shouldUseBracketedPasteForUploadedReferences(
-          bracketedPasteMode: true,
-          isAgentToolActive: false,
+        terminalBracketedPasteModeForUploads(
+          localTerminalBracketedPasteMode: true,
         ),
         isTrue,
       );
       expect(
-        shouldUseBracketedPasteForUploadedReferences(
-          bracketedPasteMode: false,
-          isAgentToolActive: false,
-          terminalIconName: 'Copilot CLI',
+        terminalBracketedPasteModeForUploads(
+          localTerminalBracketedPasteMode: false,
+          activeWindowBracketedPasteMode: true,
         ),
         isTrue,
       );
-      expect(
-        shouldUseBracketedPasteForUploadedReferences(
-          bracketedPasteMode: false,
-          isAgentToolActive: false,
-          terminalWindowTitle: 'Claude Code: project',
+    });
+  });
+
+  group('resolveTmuxBarActiveWindowBracketedPasteMode', () {
+    test('reads bracketed paste mode from the active mux window', () {
+      final windows = [
+        const TmuxWindow(
+          index: 0,
+          name: 'shell',
+          isActive: false,
+          terminalBracketedPasteMode: true,
         ),
-        isTrue,
+        const TmuxWindow(
+          index: 1,
+          name: 'composer',
+          isActive: true,
+          terminalBracketedPasteMode: true,
+        ),
+      ];
+
+      expect(resolveTmuxBarActiveWindowBracketedPasteMode(windows), isTrue);
+    });
+
+    test('leaves unknown mux state unknown', () {
+      expect(
+        resolveTmuxBarActiveWindowBracketedPasteMode(const [
+          TmuxWindow(index: 0, name: 'shell', isActive: true),
+        ]),
+        isNull,
       );
     });
   });

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -377,6 +377,48 @@ void main() {
     });
   });
 
+  group('shouldUseBracketedPasteForUploadedReferences', () {
+    test('uses bracketed paste when a known agent is active or titled', () {
+      expect(
+        shouldUseBracketedPasteForUploadedReferences(
+          bracketedPasteMode: false,
+          isAgentToolActive: true,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldUseBracketedPasteForUploadedReferences(
+          bracketedPasteMode: false,
+          isAgentToolActive: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldUseBracketedPasteForUploadedReferences(
+          bracketedPasteMode: true,
+          isAgentToolActive: false,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldUseBracketedPasteForUploadedReferences(
+          bracketedPasteMode: false,
+          isAgentToolActive: false,
+          terminalIconName: 'Copilot CLI',
+        ),
+        isTrue,
+      );
+      expect(
+        shouldUseBracketedPasteForUploadedReferences(
+          bracketedPasteMode: false,
+          isAgentToolActive: false,
+          terminalWindowTitle: 'Claude Code: project',
+        ),
+        isTrue,
+      );
+    });
+  });
+
   group('enableAndroidPhotoPickerForTerminalMedia', () {
     test('enables the existing Android image picker implementation', () {
       final imagePicker = ImagePickerAndroid();

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker_android/image_picker_android.dart';
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 import 'package:monkeyssh/domain/models/tmux_state.dart';
+import 'package:monkeyssh/domain/services/remote_file_service.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
 import 'package:xterm/xterm.dart';
 
@@ -442,6 +443,22 @@ void main() {
         isFalse,
       );
       expect(terminal.bracketedPasteMode, isTrue);
+    });
+
+    test('inherited local mode frames uploaded path segments', () {
+      final terminal = Terminal();
+
+      inheritTerminalBracketedPasteModeFromMuxWindow(
+        terminal: terminal,
+        activeWindowBracketedPasteMode: true,
+      );
+
+      expect(
+        buildTerminalAttachmentPasteSegments(const [
+          '/home/u/.cache/monkeyssh/uploads/a.png',
+        ], bracketedPasteMode: terminal.bracketedPasteMode),
+        const ['\x1b[200~/home/u/.cache/monkeyssh/uploads/a.png\x1b[201~ '],
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Plumb MonkeyMux DEC private mode 2004 as explicit `terminalBracketedPasteMode` window state through Go snapshots, restore compatibility, Dart parsing, and `TmuxWindow`
- Inherit the active MonkeyMux window's bracketed-paste mode into the local `Terminal` when mux window mode snapshots change, and sync again immediately before uploaded path insertion
- Keep unknown mux mode state nullable so older/stale helpers don't force local bracketed paste off
- Upload path insertion now relies on the local `Terminal.bracketedPasteMode` directly, with shell-escaped fallback for normal shells and unsafe paths

## Validation
- `flutter test test/domain/services/remote_file_service_test.dart test/domain/services/monkeymux_service_test.dart test/widget/terminal_screen_selection_test.dart test/widget/terminal_screen_scroll_policy_test.dart`
- `cd remote/monkeymux && go test ./...`
- `flutter analyze`
- Pre-commit hook format/analyze/tests