### PR TITLE
fix: avoid stale tmux windows on raw shells

### DIFF
--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -339,11 +339,25 @@ class TmuxService {
     session,
     priority: SshExecPriority.low,
     extraFlags: extraFlags,
+    allowDirectFallback: true,
+  );
+
+  /// Returns the tmux session whose client process belongs to this SSH
+  /// connection, without inferring another client's session from tmux defaults.
+  Future<String?> foregroundSessionNameFromClientAncestryOrThrow(
+    SshSession session, {
+    String? extraFlags,
+  }) => _foregroundSessionNameOrThrow(
+    session,
+    priority: SshExecPriority.low,
+    extraFlags: extraFlags,
+    allowDirectFallback: false,
   );
 
   Future<String?> _foregroundSessionNameOrThrow(
     SshSession session, {
     required SshExecPriority priority,
+    required bool allowDirectFallback,
     String? extraFlags,
   }) async {
     DiagnosticsLogService.instance.debug(
@@ -364,11 +378,13 @@ class TmuxService {
         .firstOrNull;
     final attachedSessionName =
         sessionName ??
-        await _directCurrentSessionName(
-          session,
-          priority: priority,
-          extraFlags: extraFlags,
-        );
+        (allowDirectFallback
+            ? await _directCurrentSessionName(
+                session,
+                priority: priority,
+                extraFlags: extraFlags,
+              )
+            : null);
     DiagnosticsLogService.instance.info(
       'tmux.query',
       'foreground_session_complete',
@@ -377,6 +393,7 @@ class TmuxService {
         'active': attachedSessionName != null,
         'usedDirectFallback':
             sessionName == null && attachedSessionName != null,
+        'directFallbackAllowed': allowDirectFallback,
       },
     );
     return attachedSessionName;
@@ -1529,6 +1546,7 @@ class TmuxService {
       session,
       priority: SshExecPriority.normal,
       extraFlags: extraFlags,
+      allowDirectFallback: true,
     );
     final hasClient = foregroundSessionName == sessionName;
     DiagnosticsLogService.instance.info(

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -6683,6 +6683,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         'hasAutoConnectCommand':
             _host?.autoConnectCommand?.trim().isNotEmpty ?? false,
         'hasTmuxAutoAttach': _host?.tmuxSessionName?.trim().isNotEmpty ?? false,
+        'configuredMuxBackend': ?_host?.remoteMuxBackend,
+        'hasAgentPreset': _autoConnectAgentPreset != null,
+        'agentPresetHasMuxSession':
+            _autoConnectAgentPreset?.usesMuxSession ?? false,
+        'agentPresetMuxBackend':
+            ?_autoConnectAgentPreset?.effectiveRemoteMuxBackend.storageValue,
       },
     );
     await _loadTheme(reason: 'initial_load');
@@ -9266,6 +9272,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
               candidateSessionName,
             );
             foregroundSessionName = active ? candidateSessionName : null;
+          } else if (muxBackend == RemoteMuxBackend.tmux &&
+              candidateSessionName == null) {
+            foregroundSessionName = await _tmuxService
+                .foregroundSessionNameFromClientAncestryOrThrow(
+                  session,
+                  extraFlags: host?.tmuxExtraFlags,
+                );
+            active = foregroundSessionName != null;
           } else {
             foregroundSessionName = await mux.foregroundSessionNameOrThrow(
               session,

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -538,6 +538,37 @@ void main() {
       },
     );
 
+    test('client ancestry lookup does not infer another tmux client', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client, connectionId: 230);
+      const service = TmuxService();
+      final execSessions = Queue<SSHSession>.of([
+        _buildOpenExecSession(stdout: 'zsh\n/usr/bin/tmux\n${_doneMarker()}'),
+        _buildOpenExecSession(stdout: _doneMarker()),
+      ]);
+
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) async => execSessions.removeFirst());
+
+      final sessionName = await service
+          .foregroundSessionNameFromClientAncestryOrThrow(session);
+
+      expect(sessionName, isNull);
+      verify(
+        () => client.execute(
+          any(that: contains('list-clients')),
+          pty: any(named: 'pty'),
+        ),
+      ).called(1);
+      verifyNever(
+        () => client.execute(
+          any(that: contains('display-message')),
+          pty: any(named: 'pty'),
+        ),
+      );
+    });
+
     test('currentSessionName returns the foreground tmux client', () async {
       final client = _MockSshClient();
       final session = _buildSession(client, connectionId: 24);

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -2509,7 +2509,10 @@ void main() {
           ),
         );
         when(
-          () => tmuxService.foregroundSessionNameOrThrow(session),
+          () => tmuxService.foregroundSessionNameFromClientAncestryOrThrow(
+            session,
+            extraFlags: any(named: 'extraFlags'),
+          ),
         ).thenAnswer((_) async {
           foregroundSessionCalls += 1;
           return foregroundSessionCalls == 1 ? null : tmuxSessionName;
@@ -2570,6 +2573,50 @@ void main() {
         expect(find.byKey(const ValueKey('tmux-handle-bar')), findsOneWidget);
         expect(foregroundSessionCalls, greaterThanOrEqualTo(2));
         expect(themeRefreshCount, greaterThanOrEqualTo(1));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'does not show another tmux client on an unconfigured raw shell',
+      (tester) async {
+        final tmuxService = _MockTmuxService();
+        when(
+          () => tmuxService.foregroundSessionNameFromClientAncestryOrThrow(
+            session,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(
+          () => tmuxService.foregroundSessionNameOrThrow(
+            session,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async => 'other-client');
+
+        await pumpScreen(tester, tmuxService: tmuxService);
+        await tester.pump(const Duration(seconds: 12));
+
+        expect(find.byKey(const ValueKey('tmux-handle-bar')), findsNothing);
+        verify(
+          () => tmuxService.foregroundSessionNameFromClientAncestryOrThrow(
+            session,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).called(greaterThanOrEqualTo(1));
+        verifyNever(
+          () => tmuxService.foregroundSessionNameOrThrow(
+            session,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        );
+        verifyNever(
+          () => tmuxService.listWindows(
+            session,
+            any(),
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        );
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );


### PR DESCRIPTION
## Summary
- require tmux client process ancestry when auto-detecting without a configured session name
- keep the direct `display-message` fallback only when verifying an explicitly known session
- prevent a raw login shell from showing another SSH client's tmux windows
- add sanitized diagnostics for the loaded host/preset mux configuration

## Diagnostic evidence
The reported PR #682 preview opened `interactive_shell` with `hasStartupCommand=false`. Detection had `hasCandidate=false`, failed to associate a tmux client through PID ancestry, then returned `active=true usedDirectFallback=true` and displayed three windows belonging to another tmux client.

The same log also reported `hasAutoConnectCommand=false` and `hasTmuxAutoAttach=false`, so no MonkeyMux startup command was configured for that connection. New diagnostics expose the backend/preset booleans needed to distinguish malformed or missing configuration without logging session names or commands.

## Testing
- `flutter analyze --fatal-warnings`
- `flutter test test/domain/services/tmux_service_control_mode_test.dart`
- targeted terminal tests for retrying legitimate ancestry detection, rejecting another client, and MonkeyMux startup