### PR TITLE
fix(terminal): repaint Copilot CLI after MonkeyMux theme change

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3332,7 +3332,6 @@ class _TmuxTerminalThemeRefreshRequest {
     required this.reason,
     required this.extraFlags,
     this.sendOuterFocusReport = false,
-    this.forceForegroundRedraw = false,
   });
 
   final TerminalThemeData theme;
@@ -3343,16 +3342,6 @@ class _TmuxTerminalThemeRefreshRequest {
   final String? extraFlags;
   final bool sendOuterFocusReport;
 
-  /// Whether the foreground TUI should be forced to fully repaint after the
-  /// theme hint is delivered.
-  ///
-  /// Set when the terminal theme colors actually change (e.g. a light/dark
-  /// switch). A DEC 2031 mode report plus a focus nudge alone are not enough
-  /// for some agents (notably Copilot CLI): they diff-repaint and leave
-  /// explicitly-colored regions such as header/footer bars painted in the old
-  /// theme ("black bars"). A synthetic PTY resize guarantees a full repaint.
-  final bool forceForegroundRedraw;
-
   _TmuxTerminalThemeRefreshRequest copyWith({
     TerminalThemeData? theme,
     SshSession? session,
@@ -3361,7 +3350,6 @@ class _TmuxTerminalThemeRefreshRequest {
     String? reason,
     String? extraFlags,
     bool? sendOuterFocusReport,
-    bool? forceForegroundRedraw,
   }) => _TmuxTerminalThemeRefreshRequest(
     theme: theme ?? this.theme,
     session: session ?? this.session,
@@ -3370,7 +3358,6 @@ class _TmuxTerminalThemeRefreshRequest {
     reason: reason ?? this.reason,
     extraFlags: extraFlags ?? this.extraFlags,
     sendOuterFocusReport: sendOuterFocusReport ?? this.sendOuterFocusReport,
-    forceForegroundRedraw: forceForegroundRedraw ?? this.forceForegroundRedraw,
   );
 }
 
@@ -3575,6 +3562,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   final List<Timer> _monkeyMuxSettledRedrawDisplayRefreshTimers = <Timer>[];
   int _monkeyMuxSettledRedrawDisplayRefreshGeneration = 0;
   int _monkeyMuxRefreshAndResizeGeneration = 0;
+  // Latched when a terminal theme *color* change needs the MonkeyMux foreground
+  // TUI to be forced to fully repaint (via a synthetic redraw resize). Kept as
+  // instance state rather than on a single refresh request so the obligation
+  // survives that request being superseded by a later same-theme forced
+  // refresh; cleared once a redraw is actually dispatched.
+  bool _monkeyMuxForcedThemeRedrawPending = false;
   Timer? _muxWindowRefreshProbeTimer;
   Timer? _muxWindowRefreshSafetyNetTimer;
   DateTime? _lastMuxWindowChangeAt;
@@ -4547,6 +4540,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
     if (_isTmuxActive && tmuxStateBelongsToSession) {
       if (_activeMuxBackend == RemoteMuxBackend.monkeyMux) {
+        if (forceForegroundRedraw) {
+          // Latch the repaint obligation so it survives this refresh request
+          // being superseded/coalesced by a later same-theme forced refresh
+          // (brightness changes fire several applies in quick succession, and
+          // preview -> "Use Theme" re-applies the same colors). It is cleared
+          // only once a redraw is actually dispatched.
+          _monkeyMuxForcedThemeRedrawPending = true;
+        }
         DiagnosticsLogService.instance.info(
           'terminal.theme',
           'monkeymux_refresh_requested',
@@ -4564,7 +4565,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             refreshGeneration: refreshGeneration,
             reason: reason,
             extraFlags: _activeTmuxExtraFlags,
-            forceForegroundRedraw: forceForegroundRedraw,
           ),
         );
         return;
@@ -5320,20 +5320,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _TmuxTerminalThemeRefreshRequest request,
   ) {
     final pendingRequest = _pendingTmuxThemeRefreshRequest;
-    final pendingIsCurrent =
+    final preservePendingOuterFocus =
         pendingRequest != null &&
+        pendingRequest.sendOuterFocusReport &&
         _isCurrentTerminalThemeRefresh(
           theme: pendingRequest.theme,
           session: pendingRequest.session,
           refreshGeneration: pendingRequest.refreshGeneration,
         );
-    final preservePendingOuterFocus =
-        pendingIsCurrent && pendingRequest.sendOuterFocusReport;
-    // A queued theme *change* must still force the foreground repaint even if a
-    // later refresh (e.g. an outer-focus nudge) coalesces on top of it.
-    final preservePendingForceRedraw =
-        pendingIsCurrent && pendingRequest.forceForegroundRedraw;
-    if (!preservePendingOuterFocus && !preservePendingForceRedraw) {
+    if (!preservePendingOuterFocus) {
       return request;
     }
     return request.copyWith(
@@ -5342,8 +5337,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           : pendingRequest.reason,
       sendOuterFocusReport:
           request.sendOuterFocusReport || preservePendingOuterFocus,
-      forceForegroundRedraw:
-          request.forceForegroundRedraw || preservePendingForceRedraw,
     );
   }
 
@@ -5464,9 +5457,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     // theme ("black bars"). Once the theme hint has been delivered, force the
     // foreground TUI to fully repaint with a synthetic PTY resize (the same
     // mechanism used on attach/restore) so those cells are re-emitted.
-    if (request.forceForegroundRedraw &&
+    //
+    // The obligation is latched (not carried on the request) so it survives a
+    // theme-change refresh being superseded by a later same-theme forced
+    // refresh whose request would not itself carry the flag.
+    if (_monkeyMuxForcedThemeRedrawPending &&
         refreshApplied &&
         _activeMuxBackend == RemoteMuxBackend.monkeyMux) {
+      _monkeyMuxForcedThemeRedrawPending = false;
+      // A synthetic redraw resize already covers any repaint a recent size
+      // change scheduled, so drop that pending follow-up to avoid repainting
+      // twice for one visual update.
+      _monkeyMuxResizeRedrawFollowUpTimer?.cancel();
+      _monkeyMuxResizeRedrawFollowUpTimer = null;
       DiagnosticsLogService.instance.info(
         'terminal.theme',
         'monkeymux_force_redraw',
@@ -7796,6 +7799,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _cancelMonkeyMuxSettledRedrawDisplayRefreshes();
     _pendingMonkeyMuxResizeSyncs.clear();
     _lastMonkeyMuxResizeSync = null;
+    _monkeyMuxForcedThemeRedrawPending = false;
   }
 
   void _refreshTerminalDisplayAfterMonkeyMuxRedraw({

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3332,6 +3332,7 @@ class _TmuxTerminalThemeRefreshRequest {
     required this.reason,
     required this.extraFlags,
     this.sendOuterFocusReport = false,
+    this.forceForegroundRedraw = false,
   });
 
   final TerminalThemeData theme;
@@ -3342,6 +3343,16 @@ class _TmuxTerminalThemeRefreshRequest {
   final String? extraFlags;
   final bool sendOuterFocusReport;
 
+  /// Whether the foreground TUI should be forced to fully repaint after the
+  /// theme hint is delivered.
+  ///
+  /// Set when the terminal theme colors actually change (e.g. a light/dark
+  /// switch). A DEC 2031 mode report plus a focus nudge alone are not enough
+  /// for some agents (notably Copilot CLI): they diff-repaint and leave
+  /// explicitly-colored regions such as header/footer bars painted in the old
+  /// theme ("black bars"). A synthetic PTY resize guarantees a full repaint.
+  final bool forceForegroundRedraw;
+
   _TmuxTerminalThemeRefreshRequest copyWith({
     TerminalThemeData? theme,
     SshSession? session,
@@ -3350,6 +3361,7 @@ class _TmuxTerminalThemeRefreshRequest {
     String? reason,
     String? extraFlags,
     bool? sendOuterFocusReport,
+    bool? forceForegroundRedraw,
   }) => _TmuxTerminalThemeRefreshRequest(
     theme: theme ?? this.theme,
     session: session ?? this.session,
@@ -3358,6 +3370,7 @@ class _TmuxTerminalThemeRefreshRequest {
     reason: reason ?? this.reason,
     extraFlags: extraFlags ?? this.extraFlags,
     sendOuterFocusReport: sendOuterFocusReport ?? this.sendOuterFocusReport,
+    forceForegroundRedraw: forceForegroundRedraw ?? this.forceForegroundRedraw,
   );
 }
 
@@ -4476,7 +4489,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       );
     }
     if (willRefresh) {
-      _refreshTerminalThemeForTui(theme, targetSession, reason: reason);
+      _refreshTerminalThemeForTui(
+        theme,
+        targetSession,
+        reason: reason,
+        forceForegroundRedraw: didThemeChange,
+      );
       return;
     }
   }
@@ -4485,6 +4503,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     TerminalThemeData theme,
     SshSession session, {
     required String reason,
+    bool forceForegroundRedraw = false,
   }) {
     _cancelTerminalThemeRefreshTimers();
     final refreshGeneration = ++_terminalThemeRefreshGeneration;
@@ -4522,6 +4541,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           theme,
           session,
           reason: '${reason}_view_ready',
+          forceForegroundRedraw: forceForegroundRedraw,
         );
       });
     }
@@ -4544,6 +4564,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             refreshGeneration: refreshGeneration,
             reason: reason,
             extraFlags: _activeTmuxExtraFlags,
+            forceForegroundRedraw: forceForegroundRedraw,
           ),
         );
         return;
@@ -5299,15 +5320,20 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _TmuxTerminalThemeRefreshRequest request,
   ) {
     final pendingRequest = _pendingTmuxThemeRefreshRequest;
-    final preservePendingOuterFocus =
+    final pendingIsCurrent =
         pendingRequest != null &&
-        pendingRequest.sendOuterFocusReport &&
         _isCurrentTerminalThemeRefresh(
           theme: pendingRequest.theme,
           session: pendingRequest.session,
           refreshGeneration: pendingRequest.refreshGeneration,
         );
-    if (!preservePendingOuterFocus) {
+    final preservePendingOuterFocus =
+        pendingIsCurrent && pendingRequest.sendOuterFocusReport;
+    // A queued theme *change* must still force the foreground repaint even if a
+    // later refresh (e.g. an outer-focus nudge) coalesces on top of it.
+    final preservePendingForceRedraw =
+        pendingIsCurrent && pendingRequest.forceForegroundRedraw;
+    if (!preservePendingOuterFocus && !preservePendingForceRedraw) {
       return request;
     }
     return request.copyWith(
@@ -5316,6 +5342,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           : pendingRequest.reason,
       sendOuterFocusReport:
           request.sendOuterFocusReport || preservePendingOuterFocus,
+      forceForegroundRedraw:
+          request.forceForegroundRedraw || preservePendingForceRedraw,
     );
   }
 
@@ -5356,6 +5384,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     var outerRefreshReason = request.reason;
     var tmuxCommandDeferred = false;
+    var refreshApplied = false;
     try {
       final mux = _activeRemoteMultiplexerService;
       DiagnosticsLogService.instance.info(
@@ -5386,6 +5415,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           request.theme,
           extraFlags: request.extraFlags,
         );
+        refreshApplied = true;
         DiagnosticsLogService.instance.info(
           'terminal.theme',
           'tmux_refresh_complete',
@@ -5427,6 +5457,30 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         },
       );
       return;
+    }
+    // A DEC 2031 mode report plus a focus nudge alone do not reliably repaint
+    // every agent after a theme switch: Copilot CLI in particular diff-repaints
+    // and leaves its explicitly-colored header/footer bars in the previous
+    // theme ("black bars"). Once the theme hint has been delivered, force the
+    // foreground TUI to fully repaint with a synthetic PTY resize (the same
+    // mechanism used on attach/restore) so those cells are re-emitted.
+    if (request.forceForegroundRedraw &&
+        refreshApplied &&
+        _activeMuxBackend == RemoteMuxBackend.monkeyMux) {
+      DiagnosticsLogService.instance.info(
+        'terminal.theme',
+        'monkeymux_force_redraw',
+        fields: {
+          'reason': request.reason,
+          'connectionId': request.session.connectionId,
+        },
+      );
+      unawaited(
+        _syncActiveMonkeyMuxTerminalSize(
+          request.session,
+          refreshVisibleTerminal: true,
+        ),
+      );
     }
     if (request.sendOuterFocusReport) {
       if (!_isOuterTuiSignalingActive(request.session)) {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -3117,6 +3117,129 @@ void main() {
     );
 
     testWidgets(
+      'MonkeyMux theme change forces a foreground redraw resize',
+      (tester) async {
+        final tmuxService = _MockTmuxService();
+        final monkeyMuxService = _MockMonkeyMuxService();
+        final windowEvents = StreamController<TmuxWindowChangeEvent>();
+        addTearDown(windowEvents.close);
+        const sessionName = 'work';
+        const initialWindows = <TmuxWindow>[
+          TmuxWindow(index: 0, name: 'agent', isActive: true, id: '@0'),
+        ];
+        host = _buildHost(
+          id: host.id,
+          tmuxSessionName: sessionName,
+          remoteMuxBackend: RemoteMuxBackend.monkeyMux,
+        );
+        // A foreground agent enables focus reporting; this is the signal that
+        // gates theme hints toward a real TUI.
+        session.terminal!.write('\x1b[?1004h');
+        when(
+          () => tmuxService.prefetchInstalledAgentTools(session),
+        ).thenAnswer((_) async {});
+        when(
+          () => monkeyMuxService.hasForegroundClientOrThrow(
+            session,
+            sessionName,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async => true);
+        when(
+          () => monkeyMuxService.listWindows(
+            session,
+            sessionName,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async => initialWindows);
+        when(
+          () => monkeyMuxService.watchWindowChanges(
+            session,
+            sessionName,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) => windowEvents.stream);
+        when(
+          () => monkeyMuxService.currentPaneContext(
+            session,
+            sessionName,
+            priority: any(named: 'priority'),
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(
+          () => monkeyMuxService.refreshTerminalTheme(
+            session,
+            sessionName,
+            any(),
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async {});
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+              tmuxServiceProvider.overrideWithValue(tmuxService),
+              monkeyMuxServiceProvider.overrideWithValue(monkeyMuxService),
+            ],
+            child: MaterialApp(
+              home: TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+        expect(find.byKey(const ValueKey('tmux-handle-bar')), findsOneWidget);
+
+        // Drain any resize/redraw follow-up timers scheduled while the screen
+        // settled, then clear, so the only redraw resize observed below is the
+        // one the theme change itself forces.
+        await tester.pump(const Duration(milliseconds: 700));
+        await tester.pump();
+        monkeyMuxService.resizeTerminalCalls.clear();
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(TerminalScreen)),
+        );
+        await container
+            .read(themeModeNotifierProvider.notifier)
+            .setThemeMode(ThemeMode.dark);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 75));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+        await tester.pump();
+
+        // The theme actually changed (light -> dark), so the foreground TUI
+        // must be forced to fully repaint via a redraw resize; otherwise
+        // Copilot CLI keeps its explicitly-colored bars in the old theme.
+        expect(
+          monkeyMuxService.resizeTerminalCalls.any((call) => call.redraw),
+          isTrue,
+          reason: 'expected a redraw resize after the theme change',
+        );
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
       'MonkeyMux window switches wait for replay before following output',
       (tester) async {
         final tmuxService = _MockTmuxService();

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -3240,6 +3240,151 @@ void main() {
     );
 
     testWidgets(
+      'MonkeyMux forced redraw survives a superseding same-theme refresh',
+      (tester) async {
+        // Regression guard for the coalescing race: a theme *change* refresh
+        // (which wants a forced redraw) that is superseded mid-flight by a
+        // forced same-theme refresh (e.g. from a brightness/app-resume
+        // re-sync, which carries no redraw obligation of its own) must still
+        // repaint the foreground TUI. Brightness changes fire several applies
+        // in quick succession, so this is the common real-world path.
+        final tmuxService = _MockTmuxService();
+        final monkeyMuxService = _MockMonkeyMuxService();
+        final windowEvents = StreamController<TmuxWindowChangeEvent>();
+        addTearDown(windowEvents.close);
+        const sessionName = 'work';
+        const initialWindows = <TmuxWindow>[
+          TmuxWindow(index: 0, name: 'agent', isActive: true, id: '@0'),
+        ];
+        host = _buildHost(
+          id: host.id,
+          tmuxSessionName: sessionName,
+          remoteMuxBackend: RemoteMuxBackend.monkeyMux,
+        );
+        session.terminal!.write('\x1b[?1004h');
+
+        // Hold the first theme refresh in flight so a second, same-theme forced
+        // refresh can supersede it before it completes.
+        final firstRefresh = Completer<void>();
+        var themeRefreshCount = 0;
+        when(
+          () => tmuxService.prefetchInstalledAgentTools(session),
+        ).thenAnswer((_) async {});
+        when(
+          () => monkeyMuxService.hasForegroundClientOrThrow(
+            session,
+            sessionName,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async => true);
+        when(
+          () => monkeyMuxService.listWindows(
+            session,
+            sessionName,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async => initialWindows);
+        when(
+          () => monkeyMuxService.watchWindowChanges(
+            session,
+            sessionName,
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) => windowEvents.stream);
+        when(
+          () => monkeyMuxService.currentPaneContext(
+            session,
+            sessionName,
+            priority: any(named: 'priority'),
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(
+          () => monkeyMuxService.refreshTerminalTheme(
+            session,
+            sessionName,
+            any(),
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) async {
+          themeRefreshCount += 1;
+          if (themeRefreshCount == 1) {
+            await firstRefresh.future;
+          }
+        });
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              databaseProvider.overrideWithValue(db),
+              hostRepositoryProvider.overrideWithValue(hostRepository),
+              monetizationServiceProvider.overrideWithValue(
+                monetizationService,
+              ),
+              monetizationStateProvider.overrideWith(
+                (ref) => Stream.value(_proMonetizationState),
+              ),
+              sharedClipboardProvider.overrideWith((ref) async => false),
+              activeSessionsProvider.overrideWith(
+                () => _TestActiveSessionsNotifier(session),
+              ),
+              tmuxServiceProvider.overrideWithValue(tmuxService),
+              monkeyMuxServiceProvider.overrideWithValue(monkeyMuxService),
+            ],
+            child: MaterialApp(
+              home: TerminalScreen(
+                hostId: host.id,
+                connectionId: session.connectionId,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+        expect(find.byKey(const ValueKey('tmux-handle-bar')), findsOneWidget);
+        await tester.pump(const Duration(milliseconds: 700));
+        await tester.pump();
+        monkeyMuxService.resizeTerminalCalls.clear();
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(TerminalScreen)),
+        );
+
+        // R1: a real light -> dark change wants a forced redraw. It starts and
+        // blocks on the completer, so it is still in flight below.
+        await container
+            .read(themeModeNotifierProvider.notifier)
+            .setThemeMode(ThemeMode.dark);
+        await tester.pump();
+        expect(themeRefreshCount, 1);
+
+        // R2: a forced same-theme re-sync bumps the refresh generation while R1
+        // is in flight, so R1 becomes stale and skips its own redraw.
+        tester.binding.platformDispatcher.onPlatformBrightnessChanged?.call();
+        await tester.pump();
+        await tester.pump();
+
+        // Release R1. It completes but is stale; R2 then runs, and the latched
+        // redraw obligation must still repaint the foreground TUI.
+        firstRefresh.complete();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+        await tester.pump();
+
+        expect(
+          monkeyMuxService.resizeTerminalCalls.any((call) => call.redraw),
+          isTrue,
+          reason:
+              'redraw must survive a same-theme refresh superseding the '
+              'theme-change refresh',
+        );
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
       'MonkeyMux window switches wait for replay before following output',
       (tester) async {
         final tmuxService = _MockTmuxService();


### PR DESCRIPTION
## Problem
After an OS/app theme switch, Copilot CLI (running in MonkeyMux) intermittently keeps dark **"black bars"** — its explicitly-colored header/footer regions — in an otherwise light theme. "Some portion of the time it works, other times it doesn't."

## Root cause
The MonkeyMux theme-change path (`theme_changed` → `sendThemeHint`) only pushes a DEC 2031 mode report + OSC 11 + a focus nudge. It **never forces a full foreground repaint**. Copilot diff-repaints and re-emits only cells it thinks changed, so its explicitly-colored bars stay painted in the previous theme. It's intermittent because Copilot sometimes repaints from the nudge and sometimes doesn't.

For contrast, the other repaint paths already force a full redraw:
- classic tmux theme refresh ends with `refresh-client`
- attach / restore / alt-buffer-exit call `simulateForegroundResize` (synthetic SIGWINCH)

The plain foreground theme-change path had no equivalent.

## Fix
When the terminal theme **colors actually change** (`didThemeChange`) on a MonkeyMux session, after the theme hint is delivered, force the foreground TUI to fully repaint via the existing `resize`+`redraw:true` path (`_syncActiveMonkeyMuxTerminalSize(refreshVisibleTerminal: true)`). Server-side this runs `resizeWithRedraw(forceRedraw=true)` → `simulateForegroundResize` → SIGWINCH → a guaranteed full repaint that re-emits every cell, including the bars, with the new theme.

This is a **client-side (Dart) change only** — no MonkeyMux helper rebuild/re-upload is required; it works with the currently deployed helper.

### Changes (`lib/presentation/screens/terminal_screen.dart`)
- Add `forceForegroundRedraw` to `_TmuxTerminalThemeRefreshRequest` (+ `copyWith`, merge-preserve, and the `_view_ready` retry path).
- `_applyTerminalThemeToSession` sets it from `didThemeChange`.
- `_refreshTerminalThemeForTui` forwards it onto the MonkeyMux request.
- `_runTmuxTerminalThemeRefresh` forces the redraw once the theme hint lands (MonkeyMux only, on success), with a `terminal.theme monkeymux_force_redraw` diagnostics entry.

### Scope
Gated to actual color changes, so window switches / reconnects / app-resumes with an unchanged theme add no extra repaints. Classic-tmux backend is unaffected (it already does `refresh-client`).

## Testing
- New regression test `MonkeyMux theme change forces a foreground redraw resize` — verified it **fails without the fix** and passes with it.
- Full `terminal_screen_test.dart` (133 tests) pass.
- `flutter analyze` clean; `dart format` applied.