### PR TITLE
fix: harden deploy and local transfer security

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -210,11 +210,39 @@ env:
   FLUTTER_VERSION: '3.44.4'
 
 jobs:
+  validate-build-inputs:
+    name: Validate Build Inputs
+    runs-on: ubuntu-latest
+    env:
+      BUILD_FLAVOR: ${{ inputs.flavor }}
+      BUILD_NAME: ${{ inputs.build-name }}
+      BUILD_NUMBER: ${{ inputs.build-number }}
+    steps:
+      - name: Validate version and flavor
+        run: |
+          if [[ "$BUILD_FLAVOR" != 'private' && "$BUILD_FLAVOR" != 'production' ]]; then
+            echo "::error title=Invalid flavor::Flavor must be private or production."
+            exit 1
+          fi
+          if [[ ! "$BUILD_NAME" =~ ^[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
+            echo "::error title=Invalid build name::Expected a semantic version such as 1.2.3 or 1.2.3-pr.42."
+            exit 1
+          fi
+          if [[ ! "$BUILD_NUMBER" =~ ^[1-9][0-9]{0,9}$ ]] ||
+             (( BUILD_NUMBER > 2147483647 )); then
+            echo "::error title=Invalid build number::Expected a positive Android-compatible build number."
+            exit 1
+          fi
+
   build-android:
     name: Build & Deploy Android (${{ inputs.flavor }})
+    needs: validate-build-inputs
     if: inputs.build-android
     runs-on: ${{ inputs.android-runner }}
     env:
+      BUILD_FLAVOR: ${{ inputs.flavor }}
+      BUILD_NAME: ${{ inputs.build-name }}
+      BUILD_NUMBER: ${{ inputs.build-number }}
       FLUTTY_PR_NUMBER: ${{ inputs.pr-number }}
       FLUTTY_PR_TITLE: ${{ inputs.pr-title }}
       FLUTTY_DIAGNOSTICS_ENABLED: ${{ inputs.enable-diagnostics || inputs.pr-number != '' }}
@@ -427,11 +455,11 @@ jobs:
             EXTRA_ANDROID_FLAGS+=(--target-platform="$ANDROID_TARGET_PLATFORM")
           fi
           flutter build appbundle \
-            --flavor ${{ inputs.flavor }} \
+            --flavor "$BUILD_FLAVOR" \
             --release \
             "${EXTRA_ANDROID_FLAGS[@]}" \
-            --build-name=${{ inputs.build-name }} \
-            --build-number=${{ inputs.build-number }} \
+            --build-name="$BUILD_NAME" \
+            --build-number="$BUILD_NUMBER" \
             --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
             --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE" \
             --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED" \
@@ -462,12 +490,12 @@ jobs:
             EXTRA_ANDROID_FLAGS+=(--target-platform="$ANDROID_TARGET_PLATFORM")
           fi
           flutter build appbundle \
-            --flavor ${{ inputs.flavor }} \
+            --flavor "$BUILD_FLAVOR" \
             --release \
             --no-tree-shake-icons \
             "${EXTRA_ANDROID_FLAGS[@]}" \
-            --build-name=${{ inputs.build-name }} \
-            --build-number=${{ inputs.build-number }} \
+            --build-name="$BUILD_NAME" \
+            --build-number="$BUILD_NUMBER" \
             --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
             --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE" \
             --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED" \
@@ -483,12 +511,12 @@ jobs:
             EXTRA_ANDROID_FLAGS+=(--target-platform="$ANDROID_TARGET_PLATFORM")
           fi
           flutter build appbundle \
-            --flavor ${{ inputs.flavor }} \
+            --flavor "$BUILD_FLAVOR" \
             --debug \
             --no-tree-shake-icons \
             "${EXTRA_ANDROID_FLAGS[@]}" \
-            --build-name=${{ inputs.build-name }} \
-            --build-number=${{ inputs.build-number }} \
+            --build-name="$BUILD_NAME" \
+            --build-number="$BUILD_NUMBER" \
             --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
             --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE" \
             --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED" \
@@ -544,7 +572,7 @@ jobs:
           AAB_PATH="${{ steps.preview-aab.outputs.path }}"
           APKS_PATH="$RUNNER_TEMP/app-${{ inputs.flavor }}-preview.apks"
           APK_DIR="$RUNNER_TEMP/app-${{ inputs.flavor }}-preview-apks"
-          APK_PATH="build/app/outputs/flutter-apk/android-apk-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}.apk"
+          APK_PATH="build/app/outputs/flutter-apk/android-apk-${BUILD_FLAVOR}-${BUILD_NAME}-${BUILD_NUMBER}.apk"
           DEBUG_KEYSTORE="$HOME/.android/debug.keystore"
 
           curl \
@@ -800,9 +828,13 @@ jobs:
 
   build-ios:
     name: Build & Deploy iOS (${{ inputs.flavor }})
+    needs: validate-build-inputs
     if: inputs.build-ios
     runs-on: macos-26
     env:
+      BUILD_FLAVOR: ${{ inputs.flavor }}
+      BUILD_NAME: ${{ inputs.build-name }}
+      BUILD_NUMBER: ${{ inputs.build-number }}
       # Keep release validation on the runner Xcode that includes the installed
       # iOS simulator runtime. Newer side-by-side Xcodes can drift ahead of the
       # available runtime and fail builds before Flutter starts.
@@ -936,12 +968,12 @@ jobs:
             EXTRA_FLAGS+=(--no-tree-shake-icons)
           fi
           flutter build ios \
-            --flavor ${{ inputs.flavor }} \
+            --flavor "$BUILD_FLAVOR" \
             --release \
             --no-codesign \
             "${EXTRA_FLAGS[@]}" \
-            --build-name=${{ inputs.build-name }} \
-            --build-number=${{ inputs.build-number }} \
+            --build-name="$BUILD_NAME" \
+            --build-number="$BUILD_NUMBER" \
             --dart-define=FLUTTY_PR_NUMBER="$FLUTTY_PR_NUMBER" \
             --dart-define=FLUTTY_PR_TITLE="$FLUTTY_PR_TITLE" \
             --dart-define=FLUTTY_DIAGNOSTICS_ENABLED="$FLUTTY_DIAGNOSTICS_ENABLED" \
@@ -1004,7 +1036,7 @@ jobs:
             if [ -d SwiftSupport ]; then
               ZIP_INPUTS+=(SwiftSupport)
             fi
-            zip -qry "../ipa/ios-unsigned-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}.ipa" "${ZIP_INPUTS[@]}"
+            zip -qry "../ipa/ios-unsigned-${BUILD_FLAVOR}-${BUILD_NAME}-${BUILD_NUMBER}.ipa" "${ZIP_INPUTS[@]}"
           )
 
       - name: Download reusable IPA artifact
@@ -1201,7 +1233,7 @@ jobs:
             exit 1
           fi
 
-          ARTIFACT_PATH="build/ios/ipa/ios-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}.ipa"
+          ARTIFACT_PATH="build/ios/ipa/ios-${BUILD_FLAVOR}-${BUILD_NAME}-${BUILD_NUMBER}.ipa"
           if [ "$IPA_PATH" != "$ARTIFACT_PATH" ]; then
             cp "$IPA_PATH" "$ARTIFACT_PATH"
           fi
@@ -1429,9 +1461,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Write private deploy build marker
+        env:
+          BUILD_NUMBER: ${{ inputs.build-number }}
         run: |
           mkdir -p build/private-deploy-marker
-          printf '%s\n' '${{ inputs.build-number }}' > build/private-deploy-marker/build-number.txt
+          printf '%s\n' "$BUILD_NUMBER" > build/private-deploy-marker/build-number.txt
 
       - name: Upload private deploy build marker
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/preview-deploy-command.yml
+++ b/.github/workflows/preview-deploy-command.yml
@@ -34,24 +34,46 @@ jobs:
              const requestKey = `comment-${requestCommentId}`;
              const requestCommentUrl = context.payload.comment.html_url;
              const requestCreatedAt = context.payload.comment.created_at;
-             const authorAssociation = context.payload.comment.author_association;
              const previewMarker = '<!-- Sticky Pull Request Commentpreview-build -->';
              const statusMarker = '<!-- preview-deploy-status -->';
             const workflowId = 'preview-deploy.yml';
             const noPreviewCommentUrl = '__NO_PREVIEW_COMMENT__';
             const activeLockTimeoutMs = 4 * 60 * 60 * 1000;
-             const allowedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+             const allowedRepositoryPermissions = new Set(['admin', 'maintain', 'write']);
              const managedReactionContents = new Set(['eyes', 'rocket', '-1']);
              const activeWorkflowStatuses = new Set(['queued', 'in_progress', 'requested', 'waiting']);
+             const buildNamePattern =
+               /^[0-9]+(?:\.[0-9]+){2}(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/;
+             const buildNumberPattern = /^[1-9][0-9]{0,9}$/;
 
             if (commandBody !== '/deploy') {
               core.info(`Ignoring PR comment without exact /deploy command: ${commandBody}`);
               return;
             }
 
-            if (!allowedAssociations.has(authorAssociation)) {
+            let requesterPermission;
+            try {
+              const {data} = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username: requester,
+              });
+              requesterPermission = data;
+            } catch (error) {
+              const status = error.status ?? error.response?.status;
+              if (status === 404) {
+                core.info(`Ignoring /deploy from ${requester}, who is not a collaborator.`);
+                return;
+              }
+              throw error;
+            }
+
+            const canDeploy =
+              allowedRepositoryPermissions.has(requesterPermission.permission) ||
+              requesterPermission.user?.permissions?.push === true;
+            if (!canDeploy) {
               core.info(
-                `Ignoring /deploy from ${requester} with association ${authorAssociation}.`,
+                `Ignoring /deploy from ${requester} with ${requesterPermission.permission} permission.`,
               );
               return;
             }
@@ -61,9 +83,13 @@ jobs:
                return body.match(pattern)?.[1] ?? '';
              };
 
+              const isTrustedWorkflowComment = (comment) =>
+                comment.user?.login === 'github-actions[bot]' && comment.user?.type === 'Bot';
+
               const findStatusComment = (comments, targetRequestKey) =>
                 [...comments].reverse().find(
                   (comment) =>
+                    isTrustedWorkflowComment(comment) &&
                     comment.body?.includes(statusMarker) &&
                     readMeta(comment.body, 'preview-deploy-request-key') === targetRequestKey,
                 );
@@ -308,16 +334,21 @@ jobs:
                return;
              }
 
-             const previewComment = [...comments].reverse().find((comment) =>
-               comment.body?.includes(previewMarker),
-            );
+             const previewComment = [...comments].reverse().find(
+               (comment) =>
+                 isTrustedWorkflowComment(comment) &&
+                 comment.body?.includes(previewMarker),
+             );
             const previewSha = pr.head.sha;
              const previewCommentUrl = previewComment?.html_url ?? '';
              const previewCommentBody = previewComment?.body ?? '';
              const previewCommentSha = readMeta(previewCommentBody, 'preview-build-source-sha');
              const previousDeploySha = readMeta(statusBody, 'preview-deploy-source-sha');
               const activeStatusComments = [...comments].filter((comment) => {
-                if (!comment.body?.includes(statusMarker)) {
+                if (
+                  !isTrustedWorkflowComment(comment) ||
+                  !comment.body?.includes(statusMarker)
+                ) {
                   return false;
                 }
 
@@ -369,6 +400,26 @@ jobs:
 
                buildName = versionLine.replace(/^version:\s*/, '').split('+')[0].trim();
                buildNumber = String(Math.floor(Date.now() / 1000 / 10));
+             }
+
+             const validBuildName = buildNamePattern.test(buildName);
+             const validBuildNumber =
+               buildNumberPattern.test(buildNumber) &&
+               Number(buildNumber) <= 2147483647;
+             if (!validBuildName || !validBuildNumber) {
+               const body = renderStatusComment({
+                 status: '❌ Invalid preview build metadata',
+                 workflow: 'Dispatch skipped',
+                 previewSha,
+                 previewCommentUrl,
+                 state: 'failed',
+                 note:
+                   '> The preview version metadata was malformed. Re-run the preview build before deploying.',
+                 requestKey,
+               });
+               await upsertStatusComment(comments, body, requestKey);
+               core.setFailed(`Invalid preview build metadata for ${previewSha}.`);
+               return;
              }
 
               const supersedeActiveRequest = async (comment) => {

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -72,12 +72,24 @@ jobs:
       - name: Validate PR is safe to deploy
         id: validate
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_PR_NUMBER: ${{ inputs.pr-number }}
+          INPUT_SOURCE_SHA: ${{ inputs.source-sha }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const pull_number = Number('${{ inputs.pr-number }}');
-            const requestedSourceSha = '${{ inputs.source-sha }}'.trim();
+            const pullNumberValue = (process.env.INPUT_PR_NUMBER || '').trim();
+            const requestedSourceSha = (process.env.INPUT_SOURCE_SHA || '').trim();
+            if (!/^[1-9][0-9]*$/.test(pullNumberValue)) {
+              core.setFailed('PR number must be a positive integer.');
+              return;
+            }
+            if (requestedSourceSha && !/^[0-9a-f]{40}$/.test(requestedSourceSha)) {
+              core.setFailed('Source SHA must be a full lowercase commit SHA.');
+              return;
+            }
+            const pull_number = Number(pullNumberValue);
             const {data: pr} = await github.rest.pulls.get({
               owner,
               repo,
@@ -133,9 +145,22 @@ jobs:
       - name: Reuse requested build version
         id: provided-version
         if: inputs.preview-build-name != '' && inputs.preview-build-number != ''
+        env:
+          PREVIEW_BUILD_NAME: ${{ inputs.preview-build-name }}
+          PREVIEW_BUILD_NUMBER: ${{ inputs.preview-build-number }}
         run: |
-          echo "build-name=${{ inputs.preview-build-name }}" >> "$GITHUB_OUTPUT"
-          echo "build-number=${{ inputs.preview-build-number }}" >> "$GITHUB_OUTPUT"
+          if [[ ! "$PREVIEW_BUILD_NAME" =~ ^[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
+            echo "::error title=Invalid build name::Expected a semantic version such as 1.2.3 or 1.2.3-pr.42."
+            exit 1
+          fi
+          if [[ ! "$PREVIEW_BUILD_NUMBER" =~ ^[1-9][0-9]{0,9}$ ]] ||
+             (( PREVIEW_BUILD_NUMBER > 2147483647 )); then
+            echo "::error title=Invalid build number::Expected a positive Android-compatible build number."
+            exit 1
+          fi
+
+          printf 'build-name=%s\n' "$PREVIEW_BUILD_NAME" >> "$GITHUB_OUTPUT"
+          printf 'build-number=%s\n' "$PREVIEW_BUILD_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Compute version
         id: source-version
@@ -144,8 +169,13 @@ jobs:
           BASE_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | cut -d'+' -f1)
           BUILD_NUMBER=$(( $(date +%s) / 10 ))
 
-          echo "build-name=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "build-number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+          if [[ ! "$BASE_VERSION" =~ ^[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
+            echo "::error title=Invalid source version::pubspec.yaml must contain a safe semantic version."
+            exit 1
+          fi
+
+          printf 'build-name=%s\n' "$BASE_VERSION" >> "$GITHUB_OUTPUT"
+          printf 'build-number=%s\n' "$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Resolve codename
         id: version-codename

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="true">localhost</domain>
         <domain includeSubdomains="false">127.0.0.1</domain>
     </domain-config>
 </network-security-config>

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -327,7 +327,12 @@ bool _portForwardBrowserLaunchIsValid(PortForwardBrowserLaunch launch) =>
     launch.tabs.isNotEmpty &&
     launch.selectedIndex >= 0 &&
     launch.selectedIndex < launch.tabs.length &&
-    launch.tabs.every((tab) => isPortForwardBrowserEntryUri(tab.uri));
+    launch.tabs.every(
+      (tab) =>
+          isPortForwardBrowserEntryUri(tab.uri) &&
+          (tab.sourceUri == null ||
+              isPortForwardBrowserEntryUri(tab.sourceUri!)),
+    );
 
 HomeScreenTab _homeScreenTabFromRoute(String? tab) => switch (tab) {
   'connections' => HomeScreenTab.connections,

--- a/lib/domain/services/port_forward_browser_service.dart
+++ b/lib/domain/services/port_forward_browser_service.dart
@@ -53,6 +53,32 @@ Uri buildPortForwardBrowserUriForBind({
   port: localPort,
 );
 
+/// Returns a stable localhost origin dedicated to [portForwardId].
+///
+/// Distinct hosts keep WebView cookies scoped to one forwarded service.
+String portForwardBrowserHostForPortForwardId(int portForwardId) =>
+    'monkeyssh-${portForwardId.abs().toRadixString(36)}.localhost';
+
+/// Rewrites a loopback [uri] for one forwarded service's browser-only relay.
+///
+/// Returns null when [uri] does not target [sourceUri].
+Uri? rewriteUriForPortForwardBrowser(
+  Uri uri, {
+  required Uri sourceUri,
+  required Uri browserUri,
+}) {
+  if ((uri.scheme != 'http' && uri.scheme != 'https') ||
+      !isPortForwardBrowserHost(uri.host) ||
+      !_samePortForwardBrowserSourceHost(uri.host, sourceUri.host) ||
+      portForwardBrowserUriPort(uri) != portForwardBrowserUriPort(sourceUri)) {
+    return null;
+  }
+  return uri.replace(
+    host: browserUri.host,
+    port: portForwardBrowserUriPort(browserUri),
+  );
+}
+
 /// Returns whether [uri] should stay inside the embedded browser.
 ///
 /// Only loopback web links whose port is owned by an active local forward are
@@ -85,19 +111,36 @@ bool isPortForwardBrowserHost(String host) {
       normalized == '::1' ||
       normalized == '[::]' ||
       normalized == '[::1]' ||
+      normalized.endsWith('.localhost') ||
       _isLoopbackIpv4Address(normalized);
 }
 
 String _browserHostForBindAddress(String localHost) {
   final host = localHost.trim().toLowerCase();
-  if (host.isEmpty || host == '0.0.0.0' || _isLoopbackIpv4Address(host)) {
+  if (host.isEmpty || host == '0.0.0.0') {
     return '127.0.0.1';
+  }
+  if (_isLoopbackIpv4Address(host)) {
+    return host;
   }
   if (host == '::' || host == '[::]' || host == '::1' || host == '[::1]') {
     return 'localhost';
   }
   return localHost.trim();
 }
+
+bool _samePortForwardBrowserSourceHost(String left, String right) {
+  final normalizedLeft = _browserHostForBindAddress(left);
+  final normalizedRight = _browserHostForBindAddress(right);
+  if (normalizedLeft == normalizedRight) {
+    return true;
+  }
+  return _isDefaultLoopbackBrowserHost(normalizedLeft) &&
+      _isDefaultLoopbackBrowserHost(normalizedRight);
+}
+
+bool _isDefaultLoopbackBrowserHost(String host) =>
+    host == '127.0.0.1' || host == 'localhost';
 
 bool _isLoopbackIpv4Address(String host) {
   final parts = host.split('.');

--- a/lib/domain/services/settings_service.dart
+++ b/lib/domain/services/settings_service.dart
@@ -54,6 +54,10 @@ abstract final class SettingKeys {
   /// Open forwarded localhost links in the embedded browser.
   static const portForwardBrowserLinks = 'port_forward_browser_links';
 
+  /// Whether legacy shared-origin WebView cookies have been cleared.
+  static const portForwardBrowserCookieIsolationMigration =
+      'port_forward_browser_cookie_isolation_v1';
+
   /// Enable shell completion popups while typing in the terminal.
   static const shellCompletions = 'shell_completions';
 

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -25,6 +25,7 @@ import 'host_key_prompt_handler_provider.dart';
 import 'host_key_verification.dart';
 import 'interactive_auth_prompt.dart';
 import 'local_notification_service.dart';
+import 'port_forward_browser_service.dart';
 import 'settings_service.dart';
 import 'ssh_exec_queue.dart';
 import 'telemetry_service.dart';
@@ -3213,6 +3214,8 @@ class SshSession {
           portForwardId: e.key,
           localHost: e.value.localHost,
           localPort: e.value.localPort,
+          browserHost: e.value.browserHost,
+          browserPort: e.value.browserPort,
           remoteHost: e.value.remoteHost,
           remotePort: e.value.remotePort,
           isLocal: e.value.isLocal,
@@ -3816,10 +3819,33 @@ class SshSession {
       return true; // Already running
     }
 
+    ServerSocket? serverSocket;
+    ServerSocket? browserServerSocket;
     try {
-      final serverSocket = await ServerSocket.bind(localHost, localPort);
+      serverSocket = await ServerSocket.bind(localHost, localPort);
+      final browserHost = portForwardBrowserHostForPortForwardId(portForwardId);
+      try {
+        browserServerSocket = await ServerSocket.bind(
+          InternetAddress.loopbackIPv4,
+          0,
+        );
+      } on Exception catch (error) {
+        DiagnosticsLogService.instance.warning(
+          'ssh.forward',
+          'browser_listener_failed',
+          fields: {
+            'connectionId': connectionId,
+            'hostId': hostId,
+            'portForwardId': portForwardId,
+            'errorType': error.runtimeType,
+          },
+        );
+      }
       final tunnel = _ActiveTunnel.local(
         serverSocket: serverSocket,
+        browserServerSocket: browserServerSocket,
+        browserHost: browserServerSocket == null ? null : browserHost,
+        browserPort: browserServerSocket?.port,
         localHost: localHost,
         localPort: serverSocket.port,
         remoteHost: remoteHost,
@@ -3828,55 +3854,24 @@ class SshSession {
 
       _activeTunnels[portForwardId] = tunnel;
 
-      // Handle incoming connections
-      tunnel.subscription = serverSocket.listen((socket) async {
-        SSHForwardChannel? forward;
-        try {
-          forward = await client.forwardLocal(remoteHost, remotePort);
-          // Pipe data bidirectionally and wait until either side finishes.
-          final forwardToSocket = forward.stream.cast<List<int>>().pipe(socket);
-          final socketToForward = socket.cast<List<int>>().pipe(forward.sink);
-
-          await Future.any<void>([forwardToSocket, socketToForward]);
-        } on SSHError catch (e) {
-          DiagnosticsLogService.instance.warning(
-            'ssh.forward',
-            'local_connection_failed',
-            fields: {
-              'connectionId': connectionId,
-              'hostId': hostId,
-              ..._diagnosticSshExecErrorFields(e),
-            },
-          );
-          _reportConnectionHealthFailureIfClosed(e, operation: 'forward_local');
-          if (kDebugMode) {
-            debugPrint('Port forward connection error: $e');
-          }
-        } on Exception catch (e) {
-          DiagnosticsLogService.instance.warning(
-            'ssh.forward',
-            'local_connection_failed',
-            fields: {'errorType': e.runtimeType},
-          );
-          if (kDebugMode) {
-            debugPrint('Port forward connection error: $e');
-          }
-        } finally {
-          try {
-            await forward?.sink.close();
-          } on Exception catch (_) {
-            // Ignore errors during cleanup.
-          }
-          try {
-            socket.destroy();
-          } on Exception catch (_) {
-            // Ignore errors during cleanup.
-          }
-        }
-      });
+      tunnel.subscription = _listenToLocalForwardConnections(
+        serverSocket,
+        remoteHost: remoteHost,
+        remotePort: remotePort,
+      );
+      if (browserServerSocket != null) {
+        tunnel.browserSubscription = _listenToLocalForwardConnections(
+          browserServerSocket,
+          remoteHost: remoteHost,
+          remotePort: remotePort,
+        );
+      }
 
       return true;
     } on Exception catch (e) {
+      _activeTunnels.remove(portForwardId);
+      await browserServerSocket?.close();
+      await serverSocket?.close();
       DiagnosticsLogService.instance.warning(
         'ssh.forward',
         'local_start_failed',
@@ -3888,6 +3883,55 @@ class SshSession {
       return false;
     }
   }
+
+  StreamSubscription<Socket> _listenToLocalForwardConnections(
+    ServerSocket serverSocket, {
+    required String remoteHost,
+    required int remotePort,
+  }) => serverSocket.listen((socket) async {
+    SSHForwardChannel? forward;
+    try {
+      forward = await client.forwardLocal(remoteHost, remotePort);
+      final forwardToSocket = forward.stream.cast<List<int>>().pipe(socket);
+      final socketToForward = socket.cast<List<int>>().pipe(forward.sink);
+
+      await Future.any<void>([forwardToSocket, socketToForward]);
+    } on SSHError catch (e) {
+      DiagnosticsLogService.instance.warning(
+        'ssh.forward',
+        'local_connection_failed',
+        fields: {
+          'connectionId': connectionId,
+          'hostId': hostId,
+          ..._diagnosticSshExecErrorFields(e),
+        },
+      );
+      _reportConnectionHealthFailureIfClosed(e, operation: 'forward_local');
+      if (kDebugMode) {
+        debugPrint('Port forward connection error: $e');
+      }
+    } on Exception catch (e) {
+      DiagnosticsLogService.instance.warning(
+        'ssh.forward',
+        'local_connection_failed',
+        fields: {'errorType': e.runtimeType},
+      );
+      if (kDebugMode) {
+        debugPrint('Port forward connection error: $e');
+      }
+    } finally {
+      try {
+        await forward?.sink.close();
+      } on Exception catch (_) {
+        // Ignore errors during cleanup.
+      }
+      try {
+        socket.destroy();
+      } on Exception catch (_) {
+        // Ignore errors during cleanup.
+      }
+    }
+  });
 
   /// Start a remote port forward tunnel.
   ///
@@ -3986,7 +4030,9 @@ class SshSession {
     final tunnel = _activeTunnels.remove(portForwardId);
     if (tunnel != null) {
       await tunnel.subscription?.cancel();
+      await tunnel.browserSubscription?.cancel();
       await tunnel.serverSocket?.close();
+      await tunnel.browserServerSocket?.close();
       tunnel.remoteForward?.close();
     }
   }
@@ -4180,6 +4226,8 @@ class ActiveTunnelInfo {
     required this.remoteHost,
     required this.remotePort,
     required this.isLocal,
+    this.browserHost,
+    this.browserPort,
   });
 
   /// The port forward database ID.
@@ -4190,6 +4238,12 @@ class ActiveTunnelInfo {
 
   /// The local port being listened on.
   final int localPort;
+
+  /// Browser-only loopback host that isolates this tunnel's cookies.
+  final String? browserHost;
+
+  /// Browser-only relay port for this tunnel.
+  final int? browserPort;
 
   /// The remote host being forwarded to.
   final String remoteHost;
@@ -4204,6 +4258,9 @@ class ActiveTunnelInfo {
 class _ActiveTunnel {
   _ActiveTunnel.local({
     required this.serverSocket,
+    required this.browserServerSocket,
+    required this.browserHost,
+    required this.browserPort,
     required this.localHost,
     required this.localPort,
     required this.remoteHost,
@@ -4218,18 +4275,27 @@ class _ActiveTunnel {
     required this.remoteHost,
     required this.remotePort,
   }) : serverSocket = null,
+       browserServerSocket = null,
+       browserHost = null,
+       browserPort = null,
        isLocal = false;
 
   final ServerSocket? serverSocket;
+  final ServerSocket? browserServerSocket;
   final SSHRemoteForward? remoteForward;
   final String localHost;
   final int localPort;
+  final String? browserHost;
+  final int? browserPort;
   final String remoteHost;
   final int remotePort;
   final bool isLocal;
   // Cancelled in SshSession.stopForward().
   // ignore: cancel_subscriptions
   StreamSubscription<dynamic>? subscription;
+  // Cancelled in SshSession.stopForward().
+  // ignore: cancel_subscriptions
+  StreamSubscription<dynamic>? browserSubscription;
 }
 
 class _AppReviewDemoSshClient implements SSHClient {

--- a/lib/presentation/screens/port_forward_browser_screen.dart
+++ b/lib/presentation/screens/port_forward_browser_screen.dart
@@ -3,20 +3,29 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:webview_flutter_android/webview_flutter_android.dart';
 
 import '../../app/theme.dart';
 import '../../domain/services/port_forward_browser_service.dart';
+import '../../domain/services/settings_service.dart';
 
 /// Initial tab configuration for the embedded browser.
 class PortForwardBrowserInitialTab {
   /// Creates an initial browser tab.
-  const PortForwardBrowserInitialTab({required this.uri, this.title});
+  const PortForwardBrowserInitialTab({
+    required this.uri,
+    this.sourceUri,
+    this.title,
+  });
 
   /// URL loaded by the tab.
   final Uri uri;
+
+  /// Original local-forward URL represented by [uri].
+  final Uri? sourceUri;
 
   /// Optional label shown until the page title is available.
   final String? title;
@@ -38,7 +47,7 @@ class PortForwardBrowserLaunch {
 }
 
 /// Embedded browser for pages exposed through local port forwards.
-class PortForwardBrowserScreen extends StatefulWidget {
+class PortForwardBrowserScreen extends ConsumerStatefulWidget {
   /// Creates a port-forward browser screen.
   const PortForwardBrowserScreen({
     required this.initialTabs,
@@ -55,11 +64,12 @@ class PortForwardBrowserScreen extends StatefulWidget {
   final int initialTabIndex;
 
   @override
-  State<PortForwardBrowserScreen> createState() =>
+  ConsumerState<PortForwardBrowserScreen> createState() =>
       _PortForwardBrowserScreenState();
 }
 
-class _PortForwardBrowserScreenState extends State<PortForwardBrowserScreen> {
+class _PortForwardBrowserScreenState
+    extends ConsumerState<PortForwardBrowserScreen> {
   TextEditingController? _addressController;
   List<_PortForwardBrowserTabState> _tabs = [];
   final _addressFocusNode = FocusNode();
@@ -161,12 +171,18 @@ class _PortForwardBrowserScreenState extends State<PortForwardBrowserScreen> {
     return tab = _PortForwardBrowserTabState(
       id: _nextTabId++,
       controller: controller,
+      browserUri: initialUri,
+      sourceUri: normalizePortForwardBrowserUri(seed.sourceUri ?? seed.uri),
       currentUri: initialUri,
       initialTitle: seed.title,
     );
   }
 
   Future<void> _initializeBrowser() async {
+    await _clearLegacySharedCookiesOnce();
+    if (!mounted) {
+      return;
+    }
     final tabs = widget.initialTabs.map(_createTab).toList(growable: true);
     final selectedTabIndex = widget.initialTabIndex;
     final addressController = TextEditingController(
@@ -178,6 +194,22 @@ class _PortForwardBrowserScreenState extends State<PortForwardBrowserScreen> {
       _addressController = addressController;
     });
     _scheduleSelectedTabLoad();
+  }
+
+  Future<void> _clearLegacySharedCookiesOnce() async {
+    final settings = ref.read(settingsServiceProvider);
+    final alreadyMigrated = await settings.getBool(
+      SettingKeys.portForwardBrowserCookieIsolationMigration,
+    );
+    if (alreadyMigrated) {
+      return;
+    }
+
+    await WebViewCookieManager().clearCookies();
+    await settings.setBool(
+      SettingKeys.portForwardBrowserCookieIsolationMigration,
+      value: true,
+    );
   }
 
   void _scheduleSelectedTabLoad() {
@@ -567,7 +599,7 @@ class _PortForwardBrowserScreenState extends State<PortForwardBrowserScreen> {
       return NavigationDecision.prevent;
     }
     if (uri.scheme == 'http' || uri.scheme == 'https') {
-      final normalizedUri = normalizePortForwardBrowserUri(uri);
+      final normalizedUri = _normalizeBrowserUri(uri);
       if (normalizedUri.toString() != uri.toString()) {
         unawaited(tab.controller.loadRequest(normalizedUri));
         return NavigationDecision.prevent;
@@ -609,13 +641,37 @@ class _PortForwardBrowserScreenState extends State<PortForwardBrowserScreen> {
     if (uri.scheme != 'http' && uri.scheme != 'https') {
       return null;
     }
-    return normalizePortForwardBrowserUri(uri);
+    return _normalizeBrowserUri(uri);
   }
 
   Uri _normalizeLoadedBrowserUri(Uri uri) =>
       uri.scheme == 'http' || uri.scheme == 'https'
-      ? normalizePortForwardBrowserUri(uri)
+      ? _normalizeBrowserUri(uri)
       : uri;
+
+  Uri _normalizeBrowserUri(Uri uri) {
+    final normalizedUri = normalizePortForwardBrowserUri(uri);
+    for (final tab in _tabs) {
+      if (_sameBrowserEndpoint(normalizedUri, tab.browserUri)) {
+        return normalizedUri;
+      }
+    }
+    for (final tab in _tabs) {
+      final rewritten = rewriteUriForPortForwardBrowser(
+        normalizedUri,
+        sourceUri: tab.sourceUri,
+        browserUri: tab.browserUri,
+      );
+      if (rewritten != null) {
+        return rewritten;
+      }
+    }
+    return normalizedUri;
+  }
+
+  bool _sameBrowserEndpoint(Uri left, Uri right) =>
+      left.host.toLowerCase() == right.host.toLowerCase() &&
+      portForwardBrowserUriPort(left) == portForwardBrowserUriPort(right);
 
   String _defaultSchemeForAddress(String address) {
     final candidate = Uri.tryParse('//$address');
@@ -639,12 +695,16 @@ class _PortForwardBrowserTabState {
   _PortForwardBrowserTabState({
     required this.id,
     required this.controller,
+    required this.browserUri,
+    required this.sourceUri,
     required this.currentUri,
     this.initialTitle,
   });
 
   final int id;
   final WebViewController controller;
+  final Uri browserUri;
+  final Uri sourceUri;
   final String? initialTitle;
   int progress = 0;
   bool canGoBack = false;

--- a/lib/presentation/screens/port_forwards_screen.dart
+++ b/lib/presentation/screens/port_forwards_screen.dart
@@ -14,6 +14,7 @@ import '../providers/entity_list_providers.dart';
 import '../widgets/brand_empty_state.dart';
 import '../widgets/brand_error_state.dart';
 import '../widgets/brand_list_skeleton.dart';
+import 'port_forward_browser_screen.dart';
 
 /// Screen displaying list of port forwards grouped by host.
 class PortForwardsScreen extends ConsumerWidget {
@@ -178,18 +179,35 @@ class PortForwardsScreen extends ConsumerWidget {
       );
       return;
     }
+    final browserHost = activeTunnel.browserHost;
+    final browserPort = activeTunnel.browserPort;
+    if (browserHost == null || browserPort == null || browserPort < 1) {
+      _showPortForwardMessage(
+        context,
+        'Could not create an isolated browser endpoint for "${portForward.name}".',
+      );
+      return;
+    }
     final browserUri = buildPortForwardBrowserUriForBind(
+      localHost: browserHost,
+      localPort: browserPort,
+    );
+    final sourceUri = buildPortForwardBrowserUriForBind(
       localHost: activeTunnel.localHost,
       localPort: activeTunnel.localPort,
     );
 
     await context.pushNamed<void>(
       Routes.portForwardBrowser,
-      queryParameters: {
-        'url': browserUri.toString(),
-        'port': browserUri.port.toString(),
-        'title': portForward.name,
-      },
+      extra: PortForwardBrowserLaunch(
+        tabs: [
+          PortForwardBrowserInitialTab(
+            uri: browserUri,
+            sourceUri: sourceUri,
+            title: portForward.name,
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -412,6 +412,29 @@ String resolveUnreadableSftpUploadMessage(List<PlatformFile> files) {
   return 'Unable to read ${files.length} selected files';
 }
 
+/// Returns an error when a picker-provided upload name is not a single file.
+@visibleForTesting
+String? validateSftpUploadFileName(String name) {
+  final trimmedName = name.trim();
+  if (trimmedName.isEmpty) {
+    return 'File name is required';
+  }
+  if (trimmedName == '.' || trimmedName == '..') {
+    return 'File name cannot be a navigation shortcut';
+  }
+  if (name.contains('/') || name.contains(r'\') || name.contains('\x00')) {
+    return 'File name cannot contain path separators';
+  }
+  return null;
+}
+
+/// Resolves the message shown when selected uploads contain unsafe names.
+@visibleForTesting
+String resolveUnsafeSftpUploadNameMessage(List<PlatformFile> files) =>
+    files.length == 1
+    ? 'The selected file has an unsafe name'
+    : '${files.length} selected files have unsafe names';
+
 /// Returns a validation error for a new remote folder name, or null if valid.
 @visibleForTesting
 String? validateSftpDirectoryName(String name) {
@@ -1920,6 +1943,31 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     }
 
     final selectedFiles = result.files;
+    final unsafeUploads = selectedFiles
+        .where((file) => validateSftpUploadFileName(file.name) != null)
+        .toList();
+    if (unsafeUploads.isNotEmpty) {
+      unawaited(
+        ref
+            .read(telemetryServiceProvider)
+            .logSftpTransferFailed(
+              direction: 'upload',
+              fileCount: selectedFiles.length,
+              sizeBytes: _selectedUploadSizeBytes(selectedFiles),
+              duration: Duration.zero,
+              failureCategory: 'invalid_name',
+            ),
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(resolveUnsafeSftpUploadNameMessage(unsafeUploads)),
+          ),
+        );
+      }
+      return;
+    }
+
     final uploads = <({PlatformFile file, Stream<List<int>>? readStream})>[
       for (final file in selectedFiles)
         (file: file, readStream: resolvePickedSftpUploadReadStream(file)),

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3158,11 +3158,13 @@ enum _TerminalExclusiveAction { sftpBrowser, tmuxNavigator }
 class _PortForwardBrowserOption {
   const _PortForwardBrowserOption({
     required this.uri,
+    required this.sourceUri,
     required this.port,
     required this.title,
   });
 
   final Uri uri;
+  final Uri sourceUri;
   final int port;
   final String title;
 }
@@ -13388,20 +13390,33 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
 
     if (isPortForwardBrowserSupported() &&
-        ref.read(portForwardBrowserLinksNotifierProvider) &&
-        shouldOpenUriInPortForwardBrowser(
+        ref.read(portForwardBrowserLinksNotifierProvider)) {
+      final options = _activePortForwardBrowserOptions();
+      _PortForwardBrowserOption? targetOption;
+      Uri? browserUri;
+      for (final option in options) {
+        final rewritten = rewriteUriForPortForwardBrowser(
           uri,
-          activeLocalPorts: _activeLocalForwardPorts(),
-        )) {
-      final browserUri = normalizePortForwardBrowserUri(uri);
-      await _openPortForwardBrowserOption(
-        _PortForwardBrowserOption(
-          uri: browserUri,
-          port: browserUri.port,
-          title: browserUri.authority,
-        ),
-      );
-      return;
+          sourceUri: option.sourceUri,
+          browserUri: option.uri,
+        );
+        if (rewritten != null) {
+          targetOption = option;
+          browserUri = rewritten;
+          break;
+        }
+      }
+      if (targetOption != null && browserUri != null) {
+        await _openPortForwardBrowserOption(
+          _PortForwardBrowserOption(
+            uri: browserUri,
+            sourceUri: targetOption.sourceUri,
+            port: targetOption.port,
+            title: targetOption.title,
+          ),
+        );
+        return;
+      }
     }
 
     var launched = false;
@@ -13417,9 +13432,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _showTerminalLinkMessage('Could not open $link');
   }
 
-  Iterable<int> _activeLocalForwardPorts() =>
-      _activePortForwardBrowserOptions().map((option) => option.port);
-
   List<_PortForwardBrowserOption> _activePortForwardBrowserOptions() {
     final connectionId = _connectionId;
     final session = connectionId == null
@@ -13431,17 +13443,26 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                   tunnel.isLocal &&
                   isPortForwardBrowserHost(tunnel.localHost) &&
                   tunnel.localPort >= 1 &&
-                  tunnel.localPort <= 65535,
+                  tunnel.localPort <= 65535 &&
+                  tunnel.browserHost != null &&
+                  tunnel.browserPort != null &&
+                  tunnel.browserPort! >= 1 &&
+                  tunnel.browserPort! <= 65535,
             )
             .map((tunnel) {
-              final uri = buildPortForwardBrowserUriForBind(
+              final sourceUri = buildPortForwardBrowserUriForBind(
                 localHost: tunnel.localHost,
                 localPort: tunnel.localPort,
               );
+              final uri = buildPortForwardBrowserUriForBind(
+                localHost: tunnel.browserHost!,
+                localPort: tunnel.browserPort!,
+              );
               return _PortForwardBrowserOption(
                 uri: uri,
+                sourceUri: sourceUri,
                 port: tunnel.localPort,
-                title: uri.authority,
+                title: sourceUri.authority,
               );
             })
             .toList(growable: false) ??
@@ -13470,7 +13491,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       extra: PortForwardBrowserLaunch(
         tabs: [
           for (final option in options)
-            PortForwardBrowserInitialTab(uri: option.uri, title: option.title),
+            PortForwardBrowserInitialTab(
+              uri: option.uri,
+              sourceUri: option.sourceUri,
+              title: option.title,
+            ),
         ],
       ),
     );

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -26,6 +26,7 @@ import 'package:monkeyssh/domain/models/terminal_themes.dart' as monkey_themes;
 import 'package:monkeyssh/domain/services/background_ssh_service.dart';
 import 'package:monkeyssh/domain/services/host_key_verification.dart';
 import 'package:monkeyssh/domain/services/interactive_auth_prompt.dart';
+import 'package:monkeyssh/domain/services/port_forward_browser_service.dart';
 import 'package:monkeyssh/domain/services/ssh_exec_queue.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/domain/services/wifi_network_service.dart';
@@ -1323,6 +1324,8 @@ void main() {
       expect(info.portForwardId, 1);
       expect(info.localHost, '127.0.0.1');
       expect(info.localPort, 3306);
+      expect(info.browserHost, isNull);
+      expect(info.browserPort, isNull);
       expect(info.remoteHost, 'db.internal');
       expect(info.remotePort, 3306);
       expect(info.isLocal, isTrue);
@@ -2528,9 +2531,15 @@ void main() {
           isTrue,
         );
 
+        final activeTunnel = session.activeTunnels.single;
+        expect(
+          activeTunnel.browserHost,
+          portForwardBrowserHostForPortForwardId(activeTunnel.portForwardId),
+        );
+        expect(activeTunnel.browserPort, isNotNull);
         final socket = await Socket.connect(
-          InternetAddress.loopbackIPv4,
-          localPort,
+          activeTunnel.browserHost,
+          activeTunnel.browserPort!,
         );
         socket.destroy();
         await Future<void>.delayed(Duration.zero);

--- a/test/presentation/screens/sftp_screen_test.dart
+++ b/test/presentation/screens/sftp_screen_test.dart
@@ -364,6 +364,31 @@ void main() {
       );
     });
 
+    test('rejects picker names that can escape the upload directory', () {
+      expect(validateSftpUploadFileName('notes.txt'), isNull);
+      expect(validateSftpUploadFileName('..'), isNotNull);
+      expect(validateSftpUploadFileName('../authorized_keys'), isNotNull);
+      expect(validateSftpUploadFileName(r'..\authorized_keys'), isNotNull);
+      expect(validateSftpUploadFileName('/tmp/payload'), isNotNull);
+      expect(validateSftpUploadFileName('bad\x00name'), isNotNull);
+    });
+
+    test('does not echo unsafe upload names in validation feedback', () {
+      expect(
+        resolveUnsafeSftpUploadNameMessage([
+          PlatformFile(name: '../authorized_keys', size: 0),
+        ]),
+        'The selected file has an unsafe name',
+      );
+      expect(
+        resolveUnsafeSftpUploadNameMessage([
+          PlatformFile(name: '../one', size: 0),
+          PlatformFile(name: r'..\two', size: 0),
+        ]),
+        '2 selected files have unsafe names',
+      );
+    });
+
     test('validates new folder names before creating directories', () {
       expect(validateSftpDirectoryName(''), 'Folder name is required');
       expect(validateSftpDirectoryName('  '), 'Folder name is required');

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -1752,6 +1752,8 @@ void main() {
               portForwardId: 42,
               localHost: '127.0.0.1',
               localPort: 49152,
+              browserHost: 'monkeyssh-16.localhost',
+              browserPort: 60142,
               remoteHost: 'example.com',
               remotePort: 80,
               isLocal: true,
@@ -1760,6 +1762,8 @@ void main() {
               portForwardId: 43,
               localHost: '0.0.0.0',
               localPort: 3000,
+              browserHost: 'monkeyssh-17.localhost',
+              browserPort: 60143,
               remoteHost: 'localhost',
               remotePort: 3000,
               isLocal: true,
@@ -1837,6 +1841,10 @@ void main() {
         final launch = openedLaunches.last;
         expect(launch.selectedIndex, 0);
         expect(launch.tabs.map((tab) => tab.uri.toString()).toList(), [
+          'http://monkeyssh-16.localhost:60142',
+          'http://monkeyssh-17.localhost:60143',
+        ]);
+        expect(launch.tabs.map((tab) => tab.sourceUri.toString()).toList(), [
           'http://127.0.0.1:49152',
           'http://127.0.0.1:3000',
         ]);

--- a/test/unit/domain/services/port_forward_browser_service_test.dart
+++ b/test/unit/domain/services/port_forward_browser_service_test.dart
@@ -116,12 +116,75 @@ void main() {
       );
     });
 
-    test('maps all IPv4 loopback bind addresses to 127.0.0.1', () {
+    test('preserves distinct IPv4 loopback bind addresses', () {
       expect(
         buildPortForwardBrowserUri(
           _buildPortForward(localHost: '127.0.0.5'),
         ).toString(),
-        'http://127.0.0.1:8080',
+        'http://127.0.0.5:8080',
+      );
+    });
+  });
+
+  group('portForwardBrowserHostForPortForwardId', () {
+    test('assigns stable distinct localhost hosts', () {
+      expect(
+        portForwardBrowserHostForPortForwardId(1),
+        'monkeyssh-1.localhost',
+      );
+      expect(
+        portForwardBrowserHostForPortForwardId(2),
+        'monkeyssh-2.localhost',
+      );
+      expect(
+        portForwardBrowserHostForPortForwardId(42),
+        portForwardBrowserHostForPortForwardId(42),
+      );
+    });
+  });
+
+  group('rewriteUriForPortForwardBrowser', () {
+    test('preserves the request while replacing the forwarded endpoint', () {
+      expect(
+        rewriteUriForPortForwardBrowser(
+          Uri.parse('https://localhost:8080/login?next=%2F'),
+          sourceUri: Uri.parse('http://127.0.0.1:8080'),
+          browserUri: Uri.parse('http://monkeyssh-42.localhost:49152'),
+        ),
+        Uri.parse('https://monkeyssh-42.localhost:49152/login?next=%2F'),
+      );
+    });
+
+    test('does not rewrite a different local port', () {
+      expect(
+        rewriteUriForPortForwardBrowser(
+          Uri.parse('http://localhost:3000'),
+          sourceUri: Uri.parse('http://127.0.0.1:8080'),
+          browserUri: Uri.parse('http://monkeyssh-42.localhost:49152'),
+        ),
+        isNull,
+      );
+    });
+
+    test('does not rewrite the same port on a different loopback host', () {
+      expect(
+        rewriteUriForPortForwardBrowser(
+          Uri.parse('http://127.0.0.2:8080'),
+          sourceUri: Uri.parse('http://127.0.0.1:8080'),
+          browserUri: Uri.parse('http://monkeyssh-1.localhost:49152'),
+        ),
+        isNull,
+      );
+    });
+
+    test('treats default loopback host spellings as equivalent', () {
+      expect(
+        rewriteUriForPortForwardBrowser(
+          Uri.parse('http://localhost:8080'),
+          sourceUri: Uri.parse('http://0.0.0.0:8080'),
+          browserUri: Uri.parse('http://monkeyssh-1.localhost:49152'),
+        ),
+        Uri.parse('http://monkeyssh-1.localhost:49152'),
       );
     });
   });
@@ -210,12 +273,12 @@ void main() {
       );
     });
 
-    test('maps IPv4 loopback URL hosts to 127.0.0.1', () {
+    test('preserves IPv4 loopback URL hosts', () {
       expect(
         normalizePortForwardBrowserUri(
           Uri.parse('http://127.0.0.5:3000/path'),
         ).toString(),
-        'http://127.0.0.1:3000/path',
+        'http://127.0.0.5:3000/path',
       );
     });
   });


### PR DESCRIPTION
## Summary
- require write-level permission for `/deploy`, trust only workflow-authored metadata, and validate build inputs before shell use
- isolate forwarded WebView cookies with per-tunnel localhost origins and clear legacy shared-origin cookies once
- reject unsafe picker filenames before constructing SFTP upload paths

## Validation
- `flutter analyze`
- `flutter test`
- `JAVA_HOME="$(/usr/libexec/java_home -v 17)" flutter build apk --debug --flavor private -t lib/main.dart`
- parsed changed workflow YAML and validated Android network security XML