### PR TITLE
perf(ci): speed up iOS deployments

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -958,7 +958,7 @@ jobs:
             bundle exec fastlane setup_signing app_identifier:xyz.depollsoft.monkeyssh
           fi
 
-      - name: Build iOS
+      - name: Build or configure iOS
         if: inputs.ios-reuse-ipa-artifact-name == ''
         env:
           DEPLOY_IOS_TO: ${{ inputs.deploy-ios-to }}
@@ -966,6 +966,10 @@ jobs:
           EXTRA_FLAGS=()
           if [ "$DEPLOY_IOS_TO" = "none" ]; then
             EXTRA_FLAGS+=(--no-tree-shake-icons)
+          else
+            # Fastlane archives deploy builds below. Generate its Xcode
+            # configuration without compiling the application a second time.
+            EXTRA_FLAGS+=(--config-only)
           fi
           flutter build ios \
             --flavor "$BUILD_FLAVOR" \
@@ -981,6 +985,8 @@ jobs:
 
       - name: Package unsigned IPA
         if: inputs.build-ios-unsigned-ipa && inputs.ios-reuse-ipa-artifact-name == '' && inputs.deploy-ios-to == 'none'
+        env:
+          SOURCE_SHA: ${{ steps.resolved-source-sha.outputs.value }}
         run: |
           APP_PATH=$(find build/ios/iphoneos -maxdepth 1 -name '*.app' -type d -print -quit)
           if [ -z "$APP_PATH" ]; then
@@ -1036,7 +1042,7 @@ jobs:
             if [ -d SwiftSupport ]; then
               ZIP_INPUTS+=(SwiftSupport)
             fi
-            zip -qry "../ipa/ios-unsigned-${BUILD_FLAVOR}-${BUILD_NAME}-${BUILD_NUMBER}.ipa" "${ZIP_INPUTS[@]}"
+            zip -qry "../ipa/ios-unsigned-${BUILD_FLAVOR}-${BUILD_NAME}-${BUILD_NUMBER}-${SOURCE_SHA}.ipa" "${ZIP_INPUTS[@]}"
           )
 
       - name: Download reusable IPA artifact
@@ -1251,7 +1257,7 @@ jobs:
         if: inputs.build-ios-unsigned-ipa && inputs.ios-reuse-ipa-artifact-name == '' && inputs.deploy-ios-to == 'none'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          path: build/ios/ipa/ios-unsigned-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}.ipa
+          path: build/ios/ipa/ios-unsigned-${{ inputs.flavor }}-${{ inputs.build-name }}-${{ inputs.build-number }}-${{ steps.resolved-source-sha.outputs.value }}.ipa
           archive: false
 
   deploy-status-summary:

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -392,7 +392,8 @@ jobs:
             const rebuildRequired =
               '${{ needs.finalize-version.outputs.rebuild-required }}' === 'true';
             const androidArtifactName = `android-unsigned-private-${buildName}-${buildNumber}`;
-            const iosArtifactName = `ios-unsigned-private-${buildName}-${buildNumber}.ipa`;
+            const iosArtifactName =
+              `ios-unsigned-private-${buildName}-${buildNumber}-${deploySha}.ipa`;
             // Android and iOS unsigned intermediates are produced by two separate
             // preview workflows (PR Preview / PR Preview iOS), so resolve each by
             // artifact name across the repo rather than assuming one shared run.
@@ -419,28 +420,72 @@ jobs:
             }
 
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const {data: previewIosWorkflow} = await github.rest.actions.getWorkflow({
+              owner,
+              repo,
+              workflow_id: 'preview-ios.yml',
+            });
 
             // Returns the run id of a non-expired artifact with the exact name that
-            // was produced by a run for the deploy SHA, or null if not present yet.
-            const findArtifactRunId = async (name) => {
+            // was produced by the expected workflow/source, or null if not present yet.
+            const findArtifactRunId = async ({
+              name,
+              expectedHeadSha = '',
+              expectedWorkflowId = null,
+            }) => {
               const artifacts = await github.paginate(
                 github.rest.actions.listArtifactsForRepo,
                 {owner, repo, name, per_page: 100},
               );
-              const match = artifacts.find(
-                (artifact) =>
-                  !artifact.expired &&
-                  artifact.name === name &&
-                  artifact.workflow_run?.head_sha === deploySha,
+              const candidates = artifacts.filter(
+                (artifact) => !artifact.expired && artifact.name === name,
               );
-              return match ? String(match.workflow_run.id) : null;
+
+              for (const artifact of candidates) {
+                const workflowRun = artifact.workflow_run;
+                if (!workflowRun?.id) {
+                  continue;
+                }
+                if (expectedHeadSha && workflowRun.head_sha !== expectedHeadSha) {
+                  continue;
+                }
+                if (expectedWorkflowId !== null) {
+                  const {data: run} = await github.rest.actions.getWorkflowRun({
+                    owner,
+                    repo,
+                    run_id: workflowRun.id,
+                  });
+                  if (
+                    run.workflow_id !== expectedWorkflowId ||
+                    run.event !== 'workflow_run'
+                  ) {
+                    continue;
+                  }
+                }
+                return String(workflowRun.id);
+              }
+
+              return null;
             };
 
             let androidRunId = null;
             let iosRunId = null;
             for (let attempt = 0; attempt < maxWaitAttempts; attempt += 1) {
-              androidRunId = androidRunId ?? (await findArtifactRunId(androidArtifactName));
-              iosRunId = iosRunId ?? (await findArtifactRunId(iosArtifactName));
+              androidRunId =
+                androidRunId ??
+                (await findArtifactRunId({
+                  name: androidArtifactName,
+                  expectedHeadSha: deploySha,
+                }));
+              // workflow_run-triggered iOS runs report main's SHA in artifact
+              // metadata. The source-qualified artifact name binds it to the PR
+              // commit, while the workflow id verifies the trusted producer.
+              iosRunId =
+                iosRunId ??
+                (await findArtifactRunId({
+                  name: iosArtifactName,
+                  expectedWorkflowId: previewIosWorkflow.id,
+                }));
               if (androidRunId && iosRunId) {
                 break;
               }
@@ -655,7 +700,7 @@ jobs:
       android-reuse-aab-is-unsigned: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' }}
       android-reuse-source-sha: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.validate-pr.outputs.deploy-sha || '' }}
       ios-reuse-run-id: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.resolve-preview-artifacts.outputs.ios-run-id || '' }}
-      ios-reuse-ipa-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('ios-unsigned-{0}-{1}-{2}.ipa', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number) || '' }}
+      ios-reuse-ipa-artifact-name: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && format('ios-unsigned-{0}-{1}-{2}-{3}.ipa', 'private', needs.finalize-version.outputs.build-name, needs.finalize-version.outputs.build-number, needs.validate-pr.outputs.deploy-sha) || '' }}
       ios-reuse-ipa-is-unsigned: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' }}
       ios-reuse-source-sha: ${{ needs.resolve-preview-artifacts.outputs.reuse-artifacts == 'true' && needs.validate-pr.outputs.deploy-sha || '' }}
       update-pr-deploy-comment: true


### PR DESCRIPTION
## Summary

- use Flutter `--config-only` for deploy builds so Fastlane performs the only iOS compilation
- bind unsigned iOS preview artifacts to the PR source SHA and verify they came from the trusted `preview-ios.yml` workflow
- avoid the erroneous 20-minute artifact wait and fallback rebuild during PR `/deploy` runs

## Expected impact

- save roughly 4 minutes by removing duplicate compilation from fresh iOS deploys
- reduce reusable PR deploys from roughly 38 minutes to 8–10 minutes, with Apple upload and processing as the remaining floor

## Validation

- ran the private iOS Flutter preparation with `--config-only` successfully
- parsed both changed workflow files as YAML
- verified the GitHub workflow/run identity fields used to authenticate preview artifacts
- reviewed the workflow diff for runtime and security issues