### PR TITLE
Fix stale Copilot window titles

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -4474,9 +4474,16 @@ flutty_process_start_epoch() {
 }
 flutty_file_mtime_epoch() {
   file=\$1
-  stat -f %m "\$file" 2>/dev/null ||
-    stat -c %Y "\$file" 2>/dev/null ||
-    return 0
+  value=\$(stat -f %m "\$file" 2>/dev/null)
+  case "\$value" in
+    ''|*[!0-9]*) ;;
+    *) printf '%s' "\$value"; return 0 ;;
+  esac
+  value=\$(stat -c %Y "\$file" 2>/dev/null)
+  case "\$value" in
+    ''|*[!0-9]*) return 0 ;;
+    *) printf '%s' "\$value" ;;
+  esac
 }
 flutty_file_is_newer_than_process() {
   file=\$1
@@ -4485,6 +4492,34 @@ flutty_file_is_newer_than_process() {
   mtime=\$(flutty_file_mtime_epoch "\$file")
   case "\$mtime" in ''|*[!0-9]*) return 1 ;; esac
   [ "\$mtime" -ge "\$((process_start_epoch - 2))" ]
+}
+flutty_copilot_lock_match() {
+  pid=\$1
+  process_start_epoch=\$2
+  [ -d "\$state_dir" ] || return 0
+  freshest_lock=
+  freshest_mtime=
+  for lock in "\$state_dir"/*/inuse."\$pid".lock; do
+    [ -e "\$lock" ] || continue
+    if [ -n "\$process_start_epoch" ]; then
+      flutty_file_is_newer_than_process "\$lock" "\$process_start_epoch" || continue
+    fi
+    lock_mtime=\$(flutty_file_mtime_epoch "\$lock")
+    case "\$lock_mtime" in ''|*[!0-9]*) continue ;; esac
+    if [ -z "\$freshest_lock" ] || [ "\$lock_mtime" -gt "\$freshest_mtime" ]; then
+      freshest_lock=\$lock
+      freshest_mtime=\$lock_mtime
+    fi
+  done
+  [ -n "\$freshest_lock" ] || return 0
+  dir=\${freshest_lock%/*}
+  session_id=\${dir##*/}
+  workspace=\$dir/workspace.yaml
+  title=
+  if [ -r "\$workspace" ]; then
+    title=\$(flutty_copilot_workspace_title "\$workspace")
+  fi
+  flutty_emit_lsof_match "\$session_id" "\$title"
 }
 flutty_iso8601_epoch() {
   value=\$1
@@ -4767,17 +4802,14 @@ END {
       session_id=
       title=
       confidence=medium
+      process_start_epoch=
       if [ "\$tool" = copilot ] && [ -d "\$state_dir" ]; then
-        for lock in "\$state_dir"/*/inuse."\$pid".lock; do
-          [ -e "\$lock" ] || continue
-          dir=\${lock%/*}
-          session_id=\${dir##*/}
-          workspace=\$dir/workspace.yaml
-          if [ -r "\$workspace" ]; then
-            title=\$(flutty_copilot_workspace_title "\$workspace")
-          fi
-          break
-        done
+        process_start_epoch=\$(flutty_process_start_epoch "\$pid")
+        lock_match=\$(flutty_copilot_lock_match "\$pid" "\$process_start_epoch")
+        if [ -n "\$lock_match" ]; then
+          session_id=\$(printf '%s' "\$lock_match" | awk -F "\$sep" '{ print \$1; exit }')
+          title=\$(printf '%s' "\$lock_match" | awk -F "\$sep" '{ print \$2; exit }')
+        fi
       fi
       if [ -z "\$session_id" ]; then
         lsof_match=\$(flutty_lsof_session_match "\$pid" "\$tool" || true)
@@ -4788,7 +4820,9 @@ END {
       fi
       if [ -z "\$session_id" ]; then
         process_cwd=\$(flutty_process_cwd "\$pid")
-        process_start_epoch=\$(flutty_process_start_epoch "\$pid")
+        if [ -z "\$process_start_epoch" ]; then
+          process_start_epoch=\$(flutty_process_start_epoch "\$pid")
+        fi
         case "\$tool" in
           codex) recent_match=\$(flutty_codex_recent_session_match "\$process_cwd" "\$process_start_epoch" "\$pid" || true) ;;
           gemini) recent_match=\$(flutty_gemini_recent_session_match "\$process_cwd" "\$process_start_epoch" || true) ;;

--- a/test/domain/services/tmux_service_agent_detection_test.dart
+++ b/test/domain/services/tmux_service_agent_detection_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
 import 'package:monkeyssh/domain/models/tmux_state.dart';
@@ -173,6 +175,7 @@ void main() {
         expect(command, contains('flutty_process_cwd'));
         expect(command, contains('flutty_process_start_epoch'));
         expect(command, contains('flutty_file_is_newer_than_process'));
+        expect(command, contains('flutty_copilot_lock_match'));
         expect(command, contains('flutty_iso8601_epoch'));
         expect(command, contains('flutty_codex_index_resume_match'));
         expect(command, contains('flutty_codex_logs_resume_match'));
@@ -211,6 +214,117 @@ void main() {
         expect(command, contains(r'ps -p "$pid" -o etime='));
         expect(command, isNot(contains('exit 0')));
       },
+    );
+
+    test(
+      'ignores stale Copilot locks when a pane PID is reused',
+      () async {
+        final home = await Directory.systemTemp.createTemp(
+          'monkeyssh-copilot-lock-test-',
+        );
+        addTearDown(() => home.delete(recursive: true));
+        final fakeBin = await Directory(
+          '${home.path}/bin',
+        ).create(recursive: true);
+        final fakePs = File('${fakeBin.path}/ps');
+        await fakePs.writeAsString(
+          [
+            '#!/bin/sh',
+            r'case "$*" in',
+            '  "-eo pid=,ppid=,comm=,args=")',
+            r"    printf '%s\n' '42 1 zsh zsh' '501 42 copilot /opt/copilot'",
+            '    ;;',
+            '  "-p 501 -o etime=")',
+            r"    printf '00:10\n'",
+            '    ;;',
+            'esac',
+            '',
+          ].join('\n'),
+        );
+        final fakeStat = File('${fakeBin.path}/stat');
+        await fakeStat.writeAsString(
+          [
+            '#!/bin/sh',
+            r'case "$1" in',
+            '  -f)',
+            r"    printf 'GNU stat filesystem output\n'",
+            '    exit 1',
+            '    ;;',
+            '  -c)',
+            r'    case "$3" in',
+            r"      *aaa-stale*) printf '1\n' ;;",
+            '      *) date +%s ;;',
+            '    esac',
+            '    ;;',
+            'esac',
+            '',
+          ].join('\n'),
+        );
+        final chmod = await Process.run('chmod', [
+          '+x',
+          fakePs.path,
+          fakeStat.path,
+        ]);
+        expect(chmod.exitCode, 0, reason: chmod.stderr as String?);
+
+        final stateDirectory = Directory('${home.path}/.copilot/session-state');
+        final staleSession = await Directory(
+          '${stateDirectory.path}/aaa-stale',
+        ).create(recursive: true);
+        await File(
+          '${staleSession.path}/workspace.yaml',
+        ).writeAsString('summary: Different Copilot session\n');
+        final staleLock = File('${staleSession.path}/inuse.501.lock');
+        await staleLock.writeAsString('501');
+        await staleLock.setLastModified(
+          DateTime.now().subtract(const Duration(minutes: 10)),
+        );
+
+        final command = buildAgentActiveSessionMetadataCommand(const {42});
+        Future<ProcessResult> runProbe() => Process.run(
+          '/bin/sh',
+          ['-c', command],
+          environment: {
+            'HOME': home.path,
+            'PATH': '${fakeBin.path}:/usr/bin:/bin',
+          },
+          includeParentEnvironment: false,
+        );
+
+        final staleResult = await runProbe();
+        expect(staleResult.exitCode, 0, reason: staleResult.stderr as String?);
+        expect(
+          parseAgentActiveSessionMetadataOutput(
+            staleResult.stdout as String,
+            const {42},
+          ),
+          isEmpty,
+        );
+
+        final currentSession = await Directory(
+          '${stateDirectory.path}/zzz-current',
+        ).create(recursive: true);
+        await File(
+          '${currentSession.path}/workspace.yaml',
+        ).writeAsString('summary: Current Copilot session\n');
+        await File(
+          '${currentSession.path}/inuse.501.lock',
+        ).writeAsString('501');
+
+        final currentResult = await runProbe();
+        expect(
+          currentResult.exitCode,
+          0,
+          reason: currentResult.stderr as String?,
+        );
+        final metadata = parseAgentActiveSessionMetadataOutput(
+          currentResult.stdout as String,
+          const {42},
+        );
+        expect(metadata[42]?.sessionId, 'zzz-current');
+        expect(metadata[42]?.title, 'Current Copilot session');
+      },
+      skip: Platform.isWindows ? 'Requires a POSIX shell.' : false,
     );
 
     test('command prefers Antigravity history title before annotation title', () {


### PR DESCRIPTION
## Summary

- ignore Copilot session locks that predate the current process so PID reuse cannot label a new window with an old session
- select the newest valid lock and keep mtime detection portable across BSD and GNU `stat`
- add a regression test covering stale/current locks and the GNU `stat` fallback

## Validation

- `flutter analyze`
- `flutter test test/domain/services/tmux_service_agent_detection_test.dart`