### PR TITLE
fix(terminal): honor DECCKM (not DECKPAM) for cursor-key encoding

### DIFF
--- a/test/unit/terminal_cursor_keys_mode_test.dart
+++ b/test/unit/terminal_cursor_keys_mode_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/xterm.dart';
+
+/// Regression tests for arrow/navigation key encoding under the terminal's
+/// cursor-key application mode (DECCKM) vs application keypad mode (DECKPAM).
+///
+/// Windows remotes (PowerShell/PSReadLine) enable application keypad mode while
+/// keeping cursor keys in their normal (CSI) form. Encoding arrows as SS3 in
+/// that state made the shell insert the literal `OA`/`OB`… characters instead
+/// of cycling through history. Arrow encoding must depend on DECCKM only.
+void main() {
+  String? emit(Terminal terminal, TerminalKey key) {
+    final output = <String>[];
+    terminal
+      ..onOutput = output.add
+      ..keyInput(key);
+    return output.isEmpty ? null : output.single;
+  }
+
+  group('cursor keys honor DECCKM, not DECKPAM', () {
+    test('default (both modes off) emits CSI arrows', () {
+      final terminal = Terminal();
+      expect(terminal.cursorKeysMode, isFalse);
+      expect(emit(terminal, TerminalKey.arrowUp), '\x1b[A');
+      expect(emit(terminal, TerminalKey.arrowDown), '\x1b[B');
+      expect(emit(terminal, TerminalKey.arrowRight), '\x1b[C');
+      expect(emit(terminal, TerminalKey.arrowLeft), '\x1b[D');
+      expect(emit(terminal, TerminalKey.home), '\x1b[H');
+      expect(emit(terminal, TerminalKey.end), '\x1b[F');
+    });
+
+    test('DECCKM on emits SS3 arrows', () {
+      final terminal = Terminal()..write('\x1b[?1h');
+      expect(terminal.cursorKeysMode, isTrue);
+      expect(emit(terminal, TerminalKey.arrowUp), '\x1bOA');
+      expect(emit(terminal, TerminalKey.arrowDown), '\x1bOB');
+      expect(emit(terminal, TerminalKey.arrowRight), '\x1bOC');
+      expect(emit(terminal, TerminalKey.arrowLeft), '\x1bOD');
+      expect(emit(terminal, TerminalKey.home), '\x1bOH');
+      expect(emit(terminal, TerminalKey.end), '\x1bOF');
+    });
+
+    test('application keypad mode alone keeps CSI arrows', () {
+      final terminal = Terminal()..write('\x1b=');
+      expect(terminal.appKeypadMode, isTrue);
+      expect(terminal.cursorKeysMode, isFalse);
+      expect(emit(terminal, TerminalKey.arrowUp), '\x1b[A');
+      expect(emit(terminal, TerminalKey.arrowDown), '\x1b[B');
+      expect(emit(terminal, TerminalKey.arrowLeft), '\x1b[D');
+      expect(emit(terminal, TerminalKey.home), '\x1b[H');
+    });
+
+    test('resetting DECCKM restores CSI arrows while keypad stays on', () {
+      // Mirrors an app enabling smkx (`ESC [ ? 1 h ESC =`) then only resetting
+      // cursor-key mode: application keypad mode may linger, but arrows must go
+      // back to CSI so a plain prompt recognizes them.
+      final terminal = Terminal()..write('\x1b[?1h\x1b=\x1b[?1l');
+      expect(terminal.appKeypadMode, isTrue);
+      expect(terminal.cursorKeysMode, isFalse);
+      expect(emit(terminal, TerminalKey.arrowUp), '\x1b[A');
+    });
+
+    test('Enter stays CR regardless of keypad mode', () {
+      final terminal = Terminal()..write('\x1b=');
+      expect(emit(terminal, TerminalKey.enter), '\r');
+    });
+  });
+}

--- a/third_party/xterm/CHANGELOG.md
+++ b/third_party/xterm/CHANGELOG.md
@@ -224,6 +224,18 @@ out of scope.
   image-heavy frames faster than it can draw them, so frames queue and the
   window switch stalls for hundreds of ms. Keep on re-sync.
 
+* Fix: cursor-key application mode. `KeytabInputHandler` derived the keytab
+  `AppCuKeys` flag from `appKeypadMode` (DECKPAM / `ESC =`) instead of
+  `cursorKeysMode` (DECCKM / `CSI ? 1 h`), so `cursorKeysMode` was tracked but
+  never consumed. Arrows/Home/End then emitted SS3 (`ESC O A`) whenever a
+  program turned on application *keypad* mode — even with cursor keys in their
+  normal (CSI) state — and stayed CSI when a program asked for application
+  *cursor* keys alone. Windows PowerShell/PSReadLine enables application keypad
+  mode at the prompt while leaving cursor keys normal, so it received SS3 arrows
+  it never requested and inserted the literal `OA`/`OB`… characters instead of
+  recalling history. `appCursorKeys` now reads `cursorKeysMode`. This is an
+  upstream 4.0.0 bug — keep the `event.state.cursorKeysMode` wiring on re-sync.
+
 
 ## [3.6.1-pre] - 2023-04-28
 * Add Termianl.onPrivateOSC callback

--- a/third_party/xterm/lib/src/core/input/handler.dart
+++ b/third_party/xterm/lib/src/core/input/handler.dart
@@ -139,7 +139,13 @@ class KeytabInputHandler implements TerminalInputHandler {
       alt: event.alt,
       shift: event.shift,
       newLineMode: event.state.lineFeedMode,
-      appCursorKeys: event.state.appKeypadMode,
+      // Cursor-key application mode (DECCKM, `CSI ? 1 h`) — not the application
+      // keypad mode (DECKPAM) — decides whether arrows/Home/End emit SS3 (`ESC
+      // O A`) or CSI (`ESC [ A`). Conflating the two made a program that turned
+      // on application keypad mode alone (e.g. PowerShell/PSReadLine) receive
+      // SS3 arrows it never asked for, so it inserted the literal characters
+      // instead of moving through history.
+      appCursorKeys: event.state.cursorKeysMode,
       appKeyPad: event.state.appKeypadMode,
       appScreen: event.altBuffer,
       macos: event.platform == TerminalTargetPlatform.macos,

--- a/third_party/xterm/test/src/terminal_input_test.dart
+++ b/third_party/xterm/test/src/terminal_input_test.dart
@@ -46,4 +46,55 @@ void main() {
 
     expect(output, ['\n']);
   });
+
+  group('cursor keys application mode (DECCKM)', () {
+    String? emit(Terminal terminal, TerminalKey key) {
+      final output = <String>[];
+      terminal.onOutput = output.add;
+      terminal.keyInput(key);
+      return output.isEmpty ? null : output.single;
+    }
+
+    test('arrows emit CSI form by default', () {
+      final terminal = Terminal();
+      expect(emit(terminal, TerminalKey.arrowUp), '\x1b[A');
+      expect(emit(terminal, TerminalKey.arrowDown), '\x1b[B');
+      expect(emit(terminal, TerminalKey.arrowRight), '\x1b[C');
+      expect(emit(terminal, TerminalKey.arrowLeft), '\x1b[D');
+      expect(emit(terminal, TerminalKey.home), '\x1b[H');
+      expect(emit(terminal, TerminalKey.end), '\x1b[F');
+    });
+
+    test('DECCKM (CSI ? 1 h) switches arrows to SS3 form', () {
+      final terminal = Terminal()..write('\x1b[?1h');
+      expect(terminal.cursorKeysMode, isTrue);
+      expect(emit(terminal, TerminalKey.arrowUp), '\x1bOA');
+      expect(emit(terminal, TerminalKey.arrowDown), '\x1bOB');
+      expect(emit(terminal, TerminalKey.arrowRight), '\x1bOC');
+      expect(emit(terminal, TerminalKey.arrowLeft), '\x1bOD');
+      expect(emit(terminal, TerminalKey.home), '\x1bOH');
+      expect(emit(terminal, TerminalKey.end), '\x1bOF');
+    });
+
+    test('DECKPAM alone keeps arrows in CSI form', () {
+      // Application keypad mode (DECKPAM, `ESC =`) must not turn cursor keys
+      // into their application (SS3) form. PowerShell/PSReadLine enables app
+      // keypad mode while leaving cursor keys normal; emitting SS3 arrows there
+      // made the shell insert the literal characters instead of recalling
+      // history.
+      final terminal = Terminal()..write('\x1b=');
+      expect(terminal.appKeypadMode, isTrue);
+      expect(terminal.cursorKeysMode, isFalse);
+      expect(emit(terminal, TerminalKey.arrowUp), '\x1b[A');
+      expect(emit(terminal, TerminalKey.arrowDown), '\x1b[B');
+      expect(emit(terminal, TerminalKey.home), '\x1b[H');
+    });
+
+    test('resetting DECCKM restores CSI arrows even if keypad stays on', () {
+      final terminal = Terminal()..write('\x1b[?1h\x1b=\x1b[?1l');
+      expect(terminal.appKeypadMode, isTrue);
+      expect(terminal.cursorKeysMode, isFalse);
+      expect(emit(terminal, TerminalKey.arrowUp), '\x1b[A');
+    });
+  });
 }


### PR DESCRIPTION
## Problem

On Windows remotes, pressing **Up** at a PowerShell prompt inserted characters (e.g. `OA`) instead of cycling through history; Enter behaved oddly as a downstream effect of the polluted input line.

## Root cause

The vendored xterm keytab input handler chose the arrow/Home/End escape form (`ESC O A` vs `ESC [ A`) from `appKeypadMode` (**DECKPAM** / `ESC =`) instead of `cursorKeysMode` (**DECCKM** / `CSI ? 1 h`). DECCKM was tracked but never consumed.

PowerShell/PSReadLine enables application **keypad** mode at the prompt while leaving cursor keys in their normal (CSI) state. The conflation made MonkeySSH emit SS3 arrows (`ESC O A`) that PSReadLine never requested — in normal cursor mode it doesn't bind those, so it inserted the literal characters. This is an upstream xterm.dart 4.0.0 bug.

Verified encoding before/after:

| modes | before | after |
|---|---|---|
| none | `ESC[A` ✓ | `ESC[A` ✓ |
| DECCKM on | `ESC[A` ✗ | `ESCOA` ✓ |
| **keypad on only (PowerShell)** | **`ESCOA` ✗** | **`ESC[A` ✓** |

## Fix

Wire `appCursorKeys` to `event.state.cursorKeysMode` so arrows/Home/End follow **DECCKM alone**, matching xterm/iTerm2/Windows Terminal.

## Tests

- New `test/unit/terminal_cursor_keys_mode_test.dart` (runs in CI): DECCKM on → SS3; DECKPAM alone → CSI; DECCKM reset with keypad still on → CSI; Enter stays CR.
- Added matching cases to the vendored `terminal_input_test.dart`.
- Full suite green (2626 passed); analyzer/format clean.
- Documented in the vendored xterm CHANGELOG so it survives upstream re-syncs.

## Notes

The mobile on-screen keyboard toolbar hardcodes CSI arrows regardless of mode, so it is correct at a normal prompt and was not the culprit — the reported symptom is the hardware-keyboard path. Left as-is to avoid unrelated mobile behavior changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
