### PR TITLE
fix(ci): select next internal patch version

### DIFF
--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -25,8 +25,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
       - name: Compute version
         id: version
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
         run: |
           VERSION_LINE="$(grep '^version:' pubspec.yaml | head -n 1)"
           if [ -z "$VERSION_LINE" ]; then
@@ -34,7 +44,13 @@ jobs:
             exit 1
           fi
 
-          BUILD_NAME="$(printf '%s' "$VERSION_LINE" | sed 's/^version:[[:space:]]*//' | cut -d'+' -f1 | xargs)"
+          BASE_VERSION="$(printf '%s' "$VERSION_LINE" | sed 's/^version:[[:space:]]*//' | cut -d'+' -f1 | xargs)"
+          VERSION_OUTPUT="$RUNNER_TEMP/internal-release-version"
+          bundle exec ruby scripts/resolve_next_app_store_patch_version.rb \
+            "$BASE_VERSION" \
+            xyz.depollsoft.monkeyssh \
+            "$VERSION_OUTPUT"
+          BUILD_NAME="$(cat "$VERSION_OUTPUT")"
           BUILD_NUMBER=$(( $(date +%s) / 10 ))
           BUILD_CODENAME=$(python3 scripts/version_codename.py "$BUILD_NAME")
           BUILD_DISPLAY="$BUILD_NAME"

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -546,9 +546,6 @@ platform :ios do
       screenshots_path: SCREENSHOTS_PATH,
       skip_binary_upload: true,
       skip_screenshots: false,
-      # Metadata sync must use the existing editable App Store version instead
-      # of inheriting the marketing version from the IPA uploaded by this lane.
-      skip_app_version_update: true,
       # Clear previously uploaded screenshots and app previews before
       # uploading the current set. Without this, deliver *appends* the new
       # screenshots to whatever is already on App Store Connect, so each sync

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -546,6 +546,9 @@ platform :ios do
       screenshots_path: SCREENSHOTS_PATH,
       skip_binary_upload: true,
       skip_screenshots: false,
+      # Metadata sync must use the existing editable App Store version instead
+      # of inheriting the marketing version from the IPA uploaded by this lane.
+      skip_app_version_update: true,
       # Clear previously uploaded screenshots and app previews before
       # uploading the current set. Without this, deliver *appends* the new
       # screenshots to whatever is already on App Store Connect, so each sync

--- a/scripts/resolve_next_app_store_patch_version.rb
+++ b/scripts/resolve_next_app_store_patch_version.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module AppStorePatchVersion
+  class ResolutionError < StandardError; end
+
+  EDITABLE_STATES = %w[
+    PREPARE_FOR_SUBMISSION
+    DEVELOPER_REJECTED
+    REJECTED
+    METADATA_REJECTED
+    WAITING_FOR_REVIEW
+    INVALID_BINARY
+  ].freeze
+
+  Version = Struct.new(:major, :minor, :patch) do
+    def to_s
+      "#{major}.#{minor}.#{patch}"
+    end
+  end
+
+  module_function
+
+  def resolve(base_version:, app_store_versions:)
+    base = parse!(base_version, label: 'base version')
+    parsed_versions = app_store_versions.each_with_object([]) do |entry, result|
+      version = parse(entry.fetch(:version))
+      next if version.nil?
+
+      result << [version, entry.fetch(:state)]
+    end
+
+    editable_versions = parsed_versions.select do |_version, state|
+      EDITABLE_STATES.include?(state)
+    end
+    editable = editable_versions
+               .map(&:first)
+               .max_by { |version| [version.major, version.minor, version.patch] }
+    if editable && !same_version_line?(editable, base)
+      raise ResolutionError,
+            "Editable App Store version #{editable} does not match " \
+            "the requested #{base.major}.#{base.minor}.x version line"
+    end
+
+    return editable.to_s if editable && editable.patch >= base.patch
+
+    existing_patches = parsed_versions
+                       .map(&:first)
+                       .select { |version| same_version_line?(version, base) }
+                       .map(&:patch)
+    next_patch = if existing_patches.empty?
+                   base.patch
+                 else
+                   [base.patch, existing_patches.max + 1].max
+                 end
+
+    Version.new(base.major, base.minor, next_patch).to_s
+  end
+
+  def parse(value)
+    match = /\A(\d+)\.(\d+)\.(\d+)\z/.match(value.to_s.strip)
+    return if match.nil?
+
+    Version.new(*match.captures.map(&:to_i))
+  end
+
+  def parse!(value, label:)
+    parse(value) || raise(
+      ResolutionError,
+      "#{label.capitalize} must use numeric x.y.z format; received #{value.inspect}",
+    )
+  end
+
+  def same_version_line?(left, right)
+    left.major == right.major && left.minor == right.minor
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  require 'spaceship'
+
+  base_version, bundle_id, output_path = ARGV
+  if [base_version, bundle_id, output_path].any? { |value| value.to_s.empty? }
+    warn 'Usage: resolve_next_app_store_patch_version.rb BASE_VERSION BUNDLE_ID OUTPUT_PATH'
+    exit 2
+  end
+
+  token = Spaceship::ConnectAPI::Token.create(
+    key_id: ENV.fetch('APP_STORE_CONNECT_API_KEY_ID'),
+    issuer_id: ENV.fetch('APP_STORE_CONNECT_API_ISSUER_ID'),
+    key: ENV.fetch('APP_STORE_CONNECT_API_KEY_CONTENT'),
+  )
+  Spaceship::ConnectAPI.token = token
+
+  app = Spaceship::ConnectAPI::App.find(bundle_id)
+  raise AppStorePatchVersion::ResolutionError, "App #{bundle_id} was not found" if app.nil?
+
+  versions = app.get_app_store_versions(
+    filter: { platform: Spaceship::ConnectAPI::Platform::IOS },
+    includes: nil,
+  ).map do |version|
+    {
+      version: version.version_string,
+      state: version.app_version_state,
+    }
+  end
+
+  resolved_version = AppStorePatchVersion.resolve(
+    base_version: base_version,
+    app_store_versions: versions,
+  )
+  File.write(output_path, "#{resolved_version}\n")
+  puts "Resolved internal release marketing version #{resolved_version}"
+end

--- a/scripts/resolve_next_app_store_patch_version_test.rb
+++ b/scripts/resolve_next_app_store_patch_version_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative 'resolve_next_app_store_patch_version'
+
+class AppStorePatchVersionTest < Minitest::Test
+  def test_increments_the_latest_used_patch
+    assert_equal(
+      '0.2.3',
+      resolve(
+        '0.2.0',
+        [
+          version('0.2.0', 'READY_FOR_DISTRIBUTION'),
+          version('0.2.2', 'REPLACED_WITH_NEW_VERSION'),
+        ],
+      ),
+    )
+  end
+
+  def test_reuses_the_current_editable_patch
+    assert_equal(
+      '0.2.1',
+      resolve(
+        '0.2.0',
+        [
+          version('0.1.9', 'REJECTED'),
+          version('0.2.0', 'READY_FOR_DISTRIBUTION'),
+          version('0.2.1', 'PREPARE_FOR_SUBMISSION'),
+        ],
+      ),
+    )
+  end
+
+  def test_uses_the_base_patch_as_a_floor
+    assert_equal(
+      '0.2.5',
+      resolve(
+        '0.2.5',
+        [version('0.2.0', 'READY_FOR_DISTRIBUTION')],
+      ),
+    )
+  end
+
+  def test_keeps_a_new_major_minor_version_line_at_its_base_patch
+    assert_equal(
+      '0.3.0',
+      resolve(
+        '0.3.0',
+        [version('0.2.9', 'READY_FOR_DISTRIBUTION')],
+      ),
+    )
+  end
+
+  def test_rejects_an_editable_version_from_another_version_line
+    error = assert_raises(AppStorePatchVersion::ResolutionError) do
+      resolve(
+        '0.2.0',
+        [version('0.3.0', 'PREPARE_FOR_SUBMISSION')],
+      )
+    end
+
+    assert_includes(error.message, 'does not match the requested 0.2.x')
+  end
+
+  def test_rejects_a_non_numeric_base_version
+    assert_raises(AppStorePatchVersion::ResolutionError) do
+      resolve('0.2', [])
+    end
+  end
+
+  private
+
+  def resolve(base_version, versions)
+    AppStorePatchVersion.resolve(
+      base_version: base_version,
+      app_store_versions: versions,
+    )
+  end
+
+  def version(value, state)
+    { version: value, state: state }
+  end
+end


### PR DESCRIPTION
## Summary
- resolve the production app next patch marketing version from App Store Connect before building
- reuse the current editable x.y.z when it matches the pubspec.yaml major/minor line
- otherwise choose max(existing z) + 1, using the repo patch as a floor
- pass the resolved version to both Android and iOS so binaries, TestFlight, Play, artifacts, and metadata stay aligned

## Root cause
The internal release kept building marketing version 0.2.0 after that version had gone live. The TestFlight upload succeeded because its build number was new, but the following metadata sync tried to change the editable App Store version back to the already-used 0.2.0, which Apple rejected.

With 0.2.0 live, the workflow now resolves 0.2.1 (reusing that editable version when it already exists). After 0.2.1 is released, the next internal release resolves 0.2.2.

## Validation
- ruby scripts/resolve_next_app_store_patch_version_test.rb
- ruby -c scripts/resolve_next_app_store_patch_version.rb
- ruby -c ios/fastlane/Fastfile