### PR TITLE
fix(ios): unblock restore with no purchase and stop duplicate store screenshots

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -546,6 +546,12 @@ platform :ios do
       screenshots_path: SCREENSHOTS_PATH,
       skip_binary_upload: true,
       skip_screenshots: false,
+      # Clear previously uploaded screenshots and app previews before
+      # uploading the current set. Without this, deliver *appends* the new
+      # screenshots to whatever is already on App Store Connect, so each sync
+      # leaves stale screenshots from older versions behind and the listing
+      # ends up with duplicates from different versions.
+      overwrite_screenshots: true,
       submit_for_review: false,
       run_precheck_before_submit: false,
       automatic_release: false,

--- a/lib/domain/services/monetization_service.dart
+++ b/lib/domain/services/monetization_service.dart
@@ -12,6 +12,7 @@ import 'package:in_app_purchase_storekit/store_kit_wrappers.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import '../models/monetization.dart';
+import 'diagnostics_log_service.dart';
 import 'settings_service.dart';
 
 const _lifetimeAlreadyActiveMessage =
@@ -30,13 +31,17 @@ class MonetizationService {
     bool? allowDebugUnlock,
     Duration purchaseTimeout = const Duration(seconds: 60),
     Duration restoreTimeout = const Duration(seconds: 45),
+    Duration restoreEmptyResultGracePeriod = const Duration(seconds: 2),
     Future<String> Function()? packageNameLoader,
+    DiagnosticsLogger? diagnostics,
   }) : _inAppPurchase = inAppPurchase ?? InAppPurchase.instance,
        _androidPlatformAddition = androidPlatformAddition,
        _allowDebugUnlock = allowDebugUnlock ?? kDebugMode,
        _purchaseTimeout = purchaseTimeout,
        _restoreTimeout = restoreTimeout,
-       _packageNameLoader = packageNameLoader ?? _loadPackageName;
+       _restoreEmptyResultGracePeriod = restoreEmptyResultGracePeriod,
+       _packageNameLoader = packageNameLoader ?? _loadPackageName,
+       _diagnostics = diagnostics ?? DiagnosticsLogService.instance;
 
   final SettingsService _settings;
   final InAppPurchase _inAppPurchase;
@@ -44,7 +49,15 @@ class MonetizationService {
   final bool _allowDebugUnlock;
   final Duration _purchaseTimeout;
   final Duration _restoreTimeout;
+  // Grace period to wait after an Apple restore finishes before concluding
+  // that there was nothing to restore. StoreKit delivers restored
+  // transactions through the purchase stream on a channel separate from the
+  // `restorePurchases` reply, so this absorbs that cross-channel delivery lag
+  // instead of blocking on the full [_restoreTimeout].
+  final Duration _restoreEmptyResultGracePeriod;
   final Future<String> Function() _packageNameLoader;
+  final DiagnosticsLogger _diagnostics;
+  Timer? _restoreEmptyResultTimer;
   final _controller = StreamController<MonetizationState>.broadcast();
   final _purchaseOptionsByOfferId = <String, _MonetizationPurchaseOption>{};
 
@@ -183,13 +196,19 @@ class MonetizationService {
       return;
     }
 
+    final requestedProductIds = await _productIdsForCurrentStorefront();
     final response = await _inAppPurchase.queryProductDetails(
-      await _productIdsForCurrentStorefront(),
+      requestedProductIds,
     );
     final catalog = _buildMonetizationCatalog(response.productDetails);
     _purchaseOptionsByOfferId
       ..clear()
       ..addAll(catalog.purchaseOptionsByOfferId);
+    _logCatalogLoaded(
+      requestedProductIds: requestedProductIds,
+      response: response,
+      offers: catalog.offers,
+    );
 
     _emit(
       _state.copyWith(
@@ -200,6 +219,40 @@ class MonetizationService {
             ? null
             : 'Could not load purchase options. Try again.',
       ),
+    );
+  }
+
+  /// Records a safe, primitive breadcrumb describing which store products the
+  /// current storefront actually returned.
+  ///
+  /// This deliberately logs only counts and booleans (never product IDs,
+  /// prices, or any user content) so a diagnostics export can reveal cases
+  /// where the store omits an expected plan — for example an App Store
+  /// subscription that is not in a returnable state, which surfaces in the app
+  /// as a paywall that is missing its monthly or annual option.
+  void _logCatalogLoaded({
+    required Set<String> requestedProductIds,
+    required ProductDetailsResponse response,
+    required List<MonetizationOffer> offers,
+  }) {
+    final billingPeriods = offers.map((offer) => offer.billingPeriod).toSet();
+    _diagnostics.info(
+      'monetization',
+      'catalog_loaded',
+      fields: {
+        'platform': defaultTargetPlatform.name,
+        'requestedCount': requestedProductIds.length,
+        'loadedProductCount': response.productDetails.length,
+        'offerCount': offers.length,
+        'notFoundCount': response.notFoundIDs.length,
+        'hasError': response.error != null,
+        'monthlyLoaded': billingPeriods.contains(
+          MonetizationBillingPeriod.monthly,
+        ),
+        'annualLoaded': billingPeriods.contains(
+          MonetizationBillingPeriod.annual,
+        ),
+      },
     );
   }
 
@@ -337,11 +390,28 @@ class MonetizationService {
     _restoreInFlight = true;
     _restoreObservedPurchaseUpdate = false;
     _emit(_state.copyWith(isLoading: true, lastError: null));
-    await _inAppPurchase.restorePurchases();
+    try {
+      await _inAppPurchase.restorePurchases();
+    } on Object catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('restorePurchases failed: $error\n$stackTrace');
+      }
+    }
+
+    // StoreKit has finished the restore/sync by the time the call above
+    // completes. A real subscription restore delivers its transaction through
+    // the purchase stream (which resolves [completer]). When there is nothing
+    // to restore, StoreKit1 emits an empty purchase list and StoreKit2 emits
+    // nothing at all, so give any in-flight stream event a brief moment to be
+    // processed and then finalize as "nothing to restore" instead of blocking
+    // on the full restore timeout.
+    _scheduleEmptyRestoreFinalization(completer);
 
     return completer.future.timeout(
       _restoreTimeout,
       onTimeout: () async {
+        _restoreEmptyResultTimer?.cancel();
+        _restoreEmptyResultTimer = null;
         _pendingPurchaseResult = null;
         _pendingOfferId = null;
         _pendingPurchaseFlowStarted = false;
@@ -358,6 +428,45 @@ class MonetizationService {
           _noActiveStorePurchaseMessage,
         );
       },
+    );
+  }
+
+  void _scheduleEmptyRestoreFinalization(
+    Completer<MonetizationActionResult> completer,
+  ) {
+    _restoreEmptyResultTimer?.cancel();
+    _restoreEmptyResultTimer = Timer(_restoreEmptyResultGracePeriod, () {
+      _restoreEmptyResultTimer = null;
+      if (_pendingPurchaseResult == completer) {
+        unawaited(_finishRestoreWithoutPurchases());
+      }
+    });
+  }
+
+  /// Resolves a pending Apple restore that produced no restorable purchases.
+  ///
+  /// Clears any stale cached subscription entitlement (preserving a lifetime
+  /// unlock) and completes the pending action with the no-purchase message.
+  /// No-ops if a purchase update was already observed so the normal
+  /// purchase-handling path can resolve the restore instead.
+  Future<void> _finishRestoreWithoutPurchases() async {
+    _restoreEmptyResultTimer?.cancel();
+    _restoreEmptyResultTimer = null;
+    final completer = _pendingPurchaseResult;
+    if (completer == null ||
+        completer.isCompleted ||
+        !_restoreInFlight ||
+        _restoreObservedPurchaseUpdate) {
+      return;
+    }
+    await _clearCachedStoreEntitlement(preserveLifetime: true);
+    // A restored transaction may have arrived while clearing; if so, let the
+    // purchase-handling path resolve the restore with the real entitlement.
+    if (_restoreObservedPurchaseUpdate) {
+      return;
+    }
+    _resolvePendingPurchase(
+      const MonetizationActionResult.failure(_noActiveStorePurchaseMessage),
     );
   }
 
@@ -386,6 +495,8 @@ class MonetizationService {
 
   /// Releases store listeners held by this service.
   Future<void> dispose() async {
+    _restoreEmptyResultTimer?.cancel();
+    _restoreEmptyResultTimer = null;
     await _purchaseSubscription?.cancel();
     await _controller.close();
   }
@@ -396,6 +507,13 @@ class MonetizationService {
       defaultTargetPlatform == TargetPlatform.macOS;
 
   void _handlePurchaseUpdates(List<PurchaseDetails> purchases) {
+    if (purchases.isEmpty) {
+      // StoreKit1 emits an empty list when a restore finishes with no
+      // transactions to restore. Resolve the pending restore right away
+      // instead of waiting for the restore timeout to elapse.
+      unawaited(_finishRestoreWithoutPurchases());
+      return;
+    }
     for (final purchase in purchases) {
       if (!MonetizationProductIds.allKnown.contains(purchase.productID)) {
         continue;
@@ -559,6 +677,8 @@ class MonetizationService {
   }
 
   void _resolvePendingPurchase(MonetizationActionResult result) {
+    _restoreEmptyResultTimer?.cancel();
+    _restoreEmptyResultTimer = null;
     final completer = _pendingPurchaseResult;
     if (completer == null || completer.isCompleted) {
       return;

--- a/test/domain/services/monetization_service_test.dart
+++ b/test/domain/services/monetization_service_test.dart
@@ -13,6 +13,7 @@ import 'package:in_app_purchase_storekit/store_kit_wrappers.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/domain/models/monetization.dart';
+import 'package:monkeyssh/domain/services/diagnostics_log_service.dart';
 import 'package:monkeyssh/domain/services/monetization_service.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -28,6 +29,39 @@ class MockInAppPurchaseAndroidPlatformAddition extends Mock
     implements InAppPurchaseAndroidPlatformAddition {}
 
 class _FakePurchaseParam extends Fake implements PurchaseParam {}
+
+class _CapturingDiagnosticsLogger implements DiagnosticsLogger {
+  final List<({String category, String message, Map<String, Object?> fields})>
+  entries = [];
+
+  @override
+  void debug(
+    String category,
+    String message, {
+    Map<String, Object?> fields = const <String, Object?>{},
+  }) => entries.add((category: category, message: message, fields: fields));
+
+  @override
+  void info(
+    String category,
+    String message, {
+    Map<String, Object?> fields = const <String, Object?>{},
+  }) => entries.add((category: category, message: message, fields: fields));
+
+  @override
+  void warning(
+    String category,
+    String message, {
+    Map<String, Object?> fields = const <String, Object?>{},
+  }) => entries.add((category: category, message: message, fields: fields));
+
+  @override
+  void error(
+    String category,
+    String message, {
+    Map<String, Object?> fields = const <String, Object?>{},
+  }) => entries.add((category: category, message: message, fields: fields));
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -565,6 +599,65 @@ void main() {
         ]),
       );
     });
+
+    test(
+      'catalog diagnostics record when the App Store omits the monthly plan',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+        when(() => inAppPurchase.isAvailable()).thenAnswer((_) async => true);
+        // The App Store returns only the annual product; the monthly product
+        // is reported as not found (e.g. it is not in a returnable state in
+        // App Store Connect), which is what makes the paywall show annual only.
+        when(() => inAppPurchase.queryProductDetails(any())).thenAnswer(
+          (_) async => ProductDetailsResponse(
+            productDetails: [
+              AppStoreProductDetails.fromSKProduct(
+                SKProductWrapper(
+                  productIdentifier: MonetizationProductIds.iosAnnualProd,
+                  localizedTitle: 'MonkeySSH Pro Annual',
+                  localizedDescription: 'Annual MonkeySSH Pro subscription',
+                  priceLocale: _usdPriceLocale,
+                  price: '50.00',
+                  subscriptionPeriod: SKProductSubscriptionPeriodWrapper(
+                    numberOfUnits: 1,
+                    unit: SKSubscriptionPeriodUnit.year,
+                  ),
+                ),
+              ),
+            ],
+            notFoundIDs: [MonetizationProductIds.iosMonthlyProd],
+          ),
+        );
+
+        final diagnostics = _CapturingDiagnosticsLogger();
+        final service = MonetizationService(
+          settings,
+          inAppPurchase: inAppPurchase,
+          allowDebugUnlock: false,
+          packageNameLoader: () async => 'xyz.depollsoft.monkeyssh',
+          diagnostics: diagnostics,
+        );
+        addTearDown(service.dispose);
+
+        await service.initialize();
+
+        final catalogEntry = diagnostics.entries.lastWhere(
+          (entry) =>
+              entry.category == 'monetization' &&
+              entry.message == 'catalog_loaded',
+        );
+        expect(catalogEntry.fields['annualLoaded'], isTrue);
+        expect(catalogEntry.fields['monthlyLoaded'], isFalse);
+        expect(catalogEntry.fields['notFoundCount'], 1);
+        expect(catalogEntry.fields['offerCount'], 1);
+        // The breadcrumb must never leak raw product identifiers.
+        expect(
+          catalogEntry.fields.values.whereType<String>(),
+          everyElement(isNot(contains('monkeyssh_pro'))),
+        );
+      },
+    );
 
     test(
       'concurrent initialize calls wait for the same in-flight work',
@@ -1410,6 +1503,132 @@ void main() {
         expect(service.currentState.isLoading, isFalse);
       },
     );
+
+    test('restore without StoreKit purchases finalizes via the grace period '
+        'instead of blocking on the restore timeout', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      await settings.setBool(SettingKeys.monetizationProUnlocked, value: true);
+      await settings.setString(
+        SettingKeys.monetizationActiveProductId,
+        MonetizationProductIds.iosMonthlyProd,
+      );
+      // StoreKit2 emits nothing on the purchase stream when there is
+      // nothing to restore, so the restore must resolve on its own.
+      when(() => inAppPurchase.restorePurchases()).thenAnswer((_) async {});
+
+      final service = MonetizationService(
+        settings,
+        inAppPurchase: inAppPurchase,
+        allowDebugUnlock: false,
+        restoreTimeout: const Duration(seconds: 30),
+        restoreEmptyResultGracePeriod: const Duration(milliseconds: 20),
+      );
+      addTearDown(service.dispose);
+
+      // The outer timeout guards the test: without the grace finalization
+      // this would block for the full 30s restore timeout.
+      final result = await service.restorePurchases().timeout(
+        const Duration(seconds: 5),
+      );
+
+      expect(result.success, isFalse);
+      expect(result.message, contains('No active'));
+      expect(service.currentState.isProUnlocked, isFalse);
+      expect(service.currentState.isLoading, isFalse);
+      expect(
+        await settings.getBool(SettingKeys.monetizationProUnlocked),
+        isFalse,
+      );
+      expect(
+        await settings.getString(SettingKeys.monetizationActiveProductId),
+        isNull,
+      );
+    });
+
+    test('restore finalizes immediately when StoreKit reports an empty '
+        'purchase list', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      await settings.setBool(SettingKeys.monetizationProUnlocked, value: true);
+      await settings.setString(
+        SettingKeys.monetizationActiveProductId,
+        MonetizationProductIds.iosMonthlyProd,
+      );
+      when(() => inAppPurchase.restorePurchases()).thenAnswer((_) async {
+        // StoreKit1 emits an empty list when nothing can be restored.
+        purchaseController.add(const <PurchaseDetails>[]);
+      });
+
+      final service = MonetizationService(
+        settings,
+        inAppPurchase: inAppPurchase,
+        allowDebugUnlock: false,
+        restoreTimeout: const Duration(seconds: 30),
+        // A long grace period proves the empty-list path resolves without
+        // waiting for either the grace period or the restore timeout.
+        restoreEmptyResultGracePeriod: const Duration(seconds: 30),
+      );
+      addTearDown(service.dispose);
+
+      final result = await service.restorePurchases().timeout(
+        const Duration(seconds: 5),
+      );
+
+      expect(result.success, isFalse);
+      expect(result.message, contains('No active'));
+      expect(service.currentState.isProUnlocked, isFalse);
+      expect(
+        await settings.getBool(SettingKeys.monetizationProUnlocked),
+        isFalse,
+      );
+    });
+
+    test('restore applies a restored StoreKit subscription and keeps the '
+        'entitlement', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final purchase = MockPurchaseDetails();
+      when(
+        () => purchase.productID,
+      ).thenReturn(MonetizationProductIds.iosMonthlyProd);
+      when(() => purchase.status).thenReturn(PurchaseStatus.restored);
+      when(() => purchase.pendingCompletePurchase).thenReturn(true);
+      when(() => purchase.transactionDate).thenReturn('1712732400000');
+      when(
+        () => inAppPurchase.completePurchase(purchase),
+      ).thenAnswer((_) async {});
+      when(() => inAppPurchase.restorePurchases()).thenAnswer((_) async {
+        purchaseController.add([purchase]);
+      });
+
+      final service = MonetizationService(
+        settings,
+        inAppPurchase: inAppPurchase,
+        allowDebugUnlock: false,
+        restoreTimeout: const Duration(seconds: 30),
+        // Long enough that the observed purchase resolves the restore
+        // before the empty-result finalization could ever run.
+        restoreEmptyResultGracePeriod: const Duration(seconds: 5),
+      );
+      addTearDown(service.dispose);
+
+      final result = await service.restorePurchases().timeout(
+        const Duration(seconds: 5),
+      );
+
+      expect(result.success, isTrue);
+      expect(service.currentState.isProUnlocked, isTrue);
+      expect(
+        service.currentState.activeProductId,
+        MonetizationProductIds.iosMonthlyProd,
+      );
+      expect(
+        await settings.getBool(SettingKeys.monetizationProUnlocked),
+        isTrue,
+      );
+    });
 
     test(
       'purchase finalization failure resolves the pending purchase',


### PR DESCRIPTION
## Summary
Fixes two confirmed iOS bugs and adds diagnostics for a third (store-side) issue.

### 1. Restore purchases hung when there was nothing to restore
StoreKit2 (the `in_app_purchase_storekit` default) emits **no** purchase-stream event on an empty restore, and StoreKit1 emits an empty list. `_handlePurchaseUpdates` only reacted to non-empty lists, so a restore with no purchases only resolved via the ~45s restore timeout.

- After `restorePurchases()` returns, a short **grace-period** timer finalizes the restore as "nothing to restore" (clears any stale cached entitlement, preserving lifetime).
- An **empty purchase list** now finalizes immediately.
- Guarded so a real restored transaction still resolves the flow normally.

### 2. Duplicate App Store screenshots from different versions
The `sync_metadata` Fastlane lane uploaded screenshots without `overwrite_screenshots`. `deliver` **appends** by default, so each sync left prior-version screenshots/app previews on the listing.

- `sync_metadata` now passes `overwrite_screenshots: true`, clearing existing screenshots and app previews before uploading the current set. The next sync cleans up the accumulated duplicates.

### 3. "Only annual subscriptions on iOS" — diagnostics (not a code bug)
The catalog correctly queries **both** monthly + annual per bundle ID and the paywall renders every returned offer (verified by existing/added tests). A missing monthly plan means StoreKit isn't returning that product — an **App Store Connect product-state** issue.

- Added a safe `monetization / catalog_loaded` diagnostics breadcrumb (`monthlyLoaded`, `annualLoaded`, `notFoundCount` — counts/booleans only, **no product IDs**) so this can be confirmed via **Settings → Diagnostics → Copy diagnostics log**.

## Testing
- `flutter analyze` — clean
- `flutter test` — full suite passes (2705 tests), including 4 new monetization tests:
  - SK2 empty-restore grace-period finalization
  - SK1 empty-list immediate finalization
  - restored-subscription happy path
  - catalog diagnostics record a missing monthly plan (and never leak product IDs)

## Notes
Issue #3 requires an App Store Connect change (ensure the monthly subscription is in a returnable/approved state); it cannot be fixed in app code.
