### PR TITLE
feat: add App Review demo mode

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -7,6 +7,7 @@ import '../domain/models/monetization.dart';
 import '../domain/services/auth_service.dart';
 import '../domain/services/port_forward_browser_service.dart';
 import '../domain/services/telemetry_service.dart';
+import '../presentation/screens/app_review_demo_screen.dart';
 import '../presentation/screens/auth_setup_screen.dart';
 import '../presentation/screens/home_screen.dart';
 import '../presentation/screens/host_edit_screen.dart';
@@ -273,6 +274,11 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: '/settings',
         name: Routes.settings,
         builder: (context, state) => const SettingsScreen(),
+      ),
+      GoRoute(
+        path: '/settings/app-review-demo',
+        name: Routes.appReviewDemo,
+        builder: (context, state) => const AppReviewDemoScreen(),
       ),
       GoRoute(
         path: '/upgrade',

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -36,6 +36,9 @@ abstract final class Routes {
   /// Settings route.
   static const settings = 'settings';
 
+  /// App Review demo route.
+  static const appReviewDemo = 'app-review-demo';
+
   /// Authentication setup route.
   static const authSetup = 'auth-setup';
 

--- a/lib/domain/services/app_review_demo_service.dart
+++ b/lib/domain/services/app_review_demo_service.dart
@@ -92,7 +92,7 @@ class AppReviewDemoService {
   static const _snippetFolderName = 'App Review Demo';
   static const _keyName = 'App Review Demo Key';
   static const _workspaceHostLabel = 'App Review Demo · MonkeyMux workspace';
-  static const _tmuxHostLabel = 'App Review Demo · tmux fallback';
+  static const _agentHostLabel = 'App Review Demo · MonkeyMux agents';
   static const _sftpHostLabel = 'App Review Demo · SFTP and tunnels';
   static const _bastionHostLabel = 'App Review Demo · bastion jump host';
   static const _demoSeededAtSetting = 'app_review_demo_seeded_at';
@@ -196,8 +196,8 @@ class AppReviewDemoService {
       createdHosts += 1;
     }
 
-    final tmuxHost = await _ensureHost(
-      label: _tmuxHostLabel,
+    final agentHost = await _ensureHost(
+      label: _agentHostLabel,
       hostname: '127.0.0.1',
       port: 2202,
       username: 'reviewer',
@@ -205,20 +205,19 @@ class AppReviewDemoService {
       groupId: groupId,
       color: '#8BCBE5',
       notes:
-          'Shows the tmux fallback path and saved startup flags for hosts that '
-          'do not use MonkeyMux.',
-      tags: 'app-review,demo,tmux',
+          'Shows additional MonkeyMux windows and saved startup presets for '
+          'agent-oriented review workflows.',
+      tags: 'app-review,demo,monkeymux,agents',
       terminalThemeLightId: TerminalThemes.monkeyLight.id,
       terminalThemeDarkId: TerminalThemes.githubDarkDefault.id,
       autoConnectSnippetId: logsSnippet.id,
       autoConnectRequiresConfirmation: true,
-      tmuxSessionName: 'review-tmux',
+      tmuxSessionName: 'review-agents',
       tmuxWorkingDirectory: '~/work/monkeyssh-demo',
-      tmuxExtraFlags: '-x 160 -y 48',
-      remoteMuxBackend: RemoteMuxBackend.tmux,
+      remoteMuxBackend: RemoteMuxBackend.monkeyMux,
       sortOrder: 2,
     );
-    if (tmuxHost.created) {
+    if (agentHost.created) {
       createdHosts += 1;
     }
 
@@ -272,12 +271,12 @@ class AppReviewDemoService {
       ),
     );
     await _agentLaunchPresetService.setPresetForHost(
-      tmuxHost.id,
+      agentHost.id,
       const AgentLaunchPreset(
         tool: AgentLaunchTool.claudeCode,
         workingDirectory: '~/work/monkeyssh-demo',
-        tmuxSessionName: 'review-tmux',
-        remoteMuxBackend: RemoteMuxBackend.tmux,
+        tmuxSessionName: 'review-agents',
+        remoteMuxBackend: RemoteMuxBackend.monkeyMux,
       ),
     );
     await _hostCliLaunchPreferencesService.setPreferencesForHost(
@@ -417,7 +416,11 @@ class AppReviewDemoService {
         autoConnectRequiresConfirmation: Value(autoConnectRequiresConfirmation),
         tmuxSessionName: Value(tmuxSessionName),
         tmuxWorkingDirectory: Value(tmuxWorkingDirectory),
-        tmuxExtraFlags: Value(tmuxExtraFlags),
+        tmuxExtraFlags: Value(
+          remoteMuxBackend == RemoteMuxBackend.monkeyMux
+              ? null
+              : tmuxExtraFlags,
+        ),
         remoteMuxBackend: Value(remoteMuxBackend?.storageValue),
         sortOrder: Value(sortOrder),
       ),

--- a/lib/domain/services/app_review_demo_service.dart
+++ b/lib/domain/services/app_review_demo_service.dart
@@ -15,6 +15,19 @@ import 'agent_launch_preset_service.dart';
 import 'host_cli_launch_preferences_service.dart';
 import 'settings_service.dart';
 
+/// Returns whether [host] is one of the seeded offline App Review demo hosts.
+bool isAppReviewDemoHost(Host host) {
+  if (!host.label.startsWith(AppReviewDemoService.demoHostLabelPrefix)) {
+    return false;
+  }
+  final tags = host.tags
+      ?.split(',')
+      .map((tag) => tag.trim())
+      .where((tag) => tag.isNotEmpty)
+      .toSet();
+  return tags?.containsAll(const {'app-review', 'demo'}) ?? false;
+}
+
 /// Result returned after preparing the local App Review demo workspace.
 class AppReviewDemoSetupResult {
   /// Creates a setup result.
@@ -83,6 +96,9 @@ class AppReviewDemoService {
   static const _sftpHostLabel = 'App Review Demo · SFTP and tunnels';
   static const _bastionHostLabel = 'App Review Demo · bastion jump host';
   static const _demoSeededAtSetting = 'app_review_demo_seeded_at';
+
+  /// Shared prefix used to identify seeded demo hosts.
+  static const demoHostLabelPrefix = 'App Review Demo ·';
 
   /// Returns whether the review demo has been prepared on this device.
   Future<bool> isPrepared() async =>

--- a/lib/domain/services/app_review_demo_service.dart
+++ b/lib/domain/services/app_review_demo_service.dart
@@ -1,0 +1,465 @@
+import 'package:drift/drift.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/database/database.dart';
+import '../../data/repositories/group_repository.dart';
+import '../../data/repositories/host_repository.dart';
+import '../../data/repositories/key_repository.dart';
+import '../../data/repositories/port_forward_repository.dart';
+import '../../data/repositories/snippet_repository.dart';
+import '../models/agent_launch_preset.dart';
+import '../models/host_cli_launch_preferences.dart';
+import '../models/remote_multiplexer.dart';
+import '../models/terminal_themes.dart';
+import 'agent_launch_preset_service.dart';
+import 'host_cli_launch_preferences_service.dart';
+import 'settings_service.dart';
+
+/// Result returned after preparing the local App Review demo workspace.
+class AppReviewDemoSetupResult {
+  /// Creates a setup result.
+  const AppReviewDemoSetupResult({
+    required this.createdHosts,
+    required this.createdKeys,
+    required this.createdSnippets,
+    required this.createdPortForwards,
+  });
+
+  /// Number of demo hosts inserted during this setup pass.
+  final int createdHosts;
+
+  /// Number of demo SSH keys inserted during this setup pass.
+  final int createdKeys;
+
+  /// Number of demo snippets inserted during this setup pass.
+  final int createdSnippets;
+
+  /// Number of demo port forwards inserted during this setup pass.
+  final int createdPortForwards;
+
+  /// Whether any database-backed demo content was newly created.
+  bool get createdAny =>
+      createdHosts > 0 ||
+      createdKeys > 0 ||
+      createdSnippets > 0 ||
+      createdPortForwards > 0;
+}
+
+/// Seeds deterministic local content for App Review without external servers.
+class AppReviewDemoService {
+  /// Creates an App Review demo service.
+  const AppReviewDemoService({
+    required GroupRepository groupRepository,
+    required HostRepository hostRepository,
+    required KeyRepository keyRepository,
+    required SnippetRepository snippetRepository,
+    required PortForwardRepository portForwardRepository,
+    required AgentLaunchPresetService agentLaunchPresetService,
+    required HostCliLaunchPreferencesService hostCliLaunchPreferencesService,
+    required SettingsService settingsService,
+  }) : _groupRepository = groupRepository,
+       _hostRepository = hostRepository,
+       _keyRepository = keyRepository,
+       _snippetRepository = snippetRepository,
+       _portForwardRepository = portForwardRepository,
+       _agentLaunchPresetService = agentLaunchPresetService,
+       _hostCliLaunchPreferencesService = hostCliLaunchPreferencesService,
+       _settingsService = settingsService;
+
+  final GroupRepository _groupRepository;
+  final HostRepository _hostRepository;
+  final KeyRepository _keyRepository;
+  final SnippetRepository _snippetRepository;
+  final PortForwardRepository _portForwardRepository;
+  final AgentLaunchPresetService _agentLaunchPresetService;
+  final HostCliLaunchPreferencesService _hostCliLaunchPreferencesService;
+  final SettingsService _settingsService;
+
+  static const _groupName = 'App Review Demo';
+  static const _snippetFolderName = 'App Review Demo';
+  static const _keyName = 'App Review Demo Key';
+  static const _workspaceHostLabel = 'App Review Demo · MonkeyMux workspace';
+  static const _tmuxHostLabel = 'App Review Demo · tmux fallback';
+  static const _sftpHostLabel = 'App Review Demo · SFTP and tunnels';
+  static const _bastionHostLabel = 'App Review Demo · bastion jump host';
+  static const _demoSeededAtSetting = 'app_review_demo_seeded_at';
+
+  /// Returns whether the review demo has been prepared on this device.
+  Future<bool> isPrepared() async =>
+      await _settingsService.getString(_demoSeededAtSetting) != null;
+
+  /// Creates any missing demo content and records the setup timestamp.
+  Future<AppReviewDemoSetupResult> prepare() async {
+    var createdHosts = 0;
+    var createdKeys = 0;
+    var createdSnippets = 0;
+    var createdPortForwards = 0;
+
+    final groupId = await _ensureGroup();
+    final snippetFolderId = await _ensureSnippetFolder();
+    final keyResult = await _ensureKey();
+    if (keyResult.created) {
+      createdKeys += 1;
+    }
+    final keyId = keyResult.id;
+
+    final bootstrapSnippet = await _ensureSnippet(
+      name: 'Review: launch Copilot in MonkeyMux',
+      command: 'cd ~/work/monkeyssh-demo && copilot --yolo',
+      description:
+          'Shows an agent launch command saved for the review workspace.',
+      folderId: snippetFolderId,
+      sortOrder: 0,
+    );
+    if (bootstrapSnippet.created) {
+      createdSnippets += 1;
+    }
+    final logsSnippet = await _ensureSnippet(
+      name: 'Review: tail app logs',
+      command: 'tail -f ~/work/monkeyssh-demo/logs/app.log',
+      description: 'A reusable terminal snippet for the demo workspace.',
+      folderId: snippetFolderId,
+      sortOrder: 1,
+    );
+    if (logsSnippet.created) {
+      createdSnippets += 1;
+    }
+    final deploySnippet = await _ensureSnippet(
+      name: 'Review: dry-run deploy',
+      command: './scripts/deploy-demo.sh --dry-run --target staging',
+      description: 'Demonstrates saved automation that requires review.',
+      folderId: snippetFolderId,
+      sortOrder: 2,
+    );
+    if (deploySnippet.created) {
+      createdSnippets += 1;
+    }
+
+    final bastionHost = await _ensureHost(
+      label: _bastionHostLabel,
+      hostname: '127.0.0.1',
+      port: 2200,
+      username: 'reviewer',
+      keyId: keyId,
+      groupId: groupId,
+      color: '#58A38C',
+      notes:
+          'Sample jump host for App Review. This row is local demo data; no '
+          'external SSH server is required to browse app setup screens.',
+      tags: 'app-review,demo,jump-host',
+      sortOrder: 0,
+    );
+    if (bastionHost.created) {
+      createdHosts += 1;
+    }
+
+    final workspaceHost = await _ensureHost(
+      label: _workspaceHostLabel,
+      hostname: '127.0.0.1',
+      port: 2201,
+      username: 'reviewer',
+      keyId: keyId,
+      groupId: groupId,
+      jumpHostId: bastionHost.id,
+      color: '#14756C',
+      notes:
+          'Primary App Review sample workspace. It shows MonkeyMux startup, '
+          'agent launch presets, SFTP, snippets, port forwarding, and '
+          'host-specific terminal themes in local app data.',
+      tags: 'app-review,demo,monkeymux,copilot,agent',
+      terminalThemeLightId: TerminalThemes.githubLightDefault.id,
+      terminalThemeDarkId: TerminalThemes.dracula.id,
+      autoConnectSnippetId: bootstrapSnippet.id,
+      autoConnectRequiresConfirmation: true,
+      tmuxSessionName: 'review-workspace',
+      tmuxWorkingDirectory: '~/work/monkeyssh-demo',
+      remoteMuxBackend: RemoteMuxBackend.monkeyMux,
+      sortOrder: 1,
+    );
+    if (workspaceHost.created) {
+      createdHosts += 1;
+    }
+
+    final tmuxHost = await _ensureHost(
+      label: _tmuxHostLabel,
+      hostname: '127.0.0.1',
+      port: 2202,
+      username: 'reviewer',
+      keyId: keyId,
+      groupId: groupId,
+      color: '#8BCBE5',
+      notes:
+          'Shows the tmux fallback path and saved startup flags for hosts that '
+          'do not use MonkeyMux.',
+      tags: 'app-review,demo,tmux',
+      terminalThemeLightId: TerminalThemes.monkeyLight.id,
+      terminalThemeDarkId: TerminalThemes.githubDarkDefault.id,
+      autoConnectSnippetId: logsSnippet.id,
+      autoConnectRequiresConfirmation: true,
+      tmuxSessionName: 'review-tmux',
+      tmuxWorkingDirectory: '~/work/monkeyssh-demo',
+      tmuxExtraFlags: '-x 160 -y 48',
+      remoteMuxBackend: RemoteMuxBackend.tmux,
+      sortOrder: 2,
+    );
+    if (tmuxHost.created) {
+      createdHosts += 1;
+    }
+
+    final sftpHost = await _ensureHost(
+      label: _sftpHostLabel,
+      hostname: '127.0.0.1',
+      port: 2222,
+      username: 'reviewer',
+      keyId: keyId,
+      groupId: groupId,
+      color: '#D6CC76',
+      notes:
+          'Shows SFTP-oriented saved configuration plus local and remote port '
+          'forward rules for App Review.',
+      tags: 'app-review,demo,sftp,port-forward',
+      autoConnectSnippetId: deploySnippet.id,
+      autoConnectRequiresConfirmation: true,
+      sortOrder: 3,
+    );
+    if (sftpHost.created) {
+      createdHosts += 1;
+    }
+
+    createdPortForwards += await _ensurePortForward(
+      name: 'Review web preview',
+      hostId: workspaceHost.id,
+      forwardType: 'local',
+      localPort: 8080,
+      remoteHost: '127.0.0.1',
+      remotePort: 3000,
+      autoStart: true,
+    );
+    createdPortForwards += await _ensurePortForward(
+      name: 'Review API tunnel',
+      hostId: sftpHost.id,
+      forwardType: 'local',
+      localPort: 8081,
+      remoteHost: '127.0.0.1',
+      remotePort: 8000,
+      autoStart: false,
+    );
+
+    await _agentLaunchPresetService.setPresetForHost(
+      workspaceHost.id,
+      const AgentLaunchPreset(
+        tool: AgentLaunchTool.copilotCli,
+        workingDirectory: '~/work/monkeyssh-demo',
+        tmuxSessionName: 'review-workspace',
+        remoteMuxBackend: RemoteMuxBackend.monkeyMux,
+        additionalArguments: '--yolo',
+      ),
+    );
+    await _agentLaunchPresetService.setPresetForHost(
+      tmuxHost.id,
+      const AgentLaunchPreset(
+        tool: AgentLaunchTool.claudeCode,
+        workingDirectory: '~/work/monkeyssh-demo',
+        tmuxSessionName: 'review-tmux',
+        remoteMuxBackend: RemoteMuxBackend.tmux,
+      ),
+    );
+    await _hostCliLaunchPreferencesService.setPreferencesForHost(
+      workspaceHost.id,
+      const HostCliLaunchPreferences(startInYoloMode: true),
+    );
+
+    await _settingsService.setString(
+      _demoSeededAtSetting,
+      DateTime.now().toIso8601String(),
+    );
+
+    return AppReviewDemoSetupResult(
+      createdHosts: createdHosts,
+      createdKeys: createdKeys,
+      createdSnippets: createdSnippets,
+      createdPortForwards: createdPortForwards,
+    );
+  }
+
+  Future<int> _ensureGroup() async {
+    final groups = await _groupRepository.getAll();
+    for (final group in groups) {
+      if (group.name == _groupName) {
+        return group.id;
+      }
+    }
+    return _groupRepository.insert(
+      GroupsCompanion.insert(
+        name: _groupName,
+        color: const Value('#14756C'),
+        icon: const Value('terminal'),
+      ),
+    );
+  }
+
+  Future<int> _ensureSnippetFolder() async {
+    final folders = await _snippetRepository.getAllFolders();
+    for (final folder in folders) {
+      if (folder.name == _snippetFolderName) {
+        return folder.id;
+      }
+    }
+    return _snippetRepository.insertFolder(
+      SnippetFoldersCompanion.insert(name: _snippetFolderName),
+    );
+  }
+
+  Future<({bool created, int id})> _ensureKey() async {
+    final keys = await _keyRepository.getAll();
+    for (final key in keys) {
+      if (key.name == _keyName) {
+        return (created: false, id: key.id);
+      }
+    }
+    final keyId = await _keyRepository.insert(
+      SshKeysCompanion.insert(
+        name: _keyName,
+        keyType: 'ed25519',
+        publicKey:
+            'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDemoAppReviewOnlyNotARealKey monkeyssh-app-review-demo',
+        privateKey: _demoPrivateKey,
+        fingerprint: const Value('SHA256:MonkeySSHAppReviewDemoOnly'),
+      ),
+    );
+    return (created: true, id: keyId);
+  }
+
+  Future<({bool created, int id})> _ensureSnippet({
+    required String name,
+    required String command,
+    required String description,
+    required int folderId,
+    required int sortOrder,
+  }) async {
+    final snippets = await _snippetRepository.getAll();
+    for (final snippet in snippets) {
+      if (snippet.name == name) {
+        return (created: false, id: snippet.id);
+      }
+    }
+    final id = await _snippetRepository.insert(
+      SnippetsCompanion.insert(
+        name: name,
+        command: command,
+        description: Value(description),
+        folderId: Value(folderId),
+        sortOrder: Value(sortOrder),
+      ),
+    );
+    return (created: true, id: id);
+  }
+
+  Future<({bool created, int id})> _ensureHost({
+    required String label,
+    required String hostname,
+    required String username,
+    required int keyId,
+    required int groupId,
+    required String color,
+    required String notes,
+    required String tags,
+    required int sortOrder,
+    int port = 22,
+    int? jumpHostId,
+    String? terminalThemeLightId,
+    String? terminalThemeDarkId,
+    int? autoConnectSnippetId,
+    bool autoConnectRequiresConfirmation = false,
+    String? tmuxSessionName,
+    String? tmuxWorkingDirectory,
+    String? tmuxExtraFlags,
+    RemoteMuxBackend? remoteMuxBackend,
+  }) async {
+    final hosts = await _hostRepository.getAll();
+    for (final host in hosts) {
+      if (host.label == label) {
+        return (created: false, id: host.id);
+      }
+    }
+    final id = await _hostRepository.insert(
+      HostsCompanion.insert(
+        label: label,
+        hostname: hostname,
+        port: Value(port),
+        username: username,
+        keyId: Value(keyId),
+        groupId: Value(groupId),
+        jumpHostId: Value(jumpHostId),
+        isFavorite: const Value(true),
+        color: Value(color),
+        notes: Value(notes),
+        tags: Value(tags),
+        terminalThemeLightId: Value(terminalThemeLightId),
+        terminalThemeDarkId: Value(terminalThemeDarkId),
+        autoConnectSnippetId: Value(autoConnectSnippetId),
+        autoConnectRequiresConfirmation: Value(autoConnectRequiresConfirmation),
+        tmuxSessionName: Value(tmuxSessionName),
+        tmuxWorkingDirectory: Value(tmuxWorkingDirectory),
+        tmuxExtraFlags: Value(tmuxExtraFlags),
+        remoteMuxBackend: Value(remoteMuxBackend?.storageValue),
+        sortOrder: Value(sortOrder),
+      ),
+    );
+    return (created: true, id: id);
+  }
+
+  Future<int> _ensurePortForward({
+    required String name,
+    required int hostId,
+    required String forwardType,
+    required int localPort,
+    required String remoteHost,
+    required int remotePort,
+    required bool autoStart,
+  }) async {
+    final portForwards = await _portForwardRepository.getAll();
+    for (final portForward in portForwards) {
+      if (portForward.name == name && portForward.hostId == hostId) {
+        return 0;
+      }
+    }
+    await _portForwardRepository.insert(
+      PortForwardsCompanion.insert(
+        name: name,
+        hostId: hostId,
+        forwardType: forwardType,
+        localPort: localPort,
+        remoteHost: remoteHost,
+        remotePort: remotePort,
+        autoStart: Value(autoStart),
+      ),
+    );
+    return 1;
+  }
+}
+
+/// Provides the local App Review demo setup service.
+final appReviewDemoServiceProvider = Provider<AppReviewDemoService>((ref) {
+  final settingsService = ref.watch(settingsServiceProvider);
+  return AppReviewDemoService(
+    groupRepository: ref.watch(groupRepositoryProvider),
+    hostRepository: ref.watch(hostRepositoryProvider),
+    keyRepository: ref.watch(keyRepositoryProvider),
+    snippetRepository: ref.watch(snippetRepositoryProvider),
+    portForwardRepository: ref.watch(portForwardRepositoryProvider),
+    agentLaunchPresetService: ref.watch(agentLaunchPresetServiceProvider),
+    hostCliLaunchPreferencesService: ref.watch(
+      hostCliLaunchPreferencesServiceProvider,
+    ),
+    settingsService: settingsService,
+  );
+});
+
+/// Whether the local App Review demo workspace has been prepared.
+final appReviewDemoPreparedProvider = FutureProvider<bool>((ref) {
+  final service = ref.watch(appReviewDemoServiceProvider);
+  return service.isPrepared();
+});
+
+const _demoPrivateKey = 'app-review-demo-placeholder-key-material';

--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -226,8 +226,12 @@ class MonkeyMuxService implements RemoteMultiplexerService {
   }) {
     final key = _MonkeyMuxWatchKey(session.connectionId, sessionName);
     if (isAppReviewDemoSession(session)) {
-      final windows = _appReviewDemoMuxState(key).windows;
+      final state = _appReviewDemoMuxState(key);
+      final windows = state.windows;
       _replaceCachedWindows(key, windows);
+      if (state.consumeInitialRender()) {
+        _renderAppReviewDemoWindow(session, state.activeWindow);
+      }
       return Future<List<TmuxWindow>>.value(windows);
     }
     final existingRequest = _windowListRequests[key];
@@ -375,10 +379,7 @@ class MonkeyMuxService implements RemoteMultiplexerService {
         workingDirectory: workingDirectory,
       );
       _replaceCachedWindows(key, state.windows);
-      writeAppReviewDemoTerminalOutput(
-        session,
-        'MonkeyMux created window ${window.index}: ${window.displayTitle}',
-      );
+      _renderAppReviewDemoWindow(session, window);
       return;
     }
     await _runControlCommand(session, sessionName, {
@@ -405,10 +406,7 @@ class MonkeyMuxService implements RemoteMultiplexerService {
       final state = _appReviewDemoMuxState(key);
       final window = state.selectWindow(windowIndex, windowId: windowId);
       _replaceCachedWindows(key, state.windows);
-      writeAppReviewDemoTerminalOutput(
-        session,
-        'MonkeyMux switched to window ${window.index}: ${window.displayTitle}',
-      );
+      _renderAppReviewDemoWindow(session, window);
       return;
     }
     await _runControlCommand(session, sessionName, {
@@ -481,10 +479,7 @@ class MonkeyMuxService implements RemoteMultiplexerService {
       final closed = state.killWindow(windowIndex);
       _replaceCachedWindows(key, state.windows);
       if (closed != null) {
-        writeAppReviewDemoTerminalOutput(
-          session,
-          'MonkeyMux closed window ${closed.index}: ${closed.displayTitle}',
-        );
+        _renderAppReviewDemoWindow(session, state.activeWindow);
       }
       return;
     }
@@ -1550,6 +1545,7 @@ class _AppReviewDemoMonkeyMuxState {
   final List<_AppReviewDemoWindowSpec> _windows;
   int _activeIndex = 0;
   int _nextId = 10;
+  bool _renderedInitial = false;
 
   Stream<TmuxWindowChangeEvent> get stream => _controller.stream;
 
@@ -1562,6 +1558,14 @@ class _AppReviewDemoMonkeyMuxState {
     for (var index = 0; index < _windows.length; index += 1)
       _windows[index].toWindow(index: index, isActive: index == _activeIndex),
   ];
+
+  bool consumeInitialRender() {
+    if (_renderedInitial) {
+      return false;
+    }
+    _renderedInitial = true;
+    return true;
+  }
 
   TmuxWindow createWindow({
     String? command,
@@ -1715,6 +1719,148 @@ class _AppReviewDemoWindowSpec {
             : AgentSessionConfidence.medium,
         idleSeconds: isActive ? 2 : 30,
       );
+}
+
+void _renderAppReviewDemoWindow(SshSession session, TmuxWindow window) {
+  writeAppReviewDemoTerminalOutput(
+    session,
+    _appReviewDemoWindowScreen(window),
+    replaceScreen: true,
+    showPrompt: false,
+  );
+}
+
+String _appReviewDemoWindowScreen(TmuxWindow window) {
+  final title = window.displayTitle;
+  final path = window.currentPath ?? '/home/reviewer/work/monkeyssh-demo';
+  final tool = window.foregroundAgentTool;
+  if (tool == AgentLaunchTool.copilotCli ||
+      window.name.toLowerCase().contains('copilot')) {
+    return '''
+GitHub Copilot CLI (demo)
+Window ${window.index}: $title
+
+> Review PR #643
+
+[1/4] Inspecting App Review demo mode       done
+[2/4] Checking local MonkeyMux windows      done
+[3/4] Running focused Flutter tests         done
+[4/4] Preparing App Review notes            done
+
+Suggested next step:
+  /deploy
+
+Files:
+  lib/domain/services/monkeymux_service.dart
+  lib/domain/services/ssh_service.dart
+''';
+  }
+  if (tool == AgentLaunchTool.claudeCode ||
+      window.name.toLowerCase().contains('claude')) {
+    return '''
+Claude Code (demo)
+Window ${window.index}: $title
+
+Working directory:
+  $path
+
+Plan
+  - tighten App Review demo flow
+  - make MonkeyMux windows interactive
+  - run flutter analyze
+
+Edit summary
+  M lib/domain/services/app_review_demo_service.dart
+  M test/domain/services/app_review_demo_ssh_service_test.dart
+
+Result: ready for review
+''';
+  }
+  if (tool == AgentLaunchTool.openCode ||
+      window.name.toLowerCase().contains('opencode')) {
+    return '''
+OpenCode (demo)
+Window ${window.index}: $title
+
+README.md
+  1  # MonkeySSH App Review Demo
+  2
+  3  Local MonkeyMux windows exercise switching,
+  4  SFTP, snippets, and port forwards.
+  5
+  6  App Review can explore without credentials.
+
+NORMAL  utf-8  ~/work/monkeyssh-demo/README.md
+''';
+  }
+  if (tool == AgentLaunchTool.codex ||
+      window.name.toLowerCase().contains('codex')) {
+    return '''
+Codex CLI (demo)
+Window ${window.index}: $title
+
+codex --yolo
+
+Task
+  implement local MonkeyMux demo window rendering
+
+Reasoning
+  - model windows in memory
+  - repaint the terminal on switch
+  - keep review data local
+
+Patch ready
+''';
+  }
+  if (tool == AgentLaunchTool.geminiCli ||
+      window.name.toLowerCase().contains('gemini')) {
+    return '''
+Gemini CLI (demo)
+Window ${window.index}: $title
+
+Context loaded:
+  PRODUCT.md
+  DESIGN.md
+  lib/domain/services/
+
+Summary
+  The App Review demo now uses local MonkeyMux state.
+  Switching windows changes this terminal screen.
+''';
+  }
+  if (tool == AgentLaunchTool.antigravity ||
+      window.name.toLowerCase().contains('antigravity')) {
+    return '''
+Antigravity (demo)
+Window ${window.index}: $title
+
+Workspace
+  ~/work/monkeyssh-demo
+
+Active objective
+  Verify mobile SSH agent workflows from the review device.
+
+Status
+  local demo transport online
+  MonkeyMux navigator online
+''';
+  }
+  return '''
+MonkeySSH SFTP / Shell (demo)
+Window ${window.index}: $title
+
+$path
+
+  [dir] logs
+  [dir] screenshots
+  [dir] src
+  144B  README.md
+   68B  package.json
+   39B  deploy-demo.sh
+
+Tip:
+  Tap the folder button to browse the same sample files in SFTP.
+''';
 }
 
 TmuxWindow? _windowFromJson(Object? value) {

--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -1763,39 +1763,42 @@ ${_ansi('38;5;245', 'tab agents   ctrl+p commands')}
       window.name.toLowerCase().contains('claude')) {
     return '''
 ${_ansi('38;5;208;1', '✻ Claude Code v2.1.201')}
-${_ansi('38;5;238', '╭────────────────────────────────────────────╮')}
-${_ansi('38;5;238', '│')}              ${_ansi('38;5;252;1', 'Welcome back!')}              ${_ansi('38;5;238', '│')}
-${_ansi('38;5;238', '│')}                                        ${_ansi('38;5;238', '│')}
-${_ansi('38;5;238', '│')}  ${_ansi('38;5;208', '▐▛███▜▌')}   Working directory         ${_ansi('38;5;238', '│')}
-${_ansi('38;5;238', '│')}  ${_ansi('38;5;208', '▝▜█████▛▘')} ${_ansi('38;5;110', path.replaceFirst('/home/reviewer/', '~/'))} ${_ansi('38;5;238', '│')}
-${_ansi('38;5;238', '│')}   ${_ansi('38;5;208', '▘▘ ▝▝')}                              ${_ansi('38;5;238', '│')}
-${_ansi('38;5;238', '╰────────────────────────────────────────────╯')}
+
+${_ansi('38;5;245', 'Welcome back')}
+${_ansi('38;5;245', 'Opus 4.8 · /fast')}
+
+${_ansi('38;5;208', '▌')} ${_ansi('38;5;252;1', 'Working directory')}
+  ${_ansi('38;5;110', path.replaceFirst('/home/reviewer/', '~/'))}
 
 ${_ansi('38;5;208', '●')} Plan
-  ${_ansi('38;5;70', '✓')} App Review demo flow
-  ${_ansi('38;5;70', '✓')} MonkeyMux windows
-  ${_ansi('38;5;70', '✓')} flutter analyze
+ ${_ansi('38;5;70', '✓')} App Review demo flow
+ ${_ansi('38;5;70', '✓')} MonkeyMux windows
+ ${_ansi('38;5;70', '✓')} flutter analyze
 
-${_ansi('38;5;245', '────────────────────────────── ↯ /fast ─')}
+${_ansi('38;5;245', '──────────── ↯ /fast ─')}
 ${_ansi('38;5;208', '❯')} Try "make the demo panes feel real"
 ''';
   }
   if (tool == AgentLaunchTool.openCode ||
       window.name.toLowerCase().contains('opencode')) {
     return '''
-${_ansi('48;2;10;10;10;38;2;238;238;238;1', '        OPEN CODE        ')}
+${_ansi('48;2;10;10;10;38;2;238;238;238;1', '      OPEN CODE      ')}
 
-${_ansi('38;2;92;156;245', '┃')} ${_ansi('48;2;30;30;30;38;2;128;128;128', 'Ask anything... "What is this project?" ')}
-${_ansi('38;2;92;156;245', '╹')} ${_ansi('38;2;30;30;30', '▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀')}
+${_ansi('38;2;92;156;245', '┃')} ${_ansi('48;2;30;30;30;38;2;128;128;128', 'Ask anything...')}
+${_ansi('38;2;92;156;245', '╹')} ${_ansi('38;2;30;30;30', '▀▀▀▀▀▀▀▀▀▀▀▀')}
 
 ${_ansi('38;2;92;156;245', 'Build')} ${_ansi('38;5;245', '· Claude Opus 4.8 Fast')}
 ${_ansi('38;5;245', 'GitHub Copilot provider')}
 
-${_ansi('38;5;36', '┌ files ───────┬ editor ───────────────┐')}
-${_ansi('38;5;36', '│')} README.md   ${_ansi('38;5;36', '│')} 1 # App Review Demo       ${_ansi('38;5;36', '│')}
-${_ansi('38;5;36', '│')} src/main    ${_ansi('38;5;36', '│')} 2 Local MonkeyMux panes   ${_ansi('38;5;36', '│')}
-${_ansi('38;5;36', '│')} logs/app    ${_ansi('38;5;36', '│')} 3 switch like real CLIs   ${_ansi('38;5;36', '│')}
-${_ansi('38;5;36', '└──────────────┴───────────────────────┘')}
+${_ansi('38;5;36', 'files')}
+  README.md
+  src/main.dart
+  logs/app.log
+
+${_ansi('38;5;36', 'editor  README.md')}
+ 1 # App Review Demo
+ 2 Local MonkeyMux panes
+ 3 switch like real CLIs
 
 ${_ansi('38;5;252', 'tab')} ${_ansi('38;5;245', 'agents')}   ${_ansi('38;5;252', 'ctrl+p')} ${_ansi('38;5;245', 'commands')}
 ''';
@@ -1804,9 +1807,9 @@ ${_ansi('38;5;252', 'tab')} ${_ansi('38;5;245', 'agents')}   ${_ansi('38;5;252',
       window.name.toLowerCase().contains('codex')) {
     return '''
 ${_ansi('38;5;51;1', 'Codex CLI (demo)')} ${_ansi('38;5;245', 'gpt-5.3-codex')}
-${_ansi('38;5;238', '╭────────────────────────────────────────────╮')}
-${_ansi('38;5;238', '│')} ${_ansi('38;5;51', '✨')} ${_ansi('38;5;252;1', 'Task')} render local MonkeyMux panes     ${_ansi('38;5;238', '│')}
-${_ansi('38;5;238', '╰────────────────────────────────────────────╯')}
+
+${_ansi('38;5;51', '✨')} ${_ansi('38;5;252;1', 'Task')}
+  render local MonkeyMux panes
 
 ${_ansi('38;5;51', 'thinking')} inspect live TUI references
 ${_ansi('38;5;51', 'thinking')} build compact ANSI mock screens
@@ -1823,11 +1826,11 @@ ${_ansi('38;5;245', '› Ask Codex for a follow-up')}
       window.name.toLowerCase().contains('gemini')) {
     return '''
 ${_ansi('38;5;99;1', '✦ Gemini CLI (demo)')} ${_ansi('38;5;245', '2.5 Pro')}
-${_ansi('38;5;99', '╭──────── loaded context ─────────╮')}
-${_ansi('38;5;99', '│')} ${_ansi('38;5;45', '✓')} PRODUCT.md                  ${_ansi('38;5;99', '│')}
-${_ansi('38;5;99', '│')} ${_ansi('38;5;45', '✓')} DESIGN.md                   ${_ansi('38;5;99', '│')}
-${_ansi('38;5;99', '│')} ${_ansi('38;5;45', '✓')} lib/domain/services        ${_ansi('38;5;99', '│')}
-${_ansi('38;5;99', '╰─────────────────────────────────╯')}
+
+${_ansi('38;5;99', 'loaded context')}
+ ${_ansi('38;5;45', '✓')} PRODUCT.md
+ ${_ansi('38;5;45', '✓')} DESIGN.md
+ ${_ansi('38;5;45', '✓')} lib/domain/services
 
 ${_ansi('38;5;45;1', 'Gemini summary')}
   Local MonkeyMux state is active.
@@ -1840,9 +1843,9 @@ ${_ansi('48;5;57;38;5;231', '  Enter prompt  ')} ${_ansi('38;5;245', 'ctrl+j new
       window.name.toLowerCase().contains('antigravity')) {
     return '''
 ${_ansi('48;5;54;38;5;231;1', ' Antigravity (demo) ')}
-${_ansi('38;5;141', '╭──────── objective ─────────╮')}
-${_ansi('38;5;141', '│')} Verify mobile SSH agents ${_ansi('38;5;141', '│')}
-${_ansi('38;5;141', '╰────────────────────────────╯')}
+
+${_ansi('38;5;141', 'objective')}
+  Verify mobile SSH agents
 
 Workspace
   ${_ansi('38;5;111', '~/work/monkeyssh-demo')}

--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -1739,105 +1739,110 @@ String _appReviewDemoWindowScreen(TmuxWindow window) {
   if (tool == AgentLaunchTool.copilotCli ||
       window.name.toLowerCase().contains('copilot')) {
     return '''
-${_ansi('48;5;24;38;5;231;1', ' GitHub Copilot CLI (demo) ')} ${_ansi('38;5;245', 'agent  gpt-5.5  Window ${window.index}')}
-${_ansi('38;5;39', '╭─ prompt ─────────────────────────────────────────────╮')}
-${_ansi('38;5;39', '│')} Review PR #643                                      ${_ansi('38;5;39', '│')}
-${_ansi('38;5;39', '╰───────────────────────────────────────────────────────╯')}
+${_ansi('48;5;24;38;5;231;1', ' GitHub Copilot CLI ')} ${_ansi('38;5;245', 'Build · gpt-5.5')}
 
-${_ansi('38;5;75;1', '●')} Reading workspace
-  ${_ansi('38;5;70', '✓')} lib/domain/services/monkeymux_service.dart
-  ${_ansi('38;5;70', '✓')} lib/domain/services/ssh_service.dart
+${_ansi('38;5;39', '┃')} ${_ansi('48;5;235;38;5;231', ' Ask Copilot to build or review code         ')}
+${_ansi('38;5;39', '┃')} Review PR #643
+${_ansi('38;5;39', '╹')} ${_ansi('38;5;238', '▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀')}
 
-${_ansi('38;5;75;1', '●')} Plan
-  ${_ansi('38;5;70', '✓')} make demo MonkeyMux windows interactive
-  ${_ansi('38;5;70', '✓')} repaint terminal on selection
-  ${_ansi('38;5;70', '✓')} keep review data local
+${_ansi('38;5;75', '●')} ${_ansi('38;5;252;1', 'Reading workspace')}
+  ${_ansi('38;5;70', '✓')} monkeymux_service.dart
+  ${_ansi('38;5;70', '✓')} ssh_service.dart
 
-${_ansi('38;5;75;1', '●')} Suggested next step
-  ${_ansi('38;5;231;48;5;25', ' /deploy ')}
+${_ansi('38;5;75', '●')} ${_ansi('38;5;252;1', 'Plan')}
+  ${_ansi('38;5;70', '✓')} local MonkeyMux state
+  ${_ansi('38;5;70', '✓')} repaint terminal on switch
+  ${_ansi('38;5;70', '✓')} deterministic App Review data
 
-${_ansi('38;5;240', '────────────────────────────────────────────────────────')}
-${_ansi('38;5;245', 'Copilot is ready. Ask a follow-up or switch MonkeyMux windows.')}
+${_ansi('48;5;25;38;5;231', ' /deploy ')} ${_ansi('38;5;245', 'ready')}
+
+${_ansi('38;5;245', 'tab agents   ctrl+p commands')}
 ''';
   }
   if (tool == AgentLaunchTool.claudeCode ||
       window.name.toLowerCase().contains('claude')) {
     return '''
-${_ansi('38;5;208;1', '✻ Claude Code (demo)')} ${_ansi('38;5;245', 'Window ${window.index} · $title')}
-${_ansi('38;5;238', '╭──────────────────────────────────────────────────────╮')}
-${_ansi('38;5;238', '│')} ${_ansi('38;5;252;1', 'Working directory')}  ${_ansi('38;5;110', path)} ${_ansi('38;5;238', '│')}
-${_ansi('38;5;238', '╰──────────────────────────────────────────────────────╯')}
+${_ansi('38;5;208;1', '✻ Claude Code v2.1.201')}
+${_ansi('38;5;238', '╭────────────────────────────────────────────╮')}
+${_ansi('38;5;238', '│')}              ${_ansi('38;5;252;1', 'Welcome back!')}              ${_ansi('38;5;238', '│')}
+${_ansi('38;5;238', '│')}                                        ${_ansi('38;5;238', '│')}
+${_ansi('38;5;238', '│')}  ${_ansi('38;5;208', '▐▛███▜▌')}   Working directory         ${_ansi('38;5;238', '│')}
+${_ansi('38;5;238', '│')}  ${_ansi('38;5;208', '▝▜█████▛▘')} ${_ansi('38;5;110', path.replaceFirst('/home/reviewer/', '~/'))} ${_ansi('38;5;238', '│')}
+${_ansi('38;5;238', '│')}   ${_ansi('38;5;208', '▘▘ ▝▝')}                              ${_ansi('38;5;238', '│')}
+${_ansi('38;5;238', '╰────────────────────────────────────────────╯')}
 
 ${_ansi('38;5;208', '●')} Plan
-  ${_ansi('38;5;70', '✓')} tighten App Review demo flow
-  ${_ansi('38;5;70', '✓')} make MonkeyMux windows interactive
-  ${_ansi('38;5;70', '✓')} run flutter analyze
+  ${_ansi('38;5;70', '✓')} App Review demo flow
+  ${_ansi('38;5;70', '✓')} MonkeyMux windows
+  ${_ansi('38;5;70', '✓')} flutter analyze
 
-${_ansi('38;5;208', '●')} Edits
-  ${_ansi('38;5;214', 'M')} lib/domain/services/app_review_demo_service.dart
-  ${_ansi('38;5;214', 'M')} test/domain/services/app_review_demo_ssh_service_test.dart
-
-${_ansi('38;5;70;1', '✔')} Result: ready for review
-${_ansi('38;5;245', 'Use the MonkeyMux bar to inspect another agent pane.')}
+${_ansi('38;5;245', '────────────────────────────── ↯ /fast ─')}
+${_ansi('38;5;208', '❯')} Try "make the demo panes feel real"
 ''';
   }
   if (tool == AgentLaunchTool.openCode ||
       window.name.toLowerCase().contains('opencode')) {
     return '''
-${_ansi('48;5;22;38;5;231;1', ' OpenCode (demo) ')} ${_ansi('38;5;245', 'README.md  Window ${window.index}')}
-${_ansi('38;5;36', '┌ files ─────────────┬ editor ─────────────────────────┐')}
-${_ansi('38;5;36', '│')}  README.md        ${_ansi('38;5;36', '│')}  1  # MonkeySSH App Review Demo        ${_ansi('38;5;36', '│')}
-${_ansi('38;5;36', '│')}  package.json     ${_ansi('38;5;36', '│')}  2                                      ${_ansi('38;5;36', '│')}
-${_ansi('38;5;36', '│')}  src/main.dart     ${_ansi('38;5;36', '│')}  3  Local MonkeyMux windows exercise   ${_ansi('38;5;36', '│')}
-${_ansi('38;5;36', '│')}  logs/app.log      ${_ansi('38;5;36', '│')}  4  switching, SFTP, snippets, tunnels. ${_ansi('38;5;36', '│')}
-${_ansi('38;5;36', '│')}                  ${_ansi('38;5;36', '│')}  5                                      ${_ansi('38;5;36', '│')}
-${_ansi('38;5;36', '│')}                  ${_ansi('38;5;36', '│')}  6  App Review can explore locally.     ${_ansi('38;5;36', '│')}
-${_ansi('38;5;36', '└──────────────────┴──────────────────────────────────┘')}
-${_ansi('48;5;235;38;5;252', ' NORMAL ')} ${_ansi('38;5;245', 'utf-8  ~/work/monkeyssh-demo/README.md')}
+${_ansi('48;2;10;10;10;38;2;238;238;238;1', '        OPEN CODE        ')}
+
+${_ansi('38;2;92;156;245', '┃')} ${_ansi('48;2;30;30;30;38;2;128;128;128', 'Ask anything... "What is this project?" ')}
+${_ansi('38;2;92;156;245', '╹')} ${_ansi('38;2;30;30;30', '▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀')}
+
+${_ansi('38;2;92;156;245', 'Build')} ${_ansi('38;5;245', '· Claude Opus 4.8 Fast')}
+${_ansi('38;5;245', 'GitHub Copilot provider')}
+
+${_ansi('38;5;36', '┌ files ───────┬ editor ───────────────┐')}
+${_ansi('38;5;36', '│')} README.md   ${_ansi('38;5;36', '│')} 1 # App Review Demo       ${_ansi('38;5;36', '│')}
+${_ansi('38;5;36', '│')} src/main    ${_ansi('38;5;36', '│')} 2 Local MonkeyMux panes   ${_ansi('38;5;36', '│')}
+${_ansi('38;5;36', '│')} logs/app    ${_ansi('38;5;36', '│')} 3 switch like real CLIs   ${_ansi('38;5;36', '│')}
+${_ansi('38;5;36', '└──────────────┴───────────────────────┘')}
+
+${_ansi('38;5;252', 'tab')} ${_ansi('38;5;245', 'agents')}   ${_ansi('38;5;252', 'ctrl+p')} ${_ansi('38;5;245', 'commands')}
 ''';
   }
   if (tool == AgentLaunchTool.codex ||
       window.name.toLowerCase().contains('codex')) {
     return '''
-${_ansi('38;5;51;1', 'Codex CLI (demo)')} ${_ansi('38;5;245', 'Window ${window.index} · $title')}
-${_ansi('38;5;238', '╭──────────────────────────────────────────────────────╮')}
-${_ansi('38;5;238', '│')} ${_ansi('38;5;231;1', 'Task')} implement local MonkeyMux demo window rendering ${_ansi('38;5;238', '│')}
-${_ansi('38;5;238', '╰──────────────────────────────────────────────────────╯')}
+${_ansi('38;5;51;1', 'Codex CLI (demo)')} ${_ansi('38;5;245', 'gpt-5.3-codex')}
+${_ansi('38;5;238', '╭────────────────────────────────────────────╮')}
+${_ansi('38;5;238', '│')} ${_ansi('38;5;51', '✨')} ${_ansi('38;5;252;1', 'Task')} render local MonkeyMux panes     ${_ansi('38;5;238', '│')}
+${_ansi('38;5;238', '╰────────────────────────────────────────────╯')}
 
-${_ansi('38;5;51', 'thinking')} model local windows as an in-memory mux
-${_ansi('38;5;51', 'thinking')} repaint terminal on select/create/close
+${_ansi('38;5;51', 'thinking')} inspect live TUI references
+${_ansi('38;5;51', 'thinking')} build compact ANSI mock screens
 
 ${_ansi('38;5;70', '✓')} service branch added
-${_ansi('38;5;70', '✓')} tests cover create and select
+${_ansi('38;5;70', '✓')} tests cover create/select
 ${_ansi('38;5;70', '✓')} analyzer clean
 
 ${_ansi('48;5;23;38;5;231', ' Patch ready ')}
+${_ansi('38;5;245', '› Ask Codex for a follow-up')}
 ''';
   }
   if (tool == AgentLaunchTool.geminiCli ||
       window.name.toLowerCase().contains('gemini')) {
     return '''
-${_ansi('38;5;99;1', '✦ Gemini CLI (demo)')} ${_ansi('38;5;245', 'Window ${window.index} · $title')}
-${_ansi('38;5;99', '╭──────────────── context ────────────────╮')}
-${_ansi('38;5;99', '│')} ${_ansi('38;5;45', '✓')} PRODUCT.md                              ${_ansi('38;5;99', '│')}
-${_ansi('38;5;99', '│')} ${_ansi('38;5;45', '✓')} DESIGN.md                               ${_ansi('38;5;99', '│')}
-${_ansi('38;5;99', '│')} ${_ansi('38;5;45', '✓')} lib/domain/services/                 ${_ansi('38;5;99', '│')}
-${_ansi('38;5;99', '╰──────────────────────────────────────────╯')}
+${_ansi('38;5;99;1', '✦ Gemini CLI (demo)')} ${_ansi('38;5;245', '2.5 Pro')}
+${_ansi('38;5;99', '╭──────── loaded context ─────────╮')}
+${_ansi('38;5;99', '│')} ${_ansi('38;5;45', '✓')} PRODUCT.md                  ${_ansi('38;5;99', '│')}
+${_ansi('38;5;99', '│')} ${_ansi('38;5;45', '✓')} DESIGN.md                   ${_ansi('38;5;99', '│')}
+${_ansi('38;5;99', '│')} ${_ansi('38;5;45', '✓')} lib/domain/services        ${_ansi('38;5;99', '│')}
+${_ansi('38;5;99', '╰─────────────────────────────────╯')}
 
-${_ansi('38;5;45;1', 'Summary')}
-  The App Review demo uses local MonkeyMux state.
-  Switching windows changes this terminal screen.
+${_ansi('38;5;45;1', 'Gemini summary')}
+  Local MonkeyMux state is active.
+  Window switches repaint the terminal.
 
-${_ansi('38;5;245', 'Ready for another prompt.')}
+${_ansi('48;5;57;38;5;231', '  Enter prompt  ')} ${_ansi('38;5;245', 'ctrl+j newline')}
 ''';
   }
   if (tool == AgentLaunchTool.antigravity ||
       window.name.toLowerCase().contains('antigravity')) {
     return '''
-${_ansi('48;5;54;38;5;231;1', ' Antigravity (demo) ')} ${_ansi('38;5;245', 'Window ${window.index} · $title')}
-${_ansi('38;5;141', '┌ objective ───────────────────────────────────────────┐')}
-${_ansi('38;5;141', '│')} Verify mobile SSH agent workflows from the review device. ${_ansi('38;5;141', '│')}
-${_ansi('38;5;141', '└──────────────────────────────────────────────────────┘')}
+${_ansi('48;5;54;38;5;231;1', ' Antigravity (demo) ')}
+${_ansi('38;5;141', '╭──────── objective ─────────╮')}
+${_ansi('38;5;141', '│')} Verify mobile SSH agents ${_ansi('38;5;141', '│')}
+${_ansi('38;5;141', '╰────────────────────────────╯')}
 
 Workspace
   ${_ansi('38;5;111', '~/work/monkeyssh-demo')}
@@ -1845,7 +1850,9 @@ Workspace
 Status
   ${_ansi('38;5;70', '●')} local demo transport online
   ${_ansi('38;5;70', '●')} MonkeyMux navigator online
-  ${_ansi('38;5;70', '●')} window switching changes the visible pane
+  ${_ansi('38;5;70', '●')} pane rendering follows window focus
+
+${_ansi('38;5;245', 'Actions: plan · inspect · patch · verify')}
 ''';
   }
   return '''

--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -151,6 +151,8 @@ class MonkeyMuxService implements RemoteMultiplexerService {
   static final _agentMetadataPeriodicSessions =
       <_MonkeyMuxWatchKey, ({SshSession session, String sessionName})>{};
   static final _windowSnapshotGenerations = <_MonkeyMuxWatchKey, int>{};
+  static final _appReviewDemoMuxStates =
+      <_MonkeyMuxWatchKey, _AppReviewDemoMonkeyMuxState>{};
   static const _agentSessionMetadataFreshTtl = Duration(seconds: 5);
 
   /// Clears MonkeyMux caches and watchers for a connection.
@@ -161,6 +163,12 @@ class MonkeyMuxService implements RemoteMultiplexerService {
       fields: {'connectionId': connectionId},
     );
     _installer.clearCache(connectionId);
+    final demoKeys = _appReviewDemoMuxStates.keys
+        .where((key) => key.connectionId == connectionId)
+        .toList(growable: false);
+    for (final key in demoKeys) {
+      _appReviewDemoMuxStates.remove(key)?.dispose();
+    }
     _windowSnapshotCache.removeWhere(
       (key, _) => key.connectionId == connectionId,
     );
@@ -217,6 +225,11 @@ class MonkeyMuxService implements RemoteMultiplexerService {
     String? extraFlags,
   }) {
     final key = _MonkeyMuxWatchKey(session.connectionId, sessionName);
+    if (isAppReviewDemoSession(session)) {
+      final windows = _appReviewDemoMuxState(key).windows;
+      _replaceCachedWindows(key, windows);
+      return Future<List<TmuxWindow>>.value(windows);
+    }
     final existingRequest = _windowListRequests[key];
     if (existingRequest != null) {
       return existingRequest;
@@ -251,6 +264,11 @@ class MonkeyMuxService implements RemoteMultiplexerService {
     String? extraFlags,
   }) {
     final key = _MonkeyMuxWatchKey(session.connectionId, sessionName);
+    if (isAppReviewDemoSession(session)) {
+      final state = _appReviewDemoMuxState(key);
+      scheduleMicrotask(state.emitWindowList);
+      return state.stream;
+    }
     final observer = _observers.putIfAbsent(
       key,
       () => _MonkeyMuxWindowChangeObserver(
@@ -308,6 +326,15 @@ class MonkeyMuxService implements RemoteMultiplexerService {
     SshExecPriority priority = SshExecPriority.normal,
     String? extraFlags,
   }) async {
+    if (isAppReviewDemoSession(session)) {
+      final active = _appReviewDemoMuxState(
+        _MonkeyMuxWatchKey(session.connectionId, sessionName),
+      ).activeWindow;
+      return TmuxPaneContext(
+        currentPath: active.currentPath,
+        currentCommand: active.currentCommand,
+      );
+    }
     final response = await _runControlCommand(session, sessionName, {
       'type': 'query_active_context',
     }, priority: priority);
@@ -339,6 +366,21 @@ class MonkeyMuxService implements RemoteMultiplexerService {
     String? workingDirectory,
     String? extraFlags,
   }) async {
+    if (isAppReviewDemoSession(session)) {
+      final key = _MonkeyMuxWatchKey(session.connectionId, sessionName);
+      final state = _appReviewDemoMuxState(key);
+      final window = state.createWindow(
+        command: command,
+        name: name,
+        workingDirectory: workingDirectory,
+      );
+      _replaceCachedWindows(key, state.windows);
+      writeAppReviewDemoTerminalOutput(
+        session,
+        'MonkeyMux created window ${window.index}: ${window.displayTitle}',
+      );
+      return;
+    }
     await _runControlCommand(session, sessionName, {
       'type': 'create_window',
       if (command != null && command.trim().isNotEmpty)
@@ -358,6 +400,17 @@ class MonkeyMuxService implements RemoteMultiplexerService {
     String? extraFlags,
     Map<int, int>? clientImageSignatures,
   }) async {
+    if (isAppReviewDemoSession(session)) {
+      final key = _MonkeyMuxWatchKey(session.connectionId, sessionName);
+      final state = _appReviewDemoMuxState(key);
+      final window = state.selectWindow(windowIndex, windowId: windowId);
+      _replaceCachedWindows(key, state.windows);
+      writeAppReviewDemoTerminalOutput(
+        session,
+        'MonkeyMux switched to window ${window.index}: ${window.displayTitle}',
+      );
+      return;
+    }
     await _runControlCommand(session, sessionName, {
       'type': 'select_window',
       if (windowId != null && windowId.trim().isNotEmpty)
@@ -387,6 +440,9 @@ class MonkeyMuxService implements RemoteMultiplexerService {
     String sessionName,
     Iterable<int> imageIds,
   ) async {
+    if (isAppReviewDemoSession(session)) {
+      return;
+    }
     final ids = <String>[
       for (final id in imageIds)
         if (id > 0) id.toString(),
@@ -419,6 +475,19 @@ class MonkeyMuxService implements RemoteMultiplexerService {
     int windowIndex, {
     String? extraFlags,
   }) async {
+    if (isAppReviewDemoSession(session)) {
+      final key = _MonkeyMuxWatchKey(session.connectionId, sessionName);
+      final state = _appReviewDemoMuxState(key);
+      final closed = state.killWindow(windowIndex);
+      _replaceCachedWindows(key, state.windows);
+      if (closed != null) {
+        writeAppReviewDemoTerminalOutput(
+          session,
+          'MonkeyMux closed window ${closed.index}: ${closed.displayTitle}',
+        );
+      }
+      return;
+    }
     await _runControlCommand(session, sessionName, {
       'type': 'close_window',
       'windowIndex': windowIndex,
@@ -436,9 +505,10 @@ class MonkeyMuxService implements RemoteMultiplexerService {
   /// UI should throttle resize syncs to avoid flooding the SSH connection with
   /// one-shot exec channels.
   bool hasLiveControlChannel(SshSession session, String sessionName) =>
-      _observers[_MonkeyMuxWatchKey(session.connectionId, sessionName)]
-          ?.isControlChannelReady ??
-      false;
+      isAppReviewDemoSession(session) ||
+      (_observers[_MonkeyMuxWatchKey(session.connectionId, sessionName)]
+              ?.isControlChannelReady ??
+          false);
 
   @override
   Future<bool> hasForegroundClientOrThrow(
@@ -446,6 +516,9 @@ class MonkeyMuxService implements RemoteMultiplexerService {
     String sessionName, {
     String? extraFlags,
   }) async {
+    if (isAppReviewDemoSession(session)) {
+      return true;
+    }
     final response = await _runControlCommand(session, sessionName, {
       'type': 'query_attach_state',
     });
@@ -465,6 +538,9 @@ class MonkeyMuxService implements RemoteMultiplexerService {
     TerminalThemeData theme, {
     String? extraFlags,
   }) async {
+    if (isAppReviewDemoSession(session)) {
+      return;
+    }
     await _runControlCommand(session, sessionName, {
       'type': 'theme_changed',
       'data': buildTerminalThemeHintReports(theme),
@@ -480,6 +556,9 @@ class MonkeyMuxService implements RemoteMultiplexerService {
     bool redraw = false,
     SshExecPriority priority = SshExecPriority.normal,
   }) async {
+    if (isAppReviewDemoSession(session)) {
+      return;
+    }
     await _runControlCommand(session, sessionName, {
       'type': 'resize',
       'width': columns,
@@ -495,6 +574,12 @@ class MonkeyMuxService implements RemoteMultiplexerService {
     String command, {
     SshExecPriority priority = SshExecPriority.normal,
   }) async {
+    if (isAppReviewDemoSession(session)) {
+      return TerminalClientCommandResult(
+        output: 'demo command completed: $command\n',
+        exitCode: 0,
+      );
+    }
     final response = await _runControlCommand(session, sessionName, {
       'type': 'run_command',
       'command': command,
@@ -1447,6 +1532,189 @@ class _MonkeyMuxWatchKey {
 
   @override
   int get hashCode => Object.hash(connectionId, sessionName);
+}
+
+_AppReviewDemoMonkeyMuxState _appReviewDemoMuxState(_MonkeyMuxWatchKey key) =>
+    MonkeyMuxService._appReviewDemoMuxStates.putIfAbsent(
+      key,
+      _AppReviewDemoMonkeyMuxState.new,
+    );
+
+class _AppReviewDemoMonkeyMuxState {
+  _AppReviewDemoMonkeyMuxState()
+    : _windows = List<_AppReviewDemoWindowSpec>.of(_initialWindows());
+
+  static const _workspace = '/home/reviewer/work/monkeyssh-demo';
+
+  final _controller = StreamController<TmuxWindowChangeEvent>.broadcast();
+  final List<_AppReviewDemoWindowSpec> _windows;
+  int _activeIndex = 0;
+  int _nextId = 10;
+
+  Stream<TmuxWindowChangeEvent> get stream => _controller.stream;
+
+  TmuxWindow get activeWindow => windows.firstWhere(
+    (window) => window.isActive,
+    orElse: () => windows.first,
+  );
+
+  List<TmuxWindow> get windows => [
+    for (var index = 0; index < _windows.length; index += 1)
+      _windows[index].toWindow(index: index, isActive: index == _activeIndex),
+  ];
+
+  TmuxWindow createWindow({
+    String? command,
+    String? name,
+    String? workingDirectory,
+  }) {
+    final tool =
+        agentLaunchToolForCommandText(command) ??
+        agentLaunchToolForCommandText(name);
+    final id = _nextId++;
+    final windowName =
+        _nonEmpty(name) ??
+        tool?.label ??
+        _nonEmpty(command)?.split(RegExp(r'\s+')).first ??
+        'shell $id';
+    final spec = _AppReviewDemoWindowSpec(
+      id: '@$id',
+      panePid: 7300 + id,
+      name: windowName,
+      currentCommand: tool?.commandName ?? _nonEmpty(command) ?? 'zsh',
+      currentPath: _nonEmpty(workingDirectory) ?? _workspace,
+      paneTitle: tool == null ? windowName : '${tool.label} · demo window',
+      agentTool: tool,
+      agentSessionTitle: tool == null ? null : 'Demo ${tool.label} session',
+    );
+    _windows.add(spec);
+    _activeIndex = _windows.length - 1;
+    emitWindowList();
+    return spec.toWindow(index: _activeIndex, isActive: true);
+  }
+
+  TmuxWindow selectWindow(int windowIndex, {String? windowId}) {
+    final targetIndex = windowId == null
+        ? windowIndex
+        : _windows.indexWhere((window) => window.id == windowId);
+    if (targetIndex >= 0 && targetIndex < _windows.length) {
+      _activeIndex = targetIndex;
+    }
+    emitWindowList();
+    return activeWindow;
+  }
+
+  TmuxWindow? killWindow(int windowIndex) {
+    if (_windows.length <= 1 ||
+        windowIndex < 0 ||
+        windowIndex >= _windows.length) {
+      return null;
+    }
+    final closed = _windows.removeAt(windowIndex);
+    if (_activeIndex >= _windows.length) {
+      _activeIndex = _windows.length - 1;
+    } else if (windowIndex < _activeIndex) {
+      _activeIndex -= 1;
+    }
+    emitWindowList();
+    return closed.toWindow(index: windowIndex, isActive: false);
+  }
+
+  void emitWindowList() {
+    if (!_controller.isClosed) {
+      _controller.add(TmuxWindowListEvent(windows));
+    }
+  }
+
+  void dispose() {
+    if (!_controller.isClosed) {
+      unawaited(_controller.close());
+    }
+  }
+
+  static List<_AppReviewDemoWindowSpec> _initialWindows() => const [
+    _AppReviewDemoWindowSpec(
+      id: '@0',
+      panePid: 7300,
+      name: 'Copilot CLI',
+      currentCommand: 'copilot',
+      currentPath: _workspace,
+      paneTitle: 'Copilot CLI · planning review notes',
+      agentTool: AgentLaunchTool.copilotCli,
+      agentSessionTitle: 'Planning review notes',
+    ),
+    _AppReviewDemoWindowSpec(
+      id: '@1',
+      panePid: 7301,
+      name: 'Claude Code',
+      currentCommand: 'claude',
+      currentPath: _workspace,
+      paneTitle: 'Claude Code · running tests',
+      agentTool: AgentLaunchTool.claudeCode,
+      agentSessionTitle: 'Running focused tests',
+    ),
+    _AppReviewDemoWindowSpec(
+      id: '@2',
+      panePid: 7302,
+      name: 'OpenCode',
+      currentCommand: 'opencode',
+      currentPath: '$_workspace/src',
+      paneTitle: 'OpenCode · editing README.md',
+      agentTool: AgentLaunchTool.openCode,
+      agentSessionTitle: 'Editing README.md',
+    ),
+    _AppReviewDemoWindowSpec(
+      id: '@3',
+      panePid: 7303,
+      name: 'SFTP',
+      currentCommand: 'zsh',
+      currentPath: _workspace,
+      paneTitle: 'SFTP · sample workspace',
+    ),
+  ];
+}
+
+class _AppReviewDemoWindowSpec {
+  const _AppReviewDemoWindowSpec({
+    required this.id,
+    required this.panePid,
+    required this.name,
+    required this.currentCommand,
+    required this.currentPath,
+    required this.paneTitle,
+    this.agentTool,
+    this.agentSessionTitle,
+  });
+
+  final String id;
+  final int panePid;
+  final String name;
+  final String currentCommand;
+  final String currentPath;
+  final String paneTitle;
+  final AgentLaunchTool? agentTool;
+  final String? agentSessionTitle;
+
+  TmuxWindow toWindow({required int index, required bool isActive}) =>
+      TmuxWindow(
+        index: index,
+        id: id,
+        panePid: panePid,
+        name: name,
+        isActive: isActive,
+        currentCommand: currentCommand,
+        currentPath: currentPath,
+        flags: isActive ? '*' : null,
+        paneTitle: paneTitle,
+        paneStartCommand: currentCommand,
+        agentTool: agentTool,
+        activeAgentSessionId: agentTool == null ? null : 'demo-$panePid',
+        agentSessionTitle: agentSessionTitle,
+        activeAgentSessionConfidence: agentTool == null
+            ? null
+            : AgentSessionConfidence.medium,
+        idleSeconds: isActive ? 2 : 30,
+      );
 }
 
 TmuxWindow? _windowFromJson(Object? value) {

--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -1730,6 +1730,8 @@ void _renderAppReviewDemoWindow(SshSession session, TmuxWindow window) {
   );
 }
 
+String _ansi(String code, String text) => '\x1b[${code}m$text\x1b[0m';
+
 String _appReviewDemoWindowScreen(TmuxWindow window) {
   final title = window.displayTitle;
   final path = window.currentPath ?? '/home/reviewer/work/monkeyssh-demo';
@@ -1737,126 +1739,126 @@ String _appReviewDemoWindowScreen(TmuxWindow window) {
   if (tool == AgentLaunchTool.copilotCli ||
       window.name.toLowerCase().contains('copilot')) {
     return '''
-GitHub Copilot CLI (demo)
-Window ${window.index}: $title
+${_ansi('48;5;24;38;5;231;1', ' GitHub Copilot CLI (demo) ')} ${_ansi('38;5;245', 'agent  gpt-5.5  Window ${window.index}')}
+${_ansi('38;5;39', '╭─ prompt ─────────────────────────────────────────────╮')}
+${_ansi('38;5;39', '│')} Review PR #643                                      ${_ansi('38;5;39', '│')}
+${_ansi('38;5;39', '╰───────────────────────────────────────────────────────╯')}
 
-> Review PR #643
+${_ansi('38;5;75;1', '●')} Reading workspace
+  ${_ansi('38;5;70', '✓')} lib/domain/services/monkeymux_service.dart
+  ${_ansi('38;5;70', '✓')} lib/domain/services/ssh_service.dart
 
-[1/4] Inspecting App Review demo mode       done
-[2/4] Checking local MonkeyMux windows      done
-[3/4] Running focused Flutter tests         done
-[4/4] Preparing App Review notes            done
+${_ansi('38;5;75;1', '●')} Plan
+  ${_ansi('38;5;70', '✓')} make demo MonkeyMux windows interactive
+  ${_ansi('38;5;70', '✓')} repaint terminal on selection
+  ${_ansi('38;5;70', '✓')} keep review data local
 
-Suggested next step:
-  /deploy
+${_ansi('38;5;75;1', '●')} Suggested next step
+  ${_ansi('38;5;231;48;5;25', ' /deploy ')}
 
-Files:
-  lib/domain/services/monkeymux_service.dart
-  lib/domain/services/ssh_service.dart
+${_ansi('38;5;240', '────────────────────────────────────────────────────────')}
+${_ansi('38;5;245', 'Copilot is ready. Ask a follow-up or switch MonkeyMux windows.')}
 ''';
   }
   if (tool == AgentLaunchTool.claudeCode ||
       window.name.toLowerCase().contains('claude')) {
     return '''
-Claude Code (demo)
-Window ${window.index}: $title
+${_ansi('38;5;208;1', '✻ Claude Code (demo)')} ${_ansi('38;5;245', 'Window ${window.index} · $title')}
+${_ansi('38;5;238', '╭──────────────────────────────────────────────────────╮')}
+${_ansi('38;5;238', '│')} ${_ansi('38;5;252;1', 'Working directory')}  ${_ansi('38;5;110', path)} ${_ansi('38;5;238', '│')}
+${_ansi('38;5;238', '╰──────────────────────────────────────────────────────╯')}
 
-Working directory:
-  $path
+${_ansi('38;5;208', '●')} Plan
+  ${_ansi('38;5;70', '✓')} tighten App Review demo flow
+  ${_ansi('38;5;70', '✓')} make MonkeyMux windows interactive
+  ${_ansi('38;5;70', '✓')} run flutter analyze
 
-Plan
-  - tighten App Review demo flow
-  - make MonkeyMux windows interactive
-  - run flutter analyze
+${_ansi('38;5;208', '●')} Edits
+  ${_ansi('38;5;214', 'M')} lib/domain/services/app_review_demo_service.dart
+  ${_ansi('38;5;214', 'M')} test/domain/services/app_review_demo_ssh_service_test.dart
 
-Edit summary
-  M lib/domain/services/app_review_demo_service.dart
-  M test/domain/services/app_review_demo_ssh_service_test.dart
-
-Result: ready for review
+${_ansi('38;5;70;1', '✔')} Result: ready for review
+${_ansi('38;5;245', 'Use the MonkeyMux bar to inspect another agent pane.')}
 ''';
   }
   if (tool == AgentLaunchTool.openCode ||
       window.name.toLowerCase().contains('opencode')) {
     return '''
-OpenCode (demo)
-Window ${window.index}: $title
-
-README.md
-  1  # MonkeySSH App Review Demo
-  2
-  3  Local MonkeyMux windows exercise switching,
-  4  SFTP, snippets, and port forwards.
-  5
-  6  App Review can explore without credentials.
-
-NORMAL  utf-8  ~/work/monkeyssh-demo/README.md
+${_ansi('48;5;22;38;5;231;1', ' OpenCode (demo) ')} ${_ansi('38;5;245', 'README.md  Window ${window.index}')}
+${_ansi('38;5;36', '┌ files ─────────────┬ editor ─────────────────────────┐')}
+${_ansi('38;5;36', '│')}  README.md        ${_ansi('38;5;36', '│')}  1  # MonkeySSH App Review Demo        ${_ansi('38;5;36', '│')}
+${_ansi('38;5;36', '│')}  package.json     ${_ansi('38;5;36', '│')}  2                                      ${_ansi('38;5;36', '│')}
+${_ansi('38;5;36', '│')}  src/main.dart     ${_ansi('38;5;36', '│')}  3  Local MonkeyMux windows exercise   ${_ansi('38;5;36', '│')}
+${_ansi('38;5;36', '│')}  logs/app.log      ${_ansi('38;5;36', '│')}  4  switching, SFTP, snippets, tunnels. ${_ansi('38;5;36', '│')}
+${_ansi('38;5;36', '│')}                  ${_ansi('38;5;36', '│')}  5                                      ${_ansi('38;5;36', '│')}
+${_ansi('38;5;36', '│')}                  ${_ansi('38;5;36', '│')}  6  App Review can explore locally.     ${_ansi('38;5;36', '│')}
+${_ansi('38;5;36', '└──────────────────┴──────────────────────────────────┘')}
+${_ansi('48;5;235;38;5;252', ' NORMAL ')} ${_ansi('38;5;245', 'utf-8  ~/work/monkeyssh-demo/README.md')}
 ''';
   }
   if (tool == AgentLaunchTool.codex ||
       window.name.toLowerCase().contains('codex')) {
     return '''
-Codex CLI (demo)
-Window ${window.index}: $title
+${_ansi('38;5;51;1', 'Codex CLI (demo)')} ${_ansi('38;5;245', 'Window ${window.index} · $title')}
+${_ansi('38;5;238', '╭──────────────────────────────────────────────────────╮')}
+${_ansi('38;5;238', '│')} ${_ansi('38;5;231;1', 'Task')} implement local MonkeyMux demo window rendering ${_ansi('38;5;238', '│')}
+${_ansi('38;5;238', '╰──────────────────────────────────────────────────────╯')}
 
-codex --yolo
+${_ansi('38;5;51', 'thinking')} model local windows as an in-memory mux
+${_ansi('38;5;51', 'thinking')} repaint terminal on select/create/close
 
-Task
-  implement local MonkeyMux demo window rendering
+${_ansi('38;5;70', '✓')} service branch added
+${_ansi('38;5;70', '✓')} tests cover create and select
+${_ansi('38;5;70', '✓')} analyzer clean
 
-Reasoning
-  - model windows in memory
-  - repaint the terminal on switch
-  - keep review data local
-
-Patch ready
+${_ansi('48;5;23;38;5;231', ' Patch ready ')}
 ''';
   }
   if (tool == AgentLaunchTool.geminiCli ||
       window.name.toLowerCase().contains('gemini')) {
     return '''
-Gemini CLI (demo)
-Window ${window.index}: $title
+${_ansi('38;5;99;1', '✦ Gemini CLI (demo)')} ${_ansi('38;5;245', 'Window ${window.index} · $title')}
+${_ansi('38;5;99', '╭──────────────── context ────────────────╮')}
+${_ansi('38;5;99', '│')} ${_ansi('38;5;45', '✓')} PRODUCT.md                              ${_ansi('38;5;99', '│')}
+${_ansi('38;5;99', '│')} ${_ansi('38;5;45', '✓')} DESIGN.md                               ${_ansi('38;5;99', '│')}
+${_ansi('38;5;99', '│')} ${_ansi('38;5;45', '✓')} lib/domain/services/                 ${_ansi('38;5;99', '│')}
+${_ansi('38;5;99', '╰──────────────────────────────────────────╯')}
 
-Context loaded:
-  PRODUCT.md
-  DESIGN.md
-  lib/domain/services/
-
-Summary
-  The App Review demo now uses local MonkeyMux state.
+${_ansi('38;5;45;1', 'Summary')}
+  The App Review demo uses local MonkeyMux state.
   Switching windows changes this terminal screen.
+
+${_ansi('38;5;245', 'Ready for another prompt.')}
 ''';
   }
   if (tool == AgentLaunchTool.antigravity ||
       window.name.toLowerCase().contains('antigravity')) {
     return '''
-Antigravity (demo)
-Window ${window.index}: $title
+${_ansi('48;5;54;38;5;231;1', ' Antigravity (demo) ')} ${_ansi('38;5;245', 'Window ${window.index} · $title')}
+${_ansi('38;5;141', '┌ objective ───────────────────────────────────────────┐')}
+${_ansi('38;5;141', '│')} Verify mobile SSH agent workflows from the review device. ${_ansi('38;5;141', '│')}
+${_ansi('38;5;141', '└──────────────────────────────────────────────────────┘')}
 
 Workspace
-  ~/work/monkeyssh-demo
-
-Active objective
-  Verify mobile SSH agent workflows from the review device.
+  ${_ansi('38;5;111', '~/work/monkeyssh-demo')}
 
 Status
-  local demo transport online
-  MonkeyMux navigator online
+  ${_ansi('38;5;70', '●')} local demo transport online
+  ${_ansi('38;5;70', '●')} MonkeyMux navigator online
+  ${_ansi('38;5;70', '●')} window switching changes the visible pane
 ''';
   }
   return '''
-MonkeySSH SFTP / Shell (demo)
-Window ${window.index}: $title
+${_ansi('48;5;236;38;5;231;1', ' MonkeySSH SFTP / Shell (demo) ')} ${_ansi('38;5;245', 'Window ${window.index} · $title')}
 
 $path
 
-  [dir] logs
-  [dir] screenshots
-  [dir] src
-  144B  README.md
-   68B  package.json
-   39B  deploy-demo.sh
+${_ansi('38;5;33', 'drwxr-xr-x')}  logs
+${_ansi('38;5;33', 'drwxr-xr-x')}  screenshots
+${_ansi('38;5;33', 'drwxr-xr-x')}  src
+${_ansi('38;5;245', '-rw-r--r--')}  144  README.md
+${_ansi('38;5;245', '-rw-r--r--')}   68  package.json
+${_ansi('38;5;245', '-rwxr-xr-x')}   39  deploy-demo.sh
 
 Tip:
   Tap the folder button to browse the same sample files in SFTP.

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -3488,6 +3488,7 @@ class SshSession {
         break;
       }
     }
+
     if (lastNonEmpty < 0) {
       return null;
     }
@@ -3963,6 +3964,21 @@ class SshSession {
   }
 }
 
+/// Whether [session] is backed by MonkeySSH's in-app App Review demo transport.
+bool isAppReviewDemoSession(SshSession session) =>
+    session.client is _AppReviewDemoSshClient;
+
+/// Writes synthetic remote output into the App Review demo terminal, if active.
+void writeAppReviewDemoTerminalOutput(SshSession session, String text) {
+  if (!isAppReviewDemoSession(session)) {
+    return;
+  }
+  final shell = session._runtime.shell;
+  if (shell is _AppReviewDemoSshSession) {
+    shell.writeDemoOutput(text);
+  }
+}
+
 class _SshConnectionHealthFailure {
   const _SshConnectionHealthFailure({
     required this.connectionId,
@@ -4380,14 +4396,27 @@ class _AppReviewDemoSshSession implements SSHSession {
   }
 
   void _writePrompt() {
-    _writeText(r'reviewer@monkeyssh-demo:~/work/monkeyssh-demo$ ');
+    _writeText(r'reviewer@demo:~/demo$ ');
   }
 
   void _writeText(String text) {
     if (_closed || _stdoutController.isClosed) {
       return;
     }
-    _stdoutController.add(Uint8List.fromList(utf8.encode(text)));
+    _stdoutController.add(
+      Uint8List.fromList(utf8.encode(_normalizeDemoTerminalOutput(text))),
+    );
+  }
+
+  void writeDemoOutput(String text) {
+    if (_closed) {
+      return;
+    }
+    _writeText('\r\n$text');
+    if (!text.endsWith('\n') && !text.endsWith('\r')) {
+      _writeText('\r\n');
+    }
+    _writePrompt();
   }
 
   Future<void> _finish({int? exitCode}) async {
@@ -4661,15 +4690,24 @@ String _demoInteractiveBanner(Host host) =>
     '''
 \x1b]0;${host.label}\x07\x1b]7;file://localhost/home/reviewer/work/monkeyssh-demo\x07MonkeySSH App Review Demo
 
-Connected to an in-app local demo shell for ${host.label}.
-No external SSH server or private credentials are required.
+Connected locally for:
+  ${host.label}
 
-Sample workspace:
-  /home/reviewer/work/monkeyssh-demo/README.md
+No external SSH server or credentials are required.
 
-Try: ls, pwd, cat README.md, monkeymux windows, copilot
+Sample workspace: ~/work/monkeyssh-demo
+
+Try:
+  ls
+  pwd
+  cat README.md
+  monkeymux windows
+  copilot
 
 ''';
+
+String _normalizeDemoTerminalOutput(String text) =>
+    text.replaceAll('\r\n', '\n').replaceAll('\n', '\r\n');
 
 String _demoInteractiveCommandOutput(String command) {
   final normalized = command.toLowerCase();

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -3969,13 +3969,22 @@ bool isAppReviewDemoSession(SshSession session) =>
     session.client is _AppReviewDemoSshClient;
 
 /// Writes synthetic remote output into the App Review demo terminal, if active.
-void writeAppReviewDemoTerminalOutput(SshSession session, String text) {
+void writeAppReviewDemoTerminalOutput(
+  SshSession session,
+  String text, {
+  bool replaceScreen = false,
+  bool showPrompt = true,
+}) {
   if (!isAppReviewDemoSession(session)) {
     return;
   }
   final shell = session._runtime.shell;
   if (shell is _AppReviewDemoSshSession) {
-    shell.writeDemoOutput(text);
+    shell.writeDemoOutput(
+      text,
+      replaceScreen: replaceScreen,
+      showPrompt: showPrompt,
+    );
   }
 }
 
@@ -4408,15 +4417,25 @@ class _AppReviewDemoSshSession implements SSHSession {
     );
   }
 
-  void writeDemoOutput(String text) {
+  void writeDemoOutput(
+    String text, {
+    bool replaceScreen = false,
+    bool showPrompt = true,
+  }) {
     if (_closed) {
       return;
     }
-    _writeText('\r\n$text');
-    if (!text.endsWith('\n') && !text.endsWith('\r')) {
+    if (replaceScreen) {
+      _writeText('\x1b[2J\x1b[H$text');
+    } else {
+      _writeText('\r\n$text');
+    }
+    if (showPrompt && !text.endsWith('\n') && !text.endsWith('\r')) {
       _writeText('\r\n');
     }
-    _writePrompt();
+    if (showPrompt) {
+      _writePrompt();
+    }
   }
 
   Future<void> _finish({int? exitCode}) async {
@@ -4691,7 +4710,7 @@ String _demoInteractiveBanner(Host host) =>
 \x1b]0;${host.label}\x07\x1b]7;file://localhost/home/reviewer/work/monkeyssh-demo\x07MonkeySSH App Review Demo
 
 Connected locally for:
-  ${host.label}
+  ${_shortDemoHostLabel(host.label)}
 
 No external SSH server or credentials are required.
 
@@ -4705,6 +4724,9 @@ Try:
   copilot
 
 ''';
+
+String _shortDemoHostLabel(String label) =>
+    label.replaceFirst('${AppReviewDemoService.demoHostLabelPrefix} ', '');
 
 String _normalizeDemoTerminalOutput(String text) =>
     text.replaceAll('\r\n', '\n').replaceAll('\n', '\r\n');

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -17,6 +17,7 @@ import '../../data/repositories/known_hosts_repository.dart';
 import '../models/remote_multiplexer.dart';
 import '../models/terminal_preview.dart';
 import '../models/terminal_theme.dart';
+import 'app_review_demo_service.dart';
 import 'background_ssh_service.dart';
 import 'clipboard_sharing_service.dart';
 import 'diagnostics_log_service.dart';
@@ -1442,6 +1443,14 @@ class SshService {
         },
       );
 
+      if (isAppReviewDemoHost(host)) {
+        return _connectToAppReviewDemoHost(
+          host,
+          useHostThemeOverrides: useHostThemeOverrides,
+          onProgress: onProgress,
+        );
+      }
+
       List<SshKey>? cachedAutoKeys;
       var didLoadAutoKeys = false;
       Future<List<SshKey>?> loadAutoKeys() async {
@@ -1629,6 +1638,54 @@ class SshService {
             'Connection setup failed. Check saved credentials and try again.',
       );
     }
+  }
+
+  Future<SshConnectionResult> _connectToAppReviewDemoHost(
+    Host host, {
+    required bool useHostThemeOverrides,
+    ConnectionProgressCallback? onProgress,
+  }) async {
+    onProgress?.call(
+      const ConnectionProgressUpdate(
+        state: SshConnectionState.connecting,
+        message: 'Starting local App Review demo session…',
+      ),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+    onProgress?.call(
+      const ConnectionProgressUpdate(
+        state: SshConnectionState.authenticating,
+        message: 'Preparing in-app demo shell…',
+      ),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+
+    final config = SshConnectionConfig.fromHost(host);
+    final client = _AppReviewDemoSshClient(host);
+    final connectionId = _nextConnectionId++;
+    _sessions[connectionId] = SshSession(
+      connectionId: connectionId,
+      hostId: host.id,
+      client: client,
+      config: config,
+      terminalThemeLightId: useHostThemeOverrides
+          ? host.terminalThemeLightId
+          : null,
+      terminalThemeDarkId: useHostThemeOverrides
+          ? host.terminalThemeDarkId
+          : null,
+    );
+    await hostRepository?.updateLastConnected(host.id);
+    DiagnosticsLogService.instance.info(
+      'ssh.connect',
+      'app_review_demo_connected',
+      fields: {'hostId': host.id, 'connectionId': connectionId},
+    );
+    return SshConnectionResult(
+      success: true,
+      client: client,
+      connectionId: connectionId,
+    );
   }
 
   /// Connect with a configuration.
@@ -4056,6 +4113,687 @@ class _ActiveTunnel {
   // ignore: cancel_subscriptions
   StreamSubscription<dynamic>? subscription;
 }
+
+class _AppReviewDemoSshClient implements SSHClient {
+  _AppReviewDemoSshClient(this.host);
+
+  final Host host;
+  final _done = Completer<void>();
+  bool _isClosed = false;
+  _AppReviewDemoSftpClient? _sftp;
+
+  @override
+  String? get remoteVersion => 'SSH-2.0-MonkeySSH_App_Review_Demo';
+
+  @override
+  bool get isClosed => _isClosed;
+
+  @override
+  Future<void> get done => _done.future;
+
+  @override
+  Future<void> get authenticated => Future<void>.value();
+
+  @override
+  String get username => host.username;
+
+  @override
+  Future<SSHSession> shell({
+    SSHPtyConfig? pty = const SSHPtyConfig(),
+    SSHX11Config? x11,
+    Map<String, String>? environment,
+  }) async => _AppReviewDemoSshSession.interactive(host);
+
+  @override
+  Future<SSHSession> execute(
+    String command, {
+    SSHPtyConfig? pty,
+    SSHX11Config? x11,
+    Map<String, String>? environment,
+  }) async {
+    if (pty != null && _looksLikeLoginShellCommand(command)) {
+      return _AppReviewDemoSshSession.interactive(host);
+    }
+    return _AppReviewDemoSshSession.completed(_demoExecOutput(command));
+  }
+
+  @override
+  Future<SftpClient> sftp() async => _sftp ??= _AppReviewDemoSftpClient();
+
+  @override
+  Future<SSHForwardChannel> forwardLocal(
+    String remoteHost,
+    int remotePort, {
+    String localHost = 'localhost',
+    int localPort = 0,
+  }) async => _AppReviewDemoForwardChannel(
+    remoteHost: remoteHost,
+    remotePort: remotePort,
+  );
+
+  @override
+  Future<SSHRemoteForward?> forwardRemote({
+    String? host,
+    int? port,
+    SSHRemoteConnectionFilter? filter,
+  }) async => null;
+
+  @override
+  Future<Uint8List> run(
+    String command, {
+    bool runInPty = false,
+    bool stdout = true,
+    bool stderr = true,
+    Map<String, String>? environment,
+  }) async => Uint8List.fromList(utf8.encode(_demoExecOutput(command)));
+
+  @override
+  Future<SSHRunResult> runWithResult(
+    String command, {
+    bool runInPty = false,
+    bool stdout = true,
+    bool stderr = true,
+    Map<String, String>? environment,
+  }) async {
+    final output = Uint8List.fromList(utf8.encode(_demoExecOutput(command)));
+    return SSHRunResult(
+      output: output,
+      stdout: stdout ? output : Uint8List(0),
+      stderr: Uint8List(0),
+      exitCode: 0,
+      exitSignal: null,
+    );
+  }
+
+  @override
+  void close() {
+    if (_isClosed) {
+      return;
+    }
+    _isClosed = true;
+    _sftp?.close();
+    if (!_done.isCompleted) {
+      _done.complete();
+    }
+  }
+
+  static bool _looksLikeLoginShellCommand(String command) =>
+      command.contains('COLORTERM=truecolor') ||
+      command.contains('TERM_PROGRAM=kitty') ||
+      command.contains('/bin/sh -lc');
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _AppReviewDemoSshSession implements SSHSession {
+  _AppReviewDemoSshSession._({required this.exitCode})
+    : _stdinController = StreamController<Uint8List>(),
+      _stdoutController = StreamController<Uint8List>(),
+      _stderrController = StreamController<Uint8List>() {
+    _stdinSubscription = _stdinController.stream.listen(_handleInput);
+  }
+
+  factory _AppReviewDemoSshSession.interactive(Host host) {
+    final session = _AppReviewDemoSshSession._(exitCode: null);
+    scheduleMicrotask(() {
+      session
+        .._writeText(_demoInteractiveBanner(host))
+        .._writePrompt();
+    });
+    return session;
+  }
+
+  factory _AppReviewDemoSshSession.completed(String stdout) {
+    final session = _AppReviewDemoSshSession._(exitCode: 0);
+    scheduleMicrotask(() async {
+      if (stdout.isNotEmpty) {
+        session._writeText(stdout);
+      }
+      await session._finish(exitCode: 0);
+    });
+    return session;
+  }
+
+  @override
+  final int? exitCode;
+
+  @override
+  SSHSessionExitSignal? get exitSignal => null;
+
+  late final StreamSubscription<Uint8List> _stdinSubscription;
+  final StreamController<Uint8List> _stdinController;
+  final StreamController<Uint8List> _stdoutController;
+  final StreamController<Uint8List> _stderrController;
+  final _done = Completer<void>();
+  final _exitCompleter = Completer<int?>();
+  final _input = StringBuffer();
+  bool _closed = false;
+
+  @override
+  StreamSink<Uint8List> get stdin => _stdinController.sink;
+
+  @override
+  Stream<Uint8List> get stdout => _stdoutController.stream;
+
+  @override
+  Stream<Uint8List> get stderr => _stderrController.stream;
+
+  @override
+  Future<void> get done => _done.future;
+
+  @override
+  void write(Uint8List data) {
+    if (!_closed) {
+      _handleInput(data);
+    }
+  }
+
+  @override
+  void resizeTerminal(
+    int width,
+    int height, [
+    int pixelWidth = 0,
+    int pixelHeight = 0,
+  ]) {}
+
+  @override
+  void close() {
+    unawaited(_finish(exitCode: exitCode));
+  }
+
+  @override
+  Future<int?> waitForExit({Duration? timeout}) {
+    final future = _exitCompleter.future;
+    return timeout == null
+        ? future
+        : future.timeout(timeout, onTimeout: () => null);
+  }
+
+  @override
+  void kill(SSHSignal signal) {
+    _writeText('^C\r\n');
+    close();
+  }
+
+  void _handleInput(Uint8List data) {
+    if (_closed) {
+      return;
+    }
+    final text = utf8.decode(data, allowMalformed: true);
+    for (var i = 0; i < text.length; i += 1) {
+      final codeUnit = text.codeUnitAt(i);
+      if (codeUnit == 0x03) {
+        _input.clear();
+        _writeText('^C\r\n');
+        _writePrompt();
+        continue;
+      }
+      if (codeUnit == 0x04) {
+        close();
+        continue;
+      }
+      if (codeUnit == 0x7F || codeUnit == 0x08) {
+        final current = _input.toString();
+        if (current.isNotEmpty) {
+          _input
+            ..clear()
+            ..write(current.substring(0, current.length - 1));
+          _writeText('\b \b');
+        }
+        continue;
+      }
+      if (codeUnit == 0x0D || codeUnit == 0x0A) {
+        final command = _input.toString().trim();
+        _input.clear();
+        _writeText('\r\n');
+        _runInteractiveCommand(command);
+        if (!_closed) {
+          _writePrompt();
+        }
+        continue;
+      }
+      if (codeUnit == 0x1B) {
+        continue;
+      }
+      final char = String.fromCharCode(codeUnit);
+      _input.write(char);
+      _writeText(char);
+    }
+  }
+
+  void _runInteractiveCommand(String command) {
+    if (command.isEmpty) {
+      return;
+    }
+    final normalized = command.toLowerCase();
+    if (normalized == 'clear') {
+      _writeText('\x1b[2J\x1b[H');
+      return;
+    }
+    if (normalized == 'exit' || normalized == 'logout') {
+      _writeText('logout\r\n');
+      close();
+      return;
+    }
+    _writeText(_demoInteractiveCommandOutput(command));
+  }
+
+  void _writePrompt() {
+    _writeText(r'reviewer@monkeyssh-demo:~/work/monkeyssh-demo$ ');
+  }
+
+  void _writeText(String text) {
+    if (_closed || _stdoutController.isClosed) {
+      return;
+    }
+    _stdoutController.add(Uint8List.fromList(utf8.encode(text)));
+  }
+
+  Future<void> _finish({int? exitCode}) async {
+    if (_closed) {
+      return;
+    }
+    _closed = true;
+    await _stdinSubscription.cancel();
+    await _stdinController.close();
+    await _stdoutController.close();
+    await _stderrController.close();
+    if (!_exitCompleter.isCompleted) {
+      _exitCompleter.complete(exitCode);
+    }
+    if (!_done.isCompleted) {
+      _done.complete();
+    }
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _AppReviewDemoSftpClient implements SftpClient {
+  _AppReviewDemoSftpClient();
+
+  static const _home = '/home/reviewer';
+  static const _workspace = '/home/reviewer/work/monkeyssh-demo';
+  final _files = Map<String, String>.from(_demoSftpFiles);
+  bool _closed = false;
+
+  @override
+  Future<SftpHandsake> get handshake =>
+      Future<SftpHandsake>.value(SftpHandsake(3, const {}));
+
+  @override
+  Future<String> absolute(String path) async => _normalizeDemoSftpPath(path);
+
+  @override
+  Future<List<SftpName>> listdir(String path) async {
+    final directory = _normalizeDemoSftpPath(path);
+    final entries = <SftpName>[];
+    for (final child in _demoSftpDirectoryChildren(directory)) {
+      final childPath = _joinDemoSftpPath(directory, child);
+      final isDirectory = _demoSftpDirectories.contains(childPath);
+      entries.add(
+        SftpName(
+          filename: child,
+          longname: child,
+          attr: isDirectory
+              ? _demoDirectoryAttrs()
+              : _demoFileAttrs(_files[childPath]?.length ?? 0),
+        ),
+      );
+    }
+    return entries;
+  }
+
+  @override
+  Future<SftpFileAttrs> stat(String path, {bool followLink = true}) async {
+    final normalized = _normalizeDemoSftpPath(path);
+    if (_demoSftpDirectories.contains(normalized)) {
+      return _demoDirectoryAttrs();
+    }
+    final content = _files[normalized];
+    if (content != null) {
+      return _demoFileAttrs(content.length);
+    }
+    throw StateError('No such file: $path');
+  }
+
+  @override
+  Future<SftpFile> open(
+    String path, {
+    SftpFileOpenMode mode = SftpFileOpenMode.read,
+  }) async {
+    final normalized = _normalizeDemoSftpPath(path);
+    _files.putIfAbsent(normalized, () => '');
+    return _AppReviewDemoSftpFile(
+      attrs: _demoFileAttrs(_files[normalized]!.length),
+      readContent: () => _files[normalized] ?? '',
+      writeContent: (value) => _files[normalized] = value,
+    );
+  }
+
+  @override
+  Future<void> mkdir(String path, [SftpFileAttrs? attrs]) async {}
+
+  @override
+  Future<void> rmdir(String dirname) async {}
+
+  @override
+  Future<void> remove(String filename) async {
+    _files.remove(_normalizeDemoSftpPath(filename));
+  }
+
+  @override
+  Future<void> rename(String oldPath, String newPath) async {
+    final oldNormalized = _normalizeDemoSftpPath(oldPath);
+    final content = _files.remove(oldNormalized);
+    if (content != null) {
+      _files[_normalizeDemoSftpPath(newPath)] = content;
+    }
+  }
+
+  @override
+  void close() {
+    _closed = true;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    if (_closed) {
+      throw StateError('Connection closed');
+    }
+    return super.noSuchMethod(invocation);
+  }
+}
+
+class _AppReviewDemoSftpFile implements SftpFile {
+  _AppReviewDemoSftpFile({
+    required SftpFileAttrs attrs,
+    required String Function() readContent,
+    required void Function(String value) writeContent,
+  }) : _attrs = attrs,
+       _readContent = readContent,
+       _writeContent = writeContent;
+
+  final String Function() _readContent;
+  final void Function(String value) _writeContent;
+  SftpFileAttrs _attrs;
+  bool _isClosed = false;
+
+  @override
+  bool get isClosed => _isClosed;
+
+  @override
+  Future<SftpFileAttrs> stat() async => _attrs;
+
+  @override
+  Stream<Uint8List> read({
+    int? length,
+    int offset = 0,
+    void Function(int bytesRead)? onProgress,
+    int chunkSize = 16 * 1024,
+    int maxPendingRequests = 64,
+  }) async* {
+    final bytes = Uint8List.fromList(utf8.encode(_readContent()));
+    final start = offset.clamp(0, bytes.length);
+    final requestedLength = length ?? bytes.length - start;
+    final end = (start + requestedLength).clamp(start, bytes.length);
+    final chunk = Uint8List.sublistView(bytes, start, end);
+    if (chunk.isNotEmpty) {
+      onProgress?.call(chunk.length);
+      yield chunk;
+    }
+  }
+
+  @override
+  Future<Uint8List> readBytes({int? length, int offset = 0}) async {
+    final builder = BytesBuilder(copy: false);
+    await for (final chunk in read(length: length, offset: offset)) {
+      builder.add(chunk);
+    }
+    return builder.takeBytes();
+  }
+
+  @override
+  Future<void> writeBytes(Uint8List data, {int offset = 0}) async {
+    final text = utf8.decode(data, allowMalformed: true);
+    _writeContent(text);
+    _attrs = _demoFileAttrs(text.length);
+  }
+
+  @override
+  Future<void> close() async {
+    _isClosed = true;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _AppReviewDemoForwardChannel implements SSHForwardChannel {
+  _AppReviewDemoForwardChannel({
+    required String remoteHost,
+    required int remotePort,
+  }) : _response = _demoForwardHttpResponse(remoteHost, remotePort) {
+    _sinkController.stream.drain<void>().ignore();
+    scheduleMicrotask(() async {
+      _streamController.add(Uint8List.fromList(utf8.encode(_response)));
+      await close();
+    });
+  }
+
+  final String _response;
+  final _streamController = StreamController<Uint8List>();
+  final _sinkController = StreamController<List<int>>();
+  final _done = Completer<void>();
+  bool _closed = false;
+
+  @override
+  Stream<Uint8List> get stream => _streamController.stream;
+
+  @override
+  StreamSink<List<int>> get sink => _sinkController.sink;
+
+  @override
+  Future<void> get done => _done.future;
+
+  @override
+  Future<void> close() async {
+    if (_closed) {
+      return;
+    }
+    _closed = true;
+    await _sinkController.close();
+    await _streamController.close();
+    if (!_done.isCompleted) {
+      _done.complete();
+    }
+  }
+
+  @override
+  void destroy() {
+    unawaited(close());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+const _demoSftpDirectories = <String>{
+  '/',
+  '/home',
+  '/home/reviewer',
+  '/home/reviewer/work',
+  '/home/reviewer/work/monkeyssh-demo',
+  '/home/reviewer/work/monkeyssh-demo/logs',
+  '/home/reviewer/work/monkeyssh-demo/src',
+  '/home/reviewer/work/monkeyssh-demo/screenshots',
+};
+
+const _demoSftpFiles = <String, String>{
+  '/home/reviewer/work/monkeyssh-demo/README.md': '''
+# MonkeySSH App Review Demo
+
+This is an in-app local demo workspace. It does not require a private SSH
+server, but it behaves like a connected terminal for review.
+''',
+  '/home/reviewer/work/monkeyssh-demo/package.json': '''
+{"scripts":{"dev":"vite --host 127.0.0.1","test":"flutter test"}}
+''',
+  '/home/reviewer/work/monkeyssh-demo/deploy-demo.sh': '''
+#!/bin/sh
+echo "dry-run deploy complete"
+''',
+  '/home/reviewer/work/monkeyssh-demo/logs/app.log': '''
+01:08:22 connected local review shell
+01:08:23 loaded MonkeyMux workspace metadata
+01:08:24 opened sample SFTP tree
+''',
+  '/home/reviewer/work/monkeyssh-demo/src/main.dart': '''
+void main() {
+  print('MonkeySSH App Review Demo');
+}
+''',
+};
+
+String _demoInteractiveBanner(Host host) =>
+    '''
+\x1b]0;${host.label}\x07\x1b]7;file://localhost/home/reviewer/work/monkeyssh-demo\x07MonkeySSH App Review Demo
+
+Connected to an in-app local demo shell for ${host.label}.
+No external SSH server or private credentials are required.
+
+Sample workspace:
+  /home/reviewer/work/monkeyssh-demo/README.md
+
+Try: ls, pwd, cat README.md, monkeymux windows, copilot
+
+''';
+
+String _demoInteractiveCommandOutput(String command) {
+  final normalized = command.toLowerCase();
+  if (normalized == 'pwd') {
+    return '/home/reviewer/work/monkeyssh-demo\r\n';
+  }
+  if (normalized == 'whoami') {
+    return 'reviewer\r\n';
+  }
+  if (normalized == 'ls' || normalized == 'ls -la') {
+    return 'README.md  deploy-demo.sh  logs  package.json  screenshots  src\r\n';
+  }
+  if (normalized == 'cat readme.md' ||
+      normalized == 'cat README.md'.toLowerCase()) {
+    return '${_demoSftpFiles['/home/reviewer/work/monkeyssh-demo/README.md']}\r\n';
+  }
+  if (normalized.contains('monkeymux') || normalized.contains('tmux')) {
+    return '''
+review-workspace
+  0  Copilot CLI     planning App Review notes
+  1  Claude Code    running focused tests
+  2  OpenCode       editing README.md
+  3  SFTP           browsing /home/reviewer/work/monkeyssh-demo
+''';
+  }
+  if (normalized.contains('copilot')) {
+    return '''
+Copilot CLI demo
+  ✓ inspected staged changes
+  ✓ prepared review notes
+  → ready for /deploy
+''';
+  }
+  if (normalized.contains('deploy-demo')) {
+    return 'dry-run deploy complete\r\n';
+  }
+  return 'demo shell: command "$command" completed locally\r\n';
+}
+
+String _demoExecOutput(String command) {
+  final normalized = command.toLowerCase();
+  if (normalized.contains('pwd')) {
+    return '/home/reviewer/work/monkeyssh-demo\n';
+  }
+  if (normalized.contains('tmux') && normalized.contains('list')) {
+    return 'review-workspace: 4 windows\n';
+  }
+  if (normalized.contains('command -v') ||
+      normalized.contains('which ') ||
+      normalized.contains('uname')) {
+    return '';
+  }
+  return '';
+}
+
+String _demoForwardHttpResponse(String remoteHost, int remotePort) {
+  const body = '''
+<!doctype html>
+<title>MonkeySSH App Review Demo</title>
+<h1>MonkeySSH forwarded preview</h1>
+<p>This page was served by the in-app demo tunnel.</p>
+''';
+  return 'HTTP/1.1 200 OK\r\n'
+      'content-type: text/html; charset=utf-8\r\n'
+      'content-length: ${utf8.encode(body).length}\r\n'
+      'connection: close\r\n'
+      '\r\n'
+      '$body';
+}
+
+List<String> _demoSftpDirectoryChildren(String directory) {
+  final children = <String>{};
+  for (final path in [..._demoSftpDirectories, ..._demoSftpFiles.keys]) {
+    if (path == directory || !path.startsWith('$directory/')) {
+      continue;
+    }
+    final remainder = path.substring(
+      directory == '/' ? 1 : directory.length + 1,
+    );
+    if (remainder.isEmpty || remainder.contains('/')) {
+      continue;
+    }
+    children.add(remainder);
+  }
+  return children.toList()..sort();
+}
+
+String _normalizeDemoSftpPath(String input) {
+  var path = input.trim();
+  if (path.isEmpty || path == '.') {
+    return _AppReviewDemoSftpClient._workspace;
+  }
+  if (path == '~') {
+    return _AppReviewDemoSftpClient._home;
+  }
+  if (path.startsWith('~/')) {
+    path = '${_AppReviewDemoSftpClient._home}/${path.substring(2)}';
+  }
+  if (!path.startsWith('/')) {
+    path = '${_AppReviewDemoSftpClient._workspace}/$path';
+  }
+  while (path.contains('//')) {
+    path = path.replaceAll('//', '/');
+  }
+  if (path.length > 1 && path.endsWith('/')) {
+    path = path.substring(0, path.length - 1);
+  }
+  return path;
+}
+
+String _joinDemoSftpPath(String directory, String child) =>
+    directory == '/' ? '/$child' : '$directory/$child';
+
+SftpFileAttrs _demoDirectoryAttrs() => SftpFileAttrs(
+  size: 0,
+  mode: const SftpFileMode.value(0x4000 | 0x01ED),
+  modifyTime: 1783325486,
+);
+
+SftpFileAttrs _demoFileAttrs(int size) => SftpFileAttrs(
+  size: size,
+  mode: const SftpFileMode.value(0x8000 | 0x01A4),
+  modifyTime: 1783325486,
+);
 
 String _telemetryAuthMethodFromHost(Host? host) {
   if (host == null) {

--- a/lib/presentation/screens/app_review_demo_screen.dart
+++ b/lib/presentation/screens/app_review_demo_screen.dart
@@ -43,7 +43,7 @@ class _AppReviewDemoScreenState extends ConsumerState<AppReviewDemoScreen> {
                 icon: Icons.dns_outlined,
                 title: 'Hosts and jump host',
                 description:
-                    'A MonkeyMux workspace, a tmux fallback host, an SFTP host, and a bastion jump host.',
+                    'A MonkeyMux workspace, an agent workspace, an SFTP host, and a bastion jump host.',
               ),
               _DemoFeatureTile(
                 icon: Icons.key_outlined,

--- a/lib/presentation/screens/app_review_demo_screen.dart
+++ b/lib/presentation/screens/app_review_demo_screen.dart
@@ -1,0 +1,429 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../app/routes.dart';
+import '../../app/theme.dart';
+import '../../domain/services/app_review_demo_service.dart';
+import '../providers/entity_list_providers.dart';
+
+/// App Review demo entry point shown from Settings > About.
+class AppReviewDemoScreen extends ConsumerStatefulWidget {
+  /// Creates an App Review demo screen.
+  const AppReviewDemoScreen({super.key});
+
+  @override
+  ConsumerState<AppReviewDemoScreen> createState() =>
+      _AppReviewDemoScreenState();
+}
+
+class _AppReviewDemoScreenState extends ConsumerState<AppReviewDemoScreen> {
+  bool _isPreparing = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final prepared = ref.watch(appReviewDemoPreparedProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('App Review Demo')),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+        children: [
+          _DemoHeaderCard(
+            prepared: prepared.asData?.value ?? false,
+            isPreparing: _isPreparing,
+            onPrepare: () => unawaited(_prepareDemo()),
+          ),
+          const SizedBox(height: 16),
+          const _DemoSection(
+            title: 'What gets loaded',
+            children: [
+              _DemoFeatureTile(
+                icon: Icons.dns_outlined,
+                title: 'Hosts and jump host',
+                description:
+                    'A MonkeyMux workspace, a tmux fallback host, an SFTP host, and a bastion jump host.',
+              ),
+              _DemoFeatureTile(
+                icon: Icons.key_outlined,
+                title: 'Key, snippets, and automation',
+                description:
+                    'A sample SSH key, review snippets, auto-connect review prompts, and coding-agent launch presets.',
+              ),
+              _DemoFeatureTile(
+                icon: Icons.alt_route_outlined,
+                title: 'Tunnels and Pro configuration examples',
+                description:
+                    'Local port-forward rules, host-specific terminal themes, and saved CLI YOLO preferences.',
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          _DemoSection(
+            title: 'Review path',
+            children: [
+              const _DemoInstructionTile(
+                number: '1',
+                title: 'Load the sample workspace',
+                description:
+                    'Tap the primary button above. It only adds local sample data and never contacts an external server.',
+              ),
+              const _DemoInstructionTile(
+                number: '2',
+                title: 'Open the seeded app surfaces',
+                description:
+                    'Use Hosts, Keys, Snippets, and Port Forwards to inspect the pre-populated content.',
+              ),
+              const _DemoInstructionTile(
+                number: '3',
+                title: 'Review connection-dependent controls',
+                description:
+                    'The demo rows show MonkeyMux/tmux startup, SFTP, tunnels, snippets, and Pro-only saved settings without requiring private SSH credentials.',
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  FilledButton.icon(
+                    onPressed: () => context.goNamed(Routes.home),
+                    icon: const Icon(Icons.home_outlined, size: 18),
+                    label: const Text('Open Hosts'),
+                  ),
+                  OutlinedButton.icon(
+                    onPressed: () => context.go('/?tab=connections'),
+                    icon: const Icon(Icons.terminal, size: 18),
+                    label: const Text('Connections'),
+                  ),
+                  OutlinedButton.icon(
+                    onPressed: () => context.pushNamed(Routes.portForwards),
+                    icon: const Icon(Icons.alt_route_outlined, size: 18),
+                    label: const Text('Port Forwards'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          const _DemoTerminalPreview(),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _prepareDemo() async {
+    if (_isPreparing) {
+      return;
+    }
+    setState(() => _isPreparing = true);
+    try {
+      final result = await ref.read(appReviewDemoServiceProvider).prepare();
+      invalidateImportedEntityProviders(ref.invalidate);
+      ref
+        ..invalidate(appReviewDemoPreparedProvider)
+        ..invalidate(appReviewDemoServiceProvider);
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            result.createdAny
+                ? 'App Review demo workspace loaded'
+                : 'App Review demo workspace is already loaded',
+          ),
+        ),
+      );
+    } on Object catch (error, stackTrace) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          library: 'app_review_demo',
+          context: ErrorDescription('while preparing App Review demo content'),
+        ),
+      );
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Could not load App Review demo data')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isPreparing = false);
+      }
+    }
+  }
+}
+
+class _DemoHeaderCard extends StatelessWidget {
+  const _DemoHeaderCard({
+    required this.prepared,
+    required this.isPreparing,
+    required this.onPrepare,
+  });
+
+  final bool prepared;
+  final bool isPreparing;
+  final VoidCallback onPrepare;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 42,
+                  height: 42,
+                  decoration: BoxDecoration(
+                    color: colorScheme.primary.withAlpha(26),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Icon(
+                    Icons.fact_check_outlined,
+                    color: colorScheme.primary,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'offline review workspace',
+                        style: FluttyTheme.displayMono(
+                          fontSize: 16,
+                          color: colorScheme.onSurface,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'Pre-populated local data for App Review. No account, private SSH server, or demo video is required.',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                _StatusPill(prepared: prepared),
+                const Spacer(),
+                FilledButton.icon(
+                  onPressed: isPreparing ? null : onPrepare,
+                  icon: isPreparing
+                      ? const SizedBox.square(
+                          dimension: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.download_for_offline_outlined),
+                  label: Text(prepared ? 'Reload demo data' : 'Load demo data'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusPill extends StatelessWidget {
+  const _StatusPill({required this.prepared});
+
+  final bool prepared;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: prepared
+            ? colorScheme.primary.withAlpha(24)
+            : colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(
+          color: prepared
+              ? colorScheme.primary.withAlpha(120)
+              : colorScheme.outline.withAlpha(120),
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            prepared ? Icons.check_circle_outline : Icons.pending_outlined,
+            size: 15,
+            color: prepared
+                ? colorScheme.primary
+                : colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 6),
+          Text(
+            prepared ? 'Loaded' : 'Not loaded',
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+              color: prepared
+                  ? colorScheme.primary
+                  : colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DemoSection extends StatelessWidget {
+  const _DemoSection({required this.title, required this.children});
+
+  final String title;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+              child: Text(
+                title,
+                style: FluttyTheme.displayMono(
+                  fontSize: 13,
+                  color: colorScheme.onSurface,
+                  letterSpacing: 0,
+                ),
+              ),
+            ),
+            ...children,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DemoFeatureTile extends StatelessWidget {
+  const _DemoFeatureTile({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) => ListTile(
+    leading: Icon(icon),
+    title: Text(title),
+    subtitle: Text(description),
+  );
+}
+
+class _DemoInstructionTile extends StatelessWidget {
+  const _DemoInstructionTile({
+    required this.number,
+    required this.title,
+    required this.description,
+  });
+
+  final String number;
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return ListTile(
+      leading: CircleAvatar(
+        radius: 14,
+        backgroundColor: colorScheme.primary.withAlpha(28),
+        child: Text(
+          number,
+          style: FluttyTheme.monoStyle.copyWith(
+            color: colorScheme.primary,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+      title: Text(title),
+      subtitle: Text(description),
+    );
+  }
+}
+
+class _DemoTerminalPreview extends StatelessWidget {
+  const _DemoTerminalPreview();
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Card(
+      color: const Color(0xFF0D1A20),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: DefaultTextStyle(
+          style: FluttyTheme.monoStyle.copyWith(
+            color: const Color(0xFFD7E7E3),
+            height: 1.45,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(Icons.terminal, size: 18, color: colorScheme.primary),
+                  const SizedBox(width: 8),
+                  Text(
+                    'demo transcript',
+                    style: FluttyTheme.displayMono(
+                      fontSize: 13,
+                      color: const Color(0xFFF0F4F3),
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              const Text(r'$ monkeymux attach review-workspace'),
+              const Text('✓ Copilot CLI · planning changes'),
+              const Text('✓ Claude Code · running tests'),
+              const Text('✓ OpenCode · editing README.md'),
+              const SizedBox(height: 8),
+              Text(
+                'Sample rows loaded by this demo carry the same session, SFTP, theme, and tunnel configuration used by the production UI.',
+                style: FluttyTheme.monoStyle.copyWith(
+                  color: const Color(0xFFAEC6C2),
+                  height: 1.45,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/app_review_demo_screen.dart
+++ b/lib/presentation/screens/app_review_demo_screen.dart
@@ -79,7 +79,7 @@ class _AppReviewDemoScreenState extends ConsumerState<AppReviewDemoScreen> {
                 number: '3',
                 title: 'Review connection-dependent controls',
                 description:
-                    'Tapping a demo host returns here instead of dialing SSH, so review can continue without private credentials.',
+                    'Tap a seeded host to open an in-app local demo shell with sample SFTP files and tunnel responses.',
               ),
               const SizedBox(height: 8),
               Padding(

--- a/lib/presentation/screens/app_review_demo_screen.dart
+++ b/lib/presentation/screens/app_review_demo_screen.dart
@@ -79,29 +79,32 @@ class _AppReviewDemoScreenState extends ConsumerState<AppReviewDemoScreen> {
                 number: '3',
                 title: 'Review connection-dependent controls',
                 description:
-                    'The demo rows show MonkeyMux/tmux startup, SFTP, tunnels, snippets, and Pro-only saved settings without requiring private SSH credentials.',
+                    'Tapping a demo host returns here instead of dialing SSH, so review can continue without private credentials.',
               ),
               const SizedBox(height: 8),
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: [
-                  FilledButton.icon(
-                    onPressed: () => context.goNamed(Routes.home),
-                    icon: const Icon(Icons.home_outlined, size: 18),
-                    label: const Text('Open Hosts'),
-                  ),
-                  OutlinedButton.icon(
-                    onPressed: () => context.go('/?tab=connections'),
-                    icon: const Icon(Icons.terminal, size: 18),
-                    label: const Text('Connections'),
-                  ),
-                  OutlinedButton.icon(
-                    onPressed: () => context.pushNamed(Routes.portForwards),
-                    icon: const Icon(Icons.alt_route_outlined, size: 18),
-                    label: const Text('Port Forwards'),
-                  ),
-                ],
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    FilledButton.icon(
+                      onPressed: () => context.goNamed(Routes.home),
+                      icon: const Icon(Icons.home_outlined, size: 18),
+                      label: const Text('Open Hosts'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: () => context.go('/?tab=connections'),
+                      icon: const Icon(Icons.terminal, size: 18),
+                      label: const Text('Connections'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: () => context.pushNamed(Routes.portForwards),
+                      icon: const Icon(Icons.alt_route_outlined, size: 18),
+                      label: const Text('Port Forwards'),
+                    ),
+                  ],
+                ),
               ),
             ],
           ),

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -7,7 +7,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../app/app_metadata.dart';
-import '../../app/routes.dart';
 import '../../app/theme.dart';
 import '../../data/database/database.dart';
 import '../../data/repositories/host_repository.dart';
@@ -22,7 +21,6 @@ import '../../domain/models/terminal_themes.dart';
 import '../../domain/models/tmux_state.dart';
 import '../../domain/services/agent_launch_preset_service.dart';
 import '../../domain/services/agent_session_discovery_service.dart';
-import '../../domain/services/app_review_demo_service.dart';
 import '../../domain/services/auth_service.dart';
 import '../../domain/services/diagnostics_log_service.dart';
 import '../../domain/services/home_screen_shortcut_service.dart';
@@ -1232,11 +1230,6 @@ class _HostRow extends ConsumerWidget {
   }
 
   Future<void> _openHostConnection(BuildContext context, WidgetRef ref) async {
-    if (isAppReviewDemoHost(host)) {
-      await _openAppReviewDemo(context);
-      return;
-    }
-
     final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
     final connectionIds = sessionsNotifier.getConnectionsForHost(host.id);
 
@@ -1361,11 +1354,6 @@ class _HostRow extends ConsumerWidget {
   }
 
   Future<void> _openNewConnection(BuildContext context, WidgetRef ref) async {
-    if (isAppReviewDemoHost(host)) {
-      await _openAppReviewDemo(context);
-      return;
-    }
-
     final result = await connectToHostWithProgressDialog(context, ref, host);
 
     if (!context.mounted) {
@@ -1385,16 +1373,6 @@ class _HostRow extends ConsumerWidget {
         '/terminal/${host.id}?connectionId=${result.connectionId}',
       );
     }
-  }
-
-  Future<void> _openAppReviewDemo(BuildContext context) async {
-    if (!context.mounted) {
-      return;
-    }
-    await context.pushNamed(
-      Routes.appReviewDemo,
-      queryParameters: {'hostId': host.id.toString()},
-    );
   }
 
   Future<void> _showContextMenu(

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../app/app_metadata.dart';
+import '../../app/routes.dart';
 import '../../app/theme.dart';
 import '../../data/database/database.dart';
 import '../../data/repositories/host_repository.dart';
@@ -21,6 +22,7 @@ import '../../domain/models/terminal_themes.dart';
 import '../../domain/models/tmux_state.dart';
 import '../../domain/services/agent_launch_preset_service.dart';
 import '../../domain/services/agent_session_discovery_service.dart';
+import '../../domain/services/app_review_demo_service.dart';
 import '../../domain/services/auth_service.dart';
 import '../../domain/services/diagnostics_log_service.dart';
 import '../../domain/services/home_screen_shortcut_service.dart';
@@ -1230,6 +1232,11 @@ class _HostRow extends ConsumerWidget {
   }
 
   Future<void> _openHostConnection(BuildContext context, WidgetRef ref) async {
+    if (isAppReviewDemoHost(host)) {
+      await _openAppReviewDemo(context);
+      return;
+    }
+
     final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
     final connectionIds = sessionsNotifier.getConnectionsForHost(host.id);
 
@@ -1354,6 +1361,11 @@ class _HostRow extends ConsumerWidget {
   }
 
   Future<void> _openNewConnection(BuildContext context, WidgetRef ref) async {
+    if (isAppReviewDemoHost(host)) {
+      await _openAppReviewDemo(context);
+      return;
+    }
+
     final result = await connectToHostWithProgressDialog(context, ref, host);
 
     if (!context.mounted) {
@@ -1373,6 +1385,16 @@ class _HostRow extends ConsumerWidget {
         '/terminal/${host.id}?connectionId=${result.connectionId}',
       );
     }
+  }
+
+  Future<void> _openAppReviewDemo(BuildContext context) async {
+    if (!context.mounted) {
+      return;
+    }
+    await context.pushNamed(
+      Routes.appReviewDemo,
+      queryParameters: {'hostId': host.id.toString()},
+    );
   }
 
   Future<void> _showContextMenu(

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -1331,6 +1331,14 @@ class _AboutSection extends ConsumerWidget {
           onTap: () => unawaited(_copyGitHubUrl(context)),
         ),
         ListTile(
+          leading: const Icon(Icons.fact_check_outlined),
+          title: const Text('App Review Demo'),
+          subtitle: const Text(
+            'Load a pre-populated local workspace for review',
+          ),
+          onTap: () => context.pushNamed(Routes.appReviewDemo),
+        ),
+        ListTile(
           leading: const Icon(Icons.description_outlined),
           title: const Text('Licenses'),
           subtitle: const Text('Open source licenses'),

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -7524,6 +7524,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return (command: null, handled: false);
     }
     if (isAppReviewDemoHost(host)) {
+      final sessionName =
+          _initialTmuxSessionName ?? host.tmuxSessionName ?? 'review-workspace';
+      _applyPreparedRemoteMuxCommand(session, (
+        backend: RemoteMuxBackend.monkeyMux,
+        command: 'app-review-demo-monkeymux',
+        sessionName: sessionName,
+        tool: null,
+      ));
       _suppressRemoteMuxDetectionConnectionId = session.connectionId;
       return (command: null, handled: true);
     }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -36,6 +36,7 @@ import '../../domain/models/terminal_themes.dart';
 import '../../domain/models/tmux_state.dart';
 import '../../domain/services/agent_launch_preset_service.dart';
 import '../../domain/services/agent_session_discovery_service.dart';
+import '../../domain/services/app_review_demo_service.dart';
 import '../../domain/services/clipboard_content_service.dart';
 import '../../domain/services/diagnostics_log_service.dart';
 import '../../domain/services/host_cli_launch_preferences_service.dart';
@@ -7521,6 +7522,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final host = _host;
     if (host == null) {
       return (command: null, handled: false);
+    }
+    if (isAppReviewDemoHost(host)) {
+      _suppressRemoteMuxDetectionConnectionId = session.connectionId;
+      return (command: null, handled: true);
     }
 
     final tmuxSession = _initialTmuxSessionName ?? host.tmuxSessionName;

--- a/test/domain/services/app_review_demo_service_test.dart
+++ b/test/domain/services/app_review_demo_service_test.dart
@@ -69,7 +69,7 @@ void main() {
       hosts.map((host) => host.label),
       containsAll([
         'App Review Demo · MonkeyMux workspace',
-        'App Review Demo · tmux fallback',
+        'App Review Demo · MonkeyMux agents',
         'App Review Demo · SFTP and tunnels',
         'App Review Demo · bastion jump host',
       ]),
@@ -85,6 +85,13 @@ void main() {
     expect(workspaceHost.tmuxSessionName, 'review-workspace');
     expect(workspaceHost.terminalThemeDarkId, TerminalThemes.dracula.id);
     expect(workspaceHost.autoConnectRequiresConfirmation, isTrue);
+
+    final agentHost = hosts.singleWhere(
+      (host) => host.label == 'App Review Demo · MonkeyMux agents',
+    );
+    expect(agentHost.remoteMuxBackend, RemoteMuxBackend.monkeyMux.storageValue);
+    expect(agentHost.tmuxSessionName, 'review-agents');
+    expect(agentHost.tmuxExtraFlags, isNull);
 
     final preset = await agentLaunchPresetService.getPresetForHost(
       workspaceHost.id,

--- a/test/domain/services/app_review_demo_service_test.dart
+++ b/test/domain/services/app_review_demo_service_test.dart
@@ -1,0 +1,121 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/data/repositories/group_repository.dart';
+import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/data/repositories/key_repository.dart';
+import 'package:monkeyssh/data/repositories/port_forward_repository.dart';
+import 'package:monkeyssh/data/repositories/snippet_repository.dart';
+import 'package:monkeyssh/data/security/secret_encryption_service.dart';
+import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
+import 'package:monkeyssh/domain/models/remote_multiplexer.dart';
+import 'package:monkeyssh/domain/models/terminal_themes.dart';
+import 'package:monkeyssh/domain/services/agent_launch_preset_service.dart';
+import 'package:monkeyssh/domain/services/app_review_demo_service.dart';
+import 'package:monkeyssh/domain/services/host_cli_launch_preferences_service.dart';
+import 'package:monkeyssh/domain/services/settings_service.dart';
+
+void main() {
+  late AppDatabase database;
+  late AppReviewDemoService service;
+  late HostRepository hostRepository;
+  late KeyRepository keyRepository;
+  late SnippetRepository snippetRepository;
+  late PortForwardRepository portForwardRepository;
+  late AgentLaunchPresetService agentLaunchPresetService;
+  late HostCliLaunchPreferencesService cliLaunchPreferencesService;
+
+  setUp(() {
+    database = AppDatabase.forTesting(NativeDatabase.memory());
+    final encryptionService = SecretEncryptionService.forTesting();
+    final settingsService = SettingsService(database);
+    hostRepository = HostRepository(database, encryptionService);
+    keyRepository = KeyRepository(database, encryptionService);
+    snippetRepository = SnippetRepository(database);
+    portForwardRepository = PortForwardRepository(database);
+    agentLaunchPresetService = AgentLaunchPresetService(settingsService);
+    cliLaunchPreferencesService = HostCliLaunchPreferencesService(
+      settingsService,
+    );
+    service = AppReviewDemoService(
+      groupRepository: GroupRepository(database),
+      hostRepository: hostRepository,
+      keyRepository: keyRepository,
+      snippetRepository: snippetRepository,
+      portForwardRepository: portForwardRepository,
+      agentLaunchPresetService: agentLaunchPresetService,
+      hostCliLaunchPreferencesService: cliLaunchPreferencesService,
+      settingsService: settingsService,
+    );
+  });
+
+  tearDown(() async {
+    await database.close();
+  });
+
+  test('prepare seeds deterministic review data', () async {
+    final result = await service.prepare();
+
+    expect(result.createdHosts, 4);
+    expect(result.createdKeys, 1);
+    expect(result.createdSnippets, 3);
+    expect(result.createdPortForwards, 2);
+    expect(await service.isPrepared(), isTrue);
+
+    final hosts = await hostRepository.getAll();
+    expect(
+      hosts.map((host) => host.label),
+      containsAll([
+        'App Review Demo · MonkeyMux workspace',
+        'App Review Demo · tmux fallback',
+        'App Review Demo · SFTP and tunnels',
+        'App Review Demo · bastion jump host',
+      ]),
+    );
+
+    final workspaceHost = hosts.singleWhere(
+      (host) => host.label == 'App Review Demo · MonkeyMux workspace',
+    );
+    expect(
+      workspaceHost.remoteMuxBackend,
+      RemoteMuxBackend.monkeyMux.storageValue,
+    );
+    expect(workspaceHost.tmuxSessionName, 'review-workspace');
+    expect(workspaceHost.terminalThemeDarkId, TerminalThemes.dracula.id);
+    expect(workspaceHost.autoConnectRequiresConfirmation, isTrue);
+
+    final preset = await agentLaunchPresetService.getPresetForHost(
+      workspaceHost.id,
+    );
+    expect(preset, isNotNull);
+    expect(preset!.tool, AgentLaunchTool.copilotCli);
+    expect(preset.remoteMuxBackend, RemoteMuxBackend.monkeyMux);
+
+    final preferences = await cliLaunchPreferencesService.getPreferencesForHost(
+      workspaceHost.id,
+    );
+    expect(preferences.startInYoloMode, isTrue);
+
+    final portForwards = await portForwardRepository.getAll();
+    expect(portForwards.map((forward) => forward.name), [
+      'Review web preview',
+      'Review API tunnel',
+    ]);
+  });
+
+  test('prepare is idempotent', () async {
+    await service.prepare();
+    final secondResult = await service.prepare();
+
+    expect(secondResult.createdHosts, 0);
+    expect(secondResult.createdKeys, 0);
+    expect(secondResult.createdSnippets, 0);
+    expect(secondResult.createdPortForwards, 0);
+    expect(await hostRepository.getAll(), hasLength(4));
+    expect(await keyRepository.getAll(), hasLength(1));
+    expect(await snippetRepository.getAll(), hasLength(3));
+    expect(await portForwardRepository.getAll(), hasLength(2));
+  });
+}

--- a/test/domain/services/app_review_demo_ssh_service_test.dart
+++ b/test/domain/services/app_review_demo_ssh_service_test.dart
@@ -1,0 +1,71 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:convert';
+
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/data/security/secret_encryption_service.dart';
+import 'package:monkeyssh/domain/services/app_review_demo_service.dart';
+import 'package:monkeyssh/domain/services/ssh_service.dart';
+
+void main() {
+  late AppDatabase database;
+  late SshService service;
+
+  setUp(() {
+    database = AppDatabase.forTesting(NativeDatabase.memory());
+    service = SshService(
+      hostRepository: HostRepository(
+        database,
+        SecretEncryptionService.forTesting(),
+      ),
+    );
+  });
+
+  tearDown(() async {
+    await service.disconnectAll();
+    await database.close();
+  });
+
+  test('connectToHost creates a usable local App Review demo session', () async {
+    final hostId = await database
+        .into(database.hosts)
+        .insert(
+          HostsCompanion.insert(
+            label:
+                '${AppReviewDemoService.demoHostLabelPrefix} MonkeyMux workspace',
+            hostname: '127.0.0.1',
+            port: const Value(2201),
+            username: 'reviewer',
+            tags: const Value('app-review,demo,monkeymux'),
+          ),
+        );
+
+    final result = await service.connectToHost(hostId);
+
+    expect(result.success, isTrue);
+    expect(result.connectionId, isNotNull);
+
+    final session = service.getSession(result.connectionId!);
+    expect(session, isNotNull);
+
+    final shell = await session!.getShell();
+    final banner = await session.shellStdoutStream.first.timeout(
+      const Duration(seconds: 1),
+    );
+    expect(banner, contains('MonkeySSH App Review Demo'));
+
+    shell.write(Uint8List.fromList(utf8.encode('pwd\r')));
+    final pwdOutput = await session.shellStdoutStream.firstWhere(
+      (chunk) => chunk.contains('/home/reviewer/work/monkeyssh-demo'),
+    );
+    expect(pwdOutput, contains('/home/reviewer/work/monkeyssh-demo'));
+
+    final sftp = await session.sftp();
+    final files = await sftp.listdir('/home/reviewer/work/monkeyssh-demo');
+    expect(files.map((file) => file.filename), contains('README.md'));
+  });
+}

--- a/test/domain/services/app_review_demo_ssh_service_test.dart
+++ b/test/domain/services/app_review_demo_ssh_service_test.dart
@@ -80,7 +80,7 @@ void main() {
       ),
     );
     final copilotScreen = session.shellStdoutStream.firstWhere(
-      (chunk) => chunk.contains('GitHub Copilot CLI (demo)'),
+      (chunk) => chunk.contains('GitHub Copilot CLI'),
     );
     final windows = await mux.listWindows(session, 'review-workspace');
     expect(await copilotScreen, contains('Review PR #643'));
@@ -105,7 +105,7 @@ void main() {
     expect(withCodex.singleWhere((window) => window.isActive).name, 'Codex');
 
     final claudeScreen = session.shellStdoutStream.firstWhere(
-      (chunk) => chunk.contains('Claude Code (demo)'),
+      (chunk) => chunk.contains('Claude Code v'),
     );
     await mux.selectWindow(session, 'review-workspace', 1);
     expect(await claudeScreen, contains('Working directory'));

--- a/test/domain/services/app_review_demo_ssh_service_test.dart
+++ b/test/domain/services/app_review_demo_ssh_service_test.dart
@@ -9,6 +9,9 @@ import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/security/secret_encryption_service.dart';
 import 'package:monkeyssh/domain/services/app_review_demo_service.dart';
+import 'package:monkeyssh/domain/services/monkeymux_installer_service.dart';
+import 'package:monkeyssh/domain/services/monkeymux_service.dart';
+import 'package:monkeyssh/domain/services/remote_file_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 
 void main() {
@@ -67,5 +70,37 @@ void main() {
     final sftp = await session.sftp();
     final files = await sftp.listdir('/home/reviewer/work/monkeyssh-demo');
     expect(files.map((file) => file.filename), contains('README.md'));
+
+    final mux = MonkeyMuxService(
+      installer: MonkeyMuxInstallerService(
+        manifestFuture: Future.value(
+          const MonkeyMuxManifest(version: 'demo', entries: []),
+        ),
+        remoteFileService: const RemoteFileService(),
+      ),
+    );
+    final windows = await mux.listWindows(session, 'review-workspace');
+    expect(windows, hasLength(4));
+    expect(
+      windows.singleWhere((window) => window.isActive).name,
+      'Copilot CLI',
+    );
+
+    await mux.createWindow(
+      session,
+      'review-workspace',
+      command: 'codex --yolo',
+      name: 'Codex',
+    );
+    final withCodex = await mux.listWindows(session, 'review-workspace');
+    expect(withCodex, hasLength(5));
+    expect(withCodex.singleWhere((window) => window.isActive).name, 'Codex');
+
+    await mux.selectWindow(session, 'review-workspace', 1);
+    final selected = await mux.listWindows(session, 'review-workspace');
+    expect(
+      selected.singleWhere((window) => window.isActive).name,
+      'Claude Code',
+    );
   });
 }

--- a/test/domain/services/app_review_demo_ssh_service_test.dart
+++ b/test/domain/services/app_review_demo_ssh_service_test.dart
@@ -79,24 +79,36 @@ void main() {
         remoteFileService: const RemoteFileService(),
       ),
     );
+    final copilotScreen = session.shellStdoutStream.firstWhere(
+      (chunk) => chunk.contains('GitHub Copilot CLI (demo)'),
+    );
     final windows = await mux.listWindows(session, 'review-workspace');
+    expect(await copilotScreen, contains('Review PR #643'));
     expect(windows, hasLength(4));
     expect(
       windows.singleWhere((window) => window.isActive).name,
       'Copilot CLI',
     );
 
+    final codexScreen = session.shellStdoutStream.firstWhere(
+      (chunk) => chunk.contains('Codex CLI (demo)'),
+    );
     await mux.createWindow(
       session,
       'review-workspace',
       command: 'codex --yolo',
       name: 'Codex',
     );
+    expect(await codexScreen, contains('Patch ready'));
     final withCodex = await mux.listWindows(session, 'review-workspace');
     expect(withCodex, hasLength(5));
     expect(withCodex.singleWhere((window) => window.isActive).name, 'Codex');
 
+    final claudeScreen = session.shellStdoutStream.firstWhere(
+      (chunk) => chunk.contains('Claude Code (demo)'),
+    );
     await mux.selectWindow(session, 'review-workspace', 1);
+    expect(await claudeScreen, contains('Working directory'));
     final selected = await mux.listWindows(session, 'review-workspace');
     expect(
       selected.singleWhere((window) => window.isActive).name,

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 
-import 'package:monkeyssh/app/routes.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/snippet_repository.dart';
@@ -21,7 +20,6 @@ import 'package:monkeyssh/domain/models/terminal_preview.dart';
 import 'package:monkeyssh/domain/models/terminal_theme.dart';
 import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/domain/services/agent_session_discovery_service.dart';
-import 'package:monkeyssh/domain/services/app_review_demo_service.dart';
 import 'package:monkeyssh/domain/services/home_screen_shortcut_service.dart';
 import 'package:monkeyssh/domain/services/host_cli_launch_preferences_service.dart';
 import 'package:monkeyssh/domain/services/monetization_service.dart';
@@ -577,75 +575,6 @@ void main() {
         find.textContaining('live terminals show up here'),
         findsOneWidget,
       );
-    });
-
-    testWidgets('app review demo host opens the offline demo route', (
-      tester,
-    ) async {
-      final db = AppDatabase.forTesting(NativeDatabase.memory());
-      addTearDown(db.close);
-      final router = GoRouter(
-        initialLocation: '/',
-        routes: [
-          GoRoute(path: '/', builder: (context, state) => const HomeScreen()),
-          GoRoute(
-            path: '/settings/app-review-demo',
-            name: Routes.appReviewDemo,
-            builder: (context, state) => Scaffold(
-              body: Text(
-                'App Review demo ${state.uri.queryParameters['hostId']}',
-              ),
-            ),
-          ),
-        ],
-      );
-      addTearDown(router.dispose);
-
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            databaseProvider.overrideWithValue(db),
-            transferIntentServiceProvider.overrideWith(
-              (ref) => _TestTransferIntentService(),
-            ),
-            homeScreenShortcutServiceProvider.overrideWith(
-              (ref) => _TestHomeScreenShortcutService(),
-            ),
-            pinnedHomeScreenShortcutHostIdsProvider.overrideWith(
-              (ref) => Stream<Set<int>>.value(const <int>{}),
-            ),
-            activeSessionsProvider.overrideWith(
-              _TestActiveSessionsNotifier.new,
-            ),
-            allHostsProvider.overrideWith(
-              (ref) => Stream.value([
-                _buildHost(
-                  id: 42,
-                  label:
-                      '${AppReviewDemoService.demoHostLabelPrefix} MonkeyMux workspace',
-                  sortOrder: 0,
-                  tags: 'app-review,demo,monkeymux',
-                ),
-              ]),
-            ),
-          ],
-          child: MediaQuery(
-            data: const MediaQueryData(size: Size(400, 800)),
-            child: MaterialApp.router(routerConfig: router),
-          ),
-        ),
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
-
-      await tester.tap(
-        find.text(
-          '${AppReviewDemoService.demoHostLabelPrefix} MonkeyMux workspace',
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.text('App Review demo 42'), findsOneWidget);
     });
 
     testWidgets('repeated connection taps push one terminal route', (

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 
+import 'package:monkeyssh/app/routes.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/snippet_repository.dart';
@@ -20,6 +21,7 @@ import 'package:monkeyssh/domain/models/terminal_preview.dart';
 import 'package:monkeyssh/domain/models/terminal_theme.dart';
 import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/domain/services/agent_session_discovery_service.dart';
+import 'package:monkeyssh/domain/services/app_review_demo_service.dart';
 import 'package:monkeyssh/domain/services/home_screen_shortcut_service.dart';
 import 'package:monkeyssh/domain/services/host_cli_launch_preferences_service.dart';
 import 'package:monkeyssh/domain/services/monetization_service.dart';
@@ -304,6 +306,7 @@ Host _buildHost({
   String? tmuxSessionName,
   String? tmuxExtraFlags,
   RemoteMuxBackend? remoteMuxBackend,
+  String? tags,
 }) => Host(
   id: id,
   label: label,
@@ -317,7 +320,7 @@ Host _buildHost({
   isFavorite: false,
   color: null,
   notes: null,
-  tags: null,
+  tags: tags,
   createdAt: DateTime(2026),
   updatedAt: DateTime(2026),
   lastConnectedAt: null,
@@ -574,6 +577,75 @@ void main() {
         find.textContaining('live terminals show up here'),
         findsOneWidget,
       );
+    });
+
+    testWidgets('app review demo host opens the offline demo route', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (context, state) => const HomeScreen()),
+          GoRoute(
+            path: '/settings/app-review-demo',
+            name: Routes.appReviewDemo,
+            builder: (context, state) => Scaffold(
+              body: Text(
+                'App Review demo ${state.uri.queryParameters['hostId']}',
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            transferIntentServiceProvider.overrideWith(
+              (ref) => _TestTransferIntentService(),
+            ),
+            homeScreenShortcutServiceProvider.overrideWith(
+              (ref) => _TestHomeScreenShortcutService(),
+            ),
+            pinnedHomeScreenShortcutHostIdsProvider.overrideWith(
+              (ref) => Stream<Set<int>>.value(const <int>{}),
+            ),
+            activeSessionsProvider.overrideWith(
+              _TestActiveSessionsNotifier.new,
+            ),
+            allHostsProvider.overrideWith(
+              (ref) => Stream.value([
+                _buildHost(
+                  id: 42,
+                  label:
+                      '${AppReviewDemoService.demoHostLabelPrefix} MonkeyMux workspace',
+                  sortOrder: 0,
+                  tags: 'app-review,demo,monkeymux',
+                ),
+              ]),
+            ),
+          ],
+          child: MediaQuery(
+            data: const MediaQueryData(size: Size(400, 800)),
+            child: MaterialApp.router(routerConfig: router),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.tap(
+        find.text(
+          '${AppReviewDemoService.demoHostLabelPrefix} MonkeyMux workspace',
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('App Review demo 42'), findsOneWidget);
     });
 
     testWidgets('repeated connection taps push one terminal route', (

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -488,7 +488,52 @@ void main() {
       expect(find.text('App version'), findsOneWidget);
       expect(find.text('0.1.1 "Allen\'s Swamp Monkey" (123)'), findsOneWidget);
       expect(find.text('GitHub'), findsOneWidget);
+      expect(find.text('App Review Demo'), findsOneWidget);
       expect(find.text('Licenses'), findsOneWidget);
+    });
+
+    testWidgets('navigates to App Review demo from About', (tester) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => const SettingsScreen(),
+          ),
+          GoRoute(
+            path: '/settings/app-review-demo',
+            name: Routes.appReviewDemo,
+            builder: (context, state) =>
+                const Scaffold(body: Text('App Review demo destination')),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            authServiceProvider.overrideWithValue(FakeAuthService()),
+            authStateProvider.overrideWith(MockAuthStateNotifier.new),
+          ],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.text('App Review Demo'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('App Review Demo'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('App Review demo destination'), findsOneWidget);
     });
 
     testWidgets('displays preview metadata when available', (tester) async {


### PR DESCRIPTION
Adds an App Review Demo entry under Settings > About. Reviewers can load deterministic local demo data covering hosts, keys, snippets, MonkeyMux/tmux configuration, SFTP-oriented setup, port forwards, host-specific themes, and launch preferences without private SSH credentials.