### PR TITLE
chore(deps): update dependencies to latest resolvable versions

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -261,10 +261,10 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "6cc0b623c0e83f7080524d8396e9301b1d78b9c66a4fdceeb0f798211303254c"
+      sha256: c21b9af62e78f86837638dda6c33506bd9444ca8a32cad2b99c07369cf9e2462
       url: "https://pub.dev"
     source: hosted
-    version: "2.34.0"
+    version: "2.34.1"
   drift_dev:
     dependency: "direct dev"
     description:
@@ -277,10 +277,10 @@ packages:
     dependency: "direct main"
     description:
       name: equatable
-      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -1373,7 +1373,7 @@ packages:
     source: hosted
     version: "0.6.0+eol"
   sqlparser:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: sqlparser
       sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
@@ -1608,10 +1608,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_platform_interface
-      sha256: e4ae5bc934b528e5b95c5e47be2812860186260cd3eed3ac62f5ed380fdd1613
+      sha256: "92c0fbabe20c788e71fd10d26cea998d0d253282e65d145aed0818731cf593ce"
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.0"
+    version: "6.9.0"
   video_player_web:
     dependency: transitive
     description:
@@ -1696,10 +1696,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter
-      sha256: e4d3474277c5043f5f3100ed27d94ad693abfd5c602b0221c719a4497e4ba1e4
+      sha256: d53e1ccf5516f25017e3c9d44c39034db352d20fa34fe200674270242c2c5111
       url: "https://pub.dev"
     source: hosted
-    version: "4.14.0"
+    version: "4.14.1"
   webview_flutter_android:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   go_router: ^17.2.3
   
   # Database
-  drift: ^2.34.0
+  drift: ^2.34.1
   sqlite3_flutter_libs: ^0.6.0+eol
   path_provider: ^2.1.6
   path: ^1.9.1
@@ -58,14 +58,14 @@ dependencies:
   flutter_svg: ^2.3.0
   google_fonts: ^8.1.0
   flutter_local_notifications: ^22.0.1
-  webview_flutter: ^4.14.0
+  webview_flutter: ^4.14.1
   webview_flutter_android: ^4.12.0
   
   # Utilities
   uuid: ^4.5.3
   intl: ^0.20.3
   collection: ^1.19.1
-  equatable: ^2.0.7
+  equatable: ^2.1.0
   pasteboard: ^0.5.0
   url_launcher: ^6.3.2
   package_info_plus: ^10.2.0
@@ -94,6 +94,11 @@ dev_dependencies:
   # Code generation
   build_runner: ^2.15.0
   drift_dev: ^2.31.0
+  # Pin: the current Flutter SDK caps analyzer at 12.x, so drift_dev is held at
+  # 2.34.0 (2.34.1+ needs analyzer ^13). drift_dev 2.34.0 calls
+  # DartPlaceholder.when(), which sqlparser removed in 0.44.6, so keep sqlparser
+  # at 0.44.5. Remove this pin once a newer Flutter SDK unblocks drift_dev.
+  sqlparser: 0.44.5
   
   # Testing
   mocktail: ^1.0.4


### PR DESCRIPTION
## Summary

Updates all direct dependencies to the newest versions resolvable under the current Flutter SDK (Dart 3.12.2).

| Package | From | To |
|---|---|---|
| drift | 2.34.0 | 2.34.1 |
| equatable | 2.0.7 | 2.1.0 |
| webview_flutter | 4.14.0 | 4.14.1 |
| video_player_platform_interface (transitive) | 6.8.0 | 6.9.0 |

### sqlparser pin

`sqlparser` is pinned to `0.44.5`. The current Flutter SDK caps `analyzer` at 12.x, which holds `drift_dev` at 2.34.0. That version calls `DartPlaceholder.when()`, removed in `sqlparser` 0.44.6, so bumping sqlparser breaks `build_runner` codegen. The pin is documented inline and should be removed once a newer Flutter SDK unblocks `drift_dev`.

## What is *not* updated (and why)

The remaining ~15 outdated packages (`analyzer`, `drift_dev` 2.34.2+, `dart_style`, `_fe_analyzer_shared`, `meta`, `matcher`, `vector_math`, `package_config`, `cli_util`, `test`, `flutter_secure_storage_darwin`, ...) are transitively blocked by the Flutter SDK's hard pins in `flutter_test` (`test_api 0.7.11`, `meta`, `matcher`, `vector_math`), which cap `analyzer < 13`. Lifting these requires **Flutter beta 3.46 (Dart 3.13)**; the newest *stable* (3.44.5) ships the same Dart 3.12.2 and changes nothing. Deferred until 3.46 reaches stable.

## Verification

- `flutter pub get` — resolves cleanly
- `dart run build_runner build` — succeeds, no generated-file changes
- `flutter analyze` — No issues found
- `flutter test` — all 2695 tests pass

Only `pubspec.yaml` and `pubspec.lock` changed.
