### PR TITLE
fix: preserve automatic actions when duplicating hosts

### DIFF
--- a/lib/data/repositories/host_repository.dart
+++ b/lib/data/repositories/host_repository.dart
@@ -153,33 +153,16 @@ class HostRepository {
   /// Duplicate an existing host and its port forwards.
   Future<int> duplicate(Host host) => _db.transaction(() async {
     final duplicateHostId = await insert(
-      HostsCompanion.insert(
-        label: '${host.label} (copy)',
-        hostname: host.hostname,
-        port: Value(host.port),
-        username: host.username,
-        password: Value(host.password),
-        keyId: Value(host.keyId),
-        groupId: Value(host.groupId),
-        jumpHostId: Value(host.jumpHostId),
-        skipJumpHostOnSsids: Value(host.skipJumpHostOnSsids),
-        isFavorite: Value(host.isFavorite),
-        color: Value(host.color),
-        notes: Value(host.notes),
-        tags: Value(host.tags),
-        terminalThemeLightId: Value(host.terminalThemeLightId),
-        terminalThemeDarkId: Value(host.terminalThemeDarkId),
-        terminalFontFamily: Value(host.terminalFontFamily),
-        autoConnectCommand: Value(host.autoConnectCommand),
-        autoConnectSnippetId: Value(host.autoConnectSnippetId),
-        autoConnectRequiresConfirmation: Value(
-          host.autoConnectRequiresConfirmation,
-        ),
-        tmuxSessionName: Value(host.tmuxSessionName),
-        tmuxWorkingDirectory: Value(host.tmuxWorkingDirectory),
-        tmuxExtraFlags: Value(host.tmuxExtraFlags),
-        remoteMuxBackend: Value(host.remoteMuxBackend),
-      ),
+      host
+          .toCompanion(false)
+          .copyWith(
+            id: const Value.absent(),
+            label: Value('${host.label} (copy)'),
+            createdAt: const Value.absent(),
+            updatedAt: const Value.absent(),
+            lastConnectedAt: const Value(null),
+            sortOrder: const Value.absent(),
+          ),
     );
 
     final portForwards = await (_db.select(
@@ -190,16 +173,13 @@ class HostRepository {
       await _db
           .into(_db.portForwards)
           .insert(
-            PortForwardsCompanion.insert(
-              name: portForward.name,
-              hostId: duplicateHostId,
-              forwardType: portForward.forwardType,
-              localHost: Value(portForward.localHost),
-              localPort: portForward.localPort,
-              remoteHost: portForward.remoteHost,
-              remotePort: portForward.remotePort,
-              autoStart: Value(portForward.autoStart),
-            ),
+            portForward
+                .toCompanion(false)
+                .copyWith(
+                  id: const Value.absent(),
+                  hostId: Value(duplicateHostId),
+                  createdAt: const Value.absent(),
+                ),
           );
     }
 

--- a/lib/domain/commands/duplicate_host_command.dart
+++ b/lib/domain/commands/duplicate_host_command.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/database/database.dart';
+import '../../data/repositories/host_repository.dart';
+import '../services/agent_launch_preset_service.dart';
+import '../services/host_cli_launch_preferences_service.dart';
+
+/// Duplicates a host and its host-scoped startup settings.
+class DuplicateHostCommand {
+  /// Creates a [DuplicateHostCommand].
+  DuplicateHostCommand({
+    required AppDatabase db,
+    required HostRepository hostRepository,
+    required AgentLaunchPresetService presetService,
+    required HostCliLaunchPreferencesService cliPreferencesService,
+  }) : _db = db,
+       _hostRepository = hostRepository,
+       _presetService = presetService,
+       _cliPreferencesService = cliPreferencesService;
+
+  final AppDatabase _db;
+  final HostRepository _hostRepository;
+  final AgentLaunchPresetService _presetService;
+  final HostCliLaunchPreferencesService _cliPreferencesService;
+
+  /// Duplicates [host], including its coding-agent preset and CLI preferences.
+  Future<int> execute(Host host) => _db.transaction(() async {
+    final preset = await _presetService.getPresetForHost(host.id);
+    final cliPreferences = await _cliPreferencesService.getPreferencesForHost(
+      host.id,
+    );
+    final duplicateHostId = await _hostRepository.duplicate(host);
+
+    if (preset != null) {
+      await _presetService.setPresetForHost(duplicateHostId, preset);
+    }
+    if (!cliPreferences.isEmpty) {
+      await _cliPreferencesService.setPreferencesForHost(
+        duplicateHostId,
+        cliPreferences,
+      );
+    }
+
+    return duplicateHostId;
+  });
+}
+
+/// Provider for [DuplicateHostCommand].
+final duplicateHostCommandProvider = Provider<DuplicateHostCommand>(
+  (ref) => DuplicateHostCommand(
+    db: ref.watch(databaseProvider),
+    hostRepository: ref.watch(hostRepositoryProvider),
+    presetService: ref.watch(agentLaunchPresetServiceProvider),
+    cliPreferencesService: ref.watch(hostCliLaunchPreferencesServiceProvider),
+  ),
+);

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -12,6 +12,7 @@ import '../../data/database/database.dart';
 import '../../data/repositories/host_repository.dart';
 import '../../data/repositories/key_repository.dart';
 import '../../data/repositories/snippet_repository.dart';
+import '../../domain/commands/duplicate_host_command.dart';
 import '../../domain/models/agent_launch_preset.dart';
 import '../../domain/models/monetization.dart';
 import '../../domain/models/remote_multiplexer.dart';
@@ -1644,7 +1645,7 @@ class _HostRow extends ConsumerWidget {
   }
 
   Future<void> _duplicateHost(BuildContext context, WidgetRef ref) async {
-    await ref.read(hostRepositoryProvider).duplicate(host);
+    await ref.read(duplicateHostCommandProvider).execute(host);
     if (context.mounted) {
       ScaffoldMessenger.of(
         context,

--- a/test/data/repositories/host_repository_test.dart
+++ b/test/data/repositories/host_repository_test.dart
@@ -36,6 +36,21 @@ class _PausingSecretEncryptionService extends SecretEncryptionService {
   }
 }
 
+Map<String, dynamic> _hostConfiguration(Host host) =>
+    Map<String, dynamic>.from(host.toJson())
+      ..remove('id')
+      ..remove('label')
+      ..remove('createdAt')
+      ..remove('updatedAt')
+      ..remove('lastConnectedAt')
+      ..remove('sortOrder');
+
+Map<String, dynamic> _portForwardConfiguration(PortForward portForward) =>
+    Map<String, dynamic>.from(portForward.toJson())
+      ..remove('id')
+      ..remove('hostId')
+      ..remove('createdAt');
+
 void main() {
   late AppDatabase db;
   late HostRepository repository;
@@ -270,7 +285,7 @@ void main() {
       expect(host.autoConnectRequiresConfirmation, isTrue);
     });
 
-    test('duplicate copies skip-jump SSIDs', () async {
+    test('duplicate copies all host configuration and port forwards', () async {
       final keyId = await db
           .into(db.sshKeys)
           .insert(
@@ -324,6 +339,10 @@ void main() {
           autoConnectCommand: const Value('tmux attach'),
           autoConnectSnippetId: Value(snippetId),
           autoConnectRequiresConfirmation: const Value(true),
+          tmuxSessionName: const Value('production'),
+          tmuxWorkingDirectory: const Value('~/src/service'),
+          tmuxExtraFlags: const Value('-x 160 -y 48'),
+          remoteMuxBackend: const Value('monkey_mux'),
         ),
       );
 
@@ -339,6 +358,7 @@ void main() {
               remoteHost: 'db.internal',
               remotePort: 5432,
               autoStart: const Value(true),
+              createdAt: Value(DateTime(2020, 4, 5, 6, 7, 8)),
             ),
           );
       await db
@@ -353,6 +373,7 @@ void main() {
               remoteHost: 'redis.internal',
               remotePort: 6379,
               autoStart: const Value(false),
+              createdAt: Value(DateTime(2021, 5, 6, 7, 8, 9)),
             ),
           );
 
@@ -393,9 +414,18 @@ void main() {
         duplicateHost.autoConnectRequiresConfirmation,
         sourceHost.autoConnectRequiresConfirmation,
       );
+      expect(duplicateHost.tmuxSessionName, sourceHost.tmuxSessionName);
+      expect(
+        duplicateHost.tmuxWorkingDirectory,
+        sourceHost.tmuxWorkingDirectory,
+      );
+      expect(duplicateHost.tmuxExtraFlags, sourceHost.tmuxExtraFlags);
+      expect(duplicateHost.remoteMuxBackend, sourceHost.remoteMuxBackend);
+      expect(_hostConfiguration(duplicateHost), _hostConfiguration(sourceHost));
       expect(duplicateHost.lastConnectedAt, isNull);
       expect(duplicateHost.createdAt, isNot(sourceHost.createdAt));
       expect(duplicateHost.updatedAt, isNot(sourceHost.updatedAt));
+      expect(duplicateHost.sortOrder, greaterThan(sourceHost.sortOrder));
 
       final duplicatePortForwards =
           await (db.select(db.portForwards)..where(
@@ -419,6 +449,7 @@ void main() {
       expect(databaseTunnel.remoteHost, 'db.internal');
       expect(databaseTunnel.remotePort, 5432);
       expect(databaseTunnel.autoStart, isTrue);
+      expect(databaseTunnel.createdAt, isNot(DateTime(2020, 4, 5, 6, 7, 8)));
 
       final redisTunnel = duplicatePortForwards.singleWhere(
         (portForward) => portForward.name == 'Redis Tunnel',
@@ -430,6 +461,20 @@ void main() {
       expect(redisTunnel.remoteHost, 'redis.internal');
       expect(redisTunnel.remotePort, 6379);
       expect(redisTunnel.autoStart, isFalse);
+      expect(redisTunnel.createdAt, isNot(DateTime(2021, 5, 6, 7, 8, 9)));
+
+      final sourcePortForwards = await (db.select(
+        db.portForwards,
+      )..where((portForward) => portForward.hostId.equals(sourceHostId))).get();
+      for (final sourcePortForward in sourcePortForwards) {
+        final duplicatePortForward = duplicatePortForwards.singleWhere(
+          (portForward) => portForward.name == sourcePortForward.name,
+        );
+        expect(
+          _portForwardConfiguration(duplicatePortForward),
+          _portForwardConfiguration(sourcePortForward),
+        );
+      }
     });
 
     test('getById returns host when exists', () async {

--- a/test/domain/commands/duplicate_host_command_test.dart
+++ b/test/domain/commands/duplicate_host_command_test.dart
@@ -1,0 +1,118 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/data/security/secret_encryption_service.dart';
+import 'package:monkeyssh/domain/commands/duplicate_host_command.dart';
+import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
+import 'package:monkeyssh/domain/models/host_cli_launch_preferences.dart';
+import 'package:monkeyssh/domain/models/remote_multiplexer.dart';
+import 'package:monkeyssh/domain/services/agent_launch_preset_service.dart';
+import 'package:monkeyssh/domain/services/host_cli_launch_preferences_service.dart';
+import 'package:monkeyssh/domain/services/settings_service.dart';
+
+class _ThrowingPresetService extends AgentLaunchPresetService {
+  _ThrowingPresetService(super.settings);
+
+  @override
+  Future<void> setPresetForHost(int hostId, AgentLaunchPreset preset) async =>
+      throw Exception('simulated preset-write failure');
+}
+
+void main() {
+  late AppDatabase db;
+  late HostRepository hostRepository;
+  late SettingsService settingsService;
+  late AgentLaunchPresetService presetService;
+  late HostCliLaunchPreferencesService cliPreferencesService;
+  late DuplicateHostCommand command;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    hostRepository = HostRepository(db, SecretEncryptionService.forTesting());
+    settingsService = SettingsService(db);
+    presetService = AgentLaunchPresetService(settingsService);
+    cliPreferencesService = HostCliLaunchPreferencesService(settingsService);
+    command = DuplicateHostCommand(
+      db: db,
+      hostRepository: hostRepository,
+      presetService: presetService,
+      cliPreferencesService: cliPreferencesService,
+    );
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('preserves a MonkeyMux coding-agent automatic action', () async {
+    const preset = AgentLaunchPreset(
+      tool: AgentLaunchTool.copilotCli,
+      workingDirectory: '~/src/monkeyssh',
+      tmuxSessionName: 'coding',
+      remoteMuxBackend: RemoteMuxBackend.monkeyMux,
+      additionalArguments: '--resume',
+    );
+    final sourceHostId = await hostRepository.insert(
+      HostsCompanion.insert(
+        label: 'Coding host',
+        hostname: 'dev.example.com',
+        username: 'developer',
+        autoConnectCommand: Value(
+          buildAgentLaunchCommand(preset, startInYoloMode: true),
+        ),
+      ),
+    );
+    await presetService.setPresetForHost(sourceHostId, preset);
+    await cliPreferencesService.setPreferencesForHost(
+      sourceHostId,
+      const HostCliLaunchPreferences(startInYoloMode: true),
+    );
+
+    final sourceHost = await hostRepository.getById(sourceHostId);
+    final duplicateHostId = await command.execute(sourceHost!);
+
+    final duplicateHost = await hostRepository.getById(duplicateHostId);
+    final duplicatePreset = await presetService.getPresetForHost(
+      duplicateHostId,
+    );
+    final duplicatePreferences = await cliPreferencesService
+        .getPreferencesForHost(duplicateHostId);
+
+    expect(duplicateHost!.autoConnectCommand, sourceHost.autoConnectCommand);
+    expect(duplicatePreset, isNotNull);
+    expect(duplicatePreset!.tool, AgentLaunchTool.copilotCli);
+    expect(duplicatePreset.workingDirectory, '~/src/monkeyssh');
+    expect(duplicatePreset.tmuxSessionName, 'coding');
+    expect(duplicatePreset.remoteMuxBackend, RemoteMuxBackend.monkeyMux);
+    expect(duplicatePreset.additionalArguments, '--resume');
+    expect(duplicatePreferences.startInYoloMode, isTrue);
+  });
+
+  test('rolls back the duplicated host when preset copying fails', () async {
+    const preset = AgentLaunchPreset(tool: AgentLaunchTool.claudeCode);
+    final sourceHostId = await hostRepository.insert(
+      HostsCompanion.insert(
+        label: 'Source host',
+        hostname: 'source.example.com',
+        username: 'developer',
+      ),
+    );
+    await presetService.setPresetForHost(sourceHostId, preset);
+    final throwingCommand = DuplicateHostCommand(
+      db: db,
+      hostRepository: hostRepository,
+      presetService: _ThrowingPresetService(settingsService),
+      cliPreferencesService: cliPreferencesService,
+    );
+
+    final sourceHost = await hostRepository.getById(sourceHostId);
+
+    await expectLater(throwingCommand.execute(sourceHost!), throwsException);
+    expect(await hostRepository.getAll(), hasLength(1));
+  });
+}


### PR DESCRIPTION
## Summary
- duplicate the complete persisted host configuration, including SSH, appearance, automation, and MonkeyMux/tmux fields
- duplicate every port-forward configuration field
- duplicate structured coding-agent presets and host-scoped CLI launch preferences
- regenerate only identity, timestamps, connection history, and display order
- keep the host and associated settings copy atomic

## Testing
- `flutter test test/data/repositories/host_repository_test.dart test/domain/commands/duplicate_host_command_test.dart`
- `flutter analyze`
- repository-wide Dart formatting check