### PR TITLE
fix: refresh attachment paste mode before insertion

### DIFF
--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -244,6 +244,37 @@ class MonkeyMuxService implements RemoteMultiplexerService {
     if (existingRequest != null) {
       return existingRequest;
     }
+    return _startWindowListRequest(session, sessionName, key);
+  }
+
+  /// Fetches a new window snapshot without reusing an older in-flight request.
+  ///
+  /// If another list request is running, this waits for it to finish and then
+  /// starts a second query so callers receive state captured after they asked
+  /// for a refresh.
+  Future<List<TmuxWindow>> refreshWindows(
+    SshSession session,
+    String sessionName, {
+    String? extraFlags,
+  }) async {
+    final key = _MonkeyMuxWatchKey(session.connectionId, sessionName);
+    if (isAppReviewDemoSession(session)) {
+      return listWindows(session, sessionName, extraFlags: extraFlags);
+    }
+    final existingRequest = _windowListRequests[key];
+    if (existingRequest != null) {
+      final requestSettled = Completer<void>();
+      existingRequest.whenComplete(requestSettled.complete).ignore();
+      await requestSettled.future;
+    }
+    return _startWindowListRequest(session, sessionName, key);
+  }
+
+  Future<List<TmuxWindow>> _startWindowListRequest(
+    SshSession session,
+    String sessionName,
+    _MonkeyMuxWatchKey key,
+  ) {
     final request = _listWindows(session, sessionName, key);
     _windowListRequests[key] = request;
     request.whenComplete(() {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -308,6 +308,19 @@ class _ClipboardUploadTarget {
       remoteShellPathForSftpPath(sftpPath, windows: windows);
 }
 
+typedef _UploadedAttachmentPasteMode = ({
+  String? activeWindowKey,
+  bool bracketedPasteMode,
+  int? connectionId,
+  bool isMuxActive,
+  RemoteMuxBackend muxBackend,
+  String? muxSessionName,
+  bool refreshAttempted,
+  bool refreshSucceeded,
+  SshSession? session,
+  Terminal terminal,
+});
+
 /// Resolves the retry schedule used for tmux detection after connect.
 @visibleForTesting
 List<Duration> resolveTmuxDetectionRetrySchedule({bool skipDelay = false}) =>
@@ -844,6 +857,28 @@ bool? resolveTmuxBarActiveWindowBracketedPasteMode(
     .firstOrNull
     ?.terminalBracketedPasteMode;
 
+/// Resolves a stable identity for the active mux window.
+@visibleForTesting
+String? resolveTmuxBarActiveWindowKey(Iterable<TmuxWindow>? windows) {
+  final activeWindow = windows?.where((window) => window.isActive).firstOrNull;
+  if (activeWindow == null) {
+    return null;
+  }
+  return activeWindow.id ?? '#${activeWindow.index}';
+}
+
+/// Whether attachment input still targets the same settled mux window.
+@visibleForTesting
+bool terminalAttachmentPasteTargetsCurrentMuxWindow({
+  required bool hasPendingWindowSelection,
+  required String? pasteWindowKey,
+  required String? currentWindowKey,
+}) =>
+    !hasPendingWindowSelection &&
+    (pasteWindowKey == null ||
+        currentWindowKey == null ||
+        currentWindowKey == pasteWindowKey);
+
 /// Applies active mux-window bracketed-paste state to the local terminal.
 @visibleForTesting
 bool inheritTerminalBracketedPasteModeFromMuxWindow({
@@ -856,6 +891,25 @@ bool inheritTerminalBracketedPasteModeFromMuxWindow({
   }
   terminal.setBracketedPasteMode(activeWindowBracketedPasteMode);
   return true;
+}
+
+/// Refreshes [terminal] from the active window in a fresh mux snapshot.
+@visibleForTesting
+Future<({bool bracketedPasteMode, String? activeWindowKey})>
+refreshTerminalBracketedPasteModeFromMuxWindows({
+  required Terminal terminal,
+  required Future<Iterable<TmuxWindow>> Function() loadWindows,
+}) async {
+  final windows = await loadWindows();
+  inheritTerminalBracketedPasteModeFromMuxWindow(
+    terminal: terminal,
+    activeWindowBracketedPasteMode:
+        resolveTmuxBarActiveWindowBracketedPasteMode(windows),
+  );
+  return (
+    bracketedPasteMode: terminal.bracketedPasteMode,
+    activeWindowKey: resolveTmuxBarActiveWindowKey(windows),
+  );
 }
 
 String _telemetryMuxBackendName(RemoteMuxBackend backend) => switch (backend) {
@@ -4782,6 +4836,188 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           resolveTmuxBarActiveWindowBracketedPasteMode(
             _currentTmuxWindowsSnapshot,
           ),
+    );
+  }
+
+  Future<_UploadedAttachmentPasteMode?>
+  _resolveUploadedAttachmentPasteMode() async {
+    _syncTerminalModesFromActiveMuxWindow();
+    final terminal = _terminal;
+    final connectionId = _connectionId;
+    final muxBackend = _activeMuxBackend;
+    final activeSession = _activeSession();
+    final isMuxActive = _isTmuxActive && _tmuxStateConnectionId == connectionId;
+    final currentActiveWindowKey = isMuxActive
+        ? resolveTmuxBarActiveWindowKey(_currentTmuxWindowsSnapshot)
+        : null;
+    final currentMuxSessionName = isMuxActive ? _tmuxSessionName : null;
+    if (!isMuxActive || muxBackend != RemoteMuxBackend.monkeyMux) {
+      return (
+        activeWindowKey: currentActiveWindowKey,
+        bracketedPasteMode: terminal.bracketedPasteMode,
+        connectionId: connectionId,
+        isMuxActive: isMuxActive,
+        muxBackend: muxBackend,
+        muxSessionName: currentMuxSessionName,
+        refreshAttempted: false,
+        refreshSucceeded: false,
+        session: activeSession,
+        terminal: terminal,
+      );
+    }
+
+    final session = activeSession;
+    final sessionName = session == null
+        ? null
+        : _activeMonkeyMuxSessionName(session);
+    if (session == null || sessionName == null) {
+      return (
+        activeWindowKey: resolveTmuxBarActiveWindowKey(
+          _currentTmuxWindowsSnapshot,
+        ),
+        bracketedPasteMode: terminal.bracketedPasteMode,
+        connectionId: connectionId,
+        isMuxActive: isMuxActive,
+        muxBackend: muxBackend,
+        muxSessionName: currentMuxSessionName,
+        refreshAttempted: false,
+        refreshSucceeded: false,
+        session: session,
+        terminal: terminal,
+      );
+    }
+
+    bool stillOwnsTerminalContext() =>
+        mounted &&
+        _connectionId == connectionId &&
+        identical(_activeSession(), session) &&
+        identical(_terminal, terminal) &&
+        _isTmuxActive == isMuxActive &&
+        _tmuxStateConnectionId == connectionId &&
+        _activeMuxBackend == muxBackend &&
+        _activeMonkeyMuxSessionName(session) == sessionName;
+
+    try {
+      final refreshedMode =
+          await refreshTerminalBracketedPasteModeFromMuxWindows(
+            terminal: terminal,
+            loadWindows: () async {
+              final windows = await _monkeyMuxService.refreshWindows(
+                session,
+                sessionName,
+                extraFlags: _activeTmuxExtraFlags,
+              );
+              return stillOwnsTerminalContext()
+                  ? windows
+                  : const <TmuxWindow>[];
+            },
+          );
+      if (!stillOwnsTerminalContext()) {
+        return null;
+      }
+      return (
+        activeWindowKey: refreshedMode.activeWindowKey,
+        bracketedPasteMode: refreshedMode.bracketedPasteMode,
+        connectionId: connectionId,
+        isMuxActive: isMuxActive,
+        muxBackend: muxBackend,
+        muxSessionName: sessionName,
+        refreshAttempted: true,
+        refreshSucceeded: true,
+        session: session,
+        terminal: terminal,
+      );
+    } on TimeoutException catch (error) {
+      _logAttachmentPasteModeRefreshFailure(session, error);
+    } on MonkeyMuxInstallException catch (error) {
+      _logAttachmentPasteModeRefreshFailure(session, error);
+    } on SSHError catch (error) {
+      _logAttachmentPasteModeRefreshFailure(session, error);
+    } on IOException catch (error) {
+      _logAttachmentPasteModeRefreshFailure(session, error);
+    }
+
+    if (!stillOwnsTerminalContext()) {
+      return null;
+    }
+    return (
+      activeWindowKey: resolveTmuxBarActiveWindowKey(
+        _currentTmuxWindowsSnapshot,
+      ),
+      bracketedPasteMode: terminal.bracketedPasteMode,
+      connectionId: connectionId,
+      isMuxActive: isMuxActive,
+      muxBackend: muxBackend,
+      muxSessionName: sessionName,
+      refreshAttempted: true,
+      refreshSucceeded: false,
+      session: session,
+      terminal: terminal,
+    );
+  }
+
+  bool _uploadedAttachmentPasteModeOwnsCurrentTerminalContext(
+    _UploadedAttachmentPasteMode pasteMode,
+  ) {
+    if (!mounted ||
+        _connectionId != pasteMode.connectionId ||
+        !identical(_activeSession(), pasteMode.session) ||
+        !identical(_terminal, pasteMode.terminal) ||
+        _isTmuxActive != pasteMode.isMuxActive ||
+        _activeMuxBackend != pasteMode.muxBackend) {
+      return false;
+    }
+    if (!pasteMode.isMuxActive) {
+      return true;
+    }
+    if (_tmuxStateConnectionId != pasteMode.connectionId) {
+      return false;
+    }
+    final session = _activeSession();
+    if (session == null) {
+      return false;
+    }
+    return pasteMode.muxBackend == RemoteMuxBackend.monkeyMux
+        ? _activeMonkeyMuxSessionName(session) == pasteMode.muxSessionName
+        : _tmuxSessionName == pasteMode.muxSessionName;
+  }
+
+  bool _sameUploadedAttachmentTerminalContext(
+    _UploadedAttachmentPasteMode previous,
+    _UploadedAttachmentPasteMode next,
+  ) =>
+      previous.connectionId == next.connectionId &&
+      identical(previous.session, next.session) &&
+      identical(previous.terminal, next.terminal) &&
+      previous.isMuxActive == next.isMuxActive &&
+      previous.muxBackend == next.muxBackend &&
+      previous.muxSessionName == next.muxSessionName;
+
+  bool _uploadedAttachmentPasteModeTargetsCurrentWindow(
+    _UploadedAttachmentPasteMode pasteMode,
+  ) {
+    final activeWindowKey = pasteMode.activeWindowKey;
+    if (!pasteMode.isMuxActive) {
+      return true;
+    }
+    return terminalAttachmentPasteTargetsCurrentMuxWindow(
+      hasPendingWindowSelection:
+          _tmuxBarKey.currentState?.hasPendingWindowSelection ?? false,
+      pasteWindowKey: activeWindowKey,
+      currentWindowKey: resolveTmuxBarActiveWindowKey(
+        _currentTmuxWindowsSnapshot,
+      ),
+    );
+  }
+
+  void _logAttachmentPasteModeRefreshFailure(SshSession session, Object error) {
+    DiagnosticsLogService.instance.warning(
+      'terminal.clipboard',
+      'attachment_mode_refresh_failed',
+      fields: {
+        'connectionId': session.connectionId,
+        'errorType': error.runtimeType,
+      },
     );
   }
 
@@ -14773,14 +15009,101 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     List<String> remotePaths, {
     required bool windows,
   }) async {
-    _syncTerminalModesFromActiveMuxWindow();
+    final pathCount = remotePaths
+        .where((remotePath) => remotePath.isNotEmpty)
+        .length;
+    if (pathCount == 0) {
+      return;
+    }
+    var pasteMode = await _resolveUploadedAttachmentPasteMode();
+    if (pasteMode == null || !mounted) {
+      return;
+    }
+    if (!_uploadedAttachmentPasteModeOwnsCurrentTerminalContext(pasteMode)) {
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'attachment_input_skipped_context_changed',
+        fields: {'connectionId': _connectionId, 'pathCount': pathCount},
+      );
+      return;
+    }
+    if (!_uploadedAttachmentPasteModeTargetsCurrentWindow(pasteMode)) {
+      final refreshedPasteMode = await _resolveUploadedAttachmentPasteMode();
+      if (refreshedPasteMode == null || !mounted) {
+        return;
+      }
+      if (!_sameUploadedAttachmentTerminalContext(
+            pasteMode,
+            refreshedPasteMode,
+          ) ||
+          !_uploadedAttachmentPasteModeOwnsCurrentTerminalContext(
+            refreshedPasteMode,
+          )) {
+        DiagnosticsLogService.instance.warning(
+          'terminal.clipboard',
+          'attachment_input_skipped_context_changed',
+          fields: {'connectionId': _connectionId, 'pathCount': pathCount},
+        );
+        return;
+      }
+      pasteMode = refreshedPasteMode;
+      if (!_uploadedAttachmentPasteModeTargetsCurrentWindow(pasteMode)) {
+        _syncTerminalModesFromActiveMuxWindow();
+        DiagnosticsLogService.instance.warning(
+          'terminal.clipboard',
+          'attachment_input_skipped_window_changed',
+          fields: {'connectionId': _connectionId, 'pathCount': pathCount},
+        );
+        return;
+      }
+    }
     final segments = buildTerminalAttachmentPasteSegments(
       remotePaths,
-      bracketedPasteMode: _terminal.bracketedPasteMode,
+      bracketedPasteMode: pasteMode.bracketedPasteMode,
       windows: windows,
+    );
+    final usedBracketedPaste = segments.any(
+      (segment) => segment.startsWith('\x1b[200~'),
+    );
+    DiagnosticsLogService.instance.debug(
+      'terminal.clipboard',
+      'attachment_input',
+      fields: {
+        'connectionId': _connectionId,
+        'pathCount': pathCount,
+        'bracketedPasteMode': pasteMode.bracketedPasteMode,
+        'usedBracketedPaste': usedBracketedPaste,
+        'modeRefreshAttempted': pasteMode.refreshAttempted,
+        'modeRefreshSucceeded': pasteMode.refreshSucceeded,
+      },
     );
     for (var i = 0; i < segments.length; i++) {
       if (!mounted) {
+        return;
+      }
+      if (!_uploadedAttachmentPasteModeOwnsCurrentTerminalContext(pasteMode)) {
+        DiagnosticsLogService.instance.warning(
+          'terminal.clipboard',
+          'attachment_input_stopped_context_changed',
+          fields: {
+            'connectionId': _connectionId,
+            'pathCount': pathCount,
+            'sentCount': i,
+          },
+        );
+        return;
+      }
+      if (!_uploadedAttachmentPasteModeTargetsCurrentWindow(pasteMode)) {
+        _syncTerminalModesFromActiveMuxWindow();
+        DiagnosticsLogService.instance.warning(
+          'terminal.clipboard',
+          'attachment_input_stopped_window_changed',
+          fields: {
+            'connectionId': _connectionId,
+            'pathCount': pathCount,
+            'sentCount': i,
+          },
+        );
         return;
       }
       _terminal.onOutput?.call(segments[i]);

--- a/lib/presentation/widgets/tmux_expandable_bar.dart
+++ b/lib/presentation/widgets/tmux_expandable_bar.dart
@@ -151,6 +151,8 @@ class _TmuxExpandableBarState extends State<_TmuxExpandableBar>
 
   List<TmuxWindow>? get currentWindowsSnapshot => _windows;
 
+  bool get hasPendingWindowSelection => _pendingSelectedWindowIndex != null;
+
   bool get _emptyWindowListEndsSession =>
       widget.activeMuxBackend == RemoteMuxBackend.monkeyMux;
 

--- a/test/domain/services/monkeymux_service_test.dart
+++ b/test/domain/services/monkeymux_service_test.dart
@@ -460,6 +460,58 @@ void main() {
         await service.clearCache(900);
       },
     );
+
+    test(
+      'refreshWindows starts a new query after an older request fails',
+      () async {
+        final client = _MockSshClient();
+        final installer = _MockMonkeyMuxInstaller();
+        final session = _buildSession(client, connectionId: 901);
+        final stdoutController = StreamController<Uint8List>();
+        final controlSession = _buildSilentControlSession(stdoutController);
+        final requests = <Map<String, Object?>>[];
+
+        when(
+          () => installer.ensureInstalled(session),
+        ).thenAnswer((_) async => _fakeInstallation);
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => controlSession);
+        when(() => controlSession.write(any())).thenAnswer((invocation) {
+          final data = invocation.positionalArguments.single as List<int>;
+          requests.add(jsonDecode(utf8.decode(data)) as Map<String, Object?>);
+        });
+
+        final service = MonkeyMuxService(
+          installer: installer,
+          agentSessionMetadataPeriodicRefreshInterval: Duration.zero,
+        )..watchWindowChanges(session, 'work');
+        final firstRequest = service.listWindows(session, 'work');
+        final freshRequest = service.refreshWindows(session, 'work');
+        await pumpEventQueue();
+
+        expect(requests, hasLength(1));
+        _respondToControlError(stdoutController, requests.single);
+        await expectLater(
+          firstRequest,
+          throwsA(isA<MonkeyMuxInstallException>()),
+        );
+        await pumpEventQueue();
+
+        expect(requests, hasLength(2));
+        _respondToWindowListRequest(
+          stdoutController,
+          requests.last,
+          terminalBracketedPasteMode: true,
+        );
+        final windows = await freshRequest;
+
+        expect(windows.single.terminalBracketedPasteMode, isTrue);
+
+        await stdoutController.close();
+        await service.clearCache(901);
+      },
+    );
   });
 }
 
@@ -540,4 +592,36 @@ SSHSession _buildRespondingControlSession(
     );
   });
   return session;
+}
+
+void _respondToWindowListRequest(
+  StreamController<Uint8List> stdoutController,
+  Map<String, Object?> request, {
+  required bool terminalBracketedPasteMode,
+}) {
+  final response = jsonEncode({
+    'id': request['id'],
+    'type': 'window_list',
+    'status': 'ok',
+    'windows': [
+      {
+        ..._fakeWindowJson,
+        'terminalBracketedPasteMode': terminalBracketedPasteMode,
+      },
+    ],
+  });
+  stdoutController.add(Uint8List.fromList(utf8.encode('$response\n')));
+}
+
+void _respondToControlError(
+  StreamController<Uint8List> stdoutController,
+  Map<String, Object?> request,
+) {
+  final response = jsonEncode({
+    'id': request['id'],
+    'type': 'error',
+    'status': 'error',
+    'error': 'stale request failed',
+  });
+  stdoutController.add(Uint8List.fromList(utf8.encode('$response\n')));
 }

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
@@ -458,6 +459,118 @@ void main() {
           '/home/u/.cache/monkeyssh/uploads/a.png',
         ], bracketedPasteMode: terminal.bracketedPasteMode),
         const ['\x1b[200~/home/u/.cache/monkeyssh/uploads/a.png\x1b[201~ '],
+      );
+    });
+  });
+
+  group('refreshTerminalBracketedPasteModeFromMuxWindows', () {
+    test(
+      'refreshes a stale disabled mode before attachment insertion',
+      () async {
+        final terminal = Terminal();
+        final windows = Completer<Iterable<TmuxWindow>>();
+        final refresh = refreshTerminalBracketedPasteModeFromMuxWindows(
+          terminal: terminal,
+          loadWindows: () => windows.future,
+        );
+
+        expect(terminal.bracketedPasteMode, isFalse);
+        windows.complete(const [
+          TmuxWindow(
+            index: 0,
+            name: 'copilot',
+            isActive: true,
+            terminalBracketedPasteMode: true,
+          ),
+        ]);
+
+        expect(await refresh, (
+          bracketedPasteMode: true,
+          activeWindowKey: '#0',
+        ));
+        expect(terminal.bracketedPasteMode, isTrue);
+      },
+    );
+
+    test('applies known disabled mode and preserves unknown mode', () async {
+      final terminal = Terminal()..setBracketedPasteMode(true);
+
+      expect(
+        await refreshTerminalBracketedPasteModeFromMuxWindows(
+          terminal: terminal,
+          loadWindows: () async => const [
+            TmuxWindow(
+              index: 0,
+              name: 'shell',
+              isActive: true,
+              terminalBracketedPasteMode: false,
+            ),
+          ],
+        ),
+        (bracketedPasteMode: false, activeWindowKey: '#0'),
+      );
+
+      terminal.setBracketedPasteMode(true);
+      expect(
+        await refreshTerminalBracketedPasteModeFromMuxWindows(
+          terminal: terminal,
+          loadWindows: () async => const [
+            TmuxWindow(index: 0, name: 'legacy', isActive: true),
+          ],
+        ),
+        (bracketedPasteMode: true, activeWindowKey: '#0'),
+      );
+    });
+
+    test('returns the stable id for the refreshed active window', () async {
+      final terminal = Terminal();
+
+      expect(
+        await refreshTerminalBracketedPasteModeFromMuxWindows(
+          terminal: terminal,
+          loadWindows: () async => const [
+            TmuxWindow(
+              index: 4,
+              id: '@9',
+              name: 'copilot',
+              isActive: true,
+              terminalBracketedPasteMode: true,
+            ),
+          ],
+        ),
+        (bracketedPasteMode: true, activeWindowKey: '@9'),
+      );
+    });
+  });
+
+  group('terminalAttachmentPasteTargetsCurrentMuxWindow', () {
+    test('rejects an optimistic window switch before its snapshot arrives', () {
+      expect(
+        terminalAttachmentPasteTargetsCurrentMuxWindow(
+          hasPendingWindowSelection: true,
+          pasteWindowKey: '@1',
+          currentWindowKey: '@1',
+        ),
+        isFalse,
+      );
+    });
+
+    test('accepts the same settled window or an unavailable snapshot', () {
+      expect(
+        terminalAttachmentPasteTargetsCurrentMuxWindow(
+          hasPendingWindowSelection: false,
+          pasteWindowKey: '@1',
+          currentWindowKey: '@1',
+        ),
+        isTrue,
+      );
+      expect(
+        terminalAttachmentPasteTargetsCurrentMuxWindow(
+          hasPendingWindowSelection: false,
+          pasteWindowKey: '@1',
+          currentWindowKey: null,
+        ),
+        isTrue,
       );
     });
   });


### PR DESCRIPTION
## Summary
- query a post-settlement MonkeyMux window snapshot before attachment insertion so DEC 2004 state cannot come from an older coalesced request
- bind staggered attachment segments to the originating terminal, SSH session, mux session, backend, and active window, stopping safely during window switches
- record privacy-safe paste-mode diagnostics and cover stale, failed, and pending-window races

## Tests
- `flutter analyze`
- `flutter test` (2,724 tests)