### PR TITLE
feat: allow cancelling an in-progress connection

### DIFF
--- a/integration_test/legacy_credentials_connection_setup_test.dart
+++ b/integration_test/legacy_credentials_connection_setup_test.dart
@@ -24,6 +24,7 @@ class _CapturingSshService extends SshService {
     SshConnectionConfig config, {
     ConnectionProgressCallback? onProgress,
     bool isJumpHost = false,
+    SshConnectionCancellationToken? cancellationToken,
   }) async {
     capturedConfig = config;
     return const SshConnectionResult(success: false, error: 'stubbed');

--- a/integration_test/settings_import_connection_cleanup_test.dart
+++ b/integration_test/settings_import_connection_cleanup_test.dart
@@ -48,6 +48,7 @@ class _FakeActiveSessionsSshService extends SshService {
     int hostId, {
     ConnectionProgressCallback? onProgress,
     bool useHostThemeOverrides = true,
+    SshConnectionCancellationToken? cancellationToken,
   }) async {
     final connectionId = _nextConnectionId++;
     final client = _MockSshClient();

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -7022,8 +7022,8 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
   final Map<int, int> _connectionHostIds = {};
   final Map<int, String> _connectionSessionTitles = {};
   final Map<int, ConnectionAttemptStatus> _connectionAttempts = {};
-  final Map<int, SshConnectionCancellationToken> _connectionCancellationTokens =
-      {};
+  final Map<int, Set<SshConnectionCancellationToken>>
+  _connectionCancellationTokens = {};
   final Map<int, StreamSubscription<void>> _disconnectSubscriptions = {};
   final Map<int, StreamSubscription<_SshConnectionHealthFailure>>
   _connectionHealthFailureSubscriptions = {};
@@ -7076,10 +7076,70 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
   }
 
   /// Connect to a host.
+  ///
+  /// The cancellation token is registered before any `await` so a cancel
+  /// request that arrives while the attempt is still warming up is honored,
+  /// and it is torn down again once the attempt settles.
   Future<SshConnectionResult> connect(
     int hostId, {
     bool forceNew = false,
     bool useHostThemeOverrides = true,
+  }) async {
+    final cancellationToken = SshConnectionCancellationToken();
+    _connectionCancellationTokens
+        .putIfAbsent(hostId, () => <SshConnectionCancellationToken>{})
+        .add(cancellationToken);
+
+    final SshConnectionResult result;
+    try {
+      result = await _runConnectAttempt(
+        hostId,
+        forceNew: forceNew,
+        useHostThemeOverrides: useHostThemeOverrides,
+        cancellationToken: cancellationToken,
+      );
+    } finally {
+      final tokens = _connectionCancellationTokens[hostId];
+      if (tokens != null) {
+        tokens.remove(cancellationToken);
+        if (tokens.isEmpty) {
+          _connectionCancellationTokens.remove(hostId);
+        }
+      }
+    }
+
+    if (!cancellationToken.isCancelled || result.cancelled) {
+      return result;
+    }
+
+    // The attempt raced past cancellation (for example it was reusing an
+    // existing session, or it finished while the request was in flight).
+    // Honor the user's intent instead of handing back a live connection.
+    final connectionId = result.connectionId;
+    if (result.success && connectionId != null && !result.reusedConnection) {
+      await disconnect(connectionId);
+    }
+    _updateConnectionAttempt(
+      hostId,
+      const ConnectionProgressUpdate(
+        state: SshConnectionState.error,
+        message: 'Connection cancelled',
+      ),
+      cancelled: true,
+    );
+    DiagnosticsLogService.instance.info(
+      'ssh.active',
+      'connect_cancelled',
+      fields: {'hostId': hostId, 'phase': 'post_attempt'},
+    );
+    return const SshConnectionResult.userCancelled();
+  }
+
+  Future<SshConnectionResult> _runConnectAttempt(
+    int hostId, {
+    required bool forceNew,
+    required bool useHostThemeOverrides,
+    required SshConnectionCancellationToken cancellationToken,
   }) async {
     final telemetry = ref.read(telemetryServiceProvider);
     final host = await _telemetryHostForConnection(hostId);
@@ -7124,21 +7184,12 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
       cancelRequested: false,
     );
 
-    final cancellationToken = SshConnectionCancellationToken();
-    _connectionCancellationTokens[hostId] = cancellationToken;
-    final SshConnectionResult result;
-    try {
-      result = await _sshService.connectToHost(
-        hostId,
-        onProgress: (update) => _updateConnectionAttempt(hostId, update),
-        useHostThemeOverrides: useHostThemeOverrides,
-        cancellationToken: cancellationToken,
-      );
-    } finally {
-      if (identical(_connectionCancellationTokens[hostId], cancellationToken)) {
-        _connectionCancellationTokens.remove(hostId);
-      }
-    }
+    final result = await _sshService.connectToHost(
+      hostId,
+      onProgress: (update) => _updateConnectionAttempt(hostId, update),
+      useHostThemeOverrides: useHostThemeOverrides,
+      cancellationToken: cancellationToken,
+    );
 
     if (result.cancelled) {
       _updateConnectionAttempt(
@@ -8090,19 +8141,23 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
     state = {...state};
   }
 
-  /// Abandon the in-flight connection attempt for [hostId].
+  /// Abandon the in-flight connection attempt(s) for [hostId].
   ///
-  /// Returns `true` when a cancellable attempt was found. The attempt future
-  /// resolves with a cancelled [SshConnectionResult] shortly afterwards.
+  /// Returns `true` when at least one cancellable attempt was found. Every
+  /// concurrent attempt for the host is cancelled, and each resolves with a
+  /// cancelled [SshConnectionResult] shortly afterwards.
   bool cancelConnectionAttempt(int hostId) {
-    final token = _connectionCancellationTokens[hostId];
-    if (token == null || token.isCancelled) {
+    final tokens = _connectionCancellationTokens[hostId];
+    final cancellable =
+        tokens?.where((token) => !token.isCancelled).toList(growable: false) ??
+        const <SshConnectionCancellationToken>[];
+    if (cancellable.isEmpty) {
       return false;
     }
     DiagnosticsLogService.instance.info(
       'ssh.active',
       'attempt_cancel_requested',
-      fields: {'hostId': hostId},
+      fields: {'hostId': hostId, 'attemptCount': cancellable.length},
     );
     final existing = _connectionAttempts[hostId];
     _updateConnectionAttempt(
@@ -8113,15 +8168,18 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
       ),
       cancelRequested: true,
     );
-    token.cancel();
+    for (final token in cancellable) {
+      token.cancel();
+    }
     return true;
   }
 
   /// Whether [hostId] currently has a cancellable connection attempt.
-  bool canCancelConnectionAttempt(int hostId) {
-    final token = _connectionCancellationTokens[hostId];
-    return token != null && !token.isCancelled;
-  }
+  bool canCancelConnectionAttempt(int hostId) =>
+      _connectionCancellationTokens[hostId]?.any(
+        (token) => !token.isCancelled,
+      ) ??
+      false;
 
   /// Surface an unexpected connection failure in the shared attempt state.
   void reportConnectionAttemptError(int hostId, String message) {

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -1248,11 +1248,24 @@ class SshConnectionResult {
     this.client,
     this.connectionId,
     this.reusedConnection = false,
+    this.cancelled = false,
     this.dependentClients = const <SSHClient>[],
   });
 
+  /// A result describing a connection attempt the user cancelled.
+  const SshConnectionResult.userCancelled({this.error = 'Connection cancelled'})
+    : success = false,
+      client = null,
+      connectionId = null,
+      reusedConnection = false,
+      cancelled = true,
+      dependentClients = const <SSHClient>[];
+
   /// Whether connection was successful.
   final bool success;
+
+  /// Whether the attempt stopped because the user cancelled it.
+  final bool cancelled;
 
   /// Error message if connection failed.
   final String? error;
@@ -1275,6 +1288,109 @@ class SshConnectionResult {
     for (final dependentClient in dependentClients) {
       dependentClient.close();
     }
+  }
+}
+
+/// Thrown when an in-flight SSH connection attempt is cancelled by the user.
+class SshConnectionCancelledException implements Exception {
+  /// Creates an [SshConnectionCancelledException].
+  const SshConnectionCancelledException([
+    this.message = 'Connection cancelled',
+  ]);
+
+  /// Human-readable description of the cancellation.
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// Cooperative cancellation signal for a single SSH connection attempt.
+///
+/// A token is single-use: once [cancel] is called it stays cancelled. Long
+/// waits inside [SshService.connect] race against [cancelled] so a stalled
+/// attempt can be abandoned immediately instead of waiting for its timeout.
+class SshConnectionCancellationToken {
+  final Completer<void> _cancelled = Completer<void>();
+
+  /// Whether cancellation has been requested.
+  bool get isCancelled => _cancelled.isCompleted;
+
+  /// Completes as soon as cancellation is requested.
+  Future<void> get cancelled => _cancelled.future;
+
+  /// Requests cancellation of the associated connection attempt.
+  void cancel() {
+    if (!_cancelled.isCompleted) {
+      _cancelled.complete();
+    }
+  }
+
+  /// Throws [SshConnectionCancelledException] when already cancelled.
+  void throwIfCancelled() {
+    if (isCancelled) {
+      throw const SshConnectionCancelledException();
+    }
+  }
+
+  /// Completes with [operation] unless cancellation happens first.
+  ///
+  /// When cancellation wins the race the returned future fails with
+  /// [SshConnectionCancelledException] and [onAbandonedValue] is invoked with
+  /// the late result (if any) so orphaned sockets and clients can be closed.
+  Future<T> guard<T>(
+    Future<T> operation, {
+    void Function(T value)? onAbandonedValue,
+  }) {
+    void abandon(T value) {
+      if (onAbandonedValue == null) {
+        return;
+      }
+      try {
+        onAbandonedValue(value);
+      } on Exception catch (error) {
+        DiagnosticsLogService.instance.debug(
+          'ssh.connect',
+          'cancel_cleanup_failed',
+          fields: {'errorType': error.runtimeType},
+        );
+      }
+    }
+
+    if (isCancelled) {
+      unawaited(operation.then(abandon, onError: (Object _, StackTrace _) {}));
+      return Future<T>.error(
+        const SshConnectionCancelledException(),
+        StackTrace.current,
+      );
+    }
+
+    final completer = Completer<T>();
+    operation.then(
+      (value) {
+        if (completer.isCompleted) {
+          abandon(value);
+          return;
+        }
+        completer.complete(value);
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        if (!completer.isCompleted) {
+          completer.completeError(error, stackTrace);
+        }
+      },
+    );
+    unawaited(
+      cancelled.then((_) {
+        if (!completer.isCompleted) {
+          completer.completeError(
+            const SshConnectionCancelledException(),
+            StackTrace.current,
+          );
+        }
+      }),
+    );
+    return completer.future;
   }
 }
 
@@ -1337,6 +1453,8 @@ class ConnectionAttemptStatus {
     required this.state,
     required this.latestMessage,
     required this.logLines,
+    this.cancelRequested = false,
+    this.cancelled = false,
   });
 
   /// The host currently being connected.
@@ -1350,6 +1468,15 @@ class ConnectionAttemptStatus {
 
   /// Rolling log of recent connection progress messages.
   final List<String> logLines;
+
+  /// Whether the user asked to abandon this attempt.
+  final bool cancelRequested;
+
+  /// Whether the attempt finished because the user cancelled it.
+  final bool cancelled;
+
+  /// Whether a cancellation request is still being wound down.
+  bool get isCancelling => cancelRequested && !cancelled && isInProgress;
 
   /// Whether the connection attempt is still actively progressing.
   bool get isInProgress =>
@@ -1452,6 +1579,7 @@ class SshService {
     int hostId, {
     ConnectionProgressCallback? onProgress,
     bool useHostThemeOverrides = true,
+    SshConnectionCancellationToken? cancellationToken,
   }) async {
     var preflightPhase = 'start';
     DiagnosticsLogService.instance.info(
@@ -1460,6 +1588,7 @@ class SshService {
       fields: {'hostId': hostId},
     );
     try {
+      cancellationToken?.throwIfCancelled();
       if (hostRepository == null) {
         DiagnosticsLogService.instance.warning(
           'ssh.connect',
@@ -1501,6 +1630,7 @@ class SshService {
           host,
           useHostThemeOverrides: useHostThemeOverrides,
           onProgress: onProgress,
+          cancellationToken: cancellationToken,
         );
       }
 
@@ -1627,9 +1757,25 @@ class SshService {
       );
 
       preflightPhase = 'connect';
-      final result = await connect(config, onProgress: onProgress);
+      cancellationToken?.throwIfCancelled();
+      final result = await connect(
+        config,
+        onProgress: onProgress,
+        cancellationToken: cancellationToken,
+      );
 
       if (result.success && result.client != null) {
+        if (cancellationToken?.isCancelled ?? false) {
+          // The user cancelled while the handshake was completing; drop the
+          // freshly established clients instead of registering a session.
+          await result.closeAll();
+          DiagnosticsLogService.instance.info(
+            'ssh.connect',
+            'connect_to_host_cancelled',
+            fields: {'hostId': hostId, 'phase': 'post_connect'},
+          );
+          return const SshConnectionResult.userCancelled();
+        }
         final connectionId = _nextConnectionId++;
         _sessions[connectionId] = SshSession(
           connectionId: connectionId,
@@ -1675,6 +1821,13 @@ class SshService {
         },
       );
       return result;
+    } on SshConnectionCancelledException {
+      DiagnosticsLogService.instance.info(
+        'ssh.connect',
+        'connect_to_host_cancelled',
+        fields: {'hostId': hostId, 'phase': preflightPhase},
+      );
+      return const SshConnectionResult.userCancelled();
     } on Exception catch (e) {
       DiagnosticsLogService.instance.warning(
         'ssh.connect',
@@ -1697,6 +1850,7 @@ class SshService {
     Host host, {
     required bool useHostThemeOverrides,
     ConnectionProgressCallback? onProgress,
+    SshConnectionCancellationToken? cancellationToken,
   }) async {
     onProgress?.call(
       const ConnectionProgressUpdate(
@@ -1705,6 +1859,9 @@ class SshService {
       ),
     );
     await Future<void>.delayed(const Duration(milliseconds: 120));
+    if (cancellationToken?.isCancelled ?? false) {
+      return const SshConnectionResult.userCancelled();
+    }
     onProgress?.call(
       const ConnectionProgressUpdate(
         state: SshConnectionState.authenticating,
@@ -1712,6 +1869,9 @@ class SshService {
       ),
     );
     await Future<void>.delayed(const Duration(milliseconds: 120));
+    if (cancellationToken?.isCancelled ?? false) {
+      return const SshConnectionResult.userCancelled();
+    }
 
     final config = SshConnectionConfig.fromHost(host);
     final client = _AppReviewDemoSshClient(host);
@@ -1742,10 +1902,15 @@ class SshService {
   }
 
   /// Connect with a configuration.
+  ///
+  /// Pass a [cancellationToken] to allow the caller to abandon a stalled
+  /// attempt; every long wait races the token so cancellation takes effect
+  /// immediately instead of after [SshConnectionConfig.connectionTimeout].
   Future<SshConnectionResult> connect(
     SshConnectionConfig config, {
     ConnectionProgressCallback? onProgress,
     bool isJumpHost = false,
+    SshConnectionCancellationToken? cancellationToken,
   }) async {
     SSHClient? client;
     final dependentClients = <SSHClient>[];
@@ -1761,7 +1926,18 @@ class SshService {
       );
     }
 
+    Future<T> guard<T>(
+      Future<T> operation, {
+      void Function(T value)? onAbandonedValue,
+    }) =>
+        cancellationToken?.guard(
+          operation,
+          onAbandonedValue: onAbandonedValue,
+        ) ??
+        operation;
+
     try {
+      cancellationToken?.throwIfCancelled();
       DiagnosticsLogService.instance.info(
         'ssh.connect',
         'connect_start',
@@ -1786,8 +1962,12 @@ class SshService {
           config.jumpHost!,
           onProgress: onProgress,
           isJumpHost: true,
+          cancellationToken: cancellationToken,
         );
         if (!jumpResult.success || jumpResult.client == null) {
+          if (jumpResult.cancelled) {
+            throw const SshConnectionCancelledException();
+          }
           return SshConnectionResult(
             success: false,
             error: 'Failed to connect to jump host: ${jumpResult.error}',
@@ -1799,7 +1979,7 @@ class SshService {
         jumpClient = jumpResult.client;
       }
 
-      Future<SSHSocket> openEndpointSocket() async {
+      Future<SSHSocket> openEndpointSocket() {
         if (jumpClient != null) {
           // Create forwarded connection through jump host.
           // SSHForwardChannel implements SSHSocket.
@@ -1807,7 +1987,10 @@ class SshService {
             SshConnectionState.connecting,
             'Opening tunnel to destination…',
           );
-          return jumpClient.forwardLocal(config.hostname, config.port);
+          return guard(
+            jumpClient.forwardLocal(config.hostname, config.port),
+            onAbandonedValue: _closeAbandonedSocket,
+          );
         }
 
         report(
@@ -1816,17 +1999,19 @@ class SshService {
               ? 'Opening jump host connection…'
               : 'Opening network connection…',
         );
-        return _socketConnector(
-          config.hostname,
-          config.port,
-          timeout: config.connectionTimeout,
+        return guard(
+          _socketConnector(
+            config.hostname,
+            config.port,
+            timeout: config.connectionTimeout,
+          ),
+          onAbandonedValue: _closeAbandonedSocket,
         );
       }
 
       final knownHosts = knownHostsRepository!;
-      final trustedHost = await knownHosts.getByHost(
-        config.hostname,
-        config.port,
+      final trustedHost = await guard(
+        knownHosts.getByHost(config.hostname, config.port),
       );
 
       if (trustedHost == null) {
@@ -1837,9 +2022,10 @@ class SshService {
         final presentedHostKey = await _probeHostKey(
           await openEndpointSocket(),
           config: config,
+          cancellationToken: cancellationToken,
         );
-        final pendingHostTrustUpdate = await verificationService.verify(
-          presentedHostKey,
+        final pendingHostTrustUpdate = await guard(
+          verificationService.verify(presentedHostKey),
         );
         await pendingHostTrustUpdate.persistTrustDecision(knownHosts);
 
@@ -1874,6 +2060,7 @@ class SshService {
           authGate,
           timeout: config.connectionTimeout,
           isJumpHost: isJumpHost,
+          cancellationToken: cancellationToken,
         );
         report(
           SshConnectionState.connected,
@@ -1928,6 +2115,7 @@ class SshService {
           authGate,
           timeout: config.connectionTimeout,
           isJumpHost: isJumpHost,
+          cancellationToken: cancellationToken,
         );
       } on SSHHostkeyError {
         if (!rejectedTrustedHostKey) {
@@ -1945,14 +2133,15 @@ class SshService {
           preparedSocket.hostKeySource,
           config: config,
           keyType: callbackKeyType,
+          cancellationToken: cancellationToken,
         );
         _confirmCapturedHostKeyMatchesCallback(
           changedHostKey,
           rejectedCallbackFingerprint,
           config: config,
         );
-        final pendingHostTrustUpdate = await verificationService.verify(
-          changedHostKey,
+        final pendingHostTrustUpdate = await guard(
+          verificationService.verify(changedHostKey),
         );
 
         final retrySocket = await openEndpointSocket();
@@ -1983,6 +2172,7 @@ class SshService {
           authGate,
           timeout: config.connectionTimeout,
           isJumpHost: isJumpHost,
+          cancellationToken: cancellationToken,
         );
         report(
           SshConnectionState.connected,
@@ -2024,6 +2214,15 @@ class SshService {
         client: client,
         dependentClients: dependentClients,
       );
+    } on SshConnectionCancelledException {
+      DiagnosticsLogService.instance.info(
+        'ssh.connect',
+        'connect_cancelled',
+        fields: {'isJumpHost': isJumpHost},
+      );
+      client?.close();
+      _closeClients(dependentClients);
+      return const SshConnectionResult.userCancelled();
     } on HostKeyVerificationException catch (e) {
       DiagnosticsLogService.instance.warning(
         'ssh.connect',
@@ -2237,6 +2436,7 @@ class SshService {
     _InteractiveAuthGate gate, {
     required Duration timeout,
     required bool isJumpHost,
+    SshConnectionCancellationToken? cancellationToken,
   }) {
     final completer = Completer<void>();
     Timer? timer;
@@ -2273,6 +2473,19 @@ class SshService {
       },
     );
 
+    if (cancellationToken != null) {
+      unawaited(
+        cancellationToken.cancelled.then((_) {
+          if (!completer.isCompleted) {
+            completer.completeError(
+              const SshConnectionCancelledException(),
+              StackTrace.current,
+            );
+          }
+        }),
+      );
+    }
+
     gate.onActivityChanged = arm;
     arm();
 
@@ -2282,6 +2495,10 @@ class SshService {
         gate.onActivityChanged = null;
       }
     });
+  }
+
+  static void _closeAbandonedSocket(SSHSocket socket) {
+    socket.destroy();
   }
 
   HostKeyVerificationService _createHostKeyVerificationService(
@@ -2304,6 +2521,7 @@ class SshService {
   Future<VerifiedHostKey> _probeHostKey(
     SSHSocket socket, {
     required SshConnectionConfig config,
+    SshConnectionCancellationToken? cancellationToken,
   }) async {
     final verificationSocket = _prepareHostKeyCapture(socket);
     SSHClient? probeClient;
@@ -2329,6 +2547,7 @@ class SshService {
         verificationSocket.hostKeySource,
         config: config,
         keyType: callbackKeyType,
+        cancellationToken: cancellationToken,
       );
       _confirmCapturedHostKeyMatchesCallback(
         presentedHostKey,
@@ -2373,14 +2592,17 @@ class SshService {
     HostKeySource hostKeySource, {
     required SshConnectionConfig config,
     required String? keyType,
+    SshConnectionCancellationToken? cancellationToken,
   }) async {
-    final hostKeyBytes = await hostKeySource.hostKeyBytes.timeout(
+    final readHostKeyBytes = hostKeySource.hostKeyBytes.timeout(
       config.connectionTimeout,
       onTimeout: () => throw HostKeyVerificationException(
         'Timed out while reading the host key for '
         '${config.hostname}:${config.port}.',
       ),
     );
+    final hostKeyBytes =
+        await (cancellationToken?.guard(readHostKeyBytes) ?? readHostKeyBytes);
     return VerifiedHostKey(
       hostname: config.hostname,
       port: config.port,
@@ -6800,6 +7022,8 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
   final Map<int, int> _connectionHostIds = {};
   final Map<int, String> _connectionSessionTitles = {};
   final Map<int, ConnectionAttemptStatus> _connectionAttempts = {};
+  final Map<int, SshConnectionCancellationToken> _connectionCancellationTokens =
+      {};
   final Map<int, StreamSubscription<void>> _disconnectSubscriptions = {};
   final Map<int, StreamSubscription<_SshConnectionHealthFailure>>
   _connectionHealthFailureSubscriptions = {};
@@ -6847,6 +7071,7 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
     _connectionHostIds.clear();
     _connectionSessionTitles.clear();
     _connectionAttempts.clear();
+    _connectionCancellationTokens.clear();
     return {};
   }
 
@@ -6896,13 +7121,49 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
         message: 'Preparing connection…',
       ),
       resetLog: true,
+      cancelRequested: false,
     );
 
-    final result = await _sshService.connectToHost(
-      hostId,
-      onProgress: (update) => _updateConnectionAttempt(hostId, update),
-      useHostThemeOverrides: useHostThemeOverrides,
-    );
+    final cancellationToken = SshConnectionCancellationToken();
+    _connectionCancellationTokens[hostId] = cancellationToken;
+    final SshConnectionResult result;
+    try {
+      result = await _sshService.connectToHost(
+        hostId,
+        onProgress: (update) => _updateConnectionAttempt(hostId, update),
+        useHostThemeOverrides: useHostThemeOverrides,
+        cancellationToken: cancellationToken,
+      );
+    } finally {
+      if (identical(_connectionCancellationTokens[hostId], cancellationToken)) {
+        _connectionCancellationTokens.remove(hostId);
+      }
+    }
+
+    if (result.cancelled) {
+      _updateConnectionAttempt(
+        hostId,
+        ConnectionProgressUpdate(
+          state: SshConnectionState.error,
+          message: result.error ?? 'Connection cancelled',
+        ),
+        cancelled: true,
+      );
+      unawaited(
+        telemetry.logConnectionFailed(
+          authMethod: _telemetryAuthMethodFromHost(host),
+          usesJumpHost: host?.jumpHostId != null,
+          duration: DateTime.now().difference(startedAt),
+          failureCategory: 'cancelled',
+        ),
+      );
+      DiagnosticsLogService.instance.info(
+        'ssh.active',
+        'connect_cancelled',
+        fields: {'hostId': hostId},
+      );
+      return result;
+    }
 
     if (result.success && result.connectionId != null) {
       final connectionId = result.connectionId!;
@@ -7800,6 +8061,8 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
     int hostId,
     ConnectionProgressUpdate update, {
     bool resetLog = false,
+    bool? cancelRequested,
+    bool cancelled = false,
   }) {
     final existing = resetLog ? null : _connectionAttempts[hostId];
     final nextLogLines = <String>[if (existing != null) ...existing.logLines];
@@ -7815,6 +8078,9 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
       state: update.state,
       latestMessage: update.message,
       logLines: List.unmodifiable(nextLogLines),
+      cancelRequested:
+          cancelRequested ?? (existing?.cancelRequested ?? false) || cancelled,
+      cancelled: cancelled,
     );
     DiagnosticsLogService.instance.info(
       'ssh.active',
@@ -7822,6 +8088,39 @@ class ActiveSessionsNotifier extends Notifier<Map<int, SshConnectionState>> {
       fields: {'hostId': hostId, 'state': update.state},
     );
     state = {...state};
+  }
+
+  /// Abandon the in-flight connection attempt for [hostId].
+  ///
+  /// Returns `true` when a cancellable attempt was found. The attempt future
+  /// resolves with a cancelled [SshConnectionResult] shortly afterwards.
+  bool cancelConnectionAttempt(int hostId) {
+    final token = _connectionCancellationTokens[hostId];
+    if (token == null || token.isCancelled) {
+      return false;
+    }
+    DiagnosticsLogService.instance.info(
+      'ssh.active',
+      'attempt_cancel_requested',
+      fields: {'hostId': hostId},
+    );
+    final existing = _connectionAttempts[hostId];
+    _updateConnectionAttempt(
+      hostId,
+      ConnectionProgressUpdate(
+        state: existing?.state ?? SshConnectionState.connecting,
+        message: 'Cancelling connection…',
+      ),
+      cancelRequested: true,
+    );
+    token.cancel();
+    return true;
+  }
+
+  /// Whether [hostId] currently has a cancellable connection attempt.
+  bool canCancelConnectionAttempt(int hostId) {
+    final token = _connectionCancellationTokens[hostId];
+    return token != null && !token.isCancelled;
   }
 
   /// Surface an unexpected connection failure in the shared attempt state.

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -1829,6 +1829,8 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         testingSnackBar.close();
       }
       if (!mounted) {
+        // The screen went away mid-test; don't leak the established client.
+        unawaited(result.closeAll());
         return;
       }
 

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -1771,8 +1771,18 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     if (!_formKey.currentState!.validate()) return;
 
     setState(() => _isBusy = true);
-    final messenger = ScaffoldMessenger.of(context)
-      ..showSnackBar(const SnackBar(content: Text('Testing connection...')));
+    final cancellationToken = SshConnectionCancellationToken();
+    final messenger = ScaffoldMessenger.of(context);
+    final testingSnackBar = messenger.showSnackBar(
+      SnackBar(
+        content: const Text('Testing connection...'),
+        duration: const Duration(minutes: 2),
+        action: SnackBarAction(
+          label: 'Cancel',
+          onPressed: cancellationToken.cancel,
+        ),
+      ),
+    );
 
     try {
       final keyRepo = ref.read(keyRepositoryProvider);
@@ -1809,8 +1819,23 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         jumpHost: jumpHostConfig,
       );
 
-      final result = await sshService.connect(config);
+      final SshConnectionResult result;
+      try {
+        result = await sshService.connect(
+          config,
+          cancellationToken: cancellationToken,
+        );
+      } finally {
+        testingSnackBar.close();
+      }
       if (!mounted) {
+        return;
+      }
+
+      if (result.cancelled) {
+        messenger.showSnackBar(
+          const SnackBar(content: Text('Connection test cancelled')),
+        );
         return;
       }
 
@@ -1838,6 +1863,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
           context: ErrorDescription('while testing a host connection'),
         ),
       );
+      testingSnackBar.close();
       if (!mounted) {
         return;
       }

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -563,6 +563,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   String _currentPath = '/';
   List<SftpName> _files = [];
   bool _isLoading = true;
+  bool _isConnectingSession = false;
   String? _error;
   final List<String> _pathHistory = ['/'];
   String? _hostLabel;
@@ -624,6 +625,13 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     super.dispose();
   }
 
+  /// Abandons the in-flight SSH connection attempt for this browser's host.
+  void _cancelConnectionAttempt() {
+    ref
+        .read(activeSessionsProvider.notifier)
+        .cancelConnectionAttempt(widget.hostId);
+  }
+
   Future<void> _connect() async {
     setState(() {
       _isLoading = true;
@@ -650,17 +658,29 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
 
       // Connect if not already connected
       if (session == null) {
-        final result = await sessionsNotifier.connect(
-          widget.hostId,
-          useHostThemeOverrides: useHostThemeOverrides,
-        );
+        setState(() => _isConnectingSession = true);
+        final SshConnectionResult result;
+        try {
+          result = await sessionsNotifier.connect(
+            widget.hostId,
+            useHostThemeOverrides: useHostThemeOverrides,
+          );
+        } finally {
+          if (mounted) {
+            setState(() => _isConnectingSession = false);
+          }
+        }
         if (!mounted) {
           return;
         }
         if (!result.success) {
           setState(() {
             _isLoading = false;
-            _error = result.error ?? 'Connection failed';
+            _error =
+                result.error ??
+                (result.cancelled
+                    ? 'Connection cancelled'
+                    : 'Connection failed');
           });
           return;
         }
@@ -1551,7 +1571,25 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
 
   Widget _buildFileList() {
     if (_isLoading) {
-      return const BrandListSkeleton();
+      if (!_isConnectingSession) {
+        return const BrandListSkeleton();
+      }
+      final isCancelling =
+          ref.watch(connectionAttemptProvider(widget.hostId))?.isCancelling ??
+          false;
+      return Column(
+        children: [
+          const Expanded(child: BrandListSkeleton()),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: TextButton.icon(
+              onPressed: isCancelling ? null : _cancelConnectionAttempt,
+              icon: const Icon(Icons.close),
+              label: Text(isCancelling ? 'Cancelling…' : 'Cancel connection'),
+            ),
+          ),
+        ],
+      );
     }
 
     if (_error != null) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -7088,6 +7088,23 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
+    if (_connectionCancelled) {
+      // The user cancelled while the attempt was still warming up, before a
+      // cancellation token existed. Drop the session instead of opening it.
+      final establishedConnectionId = _connectionId;
+      _connectionId = null;
+      if (establishedConnectionId != null && !result.reusedConnection) {
+        await _sessionsNotifier!.disconnect(establishedConnectionId);
+      }
+      if (!mounted) return;
+      setState(() {
+        _isConnecting = false;
+        _error = 'Connection cancelled';
+      });
+      _syncTerminalWakeLock(SshConnectionState.disconnected);
+      return;
+    }
+
     await _openShell(session);
   }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3409,6 +3409,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _suppressMonkeyMuxResizeSyncFromTerminalRefresh = false;
   bool _suppressTerminalAutoScrollFromTerminalRefresh = false;
   bool _isConnecting = true;
+  bool _connectionCancelled = false;
   String? _error;
   bool _showKeyboardToolbar = !_hideStoreScreenshotKeyboardToolbar;
   bool _detectedSensitiveKeyboardPrompt = false;
@@ -7023,6 +7024,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
     setState(() {
       _isConnecting = true;
+      _connectionCancelled = false;
       _error = null;
       _connectionOpenedWorkingDirectory = null;
     });
@@ -7067,7 +7069,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (!result.success || result.connectionId == null) {
       setState(() {
         _isConnecting = false;
-        _error = result.error ?? 'Connection failed';
+        _connectionCancelled = result.cancelled;
+        _error =
+            result.error ??
+            (result.cancelled ? 'Connection cancelled' : 'Connection failed');
       });
       return;
     }
@@ -11108,6 +11113,20 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
+  /// Abandons the in-flight connection attempt for this terminal's host.
+  void _cancelConnectionAttempt() {
+    final cancelled = ref
+        .read(activeSessionsProvider.notifier)
+        .cancelConnectionAttempt(widget.hostId);
+    if (!cancelled && mounted) {
+      setState(() {
+        _isConnecting = false;
+        _connectionCancelled = true;
+        _error = 'Connection cancelled';
+      });
+    }
+  }
+
   Future<void> _reconnect({bool showProgressDialog = true}) async {
     if (_isConnecting) {
       return;
@@ -11116,11 +11135,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       setState(() {
         _clearTmuxState();
         _isConnecting = true;
+        _connectionCancelled = false;
         _error = null;
       });
     } else {
       _clearTmuxState();
       _isConnecting = true;
+      _connectionCancelled = false;
       _error = null;
     }
 
@@ -12322,6 +12343,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         hasOverlayMessage: overlayMessage != null,
         isMobile: isMobile,
       );
+      final isCancellingConnection = connectionAttempt?.isCancelling ?? false;
       return Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -12329,10 +12351,18 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             const CursorBlock(size: 32),
             const SizedBox(height: 16),
             Text(
-              'connecting…',
+              isCancellingConnection ? 'cancelling…' : 'connecting…',
               style: FluttyTheme.monoStyle.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
+            ),
+            const SizedBox(height: 16),
+            TextButton.icon(
+              onPressed: isCancellingConnection
+                  ? null
+                  : _cancelConnectionAttempt,
+              icon: const Icon(Icons.close),
+              label: const Text('Cancel'),
             ),
           ],
         ),
@@ -12349,7 +12379,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         isMobile: isMobile,
       );
       return BrandErrorState(
-        title: 'Connection Error',
+        title: _connectionCancelled
+            ? 'Connection Cancelled'
+            : 'Connection Error',
         message: overlayMessage,
         onRetry: _reconnect,
       );

--- a/lib/presentation/widgets/connection_attempt_dialog.dart
+++ b/lib/presentation/widgets/connection_attempt_dialog.dart
@@ -49,7 +49,9 @@ Future<SshConnectionResult> connectToHostWithProgressDialog(
     result = const SshConnectionResult(success: false, error: message);
   }
 
-  if (result.success && result.connectionId != null && navigator.mounted) {
+  final closesDialog =
+      result.cancelled || (result.success && result.connectionId != null);
+  if (closesDialog && navigator.mounted) {
     navigator.pop();
   }
 
@@ -74,13 +76,26 @@ class _ConnectionAttemptDialog extends ConsumerWidget {
     final logLines = attempt?.logLines ?? const ['Preparing connection…'];
     final statusMessage = attempt?.latestMessage ?? 'Preparing connection…';
     final canClose = connectionState == SshConnectionState.error;
+    final wasCancelled = attempt?.cancelled ?? false;
+    final isCancelling = attempt?.isCancelling ?? false;
+    final canCancel = !canClose && !isCancelling;
+    final title = switch (true) {
+      _ when wasCancelled => 'Connection cancelled',
+      _ when isCancelling => 'Cancelling connection',
+      _ when canClose => 'Connection failed',
+      _ => 'Connecting to ${host.label}',
+    };
 
     return PopScope(
       canPop: canClose,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop || !canCancel) {
+          return;
+        }
+        sessionsNotifier.cancelConnectionAttempt(host.id);
+      },
       child: AlertDialog(
-        title: Text(
-          canClose ? 'Connection failed' : 'Connecting to ${host.label}',
-        ),
+        title: Text(title),
         content: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 420),
           child: Column(
@@ -98,7 +113,10 @@ class _ConnectionAttemptDialog extends ConsumerWidget {
               Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  _ConnectionAttemptIcon(state: connectionState),
+                  _ConnectionAttemptIcon(
+                    state: connectionState,
+                    cancelled: wasCancelled,
+                  ),
                   const SizedBox(width: 12),
                   Expanded(
                     child: Text(
@@ -154,6 +172,13 @@ class _ConnectionAttemptDialog extends ConsumerWidget {
             FilledButton(
               onPressed: () => Navigator.of(context).pop(),
               child: const Text('Close'),
+            )
+          else
+            TextButton(
+              onPressed: canCancel
+                  ? () => sessionsNotifier.cancelConnectionAttempt(host.id)
+                  : null,
+              child: Text(isCancelling ? 'Cancelling…' : 'Cancel'),
             ),
         ],
       ),
@@ -162,13 +187,17 @@ class _ConnectionAttemptDialog extends ConsumerWidget {
 }
 
 class _ConnectionAttemptIcon extends StatelessWidget {
-  const _ConnectionAttemptIcon({required this.state});
+  const _ConnectionAttemptIcon({required this.state, this.cancelled = false});
 
   final SshConnectionState state;
+  final bool cancelled;
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    if (cancelled) {
+      return Icon(Icons.cancel_outlined, color: colorScheme.onSurfaceVariant);
+    }
     return switch (state) {
       SshConnectionState.connected => Icon(
         Icons.check_circle,

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -58,6 +58,7 @@ class _CapturingSshService extends SshService {
     SshConnectionConfig config, {
     ConnectionProgressCallback? onProgress,
     bool isJumpHost = false,
+    SshConnectionCancellationToken? cancellationToken,
   }) async {
     capturedConfig = config;
     return const SshConnectionResult(success: false, error: 'stubbed');
@@ -333,6 +334,34 @@ class _FakeHostKeySocket implements SSHSocket, HostKeySource {
   void destroy() {}
 }
 
+class _DestroyTrackingSocket implements SSHSocket {
+  _DestroyTrackingSocket(this._delegate);
+
+  final SSHSocket _delegate;
+  bool destroyed = false;
+
+  @override
+  Stream<Uint8List> get stream => _delegate.stream;
+
+  @override
+  StreamSink<List<int>> get sink => _delegate.sink;
+
+  @override
+  Future<void> close() => _delegate.close();
+
+  @override
+  Future<void> flush() => _delegate.flush();
+
+  @override
+  Future<void> get done => _delegate.done;
+
+  @override
+  void destroy() {
+    destroyed = true;
+    _delegate.destroy();
+  }
+}
+
 class _FakeForwardHostKeySocket implements SSHForwardChannel, HostKeySource {
   _FakeForwardHostKeySocket(this._hostKeyBytes);
 
@@ -523,6 +552,32 @@ class _SingleCloseForwardChannel implements SSHForwardChannel {
   }
 }
 
+class _CancellableConnectSshService extends SshService {
+  final Completer<void> connectStarted = Completer<void>();
+  SshConnectionCancellationToken? receivedToken;
+
+  @override
+  Future<SshConnectionResult> connectToHost(
+    int hostId, {
+    ConnectionProgressCallback? onProgress,
+    bool useHostThemeOverrides = true,
+    SshConnectionCancellationToken? cancellationToken,
+  }) async {
+    receivedToken = cancellationToken;
+    if (!connectStarted.isCompleted) {
+      connectStarted.complete();
+    }
+    onProgress?.call(
+      const ConnectionProgressUpdate(
+        state: SshConnectionState.connecting,
+        message: 'Opening network connection…',
+      ),
+    );
+    await cancellationToken!.cancelled;
+    return const SshConnectionResult.userCancelled();
+  }
+}
+
 class _FakeActiveSessionsSshService extends SshService {
   _FakeActiveSessionsSshService({this.connectGate});
 
@@ -540,6 +595,7 @@ class _FakeActiveSessionsSshService extends SshService {
     int hostId, {
     ConnectionProgressCallback? onProgress,
     bool useHostThemeOverrides = true,
+    SshConnectionCancellationToken? cancellationToken,
   }) async {
     if (!connectStarted.isCompleted) {
       connectStarted.complete();
@@ -3791,6 +3847,48 @@ LISTEN ::1:4201
       },
     );
 
+    test('cancelConnectionAttempt aborts an in-flight connect', () async {
+      final cancellableService = _CancellableConnectSshService();
+      final hostRepository = _MockHostRepository();
+      when(() => hostRepository.getById(any())).thenAnswer((_) async => null);
+      final localContainer = ProviderContainer(
+        overrides: [
+          sshServiceProvider.overrideWithValue(cancellableService),
+          hostRepositoryProvider.overrideWithValue(hostRepository),
+          portForwardRepositoryProvider.overrideWithValue(
+            _emptyPortForwardRepository(),
+          ),
+        ],
+      );
+      addTearDown(localContainer.dispose);
+      final notifier = localContainer.read(activeSessionsProvider.notifier);
+
+      final pending = notifier.connect(42, forceNew: true);
+      await cancellableService.connectStarted.future;
+
+      expect(notifier.canCancelConnectionAttempt(42), isTrue);
+      expect(notifier.cancelConnectionAttempt(42), isTrue);
+      expect(notifier.getConnectionAttempt(42)?.cancelRequested, isTrue);
+      expect(notifier.getConnectionAttempt(42)?.isCancelling, isTrue);
+
+      final result = await pending;
+
+      expect(result.cancelled, isTrue);
+      expect(result.success, isFalse);
+      expect(notifier.getConnectionAttempt(42)?.cancelled, isTrue);
+      expect(notifier.getConnectionAttempt(42)?.isCancelling, isFalse);
+      expect(notifier.canCancelConnectionAttempt(42), isFalse);
+      expect(cancellableService.receivedToken?.isCancelled, isTrue);
+    });
+
+    test('cancelConnectionAttempt is a no-op without an attempt', () async {
+      final notifier = container.read(activeSessionsProvider.notifier);
+
+      expect(notifier.canCancelConnectionAttempt(99), isFalse);
+      expect(notifier.cancelConnectionAttempt(99), isFalse);
+      expect(notifier.getConnectionAttempt(99), isNull);
+    });
+
     test('keeps ownership on a connected sibling during reconnect', () async {
       final configurationLog = <String>[];
       final older = _RecordingAutomaticForwardSession(
@@ -6654,6 +6752,225 @@ LISTEN ::1:4201
       expect(service.capturedConfig?.jumpHost, isNotNull);
       expect(wifiNetworkService.requestPermissionCallCount, 1);
       expect(wifiNetworkService.getCurrentSsidCallCount, 1);
+    });
+  });
+
+  group('connection cancellation', () {
+    test('cancels a stalled socket connection without waiting', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final socketRequested = Completer<void>();
+      final stalledSocket = Completer<SSHSocket>();
+      addTearDown(() {
+        if (!stalledSocket.isCompleted) {
+          stalledSocket.complete(_FakeHostKeySocket(_ed25519HostKeyBlob([9])));
+        }
+      });
+      var clientFactoryCalls = 0;
+
+      final service = SshService(
+        knownHostsRepository: KnownHostsRepository(db),
+        socketConnector: (host, port, {timeout}) {
+          if (!socketRequested.isCompleted) {
+            socketRequested.complete();
+          }
+          return stalledSocket.future;
+        },
+        clientFactory:
+            (
+              socket, {
+              required username,
+              onVerifyHostKey,
+              onPasswordRequest,
+              onUserInfoRequest,
+              identities,
+              keepAliveInterval,
+            }) {
+              clientFactoryCalls++;
+              return _MockSshClient();
+            },
+      );
+
+      final token = SshConnectionCancellationToken();
+      const config = SshConnectionConfig(
+        hostname: 'stalled.example.com',
+        port: 22,
+        username: 'tester',
+        connectionTimeout: Duration(minutes: 10),
+      );
+
+      final pending = service.connect(config, cancellationToken: token);
+      await socketRequested.future;
+      token.cancel();
+      final result = await pending;
+
+      expect(result.cancelled, isTrue);
+      expect(result.success, isFalse);
+      expect(result.error, 'Connection cancelled');
+      expect(clientFactoryCalls, 0);
+    });
+
+    test('destroys a socket that arrives after cancellation', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final socketRequested = Completer<void>();
+      final stalledSocket = Completer<SSHSocket>();
+      final lateSocket = _DestroyTrackingSocket(
+        _FakeHostKeySocket(_ed25519HostKeyBlob([3, 2, 1])),
+      );
+
+      final service = SshService(
+        knownHostsRepository: KnownHostsRepository(db),
+        socketConnector: (host, port, {timeout}) {
+          if (!socketRequested.isCompleted) {
+            socketRequested.complete();
+          }
+          return stalledSocket.future;
+        },
+      );
+
+      final token = SshConnectionCancellationToken();
+      const config = SshConnectionConfig(
+        hostname: 'late-socket.example.com',
+        port: 22,
+        username: 'tester',
+      );
+
+      final pending = service.connect(config, cancellationToken: token);
+      await socketRequested.future;
+      token.cancel();
+      final result = await pending;
+      stalledSocket.complete(lateSocket);
+      await pumpEventQueue();
+
+      expect(result.cancelled, isTrue);
+      expect(lateSocket.destroyed, isTrue);
+    });
+
+    test('cancels a stalled authentication and closes the client', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final knownHostsRepository = KnownHostsRepository(db);
+      final hostKeyBytes = _ed25519HostKeyBlob([7, 7, 7]);
+      await _seedTrustedHost(
+        knownHostsRepository,
+        hostname: 'slow-auth.example.com',
+        hostKeyBytes: hostKeyBytes,
+      );
+      final client = _MockSshClient();
+      final authenticationStarted = Completer<void>();
+      when(() => client.authenticated).thenAnswer((_) {
+        if (!authenticationStarted.isCompleted) {
+          authenticationStarted.complete();
+        }
+        return Completer<void>().future;
+      });
+      when(client.close).thenReturn(null);
+
+      final service = SshService(
+        knownHostsRepository: knownHostsRepository,
+        socketConnector: (host, port, {timeout}) async =>
+            _FakeHostKeySocket(hostKeyBytes),
+        clientFactory:
+            (
+              socket, {
+              required username,
+              onVerifyHostKey,
+              onPasswordRequest,
+              onUserInfoRequest,
+              identities,
+              keepAliveInterval,
+            }) => client,
+      );
+
+      final token = SshConnectionCancellationToken();
+      const config = SshConnectionConfig(
+        hostname: 'slow-auth.example.com',
+        port: 22,
+        username: 'tester',
+        connectionTimeout: Duration(minutes: 10),
+      );
+
+      final pending = service.connect(config, cancellationToken: token);
+      await authenticationStarted.future;
+      token.cancel();
+      final result = await pending;
+
+      expect(result.cancelled, isTrue);
+      expect(result.client, isNull);
+      verify(client.close).called(1);
+    });
+
+    test(
+      'returns cancelled before connecting when already cancelled',
+      () async {
+        final db = AppDatabase.forTesting(NativeDatabase.memory());
+        addTearDown(db.close);
+        var socketConnectorCalls = 0;
+
+        final service = SshService(
+          knownHostsRepository: KnownHostsRepository(db),
+          socketConnector: (host, port, {timeout}) async {
+            socketConnectorCalls++;
+            return _FakeHostKeySocket(_ed25519HostKeyBlob([1]));
+          },
+        );
+
+        final token = SshConnectionCancellationToken()..cancel();
+        const config = SshConnectionConfig(
+          hostname: 'precancelled.example.com',
+          port: 22,
+          username: 'tester',
+        );
+
+        final result = await service.connect(config, cancellationToken: token);
+
+        expect(result.cancelled, isTrue);
+        expect(socketConnectorCalls, 0);
+      },
+    );
+
+    test('connectToHost does not register a cancelled session', () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final encryption = SecretEncryptionService.forTesting();
+      final hostRepo = HostRepository(db, encryption);
+      final hostId = await hostRepo.insert(
+        HostsCompanion.insert(
+          label: 'stalled',
+          hostname: 'stalled.example.com',
+          username: 'tester',
+        ),
+      );
+      final socketRequested = Completer<void>();
+      final stalledSocket = Completer<SSHSocket>();
+      addTearDown(() {
+        if (!stalledSocket.isCompleted) {
+          stalledSocket.complete(_FakeHostKeySocket(_ed25519HostKeyBlob([5])));
+        }
+      });
+
+      final service = SshService(
+        hostRepository: hostRepo,
+        keyRepository: KeyRepository(db, encryption),
+        knownHostsRepository: KnownHostsRepository(db),
+        socketConnector: (host, port, {timeout}) {
+          if (!socketRequested.isCompleted) {
+            socketRequested.complete();
+          }
+          return stalledSocket.future;
+        },
+      );
+
+      final token = SshConnectionCancellationToken();
+      final pending = service.connectToHost(hostId, cancellationToken: token);
+      await socketRequested.future;
+      token.cancel();
+      final result = await pending;
+
+      expect(result.cancelled, isTrue);
+      expect(result.connectionId, isNull);
+      expect(service.sessions, isEmpty);
     });
   });
 }

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -553,8 +553,15 @@ class _SingleCloseForwardChannel implements SSHForwardChannel {
 }
 
 class _CancellableConnectSshService extends SshService {
+  _CancellableConnectSshService({this.expectedAttempts = 1});
+
+  final int expectedAttempts;
   final Completer<void> connectStarted = Completer<void>();
-  SshConnectionCancellationToken? receivedToken;
+  final Completer<void> allAttemptsStarted = Completer<void>();
+  final List<SshConnectionCancellationToken> receivedTokens = [];
+
+  SshConnectionCancellationToken? get receivedToken =>
+      receivedTokens.isEmpty ? null : receivedTokens.last;
 
   @override
   Future<SshConnectionResult> connectToHost(
@@ -563,9 +570,13 @@ class _CancellableConnectSshService extends SshService {
     bool useHostThemeOverrides = true,
     SshConnectionCancellationToken? cancellationToken,
   }) async {
-    receivedToken = cancellationToken;
+    receivedTokens.add(cancellationToken!);
     if (!connectStarted.isCompleted) {
       connectStarted.complete();
+    }
+    if (receivedTokens.length >= expectedAttempts &&
+        !allAttemptsStarted.isCompleted) {
+      allAttemptsStarted.complete();
     }
     onProgress?.call(
       const ConnectionProgressUpdate(
@@ -573,7 +584,7 @@ class _CancellableConnectSshService extends SshService {
         message: 'Opening network connection…',
       ),
     );
-    await cancellationToken!.cancelled;
+    await cancellationToken.cancelled;
     return const SshConnectionResult.userCancelled();
   }
 }
@@ -3887,6 +3898,79 @@ LISTEN ::1:4201
       expect(notifier.canCancelConnectionAttempt(99), isFalse);
       expect(notifier.cancelConnectionAttempt(99), isFalse);
       expect(notifier.getConnectionAttempt(99), isNull);
+    });
+
+    test(
+      'cancelConnectionAttempt aborts every concurrent same-host attempt',
+      () async {
+        final cancellableService = _CancellableConnectSshService(
+          expectedAttempts: 2,
+        );
+        final hostRepository = _MockHostRepository();
+        when(() => hostRepository.getById(any())).thenAnswer((_) async => null);
+        final localContainer = ProviderContainer(
+          overrides: [
+            sshServiceProvider.overrideWithValue(cancellableService),
+            hostRepositoryProvider.overrideWithValue(hostRepository),
+            portForwardRepositoryProvider.overrideWithValue(
+              _emptyPortForwardRepository(),
+            ),
+          ],
+        );
+        addTearDown(localContainer.dispose);
+        final notifier = localContainer.read(activeSessionsProvider.notifier);
+
+        final first = notifier.connect(42, forceNew: true);
+        final second = notifier.connect(42, forceNew: true);
+        await cancellableService.allAttemptsStarted.future;
+
+        expect(cancellableService.receivedTokens, hasLength(2));
+        expect(notifier.cancelConnectionAttempt(42), isTrue);
+
+        final results = await Future.wait([first, second]);
+
+        expect(results.every((result) => result.cancelled), isTrue);
+        expect(
+          cancellableService.receivedTokens.every((token) => token.isCancelled),
+          isTrue,
+          reason: 'both concurrent attempts must observe cancellation',
+        );
+        expect(notifier.canCancelConnectionAttempt(42), isFalse);
+      },
+    );
+
+    test('honors cancellation that races a reused connection', () async {
+      final localSshService = _FakeActiveSessionsSshService();
+      final hostRepository = _MockHostRepository();
+      when(() => hostRepository.getById(any())).thenAnswer((_) async => null);
+      final localContainer = ProviderContainer(
+        overrides: [
+          sshServiceProvider.overrideWithValue(localSshService),
+          hostRepositoryProvider.overrideWithValue(hostRepository),
+          portForwardRepositoryProvider.overrideWithValue(
+            _emptyPortForwardRepository(),
+          ),
+        ],
+      );
+      addTearDown(localContainer.dispose);
+      final notifier = localContainer.read(activeSessionsProvider.notifier);
+
+      final established = await notifier.connect(42, forceNew: true);
+      expect(established.success, isTrue);
+
+      // A reusing attempt cancelled before it settles must not hand back the
+      // live session, but must also leave that shared session connected.
+      final reusing = notifier.connect(42);
+      notifier.cancelConnectionAttempt(42);
+      final result = await reusing;
+
+      expect(result.cancelled, isTrue);
+      expect(result.connectionId, isNull);
+      expect(
+        localSshService.getSession(established.connectionId!),
+        isNotNull,
+        reason: 'a reused session belongs to the earlier caller',
+      );
     });
 
     test('keeps ownership on a connected sibling during reconnect', () async {

--- a/test/widget/connection_attempt_dialog_test.dart
+++ b/test/widget/connection_attempt_dialog_test.dart
@@ -1,0 +1,181 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/domain/models/monetization.dart';
+import 'package:monkeyssh/domain/services/monetization_service.dart';
+import 'package:monkeyssh/domain/services/ssh_service.dart';
+import 'package:monkeyssh/presentation/widgets/connection_attempt_dialog.dart';
+
+class _MockHostRepository extends Mock implements HostRepository {}
+
+class _MockMonetizationService extends Mock implements MonetizationService {}
+
+const _freeMonetizationState = MonetizationState(
+  billingAvailability: MonetizationBillingAvailability.unavailable,
+  entitlements: MonetizationEntitlements.free(),
+  offers: [],
+  debugUnlockAvailable: false,
+  debugUnlocked: false,
+);
+
+/// Stalls until the caller cancels, mirroring an unresponsive SSH endpoint.
+class _StalledSshService extends SshService {
+  final Completer<void> connectStarted = Completer<void>();
+
+  @override
+  Future<SshConnectionResult> connectToHost(
+    int hostId, {
+    ConnectionProgressCallback? onProgress,
+    bool useHostThemeOverrides = true,
+    SshConnectionCancellationToken? cancellationToken,
+  }) async {
+    if (!connectStarted.isCompleted) {
+      connectStarted.complete();
+    }
+    onProgress?.call(
+      const ConnectionProgressUpdate(
+        state: SshConnectionState.connecting,
+        message: 'Opening network connection…',
+      ),
+    );
+    await cancellationToken!.cancelled;
+    return const SshConnectionResult.userCancelled();
+  }
+}
+
+Host _host() => Host(
+  id: 42,
+  label: 'stalled box',
+  hostname: 'stalled.example.com',
+  port: 22,
+  username: 'tester',
+  isFavorite: false,
+  autoConnectRequiresConfirmation: false,
+  autoForwardPorts: false,
+  sortOrder: 0,
+  createdAt: DateTime(2024),
+  updatedAt: DateTime(2024),
+);
+
+void main() {
+  group('connectToHostWithProgressDialog', () {
+    testWidgets('cancels a stalled connection from the dialog', (tester) async {
+      final sshService = _StalledSshService();
+      final hostRepository = _MockHostRepository();
+      when(() => hostRepository.getById(any())).thenAnswer((_) async => null);
+      final monetizationService = _MockMonetizationService();
+      when(
+        () => monetizationService.currentState,
+      ).thenReturn(_freeMonetizationState);
+
+      SshConnectionResult? result;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sshServiceProvider.overrideWithValue(sshService),
+            hostRepositoryProvider.overrideWithValue(hostRepository),
+            monetizationServiceProvider.overrideWithValue(monetizationService),
+            monetizationStateProvider.overrideWith(
+              (ref) => Stream.value(_freeMonetizationState),
+            ),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: Consumer(
+                builder: (context, ref, _) => TextButton(
+                  onPressed: () async {
+                    result = await connectToHostWithProgressDialog(
+                      context,
+                      ref,
+                      _host(),
+                    );
+                  },
+                  child: const Text('Connect'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Connect'));
+      await tester.pump();
+      await sshService.connectStarted.future;
+      await tester.pump();
+
+      expect(find.text('Connecting to stalled box'), findsOneWidget);
+      expect(find.widgetWithText(TextButton, 'Cancel'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(result, isNotNull);
+      expect(result!.cancelled, isTrue);
+      expect(result!.success, isFalse);
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+
+    testWidgets('cancels a stalled connection from a back gesture', (
+      tester,
+    ) async {
+      final sshService = _StalledSshService();
+      final hostRepository = _MockHostRepository();
+      when(() => hostRepository.getById(any())).thenAnswer((_) async => null);
+      final monetizationService = _MockMonetizationService();
+      when(
+        () => monetizationService.currentState,
+      ).thenReturn(_freeMonetizationState);
+
+      SshConnectionResult? result;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sshServiceProvider.overrideWithValue(sshService),
+            hostRepositoryProvider.overrideWithValue(hostRepository),
+            monetizationServiceProvider.overrideWithValue(monetizationService),
+            monetizationStateProvider.overrideWith(
+              (ref) => Stream.value(_freeMonetizationState),
+            ),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: Consumer(
+                builder: (context, ref, _) => TextButton(
+                  onPressed: () async {
+                    result = await connectToHostWithProgressDialog(
+                      context,
+                      ref,
+                      _host(),
+                    );
+                  },
+                  child: const Text('Connect'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Connect'));
+      await tester.pump();
+      await sshService.connectStarted.future;
+      await tester.pump();
+
+      expect(find.byType(AlertDialog), findsOneWidget);
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(result, isNotNull);
+      expect(result!.cancelled, isTrue);
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

A stalling SSH connection attempt could only be escaped by waiting out the timeout (up to 30s per phase, and phases chain — host key probe, auth, jump host hops) or force-quitting the app. There was no cancel affordance anywhere in the connect flow.

## What changed

**Core cancellation (`ssh_service.dart`)**
- New `SshConnectionCancellationToken` + `SshConnectionCancelledException`, and a `cancelled` flag on `SshConnectionResult`.
- The token is threaded through `SshService.connectToHost` / `connect`, including jump-host recursion. Every long wait races the token — socket connect, tunnel open, host key probe/read, host key trust prompt, and authentication — so cancelling takes effect immediately rather than after `connectionTimeout`.
- Cleanup is handled on the cancel path: clients are closed, and sockets that resolve *after* cancellation are destroyed instead of leaking. A connection that completes its handshake just as the user cancels is torn down instead of being registered as a session.

**State (`ActiveSessionsNotifier`)**
- Tracks a token per in-flight host attempt; adds `cancelConnectionAttempt(hostId)` and `canCancelConnectionAttempt(hostId)`.
- `ConnectionAttemptStatus` gains `cancelRequested` / `cancelled` and an `isCancelling` helper so the UI can show a wind-down state.
- Cancelled attempts are reported to telemetry under the existing allowlisted `cancelled` failure category instead of looking like a generic failure.

**UI**
- Connect progress dialog: **Cancel** button, plus back gesture / Escape requests cancellation. The dialog closes itself on cancellation instead of showing a "Connection failed" error.
- Terminal connecting view: **Cancel** action, `connecting…` becomes `cancelling…`, and the resulting state reads "Connection Cancelled" with Reconnect.
- SFTP browser: **Cancel connection** action while the session is being established.
- Host edit "Test connection": the progress snackbar now has a **Cancel** action.

## Testing

- `flutter analyze` — clean.
- New unit tests in `test/domain/services/ssh_service_test.dart`: cancelling a stalled socket connect, destroying a socket that arrives after cancellation, cancelling a stalled authentication (asserts the client is closed), pre-cancelled tokens skipping the connector, `connectToHost` not registering a cancelled session, and notifier-level `cancelConnectionAttempt` behaviour.
- New `test/widget/connection_attempt_dialog_test.dart`: cancelling from the dialog button and from a back gesture.
- Full `flutter test` suite passes (2,914 tests).