### PR TITLE
fix: address new Crashlytics regressions

### DIFF
--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
@@ -31,6 +31,7 @@ class MainActivity : FlutterFragmentActivity() {
     private var hasRequestedNotificationPermission = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        MonkeySshApplication.from(this).ensureSharedFlutterEngine()
         super.onCreate(savedInstanceState)
         SshServiceChannelHandler.attachActivity(this)
         handleTransferIntent(intent)

--- a/lib/domain/services/ssh_error_policy.dart
+++ b/lib/domain/services/ssh_error_policy.dart
@@ -1,12 +1,18 @@
 import 'package:dartssh2/dartssh2.dart';
 
 const _channelUploadLoopFrame = 'SSHChannelController._uploadLoop';
+const _channelCloseFrame = 'SSHChannelController._sendEOFIfNeeded';
 
 /// Whether [error] is a late channel write after the SSH transport closed.
 ///
 /// dartssh2 starts channel upload loops internally without exposing their
 /// futures. A transport disconnect can therefore race a queued write and reach
-/// the platform error handler even though the connection shutdown is expected.
+/// the platform error handler. Closing a channel after the same disconnect can
+/// also try to send EOF over the closed transport. Both are expected teardown.
 bool isExpectedSshChannelTeardownError(Object error, StackTrace stackTrace) =>
     error is SSHStateError &&
-    stackTrace.toString().contains(_channelUploadLoopFrame);
+    (_containsFrame(stackTrace, _channelUploadLoopFrame) ||
+        _containsFrame(stackTrace, _channelCloseFrame));
+
+bool _containsFrame(StackTrace stackTrace, String frame) =>
+    stackTrace.toString().contains(frame);

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -5055,7 +5055,7 @@ while($true){
     final cachedSftp = _sftpClient;
     if (sftpClient != null) {
       if (cachedSftp == null) {
-        unawaited(sftpClient.close());
+        _closeSftpClientBestEffort(sftpClient);
         return;
       }
       if (!identical(sftpClient, cachedSftp)) {
@@ -5065,8 +5065,33 @@ while($true){
     _sftpClient = null;
     _sftpClientFuture = null;
     if (cachedSftp != null) {
-      unawaited(cachedSftp.close());
+      _closeSftpClientBestEffort(cachedSftp);
     }
+  }
+
+  void _closeSftpClientBestEffort(SftpClient sftpClient) {
+    unawaited(
+      sftpClient.close().then<void>(
+        (_) {},
+        onError: (Object error, StackTrace _) {
+          DiagnosticsLogService.instance.warning(
+            'ssh.sftp',
+            'close_failed',
+            fields: {
+              'connectionId': connectionId,
+              'hostId': hostId,
+              'errorType': error.runtimeType,
+            },
+          );
+          if (error is SSHError) {
+            _reportConnectionHealthFailureIfClosed(
+              error,
+              operation: 'sftp_close',
+            );
+          }
+        },
+      ),
+    );
   }
 
   Future<SftpClient> _openSftpClient() async {
@@ -5462,9 +5487,9 @@ while($true){
       }
     } finally {
       try {
-        await forward?.sink.close();
-      } on Exception catch (_) {
-        // Ignore errors during cleanup.
+        forward?.destroy();
+      } on SSHError catch (_) {
+        // The transport may already be closed during channel teardown.
       }
       try {
         socket.destroy();
@@ -5575,9 +5600,9 @@ while($true){
           }
         } finally {
           try {
-            await channel.sink.close();
-          } on Exception catch (_) {
-            // Ignore cleanup errors.
+            channel.destroy();
+          } on SSHError catch (_) {
+            // The transport may already be closed during channel teardown.
           }
           try {
             socket?.destroy();

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -10203,6 +10203,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       switch (action) {
         case TmuxSwitchWindowAction(:final windowIndex):
           await _switchTmuxWindow(session, windowIndex);
+          if (!mounted) return;
           unawaited(
             ref
                 .read(telemetryServiceProvider)
@@ -10212,6 +10213,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           );
         case TmuxNewWindowAction(:final command, :final windowName):
           await _createTmuxWindow(session, command: command, name: windowName);
+          if (!mounted) return;
           unawaited(
             ref
                 .read(telemetryServiceProvider)
@@ -10229,6 +10231,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             command: resumeCommand,
             workingDirectory: workingDirectory,
           );
+          if (!mounted) return;
           final tool = agentLaunchToolForCommandText(resumeCommand);
           unawaited(
             ref
@@ -10535,12 +10538,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         session,
         refreshVisibleTerminal: true,
       );
+      if (!mounted) return;
     }
     await backend.createWindow(
       command: command,
       name: name,
       workingDirectory: resolvedWorkingDirectory,
     );
+    if (!mounted) return;
     final tool = agentLaunchToolForCommandText(command);
     if (tool != null) {
       unawaited(

--- a/test/domain/services/ssh_error_policy_test.dart
+++ b/test/domain/services/ssh_error_policy_test.dart
@@ -28,4 +28,20 @@ void main() {
       isFalse,
     );
   });
+
+  test('recognizes channel EOF writes after the transport closes', () {
+    final stackTrace = StackTrace.fromString(
+      '#0 SSHTransport.sendPacket\n'
+      '#1 SSHChannelController._sendEOFIfNeeded\n'
+      '#2 SSHChannelController.close\n',
+    );
+
+    expect(
+      isExpectedSshChannelTeardownError(
+        SSHStateError('Transport is closed'),
+        stackTrace,
+      ),
+      isTrue,
+    );
+  });
 }

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -493,6 +493,7 @@ class _SingleCloseForwardChannel implements SSHForwardChannel {
 
   final _streamController = StreamController<Uint8List>();
   final _sinkController = StreamController<List<int>>.broadcast();
+  int destroyCalls = 0;
 
   @override
   // ignore: close_sinks
@@ -500,6 +501,8 @@ class _SingleCloseForwardChannel implements SSHForwardChannel {
 
   @override
   Stream<Uint8List> get stream => _streamController.stream;
+
+  Future<void> closeIncoming() => _streamController.close();
 
   @override
   Future<void> close() async {
@@ -519,7 +522,10 @@ class _SingleCloseForwardChannel implements SSHForwardChannel {
 
   @override
   void destroy() {
-    unawaited(close());
+    destroyCalls++;
+    if (!_streamController.isClosed) {
+      unawaited(_streamController.close());
+    }
   }
 }
 
@@ -3127,6 +3133,32 @@ LISTEN ::1:4201
       verify(sftp.close).called(1);
     });
 
+    test('discarding SFTP consumes close errors after disconnect', () async {
+      final client = _MockSshClient();
+      final sftp = _MockSftpClient();
+      final session = SshSession(
+        connectionId: 11,
+        hostId: 2,
+        client: client,
+        config: const SshConnectionConfig(
+          hostname: 'example.com',
+          port: 22,
+          username: 'tester',
+        ),
+      );
+
+      when(client.sftp).thenAnswer((_) async => sftp);
+      when(sftp.close).thenAnswer(
+        (_) => Future<void>.error(SSHStateError('Transport is closed')),
+      );
+
+      final opened = await session.sftp();
+      session.discardSftpClient(opened);
+      await pumpEventQueue();
+
+      verify(sftp.close).called(1);
+    });
+
     test('does not retry non-transient SFTP channel open failures', () async {
       final client = _MockSshClient();
       final session = SshSession(
@@ -4595,55 +4627,124 @@ LISTEN ::1:4201
       },
     );
 
-    test('local forward cleanup closes the SSH sink exactly once', () async {
-      final client = _MockSshClient();
-      final forward = _SingleCloseForwardChannel();
-      final session = SshSession(
-        connectionId: 1,
-        hostId: 42,
-        client: client,
-        config: const SshConnectionConfig(
-          hostname: 'host.example.com',
-          port: 22,
-          username: 'tester',
-        ),
-      );
-      final localPort = await _unusedLoopbackPort();
-      when(
-        () => client.forwardLocal('remote.example.com', 80),
-      ).thenAnswer((_) async => forward);
+    test(
+      'local forward cleanup destroys the channel without closing its sink',
+      () async {
+        final client = _MockSshClient();
+        final forward = _SingleCloseForwardChannel();
+        final session = SshSession(
+          connectionId: 1,
+          hostId: 42,
+          client: client,
+          config: const SshConnectionConfig(
+            hostname: 'host.example.com',
+            port: 22,
+            username: 'tester',
+          ),
+        );
+        final localPort = await _unusedLoopbackPort();
+        when(
+          () => client.forwardLocal('remote.example.com', 80),
+        ).thenAnswer((_) async => forward);
 
-      addTearDown(() async {
-        await session.stopAllForwards();
-        await forward.close();
-      });
+        addTearDown(() async {
+          await session.stopAllForwards();
+          await forward.close();
+        });
 
-      expect(
-        await session.startLocalForward(
-          portForwardId: 1,
-          localHost: InternetAddress.loopbackIPv4.address,
-          localPort: localPort,
-          remoteHost: 'remote.example.com',
-          remotePort: 80,
-        ),
-        isTrue,
-      );
+        expect(
+          await session.startLocalForward(
+            portForwardId: 1,
+            localHost: InternetAddress.loopbackIPv4.address,
+            localPort: localPort,
+            remoteHost: 'remote.example.com',
+            remotePort: 80,
+          ),
+          isTrue,
+        );
 
-      final socket = await Socket.connect(
-        InternetAddress.loopbackIPv4,
-        localPort,
-      );
-      await socket.close();
-      // The socket close travels through the real loopback listener, so the
-      // cleanup is not guaranteed to have run after a fixed number of event
-      // loop turns; a loaded machine reliably fails that assumption. Wait for
-      // the first close, then let the queue settle so a duplicate close would
-      // still be counted before asserting it happened exactly once.
-      await _waitForCondition(() => forward.sink.closeAttempts >= 1);
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+        final socket = await Socket.connect(
+          InternetAddress.loopbackIPv4,
+          localPort,
+        );
+        await socket.close();
+        await _waitForCondition(() => forward.destroyCalls >= 1);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
 
-      expect(forward.sink.closeAttempts, 1);
-    });
+        expect(forward.sink.closeAttempts, 0);
+        expect(forward.destroyCalls, 1);
+      },
+    );
+
+    test(
+      'remote forward cleanup destroys the channel without closing its sink',
+      () async {
+        final client = _MockSshClient();
+        final remoteForward = _MockRemoteForward();
+        final connections = StreamController<SSHForwardChannel>();
+        final forward = _SingleCloseForwardChannel();
+        final targetServer = await ServerSocket.bind(
+          InternetAddress.loopbackIPv4,
+          0,
+        );
+        final acceptedSocket = Completer<Socket>();
+        final targetSubscription = targetServer.listen((socket) {
+          if (!acceptedSocket.isCompleted) {
+            acceptedSocket.complete(socket);
+          }
+        });
+        final session = SshSession(
+          connectionId: 1,
+          hostId: 42,
+          client: client,
+          config: const SshConnectionConfig(
+            hostname: 'host.example.com',
+            port: 22,
+            username: 'tester',
+          ),
+        );
+
+        when(() => remoteForward.host).thenReturn('127.0.0.1');
+        when(() => remoteForward.port).thenReturn(8022);
+        when(
+          () => remoteForward.connections,
+        ).thenAnswer((_) => connections.stream);
+        when(remoteForward.close).thenReturn(null);
+        when(
+          () => client.forwardRemote(host: '127.0.0.1', port: 8022),
+        ).thenAnswer((_) async => remoteForward);
+
+        addTearDown(() async {
+          await session.stopAllForwards();
+          await connections.close();
+          await targetSubscription.cancel();
+          await targetServer.close();
+          if (acceptedSocket.isCompleted) {
+            (await acceptedSocket.future).destroy();
+          }
+          await forward.close();
+        });
+
+        expect(
+          await session.startRemoteForward(
+            portForwardId: 1,
+            remoteHost: '127.0.0.1',
+            remotePort: 8022,
+            localHost: InternetAddress.loopbackIPv4.address,
+            localPort: targetServer.port,
+          ),
+          isTrue,
+        );
+
+        connections.add(forward);
+        await acceptedSocket.future;
+        await forward.closeIncoming();
+        await _waitForCondition(() => forward.destroyCalls >= 1);
+
+        expect(forward.sink.closeAttempts, 0);
+        expect(forward.destroyCalls, 1);
+      },
+    );
 
     test(
       'removes stale sessions when remote forwards report a closed transport',

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -6547,6 +6547,52 @@ void main() {
     );
 
     testWidgets(
+      'new window completion after disposal does not read providers',
+      (tester) async {
+        final tmuxService = _MockTmuxService();
+        final createWindowCompleter = Completer<void>();
+        await pumpTmuxScreen(tester, tmuxService);
+        when(
+          () => tmuxService.createWindow(
+            session,
+            'work',
+            command: any(named: 'command'),
+            name: any(named: 'name'),
+            workingDirectory: any(named: 'workingDirectory'),
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).thenAnswer((_) => createWindowCompleter.future);
+
+        await tester.tap(find.byKey(const ValueKey('tmux-handle-bar')));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+        await tester.tap(find.text('New Window'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Empty window'));
+        await tester.pump();
+
+        verify(
+          () => tmuxService.createWindow(
+            session,
+            'work',
+            command: any(named: 'command'),
+            name: any(named: 'name'),
+            workingDirectory: any(named: 'workingDirectory'),
+            extraFlags: any(named: 'extraFlags'),
+          ),
+        ).called(1);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        createWindowCompleter.complete();
+        await tester.pump();
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
       'uses a collapsible tmux sidebar on wide terminal layouts',
       (tester) async {
         await tester.binding.setSurfaceSize(const Size(1100, 800));


### PR DESCRIPTION
## Summary
- restore the shared FlutterEngine before restored Flutter fragments attach
- make local, remote, and SFTP teardown safe after the SSH transport closes
- stop tmux window actions from reading Riverpod providers after disposal
- cover each post-merge Crashlytics path with regression tests

## Validation
- flutter analyze
- flutter test
- JDK 17 :app:compilePrivateDebugKotlin