### PR TITLE
feat(android): add themed host icon for home-screen shortcuts

### DIFF
--- a/android/app/src/main/res/drawable/ic_shortcut_host_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_shortcut_host_foreground.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Adaptive foreground for host quick-action shortcuts: a white "dns" server
+     glyph (matching the Hosts tab icon) centered within the 108dp safe zone.
+     The teal background and app badge are supplied by the adaptive icon and
+     launcher respectively. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group
+        android:translateX="30"
+        android:translateY="30"
+        android:scaleX="2"
+        android:scaleY="2">
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:pathData="M20,13H4c-0.55,0 -1,0.45 -1,1v6c0,0.55 0.45,1 1,1h16c0.55,0 1,-0.45 1,-1v-6c0,-0.55 -0.45,-1 -1,-1zM7,19c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM20,3H4c-0.55,0 -1,0.45 -1,1v6c0,0.55 0.45,1 1,1h16c0.55,0 1,-0.45 1,-1V4c0,-0.55 -0.45,-1 -1,-1zM7,9c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2z" />
+    </group>
+</vector>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_shortcut_host.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_shortcut_host.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Adaptive icon (API 26+) for host quick-action shortcuts. Uses the shared
+     MonkeySSH brand teal so the shortcut reads as ours; the launcher masks it
+     to the device icon shape and badges it with the app icon when pinned. -->
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+  <background android:drawable="@color/ic_launcher_background"/>
+  <foreground android:drawable="@drawable/ic_shortcut_host_foreground"/>
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap/ic_shortcut_host.xml
+++ b/android/app/src/main/res/mipmap/ic_shortcut_host.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Legacy fallback (API 24/25, which predate adaptive icons) for host
+     quick-action shortcuts: a MonkeySSH-teal rounded square with the white
+     "dns" server glyph. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="@color/ic_launcher_background"
+        android:pathData="M28,6h52a22,22 0 0 1 22,22v52a22,22 0 0 1 -22,22h-52a22,22 0 0 1 -22,-22v-52a22,22 0 0 1 22,-22z" />
+    <group
+        android:translateX="30"
+        android:translateY="30"
+        android:scaleX="2"
+        android:scaleY="2">
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:pathData="M20,13H4c-0.55,0 -1,0.45 -1,1v6c0,0.55 0.45,1 1,1h16c0.55,0 1,-0.45 1,-1v-6c0,-0.55 -0.45,-1 -1,-1zM7,19c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM20,3H4c-0.55,0 -1,0.45 -1,1v6c0,0.55 0.45,1 1,1h16c0.55,0 1,-0.45 1,-1V4c0,-0.55 -0.45,-1 -1,-1zM7,9c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2z" />
+    </group>
+</vector>

--- a/android/app/src/main/res/raw/keep.xml
+++ b/android/app/src/main/res/raw/keep.xml
@@ -3,11 +3,16 @@
   Keep the host home-screen shortcut icon from being removed by the release
   resource shrinker.
 
-  These resources are referenced only at runtime by name (the quick_actions
-  plugin resolves ShortcutItem.icon via Resources.getIdentifier), and that name
-  originates as a Dart string. The Android resource shrinker cannot see that
-  reference, so it marks the icon "not reachable" and strips it from release
-  builds — which is why the shortcut shows a blank icon. Explicitly keep it.
+  Flutter's Gradle plugin enables resource shrinking for release builds
+  (FlutterPlugin sets isMinifyEnabled/isShrinkResources on the release build
+  type), so it is on even though this project's build.gradle.kts does not set
+  it explicitly.
+
+  The shortcut icon is referenced only at runtime by name: the quick_actions
+  plugin resolves ShortcutItem.icon via Resources.getIdentifier, and that name
+  originates as a Dart string. The resource shrinker cannot see that reference,
+  so in release builds it marks the icon "not reachable" and strips it, leaving
+  the shortcut with a blank icon. Explicitly keep it here.
 -->
 <resources xmlns:tools="http://schemas.android.com/tools"
     tools:keep="@mipmap/ic_shortcut_host,@drawable/ic_shortcut_host_foreground" />

--- a/android/app/src/main/res/raw/keep.xml
+++ b/android/app/src/main/res/raw/keep.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Keep the host home-screen shortcut icon from being removed by the release
+  resource shrinker.
+
+  These resources are referenced only at runtime by name (the quick_actions
+  plugin resolves ShortcutItem.icon via Resources.getIdentifier), and that name
+  originates as a Dart string. The Android resource shrinker cannot see that
+  reference, so it marks the icon "not reachable" and strips it from release
+  builds — which is why the shortcut shows a blank icon. Explicitly keep it.
+-->
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@mipmap/ic_shortcut_host,@drawable/ic_shortcut_host_foreground" />

--- a/lib/domain/services/home_screen_shortcut_service.dart
+++ b/lib/domain/services/home_screen_shortcut_service.dart
@@ -16,11 +16,31 @@ const homeScreenShortcutHostTypePrefix = 'host:';
 /// Maximum number of hosts surfaced in the app icon's quick actions.
 const maxHomeScreenShortcutItems = 4;
 
+/// Android drawable/mipmap resource name used as the icon for host
+/// home-screen shortcuts.
+///
+/// The `quick_actions` Android plugin resolves this via
+/// `Resources.getIdentifier(name, "drawable"|"mipmap", ...)`. The resource is
+/// a MonkeySSH-teal server glyph; launchers badge pinned shortcuts with the
+/// app icon automatically.
+const homeScreenShortcutHostIconResourceName = 'ic_shortcut_host';
+
 /// Whether the current platform supports app-icon home-screen shortcuts.
 bool get supportsHomeScreenShortcutActions =>
     !kIsWeb &&
     (defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS);
+
+/// The native shortcut icon name for host shortcuts, or `null` when the
+/// current platform bundles no themed host icon.
+///
+/// Only Android ships a themed host icon
+/// ([homeScreenShortcutHostIconResourceName]). iOS resolves the icon from the
+/// asset catalog, where none is bundled, so it keeps the system default.
+String? get homeScreenShortcutHostIconName =>
+    !kIsWeb && defaultTargetPlatform == TargetPlatform.android
+    ? homeScreenShortcutHostIconResourceName
+    : null;
 
 /// Builds the platform shortcut payload for a host ID.
 String buildHomeScreenShortcutHostType(int hostId) {
@@ -151,12 +171,20 @@ String _buildHomeScreenShortcutSubtitle(Host host) {
 }
 
 /// Builds the platform shortcut items for the selected hosts.
-List<ShortcutItem> buildHomeScreenShortcutItems(Iterable<Host> hosts) => hosts
+///
+/// [iconName] is the optional native icon resource name applied to every item;
+/// pass [homeScreenShortcutHostIconName] to use the themed host icon where the
+/// platform bundles one.
+List<ShortcutItem> buildHomeScreenShortcutItems(
+  Iterable<Host> hosts, {
+  String? iconName,
+}) => hosts
     .map(
       (host) => ShortcutItem(
         type: buildHomeScreenShortcutHostType(host.id),
         localizedTitle: host.label,
         localizedSubtitle: _buildHomeScreenShortcutSubtitle(host),
+        icon: iconName,
       ),
     )
     .toList(growable: false);
@@ -251,6 +279,7 @@ class HomeScreenShortcutService {
     await initialize();
     final shortcutItems = buildHomeScreenShortcutItems(
       selectHomeScreenShortcutHosts(hosts, pinnedHostIds: pinnedHostIds),
+      iconName: homeScreenShortcutHostIconName,
     );
 
     try {

--- a/test/domain/services/home_screen_shortcut_service_test.dart
+++ b/test/domain/services/home_screen_shortcut_service_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: public_member_api_docs, avoid_redundant_argument_values
 
 import 'package:drift/native.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:monkeyssh/data/database/database.dart';
@@ -111,6 +112,40 @@ void main() {
         shortcutItems.last.localizedSubtitle,
         'root@beta.example.com:2202',
       );
+    });
+
+    test('omits an icon when no icon name is provided', () {
+      final shortcutItems = buildHomeScreenShortcutItems(<Host>[
+        _buildHost(id: 1, label: 'alpha', sortOrder: 0),
+      ]);
+
+      expect(shortcutItems.single.icon, isNull);
+    });
+
+    test('applies the provided icon name to every shortcut item', () {
+      final shortcutItems = buildHomeScreenShortcutItems(<Host>[
+        _buildHost(id: 1, label: 'alpha', sortOrder: 0),
+        _buildHost(id: 2, label: 'beta', sortOrder: 1),
+      ], iconName: homeScreenShortcutHostIconResourceName);
+
+      expect(
+        shortcutItems.map((item) => item.icon),
+        everyElement(equals('ic_shortcut_host')),
+      );
+    });
+  });
+
+  group('home screen shortcut host icon name', () {
+    tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    test('is the Android drawable resource on Android', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      expect(homeScreenShortcutHostIconName, 'ic_shortcut_host');
+    });
+
+    test('is null on iOS (no bundled asset-catalog icon)', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      expect(homeScreenShortcutHostIconName, isNull);
     });
   });
 


### PR DESCRIPTION
## Problem
On Android, host home-screen shortcuts (the `quick_actions` app shortcuts) showed **no icon** — just a blank/generic placeholder in the long-press menu and when pinned to the home screen.

## Fix
Add a MonkeySSH-branded **host icon**: a white server (`dns`) glyph — the same mark the **Hosts** tab uses — on the brand teal (`#14756c`, shared with the launcher icon background).

- `mipmap-anydpi-v26/ic_shortcut_host.xml` — adaptive icon (API 26+): teal background + server foreground, masked to the device icon shape.
- `drawable/ic_shortcut_host_foreground.xml` — the white `dns` glyph, centered in the adaptive safe zone.
- `mipmap/ic_shortcut_host.xml` — legacy vector fallback for API 24/25 (predates adaptive icons).
- Dart: `ShortcutItem.icon` is now set to `ic_shortcut_host`, gated to Android via `homeScreenShortcutHostIconName`.

The `quick_actions` Android plugin resolves the icon by name (`getIdentifier(..., "drawable"|"mipmap")`). The resource is named so the `drawable` lookup misses and the `mipmap` (adaptive) variant is used.

### On badging with the MonkeySSH logo
The launcher does this automatically: when a shortcut is **pinned to the home screen** as its own icon, Android overlays the app's launcher icon (the monkey) as a corner **badge** — no work needed on our side. In the long-press app-shortcut popup it shows unbadged. That's why the icon itself is a plain host glyph rather than the monkey; baking the monkey in would double up once the launcher badges it.

### iOS
Left unchanged — iOS resolves shortcut icons from the asset catalog (none bundled), so `homeScreenShortcutHostIconName` returns `null` there and iOS keeps the system default.

## Testing
- `flutter analyze` — clean.
- `flutter test test/domain/services/home_screen_shortcut_service_test.dart` — 13 passed (added icon-wiring + per-platform icon-name tests).
- Full suite via pre-commit hook — 2630 passed.
- `flutter build apk --debug --flavor private` — AAPT2 parses the vectors/adaptive icon; verified `mipmap/ic_shortcut_host` (default + `anydpi-v26`) is packaged in the APK.