### PR TITLE
fix: stop terminal height shrink destroying rows below the cursor

### DIFF
--- a/third_party/xterm/lib/src/core/buffer/buffer.dart
+++ b/third_party/xterm/lib/src/core/buffer/buffer.dart
@@ -510,11 +510,43 @@ class Buffer {
         }
       }
     } else {
-      // Shrink smaller
+      // Shrink smaller.
+      //
+      // Each step must give up one viewport row, and there are two ways to do
+      // that. Popping the last buffer line keeps the viewport anchored to the
+      // cursor but destroys that line outright. Decrementing the cursor keeps
+      // every line: the viewport is bottom-anchored (its top row is
+      // lines.length - viewHeight), so the viewport slides down one row and
+      // the previous top row survives above it.
+      //
+      // The old rule popped whenever the cursor still fit inside the smaller
+      // viewport, destroying rows below the cursor even when they held
+      // content. Full-screen TUIs such as Copilot CLI park the cursor on
+      // their input line with live status rows below it and repaint with
+      // cursor-relative movements, so every keyboard-animation resize step
+      // deleted a row the program still owned and desynchronized all of its
+      // later repaints — stranding stale, blank-looking regions in the
+      // scrollback that no future output repairs.
+      //
+      // Instead, reclaim the bottom row only when it is genuinely empty and
+      // below the cursor (what real terminals do), otherwise slide the
+      // viewport, and destroy a row with content only when the cursor is
+      // already at the viewport top and there is no other way to shrink.
+      //
+      // The cursor's buffer row is captured once before the loop: it cannot
+      // change inside it (pops only remove rows below the cursor, and slides
+      // do not move buffer rows), while recomputing [absoluteCursorY]
+      // mid-loop would drift because its scrollBack term still reads the
+      // pre-resize view height as lines are popped.
+      final cursorRow = absoluteCursorY;
       for (var i = 0; i < oldHeight - newHeight; i++) {
-        if (_cursorY > newHeight - 1) {
+        final lastIndex = lines.length - 1;
+        final lastIsBelowCursor = lastIndex > cursorRow;
+        if (lastIsBelowCursor && _isRowEmptyForShrink(lastIndex)) {
+          lines.pop();
+        } else if (_cursorY > 0) {
           _cursorY--;
-        } else {
+        } else if (lastIsBelowCursor) {
           lines.pop();
         }
       }
@@ -538,6 +570,27 @@ class Buffer {
         lines.forEach((item) => item.resize(newWidth));
       }
     }
+  }
+
+  /// Whether the row at [index] holds nothing that a height shrink must keep.
+  ///
+  /// Measures the line's full retained capacity, not just the visible
+  /// columns: when reflow is off (and always on the alt buffer) a width
+  /// shrink hides the cells past the new width but retains them so they
+  /// reappear when the width grows back. A row whose only text sits in that
+  /// hidden range would read as blank across the visible columns, and popping
+  /// it would destroy cells the non-reflowing contract promises to restore.
+  ///
+  /// Rows carrying Kitty image placements are also kept even though they may
+  /// contain no code points: the placement hangs off a [CellAnchor] on the
+  /// line, so popping the line detaches the anchor and loses the image. This
+  /// includes in-flight decodes, whose anchors are registered before the
+  /// image bytes finish arriving.
+  bool _isRowEmptyForShrink(int index) {
+    if (lines[index].getTrimmedLength() != 0) {
+      return false;
+    }
+    return graphics.physicalPlacementAnchorsInRow(index).isEmpty;
   }
 
   /// Create a new [CellAnchor] at the specified [x] and [y] coordinates.

--- a/third_party/xterm/test/src/core/buffer/buffer_test.dart
+++ b/third_party/xterm/test/src/core/buffer/buffer_test.dart
@@ -107,6 +107,128 @@ void main() {
         expect(line.length, 20);
       }
     });
+
+    test('preserves rows below the cursor when shrinking (TUI footer)', () {
+      // Full-screen TUIs such as Copilot CLI park the cursor on their input
+      // line and keep live status rows below it. A height shrink must not
+      // destroy those rows: the program still owns them and repaints with
+      // cursor-relative movements, so deleting them desynchronizes every
+      // later repaint. On the alt buffer, rows shed to make room must come
+      // from the top (as xterm.js does), never from below the cursor.
+      final terminal = Terminal();
+      terminal.resize(10, 10);
+      terminal.write('\x1b[?1049h');
+      for (var i = 0; i < 10; i++) {
+        terminal.write('\x1b[${i + 1};1HL$i');
+      }
+      terminal.write('\x1b[8;1H'); // cursor on row index 7, above L8/L9
+
+      terminal.resize(10, 6);
+
+      final buffer = terminal.buffer;
+      expect(buffer.height, 6);
+      for (var i = 0; i < 6; i++) {
+        expect(buffer.lines[i].getText(), 'L${i + 4}');
+      }
+      // The cursor stays on its own line, with the footer intact below it.
+      expect(buffer.lines[buffer.absoluteCursorY].getText(), 'L7');
+      expect(buffer.lines[buffer.absoluteCursorY + 1].getText(), 'L8');
+      expect(buffer.lines[buffer.absoluteCursorY + 2].getText(), 'L9');
+
+      terminal.resize(10, 10);
+
+      expect(buffer.height, 10);
+      for (var i = 0; i < 6; i++) {
+        expect(buffer.lines[i].getText(), 'L${i + 4}');
+      }
+      expect(buffer.lines[buffer.absoluteCursorY].getText(), 'L7');
+    });
+
+    test('round-trips a keyboard-animation resize flurry losslessly', () {
+      // A mobile on-screen keyboard animates the viewport through many
+      // intermediate heights. On the main buffer, replaying such a flurry
+      // must return the exact original screen once the keyboard closes.
+      final terminal = Terminal();
+      terminal.resize(69, 55);
+      for (var i = 0; i < 55; i++) {
+        terminal.write('\x1b[${i + 1};1Htranscript row $i');
+      }
+      terminal.write('\x1b[53;1H'); // input line with two footer rows below
+
+      final before = [
+        for (var i = 0; i < terminal.buffer.height; i++)
+          terminal.buffer.lines[i].getText(),
+      ];
+      final cursorRowBefore = terminal.buffer.absoluteCursorY;
+
+      for (final rows in [41, 34, 33, 30, 29, 28, 29, 38, 50, 54, 55]) {
+        terminal.resize(69, rows);
+      }
+
+      final buffer = terminal.buffer;
+      expect(buffer.height, before.length);
+      expect(buffer.scrollBack, 0);
+      for (var i = 0; i < before.length; i++) {
+        expect(buffer.lines[i].getText(), before[i]);
+      }
+      expect(buffer.absoluteCursorY, cursorRowBefore);
+    });
+
+    test('reclaims trailing blank rows instead of creating scrollback', () {
+      // A shell with a prompt at the top and nothing below it should not have
+      // its blank region converted into scrollback lines on shrink.
+      final terminal = Terminal();
+      terminal.resize(10, 10);
+      terminal.write('user@host>');
+      terminal.write('\x1b[1;1H');
+
+      terminal.resize(10, 5);
+
+      final buffer = terminal.buffer;
+      expect(buffer.height, 5);
+      expect(buffer.scrollBack, 0);
+      expect(buffer.lines[0].getText(), 'user@host>');
+      expect(buffer.absoluteCursorY, 0);
+    });
+
+    test('does not reclaim rows whose text is hidden by a width shrink', () {
+      // With reflow off, a width shrink retains the cells past the new width
+      // so they reappear when the width grows back. A row whose only text
+      // lives in that hidden range must not be read as blank and destroyed by
+      // a later height shrink.
+      final terminal = Terminal(reflowEnabled: false);
+      terminal.resize(10, 10);
+      terminal.write('\x1b[6;7HTAIL'); // row index 5, columns 6-9
+      terminal.write('\x1b[3;1H'); // cursor on row index 2
+
+      terminal.resize(6, 10); // hides TAIL beyond column 5
+      terminal.resize(6, 5); // must not pop the row holding hidden cells
+      terminal.resize(10, 5); // hidden cells reappear
+
+      final buffer = terminal.buffer;
+      expect(buffer.lines[5].getText(), 'TAIL');
+      expect(buffer.lines[5].getTrimmedLength(), 10);
+      expect(buffer.absoluteCursorY, 2);
+    });
+
+    test('does not reclaim rows holding image placement anchors', () {
+      // A row whose only content is a Kitty image placement has no code
+      // points, but popping it would detach the anchor and lose the image.
+      final terminal = Terminal();
+      terminal.resize(10, 10);
+      terminal.write('\x1b[8;1H'); // cursor on row index 7
+
+      final buffer = terminal.buffer;
+      final anchor = buffer.createAnchor(0, 8);
+      buffer.graphics.retainPendingPlacementAnchor(anchor);
+
+      terminal.resize(10, 6);
+
+      expect(anchor.attached, isTrue);
+      expect(anchor.y, 8);
+      expect(buffer.height, 9); // only the blank, unanchored row 9 was popped
+      expect(buffer.absoluteCursorY, 7);
+    });
   });
 
   group('Buffer.deleteLines()', () {


### PR DESCRIPTION
## Summary

Fixes the Copilot CLI blank-transcript bug: the terminal viewport goes blank (except Copilot's scrollbar and bottom chrome) and stays blank until a full repaint (zoom, reconnect).

- Root cause is app-local, in the vendored xterm core: `Buffer.resize()` popped the **bottom** buffer line on every height-shrink step whenever the cursor still fit inside the smaller viewport, destroying that row outright. Copilot CLI parks its cursor on its input line with live status rows *below* it, so each frame of the on-screen-keyboard open/close animation (rows 55→41→…→28 in diagnostics captures) deleted a row the TUI still owned. Copilot repaints differentially with cursor-relative movements against its own screen model, so the deletions desynchronized every later repaint — stranding ever-growing blank regions that scrolling then revealed.
- The shrink path now reclaims a bottom row only when it is genuinely empty and below the cursor, otherwise slides the bottom-anchored viewport (lossless — on the alt buffer the existing `clearScrollback()` then sheds rows from the top, matching xterm.js semantics), and destroys a content row only when the cursor is at the viewport top with no other way to shrink.
- Row emptiness is measured across the line's full retained capacity, so text hidden by a non-reflowing width shrink (the alt-buffer contract) survives, and rows anchoring Kitty image placements — including in-flight decodes — are never reclaimed.

Other suspects were ruled out with live reproductions before landing here: Copilot CLI driven directly in a PTY and through a real local MonkeyMux server (control-channel resize dances, width-1 redraw dance, SGR wheel-event bursts mid-dance) both render correctly, pinning the bug to the app-local buffer. The OSC 110/111 events in the failing capture were a coincidental Copilot process restart.

Related: #704 gates the forced MonkeyMux theme-redraw dance and is orthogonal to this fix. A parallel diagnosis branch `fix/terminal-resize-content-loss` converges on the same root cause; this PR additionally captures the cursor's buffer row once before the shrink loop, since recomputing `absoluteCursorY` mid-loop drifts as lines are popped (its scrollBack term still reads the pre-resize view height).

## Test plan

- [x] New regression tests: TUI footer survives shrink (alt buffer, xterm.js-style top shed), real keyboard-animation resize flurry round-trips losslessly on the main buffer, trailing blank rows are still reclaimed without creating scrollback, rows with width-hidden text are not destroyed, rows anchoring image placements are not destroyed
- [x] Vendored xterm suite: 299 tests pass (2 pre-existing `textScaler` failures unaffected, fail on main too)
- [x] Full app suite: 2,931 tests pass; `dart analyze` clean
- [ ] On-device validation: run Copilot CLI over MonkeyMux on a phone, toggle the keyboard repeatedly while scrolling the transcript, confirm no blank regions appear

Made with [Cursor](https://cursor.com)