### PR TITLE
fix(monkeymux): time out control-channel requests so the window switcher cannot hang

### DIFF
--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -129,12 +129,18 @@ class MonkeyMuxService implements RemoteMultiplexerService {
     Duration agentSessionMetadataPeriodicRefreshInterval = const Duration(
       seconds: 10,
     ),
+    @visibleForTesting Duration? controlResponseTimeout,
   }) : _installer = installer,
        _agentSessionMetadataPeriodicRefreshInterval =
-           agentSessionMetadataPeriodicRefreshInterval;
+           agentSessionMetadataPeriodicRefreshInterval,
+       _controlResponseTimeout = controlResponseTimeout;
 
   final MonkeyMuxInstallerService _installer;
   final Duration _agentSessionMetadataPeriodicRefreshInterval;
+
+  /// Overrides the per-command control-response timeout in tests. When null,
+  /// production timeouts based on the command type are used.
+  final Duration? _controlResponseTimeout;
 
   static final _observers =
       <_MonkeyMuxWatchKey, _MonkeyMuxWindowChangeObserver>{};
@@ -306,6 +312,7 @@ class MonkeyMuxService implements RemoteMultiplexerService {
           _observers.remove(key);
           _cancelAgentMetadataPeriodicRefresh(key);
         },
+        controlResponseTimeoutOverride: _controlResponseTimeout,
       ),
     );
     final cachedWindows = _windowSnapshotCache[key];
@@ -1122,6 +1129,7 @@ class _MonkeyMuxWindowChangeObserver {
     required this.onWindowList,
     required this.onWindowSnapshot,
     required this.onDispose,
+    this.controlResponseTimeoutOverride,
   }) : _controller = StreamController<TmuxWindowChangeEvent>.broadcast() {
     _controller
       ..onListen = _ensureStarted
@@ -1134,6 +1142,10 @@ class _MonkeyMuxWindowChangeObserver {
   final ValueChanged<List<TmuxWindow>> onWindowList;
   final ValueChanged<TmuxWindow> onWindowSnapshot;
   final VoidCallback onDispose;
+
+  /// Overrides the per-command control-response timeout in tests. When null,
+  /// production timeouts based on the command type are used.
+  final Duration? controlResponseTimeoutOverride;
   final StreamController<TmuxWindowChangeEvent> _controller;
   final _normalCommandQueue = Queue<_MonkeyMuxControlRequest>();
   final _lowCommandQueue = Queue<_MonkeyMuxControlRequest>();
@@ -1255,12 +1267,35 @@ class _MonkeyMuxWindowChangeObserver {
       _pendingCommands[request.id] = request;
       try {
         controlSession.write(utf8.encode('${jsonEncode(request.payload)}\n'));
+        request.scheduleTimeout(
+          controlResponseTimeoutOverride ??
+              _oneShotResponseTimeout(request.payload),
+          () => _handleRequestTimeout(request),
+        );
       } on Object catch (error, stackTrace) {
         _pendingCommands.remove(request.id);
         _handleError(error, stackTrace);
         Error.throwWithStackTrace(error, stackTrace);
       }
     }
+  }
+
+  void _handleRequestTimeout(_MonkeyMuxControlRequest request) {
+    if (_disposed) return;
+    if (!_pendingCommands.containsKey(request.id)) return;
+    DiagnosticsLogService.instance.warning(
+      'monkeymux.watch',
+      'request_timeout',
+      fields: {'connectionId': session.connectionId},
+    );
+    // A missing response means the shared control channel is wedged: further
+    // commands would also stall. Fail the in-flight requests and recycle the
+    // channel so the next command runs on a fresh session instead of leaving
+    // the UI stuck on a perpetual spinner.
+    _handleError(
+      TimeoutException('MonkeyMux control command timed out.'),
+      StackTrace.current,
+    );
   }
 
   void _handleLine(String line) {
@@ -1421,17 +1456,31 @@ class _MonkeyMuxControlRequest {
   final String id;
   final Map<String, Object?> payload;
   final _completer = Completer<_MonkeyMuxControlResponse>();
+  Timer? _timeoutTimer;
 
   Future<_MonkeyMuxControlResponse> get future => _completer.future;
 
+  /// Arms a one-shot timer that fires when no response arrives in time.
+  ///
+  /// The control channel is shared across commands, so a lost, dropped, or
+  /// unparseable response would otherwise leave this request pending forever
+  /// and stall the window switcher on a perpetual spinner.
+  void scheduleTimeout(Duration timeout, void Function() onTimeout) {
+    _timeoutTimer ??= Timer(timeout, onTimeout);
+  }
+
   void complete(_MonkeyMuxControlResponse response) {
     if (!_completer.isCompleted) {
+      _timeoutTimer?.cancel();
+      _timeoutTimer = null;
       _completer.complete(response);
     }
   }
 
   void completeError(Object error, StackTrace stackTrace) {
     if (!_completer.isCompleted) {
+      _timeoutTimer?.cancel();
+      _timeoutTimer = null;
       _completer.completeError(error, stackTrace);
     }
   }

--- a/test/domain/services/monkeymux_service_test.dart
+++ b/test/domain/services/monkeymux_service_test.dart
@@ -1,10 +1,18 @@
 // ignore_for_file: public_member_api_docs
 
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
 import 'package:monkeyssh/domain/models/remote_multiplexer.dart';
 import 'package:monkeyssh/domain/models/tmux_state.dart';
+import 'package:monkeyssh/domain/services/monkeymux_installer_service.dart';
 import 'package:monkeyssh/domain/services/monkeymux_service.dart';
+import 'package:monkeyssh/domain/services/ssh_service.dart';
 
 void main() {
   group('RemoteMuxBackendPresentation', () {
@@ -396,4 +404,140 @@ void main() {
       expect(windows.single.agentSessionTitle, 'Current Copilot session');
     });
   });
+
+  group('MonkeyMux control channel timeout', () {
+    setUpAll(() => registerFallbackValue(Uint8List(0)));
+
+    test(
+      'listWindows fails instead of hanging when no response arrives',
+      () async {
+        final client = _MockSshClient();
+        final installer = _MockMonkeyMuxInstaller();
+        final session = _buildSession(client, connectionId: 900);
+        // A control channel that opens successfully but never emits a response
+        // line reproduces the stuck window switcher: without a timeout the
+        // request completer would never resolve.
+        final stdoutController = StreamController<Uint8List>();
+        final controlSession = _buildSilentControlSession(stdoutController);
+
+        when(
+          () => installer.ensureInstalled(session),
+        ).thenAnswer((_) async => _fakeInstallation);
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => controlSession);
+
+        final service = MonkeyMuxService(
+          installer: installer,
+          agentSessionMetadataPeriodicRefreshInterval: Duration.zero,
+          controlResponseTimeout: const Duration(milliseconds: 80),
+        );
+
+        // Registering the observer routes listWindows through the persistent
+        // control channel, which is the path that previously lacked a timeout.
+        final stuckReload = (service..watchWindowChanges(session, 'work'))
+            .listWindows(session, 'work');
+
+        await expectLater(stuckReload, throwsA(isA<TimeoutException>()));
+
+        // A subsequent reload succeeds once the control channel responds, proving
+        // the timeout unblocks the window switcher instead of wedging it.
+        final reconnectController = StreamController<Uint8List>();
+        final reconnectSession = _buildRespondingControlSession(
+          reconnectController,
+          window: _fakeWindowJson,
+        );
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => reconnectSession);
+
+        final windows = await service.listWindows(session, 'work');
+        expect(windows, hasLength(1));
+        expect(windows.single.name, 'Codex');
+
+        await reconnectController.close();
+        await stdoutController.close();
+        await service.clearCache(900);
+      },
+    );
+  });
+}
+
+class _MockSshClient extends Mock implements SSHClient {}
+
+class _MockExecSession extends Mock implements SSHSession {}
+
+class _MockByteSink extends Mock implements StreamSink<Uint8List> {}
+
+class _MockMonkeyMuxInstaller extends Mock
+    implements MonkeyMuxInstallerService {}
+
+const _fakeInstallation = MonkeyMuxInstallation(
+  executablePath: '/home/tester/.monkeyssh/bin/monkeymux',
+  platform: 'linux-amd64',
+  version: '0.1.89',
+);
+
+const _fakeWindowJson = <String, Object?>{
+  'id': '@1',
+  'index': 0,
+  'name': 'Codex',
+  'active': true,
+  'currentCommand': 'codex',
+};
+
+SshSession _buildSession(SSHClient client, {int connectionId = 1}) =>
+    SshSession(
+      connectionId: connectionId,
+      hostId: 1,
+      client: client,
+      config: const SshConnectionConfig(
+        hostname: 'example.com',
+        port: 22,
+        username: 'tester',
+      ),
+    );
+
+SSHSession _buildSilentControlSession(
+  StreamController<Uint8List> stdoutController,
+) {
+  final session = _MockExecSession();
+  final stdinSink = _MockByteSink();
+  when(stdinSink.close).thenAnswer((_) async {});
+  when(() => session.stdout).thenAnswer((_) => stdoutController.stream);
+  when(() => session.stderr).thenAnswer((_) => const Stream<Uint8List>.empty());
+  when(() => session.done).thenAnswer((_) => Completer<void>().future);
+  when(() => session.stdin).thenAnswer((_) => stdinSink);
+  when(session.close).thenAnswer((_) {});
+  when(() => session.write(any())).thenAnswer((_) {});
+  return session;
+}
+
+SSHSession _buildRespondingControlSession(
+  StreamController<Uint8List> stdoutController, {
+  required Map<String, Object?> window,
+}) {
+  final session = _MockExecSession();
+  final stdinSink = _MockByteSink();
+  when(stdinSink.close).thenAnswer((_) async {});
+  when(() => session.stdout).thenAnswer((_) => stdoutController.stream);
+  when(() => session.stderr).thenAnswer((_) => const Stream<Uint8List>.empty());
+  when(() => session.done).thenAnswer((_) => Completer<void>().future);
+  when(() => session.stdin).thenAnswer((_) => stdinSink);
+  when(session.close).thenAnswer((_) {});
+  when(() => session.write(any())).thenAnswer((invocation) {
+    final data = invocation.positionalArguments.single as List<int>;
+    final request = jsonDecode(utf8.decode(data)) as Map<String, Object?>;
+    final response = jsonEncode({
+      'id': request['id'],
+      'type': 'window_list',
+      'status': 'ok',
+      'windows': [window],
+    });
+    scheduleMicrotask(
+      () =>
+          stdoutController.add(Uint8List.fromList(utf8.encode('$response\n'))),
+    );
+  });
+  return session;
 }


### PR DESCRIPTION
## Problem

Sometimes a MonkeyMux window gets **stuck on a perpetual loading spinner** in the window switcher. In the reported diagnostics the connection is healthy and MonkeyMux is watching, yet the switcher never renders windows:

- `tmux.ui bar_reload_start ... generation=1` appears, but there is **no** `bar_reload_result` / `bar_reload_failed` / `bar_reload_preserved_previous` afterwards.
- A later reload only logs `bar_reload_queued`, because the first one never released `_loadingWindows`.

## Root cause

`TmuxExpandableBar._loadWindows()` awaits `MonkeyMuxService.listWindows()`, which for an active watch routes through the **persistent control channel** (`_MonkeyMuxWindowChangeObserver.runCommand`). That path awaited the request's response `Completer` with **no timeout**.

The one-shot control path (`_runOneShotControlCommand`) already wraps its read in `.timeout(...)`, but the observer path did not. So if a `list_windows` response is lost — dropped as unparseable in `_handleLine` (lines where `tryParse == null` are silently ignored) or never sent while the channel stays open — the completer never resolves. `listWindows()` hangs forever, `_loadingWindows` stays `true` (blocking all later reloads via the in-flight coalescing), and `_isLoading` never flips to `false` -> infinite spinner.

## Fix

Give the persistent control channel the same bounded lifetime as the one-shot path:

- Arm a per-request timer when a command is written (10s for control commands, 25s for `run_command`, reusing `_oneShotResponseTimeout`).
- On timeout, fail the in-flight requests and **recycle the wedged channel** (via the existing `_handleError` path) so the next command runs on a fresh session and the switcher recovers on its own.
- Cancel the timer whenever a request completes or errors.

This is general: every observer control command (`list_windows`, `query_active_context`, `create_window`, agent-metadata `run_command`, ...) is now bounded.

## Testing

- New regression test `listWindows fails instead of hanging when no response arrives`: a control channel that opens but never responds now makes `listWindows()` error with `TimeoutException` instead of hanging, and a follow-up reload on a responding channel succeeds (proving recovery). Verified it times out at 10s **without** the fix and passes **with** it.
- `flutter analyze` — no issues.
- Full `flutter test` suite green (2676 tests) via the pre-commit hook.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
