### PR TITLE
feat: polish app usability and accessibility

### DIFF
--- a/.impeccable/critique/2026-07-09T18-37-19Z__lib-presentation.md
+++ b/.impeccable/critique/2026-07-09T18-37-19Z__lib-presentation.md
@@ -1,0 +1,140 @@
+---
+target: whole app (lib/presentation)
+total_score: 30
+p0_count: 0
+p1_count: 2
+timestamp: 2026-07-09T18-37-19Z
+slug: lib-presentation
+---
+# Whole-App Design Critique
+
+**Target:** `lib/presentation`  
+**Baseline:** `origin/main` at `75cd6ae3`
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|------:|-----------|
+| 1 | Visibility of System Status | 3 | Connection, loading, and session states are strong; ordinary transfer progress and reconnect recovery are less persistent. |
+| 2 | Match System / Real World | 3 | The terminal vocabulary fits expert users, but Connections, windows, sessions, and AI Sessions overlap without a clear model. |
+| 3 | User Control and Freedom | 3 | Back, cancel, unsaved-change guards, and safe host-key rejection are strong; destructive mux actions and connection recovery lack undo or direct alternatives. |
+| 4 | Consistency and Standards | 4 | Shared themes, mono titles, hairline surfaces, branded async states, and responsive navigation form a coherent system. |
+| 5 | Error Prevention | 3 | Destructive confirmations and safe security defaults are good; PIN setup advances at four digits although completion requires six. |
+| 6 | Recognition Rather Than Recall | 3 | Main navigation is labeled, but Port Forwards, terminal gestures, and recent agent sessions are hidden behind contextual disclosures. |
+| 7 | Flexibility and Efficiency | 4 | Snippets, presets, modifier keys, gestures, themes, favorites, SFTP, and MonkeyMux provide excellent expert acceleration. |
+| 8 | Aesthetic and Minimalist Design | 3 | The core is quiet and work-first; dense menus and generic utility/settings surfaces weaken hierarchy. |
+| 9 | Error Recovery | 2 | The first-connect failure dialog preserves a useful log but offers only Close, with no Retry or Edit Host path. |
+| 10 | Help and Documentation | 2 | Inline field help is useful, but there is no discoverable gesture/shortcut guide or searchable task help. |
+| **Total** | | **30/40** | **Good — a strong product identity with several high-impact usability gaps.** |
+
+## Anti-Patterns Verdict
+
+### LLM assessment
+
+This does **not** look AI-generated. MonkeySSH has a committed identity: JetBrains Mono as the display voice, the cursor-block mark, restrained near-black layering, branded loading/empty/error states, and a terminal/MonkeyMux composition built around real work. It avoids gradient text, glassmorphism, decorative motion, side-stripe accents, and repetitive card grids.
+
+Generic Material residue remains in long forms, Settings, and Upgrade. Terminal-driven themes can also erase Signal Teal and produce pale cream/salmon accents in the current store screenshots, weakening the app's distinctive signal and drifting toward an explicit anti-reference.
+
+### Deterministic scan
+
+The bundled detector returned `[]` with exit code 0 for `lib/presentation`. This is **not a clean bill of health**: all 65 target files are Dart, and the detector's scannable extension set excludes `.dart`. It provided no usable Flutter findings, rule names, or locations, and produced no false positives to evaluate.
+
+### Visual overlays
+
+No reliable user-visible overlay is available. MonkeySSH is a native Flutter target with no Flutter web entry page, so there was no browser-rendered app surface on which to preflight mutation or inject the detector. Current committed iPhone/iPad and Android store screenshots were used as visual evidence instead.
+
+## Overall Impression
+
+MonkeySSH feels like a credible professional SSH client, especially once a user reaches the terminal and MonkeyMux. The terminal is the visual peak, the app chrome recedes correctly, and security decisions are unusually well explained. The biggest opportunity is to make the surrounding shell match the quality of the core: enforce accessibility across derived themes, shorten recovery after connection failure, and expose the fastest route back to an agent session.
+
+## Cognitive Load
+
+**Moderate: three of eight checks fail.**
+
+- **Chunking:** Settings presents nine long sections in a single scroll, and terminal configuration exposes many consecutive controls.
+- **Minimal choices:** the host context menu reaches seven actions (`home_screen.dart:1402-1486`), the SFTP action sheet reaches seven (`sftp_screen.dart:1604-1697`), and terminal overflow exposes several top-level actions plus submenus (`terminal_screen.dart:10562-10643`).
+- **Progressive disclosure:** advanced host configuration is handled well, but Port Forwards, gestures, and AI session history are hidden rather than intentionally introduced.
+
+Single focus, grouping, visual hierarchy, one-decision-at-a-time setup, and preservation of task context are generally strong.
+
+## Emotional Journey
+
+- **Setup and unlock:** calm, serious, and trust-building. Biometric guidance and private-by-default language work; the four-digit Next/six-digit completion mismatch creates an avoidable early wobble.
+- **Connection:** the live log and stage feedback are excellent reassurance. Failure is the emotional low point because the narrative ends with only Close.
+- **Terminal and MonkeyMux:** the product's peak. The user's work dominates, active/waiting states are glanceable, and bottom/side navigation adapts without crowding the terminal.
+- **SFTP and utilities:** capable but less composed, especially on wide screens and in long action sheets.
+- **End state:** returning to Hosts after the final disconnect is functional but abrupt; there is little closure or direct “resume later” reassurance.
+
+## What's Working
+
+1. **The work is genuinely the loudest thing.** Terminal and editor content own the screen while MonkeyMux remains available through adaptive bottom or side navigation.
+2. **Trust is visible.** Host-key replacement, imported-command review, encrypted transfers, opt-in telemetry, and unsaved-change protection use serious language and safe defaults.
+3. **Expert efficiency is exceptional.** Direct connection, persistent sessions, snippets, completion, modifier keys, SFTP context, presets, and window navigation support real remote development rather than a toy terminal workflow.
+
+## Priority Issues
+
+### 1. **P1 — Accessibility has no reliable floor across terminal-driven themes**
+
+**Why it matters:** The theme accepts a terminal cursor as the primary accent at only 2.5:1 contrast (`lib/app/theme.dart:567-606`), then uses that primary as text for tabs and text buttons. Hint text further reduces the secondary color to alpha 150 (`lib/app/theme.dart:245-267`). The MonkeyMux close action is 30×30 and immediately destructive (`lib/presentation/widgets/tmux_expandable_bar.dart:1867-1885`). These directly violate the product's WCAG AA and 44-point target commitments.
+
+**Fix:** Resolve separate surface and text accent roles; clamp text accents and muted text to 4.5:1 on their actual backgrounds; remove low-alpha body/hint styling; enforce 44×44 interactive targets; add confirmation or short undo for closing a remote window; test at 200% text scale in default, light, and representative terminal-derived themes.
+
+**Suggested command:** `/impeccable audit lib/presentation`
+
+### 2. **P1 — First-connect failure is a recovery cul-de-sac**
+
+**Why it matters:** The connection dialog gives excellent live context, but after failure it offers only Close (`lib/presentation/widgets/connection_attempt_dialog.dart:61-158`). A mobile user under pressure must dismiss it, find the host again, infer whether to edit credentials, and repeat the flow.
+
+**Fix:** Preserve the connection log and offer stage-aware actions: **Retry**, **Edit Host**, and **Close**. Identify whether failure occurred during networking, host-key verification, authentication, or startup. Keep entered configuration and return focus to the exact field that needs attention.
+
+**Suggested command:** `/impeccable harden connection failures`
+
+### 3. **P2 — The fastest route back to an agent session is too deeply disclosed**
+
+**Why it matters:** Primary navigation exposes Hosts, Connections, Keys, and Snippets (`lib/presentation/screens/home_screen.dart:487-513`), while Port Forwards has routes but no normal top-level entry. Recent AI sessions sit under a connected host's expanded window list and a second AI Sessions disclosure (`lib/presentation/screens/home_screen.dart:3653-3744`). This weakens the promise of reaching the right agent session in seconds.
+
+**Fix:** Add a direct **Resume latest agent** action to relevant host/connection rows. Clarify the IA around **Hosts / Sessions / Tools / Settings**, grouping Keys, Snippets, and Port Forwards under Tools if testing confirms that model. Preserve the current direct Connections path for users who already know it.
+
+**Suggested command:** `/impeccable shape primary navigation and resume flow`
+
+### 4. **P2 — Mobile creation and form completion ignore the thumb zone**
+
+**Why it matters:** Add Host, New Folder, and Add Snippet live in top panel headers (`lib/presentation/screens/home_screen.dart:881-890,2401-2416`), and host Save/Test actions appear only after a long form. SFTP already demonstrates the correct bottom-FAB precedent. The current placement contradicts the product's first design principle: one-handed by default.
+
+**Fix:** Use a mobile FAB or sticky bottom action bar for creation and Save/Test; retain header actions on wide layouts. Move secondary terminal controls from the crowded top-right bar into a thumb-reachable sheet while keeping the most frequent control visible.
+
+**Suggested command:** `/impeccable adapt mobile primary actions`
+
+### 5. **P2 — Dense action menus slow both recognition and expert flow**
+
+**Why it matters:** Host, SFTP, and terminal menus exceed the four-item working-memory threshold. Destructive, management, sharing, and primary task actions compete in one flat list, increasing scan time and mis-tap risk.
+
+**Fix:** Promote the two or three contextually primary actions, group secondary actions into clearly labeled sections or submenus, and isolate destructive actions. Add a concise gesture/shortcut guide so power features become learnable instead of remaining hidden.
+
+**Suggested command:** `/impeccable distill action menus and shortcuts`
+
+## Persona Red Flags
+
+**Alex — impatient power user:** The terminal accelerators are excellent, but Alex still scans seven-item host and SFTP menus, cannot invoke a global command surface, and must expand multiple disclosures to reach recent AI sessions. The hidden Port Forwards route breaks recognition.
+
+**Sam — accessibility-dependent user:** Sam encounters primary-as-text colors that may be only 2.5:1, low-alpha hints, a 30×30 destructive close target, and custom terminal controls whose mobile tooltips may not provide complete screen-reader guidance. Status badges correctly pair icons and text, which is a strong foundation.
+
+**Casey — distracted mobile user:** Casey benefits from bottom navigation, the MonkeyMux sheet, and the SFTP FAB, then must reach top-right for Add Host/Add Snippet and multiple terminal controls. A failed first connection provides no immediate recovery, creating a high-abandonment interruption.
+
+**Rin — remote agentic developer:** Rin reconnects between meetings to reach the agent waiting for input. Active connections and MonkeyMux work well once found, but recent-agent history is nested and connection failure returns Rin to manual diagnosis. Low-contrast muted labels are particularly costly in the glance-and-go, possibly sunlit context described by the product.
+
+## Minor Observations
+
+- PIN setup advances at four digits although the copy and completion logic require six (`lib/presentation/screens/auth_setup_screen.dart:220-272` and `:70-79`).
+- The selected Snippets filter in current store imagery reads closer to disabled than selected.
+- Terminal-derived cream/salmon accents obscure the Signal Teal identity in flagship screenshots.
+- SFTP breadcrumbs collapse deep paths effectively, but can hide too much location context.
+- Wide Snippets and SFTP layouts stretch rows across large canvases rather than introducing list/detail composition.
+- Settings is coherent but visually becomes a long stock `ListTile` catalogue.
+
+## Questions to Consider
+
+1. If “back in the right agent session in seconds” is the promise, should **Resume latest** be visible before opening a connection?
+2. Should terminal palettes recolor all app chrome, or should navigation and trust cues retain a contrast-safe Signal Teal identity?
+3. Can the app keep expert density while reducing each decision point to two or three primary actions?
+4. What should the safe primary recovery from connection failure be: Retry, Edit Host, or a stage-specific recommendation?

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -182,7 +182,9 @@ saturated signal (teal) plus two functional status hues (red, amber).
 - **Signal Teal** (`#14756C`): The single accent, sampled from the app icon.
   Primary buttons, FAB, active tab/indicator, focused input border, selected
   states, links. The one bright thing on a screen — use it where the eye should
-  land, nowhere else.
+  land, nowhere else. It is the identity seed; the resolved Material role may
+  shift only in luminance, preserving its hue, until it clears 4.5:1 against
+  every active app surface.
 - **Soft Teal** (`#58A38C`): The lighter accent. Selected chips, accent
   gradients, and tints where full Signal Teal would be too loud.
 
@@ -299,8 +301,9 @@ dark surfaces, use a tonal step or a Hairline border instead.
 
 ### Buttons
 - **Shape:** Rounded 12px (`rounded.md`); padding 24×16px.
-- **Primary (FilledButton):** Signal Teal background, white label, Inter 600
-  15px, flat (elevation 0) with the teal glow on dark.
+- **Primary (FilledButton):** Contrast-resolved Signal Teal background,
+  black-or-white readable label, Inter 600 15px, flat (elevation 0) with the
+  teal glow on dark.
 - **Secondary (OutlinedButton):** Transparent fill, 1.5px Hairline border,
   Terminal White label.
 - **Tertiary (TextButton):** Signal Teal label, no fill, 16×12px padding.
@@ -353,11 +356,12 @@ MonkeySSH's defining trait is that the **entire app theme can be re-derived from
 the active terminal theme**. Background, surfaces, text, and borders are computed
 by blending the terminal's own colors, and the accent is chosen by a
 contrast-aware scorer (preferring a saturated cursor color, otherwise the most
-vivid, sufficiently contrasty ANSI color). A built-in readable-text helper picks
-black or white per surface so labels never fall below contrast. When building new
-surfaces, **consume the resolved `ColorScheme`/`ThemeData` — never hardcode the
-hex values above** — so every screen automatically follows both the app default
-and any terminal-driven theme.
+vivid ANSI color), then adjusted along that hue until text-facing use clears
+WCAG AA on the background, surface, and raised surface. A built-in readable-text
+helper picks black or white per filled role. When building new surfaces,
+**consume the resolved `ColorScheme`/`ThemeData` — never hardcode the hex values
+above** — so every screen automatically follows both the app default and any
+terminal-driven theme.
 
 ### Signature Motif: The Cursor Block ▮
 A solid block glyph (▮, U+25AE) is MonkeySSH's brand mark — the blinking cursor

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -331,6 +331,9 @@ bool _portForwardBrowserLaunchIsValid(PortForwardBrowserLaunch launch) =>
 
 HomeScreenTab _homeScreenTabFromRoute(String? tab) => switch (tab) {
   'connections' => HomeScreenTab.connections,
+  'keys' => HomeScreenTab.keys,
+  'snippets' => HomeScreenTab.snippets,
+  'port-forwards' => HomeScreenTab.portForwards,
   _ => HomeScreenTab.hosts,
 };
 

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -18,6 +18,7 @@ abstract final class FluttyTheme {
   static const _textSecondary = Color(0xFF8A8A9A);
   static const _errorColor = Color(0xFFFF4757);
   static const _warningColor = Color(0xFFFFBE00);
+  static const _minimumTextContrastRatio = 4.55;
 
   // Light theme equivalents
   static const _backgroundLight = Color(0xFFF8F9FC);
@@ -79,22 +80,34 @@ abstract final class FluttyTheme {
     final background =
         terminalTheme?.background ??
         (isDark ? _backgroundDark : _backgroundLight);
-    final textPrimary =
-        terminalTheme?.foreground ?? (isDark ? _textPrimary : Colors.black87);
-    final textSecondary = terminalTheme == null
-        ? (isDark ? _textSecondary : Colors.black54)
-        : _blend(background, textPrimary, isDark ? 0.62 : 0.84);
     final surface =
         terminalTheme?.background ?? (isDark ? _surfaceDark : _surfaceLight);
+    final textPrimary = _opaqueAgainst(
+      terminalTheme?.foreground ?? (isDark ? _textPrimary : Colors.black87),
+      background,
+    );
     final card = terminalTheme == null
         ? (isDark ? _cardDark : _cardLight)
         : _blend(background, textPrimary, isDark ? 0.07 : 0.025);
     final border = terminalTheme == null
         ? (isDark ? _borderDark : _borderLight)
         : _blend(background, textPrimary, isDark ? 0.18 : 0.16);
-    final primary = terminalTheme == null
+    final rawTextSecondary = terminalTheme == null
+        ? (isDark ? _textSecondary : Colors.black54)
+        : _blend(background, textPrimary, isDark ? 0.62 : 0.84);
+    final textSecondary = _ensureMinimumContrast(
+      _opaqueAgainst(rawTextSecondary, background),
+      against: [background, surface, card],
+      minimumRatio: _minimumTextContrastRatio,
+    );
+    final rawPrimary = terminalTheme == null
         ? _accentTeal
         : _resolveTerminalAccent(terminalTheme);
+    final primary = _ensureMinimumContrast(
+      rawPrimary,
+      against: [background, surface, card],
+      minimumRatio: _minimumTextContrastRatio,
+    );
     final primarySoft = terminalTheme == null
         ? _accentTealSoft
         : _blend(background, primary, isDark ? 0.55 : 0.28);
@@ -111,28 +124,27 @@ abstract final class FluttyTheme {
     final snackBarForeground = _readableTextColor(snackBarBackground);
     final tooltipBackground = isDark ? card : overlayBackground;
     final tooltipForeground = _readableTextColor(tooltipBackground);
-    final onPrimary = terminalTheme == null
-        ? Colors.white
-        : _readableTextColor(primary);
-    final onTertiary = terminalTheme == null
-        ? Colors.black
-        : _readableTextColor(warning);
-    final onError = terminalTheme == null
-        ? Colors.white
-        : _readableTextColor(error);
+    final onPrimary = _readableTextColor(primary);
+    final onTertiary = _readableTextColor(warning);
+    final onError = _readableTextColor(error);
 
     final colorScheme = ColorScheme(
       brightness: brightness,
       primary: primary,
       onPrimary: onPrimary,
+      primaryContainer: primarySoft,
+      onPrimaryContainer: _readableTextColor(primarySoft),
       secondary: card,
       onSecondary: textPrimary,
+      secondaryContainer: card,
+      onSecondaryContainer: textPrimary,
       tertiary: warning,
       onTertiary: onTertiary,
       error: error,
       onError: onError,
       surface: surface,
       onSurface: textPrimary,
+      onSurfaceVariant: textSecondary,
       surfaceContainerHighest: card,
       outline: border,
       outlineVariant: border.withAlpha(isDark ? 128 : 180),
@@ -263,7 +275,7 @@ abstract final class FluttyTheme {
           vertical: 16,
         ),
         labelStyle: TextStyle(color: textSecondary),
-        hintStyle: TextStyle(color: textSecondary.withAlpha(150)),
+        hintStyle: TextStyle(color: textSecondary),
         prefixIconColor: textSecondary,
       ),
 
@@ -338,12 +350,14 @@ abstract final class FluttyTheme {
       chipTheme: ChipThemeData(
         backgroundColor: card,
         selectedColor: primarySoft,
-        labelStyle: _inter(
-          fontSize: 13,
-          fontWeight: FontWeight.w500,
-          // Material 3 InputChip leaves the label transparent if labelStyle
-          // is supplied without a color, so pin one here.
-          color: textPrimary,
+        labelStyle: WidgetStateTextStyle.resolveWith(
+          (states) => _inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w500,
+            color: states.contains(WidgetState.selected)
+                ? _readableTextColor(primarySoft)
+                : textPrimary,
+          ),
         ),
         side: BorderSide(color: border),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
@@ -564,6 +578,58 @@ abstract final class FluttyTheme {
 
   static Color _blend(Color background, Color foreground, double amount) =>
       Color.lerp(background, foreground, amount)!;
+
+  static Color _opaqueAgainst(Color foreground, Color background) =>
+      Color.alphaBlend(foreground, background).withAlpha(255);
+
+  static Color _ensureMinimumContrast(
+    Color color, {
+    required List<Color> against,
+    required double minimumRatio,
+  }) {
+    final opaqueColor = color.withAlpha(255);
+    if (_minimumContrastRatio(opaqueColor, against) >= minimumRatio) {
+      return opaqueColor;
+    }
+
+    Color? bestColor;
+    var bestBlendAmount = double.infinity;
+    for (final target in const [Colors.white, Colors.black]) {
+      if (_minimumContrastRatio(target, against) < minimumRatio) {
+        continue;
+      }
+
+      var low = 0.0;
+      var high = 1.0;
+      for (var i = 0; i < 16; i++) {
+        final amount = (low + high) / 2;
+        final candidate = Color.lerp(opaqueColor, target, amount)!;
+        if (_minimumContrastRatio(candidate, against) >= minimumRatio) {
+          high = amount;
+        } else {
+          low = amount;
+        }
+      }
+      if (high < bestBlendAmount) {
+        bestBlendAmount = high;
+        bestColor = Color.lerp(opaqueColor, target, high)!.withAlpha(255);
+      }
+    }
+
+    if (bestColor != null) {
+      return bestColor;
+    }
+    return _minimumContrastRatio(Colors.white, against) >=
+            _minimumContrastRatio(Colors.black, against)
+        ? Colors.white
+        : Colors.black;
+  }
+
+  static double _minimumContrastRatio(Color color, List<Color> backgrounds) =>
+      backgrounds
+          .map((background) => _contrastRatio(color, background))
+          .reduce((a, b) => a < b ? a : b);
+
   static Color _resolveTerminalAccent(TerminalThemeData theme) {
     // Prefer the theme's cursor color when its designer chose a strongly
     // saturated, sufficiently contrasty value. Themes that use a near-neutral

--- a/lib/presentation/screens/auth_setup_screen.dart
+++ b/lib/presentation/screens/auth_setup_screen.dart
@@ -245,7 +245,7 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
         inputFormatters: [FilteringTextInputFormatter.digitsOnly],
         onChanged: (_) => setState(() => _error = null),
         onSubmitted: (_) {
-          if (_pinController.text.length >= 4) {
+          if (_pinController.text.length >= 6) {
             setState(() {
               _step = 2;
               _error = null;
@@ -262,7 +262,7 @@ class _AuthSetupScreenState extends ConsumerState<AuthSetupScreen> {
           ),
           const Spacer(),
           ElevatedButton(
-            onPressed: _pinController.text.length >= 4
+            onPressed: _pinController.text.length >= 6
                 ? () => setState(() {
                     _step = 2;
                     _error = null;

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -51,7 +51,9 @@ import '../widgets/panel_header.dart';
 import '../widgets/premium_access.dart';
 import '../widgets/reorder_helpers.dart';
 import '../widgets/snippet_folder_dialog.dart';
+import '../widgets/tmux_window_navigator.dart';
 import '../widgets/tmux_window_status_badge.dart';
+import 'port_forwards_screen.dart';
 import 'snippet_edit_screen.dart';
 import 'transfer_screen.dart';
 
@@ -61,6 +63,8 @@ const _redactStoreScreenshotIdentities = bool.fromEnvironment(
 const _connectionTileHorizontalPadding = 16.0;
 const _connectionTileMinLeadingWidth = 40.0;
 const _connectionTileHorizontalTitleGap = 16.0;
+const _mobileBreakpoint = 600.0;
+const _compactPanelActionBreakpoint = 520.0;
 const _connectionPreviewLeadingInset =
     _connectionTileHorizontalPadding +
     _connectionTileMinLeadingWidth +
@@ -79,6 +83,9 @@ enum HomeScreenTab {
 
   /// Snippet management.
   snippets,
+
+  /// SSH port-forward management.
+  portForwards,
 }
 
 /// The main home screen - Termius-style sidebar layout.
@@ -158,9 +165,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   final Queue<int> _pendingHomeScreenShortcutHostIds = Queue<int>();
   int? _activeHomeScreenShortcutHostId;
   bool _isHandlingHomeScreenShortcut = false;
-
-  // Breakpoint for switching between mobile and desktop layout
-  static const double _mobileBreakpoint = 600;
 
   @override
   void initState() {
@@ -510,6 +514,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           selectedIcon: Icon(Icons.code_rounded),
           label: 'Snippets',
         ),
+        NavigationDestination(
+          icon: Icon(Icons.alt_route_outlined),
+          selectedIcon: Icon(Icons.alt_route_rounded),
+          label: 'Forwards',
+        ),
       ],
     ),
   );
@@ -613,6 +622,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                     selected: _selectedIndex == 3,
                     onTap: () => setState(() => _selectedIndex = 3),
                   ),
+                  _NavItem(
+                    icon: Icons.alt_route_rounded,
+                    label: 'Port Forwards',
+                    selected: _selectedIndex == 4,
+                    onTap: () => setState(() => _selectedIndex = 4),
+                  ),
 
                   const Spacer(),
 
@@ -660,6 +675,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           1 => const _ConnectionsPanel(),
           2 => const _KeysPanel(),
           3 => const SnippetsPanel(),
+          4 => const _PortForwardsHomePanel(),
           _ => const HostsPanel(),
         },
       ),
@@ -719,16 +735,20 @@ class _NavItem extends StatelessWidget {
                   size: 20,
                   color: selected
                       ? colorScheme.primary
-                      : colorScheme.onSurface.withAlpha(150),
+                      : colorScheme.onSurfaceVariant,
                 ),
                 const SizedBox(width: 12),
-                Text(
-                  label,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: selected
-                        ? colorScheme.primary
-                        : colorScheme.onSurface.withAlpha(200),
-                    fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+                Expanded(
+                  child: Text(
+                    label,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: selected
+                          ? colorScheme.primary
+                          : colorScheme.onSurfaceVariant,
+                      fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+                    ),
                   ),
                 ),
               ],
@@ -738,6 +758,54 @@ class _NavItem extends StatelessWidget {
       ),
     );
   }
+}
+
+class _AdaptivePanelShell extends StatelessWidget {
+  const _AdaptivePanelShell({
+    required this.title,
+    required this.child,
+    this.headerActions = const [],
+    this.compactAction,
+  });
+
+  final String title;
+  final Widget child;
+  final List<Widget> headerActions;
+  final Widget? compactAction;
+
+  @override
+  Widget build(BuildContext context) => LayoutBuilder(
+    builder: (context, constraints) {
+      final isCompact = constraints.maxWidth < _compactPanelActionBreakpoint;
+      final compactAction = this.compactAction;
+
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          PanelHeader(
+            title: title,
+            actions: isCompact ? const [] : headerActions,
+          ),
+          Expanded(
+            child: Stack(
+              children: [
+                Positioned.fill(
+                  bottom: isCompact && compactAction != null ? 88 : 0,
+                  child: child,
+                ),
+                if (isCompact && compactAction != null)
+                  Positioned(
+                    right: FluttyTheme.spacingMd,
+                    bottom: FluttyTheme.spacingMd,
+                    child: compactAction,
+                  ),
+              ],
+            ),
+          ),
+        ],
+      );
+    },
+  );
 }
 
 class _TelemetryOptInPromptCard extends ConsumerWidget {
@@ -873,25 +941,27 @@ class HostsPanel extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final hostsAsync = ref.watch(allHostsProvider);
+    final hasHosts = hostsAsync.asData?.value.isNotEmpty ?? false;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        // Header bar
-        PanelHeader(
-          title: 'hosts',
-          actions: [
-            _ActionButton(
-              icon: Icons.add,
-              label: 'Add Host',
-              onTap: () => context.push('/hosts/add'),
-              primary: true,
-            ),
-          ],
+    return _AdaptivePanelShell(
+      title: 'hosts',
+      headerActions: [
+        _ActionButton(
+          icon: Icons.add,
+          label: 'Add Host',
+          onTap: () => context.push('/hosts/add'),
+          primary: true,
         ),
-
-        Expanded(child: _buildHostsBody(context, ref, hostsAsync)),
       ],
+      compactAction: hasHosts
+          ? FloatingActionButton.extended(
+              heroTag: 'home-add-host',
+              onPressed: () => context.push('/hosts/add'),
+              icon: const Icon(Icons.add),
+              label: const Text('Add Host'),
+            )
+          : null,
+      child: _buildHostsBody(context, ref, hostsAsync),
     );
   }
 
@@ -1015,6 +1085,7 @@ class HostsPanel extends ConsumerWidget {
 enum _HostContextAction {
   connect,
   newConnection,
+  manage,
   toggleHomeScreen,
   disconnect,
   edit,
@@ -1160,7 +1231,7 @@ class _HostRow extends ConsumerWidget {
                               : '${host.username}@${host.hostname}',
                           style: FluttyTheme.monoStyle.copyWith(
                             fontSize: 11,
-                            color: colorScheme.onSurface.withAlpha(160),
+                            color: colorScheme.onSurfaceVariant,
                           ),
                         ),
                         if (connectionAttemptMessage != null) ...[
@@ -1192,7 +1263,7 @@ class _HostRow extends ConsumerWidget {
                           ':${host.port}',
                           style: FluttyTheme.monoStyle.copyWith(
                             fontSize: 10,
-                            color: colorScheme.onSurface.withAlpha(160),
+                            color: colorScheme.onSurfaceVariant,
                           ),
                         ),
                       ),
@@ -1380,7 +1451,6 @@ class _HostRow extends ConsumerWidget {
     WidgetRef ref,
     Offset globalPosition,
   ) async {
-    final colorScheme = Theme.of(context).colorScheme;
     final pinnedHomeScreenShortcutHostIds = ref.read(
       pinnedHomeScreenShortcutHostIdsProvider,
     );
@@ -1399,7 +1469,7 @@ class _HostRow extends ConsumerWidget {
     if (overlayBox == null) {
       return;
     }
-    final selection = await showMenu<_HostContextAction>(
+    var selection = await showMenu<_HostContextAction>(
       context: context,
       position: RelativeRect.fromRect(
         Rect.fromLTWH(globalPosition.dx, globalPosition.dy, 0, 0),
@@ -1431,56 +1501,14 @@ class _HostRow extends ConsumerWidget {
               title: Text(disconnectLabel),
             ),
           ),
-        if (supportsHomeScreenShortcutActions)
-          PopupMenuItem<_HostContextAction>(
-            value: _HostContextAction.toggleHomeScreen,
-            child: ListTile(
-              contentPadding: EdgeInsets.zero,
-              leading: Icon(
-                isPinnedToHomeScreen ? Icons.home_rounded : Icons.home_outlined,
-              ),
-              title: Text(
-                isPinnedToHomeScreen
-                    ? 'Remove from Home Screen'
-                    : 'Add to Home Screen',
-              ),
-            ),
-          ),
         const PopupMenuDivider(),
         const PopupMenuItem<_HostContextAction>(
-          value: _HostContextAction.edit,
+          value: _HostContextAction.manage,
           child: ListTile(
             contentPadding: EdgeInsets.zero,
-            leading: Icon(Icons.edit_outlined),
-            title: Text('Edit'),
-          ),
-        ),
-        const PopupMenuItem<_HostContextAction>(
-          value: _HostContextAction.duplicate,
-          child: ListTile(
-            contentPadding: EdgeInsets.zero,
-            leading: Icon(Icons.copy),
-            title: Text('Duplicate'),
-          ),
-        ),
-        PopupMenuItem<_HostContextAction>(
-          value: _HostContextAction.export,
-          child: ListTile(
-            contentPadding: EdgeInsets.zero,
-            leading: Icon(useShareSheet ? Icons.share : Icons.save_alt),
-            title: Text(
-              useShareSheet
-                  ? 'Share Encrypted (Pro)'
-                  : 'Export Encrypted File (Pro)',
-            ),
-          ),
-        ),
-        PopupMenuItem<_HostContextAction>(
-          value: _HostContextAction.delete,
-          child: ListTile(
-            contentPadding: EdgeInsets.zero,
-            leading: Icon(Icons.delete_outline, color: colorScheme.error),
-            title: Text('Delete', style: TextStyle(color: colorScheme.error)),
+            leading: Icon(Icons.tune_outlined),
+            title: Text('Manage host'),
+            trailing: Icon(Icons.chevron_right),
           ),
         ),
       ],
@@ -1489,6 +1517,15 @@ class _HostRow extends ConsumerWidget {
     if (!context.mounted || selection == null) {
       return;
     }
+    if (selection == _HostContextAction.manage) {
+      selection = await _showManageHostActions(
+        context,
+        isPinnedToHomeScreen: isPinnedToHomeScreen,
+      );
+      if (!context.mounted || selection == null) {
+        return;
+      }
+    }
 
     switch (selection) {
       case _HostContextAction.connect:
@@ -1496,6 +1533,8 @@ class _HostRow extends ConsumerWidget {
         return;
       case _HostContextAction.newConnection:
         await _openNewConnection(context, ref);
+        return;
+      case _HostContextAction.manage:
         return;
       case _HostContextAction.toggleHomeScreen:
         await _toggleHomeScreenShortcut(
@@ -1521,6 +1560,84 @@ class _HostRow extends ConsumerWidget {
         return;
     }
   }
+
+  Future<_HostContextAction?> _showManageHostActions(
+    BuildContext context, {
+    required bool isPinnedToHomeScreen,
+  }) => showModalBottomSheet<_HostContextAction>(
+    context: context,
+    builder: (sheetContext) {
+      final colorScheme = Theme.of(sheetContext).colorScheme;
+      void select(_HostContextAction action) =>
+          Navigator.pop(sheetContext, action);
+
+      return SafeArea(
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 20, 20, 8),
+                child: Text(
+                  host.label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: FluttyTheme.displayMono(
+                    fontSize: 16,
+                    color: colorScheme.onSurface,
+                  ),
+                ),
+              ),
+              ListTile(
+                leading: const Icon(Icons.edit_outlined),
+                title: const Text('Edit host'),
+                onTap: () => select(_HostContextAction.edit),
+              ),
+              ListTile(
+                leading: const Icon(Icons.copy),
+                title: const Text('Duplicate'),
+                onTap: () => select(_HostContextAction.duplicate),
+              ),
+              const Divider(),
+              if (supportsHomeScreenShortcutActions)
+                ListTile(
+                  leading: Icon(
+                    isPinnedToHomeScreen
+                        ? Icons.home_rounded
+                        : Icons.home_outlined,
+                  ),
+                  title: Text(
+                    isPinnedToHomeScreen
+                        ? 'Remove from Home Screen'
+                        : 'Add to Home Screen',
+                  ),
+                  onTap: () => select(_HostContextAction.toggleHomeScreen),
+                ),
+              ListTile(
+                leading: Icon(useShareSheet ? Icons.share : Icons.save_alt),
+                title: Text(
+                  useShareSheet
+                      ? 'Share Encrypted (Pro)'
+                      : 'Export Encrypted File (Pro)',
+                ),
+                onTap: () => select(_HostContextAction.export),
+              ),
+              const Divider(),
+              ListTile(
+                leading: Icon(Icons.delete_outline, color: colorScheme.error),
+                title: Text(
+                  'Delete host',
+                  style: TextStyle(color: colorScheme.error),
+                ),
+                onTap: () => select(_HostContextAction.delete),
+              ),
+            ],
+          ),
+        ),
+      );
+    },
+  );
 
   Future<void> _toggleHomeScreenShortcut(
     BuildContext context,
@@ -1908,6 +2025,30 @@ class _ConnectionsPanel extends ConsumerWidget {
   );
 }
 
+class _PortForwardsHomePanel extends StatelessWidget {
+  const _PortForwardsHomePanel();
+
+  @override
+  Widget build(BuildContext context) => _AdaptivePanelShell(
+    title: 'port forwards',
+    headerActions: [
+      _ActionButton(
+        icon: Icons.add,
+        label: 'Add Forward',
+        onTap: () => context.push('/port-forwards/add'),
+        primary: true,
+      ),
+    ],
+    compactAction: FloatingActionButton.extended(
+      heroTag: 'home-add-port-forward',
+      onPressed: () => context.push('/port-forwards/add'),
+      icon: const Icon(Icons.add),
+      label: const Text('Add Forward'),
+    ),
+    child: const PortForwardsPanel(),
+  );
+}
+
 class _ConnectionPreviewText extends StatelessWidget {
   const _ConnectionPreviewText({
     required this.endpoint,
@@ -1983,13 +2124,10 @@ class _ActionButton extends StatelessWidget {
 
     return TextButton.icon(
       onPressed: onTap,
-      icon: Icon(icon, size: 16, color: colorScheme.onSurface.withAlpha(150)),
+      icon: Icon(icon, size: 16, color: colorScheme.onSurfaceVariant),
       label: Text(
         label,
-        style: TextStyle(
-          fontSize: 13,
-          color: colorScheme.onSurface.withAlpha(150),
-        ),
+        style: TextStyle(fontSize: 13, color: colorScheme.onSurfaceVariant),
       ),
     );
   }
@@ -2018,11 +2156,7 @@ class _SmallIconButton extends StatelessWidget {
         child: ConstrainedBox(
           constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
           child: Center(
-            child: Icon(
-              icon,
-              size: 16,
-              color: colorScheme.onSurface.withAlpha(120),
-            ),
+            child: Icon(icon, size: 16, color: colorScheme.onSurfaceVariant),
           ),
         ),
       ),
@@ -2051,38 +2185,37 @@ class _KeysPanel extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final keysAsync = ref.watch(allKeysProvider);
+    final hasKeys = keysAsync.asData?.value.isNotEmpty ?? false;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        // Header bar
-        PanelHeader(
-          title: 'keys',
-          actions: [
-            _ActionButton(
-              icon: Icons.add,
-              label: 'Add Key',
-              onTap: () => context.push('/keys/add'),
-              primary: true,
-            ),
-          ],
-        ),
-
-        // Keys list
-        Expanded(
-          child: keysAsync.when(
-            loading: () => const BrandListSkeleton(),
-            error: (_, _) => BrandErrorState(
-              title: 'couldn’t load keys',
-              message: 'Your SSH keys didn’t load.',
-              onRetry: () => ref.invalidate(allKeysProvider),
-            ),
-            data: (keys) => keys.isEmpty
-                ? _buildEmptyState(context)
-                : _buildKeysList(context, ref, keys),
-          ),
+    return _AdaptivePanelShell(
+      title: 'keys',
+      headerActions: [
+        _ActionButton(
+          icon: Icons.add,
+          label: 'Add Key',
+          onTap: () => context.push('/keys/add'),
+          primary: true,
         ),
       ],
+      compactAction: hasKeys
+          ? FloatingActionButton.extended(
+              heroTag: 'home-add-key',
+              onPressed: () => context.push('/keys/add'),
+              icon: const Icon(Icons.add),
+              label: const Text('Add Key'),
+            )
+          : null,
+      child: keysAsync.when(
+        loading: () => const BrandListSkeleton(),
+        error: (_, _) => BrandErrorState(
+          title: 'couldn’t load keys',
+          message: 'Your SSH keys didn’t load.',
+          onRetry: () => ref.invalidate(allKeysProvider),
+        ),
+        data: (keys) => keys.isEmpty
+            ? _buildEmptyState(context)
+            : _buildKeysList(context, ref, keys),
+      ),
     );
   }
 
@@ -2175,7 +2308,7 @@ class _KeyRow extends ConsumerWidget {
                       sshKey.keyType.toUpperCase(),
                       style: FluttyTheme.monoStyle.copyWith(
                         fontSize: 10,
-                        color: colorScheme.onSurface.withAlpha(160),
+                        color: colorScheme.onSurfaceVariant,
                       ),
                     ),
                   ],
@@ -2393,50 +2526,80 @@ class _SnippetsPanelState extends ConsumerState<SnippetsPanel> {
   Widget build(BuildContext context) {
     final snippetsAsync = ref.watch(allSnippetsProvider);
     final foldersAsync = ref.watch(allSnippetFoldersProvider);
+    final hasContent =
+        (snippetsAsync.asData?.value.isNotEmpty ?? false) ||
+        (foldersAsync.asData?.value.isNotEmpty ?? false);
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        // Header bar
-        PanelHeader(
-          title: 'snippets',
-          actions: [
-            _ActionButton(
-              icon: Icons.create_new_folder_outlined,
-              label: 'New Folder',
-              onTap: () => unawaited(_createFolder(context)),
+    return _AdaptivePanelShell(
+      title: 'snippets',
+      headerActions: [
+        _ActionButton(
+          icon: Icons.create_new_folder_outlined,
+          label: 'New Folder',
+          onTap: () => unawaited(_createFolder(context)),
+        ),
+        const SizedBox(width: 8),
+        _ActionButton(
+          icon: Icons.add,
+          label: 'Add Snippet',
+          onTap: () => _addSnippet(context),
+          primary: true,
+        ),
+      ],
+      compactAction: hasContent
+          ? FloatingActionButton.extended(
+              heroTag: 'home-create-snippet-content',
+              onPressed: () => _showCreateActions(context),
+              icon: const Icon(Icons.add),
+              label: const Text('New'),
+            )
+          : null,
+      child: snippetsAsync.when(
+        loading: () => const BrandListSkeleton(),
+        error: (_, _) => BrandErrorState(
+          title: 'couldn’t load snippets',
+          message: 'Your snippets didn’t load.',
+          onRetry: () => ref.invalidate(allSnippetsProvider),
+        ),
+        data: (snippets) => foldersAsync.when(
+          loading: () => const BrandListSkeleton(),
+          error: (_, _) => BrandErrorState(
+            title: 'couldn’t load folders',
+            message: 'Your snippet folders didn’t load.',
+            onRetry: () => ref.invalidate(allSnippetFoldersProvider),
+          ),
+          data: (folders) => _buildSnippetsBody(context, snippets, folders),
+        ),
+      ),
+    );
+  }
+
+  void _showCreateActions(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (sheetContext) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.add),
+              title: const Text('Add Snippet'),
+              onTap: () {
+                Navigator.pop(sheetContext);
+                _addSnippet(context);
+              },
             ),
-            const SizedBox(width: 8),
-            _ActionButton(
-              icon: Icons.add,
-              label: 'Add Snippet',
-              onTap: () => _addSnippet(context),
-              primary: true,
+            ListTile(
+              leading: const Icon(Icons.create_new_folder_outlined),
+              title: const Text('New Folder'),
+              onTap: () {
+                Navigator.pop(sheetContext);
+                unawaited(_createFolder(context));
+              },
             ),
           ],
         ),
-
-        // Snippets list
-        Expanded(
-          child: snippetsAsync.when(
-            loading: () => const BrandListSkeleton(),
-            error: (_, _) => BrandErrorState(
-              title: 'couldn’t load snippets',
-              message: 'Your snippets didn’t load.',
-              onRetry: () => ref.invalidate(allSnippetsProvider),
-            ),
-            data: (snippets) => foldersAsync.when(
-              loading: () => const BrandListSkeleton(),
-              error: (_, _) => BrandErrorState(
-                title: 'couldn’t load folders',
-                message: 'Your snippet folders didn’t load.',
-                onRetry: () => ref.invalidate(allSnippetFoldersProvider),
-              ),
-              data: (folders) => _buildSnippetsBody(context, snippets, folders),
-            ),
-          ),
-        ),
-      ],
+      ),
     );
   }
 
@@ -2862,7 +3025,7 @@ class _SnippetRow extends ConsumerWidget {
                       overflow: TextOverflow.ellipsis,
                       style: FluttyTheme.monoStyle.copyWith(
                         fontSize: 10,
-                        color: colorScheme.onSurface.withAlpha(150),
+                        color: colorScheme.onSurfaceVariant,
                       ),
                     ),
                     if (folderName case final folderName?) ...[
@@ -2872,7 +3035,7 @@ class _SnippetRow extends ConsumerWidget {
                           Icon(
                             Icons.folder_outlined,
                             size: 12,
-                            color: colorScheme.onSurface.withAlpha(140),
+                            color: colorScheme.onSurfaceVariant,
                           ),
                           const SizedBox(width: 4),
                           Flexible(
@@ -2881,7 +3044,7 @@ class _SnippetRow extends ConsumerWidget {
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                               style: theme.textTheme.labelSmall?.copyWith(
-                                color: colorScheme.onSurface.withAlpha(120),
+                                color: colorScheme.onSurfaceVariant,
                               ),
                             ),
                           ),
@@ -3316,6 +3479,20 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
         'Copilot CLI, or OpenCode sessions.',
   );
 
+  Future<void> _openRecentAgentSessions() async {
+    if (!_hasAgentSessionAccess) {
+      await _handleLockedAiSessionsTap();
+      return;
+    }
+    setState(() {
+      _expanded = true;
+      _showSessions = true;
+      _hasInitializedSessionProviders = true;
+    });
+    _persistUiState();
+    await _prefetchPreferredSessionProvider();
+  }
+
   String? _resolveRecentSessionScopeWorkingDirectory(SshSession session) {
     final activeWindow = _windows?.where((w) => w.isActive).firstOrNull;
     return resolveAgentSessionScopeWorkingDirectory(
@@ -3615,12 +3792,16 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                 children: [
                   _buildMuxSummaryIcon(theme),
                   const SizedBox(width: 4),
-                  Text(
-                    _sessionName != null
-                        ? '$_sessionName · ${windows.length} windows'
-                        : '${_muxBackend.label} · ${windows.length} windows',
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
+                  Expanded(
+                    child: Text(
+                      _sessionName != null
+                          ? '$_sessionName · ${windows.length} windows'
+                          : '${_muxBackend.label} · ${windows.length} windows',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
                     ),
                   ),
                   if (alertCount > 0) ...[
@@ -3639,7 +3820,20 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                       ),
                     ),
                   ],
-                  const Spacer(),
+                  TextButton.icon(
+                    key: ValueKey<String>(
+                      'recent-agents-${widget.connectionId}',
+                    ),
+                    onPressed: () => unawaited(_openRecentAgentSessions()),
+                    style: TextButton.styleFrom(
+                      foregroundColor: theme.colorScheme.onSurfaceVariant,
+                      minimumSize: const Size(44, 44),
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      textStyle: theme.textTheme.labelSmall,
+                    ),
+                    icon: const Icon(Icons.smart_toy_outlined, size: 14),
+                    label: const Text('Agents'),
+                  ),
                   Icon(
                     _expanded ? Icons.expand_less : Icons.expand_more,
                     size: 16,
@@ -3800,6 +3994,18 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
       );
     }
     return Icon(Icons.window_outlined, size: 14, color: color);
+  }
+
+  Future<void> _confirmCloseWindow(TmuxWindow window) async {
+    final confirmed = await confirmCloseRemoteWindow(
+      context: context,
+      windowTitle: window.displayTitle,
+      closesLastWindow: (_windows?.length ?? 0) <= 1,
+    );
+    if (!mounted || !confirmed) {
+      return;
+    }
+    _closeWindow(window.index);
   }
 
   void _closeWindow(int windowIndex) {
@@ -4121,14 +4327,16 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
               padding: const EdgeInsets.only(left: 6, right: 6),
               child: TmuxWindowStatusBadge(window: window),
             ),
-            // Close button.
-            GestureDetector(
-              onTap: () => _closeWindow(window.index),
-              child: Icon(
-                Icons.close,
-                size: 14,
-                color: theme.colorScheme.onSurfaceVariant,
+            IconButton(
+              tooltip: 'Close window',
+              icon: const Icon(Icons.close, size: 16),
+              color: theme.colorScheme.onSurfaceVariant,
+              style: IconButton.styleFrom(
+                fixedSize: const Size.square(44),
+                visualDensity: VisualDensity.standard,
+                padding: EdgeInsets.zero,
               ),
+              onPressed: () => unawaited(_confirmCloseWindow(window)),
             ),
           ],
         ),

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -4297,18 +4297,10 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(
-                    title,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: window.isActive
-                          ? theme.colorScheme.primary
-                          : theme.colorScheme.onSurface,
-                      fontWeight: window.isActive
-                          ? FontWeight.bold
-                          : FontWeight.normal,
-                    ),
+                  TmuxWindowTitleText(
+                    title: title,
+                    isActive: window.isActive,
+                    fontSize: 12,
                   ),
                   if (secondaryTitle != null)
                     Text(

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -35,6 +35,10 @@ import '../widgets/unsaved_changes_guard.dart';
 import 'transfer_screen.dart';
 
 const _hostFieldHelperMaxLines = 4;
+const _hostEditWideActionBreakpoint = 600.0;
+const _hostEditFormPadding = 16.0;
+const _hostEditInlineActionBreakpoint =
+    _hostEditWideActionBreakpoint - (_hostEditFormPadding * 2);
 const _hostStartupModeOptions = <HostStartupMode>[
   HostStartupMode.none,
   HostStartupMode.monkeyMux,
@@ -424,13 +428,21 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
               ),
             ],
           ),
+          bottomNavigationBar: isLoading
+              ? null
+              : LayoutBuilder(
+                  builder: (context, constraints) =>
+                      constraints.maxWidth < _hostEditWideActionBreakpoint
+                      ? _buildCompactActionBar(isEditing)
+                      : const SizedBox.shrink(),
+                ),
           body: isLoading
               ? const Center(child: CircularProgressIndicator())
               : Form(
                   key: _formKey,
                   child: SingleChildScrollView(
                     controller: _scrollController,
-                    padding: const EdgeInsets.all(16),
+                    padding: const EdgeInsets.all(_hostEditFormPadding),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
@@ -793,28 +805,24 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                         _buildPortForwardsSection(context, isEditing),
                         const SizedBox(height: 32),
 
-                        // Save button
-                        FilledButton.icon(
-                          key: const Key('host-save-button'),
-                          onPressed: _isBusy ? null : _saveHost,
-                          icon: _isBusy
-                              ? const SizedBox(
-                                  width: 18,
-                                  height: 18,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                  ),
-                                )
-                              : const Icon(Icons.save),
-                          label: Text(isEditing ? 'Save Changes' : 'Add Host'),
-                        ),
-                        const SizedBox(height: 16),
-
-                        // Test connection button
-                        OutlinedButton.icon(
-                          onPressed: _isBusy ? null : _testConnection,
-                          icon: const Icon(Icons.network_check),
-                          label: const Text('Test Connection'),
+                        LayoutBuilder(
+                          builder: (context, constraints) {
+                            if (constraints.maxWidth <
+                                _hostEditInlineActionBreakpoint) {
+                              return const SizedBox.shrink();
+                            }
+                            return Column(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: [
+                                _buildSaveButton(
+                                  isEditing: isEditing,
+                                  compact: false,
+                                ),
+                                const SizedBox(height: 16),
+                                _buildTestButton(compact: false),
+                              ],
+                            );
+                          },
                         ),
                       ],
                     ),
@@ -824,6 +832,60 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
       ),
     );
   }
+
+  Widget _buildCompactActionBar(bool isEditing) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Material(
+      color: colorScheme.surface,
+      child: SafeArea(
+        top: false,
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+          decoration: BoxDecoration(
+            border: Border(top: BorderSide(color: colorScheme.outlineVariant)),
+          ),
+          child: Row(
+            children: [
+              Expanded(child: _buildTestButton(compact: true)),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _buildSaveButton(isEditing: isEditing, compact: true),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSaveButton({required bool isEditing, required bool compact}) =>
+      FilledButton.icon(
+        key: const Key('host-save-button'),
+        onPressed: _isBusy ? null : _saveHost,
+        icon: _isBusy
+            ? const SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : Icon(isEditing ? Icons.save : Icons.add),
+        label: Text(
+          compact
+              ? isEditing
+                    ? 'Save'
+                    : 'Add Host'
+              : isEditing
+              ? 'Save Changes'
+              : 'Add Host',
+        ),
+      );
+
+  Widget _buildTestButton({required bool compact}) => OutlinedButton.icon(
+    key: const Key('host-test-button'),
+    onPressed: _isBusy ? null : _testConnection,
+    icon: const Icon(Icons.network_check),
+    label: Text(compact ? 'Test' : 'Test Connection'),
+  );
 
   HostStartupMode _resolveStartupMode({
     required Host host,

--- a/lib/presentation/screens/keys_screen.dart
+++ b/lib/presentation/screens/keys_screen.dart
@@ -163,7 +163,7 @@ class _KeyListTile extends StatelessWidget {
         _getKeyTypeLabel(),
         style: FluttyTheme.monoStyle.copyWith(
           fontSize: 11,
-          color: theme.colorScheme.onSurface.withAlpha(160),
+          color: theme.colorScheme.onSurfaceVariant,
         ),
       ),
       trailing: PopupMenuButton<String>(

--- a/lib/presentation/screens/port_forwards_screen.dart
+++ b/lib/presentation/screens/port_forwards_screen.dart
@@ -21,34 +21,43 @@ class PortForwardsScreen extends ConsumerWidget {
   const PortForwardsScreen({super.key});
 
   @override
+  Widget build(BuildContext context, WidgetRef ref) => Scaffold(
+    appBar: AppBar(title: const Text('Port Forwards')),
+    body: const PortForwardsPanel(),
+    floatingActionButton: FloatingActionButton.extended(
+      onPressed: () => context.push('/port-forwards/add'),
+      icon: const Icon(Icons.add),
+      label: const Text('Add Forward'),
+    ),
+  );
+}
+
+/// Port-forward content shared by the standalone screen and the home shell.
+class PortForwardsPanel extends ConsumerWidget {
+  /// Creates the port-forward list panel.
+  const PortForwardsPanel({super.key});
+
+  @override
   Widget build(BuildContext context, WidgetRef ref) {
     final portForwardsAsync = ref.watch(allPortForwardsProvider);
     final hostsAsync = ref.watch(allHostsProvider);
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Port Forwards')),
-      body: portForwardsAsync.when(
+    return portForwardsAsync.when(
+      loading: () => const BrandListSkeleton(),
+      error: (_, _) => BrandErrorState(
+        title: 'couldn’t load forwards',
+        message: 'Your port forwards didn’t load.',
+        onRetry: () => ref.invalidate(allPortForwardsProvider),
+      ),
+      data: (portForwards) => hostsAsync.when(
         loading: () => const BrandListSkeleton(),
         error: (_, _) => BrandErrorState(
-          title: 'couldn’t load forwards',
-          message: 'Your port forwards didn’t load.',
-          onRetry: () => ref.invalidate(allPortForwardsProvider),
+          title: 'couldn’t load hosts',
+          message: 'Your saved hosts didn’t load.',
+          onRetry: () => ref.invalidate(allHostsProvider),
         ),
-        data: (portForwards) => hostsAsync.when(
-          loading: () => const BrandListSkeleton(),
-          error: (_, _) => BrandErrorState(
-            title: 'couldn’t load hosts',
-            message: 'Your saved hosts didn’t load.',
-            onRetry: () => ref.invalidate(allHostsProvider),
-          ),
-          data: (hosts) =>
-              _buildPortForwardsList(context, ref, portForwards, hosts),
-        ),
-      ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () => context.push('/port-forwards/add'),
-        icon: const Icon(Icons.add),
-        label: const Text('Add Forward'),
+        data: (hosts) =>
+            _buildPortForwardsList(context, ref, portForwards, hosts),
       ),
     );
   }

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -1609,92 +1609,185 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     );
     showModalBottomSheet<void>(
       context: context,
-      builder: (context) => SafeArea(
+      builder: (sheetContext) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (file.attr.isDirectory) ...[
+              ListTile(
+                leading: const Icon(Icons.info_outline),
+                title: const Text('Info'),
+                onTap: () => _afterClosingOptions(
+                  sheetContext,
+                  () => _showFileInfo(file),
+                ),
+              ),
+              ListTile(
+                leading: const Icon(Icons.copy_all_outlined),
+                title: const Text('Copy as path'),
+                onTap: () => _afterClosingOptions(
+                  sheetContext,
+                  () => unawaited(_copyRemotePath(file)),
+                ),
+              ),
+              ListTile(
+                leading: const Icon(Icons.drive_file_rename_outline),
+                title: const Text('Rename'),
+                onTap: () => _afterClosingOptions(
+                  sheetContext,
+                  () => _showRenameDialog(file),
+                ),
+              ),
+              ListTile(
+                leading: Icon(
+                  Icons.delete_outline,
+                  color: Theme.of(sheetContext).colorScheme.error,
+                ),
+                title: Text(
+                  'Delete',
+                  style: TextStyle(
+                    color: Theme.of(sheetContext).colorScheme.error,
+                  ),
+                ),
+                onTap: () =>
+                    _afterClosingOptions(sheetContext, () => _deleteFile(file)),
+              ),
+            ] else ...[
+              ListTile(
+                leading: Icon(
+                  previewKind == null
+                      ? Icons.edit_outlined
+                      : Icons.open_in_new_outlined,
+                ),
+                title: Text(previewKind == null ? 'Edit' : 'Open…'),
+                onTap: () => _afterClosingOptions(
+                  sheetContext,
+                  previewKind == null
+                      ? () => unawaited(_editTextFile(file))
+                      : () => _showOpenFileOptions(file, previewKind),
+                ),
+              ),
+              ListTile(
+                leading: const Icon(Icons.download),
+                title: const Text('Download'),
+                onTap: () => _afterClosingOptions(
+                  sheetContext,
+                  () => unawaited(_downloadFile(file)),
+                ),
+              ),
+              ListTile(
+                leading: const Icon(Icons.copy_all_outlined),
+                title: const Text('Copy as path'),
+                onTap: () => _afterClosingOptions(
+                  sheetContext,
+                  () => unawaited(_copyRemotePath(file)),
+                ),
+              ),
+              ListTile(
+                leading: const Icon(Icons.tune_outlined),
+                title: const Text('Manage file'),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => _afterClosingOptions(
+                  sheetContext,
+                  () => _showManageFileOptions(file),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showOpenFileOptions(SftpName file, SftpPreviewKind previewKind) {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (sheetContext) => SafeArea(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
             ListTile(
-              leading: const Icon(Icons.info_outline),
-              title: const Text('Info'),
-              onTap: () {
-                Navigator.pop(context);
-                _showFileInfo(file);
-              },
-            ),
-            if (previewKind != null)
-              ListTile(
-                leading: Icon(
-                  previewKind == SftpPreviewKind.video
-                      ? Icons.video_file_outlined
-                      : Icons.image_outlined,
-                ),
-                title: Text(
-                  previewKind == SftpPreviewKind.video
-                      ? 'Preview video'
-                      : 'View',
-                ),
-                onTap: () {
-                  Navigator.pop(context);
-                  switch (previewKind) {
-                    case SftpPreviewKind.image:
-                      unawaited(_previewImageFile(file));
-                    case SftpPreviewKind.video:
-                      unawaited(_previewVideoFile(file));
-                  }
-                },
-              ),
-            if (!file.attr.isDirectory)
-              ListTile(
-                leading: const Icon(Icons.edit_outlined),
-                title: const Text('Edit'),
-                onTap: () {
-                  Navigator.pop(context);
-                  unawaited(_editTextFile(file));
-                },
-              ),
-            if (!file.attr.isDirectory)
-              ListTile(
-                leading: const Icon(Icons.download),
-                title: const Text('Download'),
-                onTap: () {
-                  Navigator.pop(context);
-                  unawaited(_downloadFile(file));
-                },
-              ),
-            ListTile(
-              leading: const Icon(Icons.copy_all_outlined),
-              title: const Text('Copy as path'),
-              onTap: () async {
-                Navigator.pop(context);
-                await _copyRemotePath(file);
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.drive_file_rename_outline),
-              title: const Text('Rename'),
-              onTap: () {
-                Navigator.pop(context);
-                _showRenameDialog(file);
-              },
-            ),
-            ListTile(
               leading: Icon(
-                Icons.delete_outline,
-                color: Theme.of(context).colorScheme.error,
+                previewKind == SftpPreviewKind.video
+                    ? Icons.video_file_outlined
+                    : Icons.image_outlined,
               ),
               title: Text(
-                'Delete',
-                style: TextStyle(color: Theme.of(context).colorScheme.error),
+                previewKind == SftpPreviewKind.video
+                    ? 'Preview video'
+                    : 'View image',
               ),
-              onTap: () {
-                Navigator.pop(context);
-                _deleteFile(file);
-              },
+              onTap: () => _afterClosingOptions(sheetContext, () {
+                switch (previewKind) {
+                  case SftpPreviewKind.image:
+                    unawaited(_previewImageFile(file));
+                  case SftpPreviewKind.video:
+                    unawaited(_previewVideoFile(file));
+                }
+              }),
+            ),
+            ListTile(
+              leading: const Icon(Icons.edit_outlined),
+              title: const Text('Open in editor'),
+              onTap: () => _afterClosingOptions(
+                sheetContext,
+                () => unawaited(_editTextFile(file)),
+              ),
             ),
           ],
         ),
       ),
     );
+  }
+
+  void _showManageFileOptions(SftpName file) {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (sheetContext) {
+        final colorScheme = Theme.of(sheetContext).colorScheme;
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.info_outline),
+                title: const Text('Info'),
+                onTap: () => _afterClosingOptions(
+                  sheetContext,
+                  () => _showFileInfo(file),
+                ),
+              ),
+              ListTile(
+                leading: const Icon(Icons.drive_file_rename_outline),
+                title: const Text('Rename'),
+                onTap: () => _afterClosingOptions(
+                  sheetContext,
+                  () => _showRenameDialog(file),
+                ),
+              ),
+              ListTile(
+                leading: Icon(Icons.delete_outline, color: colorScheme.error),
+                title: Text(
+                  'Delete',
+                  style: TextStyle(color: colorScheme.error),
+                ),
+                onTap: () =>
+                    _afterClosingOptions(sheetContext, () => _deleteFile(file)),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _afterClosingOptions(BuildContext sheetContext, VoidCallback action) {
+    Navigator.pop(sheetContext);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        action();
+      }
+    });
   }
 
   void _showFileInfo(SftpName file) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3877,11 +3877,41 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     ),
   ];
 
+  List<Widget> _terminalToolsMenuItems(BuildContext context) => [
+    if (isPortForwardBrowserSupported())
+      _terminalOverflowMenuItem(
+        context: context,
+        icon: Icons.open_in_browser_outlined,
+        label: 'Open Forwarded Browser',
+        action: 'open_port_forward_browser',
+      ),
+    if (_workingDirectoryPath != null)
+      _terminalOverflowMenuItem(
+        context: context,
+        icon: Icons.folder_copy_outlined,
+        label: 'Copy Current Directory',
+        action: 'copy_working_directory',
+      ),
+    if (_currentTerminalSelectionText() != null)
+      _terminalOverflowMenuItem(
+        context: context,
+        icon: Icons.code_rounded,
+        label: 'Create Snippet',
+        action: 'create_snippet',
+      ),
+  ];
+
   List<Widget> _terminalOptionsMenuItems({
     required BuildContext context,
     required bool hasTerminalInfo,
     required bool isMobile,
   }) => [
+    _terminalOverflowMenuItem(
+      context: context,
+      icon: Icons.palette_outlined,
+      label: 'Change Theme',
+      action: 'change_theme',
+    ),
     if (hasTerminalInfo)
       _terminalOverflowMenuItem(
         context: context,
@@ -3912,6 +3942,23 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       label: 'Shell Completion Popups',
       checked: ref.read(shellCompletionsNotifierProvider),
       action: 'toggle_shell_completions',
+    ),
+    if (!isMobile)
+      _terminalOverflowMenuItem(
+        context: context,
+        icon: _isNativeSelectionMode
+            ? Icons.deselect_rounded
+            : Icons.select_all_rounded,
+        label: _isNativeSelectionMode
+            ? 'Exit Native Selection'
+            : 'Native Selection',
+        action: 'native_select',
+      ),
+    _terminalOverflowMenuItem(
+      context: context,
+      icon: Icons.help_outline_rounded,
+      label: 'Controls & Gestures',
+      action: 'terminal_help',
     ),
   ];
 
@@ -10576,18 +10623,22 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                   label: 'Snippets',
                   action: 'snippets',
                 ),
-                _terminalOverflowMenuItem(
+                _terminalOverflowSubmenuButton(
                   context: context,
-                  icon: Icons.palette_outlined,
-                  label: 'Change Theme',
-                  action: 'change_theme',
+                  isMobile: isMobile,
+                  icon: Icons.paste_rounded,
+                  label: 'Paste',
+                  menuChildren: _terminalPastingMenuItems(context),
                 ),
-                if (isPortForwardBrowserSupported())
-                  _terminalOverflowMenuItem(
+                if (isPortForwardBrowserSupported() ||
+                    _workingDirectoryPath != null ||
+                    _currentTerminalSelectionText() != null)
+                  _terminalOverflowSubmenuButton(
                     context: context,
-                    icon: Icons.open_in_browser_outlined,
-                    label: 'Open Forwarded Browser',
-                    action: 'open_port_forward_browser',
+                    isMobile: isMobile,
+                    icon: Icons.build_outlined,
+                    label: 'Tools',
+                    menuChildren: _terminalToolsMenuItems(context),
                   ),
                 _terminalOverflowSubmenuButton(
                   context: context,
@@ -10599,39 +10650,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                     hasTerminalInfo: statusChips.isNotEmpty,
                     isMobile: isMobile,
                   ),
-                ),
-                _terminalOverflowMenuDivider(context),
-                if (!isMobile)
-                  _terminalOverflowMenuItem(
-                    context: context,
-                    icon: _isNativeSelectionMode
-                        ? Icons.deselect_rounded
-                        : Icons.select_all_rounded,
-                    label: _isNativeSelectionMode
-                        ? 'Exit Native Selection'
-                        : 'Native Selection',
-                    action: 'native_select',
-                  ),
-                if (_workingDirectoryPath != null)
-                  _terminalOverflowMenuItem(
-                    context: context,
-                    icon: Icons.folder_copy_outlined,
-                    label: 'Copy Current Directory',
-                    action: 'copy_working_directory',
-                  ),
-                if (_currentTerminalSelectionText() != null)
-                  _terminalOverflowMenuItem(
-                    context: context,
-                    icon: Icons.code_rounded,
-                    label: 'Create Snippet',
-                    action: 'create_snippet',
-                  ),
-                _terminalOverflowSubmenuButton(
-                  context: context,
-                  isMobile: isMobile,
-                  icon: Icons.paste_rounded,
-                  label: 'Paste',
-                  menuChildren: _terminalPastingMenuItems(context),
                 ),
                 _terminalOverflowMenuDivider(context),
                 _terminalOverflowMenuItem(
@@ -11775,6 +11793,71 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     return paneDirectory;
   }
 
+  Future<void> _showTerminalControlsHelp() => showModalBottomSheet<void>(
+    context: context,
+    requestFocus: terminalOverlayRouteRequestFocus(context),
+    showDragHandle: true,
+    builder: (sheetContext) {
+      final theme = Theme.of(sheetContext);
+      return SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(12, 0, 12, 16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(8, 4, 8, 8),
+                child: Text(
+                  'terminal controls',
+                  style: FluttyTheme.displayMono(
+                    fontSize: 18,
+                    color: theme.colorScheme.onSurface,
+                  ),
+                ),
+              ),
+              const ListTile(
+                leading: Icon(Icons.touch_app_outlined),
+                title: Text('Type'),
+                subtitle: Text(
+                  'Tap the terminal or use the keyboard button to start typing.',
+                ),
+              ),
+              const ListTile(
+                leading: Icon(Icons.pinch_outlined),
+                title: Text('Resize text'),
+                subtitle: Text(
+                  'Pinch the terminal or remote editor to adjust text size.',
+                ),
+              ),
+              const ListTile(
+                leading: Icon(Icons.keyboard_alt_outlined),
+                title: Text('Extra keys'),
+                subtitle: Text(
+                  'Use Fn for modifiers, navigation keys, and saved snippets.',
+                ),
+              ),
+              const ListTile(
+                leading: Icon(Icons.select_all_outlined),
+                title: Text('Select output'),
+                subtitle: Text(
+                  'Select terminal text to copy, share, or save as a snippet.',
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+                child: FilledButton(
+                  onPressed: () => Navigator.pop(sheetContext),
+                  child: const Text('Done'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    },
+  );
+
   Future<void> _handleMenuAction(String action) async {
     switch (action) {
       case 'snippets':
@@ -11809,6 +11892,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         if (!enabled) {
           _hideShellCompletionPopup();
         }
+        break;
+      case 'terminal_help':
+        await _showTerminalControlsHelp();
         break;
       case 'native_select':
         _toggleNativeSelectionMode();

--- a/lib/presentation/widgets/brand_empty_state.dart
+++ b/lib/presentation/widgets/brand_empty_state.dart
@@ -78,7 +78,7 @@ class BrandEmptyState extends StatelessWidget {
                 style: FluttyTheme.displayMono(
                   fontSize: 15,
                   fontWeight: FontWeight.w500,
-                  color: colorScheme.onSurface.withAlpha(160),
+                  color: colorScheme.onSurfaceVariant,
                   letterSpacing: 0,
                 ),
               ),
@@ -86,7 +86,7 @@ class BrandEmptyState extends StatelessWidget {
                 text: r':~$',
                 style: FluttyTheme.displayMono(
                   fontSize: 15,
-                  color: colorScheme.onSurface.withAlpha(110),
+                  color: colorScheme.onSurfaceVariant,
                   letterSpacing: 0,
                 ),
               ),
@@ -95,10 +95,7 @@ class BrandEmptyState extends StatelessWidget {
                 baseline: TextBaseline.alphabetic,
                 child: Padding(
                   padding: const EdgeInsets.only(left: 6),
-                  child: CursorBlock(
-                    size: 16,
-                    color: colorScheme.onSurface.withAlpha(170),
-                  ),
+                  child: CursorBlock(size: 16, color: colorScheme.primary),
                 ),
               ),
             ],
@@ -108,16 +105,14 @@ class BrandEmptyState extends StatelessWidget {
         Text(
           title,
           textAlign: TextAlign.center,
-          style: FluttyTheme.displayMono(
-            color: colorScheme.onSurface.withAlpha(230),
-          ),
+          style: FluttyTheme.displayMono(color: colorScheme.onSurface),
         ),
         const SizedBox(height: FluttyTheme.spacingSm),
         Text(
           message,
           textAlign: TextAlign.center,
           style: theme.textTheme.bodyMedium?.copyWith(
-            color: colorScheme.onSurface.withAlpha(140),
+            color: colorScheme.onSurfaceVariant,
           ),
         ),
         if (primaryLabel != null && onPrimary != null) ...[

--- a/lib/presentation/widgets/brand_error_state.dart
+++ b/lib/presentation/widgets/brand_error_state.dart
@@ -47,14 +47,14 @@ class BrandErrorState extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(icon, size: 32, color: colorScheme.onSurface.withAlpha(150)),
+            Icon(icon, size: 32, color: colorScheme.onSurfaceVariant),
             const SizedBox(height: FluttyTheme.spacingMd),
             Text(
               title,
               textAlign: TextAlign.center,
               style: FluttyTheme.displayMono(
                 fontSize: 16,
-                color: colorScheme.onSurface.withAlpha(230),
+                color: colorScheme.onSurface,
               ),
             ),
             if (message != null) ...[
@@ -63,7 +63,7 @@ class BrandErrorState extends StatelessWidget {
                 message!,
                 textAlign: TextAlign.center,
                 style: theme.textTheme.bodyMedium?.copyWith(
-                  color: colorScheme.onSurface.withAlpha(170),
+                  color: colorScheme.onSurfaceVariant,
                 ),
               ),
             ],

--- a/lib/presentation/widgets/connection_attempt_dialog.dart
+++ b/lib/presentation/widgets/connection_attempt_dialog.dart
@@ -1,11 +1,16 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../app/theme.dart';
 import '../../data/database/database.dart';
 import '../../domain/models/monetization.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/ssh_service.dart';
+
+enum _ConnectionAttemptDialogOutcome { editHost }
 
 /// Runs a host connection while showing a live progress dialog.
 Future<SshConnectionResult> connectToHostWithProgressDialog(
@@ -22,64 +27,115 @@ Future<SshConnectionResult> connectToHostWithProgressDialog(
   final useHostThemeOverrides = monetizationState.allowsFeature(
     MonetizationFeature.hostSpecificThemes,
   );
-  final dialogFuture = showDialog<void>(
+  var result = const SshConnectionResult(
+    success: false,
+    error: 'Connection cancelled.',
+  );
+  var connectionInProgress = false;
+  var dialogIsActive = true;
+
+  Future<void> runConnection({required bool isRetry}) async {
+    if (connectionInProgress) {
+      return;
+    }
+    connectionInProgress = true;
+    try {
+      result = await sessionsNotifier.connect(
+        host.id,
+        forceNew: isRetry || forceNew,
+        useHostThemeOverrides: useHostThemeOverrides,
+      );
+    } catch (error, stackTrace) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          library: 'connection_attempt_dialog',
+          context: ErrorDescription('while connecting to host ${host.id}'),
+        ),
+      );
+      const message =
+          'Connection failed. Check the host settings and try again.';
+      sessionsNotifier.reportConnectionAttemptError(host.id, message);
+      result = const SshConnectionResult(success: false, error: message);
+    } finally {
+      connectionInProgress = false;
+    }
+
+    if (result.success &&
+        result.connectionId != null &&
+        dialogIsActive &&
+        navigator.mounted) {
+      navigator.pop();
+    }
+  }
+
+  final dialogFuture = showDialog<_ConnectionAttemptDialogOutcome>(
     context: context,
     barrierDismissible: false,
-    builder: (_) => _ConnectionAttemptDialog(host: host),
+    builder: (_) => _ConnectionAttemptDialog(
+      host: host,
+      onRetry: () => runConnection(isRetry: true),
+    ),
   );
+  final trackedDialogFuture = dialogFuture.whenComplete(() {
+    dialogIsActive = false;
+  });
 
-  late final SshConnectionResult result;
-  try {
-    result = await sessionsNotifier.connect(
-      host.id,
-      forceNew: forceNew,
-      useHostThemeOverrides: useHostThemeOverrides,
-    );
-  } catch (error, stackTrace) {
-    FlutterError.reportError(
-      FlutterErrorDetails(
-        exception: error,
-        stack: stackTrace,
-        library: 'connection_attempt_dialog',
-        context: ErrorDescription('while connecting to host ${host.id}'),
-      ),
-    );
-    const message = 'Connection failed. Check the host settings and try again.';
-    sessionsNotifier.reportConnectionAttemptError(host.id, message);
-    result = const SshConnectionResult(success: false, error: message);
-  }
-
-  if (result.success && result.connectionId != null && navigator.mounted) {
-    navigator.pop();
-  }
-
-  await dialogFuture;
+  await runConnection(isRetry: false);
+  final outcome = await trackedDialogFuture;
   sessionsNotifier.clearConnectionAttempt(host.id);
+  if (outcome == _ConnectionAttemptDialogOutcome.editHost && context.mounted) {
+    await context.push('/hosts/edit/${host.id}');
+  }
   return result;
 }
 
-class _ConnectionAttemptDialog extends ConsumerWidget {
-  const _ConnectionAttemptDialog({required this.host});
+class _ConnectionAttemptDialog extends ConsumerStatefulWidget {
+  const _ConnectionAttemptDialog({required this.host, required this.onRetry});
 
   final Host host;
+  final Future<void> Function() onRetry;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_ConnectionAttemptDialog> createState() =>
+      _ConnectionAttemptDialogState();
+}
+
+class _ConnectionAttemptDialogState
+    extends ConsumerState<_ConnectionAttemptDialog> {
+  bool _isRetrying = false;
+
+  Future<void> _retry() async {
+    if (_isRetrying) {
+      return;
+    }
+    setState(() => _isRetrying = true);
+    await widget.onRetry();
+    if (mounted) {
+      setState(() => _isRetrying = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     ref.watch(activeSessionsProvider);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
-    final attempt = sessionsNotifier.getConnectionAttempt(host.id);
+    final attempt = sessionsNotifier.getConnectionAttempt(widget.host.id);
     final connectionState = attempt?.state ?? SshConnectionState.connecting;
     final logLines = attempt?.logLines ?? const ['Preparing connection…'];
     final statusMessage = attempt?.latestMessage ?? 'Preparing connection…';
-    final canClose = connectionState == SshConnectionState.error;
+    final hasError = connectionState == SshConnectionState.error;
 
     return PopScope(
-      canPop: canClose,
+      canPop: hasError && !_isRetrying,
       child: AlertDialog(
         title: Text(
-          canClose ? 'Connection failed' : 'Connecting to ${host.label}',
+          hasError && !_isRetrying
+              ? 'Connection failed'
+              : 'Connecting to ${widget.host.label}',
         ),
         content: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 420),
@@ -88,7 +144,8 @@ class _ConnectionAttemptDialog extends ConsumerWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                '${host.username}@${host.hostname}:${host.port}',
+                '${widget.host.username}@${widget.host.hostname}:'
+                '${widget.host.port}',
                 style: FluttyTheme.monoStyle.copyWith(
                   fontSize: 11,
                   color: colorScheme.onSurfaceVariant,
@@ -110,6 +167,15 @@ class _ConnectionAttemptDialog extends ConsumerWidget {
                   ),
                 ],
               ),
+              if (hasError) ...[
+                const SizedBox(height: 8),
+                Text(
+                  connectionFailureRecoveryHint(statusMessage),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
               const SizedBox(height: 16),
               Container(
                 width: double.infinity,
@@ -150,15 +216,57 @@ class _ConnectionAttemptDialog extends ConsumerWidget {
           ),
         ),
         actions: [
-          if (canClose)
-            FilledButton(
-              onPressed: () => Navigator.of(context).pop(),
+          if (hasError) ...[
+            TextButton(
+              onPressed: _isRetrying ? null : () => Navigator.of(context).pop(),
               child: const Text('Close'),
             ),
+            OutlinedButton(
+              onPressed: _isRetrying
+                  ? null
+                  : () => Navigator.of(
+                      context,
+                    ).pop(_ConnectionAttemptDialogOutcome.editHost),
+              child: const Text('Edit Host'),
+            ),
+            FilledButton(
+              onPressed: _isRetrying ? null : () => unawaited(_retry()),
+              child: Text(_isRetrying ? 'Retrying…' : 'Retry'),
+            ),
+          ],
         ],
       ),
     );
   }
+}
+
+/// Returns concise recovery guidance for a failed connection message.
+@visibleForTesting
+String connectionFailureRecoveryHint(String message) {
+  final normalized = message.toLowerCase();
+  if (normalized.contains('host key')) {
+    return 'Review the host key details before retrying.';
+  }
+  if (normalized.contains('auth') ||
+      normalized.contains('password') ||
+      normalized.contains('credential') ||
+      normalized.contains('private key')) {
+    return 'Check the username, password, and SSH key, then retry.';
+  }
+  if (normalized.contains('timeout') ||
+      normalized.contains('timed out') ||
+      normalized.contains('network') ||
+      normalized.contains('socket') ||
+      normalized.contains('refused') ||
+      normalized.contains('unreachable')) {
+    return 'Check the hostname, port, and network, then retry.';
+  }
+  if (normalized.contains('setup') ||
+      normalized.contains('startup') ||
+      normalized.contains('command')) {
+    return 'Check this host\'s startup settings, then retry.';
+  }
+  return 'Retry now or edit the host settings before trying again.';
 }
 
 class _ConnectionAttemptIcon extends StatelessWidget {

--- a/lib/presentation/widgets/message_of_the_day.dart
+++ b/lib/presentation/widgets/message_of_the_day.dart
@@ -49,7 +49,7 @@ class MessageOfTheDay extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final promptStyle = FluttyTheme.monoStyle.copyWith(
       fontSize: 12,
-      color: colorScheme.onSurface.withAlpha(110),
+      color: colorScheme.onSurfaceVariant,
     );
     final messageStyle = FluttyTheme.monoStyle.copyWith(
       fontSize: 12,
@@ -73,10 +73,7 @@ class MessageOfTheDay extends StatelessWidget {
               baseline: TextBaseline.alphabetic,
               child: Padding(
                 padding: const EdgeInsets.only(left: 4),
-                child: CursorBlock(
-                  size: 13,
-                  color: colorScheme.onSurface.withAlpha(140),
-                ),
+                child: CursorBlock(size: 13, color: colorScheme.primary),
               ),
             ),
           ],

--- a/lib/presentation/widgets/tmux_expandable_bar.dart
+++ b/lib/presentation/widgets/tmux_expandable_bar.dart
@@ -1776,6 +1776,27 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
     );
   }
 
+  Future<void> _confirmCloseWindow(TmuxWindow window) async {
+    final confirmed = await confirmCloseRemoteWindow(
+      context: context,
+      windowTitle: window.displayTitle,
+      closesLastWindow: (_windows?.length ?? 0) <= 1,
+    );
+    if (!mounted || !confirmed) {
+      return;
+    }
+
+    unawaited(widget.onAction(TmuxCloseWindowAction(window.index)));
+    setState(() {
+      _windows = _windows?.where((w) => w.index != window.index).toList();
+      if (_pendingSelectedWindowIndex == window.index) {
+        _pendingSelectedWindowIndex = null;
+        _pendingSelectionTimer?.cancel();
+        _pendingSelectionTimer = null;
+      }
+    });
+  }
+
   Widget _buildWindowTile(ThemeData theme, TmuxWindow window) {
     final isActive = window.isActive;
     final title = _redactStoreScreenshotIdentities
@@ -1794,8 +1815,9 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
         : theme.colorScheme.onSurfaceVariant;
 
     return ListTile(
-      dense: true,
+      dense: false,
       visualDensity: _denseTileVisualDensity,
+      minTileHeight: 48,
       minVerticalPadding: 2,
       contentPadding: const EdgeInsets.only(left: 12, right: 4),
       horizontalTitleGap: 10,
@@ -1866,23 +1888,13 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           ),
           IconButton(
             icon: const Icon(Icons.close, size: 16),
-            visualDensity: VisualDensity.compact,
-            constraints: const BoxConstraints.tightFor(width: 30, height: 30),
-            padding: EdgeInsets.zero,
+            style: IconButton.styleFrom(
+              fixedSize: const Size.square(44),
+              visualDensity: VisualDensity.standard,
+              padding: EdgeInsets.zero,
+            ),
             tooltip: 'Close window',
-            onPressed: () {
-              widget.onAction(TmuxCloseWindowAction(window.index));
-              setState(() {
-                _windows = _windows
-                    ?.where((w) => w.index != window.index)
-                    .toList();
-                if (_pendingSelectedWindowIndex == window.index) {
-                  _pendingSelectedWindowIndex = null;
-                  _pendingSelectionTimer?.cancel();
-                  _pendingSelectionTimer = null;
-                }
-              });
-            },
+            onPressed: () => unawaited(_confirmCloseWindow(window)),
           ),
         ],
       ),

--- a/lib/presentation/widgets/tmux_expandable_bar.dart
+++ b/lib/presentation/widgets/tmux_expandable_bar.dart
@@ -1856,16 +1856,7 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
           ),
           const SizedBox(width: 8),
           Expanded(
-            child: Text(
-              title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: isActive
-                  ? theme.textTheme.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    )
-                  : null,
-            ),
+            child: TmuxWindowTitleText(title: title, isActive: isActive),
           ),
         ],
       ),

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -898,15 +898,9 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
           ),
           const SizedBox(width: 8),
           Expanded(
-            child: Text(
-              window.displayTitle,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: isActive
-                  ? theme.textTheme.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    )
-                  : null,
+            child: TmuxWindowTitleText(
+              title: window.displayTitle,
+              isActive: isActive,
             ),
           ),
         ],

--- a/lib/presentation/widgets/tmux_window_navigator.dart
+++ b/lib/presentation/widgets/tmux_window_navigator.dart
@@ -61,6 +61,44 @@ String _telemetryAgentToolName(String toolName) {
   return tool?.name ?? toolName.toLowerCase().replaceAll(' ', '_');
 }
 
+/// Confirms a destructive remote-window close.
+Future<bool> confirmCloseRemoteWindow({
+  required BuildContext context,
+  required String windowTitle,
+  required bool closesLastWindow,
+}) async =>
+    await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        final colorScheme = Theme.of(dialogContext).colorScheme;
+        return AlertDialog(
+          title: const Text('Close window?'),
+          content: Text(
+            closesLastWindow
+                ? 'Close "$windowTitle"? This ends the remote workspace and '
+                      'any work running in it.'
+                : 'Close "$windowTitle"? Any work running in this window '
+                      'will stop.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext, false),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(dialogContext, true),
+              style: FilledButton.styleFrom(
+                backgroundColor: colorScheme.error,
+                foregroundColor: colorScheme.onError,
+              ),
+              child: const Text('Close'),
+            ),
+          ],
+        );
+      },
+    ) ??
+    false;
+
 /// Shows the tmux window navigator bottom sheet.
 ///
 /// Returns the action the user selected, or `null` if dismissed.
@@ -607,8 +645,15 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
     Navigator.pop(context, TmuxSwitchWindowAction(windowIndex));
   }
 
-  void _closeWindow(int windowIndex) {
-    Navigator.pop(context, TmuxCloseWindowAction(windowIndex));
+  Future<void> _closeWindow(TmuxWindow window) async {
+    final confirmed = await confirmCloseRemoteWindow(
+      context: context,
+      windowTitle: window.displayTitle,
+      closesLastWindow: (_windows?.length ?? 0) <= 1,
+    );
+    if (mounted && confirmed) {
+      Navigator.pop(context, TmuxCloseWindowAction(window.index));
+    }
   }
 
   void _createNewWindow({String? command, String? name}) {
@@ -812,8 +857,9 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
         : theme.colorScheme.onSurfaceVariant;
 
     return ListTile(
-      dense: true,
+      dense: false,
       visualDensity: _tmuxNavigatorDenseVisualDensity,
+      minTileHeight: 48,
       minVerticalPadding: 2,
       contentPadding: const EdgeInsets.only(left: 16, right: 4),
       horizontalTitleGap: 10,
@@ -884,11 +930,13 @@ class _TmuxNavigatorSheetState extends State<_TmuxNavigatorSheet> {
           ),
           IconButton(
             icon: const Icon(Icons.close, size: 16),
-            visualDensity: VisualDensity.compact,
-            constraints: const BoxConstraints.tightFor(width: 44, height: 44),
-            padding: EdgeInsets.zero,
+            style: IconButton.styleFrom(
+              fixedSize: const Size.square(44),
+              visualDensity: VisualDensity.standard,
+              padding: EdgeInsets.zero,
+            ),
             tooltip: 'Close window',
-            onPressed: () => _closeWindow(window.index),
+            onPressed: () => unawaited(_closeWindow(window)),
           ),
         ],
       ),

--- a/lib/presentation/widgets/tmux_window_status_badge.dart
+++ b/lib/presentation/widgets/tmux_window_status_badge.dart
@@ -2,7 +2,44 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../../app/theme.dart';
 import '../../domain/models/tmux_state.dart';
+
+/// Consistent terminal-native title text for a remote multiplexer window.
+///
+/// Selection changes weight only; the font family and size remain stable so a
+/// title never jumps when its window becomes active.
+class TmuxWindowTitleText extends StatelessWidget {
+  /// Creates a remote-window title.
+  const TmuxWindowTitleText({
+    required this.title,
+    required this.isActive,
+    this.fontSize = 13,
+    super.key,
+  });
+
+  /// Window title text.
+  final String title;
+
+  /// Whether the window is currently active.
+  final bool isActive;
+
+  /// Title size shared by active and inactive states.
+  final double fontSize;
+
+  @override
+  Widget build(BuildContext context) => Text(
+    title,
+    maxLines: 1,
+    overflow: TextOverflow.ellipsis,
+    style: FluttyTheme.monoStyle.copyWith(
+      fontSize: fontSize,
+      fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
+      color: Theme.of(context).colorScheme.onSurface,
+      height: 1.2,
+    ),
+  );
+}
 
 /// Compact status badge for a tmux window.
 class TmuxWindowStatusBadge extends StatefulWidget {

--- a/test/app/theme_test.dart
+++ b/test/app/theme_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/app/app.dart';
 import 'package:monkeyssh/app/theme.dart';
-import 'package:monkeyssh/domain/models/terminal_theme.dart';
 import 'package:monkeyssh/domain/models/terminal_themes.dart';
 import 'package:monkeyssh/domain/services/settings_service.dart';
 import 'package:monkeyssh/domain/services/terminal_theme_service.dart';
@@ -33,8 +32,11 @@ void main() {
       expect(theme.colorScheme.onSurface, terminalTheme.foreground);
       expect(theme.textTheme.titleLarge?.color, terminalTheme.foreground);
       expect(
-        _terminalAccentCandidates(terminalTheme),
-        contains(theme.colorScheme.primary),
+        _minimumContrastRatio(theme.colorScheme.primary, [
+          theme.scaffoldBackgroundColor,
+          theme.colorScheme.surfaceContainerHighest,
+        ]),
+        greaterThanOrEqualTo(4.5),
       );
     });
 
@@ -130,12 +132,18 @@ void main() {
                 ? Brightness.dark
                 : Brightness.light,
           );
+          final primary = theme.colorScheme.primary;
           expect(
-            theme.colorScheme.primary,
-            terminalTheme.cursor,
-            reason:
-                '${terminalTheme.name} should drive Material primary from '
-                'its saturated cursor color.',
+            _hueDistance(primary, terminalTheme.cursor),
+            lessThan(1),
+            reason: '${terminalTheme.name} should retain its cursor hue.',
+          );
+          expect(
+            _minimumContrastRatio(primary, [
+              theme.scaffoldBackgroundColor,
+              theme.colorScheme.surfaceContainerHighest,
+            ]),
+            greaterThanOrEqualTo(4.5),
           );
         }
       },
@@ -151,22 +159,70 @@ void main() {
       // should come from the saturated candidate list instead.
       expect(theme.colorScheme.primary, isNot(TerminalThemes.dracula.cursor));
       expect(
-        _terminalAccentCandidates(TerminalThemes.dracula),
-        contains(theme.colorScheme.primary),
+        HSLColor.fromColor(theme.colorScheme.primary).saturation,
+        greaterThan(0.4),
       );
     });
+
+    test(
+      'keeps text-facing theme roles opaque and WCAG AA across palettes',
+      () {
+        final themes = <ThemeData>[
+          FluttyTheme.light,
+          FluttyTheme.dark,
+          for (final terminalTheme in TerminalThemes.all)
+            FluttyTheme.fromTerminalTheme(
+              terminalTheme,
+              brightness: terminalTheme.isDark
+                  ? Brightness.dark
+                  : Brightness.light,
+            ),
+        ];
+
+        for (final theme in themes) {
+          final surfaces = [
+            theme.scaffoldBackgroundColor,
+            theme.colorScheme.surface,
+            theme.colorScheme.surfaceContainerHighest,
+          ];
+          final textColors = [
+            theme.colorScheme.primary,
+            theme.colorScheme.onSurfaceVariant,
+            theme.inputDecorationTheme.hintStyle!.color!,
+            theme.textTheme.bodyMedium!.color!,
+            theme.textTheme.bodySmall!.color!,
+          ];
+
+          for (final color in textColors) {
+            expect(color.a, 1);
+            expect(
+              _minimumContrastRatio(color, surfaces),
+              greaterThanOrEqualTo(4.5),
+              reason:
+                  '${theme.colorScheme.brightness} theme role $color should '
+                  'remain readable on every app surface.',
+            );
+          }
+        }
+      },
+    );
   });
 }
 
-Set<Color> _terminalAccentCandidates(TerminalThemeData theme) => {
-  theme.blue,
-  theme.cyan,
-  theme.magenta,
-  theme.green,
-  theme.brightBlue,
-  theme.brightCyan,
-  theme.brightMagenta,
-  theme.cursor,
-  theme.yellow,
-  theme.red,
-};
+double _hueDistance(Color a, Color b) {
+  final difference = (HSLColor.fromColor(a).hue - HSLColor.fromColor(b).hue)
+      .abs();
+  return difference > 180 ? 360 - difference : difference;
+}
+
+double _minimumContrastRatio(Color color, List<Color> backgrounds) =>
+    backgrounds
+        .map((background) => _contrastRatio(color, background))
+        .reduce((a, b) => a < b ? a : b);
+
+double _contrastRatio(Color a, Color b) {
+  final lighter = a.computeLuminance() > b.computeLuminance() ? a : b;
+  final darker = identical(lighter, a) ? b : a;
+  return (lighter.computeLuminance() + 0.05) /
+      (darker.computeLuminance() + 0.05);
+}

--- a/test/presentation/screens/sftp_screen_test.dart
+++ b/test/presentation/screens/sftp_screen_test.dart
@@ -602,6 +602,79 @@ void main() {
       },
     );
 
+    testWidgets('groups file actions behind open and manage choices', (
+      tester,
+    ) async {
+      final sshClient = _MockSshClient();
+      final sftp = _MockSftpClient();
+      final monetizationService = _MockMonetizationService();
+      final session = SshSession(
+        connectionId: 7,
+        hostId: 1,
+        client: sshClient,
+        config: const SshConnectionConfig(
+          hostname: 'demo.example.com',
+          port: 22,
+          username: 'demo',
+        ),
+      );
+
+      when(
+        () => monetizationService.currentState,
+      ).thenReturn(_proMonetizationState);
+      when(sshClient.sftp).thenAnswer((_) async => sftp);
+      when(() => sftp.absolute('.')).thenAnswer((_) async => '/home/demo');
+      when(() => sftp.listdir('/home/demo')).thenAnswer(
+        (_) async => [
+          SftpName(
+            filename: 'picture.png',
+            longname: 'picture.png',
+            attr: SftpFileAttrs(
+              size: _onePixelPngBytes.length,
+              mode: const SftpFileMode.value(1 << 15),
+            ),
+          ),
+        ],
+      );
+      when(sftp.close).thenAnswer((_) async {});
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            activeSessionsProvider.overrideWith(
+              () => _TestActiveSessionsNotifier(session),
+            ),
+            monetizationServiceProvider.overrideWithValue(monetizationService),
+            monetizationStateProvider.overrideWith(
+              (ref) => Stream.value(_proMonetizationState),
+            ),
+          ],
+          child: const MaterialApp(
+            home: SftpScreen(hostId: 1, connectionId: 7),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('More actions for picture.png'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Open…'), findsOneWidget);
+      expect(find.text('Download'), findsOneWidget);
+      expect(find.text('Copy as path'), findsOneWidget);
+      expect(find.text('Manage file'), findsOneWidget);
+      expect(find.text('Rename'), findsNothing);
+      expect(find.text('Delete'), findsNothing);
+
+      await tester.tap(find.text('Manage file'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Info'), findsOneWidget);
+      expect(find.text('Rename'), findsOneWidget);
+      expect(find.text('Delete'), findsOneWidget);
+      expect(find.text('Download'), findsNothing);
+    });
+
     testWidgets('handles stale SSH errors while opening the browser', (
       tester,
     ) async {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1822,9 +1822,7 @@ void main() {
         await tester.pump();
         await tester.pump();
 
-        await tester.tap(find.byIcon(Icons.more_vert));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
+        await openTerminalOverflowSubmenu(tester, 'Tools');
         final browserItem = terminalMenuItemButton('Open Forwarded Browser');
         expect(browserItem, findsOneWidget);
 
@@ -1865,6 +1863,21 @@ void main() {
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),
     );
 
+    testWidgets('overflow menu explains terminal controls and gestures', (
+      tester,
+    ) async {
+      await pumpScreen(tester);
+
+      await openTerminalOverflowSubmenu(tester, 'Options');
+      await tester.tap(terminalMenuItemButton('Controls & Gestures'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('terminal controls'), findsOneWidget);
+      expect(find.text('Resize text'), findsOneWidget);
+      expect(find.text('Extra keys'), findsOneWidget);
+      expect(find.text('Select output'), findsOneWidget);
+    });
+
     testWidgets(
       'overflow menu shows Create Snippet when system selection has text',
       (tester) async {
@@ -1874,7 +1887,7 @@ void main() {
 
         Finder createSnippetItem() => terminalMenuItemButton('Create Snippet');
 
-        await openTerminalOverflowMenu(tester);
+        await openTerminalOverflowSubmenu(tester, 'Tools');
         expect(createSnippetItem(), findsNothing);
 
         await tester.tapAt(const Offset(2, 2));
@@ -1894,7 +1907,7 @@ void main() {
         );
         await tester.pump();
 
-        await openTerminalOverflowMenu(tester);
+        await openTerminalOverflowSubmenu(tester, 'Tools');
         expect(createSnippetItem(), findsOneWidget);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),
@@ -3875,7 +3888,13 @@ void main() {
           (widget) => widget is IconButton && widget.tooltip == 'Close window',
         );
         expect(closeWindowButton, findsOneWidget);
+        final closeWindowSize = tester.getSize(closeWindowButton);
+        expect(closeWindowSize.width, greaterThanOrEqualTo(44));
+        expect(closeWindowSize.height, greaterThanOrEqualTo(44));
         await tester.tap(closeWindowButton);
+        await tester.pumpAndSettle();
+        expect(find.text('Close window?'), findsOneWidget);
+        await tester.tap(find.widgetWithText(FilledButton, 'Close'));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 100));
 

--- a/test/widget/auth_setup_screen_test.dart
+++ b/test/widget/auth_setup_screen_test.dart
@@ -68,6 +68,11 @@ void main() {
     await tester.enterText(find.byType(TextField).first, '1234');
     await tester.pump();
 
+    expect(tester.widget<ElevatedButton>(nextButton).onPressed, isNull);
+
+    await tester.enterText(find.byType(TextField).first, '123456');
+    await tester.pump();
+
     expect(tester.widget<ElevatedButton>(nextButton).onPressed, isNotNull);
   });
 
@@ -97,7 +102,7 @@ void main() {
 
     await tester.tap(find.text('PIN Code'));
     await tester.pumpAndSettle();
-    await tester.enterText(find.byType(TextField).first, '1234');
+    await tester.enterText(find.byType(TextField).first, '123456');
     await tester.pump();
     await tester.tap(find.widgetWithText(ElevatedButton, 'Next'));
     await tester.pumpAndSettle();

--- a/test/widget/connection_attempt_dialog_test.dart
+++ b/test/widget/connection_attempt_dialog_test.dart
@@ -1,0 +1,316 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/domain/models/monetization.dart';
+import 'package:monkeyssh/domain/services/monetization_service.dart';
+import 'package:monkeyssh/domain/services/ssh_service.dart';
+import 'package:monkeyssh/presentation/widgets/connection_attempt_dialog.dart';
+
+const _proState = MonetizationState(
+  billingAvailability: MonetizationBillingAvailability.available,
+  entitlements: MonetizationEntitlements.pro(),
+  offers: [],
+  debugUnlockAvailable: false,
+  debugUnlocked: false,
+);
+
+final _host = Host(
+  id: 1,
+  label: 'Build Server',
+  hostname: 'build.example.com',
+  port: 22,
+  username: 'developer',
+  isFavorite: false,
+  createdAt: DateTime(2024),
+  updatedAt: DateTime(2024),
+  autoConnectRequiresConfirmation: false,
+  sortOrder: 0,
+);
+
+class _MockMonetizationService extends Mock implements MonetizationService {}
+
+MonetizationService _buildMonetizationService() {
+  final service = _MockMonetizationService();
+  when(() => service.currentState).thenReturn(_proState);
+  return service;
+}
+
+class _RetryActiveSessionsNotifier extends ActiveSessionsNotifier {
+  _RetryActiveSessionsNotifier({
+    required this.succeedsOnRetry,
+    this.retryCompleter,
+    this.retryStartGate,
+  });
+
+  final bool succeedsOnRetry;
+  final Completer<SshConnectionResult>? retryCompleter;
+  final Completer<void>? retryStartGate;
+  final List<bool> forceNewValues = [];
+  ConnectionAttemptStatus? attempt;
+  bool cleared = false;
+
+  @override
+  Map<int, SshConnectionState> build() => <int, SshConnectionState>{};
+
+  @override
+  ConnectionAttemptStatus? getConnectionAttempt(int hostId) => attempt;
+
+  @override
+  Future<SshConnectionResult> connect(
+    int hostId, {
+    bool forceNew = false,
+    bool useHostThemeOverrides = true,
+  }) async {
+    forceNewValues.add(forceNew);
+    if (succeedsOnRetry && forceNewValues.length > 1) {
+      await retryStartGate?.future;
+      final completer = retryCompleter;
+      if (completer != null) {
+        attempt = const ConnectionAttemptStatus(
+          hostId: 1,
+          state: SshConnectionState.connecting,
+          latestMessage: 'Retrying connection',
+          logLines: ['Preparing connection...', 'Retrying connection'],
+        );
+        state = {...state};
+        return completer.future;
+      }
+      attempt = const ConnectionAttemptStatus(
+        hostId: 1,
+        state: SshConnectionState.connected,
+        latestMessage: 'Connected',
+        logLines: ['Preparing connection...', 'Connected'],
+      );
+      state = {42: SshConnectionState.connected};
+      return const SshConnectionResult(success: true, connectionId: 42);
+    }
+
+    attempt = const ConnectionAttemptStatus(
+      hostId: 1,
+      state: SshConnectionState.error,
+      latestMessage: 'Authentication failed',
+      logLines: ['Preparing connection...', 'Authentication failed'],
+    );
+    state = {...state};
+    return const SshConnectionResult(
+      success: false,
+      error: 'Authentication failed',
+    );
+  }
+
+  @override
+  void clearConnectionAttempt(int hostId) {
+    cleared = true;
+    attempt = null;
+    state = {...state};
+  }
+}
+
+class _ConnectButton extends ConsumerWidget {
+  const _ConnectButton({required this.onResult});
+
+  final ValueChanged<SshConnectionResult> onResult;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) => FilledButton(
+    onPressed: () => unawaited(
+      connectToHostWithProgressDialog(
+        context,
+        ref,
+        _host,
+        forceNew: false,
+      ).then(onResult),
+    ),
+    child: const Text('Connect'),
+  );
+}
+
+void main() {
+  test('returns stage-specific connection recovery guidance', () {
+    expect(
+      connectionFailureRecoveryHint('Host key changed'),
+      'Review the host key details before retrying.',
+    );
+    expect(
+      connectionFailureRecoveryHint('Authentication failed'),
+      'Check the username, password, and SSH key, then retry.',
+    );
+    expect(
+      connectionFailureRecoveryHint('Connection refused'),
+      'Check the hostname, port, and network, then retry.',
+    );
+  });
+
+  testWidgets('retry returns the successful connection result', (tester) async {
+    final notifier = _RetryActiveSessionsNotifier(succeedsOnRetry: true);
+    final monetizationService = _buildMonetizationService();
+    SshConnectionResult? result;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          activeSessionsProvider.overrideWith(() => notifier),
+          monetizationServiceProvider.overrideWithValue(monetizationService),
+          monetizationStateProvider.overrideWith(
+            (ref) => Stream.value(_proState),
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: _ConnectButton(onResult: (value) => result = value),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Connect'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Connection failed'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+    expect(find.text('Edit Host'), findsOneWidget);
+    expect(
+      find.text('Check the username, password, and SSH key, then retry.'),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('Retry'));
+    await tester.pumpAndSettle();
+
+    expect(result?.success, isTrue);
+    expect(result?.connectionId, 42);
+    expect(notifier.forceNewValues, [false, true]);
+    expect(notifier.cleared, isTrue);
+    expect(find.text('Connection failed'), findsNothing);
+  });
+
+  testWidgets('retry synchronously disables dismissal actions', (tester) async {
+    final retryCompleter = Completer<SshConnectionResult>();
+    final retryStartGate = Completer<void>();
+    final notifier = _RetryActiveSessionsNotifier(
+      succeedsOnRetry: true,
+      retryCompleter: retryCompleter,
+      retryStartGate: retryStartGate,
+    );
+    final monetizationService = _buildMonetizationService();
+    SshConnectionResult? result;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          activeSessionsProvider.overrideWith(() => notifier),
+          monetizationServiceProvider.overrideWithValue(monetizationService),
+          monetizationStateProvider.overrideWith(
+            (ref) => Stream.value(_proState),
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: _ConnectButton(onResult: (value) => result = value),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Connect'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Retry'));
+    await tester.pump();
+
+    expect(find.text('Retrying…'), findsOneWidget);
+    expect(
+      tester
+          .widget<TextButton>(find.widgetWithText(TextButton, 'Close'))
+          .onPressed,
+      isNull,
+    );
+    expect(
+      tester
+          .widget<OutlinedButton>(
+            find.widgetWithText(OutlinedButton, 'Edit Host'),
+          )
+          .onPressed,
+      isNull,
+    );
+    expect(
+      tester
+          .widget<FilledButton>(find.widgetWithText(FilledButton, 'Retrying…'))
+          .onPressed,
+      isNull,
+    );
+    expect(
+      tester.widget<PopScope<Object?>>(find.byType(PopScope)).canPop,
+      isFalse,
+    );
+
+    retryStartGate.complete();
+    await tester.pump();
+    retryCompleter.complete(
+      const SshConnectionResult(success: true, connectionId: 42),
+    );
+    await tester.pumpAndSettle();
+
+    expect(result?.success, isTrue);
+  });
+
+  testWidgets('Edit Host opens the failed host without losing the result', (
+    tester,
+  ) async {
+    final notifier = _RetryActiveSessionsNotifier(succeedsOnRetry: false);
+    final monetizationService = _buildMonetizationService();
+    SshConnectionResult? result;
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => Scaffold(
+            body: _ConnectButton(onResult: (value) => result = value),
+          ),
+        ),
+        GoRoute(
+          path: '/hosts/edit/:hostId',
+          builder: (context, state) => Scaffold(
+            body: Text('Editing host ${state.pathParameters['hostId']}'),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          activeSessionsProvider.overrideWith(() => notifier),
+          monetizationServiceProvider.overrideWithValue(monetizationService),
+          monetizationStateProvider.overrideWith(
+            (ref) => Stream.value(_proState),
+          ),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Connect'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Edit Host'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Editing host 1'), findsOneWidget);
+    expect(notifier.cleared, isTrue);
+    expect(result, isNull);
+
+    router.pop();
+    await tester.pumpAndSettle();
+
+    expect(result?.success, isFalse);
+    expect(result?.error, 'Authentication failed');
+  });
+}

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -32,6 +32,7 @@ import 'package:monkeyssh/domain/services/transfer_intent_service.dart';
 import 'package:monkeyssh/presentation/providers/entity_list_providers.dart';
 import 'package:monkeyssh/presentation/providers/host_row_providers.dart';
 import 'package:monkeyssh/presentation/screens/home_screen.dart';
+import 'package:monkeyssh/presentation/screens/port_forwards_screen.dart';
 import 'package:monkeyssh/presentation/widgets/connection_preview_snippet.dart';
 import 'package:xterm/xterm.dart' hide TerminalThemes;
 
@@ -515,6 +516,167 @@ void main() {
       await tester.pump();
 
       verify(() => snippetRepository.reorderByIds([2, 1])).called(1);
+    });
+  });
+
+  group('HomeScreen adaptive actions', () {
+    testWidgets('moves populated host creation to a mobile FAB', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      await tester.pumpWidget(
+        buildMobileHomeScreen(
+          db: db,
+          overrides: [
+            activeSessionsProvider.overrideWith(
+              _TestActiveSessionsNotifier.new,
+            ),
+            allHostsProvider.overrideWith(
+              (ref) => Stream.value([
+                _buildHost(id: 1, label: 'Alpha', sortOrder: 0),
+              ]),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(
+        find.widgetWithText(FloatingActionButton, 'Add Host'),
+        findsOneWidget,
+      );
+      expect(find.widgetWithText(FilledButton, 'Add Host'), findsNothing);
+    });
+
+    testWidgets('exposes port forwards as a fifth home destination', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      await tester.pumpWidget(
+        buildMobileHomeScreen(
+          db: db,
+          overrides: [
+            activeSessionsProvider.overrideWith(
+              _TestActiveSessionsNotifier.new,
+            ),
+            allHostsProvider.overrideWith(
+              (ref) => Stream.value(const <Host>[]),
+            ),
+            allPortForwardsProvider.overrideWith(
+              (ref) => Stream.value(const <PortForward>[]),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.tap(find.byIcon(Icons.alt_route_outlined));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(
+        tester.widget<NavigationBar>(find.byType(NavigationBar)).selectedIndex,
+        4,
+      );
+      expect(find.byType(PortForwardsPanel), findsOneWidget);
+      expect(find.text('no forwards yet'), findsOneWidget);
+      expect(
+        find.widgetWithText(FloatingActionButton, 'Add Forward'),
+        findsOneWidget,
+      );
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+    });
+
+    testWidgets('keeps all five destinations usable at narrow widths', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(320, 640));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      await tester.pumpWidget(
+        buildMobileHomeScreen(
+          db: db,
+          overrides: [
+            activeSessionsProvider.overrideWith(
+              _TestActiveSessionsNotifier.new,
+            ),
+            allHostsProvider.overrideWith(
+              (ref) => Stream.value(const <Host>[]),
+            ),
+          ],
+          size: const Size(320, 640),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      final navigationBar = tester.widget<NavigationBar>(
+        find.byType(NavigationBar),
+      );
+      expect(navigationBar.destinations, hasLength(5));
+      expect(find.text('Forwards'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('keeps desktop navigation readable at 200 percent text', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            transferIntentServiceProvider.overrideWith(
+              (ref) => _TestTransferIntentService(),
+            ),
+            homeScreenShortcutServiceProvider.overrideWith(
+              (ref) => _TestHomeScreenShortcutService(),
+            ),
+            pinnedHomeScreenShortcutHostIdsProvider.overrideWith(
+              (ref) => Stream<Set<int>>.value(const <int>{}),
+            ),
+            activeSessionsProvider.overrideWith(
+              _TestActiveSessionsNotifier.new,
+            ),
+            allHostsProvider.overrideWith(
+              (ref) => Stream.value(const <Host>[]),
+            ),
+          ],
+          child: MaterialApp(
+            home: Builder(
+              builder: (context) => MediaQuery(
+                data: MediaQuery.of(
+                  context,
+                ).copyWith(textScaler: const TextScaler.linear(2)),
+                child: const HomeScreen(),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Port Forwards'), findsOneWidget);
+      expect(tester.takeException(), isNull);
     });
   });
 
@@ -1013,6 +1175,46 @@ void main() {
       ),
       findsOneWidget,
     );
+  });
+
+  testWidgets('groups secondary host actions under Manage host', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(400, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    await tester.pumpWidget(
+      buildMobileHomeScreen(
+        db: db,
+        overrides: [
+          activeSessionsProvider.overrideWith(_TestActiveSessionsNotifier.new),
+          allHostsProvider.overrideWith(
+            (ref) =>
+                Stream.value([_buildHost(id: 1, label: 'Alpha', sortOrder: 0)]),
+          ),
+        ],
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    await tester.tap(find.byTooltip('Host actions'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Connect'), findsOneWidget);
+    expect(find.text('New connection'), findsOneWidget);
+    expect(find.text('Manage host'), findsOneWidget);
+    expect(find.text('Delete host'), findsNothing);
+
+    await tester.tap(find.text('Manage host'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Edit host'), findsOneWidget);
+    expect(find.text('Duplicate'), findsOneWidget);
+    expect(find.text('Delete host'), findsOneWidget);
+    expect(find.text('Connect'), findsNothing);
   });
 
   testWidgets('updates the tmux badge when host session info loads later', (
@@ -1587,12 +1789,15 @@ void main() {
         const HostCliLaunchPreferences(startInYoloMode: true),
       );
 
-      await tester.tap(find.text('work · 1 windows'));
+      await tester.tap(find.byKey(const ValueKey('recent-agents-7')));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
-      await tester.tap(find.text('AI Sessions'));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
+      expect(find.text('AI Sessions'), findsOneWidget);
+      final closeWindowButton = find.byTooltip('Close window');
+      expect(closeWindowButton, findsOneWidget);
+      final closeWindowSize = tester.getSize(closeWindowButton);
+      expect(closeWindowSize.width, greaterThanOrEqualTo(44));
+      expect(closeWindowSize.height, greaterThanOrEqualTo(44));
       await tester.drag(find.text('work · 1 windows'), const Offset(0, -120));
       await tester.pump();
       await tester.tap(find.text('Codex'));

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -183,12 +183,13 @@ Future<_HostEditTestHarness> _pumpHostCreateScreen(
   WidgetTester tester, {
   bool hasPro = false,
   List<Snippet> snippets = const [],
+  Size surfaceSize = const Size(420, 900),
 }) async {
   final database = AppDatabase.forTesting(NativeDatabase.memory());
   final encryptionService = SecretEncryptionService.forTesting();
   addTearDown(database.close);
   addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.binding.setSurfaceSize(const Size(420, 900));
+  await tester.binding.setSurfaceSize(surfaceSize);
 
   final hostRepository = _FakeHostRepository(
     host: _testHost(
@@ -291,11 +292,6 @@ Future<void> _tapBottomSave(WidgetTester tester) async {
     const Key('host-save-button'),
     skipOffstage: false,
   );
-  await tester.scrollUntilVisible(
-    saveButton,
-    200,
-    scrollable: find.byType(Scrollable).first,
-  );
   await tester.ensureVisible(saveButton);
   tester.widget<FilledButton>(saveButton).onPressed!();
   await tester.pump();
@@ -346,6 +342,31 @@ void main() {
   });
 
   group('HostEditScreen', () {
+    testWidgets('keeps save and test actions in thumb reach on mobile', (
+      tester,
+    ) async {
+      await _pumpHostCreateScreen(tester);
+
+      final saveButton = find.byKey(const Key('host-save-button'));
+      final testButton = find.byKey(const Key('host-test-button'));
+
+      expect(saveButton, findsOneWidget);
+      expect(testButton, findsOneWidget);
+      expect(tester.getBottomRight(saveButton).dy, lessThanOrEqualTo(900));
+      expect(tester.getBottomRight(testButton).dy, lessThanOrEqualTo(900));
+      expect(find.text('Test Connection'), findsNothing);
+      expect(find.text('Test'), findsOneWidget);
+    });
+
+    testWidgets('keeps inline actions at the wide breakpoint', (tester) async {
+      await _pumpHostCreateScreen(tester, surfaceSize: const Size(600, 900));
+
+      expect(find.byKey(const Key('host-save-button')), findsOneWidget);
+      expect(find.byKey(const Key('host-test-button')), findsOneWidget);
+      expect(find.text('Test Connection'), findsOneWidget);
+      expect(find.text('Test'), findsNothing);
+    });
+
     testWidgets(
       'scrolls to the first base field and summarizes validation errors',
       (tester) async {
@@ -1311,6 +1332,12 @@ void main() {
         expect(yoloFinder, findsOneWidget);
         expect(tester.widget<CheckboxListTile>(yoloFinder).value, isFalse);
 
+        await tester.scrollUntilVisible(
+          yoloFinder,
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.ensureVisible(yoloFinder);
         await tester.tap(yoloFinder);
         await tester.pump();
 

--- a/test/widget/hosts_screen_test.dart
+++ b/test/widget/hosts_screen_test.dart
@@ -253,10 +253,15 @@ void main() {
     expect(find.text('New connection'), findsOneWidget);
     expect(find.text('Disconnect'), findsNothing);
     expect(find.text('Disconnect all'), findsNothing);
-    expect(find.text('Edit'), findsOneWidget);
+    expect(find.text('Manage host'), findsOneWidget);
+
+    await tester.tap(find.text('Manage host'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Edit host'), findsOneWidget);
     expect(find.text('Duplicate'), findsOneWidget);
     expect(find.text('Export Encrypted File (Pro)'), findsOneWidget);
-    expect(find.text('Delete'), findsOneWidget);
+    expect(find.text('Delete host'), findsOneWidget);
   });
 
   testWidgets(

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -344,6 +344,19 @@ void main() {
       await tester.tap(find.text('Open'));
       await tester.pumpAndSettle();
 
+      final closeWindowButtons = find.byTooltip('Close window');
+      expect(closeWindowButtons, findsNWidgets(windows.length));
+      final closeWindowSize = tester.getSize(closeWindowButtons.first);
+      expect(closeWindowSize.width, greaterThanOrEqualTo(44));
+      expect(closeWindowSize.height, greaterThanOrEqualTo(44));
+      await tester.tap(closeWindowButtons.first);
+      await tester.pumpAndSettle();
+      expect(find.text('Close window?'), findsOneWidget);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      await tester.drag(find.byType(Scrollable).last, const Offset(0, -120));
+      await tester.pumpAndSettle();
+
       expect(find.text('Recent AI Sessions'), findsOneWidget);
       expect(find.text('Claude Code'), findsOneWidget);
       expect(find.byIcon(Icons.expand_more), findsOneWidget);
@@ -448,6 +461,8 @@ void main() {
       );
 
       await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      await tester.drag(find.byType(Scrollable).last, const Offset(0, -120));
       await tester.pumpAndSettle();
       await tester.ensureVisible(find.text('Recent AI Sessions'));
       await tester.pump();

--- a/test/widget/tmux_window_navigator_test.dart
+++ b/test/widget/tmux_window_navigator_test.dart
@@ -94,6 +94,42 @@ void main() {
     });
   });
 
+  testWidgets('keeps window title size stable across selection', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              TmuxWindowTitleText(
+                key: Key('active-window-title'),
+                title: 'Active workspace',
+                isActive: true,
+              ),
+              TmuxWindowTitleText(
+                key: Key('inactive-window-title'),
+                title: 'Inactive workspace',
+                isActive: false,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    Text titleText(Key key) => tester.widget<Text>(
+      find.descendant(of: find.byKey(key), matching: find.byType(Text)),
+    );
+
+    final activeTitle = titleText(const Key('active-window-title'));
+    final inactiveTitle = titleText(const Key('inactive-window-title'));
+    expect(activeTitle.style?.fontSize, inactiveTitle.style?.fontSize);
+    expect(activeTitle.style?.fontFamily, inactiveTitle.style?.fontFamily);
+    expect(activeTitle.style?.fontWeight, FontWeight.w600);
+    expect(inactiveTitle.style?.fontWeight, FontWeight.w500);
+  });
+
   group('tmux navigator UI', () {
     final windows = [
       const TmuxWindow(


### PR DESCRIPTION
## Summary

- enforce WCAG-AA contrast across terminal-driven app themes and make destructive remote-window controls accessible and confirmed
- add retry/edit recovery for failed SSH connections, direct recent-agent access, and a discoverable Port Forwards destination
- move compact-screen actions into thumb reach, simplify host/SFTP/terminal menus, and add terminal control guidance
- align PIN validation, design documentation, and regression coverage with the updated interaction model

## Validation

- `flutter analyze --no-pub`
- `flutter test --no-pub --reporter compact` (2,723 tests)
- `JAVA_HOME="$(/usr/libexec/java_home -v 17)" flutter build apk --debug --flavor private -t lib/main.dart`