### PR TITLE
fix: refresh Copilot composer theme on Windows remotes

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -4708,10 +4708,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     // foreground TUI. Codex treats those bytes as user input, and its crossterm
     // color re-query can also be disrupted by unrelated terminal reports.
     // Always send a synthetic focus transition so focus-aware TUIs re-query OSC
-    // 10/11 through the normal path; only send the private theme-mode and
-    // default-color response cycle to apps that explicitly requested DEC 2031
-    // color-scheme updates.
+    // 10/11 through the normal path. Also push default-color reports when the
+    // app requested DEC 2031 updates or when Windows ConPTY is active: ConPTY
+    // consumes the OSC 10/11 queries Copilot CLI uses to repaint its composer.
     final includeThemeModeReport = session.terminalColorSchemeUpdatesMode;
+    final includeDefaultColorReports =
+        includeThemeModeReport || session.terminalWin32InputMode;
     _refreshTerminalThemeReportsForTui(
       theme,
       includeThemeModeReport: false,
@@ -4726,6 +4728,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         includeFocusReport: false,
         reason: '${reason}_plain_theme_mode',
       );
+    }
+    if (includeDefaultColorReports) {
       for (final delay in const [
         Duration(milliseconds: 330),
         Duration(milliseconds: 410),

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -2335,6 +2335,47 @@ void main() {
     );
 
     testWidgets(
+      'pushes updated default colors through Windows ConPTY on theme changes',
+      (tester) async {
+        await pumpScreen(tester);
+        shellStdoutController.add(
+          Uint8List.fromList(utf8.encode('\x1b[?9001h\x1b[?1004h')),
+        );
+        await tester.pump(const Duration(milliseconds: 20));
+        expect(session.terminalWin32InputMode, isTrue);
+        shellWrites.clear();
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(TerminalScreen)),
+        );
+        await container
+            .read(themeModeNotifierProvider.notifier)
+            .setThemeMode(ThemeMode.dark);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
+
+        final writtenShellText = utf8.decode(
+          shellWrites.expand((chunk) => chunk).toList(growable: false),
+        );
+        final decodedWin32Input = writtenShellText.replaceAllMapped(
+          RegExp(r'\x1b\[0;0;(\d+);1;0;1_'),
+          (match) => String.fromCharCode(int.parse(match.group(1)!)),
+        );
+        expect(
+          decodedWin32Input,
+          contains(
+            buildTerminalThemeDefaultColorReports(
+              monkey_themes.TerminalThemes.defaultDarkTheme,
+            ),
+          ),
+        );
+        expect(decodedWin32Input, contains('\x1b[O\x1b[I'));
+        expect(decodedWin32Input, isNot(contains('\x1b[?997;1n')));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
       'refreshes an active TUI when assigning the first session theme',
       (tester) async {
         await pumpScreen(tester);


### PR DESCRIPTION
## Problem

On a Windows remote, the Copilot CLI composer keeps its old colors after a terminal theme change (theme mode switch, system brightness change, or terminal theme setting change). The composer stays painted in the previous theme until the app is restarted or the session reconnects.

The root cause is Windows ConPTY. Copilot CLI repaints its composer by re-querying the terminal's default foreground/background via OSC 10/11, but conhost consumes those queries without forwarding them, so the app never learns the new colors.

MonkeySSH already detects ConPTY (it requests DEC private mode 9001, win32-input-mode) and already knows how to deliver OSC replies through it by re-encoding them as win32-input-mode key events. But on a theme change, the plain-TUI refresh path only volunteered default-color reports when the app had explicitly enabled DEC 2031 color-scheme updates. Copilot CLI does not enable DEC 2031 on this path, so the reports were never sent and only the synthetic focus transition arrived — which is useless when the follow-up OSC 10/11 query is swallowed by ConPTY.

## Fix

Treat an active win32-input-mode (i.e. a ConPTY sits between MonkeySSH and the foreground app) as an additional trigger for volunteering default-color reports during a theme refresh, alongside the existing DEC 2031 condition.

The DEC 2031 theme-mode report cycle is unchanged and still gated on DEC 2031 only; this change affects just the OSC 10/11 default-color reports. Those reports are already ConPTY-safe: the session runtime re-encodes OSC/DCS output as win32-input-mode key events whenever the mode is active.

This mirrors the existing OSC 4 handling in `SshSession._handlePrivateOsc`, which volunteers the same default-color reports alongside palette answers for exactly this ConPTY limitation. The theme-change path now gets the same treatment.

## Behavior notes

- POSIX remotes are unaffected: `terminalWin32InputMode` is only ever true when the remote ConPTY requests DEC 9001.
- Bare shell prompts are unaffected: the whole path is still gated behind `_shouldRefreshPlainTerminalTui`, so nothing is sent unless a foreground TUI has signaled itself.
- Codex-style TUIs are unaffected on POSIX: no unsolicited OSC 4 palette fragments are introduced, only OSC 10/11 defaults, and only under ConPTY.

## Testing

- New regression test: `pushes updated default colors through Windows ConPTY on theme changes` — enables win32-input-mode plus focus reporting, switches theme mode, decodes the win32-input-mode key events written to the shell, and asserts the dark-theme OSC 10/11 default-color reports arrive along with the focus transition.
- `flutter analyze` — no issues.
- Full `flutter test` suite via the pre-commit hook — 2932 tests passed.
