### PR TITLE
fix: address Crashlytics crash paths

### DIFF
--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
@@ -1,7 +1,6 @@
 package xyz.depollsoft.monkeyssh
 
 import android.Manifest
-import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -37,8 +36,10 @@ class MainActivity : FlutterFragmentActivity() {
         handleTransferIntent(intent)
     }
 
-    override fun provideFlutterEngine(context: Context): FlutterEngine =
-        MonkeySshApplication.from(context).ensureSharedFlutterEngine()
+    override fun getCachedEngineId(): String {
+        MonkeySshApplication.from(this).ensureSharedFlutterEngine()
+        return MonkeySshApplication.SHARED_ENGINE_ID
+    }
 
     override fun shouldDestroyEngineWithHost(): Boolean = false
 

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MonkeySshApplication.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MonkeySshApplication.kt
@@ -3,12 +3,15 @@ package xyz.depollsoft.monkeyssh
 import android.app.Application
 import android.content.Context
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.FlutterEngineCache
 import io.flutter.embedding.engine.dart.DartExecutor
 import io.flutter.plugins.GeneratedPluginRegistrant
 
 class MonkeySshApplication : Application() {
 
     companion object {
+        const val SHARED_ENGINE_ID = "monkeyssh_shared_engine"
+
         fun from(context: Context): MonkeySshApplication =
             context.applicationContext as MonkeySshApplication
     }
@@ -26,6 +29,7 @@ class MonkeySshApplication : Application() {
         engine.dartExecutor.executeDartEntrypoint(
             DartExecutor.DartEntrypoint.createDefault()
         )
+        FlutterEngineCache.getInstance().put(SHARED_ENGINE_ID, engine)
         sharedFlutterEngine = engine
         return engine
     }

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/SshConnectionService.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/SshConnectionService.kt
@@ -104,6 +104,12 @@ class SshConnectionService : Service() {
     override fun onCreate() {
         super.onCreate()
         createNotificationChannel()
+        val status = Companion.latestStatus ?: ConnectionStatus(
+            connectionCount = 1,
+            connectedCount = 0
+        )
+        startForeground(NOTIFICATION_ID, buildNotification(status))
+        isPresenting = true
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -122,7 +128,7 @@ class SshConnectionService : Service() {
         }
 
         refreshPresentation()
-        return START_STICKY
+        return START_NOT_STICKY
     }
 
     override fun onDestroy() {

--- a/lib/domain/services/ssh_error_policy.dart
+++ b/lib/domain/services/ssh_error_policy.dart
@@ -1,0 +1,12 @@
+import 'package:dartssh2/dartssh2.dart';
+
+const _channelUploadLoopFrame = 'SSHChannelController._uploadLoop';
+
+/// Whether [error] is a late channel write after the SSH transport closed.
+///
+/// dartssh2 starts channel upload loops internally without exposing their
+/// futures. A transport disconnect can therefore race a queued write and reach
+/// the platform error handler even though the connection shutdown is expected.
+bool isExpectedSshChannelTeardownError(Object error, StackTrace stackTrace) =>
+    error is SSHStateError &&
+    stackTrace.toString().contains(_channelUploadLoopFrame);

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -2656,6 +2656,28 @@ class _PreparedHostKeySocket {
   final HostKeySource hostKeySource;
 }
 
+class _NonClosingStreamSink<T> implements StreamSink<T> {
+  const _NonClosingStreamSink(this._delegate);
+
+  final StreamSink<T> _delegate;
+
+  @override
+  void add(T data) => _delegate.add(data);
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) =>
+      _delegate.addError(error, stackTrace);
+
+  @override
+  Future<void> addStream(Stream<T> stream) => _delegate.addStream(stream);
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<void> get done => _delegate.done;
+}
+
 Map<String, Object?> _diagnosticSshExecErrorFields(Object error) => {
   'errorType': error.runtimeType,
   if (error is SSHChannelOpenError) ...{
@@ -5395,7 +5417,9 @@ while($true){
     try {
       forward = await client.forwardLocal(remoteHost, remotePort);
       final forwardToSocket = forward.stream.cast<List<int>>().pipe(socket);
-      final socketToForward = socket.cast<List<int>>().pipe(forward.sink);
+      final socketToForward = socket.cast<List<int>>().pipe(
+        _NonClosingStreamSink(forward.sink),
+      );
 
       await Future.any<void>([forwardToSocket, socketToForward]);
     } on SSHError catch (e) {
@@ -5521,7 +5545,9 @@ while($true){
         try {
           socket = await Socket.connect(localHost, localPort);
           final remoteToLocal = channel.stream.cast<List<int>>().pipe(socket);
-          final localToRemote = socket.cast<List<int>>().pipe(channel.sink);
+          final localToRemote = socket.cast<List<int>>().pipe(
+            _NonClosingStreamSink(channel.sink),
+          );
           await Future.any<void>([remoteToLocal, localToRemote]);
         } on Exception catch (e) {
           DiagnosticsLogService.instance.warning(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,10 +11,12 @@ import 'app/app_metadata.dart';
 import 'app/host_key_prompt.dart';
 import 'app/interactive_auth_prompt.dart';
 import 'data/database/database.dart';
+import 'domain/services/diagnostics_log_service.dart';
 import 'domain/services/host_key_prompt_handler_provider.dart';
 import 'domain/services/interactive_auth_prompt.dart';
 import 'domain/services/performance_diagnostics_service.dart';
 import 'domain/services/settings_service.dart';
+import 'domain/services/ssh_error_policy.dart';
 import 'domain/services/telemetry_service.dart';
 
 /// Entry point for the MonkeySSH client.
@@ -91,6 +93,15 @@ void _installTelemetryErrorHandlers(TelemetryService telemetryService) {
 
   final previousPlatformErrorHandler = PlatformDispatcher.instance.onError;
   PlatformDispatcher.instance.onError = (error, stackTrace) {
+    if (isExpectedSshChannelTeardownError(error, stackTrace)) {
+      DiagnosticsLogService.instance.info(
+        'ssh.channel',
+        'late_write_ignored',
+        fields: {'errorType': error.runtimeType},
+      );
+      previousPlatformErrorHandler?.call(error, stackTrace);
+      return true;
+    }
     unawaited(
       telemetryService
           .recordError(error, stackTrace, fatal: true)

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -3155,19 +3155,19 @@ class _TmuxConnectionBadgeState extends ConsumerState<_TmuxConnectionBadge> {
   }
 
   Future<bool> _loadHostAgentPreferences([int? hostId]) async {
+    if (!mounted) return false;
+    final activeSessions = ref.read(activeSessionsProvider.notifier);
+    final presetService = ref.read(agentLaunchPresetServiceProvider);
+    final cliLaunchPreferencesService = ref.read(
+      hostCliLaunchPreferencesServiceProvider,
+    );
     final resolvedHostId =
-        hostId ??
-        ref
-            .read(activeSessionsProvider.notifier)
-            .getSession(widget.connectionId)
-            ?.hostId;
+        hostId ?? activeSessions.getSession(widget.connectionId)?.hostId;
     if (resolvedHostId == null) return false;
 
-    final preset = await ref
-        .read(agentLaunchPresetServiceProvider)
-        .getPresetForHost(resolvedHostId);
-    final cliLaunchPreferences = await ref
-        .read(hostCliLaunchPreferencesServiceProvider)
+    final preset = await presetService.getPresetForHost(resolvedHostId);
+    if (!mounted) return false;
+    final cliLaunchPreferences = await cliLaunchPreferencesService
         .getPreferencesForHost(resolvedHostId);
     if (!mounted) return false;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: "direct main"
     description:
       name: dartssh2
-      sha256: "8af742da413dd1d6479f6f884d2db59385a6666326a3df7cb696436059319b15"
+      sha256: e13ce3ae337347a409e228be0d47befd3f06ba76fefa642b4fe35427ad380a3b
       url: "https://pub.dev"
     source: hosted
-    version: "2.22.0"
+    version: "2.22.1"
   dbus:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   path: ^1.9.1
   
   # SSH
-  dartssh2: ^2.22.0
+  dartssh2: 2.22.1
   
   # Terminal
   # Vendored fork of xterm.dart 4.0.0 (upstream unmaintained since 2024-02).

--- a/test/domain/services/ssh_error_policy_test.dart
+++ b/test/domain/services/ssh_error_policy_test.dart
@@ -1,0 +1,31 @@
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:monkeyssh/domain/services/ssh_error_policy.dart';
+
+void main() {
+  test('recognizes late dartssh2 channel writes during teardown', () {
+    final stackTrace = StackTrace.fromString(
+      '#0 SSHTransport.sendPacket\n'
+      '#1 SSHChannelController._uploadLoop.<anonymous closure>\n',
+    );
+
+    expect(
+      isExpectedSshChannelTeardownError(
+        SSHStateError('Transport is closed'),
+        stackTrace,
+      ),
+      isTrue,
+    );
+  });
+
+  test('does not hide SSH state errors from other operations', () {
+    expect(
+      isExpectedSshChannelTeardownError(
+        SSHStateError('Transport is closed'),
+        StackTrace.fromString('#0 SshSession.execute\n'),
+      ),
+      isFalse,
+    );
+  });
+}

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -437,6 +437,70 @@ class _OwnershipActiveSessionsNotifier extends ActiveSessionsNotifier {
       connectionStates[connectionId] ?? SshConnectionState.disconnected;
 }
 
+class _ThrowOnRepeatedCloseSink implements StreamSink<List<int>> {
+  _ThrowOnRepeatedCloseSink(this._delegate);
+
+  final StreamSink<List<int>> _delegate;
+  int closeAttempts = 0;
+
+  @override
+  void add(List<int> data) => _delegate.add(data);
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) =>
+      _delegate.addError(error, stackTrace);
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) =>
+      _delegate.addStream(stream);
+
+  @override
+  Future<void> close() {
+    closeAttempts++;
+    if (closeAttempts > 1) {
+      throw StateError('Sink already closed');
+    }
+    return _delegate.close();
+  }
+
+  @override
+  Future<void> get done => _delegate.done;
+}
+
+class _SingleCloseForwardChannel implements SSHForwardChannel {
+  _SingleCloseForwardChannel() {
+    sink = _ThrowOnRepeatedCloseSink(_sinkController.sink);
+  }
+
+  final _streamController = StreamController<Uint8List>();
+  final _sinkController = StreamController<List<int>>.broadcast();
+
+  @override
+  // ignore: close_sinks
+  late final _ThrowOnRepeatedCloseSink sink;
+
+  @override
+  Stream<Uint8List> get stream => _streamController.stream;
+
+  @override
+  Future<void> close() async {
+    if (!_streamController.isClosed) {
+      await _streamController.close();
+    }
+    if (!_sinkController.isClosed) {
+      await _sinkController.close();
+    }
+  }
+
+  @override
+  Future<void> get done async {}
+
+  @override
+  void destroy() {
+    unawaited(close());
+  }
+}
+
 class _FakeActiveSessionsSshService extends SshService {
   _FakeActiveSessionsSshService({this.connectGate});
 
@@ -4452,6 +4516,51 @@ LISTEN ::1:4201
         );
       },
     );
+
+    test('local forward cleanup closes the SSH sink exactly once', () async {
+      final client = _MockSshClient();
+      final forward = _SingleCloseForwardChannel();
+      final session = SshSession(
+        connectionId: 1,
+        hostId: 42,
+        client: client,
+        config: const SshConnectionConfig(
+          hostname: 'host.example.com',
+          port: 22,
+          username: 'tester',
+        ),
+      );
+      final localPort = await _unusedLoopbackPort();
+      when(
+        () => client.forwardLocal('remote.example.com', 80),
+      ).thenAnswer((_) async => forward);
+
+      addTearDown(() async {
+        await session.stopAllForwards();
+        await forward.close();
+      });
+
+      expect(
+        await session.startLocalForward(
+          portForwardId: 1,
+          localHost: InternetAddress.loopbackIPv4.address,
+          localPort: localPort,
+          remoteHost: 'remote.example.com',
+          remotePort: 80,
+        ),
+        isTrue,
+      );
+
+      final socket = await Socket.connect(
+        InternetAddress.loopbackIPv4,
+        localPort,
+      );
+      await socket.close();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(forward.sink.closeAttempts, 1);
+    });
 
     test(
       'removes stale sessions when remote forwards report a closed transport',

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -13,12 +13,14 @@ import 'package:mocktail/mocktail.dart';
 import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/snippet_repository.dart';
+import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
 import 'package:monkeyssh/domain/models/host_cli_launch_preferences.dart';
 import 'package:monkeyssh/domain/models/monetization.dart';
 import 'package:monkeyssh/domain/models/remote_multiplexer.dart';
 import 'package:monkeyssh/domain/models/terminal_preview.dart';
 import 'package:monkeyssh/domain/models/terminal_theme.dart';
 import 'package:monkeyssh/domain/models/tmux_state.dart';
+import 'package:monkeyssh/domain/services/agent_launch_preset_service.dart';
 import 'package:monkeyssh/domain/services/agent_session_discovery_service.dart';
 import 'package:monkeyssh/domain/services/home_screen_shortcut_service.dart';
 import 'package:monkeyssh/domain/services/host_cli_launch_preferences_service.dart';
@@ -47,6 +49,12 @@ class _MockMonkeyMuxService extends Mock implements MonkeyMuxService {}
 
 class _MockAgentSessionDiscoveryService extends Mock
     implements AgentSessionDiscoveryService {}
+
+class _MockAgentLaunchPresetService extends Mock
+    implements AgentLaunchPresetService {}
+
+class _MockHostCliLaunchPreferencesService extends Mock
+    implements HostCliLaunchPreferencesService {}
 
 class _MockMonetizationService extends Mock implements MonetizationService {}
 
@@ -1092,6 +1100,81 @@ void main() {
 
     expect(find.text('correct-session · 1 windows'), findsOneWidget);
     expect(find.text('wrong-session · 1 windows'), findsNothing);
+  });
+
+  testWidgets('stops loading tmux preferences after badge disposal', (
+    tester,
+  ) async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final presetService = _MockAgentLaunchPresetService();
+    final cliLaunchPreferencesService = _MockHostCliLaunchPreferencesService();
+    final tmuxService = _MockTmuxService();
+    final presetCompleter = Completer<AgentLaunchPreset?>();
+    final sshClient = _MockSshClient();
+    var presetLoadStarted = false;
+    final session = SshSession(
+      connectionId: 7,
+      hostId: 1,
+      client: sshClient,
+      config: const SshConnectionConfig(
+        hostname: 'alpha.example.com',
+        port: 22,
+        username: 'root',
+      ),
+    );
+    final sessionsNotifier = _MutableActiveSessionsNotifier(
+      initialConnections: [_buildActiveConnection(connectionId: 7, hostId: 1)],
+      initialSessions: [session],
+    );
+
+    when(() => presetService.getPresetForHost(1)).thenAnswer((_) {
+      presetLoadStarted = true;
+      return presetCompleter.future;
+    });
+    when(
+      () => cliLaunchPreferencesService.getPreferencesForHost(1),
+    ).thenAnswer((_) async => const HostCliLaunchPreferences());
+    when(() => tmuxService.isTmuxActive(session)).thenAnswer((_) async => true);
+    when(
+      () => tmuxService.currentSessionName(session),
+    ).thenAnswer((_) async => 'work');
+    when(
+      () => tmuxService.watchWindowChanges(session, 'work'),
+    ).thenAnswer((_) => const Stream<TmuxWindowChangeEvent>.empty());
+    when(
+      () => tmuxService.listWindows(session, 'work'),
+    ).thenAnswer((_) async => const <TmuxWindow>[]);
+
+    await tester.pumpWidget(
+      buildMobileHomeScreen(
+        db: db,
+        overrides: [
+          activeSessionsProvider.overrideWith(() => sessionsNotifier),
+          allHostsProvider.overrideWith(
+            (ref) =>
+                Stream.value([_buildHost(id: 1, label: 'Alpha', sortOrder: 0)]),
+          ),
+          agentLaunchPresetServiceProvider.overrideWithValue(presetService),
+          hostCliLaunchPreferencesServiceProvider.overrideWithValue(
+            cliLaunchPreferencesService,
+          ),
+          tmuxServiceProvider.overrideWithValue(tmuxService),
+        ],
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.text('Connections').first);
+    await tester.pump();
+    expect(presetLoadStarted, isTrue);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    presetCompleter.complete(null);
+    await tester.pump();
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    verifyNever(() => cliLaunchPreferencesService.getPreferencesForHost(any()));
   });
 
   testWidgets(


### PR DESCRIPTION
## Summary
- prevent late dartssh2 channel writes and forward cleanup from surfacing as fatal crashes
- avoid disposed Riverpod reads while loading connection badge preferences
- make Android foreground-service startup and shared FlutterEngine ownership lifecycle-safe
- pin dartssh2 2.22.1 for the overlapping keepalive fix

## Validation
- flutter analyze
- flutter test
- JDK 17 :app:compilePrivateDebugKotlin