### PR TITLE
fix: clear stale terminal keyboard inset

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -11092,9 +11092,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.inactive) {
+      final shouldRestoreKeyboard = state == AppLifecycleState.paused
+          ? _dismissTerminalKeyboardForAppBackground()
+          : _shouldRestoreTerminalKeyboardAfterTemporaryDismissal;
       _restoreKeyboardAfterAppResume =
-          _restoreKeyboardAfterAppResume ||
-          _shouldRestoreTerminalKeyboardAfterTemporaryDismissal;
+          _restoreKeyboardAfterAppResume || shouldRestoreKeyboard;
       _wasBackgrounded = true;
       _stopSharedClipboardSync();
       _syncTerminalWakeLock();
@@ -11316,6 +11318,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _collapseTmuxBarIfExpanded();
       },
       child: Scaffold(
+        resizeToAvoidBottomInset: !isMobile || systemKeyboardVisible,
         backgroundColor: theme.colorScheme.surface,
         appBar: AppBar(
           titleSpacing: 8,
@@ -11683,6 +11686,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
     _restoreTerminalFocus(forceShowSystemKeyboard: true);
+  }
+
+  bool _dismissTerminalKeyboardForAppBackground() {
+    if (!_isMobilePlatform) {
+      return false;
+    }
+    final wasKeyboardVisible = _terminalTextInputController.isKeyboardVisible;
+    final shouldRestore = wasKeyboardVisible && _terminalFocusNode.hasFocus;
+    unawaited(SystemChannels.textInput.invokeMethod<void>('TextInput.hide'));
+    if (wasKeyboardVisible) {
+      _terminalFocusNode.unfocus();
+    }
+    return shouldRestore;
   }
 
   void _handleKeyboardToolbarKeyPressed() {

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -38,6 +38,7 @@ import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/domain/services/tmux_service.dart';
 import 'package:monkeyssh/presentation/screens/port_forward_browser_screen.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
+import 'package:monkeyssh/presentation/widgets/keyboard_toolbar.dart';
 import 'package:monkeyssh/presentation/widgets/monkey_terminal_view.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_text_input_handler.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
@@ -7569,10 +7570,14 @@ void main() {
         tester.testTextInput.log.clear();
         tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
         await tester.pump();
-        tester.testTextInput.hide();
-        await tester.pump();
 
         expect(tester.testTextInput.isVisible, isFalse);
+        expect(
+          tester.testTextInput.log.where(
+            (call) => call.method == 'TextInput.hide',
+          ),
+          isNotEmpty,
+        );
 
         tester.binding.handleAppLifecycleStateChanged(
           AppLifecycleState.resumed,
@@ -7681,6 +7686,7 @@ void main() {
         expect(tester.testTextInput.isVisible, isFalse);
         expect(find.byTooltip('Show system keyboard'), findsOneWidget);
         expect(find.byTooltip('Hide system keyboard'), findsNothing);
+        expect(tester.getBottomLeft(find.byType(KeyboardToolbar)).dy, 844);
 
         tester.testTextInput.log.clear();
         await tester.tap(find.byTooltip('Show system keyboard'));
@@ -7701,8 +7707,12 @@ void main() {
         await tester.pump();
         expect(find.byTooltip('Hide system keyboard'), findsOneWidget);
         expect(find.byTooltip('Show system keyboard'), findsNothing);
+        expect(tester.getBottomLeft(find.byType(KeyboardToolbar)).dy, 344);
       },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+      variant: const TargetPlatformVariant({
+        TargetPlatform.android,
+        TargetPlatform.iOS,
+      }),
     );
 
     testWidgets(


### PR DESCRIPTION
## Summary
- detach a visible terminal input connection when the app pauses, then restore it on resume
- ignore a stale bottom inset unless the terminal also considers the system keyboard visible
- cover stale inset layout on Android and iOS

## Testing
- flutter analyze
- flutter test test/presentation/screens/terminal_screen_test.dart --name "TerminalScreen mobile IME wiring"
- full pre-commit test suite