### PR TITLE
Automate MonkeyMux restore after helper upgrades

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -8347,19 +8347,28 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (configuredBackend == RemoteMuxBackend.monkeyMux ||
         configuredBackend == RemoteMuxBackend.auto) {
       try {
+        MonkeyMuxServerUpdatePolicy? requestedUpdatePolicy;
         final installation = await _monkeyMuxInstallerService.ensureInstalled(
           session,
           priority: SshExecPriority.normal,
-          confirmInstall: (request) => _confirmMonkeyMuxInstall(
-            request,
-            resolveRunningStatus: () => _monkeyMuxService
-                .runningServerStatusFromInstalledHelpers(session, sessionName),
-          ),
+          confirmInstall: (request) async {
+            final decision = await _confirmMonkeyMuxInstall(
+              request,
+              resolveRunningStatus: () =>
+                  _monkeyMuxService.runningServerStatusFromInstalledHelpers(
+                    session,
+                    sessionName,
+                  ),
+            );
+            requestedUpdatePolicy = decision.updatePolicy;
+            return decision.install;
+          },
         );
         final updatePolicy = await _resolveMonkeyMuxServerUpdatePolicy(
           session,
           installation,
           sessionName,
+          preferredUpdatePolicy: requestedUpdatePolicy,
         );
         final terminalThemeReports = buildTerminalThemeHintReports(
           session.terminalTheme ?? _resolveEffectiveTerminalTheme(),
@@ -8440,8 +8449,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   Future<MonkeyMuxServerUpdatePolicy> _resolveMonkeyMuxServerUpdatePolicy(
     SshSession session,
     MonkeyMuxInstallation installation,
-    String sessionName,
-  ) async {
+    String sessionName, {
+    MonkeyMuxServerUpdatePolicy? preferredUpdatePolicy,
+  }) async {
     session.monkeyMuxViewportClippingEnabled = false;
     session.terminal?.resetHostResizeState();
     final status = await _monkeyMuxService.runningServerStatus(
@@ -8461,16 +8471,34 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
     final bundledVersionIsNewer =
         versionComparison != null && versionComparison > 0;
+    if (bundledVersionIsNewer) {
+      final updatePolicy =
+          preferredUpdatePolicy ??
+          await _confirmMonkeyMuxRunningServerUpdate(
+            status: status,
+            bundledVersion: installation.version,
+          );
+      DiagnosticsLogService.instance.info(
+        'monkeymux.install',
+        updatePolicy == MonkeyMuxServerUpdatePolicy.always
+            ? 'upgrade_restore_accepted'
+            : 'upgrade_restore_deferred',
+        fields: {
+          'connectionId': session.connectionId,
+          'supportsShutdown': status.supportsShutdown,
+          'installedDuringCall': installation.installedDuringCall,
+        },
+      );
+      return updatePolicy;
+    }
     DiagnosticsLogService.instance.info(
       'monkeymux.install',
-      bundledVersionIsNewer
-          ? 'upgrade_deferred_running_server'
-          : 'version_mismatch_running_server_kept',
+      'version_mismatch_running_server_kept',
       fields: {
         'connectionId': session.connectionId,
         'supportsShutdown': status.supportsShutdown,
         'installedDuringCall': installation.installedDuringCall,
-        'bundledVersionIsNewer': bundledVersionIsNewer,
+        'bundledVersionIsNewer': false,
       },
     );
     _showMonkeyMuxVersionMismatchNotice(
@@ -8481,6 +8509,124 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       versionComparison: versionComparison,
     );
     return MonkeyMuxServerUpdatePolicy.never;
+  }
+
+  Future<MonkeyMuxServerUpdatePolicy> _confirmMonkeyMuxRunningServerUpdate({
+    required MonkeyMuxServerStatus status,
+    required String bundledVersion,
+    MonkeyMuxInstallRequest? installRequest,
+  }) async {
+    if (!mounted) {
+      return MonkeyMuxServerUpdatePolicy.never;
+    }
+    final runningVersion = status.version?.trim();
+    final currentVersionLabel = runningVersion == null || runningVersion.isEmpty
+        ? 'current version'
+        : runningVersion;
+    final warning = status.supportsShutdown
+        ? 'Updating may briefly interrupt running programs. Some restored '
+              'sessions may not resume exactly where they left off.'
+        : 'The running helper cannot stop itself cleanly. Updating may '
+              'interrupt sessions and can leave old processes running while '
+              'MonkeySSH restores the windows.';
+    final decision = await showDialog<MonkeyMuxServerUpdatePolicy>(
+      context: context,
+      barrierDismissible: false,
+      requestFocus: terminalOverlayRouteRequestFocus(context),
+      builder: (context) {
+        final theme = Theme.of(context);
+        final colorScheme = theme.colorScheme;
+        return AlertDialog(
+          title: Text(
+            'Update running MonkeyMux?',
+            style: FluttyTheme.displayMono(
+              fontSize: 18,
+              color: colorScheme.onSurface,
+            ),
+          ),
+          content: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 440),
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    installRequest == null
+                        ? 'MonkeySSH can restart this workspace with helper '
+                              '$bundledVersion and automatically restore its '
+                              'existing windows.'
+                        : 'MonkeySSH will upload helper $bundledVersion. It can '
+                              'then restart this workspace and automatically '
+                              'restore its existing windows.',
+                  ),
+                  const SizedBox(height: 16),
+                  Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: colorScheme.surfaceContainerHighest,
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(color: colorScheme.tertiary),
+                    ),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Icon(
+                          Icons.warning_amber_rounded,
+                          color: colorScheme.tertiary,
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Text(
+                            warning,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: colorScheme.onSurface,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Use $currentVersionLabel for now to connect without '
+                    'changing the running workspace.',
+                  ),
+                  if (installRequest case final request?) ...[
+                    const SizedBox(height: 16),
+                    Text('Running version: $currentVersionLabel'),
+                    Text('Bundled version: $bundledVersion'),
+                    Text('Platform: ${request.platform}'),
+                    Text('Size: ${_formatMonkeyMuxInstallSize(request.size)}'),
+                    const SizedBox(height: 12),
+                    const Text(
+                      'The versioned helper is stored under '
+                      '~/.monkeyssh/bin/monkeymux. A managed launcher is added '
+                      'to ~/.local/bin so it can also be used from the host '
+                      'terminal.',
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () =>
+                  Navigator.pop(context, MonkeyMuxServerUpdatePolicy.never),
+              child: Text('Use $currentVersionLabel for now'),
+            ),
+            FilledButton(
+              onPressed: () =>
+                  Navigator.pop(context, MonkeyMuxServerUpdatePolicy.always),
+              child: const Text('Update and restore'),
+            ),
+          ],
+        );
+      },
+    );
+    return decision ?? MonkeyMuxServerUpdatePolicy.never;
   }
 
   void _showMonkeyMuxVersionMismatchNotice({
@@ -8497,12 +8643,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (_lastMonkeyMuxUpgradeDeferredNotice == noticeKey) return;
     _lastMonkeyMuxUpgradeDeferredNotice = noticeKey;
     late final String message;
-    if (versionComparison != null && versionComparison > 0) {
-      message =
-          'MonkeyMux $bundledVersion is installed, but this workspace is still '
-          'running ${runningLabel ?? 'an older version'}. Close all MonkeyMux '
-          'windows, then reconnect to finish updating.';
-    } else if (versionComparison != null && versionComparison < 0) {
+    if (versionComparison != null && versionComparison < 0) {
       message =
           'This workspace is running MonkeyMux '
           '${runningLabel ?? 'a newer version'}, newer than bundled '
@@ -8517,18 +8658,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
   }
 
-  Future<bool> _confirmMonkeyMuxInstall(
+  Future<({bool install, MonkeyMuxServerUpdatePolicy? updatePolicy})>
+  _confirmMonkeyMuxInstall(
     MonkeyMuxInstallRequest request, {
     Future<MonkeyMuxServerStatus?> Function()? resolveRunningStatus,
   }) async {
     if (!mounted) {
-      return false;
+      return (install: false, updatePolicy: null);
     }
     MonkeyMuxServerStatus? runningStatus;
     if (resolveRunningStatus != null) {
       runningStatus = await resolveRunningStatus();
       if (!mounted) {
-        return false;
+        return (install: false, updatePolicy: null);
       }
     }
     final updateStatus =
@@ -8541,24 +8683,27 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
     final bundledVersionIsNewer =
         versionComparison != null && versionComparison > 0;
+    if (updateStatus != null && bundledVersionIsNewer) {
+      final updatePolicy = await _confirmMonkeyMuxRunningServerUpdate(
+        status: updateStatus,
+        bundledVersion: request.version,
+        installRequest: request,
+      );
+      if (!mounted) {
+        return (install: false, updatePolicy: null);
+      }
+      return (install: true, updatePolicy: updatePolicy);
+    }
     final title = switch ((updateStatus, bundledVersionIsNewer)) {
       (null, _) => 'Install MonkeyMux helper?',
-      (_, true) => 'Update MonkeyMux helper?',
       _ => 'Install bundled MonkeyMux helper?',
     };
-    final confirmLabel = bundledVersionIsNewer ? 'Update' : 'Install';
     final runningVersionLabel = updateStatus?.version?.trim();
     late final String explanation;
     if (updateStatus == null) {
       explanation =
           'MonkeySSH needs to upload its bundled MonkeyMux helper before using '
           'MonkeyMux on this connected host.';
-    } else if (versionComparison != null && versionComparison > 0) {
-      explanation =
-          'This MonkeyMux workspace is running helper '
-          '${runningVersionLabel ?? 'unknown'}. MonkeySSH will upload helper '
-          '${request.version} without interrupting its windows. Close all '
-          'MonkeyMux windows, then reconnect to start the new helper.';
     } else if (versionComparison != null && versionComparison < 0) {
       explanation =
           'This workspace is running helper ${runningVersionLabel ?? 'unknown'}, '
@@ -8602,12 +8747,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           ),
           FilledButton(
             onPressed: () => Navigator.pop(context, true),
-            child: Text(confirmLabel),
+            child: const Text('Install'),
           ),
         ],
       ),
     );
-    return confirmed ?? false;
+    return (install: confirmed ?? false, updatePolicy: null);
   }
 
   String _formatMonkeyMuxInstallSize(int bytes) {
@@ -8680,14 +8825,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
     late String attachCommand;
     try {
+      MonkeyMuxServerUpdatePolicy? requestedUpdatePolicy;
       final installation = await _monkeyMuxInstallerService.ensureInstalled(
         session,
         priority: SshExecPriority.normal,
-        confirmInstall: (request) => _confirmMonkeyMuxInstall(
-          request,
-          resolveRunningStatus: () => _monkeyMuxService
-              .runningServerStatusFromInstalledHelpers(session, sessionName),
-        ),
+        confirmInstall: (request) async {
+          final decision = await _confirmMonkeyMuxInstall(
+            request,
+            resolveRunningStatus: () => _monkeyMuxService
+                .runningServerStatusFromInstalledHelpers(session, sessionName),
+          );
+          requestedUpdatePolicy = decision.updatePolicy;
+          return decision.install;
+        },
       );
       DiagnosticsLogService.instance.info(
         'terminal.agent_launch',
@@ -8702,6 +8852,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         session,
         installation,
         sessionName,
+        preferredUpdatePolicy: requestedUpdatePolicy,
       );
       final terminalThemeReports = buildTerminalThemeHintReports(
         session.terminalTheme ?? _resolveEffectiveTerminalTheme(),

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -6457,16 +6457,32 @@ void main() {
 
     for (final testCase in const [
       (
-        name: 'installs helper without restarting an older MonkeyMux server',
+        name: 'updates and restores an older MonkeyMux server',
         runningVersion: '0.1.13',
-        dialogTitle: 'Update MonkeyMux helper?',
-        confirmLabel: 'Update',
+        dialogTitle: 'Update running MonkeyMux?',
+        confirmLabel: 'Update and restore',
         dialogMessage:
-            'MonkeySSH will upload helper 0.1.14 without interrupting its windows.',
-        notice:
-            'MonkeyMux 0.1.14 is installed, but this workspace is still running '
-            '0.1.13. Close all MonkeyMux windows, then reconnect to finish '
-            'updating.',
+            'MonkeySSH will upload helper 0.1.14. It can then restart this '
+            'workspace',
+        capabilities: <String>{},
+        showsUpgradeDecision: true,
+        warningMessage: 'The running helper cannot stop itself cleanly',
+        updatePolicy: MonkeyMuxServerUpdatePolicy.always,
+        notice: null,
+      ),
+      (
+        name: 'connects to an older MonkeyMux server when update is deferred',
+        runningVersion: '0.1.13',
+        dialogTitle: 'Update running MonkeyMux?',
+        confirmLabel: 'Use 0.1.13 for now',
+        dialogMessage:
+            'MonkeySSH will upload helper 0.1.14. It can then restart this '
+            'workspace',
+        capabilities: {'shutdown'},
+        showsUpgradeDecision: true,
+        warningMessage: 'Updating may briefly interrupt running programs',
+        updatePolicy: MonkeyMuxServerUpdatePolicy.never,
+        notice: null,
       ),
       (
         name: 'keeps a newer MonkeyMux server without downgrade guidance',
@@ -6474,6 +6490,10 @@ void main() {
         dialogTitle: 'Install bundled MonkeyMux helper?',
         confirmLabel: 'Install',
         dialogMessage: 'newer than bundled 0.1.14',
+        capabilities: {'shutdown'},
+        showsUpgradeDecision: false,
+        warningMessage: null,
+        updatePolicy: MonkeyMuxServerUpdatePolicy.never,
         notice:
             'This workspace is running MonkeyMux 0.1.15, newer than bundled '
             '0.1.14. Keeping the running server.',
@@ -6484,6 +6504,10 @@ void main() {
         dialogTitle: 'Install bundled MonkeyMux helper?',
         confirmLabel: 'Install',
         dialogMessage: 'running a different MonkeyMux version',
+        capabilities: {'shutdown'},
+        showsUpgradeDecision: false,
+        warningMessage: null,
+        updatePolicy: MonkeyMuxServerUpdatePolicy.never,
         notice:
             'This workspace is running a different MonkeyMux version. Keeping '
             'the running server to avoid interrupting its windows.',
@@ -6500,11 +6524,11 @@ void main() {
         final monkeyMuxService = _MockMonkeyMuxService()
           ..installedHelpersStatus = MonkeyMuxServerStatus(
             version: testCase.runningVersion,
-            capabilities: const {'shutdown'},
+            capabilities: testCase.capabilities,
           )
           ..runningStatus = MonkeyMuxServerStatus(
             version: testCase.runningVersion,
-            capabilities: const {'shutdown'},
+            capabilities: testCase.capabilities,
           );
         final tmuxService = _MockTmuxService();
         const sessionName = 'work';
@@ -6586,22 +6610,35 @@ void main() {
           find.text('Running version: ${testCase.runningVersion ?? 'unknown'}'),
           findsOneWidget,
         );
-        expect(find.text('Update MonkeyMux?'), findsNothing);
         expect(find.textContaining(testCase.dialogMessage), findsOneWidget);
+        if (testCase.showsUpgradeDecision) {
+          expect(
+            find.textContaining('automatically restore its existing windows'),
+            findsOneWidget,
+          );
+          expect(find.textContaining(testCase.warningMessage!), findsOneWidget);
+          expect(find.text('Use 0.1.13 for now'), findsOneWidget);
+          expect(find.text('Update and restore'), findsOneWidget);
+          expect(
+            find.textContaining('Close all MonkeyMux windows'),
+            findsNothing,
+          );
+        }
         expect(executedCommands, isEmpty);
 
-        await tester.tap(
-          find.widgetWithText(FilledButton, testCase.confirmLabel),
-        );
+        await tester.tap(find.text(testCase.confirmLabel));
         await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
+        await tester.pump(const Duration(milliseconds: 300));
 
         expect(find.text(testCase.dialogTitle), findsNothing);
-        expect(find.text('Update MonkeyMux?'), findsNothing);
+        expect(find.text('Update running MonkeyMux?'), findsNothing);
         expect(executedCommands, hasLength(1));
         final startupCommand = executedCommands.single;
         expect(startupCommand, contains("'/tmp/monkeymux' attach"));
-        expect(startupCommand, contains('--update-policy never'));
+        expect(
+          startupCommand,
+          contains('--update-policy ${testCase.updatePolicy.cliValue}'),
+        );
         expect(shellWrites.map(utf8.decode).join(), isEmpty);
         expect(monkeyMuxInstallerService.acceptedConfirmations, <bool>[true]);
         expect(
@@ -6609,7 +6646,11 @@ void main() {
           1,
         );
         expect(monkeyMuxService.runningServerStatusCalls, 1);
-        expect(find.text(testCase.notice), findsOneWidget);
+        if (testCase.notice case final notice?) {
+          expect(find.text(notice), findsOneWidget);
+        } else {
+          expect(find.byType(SnackBar), findsNothing);
+        }
         await tester.pumpWidget(const SizedBox.shrink());
         await tester.pump();
       }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));


### PR DESCRIPTION
## Summary
- replace the close-all-windows/reconnect dead end with a single upgrade decision
- automatically snapshot, restart, and restore MonkeyMux windows when users choose **Update and restore**
- let users connect to the currently running helper for now, while preserving newer-server downgrade protection
- warn when the restart may interrupt sessions or the old helper cannot shut down cleanly

## Testing
- `flutter analyze lib/presentation/screens/terminal_screen.dart test/presentation/screens/terminal_screen_test.dart`
- `flutter test test/presentation/screens/terminal_screen_test.dart --name '(older|newer|unknown) MonkeyMux server|status probe'`