### PR TITLE
fix: keep Copilot CLI OSC 8 links tappable

### DIFF
--- a/lib/domain/services/terminal_hyperlink_tracker.dart
+++ b/lib/domain/services/terminal_hyperlink_tracker.dart
@@ -86,7 +86,7 @@ class TerminalHyperlinkTracker {
 
     final activeHyperlink = _pendingHyperlink;
     if (activeHyperlink != null &&
-        _containsOffset(
+        _containsExclusiveOffset(
           start: activeHyperlink.startAnchor.offset,
           end: _currentCursorOffset(terminal),
           target: offset,
@@ -117,14 +117,18 @@ class TerminalHyperlinkTracker {
     _pruneDetachedHyperlinks();
 
     final queryStart = CellOffset(startColumn, row);
-    final queryEnd = CellOffset(endColumn + 1, row);
-    bool intersects(CellOffset start, CellOffset end) =>
-        _compareOffsets(start, queryEnd) < 0 &&
+    final queryEndInclusive = CellOffset(endColumn, row);
+    final queryEndExclusive = CellOffset(endColumn + 1, row);
+    bool intersectsExclusive(CellOffset start, CellOffset end) =>
+        _compareOffsets(start, queryEndExclusive) < 0 &&
         _compareOffsets(queryStart, end) < 0;
+    bool intersectsInclusive(CellOffset start, CellOffset end) =>
+        _compareOffsets(start, queryEndInclusive) <= 0 &&
+        _compareOffsets(queryStart, end) <= 0;
 
     final activeHyperlink = _pendingHyperlink;
     if (activeHyperlink != null &&
-        intersects(
+        intersectsExclusive(
           activeHyperlink.startAnchor.offset,
           _currentCursorOffset(terminal),
         )) {
@@ -133,9 +137,9 @@ class TerminalHyperlinkTracker {
 
     for (final hyperlink in _trackedHyperlinks) {
       if (hyperlink.attached &&
-          intersects(
+          intersectsInclusive(
             hyperlink.startAnchor.offset,
-            hyperlink.endAnchor.offset,
+            hyperlink.lastCellAnchor.offset,
           )) {
         return true;
       }
@@ -182,7 +186,7 @@ class TerminalHyperlinkTracker {
       if (hyperlink.attached) {
         consider(
           hyperlink.startAnchor.offset,
-          hyperlink.endAnchor.offset,
+          hyperlink.lastCellAnchor.offset,
           hyperlink.uri,
         );
       }
@@ -214,11 +218,33 @@ class TerminalHyperlinkTracker {
       return;
     }
 
-    final endAnchor = terminal.buffer.createAnchorFromCursor();
+    final endOffset = _currentCursorOffset(terminal);
+    if (!pendingHyperlink.attached ||
+        _compareOffsets(pendingHyperlink.startAnchor.offset, endOffset) >= 0) {
+      pendingHyperlink.dispose();
+      _pendingHyperlink = null;
+      return;
+    }
+
+    final lastCellOffset = _previousCellOffset(
+      endOffset,
+      terminal.buffer.viewWidth,
+    );
+    if (lastCellOffset == null ||
+        _compareOffsets(pendingHyperlink.startAnchor.offset, lastCellOffset) >
+            0) {
+      pendingHyperlink.dispose();
+      _pendingHyperlink = null;
+      return;
+    }
+
+    final lastCellAnchor = terminal.buffer.createAnchorFromOffset(
+      lastCellOffset,
+    );
     final hyperlink = _TrackedTerminalHyperlink(
       uri: pendingHyperlink.uri,
       startAnchor: pendingHyperlink.startAnchor,
-      endAnchor: endAnchor,
+      lastCellAnchor: lastCellAnchor,
     );
 
     if (hyperlink.isEmpty) {
@@ -279,21 +305,21 @@ class _TrackedTerminalHyperlink {
   _TrackedTerminalHyperlink({
     required this.uri,
     required this.startAnchor,
-    required this.endAnchor,
+    required this.lastCellAnchor,
   });
 
   final Uri uri;
   final CellAnchor startAnchor;
-  final CellAnchor endAnchor;
+  final CellAnchor lastCellAnchor;
 
-  bool get attached => startAnchor.attached && endAnchor.attached;
+  bool get attached => startAnchor.attached && lastCellAnchor.attached;
 
   bool get isEmpty {
     if (!attached) {
       return true;
     }
 
-    return _compareOffsets(startAnchor.offset, endAnchor.offset) >= 0;
+    return _compareOffsets(startAnchor.offset, lastCellAnchor.offset) > 0;
   }
 
   bool contains(CellOffset offset) {
@@ -301,24 +327,40 @@ class _TrackedTerminalHyperlink {
       return false;
     }
 
-    return _containsOffset(
+    return _containsInclusiveOffset(
       start: startAnchor.offset,
-      end: endAnchor.offset,
+      end: lastCellAnchor.offset,
       target: offset,
     );
   }
 
   void dispose() {
     startAnchor.dispose();
-    endAnchor.dispose();
+    lastCellAnchor.dispose();
   }
 }
 
-bool _containsOffset({
+bool _containsExclusiveOffset({
   required CellOffset start,
   required CellOffset end,
   required CellOffset target,
 }) => _compareOffsets(start, target) <= 0 && _compareOffsets(target, end) < 0;
+
+bool _containsInclusiveOffset({
+  required CellOffset start,
+  required CellOffset end,
+  required CellOffset target,
+}) => _compareOffsets(start, target) <= 0 && _compareOffsets(target, end) <= 0;
+
+CellOffset? _previousCellOffset(CellOffset offset, int lineWidth) {
+  if (offset.x > 0) {
+    return CellOffset(offset.x - 1, offset.y);
+  }
+  if (offset.y <= 0 || lineWidth <= 0) {
+    return null;
+  }
+  return CellOffset(lineWidth - 1, offset.y - 1);
+}
 
 int _compareOffsets(CellOffset a, CellOffset b) {
   if (a.y != b.y) {

--- a/test/domain/services/terminal_hyperlink_tracker_test.dart
+++ b/test/domain/services/terminal_hyperlink_tracker_test.dart
@@ -110,6 +110,37 @@ void main() {
       );
     });
 
+    test('retains a TUI link when trailing cells are erased', () {
+      const url = 'https://github.com';
+      terminal.write(
+        '\u001b[4;2H'
+        '\u001b[4m'
+        '\u001b]8;id=md-link;$url\u0007'
+        'LINKTARGET'
+        '\u001b[0m'
+        '\u001b]8;;\u0007'
+        '\u001b[K',
+      );
+
+      expect(tracker.trackedHyperlinkCount, 1);
+      expect(tracker.resolveLinkAt(const CellOffset(1, 3)), url);
+      expect(tracker.resolveLinkAt(const CellOffset(10, 3)), url);
+      expect(tracker.resolveLinkAt(const CellOffset(11, 3)), isNull);
+    });
+
+    test('drops a TUI link when its rendered cells are erased', () {
+      terminal
+        ..write(
+          '\u001b]8;;https://example.com/erased\u0007'
+          'link'
+          '\u001b]8;;\u0007',
+        )
+        ..write('\r\u001b[K');
+
+      expect(tracker.resolveLinkAt(const CellOffset(0, 0)), isNull);
+      expect(tracker.trackedHyperlinkCount, 0);
+    });
+
     test('tracks an OSC 8 link delivered across separate writes', () {
       terminal
         ..write('\u001b]8;;https://example.com/chunked\u0007')
@@ -150,6 +181,11 @@ void main() {
         tracker.resolveLinkAt(const CellOffset(1, 1)),
         'https://example.com/reflow',
       );
+      expect(
+        tracker.resolveLinkAt(const CellOffset(5, 1)),
+        'https://example.com/reflow',
+      );
+      expect(tracker.resolveLinkAt(const CellOffset(0, 2)), isNull);
     });
 
     test('prunes detached hyperlinks while processing later OSC 8 output', () {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1424,14 +1424,23 @@ void main() {
         );
 
         await pumpScreen(tester);
-        // A real CLI (gh, `ls --hyperlink`, build tools, …) emits an OSC 8
-        // hyperlink whose label is plain text and whose URL is hidden, and its
-        // TUI enables SGR mouse tracking. Tapping the label must open the URL
-        // locally rather than forwarding a mouse click to the host (which would
-        // make the remote process open it server-side over SSH).
+        // Copilot CLI emits an OSC 8 hyperlink, closes it at the end of the
+        // label, and immediately erases the rest of that rendered TUI row. It
+        // also enables SGR mouse tracking. Tapping the label must still open the
+        // URL locally rather than forwarding an inert click to the host.
         session.terminal!
           ..write('\x1b[?1003h\x1b[?1006h')
-          ..write('\x1b]8;;$url\x07Issue #1\x1b]8;;\x07');
+          ..write(
+            [
+              '\x1b[4;2H',
+              '\x1b[4m',
+              '\x1b]8;id=md-link;$url\x07',
+              'Issue #1',
+              '\x1b[0m',
+              '\x1b]8;;\x07',
+              '\x1b[K',
+            ].join(),
+          );
         await tester.pumpAndSettle();
 
         final render = tester
@@ -1451,7 +1460,7 @@ void main() {
 
         // Tapping the hyperlink label opens locally and forwards nothing.
         shellWrites.clear();
-        await tester.tapAt(cellCenter(const CellOffset(3, 0)));
+        await tester.tapAt(cellCenter(const CellOffset(3, 3)));
         await tester.pumpAndSettle();
 
         expect(launchedUrls, [url]);


### PR DESCRIPTION
## Summary

- anchor closed OSC 8 hyperlinks to their final rendered cell
- preserve links when mouse-enabled TUIs such as Copilot CLI erase the remaining row with `CSI K`
- retain invalidation for erased labels and preserve wrapped-link reflow behavior

## Testing

- `flutter analyze`
- `flutter test test/domain/services/terminal_hyperlink_tracker_test.dart`
- `flutter test test/presentation/screens/terminal_screen_test.dart --name "tapping an OSC 8 hyperlink opens locally without forwarding a mouse click to the host"`
- repository pre-commit suite