### PR TITLE
fix: prefer text clipboard payloads on Android

### DIFF
--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
@@ -1,6 +1,7 @@
 package xyz.depollsoft.monkeyssh
 
 import android.Manifest
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -63,6 +64,9 @@ class MainActivity : FlutterFragmentActivity() {
         )
         clipboardMethodChannel?.setMethodCallHandler { call, result ->
             when (call.method) {
+                "readExplicitText" -> {
+                    result.success(readExplicitClipboardText())
+                }
                 "readContentUri" -> {
                     val uriString = call.argument<String>("uri")
                     if (uriString.isNullOrBlank()) {
@@ -98,6 +102,18 @@ class MainActivity : FlutterFragmentActivity() {
         }
 
         notifyIncomingTransferPayload()
+    }
+
+    private fun readExplicitClipboardText(): String? {
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clip = clipboard.primaryClip ?: return null
+        for (index in 0 until clip.itemCount) {
+            val text = clip.getItemAt(index).text?.toString()
+            if (!text.isNullOrEmpty()) {
+                return text
+            }
+        }
+        return null
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/lib/domain/services/clipboard_content_service.dart
+++ b/lib/domain/services/clipboard_content_service.dart
@@ -1,13 +1,11 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Reads Android content-URI clipboard entries via the platform channel.
+/// Reads Android clipboard metadata and content-URI entries.
 ///
 /// The native side handles the `xyz.depollsoft.monkeyssh/clipboard_content`
-/// channel and exposes a single `readContentUri` method that accepts a
-/// `content://` URI and returns the file name and raw bytes.  This service
-/// wraps that channel so the screen widget can be tested without a live
-/// platform channel.
+/// channel. This service wraps that channel so the screen widget can be tested
+/// without a live platform channel.
 class ClipboardContentService {
   /// Creates a [ClipboardContentService] backed by the given [channel].
   ///
@@ -20,6 +18,13 @@ class ClipboardContentService {
   }) : _channel = channel;
 
   final MethodChannel _channel;
+
+  /// Reads text stored directly on an Android clipboard item.
+  ///
+  /// Unlike Flutter's plain-text clipboard API, this does not coerce a
+  /// content URI into its string representation.
+  Future<String?> readExplicitText() =>
+      _channel.invokeMethod<String>('readExplicitText');
 
   /// Reads the content at [uri] and returns its file name and raw bytes.
   ///

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1463,6 +1463,79 @@ resolveTerminalUploadPickerRequest({required bool media}) => (
   failureContext: media ? 'Media picker upload' : 'File picker upload',
 );
 
+/// Clipboard data selected for one terminal paste action.
+typedef TerminalClipboardPastePayload = ({
+  String? text,
+  Uint8List? imageBytes,
+  List<String> files,
+});
+
+/// Reads clipboard representations in the order appropriate for terminal paste.
+///
+/// Android clipboard APIs can coerce an image or file URI into plain text. An
+/// explicit text item must therefore win before URI-backed image/file probes,
+/// while image-only clips retain the existing upload behavior.
+@visibleForTesting
+Future<TerminalClipboardPastePayload> resolveTerminalClipboardPastePayload({
+  required bool isAndroid,
+  required Future<String?> Function() readExplicitAndroidText,
+  required Future<Uint8List?> Function() readImage,
+  required Future<List<String>> Function() readFiles,
+  required Future<String?> Function() readText,
+}) async {
+  if (isAndroid) {
+    final explicitText = await readExplicitAndroidText();
+    if (explicitText != null && explicitText.isNotEmpty) {
+      final TerminalClipboardPastePayload payload = (
+        text: explicitText,
+        imageBytes: null,
+        files: const [],
+      );
+      return payload;
+    }
+
+    final imageBytes = await readImage();
+    if (imageBytes != null && imageBytes.isNotEmpty) {
+      final TerminalClipboardPastePayload payload = (
+        text: null,
+        imageBytes: imageBytes,
+        files: const [],
+      );
+      return payload;
+    }
+  }
+
+  final files = await readFiles();
+  if (files.isNotEmpty) {
+    final TerminalClipboardPastePayload payload = (
+      text: null,
+      imageBytes: null,
+      files: files,
+    );
+    return payload;
+  }
+
+  if (!isAndroid) {
+    final imageBytes = await readImage();
+    if (imageBytes != null && imageBytes.isNotEmpty) {
+      final TerminalClipboardPastePayload payload = (
+        text: null,
+        imageBytes: imageBytes,
+        files: const [],
+      );
+      return payload;
+    }
+  }
+
+  final text = await readText();
+  final TerminalClipboardPastePayload payload = (
+    text: text == null || text.isEmpty ? null : text,
+    imageBytes: null,
+    files: const [],
+  );
+  return payload;
+}
+
 /// Whether terminal media paste should use a native photo-library picker.
 @visibleForTesting
 bool shouldUsePhotoLibraryPickerForTerminalMedia({
@@ -15248,30 +15321,27 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   Future<void> _pasteClipboard() async {
     try {
-      if (_isAndroidPlatform) {
-        final imageBytes = await Pasteboard.image;
-        if (imageBytes != null && imageBytes.isNotEmpty) {
-          await _pasteClipboardImage(imageBytes);
-          return;
-        }
-      }
-
-      final clipboardFiles = await Pasteboard.files();
-      if (clipboardFiles.isNotEmpty) {
-        await _pasteClipboardFiles(clipboardFiles);
+      final payload = await resolveTerminalClipboardPastePayload(
+        isAndroid: _isAndroidPlatform,
+        readExplicitAndroidText: () =>
+            ref.read(clipboardContentServiceProvider).readExplicitText(),
+        readImage: () => Pasteboard.image,
+        readFiles: Pasteboard.files,
+        readText: _readSystemClipboardText,
+      );
+      final imageBytes = payload.imageBytes;
+      if (imageBytes != null) {
+        await _pasteClipboardImage(imageBytes);
         return;
       }
 
-      if (!_isAndroidPlatform) {
-        final imageBytes = await Pasteboard.image;
-        if (imageBytes != null && imageBytes.isNotEmpty) {
-          await _pasteClipboardImage(imageBytes);
-          return;
-        }
+      if (payload.files.isNotEmpty) {
+        await _pasteClipboardFiles(payload.files);
+        return;
       }
 
-      final text = await _readSystemClipboardText();
-      if (text == null || text.isEmpty) {
+      final text = payload.text;
+      if (text == null) {
         _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
         _showClipboardMessage('Clipboard is empty');
         return;

--- a/test/domain/services/clipboard_content_service_test.dart
+++ b/test/domain/services/clipboard_content_service_test.dart
@@ -18,6 +18,20 @@ void main() {
   });
 
   group('ClipboardContentService', () {
+    test('readExplicitText returns uncoerced clipboard text', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(clipboardChannel, (call) async {
+            if (call.method == 'readExplicitText') {
+              return 'echo bracketed paste';
+            }
+            return null;
+          });
+
+      const service = ClipboardContentService();
+
+      expect(await service.readExplicitText(), 'echo bracketed paste');
+    });
+
     test(
       'readContentUri returns name and bytes from the platform channel',
       () async {

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -14,6 +14,90 @@ import 'package:xterm/xterm.dart';
 class _FakeImagePickerPlatform extends ImagePickerPlatform {}
 
 void main() {
+  group('resolveTerminalClipboardPastePayload', () {
+    test(
+      'prefers explicit Android text over image and file variants',
+      () async {
+        var readImage = false;
+        var readFiles = false;
+        var readFallbackText = false;
+
+        final payload = await resolveTerminalClipboardPastePayload(
+          isAndroid: true,
+          readExplicitAndroidText: () async => 'echo bracketed paste',
+          readImage: () async {
+            readImage = true;
+            return Uint8List.fromList([1, 2, 3]);
+          },
+          readFiles: () async {
+            readFiles = true;
+            return const ['content://clipboard/image'];
+          },
+          readText: () async {
+            readFallbackText = true;
+            return 'content://clipboard/image';
+          },
+        );
+
+        expect(payload.text, 'echo bracketed paste');
+        expect(payload.imageBytes, isNull);
+        expect(payload.files, isEmpty);
+        expect(readImage, isFalse);
+        expect(readFiles, isFalse);
+        expect(readFallbackText, isFalse);
+      },
+    );
+
+    test(
+      'keeps Android image upload for clips without explicit text',
+      () async {
+        final imageBytes = Uint8List.fromList([1, 2, 3]);
+        var readFiles = false;
+        var readFallbackText = false;
+
+        final payload = await resolveTerminalClipboardPastePayload(
+          isAndroid: true,
+          readExplicitAndroidText: () async => null,
+          readImage: () async => imageBytes,
+          readFiles: () async {
+            readFiles = true;
+            return const ['content://clipboard/image'];
+          },
+          readText: () async {
+            readFallbackText = true;
+            return 'content://clipboard/image';
+          },
+        );
+
+        expect(payload.text, isNull);
+        expect(payload.imageBytes, same(imageBytes));
+        expect(payload.files, isEmpty);
+        expect(readFiles, isFalse);
+        expect(readFallbackText, isFalse);
+      },
+    );
+
+    test('uses Android clipboard files when no text or image exists', () async {
+      final payload = await resolveTerminalClipboardPastePayload(
+        isAndroid: true,
+        readExplicitAndroidText: () async => null,
+        readImage: () async => null,
+        readFiles: () async => const [
+          'content://clipboard/first',
+          'content://clipboard/second',
+        ],
+        readText: () async => 'content://clipboard/first',
+      );
+
+      expect(payload.text, isNull);
+      expect(payload.imageBytes, isNull);
+      expect(payload.files, const [
+        'content://clipboard/first',
+        'content://clipboard/second',
+      ]);
+    });
+  });
+
   group('trimTerminalSelectionText', () {
     test('trims trailing padding on each line only', () {
       expect(


### PR DESCRIPTION
## Summary
- read explicit Android `ClipData.Item.text` without coercing URI-backed clipboard content
- prefer real text before image/file upload representations so terminal paste reaches xterm and bracketed-paste handling
- preserve image-first and file fallback behavior when the clipboard has no explicit text

## Testing
- `flutter analyze lib/domain/services/clipboard_content_service.dart lib/presentation/screens/terminal_screen.dart test/domain/services/clipboard_content_service_test.dart test/widget/terminal_screen_selection_test.dart`
- `flutter test test/domain/services/clipboard_content_service_test.dart test/widget/terminal_screen_selection_test.dart`
- `:app:compilePrivateDebugKotlin`