### PR TITLE
feat: add local terminal hosts for desktop and Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -114,5 +114,11 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- Android 11+ package visibility for AVF Linux Terminal detection/launch. -->
+        <package android:name="com.android.virtualization.terminal" />
+        <intent>
+            <action android:name="android.virtualization.VM_TERMINAL" />
+            <category android:name="android.intent.category.DEFAULT" />
+        </intent>
     </queries>
 </manifest>

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/LinuxTerminalChannelHandler.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/LinuxTerminalChannelHandler.kt
@@ -1,0 +1,180 @@
+package xyz.depollsoft.monkeyssh
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.provider.Settings
+import android.util.Log
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Launches Google's AVF Linux Terminal app and related settings screens.
+ *
+ * Package/action names come from AOSP TerminalApp:
+ * `com.android.virtualization.terminal` with action
+ * `android.virtualization.VM_TERMINAL`.
+ */
+object LinuxTerminalChannelHandler {
+    private const val CHANNEL = "xyz.depollsoft.monkeyssh/linux_terminal"
+    private const val TAG = "LinuxTerminalChannel"
+
+    private const val TERMINAL_PACKAGE = "com.android.virtualization.terminal"
+    private const val TERMINAL_MAIN_ACTIVITY =
+        "com.android.virtualization.terminal.MainActivity"
+    private const val TERMINAL_PORT_FORWARD_ACTIVITY =
+        "com.android.virtualization.terminal.SettingsPortForwardingActivity"
+    private const val ACTION_VM_TERMINAL = "android.virtualization.VM_TERMINAL"
+
+    private var methodChannel: MethodChannel? = null
+
+    fun attachToEngine(flutterEngine: FlutterEngine, applicationContext: Context) {
+        if (methodChannel != null) {
+            return
+        }
+
+        methodChannel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            CHANNEL,
+        ).apply {
+            setMethodCallHandler { call, result ->
+                handleMethodCall(
+                    call = call,
+                    result = result,
+                    applicationContext = applicationContext,
+                )
+            }
+        }
+    }
+
+    private fun handleMethodCall(
+        call: MethodCall,
+        result: MethodChannel.Result,
+        applicationContext: Context,
+    ) {
+        when (call.method) {
+            "getStatus" -> result.success(getStatus(applicationContext))
+            "openTerminal" -> result.success(openTerminal(applicationContext))
+            "openDeveloperOptions" ->
+                result.success(openDeveloperOptions(applicationContext))
+            "openPortForwardingSettings" ->
+                result.success(openPortForwardingSettings(applicationContext))
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun getStatus(context: Context): Map<String, Any?> {
+        val packageManager = context.packageManager
+        val installed = isPackageInstalled(packageManager, TERMINAL_PACKAGE)
+        val enabled = if (!installed) {
+            false
+        } else {
+            try {
+                packageManager.getApplicationInfo(TERMINAL_PACKAGE, 0).enabled
+            } catch (error: PackageManager.NameNotFoundException) {
+                false
+            }
+        }
+        val canLaunch = installed && enabled && resolveTerminalIntent(context) != null
+        return mapOf(
+            "installed" to installed,
+            "enabled" to enabled,
+            "canLaunch" to canLaunch,
+            "packageName" to TERMINAL_PACKAGE,
+        )
+    }
+
+    private fun openTerminal(context: Context): Boolean {
+        val intent = resolveTerminalIntent(context) ?: return false
+        return launchIntent(context, intent)
+    }
+
+    private fun openDeveloperOptions(context: Context): Boolean {
+        val intent = Intent(Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        if (launchIntent(context, intent)) {
+            return true
+        }
+        val fallback = Intent(Settings.ACTION_SETTINGS).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        return launchIntent(context, fallback)
+    }
+
+    private fun openPortForwardingSettings(context: Context): Boolean {
+        val intent = Intent().apply {
+            setClassName(TERMINAL_PACKAGE, TERMINAL_PORT_FORWARD_ACTIVITY)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        if (launchIntent(context, intent)) {
+            return true
+        }
+        // Fall back to launching the terminal app itself.
+        return openTerminal(context)
+    }
+
+    private fun resolveTerminalIntent(context: Context): Intent? {
+        val packageManager = context.packageManager
+
+        val actionIntent = Intent(ACTION_VM_TERMINAL).apply {
+            setPackage(TERMINAL_PACKAGE)
+            addCategory(Intent.CATEGORY_DEFAULT)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        if (actionIntent.resolveActivity(packageManager) != null) {
+            return actionIntent
+        }
+
+        val componentIntent = Intent().apply {
+            setClassName(TERMINAL_PACKAGE, TERMINAL_MAIN_ACTIVITY)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        if (componentIntent.resolveActivity(packageManager) != null) {
+            return componentIntent
+        }
+
+        return packageManager.getLaunchIntentForPackage(TERMINAL_PACKAGE)?.apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    }
+
+    private fun isPackageInstalled(
+        packageManager: PackageManager,
+        packageName: String,
+    ): Boolean {
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                packageManager.getPackageInfo(
+                    packageName,
+                    PackageManager.PackageInfoFlags.of(0),
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                packageManager.getPackageInfo(packageName, 0)
+            }
+            true
+        } catch (_: PackageManager.NameNotFoundException) {
+            false
+        }
+    }
+
+    private fun launchIntent(context: Context, intent: Intent): Boolean {
+        return try {
+            context.startActivity(intent)
+            true
+        } catch (error: ActivityNotFoundException) {
+            Log.w(TAG, "Activity not found for ${intent.action ?: intent.component}", error)
+            false
+        } catch (error: SecurityException) {
+            Log.w(TAG, "Launch denied for ${intent.action ?: intent.component}", error)
+            false
+        } catch (error: RuntimeException) {
+            Log.w(TAG, "Launch failed for ${intent.action ?: intent.component}", error)
+            false
+        }
+    }
+}

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MonkeySshApplication.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MonkeySshApplication.kt
@@ -27,6 +27,7 @@ class MonkeySshApplication : Application() {
         GeneratedPluginRegistrant.registerWith(engine)
         SshServiceChannelHandler.attachToEngine(engine, applicationContext)
         DeviceDebugChannelHandler.attachToEngine(engine, applicationContext)
+        LinuxTerminalChannelHandler.attachToEngine(engine, applicationContext)
         engine.dartExecutor.executeDartEntrypoint(
             DartExecutor.DartEntrypoint.createDefault()
         )

--- a/integration_test/terminal_screen_system_selection_test.dart
+++ b/integration_test/terminal_screen_system_selection_test.dart
@@ -53,6 +53,7 @@ class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
 Host _buildHost({required int id}) => Host(
   id: id,
   label: 'Terminal selection test host',
+  hostKind: 'ssh',
   hostname: 'terminal.example.com',
   port: 22,
   username: 'root',

--- a/integration_test/terminal_selection_reentry_device_test.dart
+++ b/integration_test/terminal_selection_reentry_device_test.dart
@@ -55,6 +55,7 @@ class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
 Host _buildHost({required int id}) => Host(
   id: id,
   label: 'Terminal selection test host',
+  hostKind: 'ssh',
   hostname: 'terminal.example.com',
   port: 22,
   username: 'root',

--- a/integration_test/tmux_notification_navigation_validation_test.dart
+++ b/integration_test/tmux_notification_navigation_validation_test.dart
@@ -65,6 +65,7 @@ class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
 Host _buildHost({required int id, required String tmuxSessionName}) => Host(
   id: id,
   label: 'Notification navigation validation',
+  hostKind: 'ssh',
   hostname: 'terminal.example.com',
   port: 22,
   username: 'root',

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -213,6 +213,8 @@ class _BackgroundLifecycleBridgeState
     if (launchTerminalNotification != null) {
       _handleTerminalNotification(launchTerminalNotification);
     }
+    // Linux Terminal setup actions are consumed by
+    // AndroidLinuxTerminalSetupService.start() so cold-start taps still run.
   }
 
   bool _canOpenTmuxAlertNotification(AuthState authState) =>

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -7,6 +8,7 @@ import '../data/database/database.dart';
 import '../data/repositories/host_repository.dart';
 import '../domain/models/terminal_theme.dart';
 import '../domain/models/terminal_themes.dart';
+import '../domain/services/android_linux_terminal_setup_service.dart';
 import '../domain/services/auth_service.dart';
 import '../domain/services/background_ssh_service.dart';
 import '../domain/services/home_screen_shortcut_service.dart';
@@ -152,6 +154,10 @@ class _BackgroundLifecycleBridgeState
       syncForegroundBackgroundStatus: _syncForegroundBackgroundStatus,
       runStartupTask: _runLifecycleSync,
     );
+    // Keep Android Linux Terminal setup notification actions alive app-wide.
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
+      ref.read(androidLinuxTerminalSetupServiceProvider);
+    }
     _bootstrapController.start();
     _runLifecycleSync(
       _recordTelemetryPromptAppLaunch,

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../domain/models/host_kind.dart';
 import '../domain/models/monetization.dart';
 import '../domain/services/auth_service.dart';
 import '../domain/services/port_forward_browser_service.dart';
@@ -136,8 +137,16 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/hosts/add',
         name: 'host-add',
-        builder: (context, state) =>
-            HostEditScreen(initialSshUrl: state.uri.queryParameters['sshUrl']),
+        builder: (context, state) {
+          final kindParam = state.uri.queryParameters['kind'];
+          final initialHostKind = kindParam == 'local'
+              ? HostKind.local
+              : HostKind.ssh;
+          return HostEditScreen(
+            initialSshUrl: state.uri.queryParameters['sshUrl'],
+            initialHostKind: initialHostKind,
+          );
+        },
       ),
       GoRoute(
         path: '/hosts/edit/:hostId',

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -139,7 +139,8 @@ final routerProvider = Provider<GoRouter>((ref) {
         name: 'host-add',
         builder: (context, state) {
           final kindParam = state.uri.queryParameters['kind'];
-          final initialHostKind = kindParam == 'local'
+          final initialHostKind =
+              kindParam == 'local' && isLocalTerminalSupported()
               ? HostKind.local
               : HostKind.ssh;
           return HostEditScreen(

--- a/lib/data/database/database.dart
+++ b/lib/data/database/database.dart
@@ -18,10 +18,13 @@ class Hosts extends Table {
   /// Display label for the host.
   TextColumn get label => text().withLength(min: 1, max: 255)();
 
+  /// Host transport kind (`ssh` or `local`). Defaults to SSH.
+  TextColumn get hostKind => text().withDefault(const Constant('ssh'))();
+
   /// Hostname or IP address.
   TextColumn get hostname => text().withLength(min: 1, max: 255)();
 
-  /// SSH port (default 22).
+  /// SSH port (default 22). Local terminals store `0`.
   IntColumn get port => integer().withDefault(const Constant(22))();
 
   /// Username for authentication.
@@ -333,7 +336,7 @@ class AppDatabase extends _$AppDatabase {
   final AppleDatabaseFilePolicyApplier _appleDatabaseFilePolicyApplier;
 
   @override
-  int get schemaVersion => 10;
+  int get schemaVersion => 11;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -413,6 +416,12 @@ class AppDatabase extends _$AppDatabase {
         }
         if (!hostColumnNames.contains(hosts.portProxyName.$name)) {
           await m.addColumn(hosts, hosts.portProxyName);
+        }
+      }
+      if (from < 11) {
+        final hostColumnNames = await _readColumnNames('hosts');
+        if (!hostColumnNames.contains(hosts.hostKind.$name)) {
+          await m.addColumn(hosts, hosts.hostKind);
         }
       }
     },

--- a/lib/data/database/database.g.dart
+++ b/lib/data/database/database.g.dart
@@ -2021,6 +2021,18 @@ class $HostsTable extends Hosts with TableInfo<$HostsTable, Host> {
     type: DriftSqlType.string,
     requiredDuringInsert: true,
   );
+  static const VerificationMeta _hostKindMeta = const VerificationMeta(
+    'hostKind',
+  );
+  @override
+  late final GeneratedColumn<String> hostKind = GeneratedColumn<String>(
+    'host_kind',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('ssh'),
+  );
   static const VerificationMeta _hostnameMeta = const VerificationMeta(
     'hostname',
   );
@@ -2359,6 +2371,7 @@ class $HostsTable extends Hosts with TableInfo<$HostsTable, Host> {
   List<GeneratedColumn> get $columns => [
     id,
     label,
+    hostKind,
     hostname,
     port,
     username,
@@ -2410,6 +2423,12 @@ class $HostsTable extends Hosts with TableInfo<$HostsTable, Host> {
       );
     } else if (isInserting) {
       context.missing(_labelMeta);
+    }
+    if (data.containsKey('host_kind')) {
+      context.handle(
+        _hostKindMeta,
+        hostKind.isAcceptableOrUnknown(data['host_kind']!, _hostKindMeta),
+      );
     }
     if (data.containsKey('hostname')) {
       context.handle(
@@ -2645,6 +2664,10 @@ class $HostsTable extends Hosts with TableInfo<$HostsTable, Host> {
         DriftSqlType.string,
         data['${effectivePrefix}label'],
       )!,
+      hostKind: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}host_kind'],
+      )!,
       hostname: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}hostname'],
@@ -2773,10 +2796,13 @@ class Host extends DataClass implements Insertable<Host> {
   /// Display label for the host.
   final String label;
 
+  /// Host transport kind (`ssh` or `local`). Defaults to SSH.
+  final String hostKind;
+
   /// Hostname or IP address.
   final String hostname;
 
-  /// SSH port (default 22).
+  /// SSH port (default 22). Local terminals store `0`.
   final int port;
 
   /// Username for authentication.
@@ -2870,6 +2896,7 @@ class Host extends DataClass implements Insertable<Host> {
   const Host({
     required this.id,
     required this.label,
+    required this.hostKind,
     required this.hostname,
     required this.port,
     required this.username,
@@ -2904,6 +2931,7 @@ class Host extends DataClass implements Insertable<Host> {
     final map = <String, Expression>{};
     map['id'] = Variable<int>(id);
     map['label'] = Variable<String>(label);
+    map['host_kind'] = Variable<String>(hostKind);
     map['hostname'] = Variable<String>(hostname);
     map['port'] = Variable<int>(port);
     map['username'] = Variable<String>(username);
@@ -2979,6 +3007,7 @@ class Host extends DataClass implements Insertable<Host> {
     return HostsCompanion(
       id: Value(id),
       label: Value(label),
+      hostKind: Value(hostKind),
       hostname: Value(hostname),
       port: Value(port),
       username: Value(username),
@@ -3054,6 +3083,7 @@ class Host extends DataClass implements Insertable<Host> {
     return Host(
       id: serializer.fromJson<int>(json['id']),
       label: serializer.fromJson<String>(json['label']),
+      hostKind: serializer.fromJson<String>(json['hostKind']),
       hostname: serializer.fromJson<String>(json['hostname']),
       port: serializer.fromJson<int>(json['port']),
       username: serializer.fromJson<String>(json['username']),
@@ -3106,6 +3136,7 @@ class Host extends DataClass implements Insertable<Host> {
     return <String, dynamic>{
       'id': serializer.toJson<int>(id),
       'label': serializer.toJson<String>(label),
+      'hostKind': serializer.toJson<String>(hostKind),
       'hostname': serializer.toJson<String>(hostname),
       'port': serializer.toJson<int>(port),
       'username': serializer.toJson<String>(username),
@@ -3142,6 +3173,7 @@ class Host extends DataClass implements Insertable<Host> {
   Host copyWith({
     int? id,
     String? label,
+    String? hostKind,
     String? hostname,
     int? port,
     String? username,
@@ -3173,6 +3205,7 @@ class Host extends DataClass implements Insertable<Host> {
   }) => Host(
     id: id ?? this.id,
     label: label ?? this.label,
+    hostKind: hostKind ?? this.hostKind,
     hostname: hostname ?? this.hostname,
     port: port ?? this.port,
     username: username ?? this.username,
@@ -3231,6 +3264,7 @@ class Host extends DataClass implements Insertable<Host> {
     return Host(
       id: data.id.present ? data.id.value : this.id,
       label: data.label.present ? data.label.value : this.label,
+      hostKind: data.hostKind.present ? data.hostKind.value : this.hostKind,
       hostname: data.hostname.present ? data.hostname.value : this.hostname,
       port: data.port.present ? data.port.value : this.port,
       username: data.username.present ? data.username.value : this.username,
@@ -3300,6 +3334,7 @@ class Host extends DataClass implements Insertable<Host> {
     return (StringBuffer('Host(')
           ..write('id: $id, ')
           ..write('label: $label, ')
+          ..write('hostKind: $hostKind, ')
           ..write('hostname: $hostname, ')
           ..write('port: $port, ')
           ..write('username: $username, ')
@@ -3338,6 +3373,7 @@ class Host extends DataClass implements Insertable<Host> {
   int get hashCode => Object.hashAll([
     id,
     label,
+    hostKind,
     hostname,
     port,
     username,
@@ -3373,6 +3409,7 @@ class Host extends DataClass implements Insertable<Host> {
       (other is Host &&
           other.id == this.id &&
           other.label == this.label &&
+          other.hostKind == this.hostKind &&
           other.hostname == this.hostname &&
           other.port == this.port &&
           other.username == this.username &&
@@ -3407,6 +3444,7 @@ class Host extends DataClass implements Insertable<Host> {
 class HostsCompanion extends UpdateCompanion<Host> {
   final Value<int> id;
   final Value<String> label;
+  final Value<String> hostKind;
   final Value<String> hostname;
   final Value<int> port;
   final Value<String> username;
@@ -3438,6 +3476,7 @@ class HostsCompanion extends UpdateCompanion<Host> {
   const HostsCompanion({
     this.id = const Value.absent(),
     this.label = const Value.absent(),
+    this.hostKind = const Value.absent(),
     this.hostname = const Value.absent(),
     this.port = const Value.absent(),
     this.username = const Value.absent(),
@@ -3470,6 +3509,7 @@ class HostsCompanion extends UpdateCompanion<Host> {
   HostsCompanion.insert({
     this.id = const Value.absent(),
     required String label,
+    this.hostKind = const Value.absent(),
     required String hostname,
     this.port = const Value.absent(),
     required String username,
@@ -3504,6 +3544,7 @@ class HostsCompanion extends UpdateCompanion<Host> {
   static Insertable<Host> custom({
     Expression<int>? id,
     Expression<String>? label,
+    Expression<String>? hostKind,
     Expression<String>? hostname,
     Expression<int>? port,
     Expression<String>? username,
@@ -3536,6 +3577,7 @@ class HostsCompanion extends UpdateCompanion<Host> {
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (label != null) 'label': label,
+      if (hostKind != null) 'host_kind': hostKind,
       if (hostname != null) 'hostname': hostname,
       if (port != null) 'port': port,
       if (username != null) 'username': username,
@@ -3578,6 +3620,7 @@ class HostsCompanion extends UpdateCompanion<Host> {
   HostsCompanion copyWith({
     Value<int>? id,
     Value<String>? label,
+    Value<String>? hostKind,
     Value<String>? hostname,
     Value<int>? port,
     Value<String>? username,
@@ -3610,6 +3653,7 @@ class HostsCompanion extends UpdateCompanion<Host> {
     return HostsCompanion(
       id: id ?? this.id,
       label: label ?? this.label,
+      hostKind: hostKind ?? this.hostKind,
       hostname: hostname ?? this.hostname,
       port: port ?? this.port,
       username: username ?? this.username,
@@ -3651,6 +3695,9 @@ class HostsCompanion extends UpdateCompanion<Host> {
     }
     if (label.present) {
       map['label'] = Variable<String>(label.value);
+    }
+    if (hostKind.present) {
+      map['host_kind'] = Variable<String>(hostKind.value);
     }
     if (hostname.present) {
       map['hostname'] = Variable<String>(hostname.value);
@@ -3756,6 +3803,7 @@ class HostsCompanion extends UpdateCompanion<Host> {
     return (StringBuffer('HostsCompanion(')
           ..write('id: $id, ')
           ..write('label: $label, ')
+          ..write('hostKind: $hostKind, ')
           ..write('hostname: $hostname, ')
           ..write('port: $port, ')
           ..write('username: $username, ')
@@ -6865,6 +6913,7 @@ typedef $$HostsTableCreateCompanionBuilder =
     HostsCompanion Function({
       Value<int> id,
       required String label,
+      Value<String> hostKind,
       required String hostname,
       Value<int> port,
       required String username,
@@ -6898,6 +6947,7 @@ typedef $$HostsTableUpdateCompanionBuilder =
     HostsCompanion Function({
       Value<int> id,
       Value<String> label,
+      Value<String> hostKind,
       Value<String> hostname,
       Value<int> port,
       Value<String> username,
@@ -7036,6 +7086,11 @@ class $$HostsTableFilterComposer extends Composer<_$AppDatabase, $HostsTable> {
 
   ColumnFilters<String> get label => $composableBuilder(
     column: $table.label,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get hostKind => $composableBuilder(
+    column: $table.hostKind,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -7296,6 +7351,11 @@ class $$HostsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get hostKind => $composableBuilder(
+    column: $table.hostKind,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get hostname => $composableBuilder(
     column: $table.hostname,
     builder: (column) => ColumnOrderings(column),
@@ -7524,6 +7584,9 @@ class $$HostsTableAnnotationComposer
 
   GeneratedColumn<String> get label =>
       $composableBuilder(column: $table.label, builder: (column) => column);
+
+  GeneratedColumn<String> get hostKind =>
+      $composableBuilder(column: $table.hostKind, builder: (column) => column);
 
   GeneratedColumn<String> get hostname =>
       $composableBuilder(column: $table.hostname, builder: (column) => column);
@@ -7780,6 +7843,7 @@ class $$HostsTableTableManager
               ({
                 Value<int> id = const Value.absent(),
                 Value<String> label = const Value.absent(),
+                Value<String> hostKind = const Value.absent(),
                 Value<String> hostname = const Value.absent(),
                 Value<int> port = const Value.absent(),
                 Value<String> username = const Value.absent(),
@@ -7812,6 +7876,7 @@ class $$HostsTableTableManager
               }) => HostsCompanion(
                 id: id,
                 label: label,
+                hostKind: hostKind,
                 hostname: hostname,
                 port: port,
                 username: username,
@@ -7846,6 +7911,7 @@ class $$HostsTableTableManager
               ({
                 Value<int> id = const Value.absent(),
                 required String label,
+                Value<String> hostKind = const Value.absent(),
                 required String hostname,
                 Value<int> port = const Value.absent(),
                 required String username,
@@ -7878,6 +7944,7 @@ class $$HostsTableTableManager
               }) => HostsCompanion.insert(
                 id: id,
                 label: label,
+                hostKind: hostKind,
                 hostname: hostname,
                 port: port,
                 username: username,

--- a/lib/domain/commands/save_host_command.dart
+++ b/lib/domain/commands/save_host_command.dart
@@ -5,6 +5,7 @@ import '../../data/database/database.dart';
 import '../../data/repositories/host_repository.dart';
 import '../models/agent_launch_preset.dart';
 import '../models/host_cli_launch_preferences.dart';
+import '../models/host_kind.dart';
 import '../models/remote_multiplexer.dart';
 import '../services/agent_launch_preset_service.dart';
 import '../services/host_cli_launch_preferences_service.dart';
@@ -23,6 +24,7 @@ class SaveHostInput {
     required this.username,
     required this.autoConnectRequiresConfirmation,
     required this.isFavorite,
+    this.hostKind = HostKind.ssh,
     this.autoForwardPorts = false,
     this.password,
     this.tags,
@@ -44,6 +46,9 @@ class SaveHostInput {
 
   /// Display label.
   final String label;
+
+  /// Transport kind for this host.
+  final HostKind hostKind;
 
   /// Hostname or IP address.
   final String hostname;
@@ -201,6 +206,7 @@ class SaveHostCommand {
       await _hostRepository.update(
         existingHost.copyWith(
           label: input.label,
+          hostKind: input.hostKind.storageValue,
           hostname: input.hostname,
           port: input.port,
           username: input.username,
@@ -231,6 +237,7 @@ class SaveHostCommand {
       savedHostId = await _hostRepository.insert(
         HostsCompanion.insert(
           label: input.label,
+          hostKind: drift.Value(input.hostKind.storageValue),
           hostname: input.hostname,
           port: drift.Value(input.port),
           username: input.username,

--- a/lib/domain/models/host_kind.dart
+++ b/lib/domain/models/host_kind.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+import '../../data/database/database.dart';
+
+/// How a saved host opens a terminal session.
+enum HostKind {
+  /// Network SSH host (default).
+  ssh,
+
+  /// Local interactive shell on this device (desktop + Android sandbox).
+  local,
+}
+
+/// Presentation and storage helpers for [HostKind].
+extension HostKindX on HostKind {
+  /// Stable database/storage value.
+  String get storageValue => switch (this) {
+    HostKind.ssh => 'ssh',
+    HostKind.local => 'local',
+  };
+
+  /// Short diagnostics value.
+  String get diagnosticsValue => storageValue;
+
+  /// Human-readable label for UI.
+  String get label => switch (this) {
+    HostKind.ssh => 'SSH',
+    HostKind.local => 'Local Terminal',
+  };
+}
+
+/// Parses a stored host-kind value. Unknown/null values default to SSH.
+HostKind hostKindFromStorage(String? value) {
+  switch (value?.trim().toLowerCase()) {
+    case 'local':
+      return HostKind.local;
+    case 'ssh':
+    case null:
+    case '':
+      return HostKind.ssh;
+    default:
+      return HostKind.ssh;
+  }
+}
+
+/// Returns the kind for [host].
+HostKind hostKindOf(Host host) => hostKindFromStorage(host.hostKind);
+
+/// Whether [host] opens a local device shell instead of SSH.
+bool isLocalTerminalHost(Host host) => hostKindOf(host) == HostKind.local;
+
+/// Whether this build/platform can spawn a local interactive PTY shell.
+bool isLocalTerminalSupported({TargetPlatform? platform}) {
+  if (kIsWeb) {
+    return false;
+  }
+  final resolved = platform ?? defaultTargetPlatform;
+  return switch (resolved) {
+    TargetPlatform.android ||
+    TargetPlatform.linux ||
+    TargetPlatform.macOS ||
+    TargetPlatform.windows => true,
+    _ => false,
+  };
+}
+
+/// Default display label for a new local terminal host on this platform.
+String defaultLocalTerminalHostLabel({TargetPlatform? platform}) {
+  final resolved = platform ?? defaultTargetPlatform;
+  return switch (resolved) {
+    TargetPlatform.macOS => 'This Mac',
+    TargetPlatform.windows => 'This PC',
+    TargetPlatform.linux => 'This Linux PC',
+    TargetPlatform.android => 'This Android device',
+    _ => 'Local Terminal',
+  };
+}
+
+/// Default username shown for a local terminal host.
+String defaultLocalTerminalUsername() {
+  if (kIsWeb) {
+    return 'local';
+  }
+  final env = Platform.environment;
+  final fromEnv = env['USER'] ?? env['USERNAME'] ?? env['LOGNAME'];
+  final trimmed = fromEnv?.trim();
+  if (trimmed != null && trimmed.isNotEmpty) {
+    return trimmed;
+  }
+  return 'local';
+}
+
+/// Canonical hostname stored for local terminal hosts.
+const String localTerminalHostname = 'local';
+
+/// Canonical port stored for local terminal hosts (unused for connect).
+const int localTerminalPort = 0;

--- a/lib/domain/services/android_linux_terminal_launcher.dart
+++ b/lib/domain/services/android_linux_terminal_launcher.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Status of the system AVF Linux Terminal app on this device.
+@immutable
+class AndroidLinuxTerminalStatus {
+  /// Creates a terminal status snapshot.
+  const AndroidLinuxTerminalStatus({
+    required this.installed,
+    required this.enabled,
+    required this.canLaunch,
+    this.packageName,
+  });
+
+  /// Parses a method-channel map.
+  factory AndroidLinuxTerminalStatus.fromMap(Map<Object?, Object?> map) =>
+      AndroidLinuxTerminalStatus(
+        installed: map['installed'] == true,
+        enabled: map['enabled'] == true,
+        canLaunch: map['canLaunch'] == true,
+        packageName: map['packageName'] as String?,
+      );
+
+  /// Status used when the channel is unavailable.
+  static const unavailable = AndroidLinuxTerminalStatus(
+    installed: false,
+    enabled: false,
+    canLaunch: false,
+  );
+
+  /// Whether the Terminal package is installed.
+  final bool installed;
+
+  /// Whether the Terminal package is enabled.
+  final bool enabled;
+
+  /// Whether MonkeySSH can launch Terminal right now.
+  final bool canLaunch;
+
+  /// Package name reported by the platform channel.
+  final String? packageName;
+}
+
+/// Platform bridge for launching Android's AVF Linux Terminal app.
+class AndroidLinuxTerminalLauncher {
+  /// Creates a launcher.
+  AndroidLinuxTerminalLauncher({MethodChannel? channel})
+    : _channel =
+          channel ??
+          const MethodChannel('xyz.depollsoft.monkeyssh/linux_terminal');
+
+  final MethodChannel _channel;
+
+  /// Whether this launcher can run on the current platform.
+  bool get isSupported =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+
+  /// Returns Terminal package/install status.
+  Future<AndroidLinuxTerminalStatus> getStatus() async {
+    if (!isSupported) {
+      return AndroidLinuxTerminalStatus.unavailable;
+    }
+    try {
+      final raw = await _channel.invokeMethod<Map<Object?, Object?>>(
+        'getStatus',
+      );
+      if (raw == null) {
+        return AndroidLinuxTerminalStatus.unavailable;
+      }
+      return AndroidLinuxTerminalStatus.fromMap(raw);
+    } on MissingPluginException {
+      return AndroidLinuxTerminalStatus.unavailable;
+    } on PlatformException {
+      return AndroidLinuxTerminalStatus.unavailable;
+    }
+  }
+
+  /// Opens the Linux Terminal app when possible.
+  Future<bool> openTerminal() async {
+    if (!isSupported) {
+      return false;
+    }
+    try {
+      return await _channel.invokeMethod<bool>('openTerminal') ?? false;
+    } on MissingPluginException {
+      return false;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  /// Opens Developer Options so the user can enable Linux Terminal.
+  Future<bool> openDeveloperOptions() async {
+    if (!isSupported) {
+      return false;
+    }
+    try {
+      return await _channel.invokeMethod<bool>('openDeveloperOptions') ?? false;
+    } on MissingPluginException {
+      return false;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  /// Opens Terminal port-forwarding settings when available.
+  Future<bool> openPortForwardingSettings() async {
+    if (!isSupported) {
+      return false;
+    }
+    try {
+      return await _channel.invokeMethod<bool>('openPortForwardingSettings') ??
+          false;
+    } on MissingPluginException {
+      return false;
+    } on PlatformException {
+      return false;
+    }
+  }
+}

--- a/lib/domain/services/android_linux_terminal_setup_service.dart
+++ b/lib/domain/services/android_linux_terminal_setup_service.dart
@@ -136,6 +136,7 @@ class AndroidLinuxTerminalSetupService {
   String? _activePublicKey;
   String? _activeScript;
   bool _disposed = false;
+  bool _finishInFlight = false;
 
   /// Latest setup state.
   AndroidLinuxTerminalSetupState get state => _state;
@@ -150,6 +151,16 @@ class AndroidLinuxTerminalSetupService {
   void start() {
     _notificationSubscription ??= _notificationService.linuxTerminalSetupTaps
         .listen(_handleNotificationAction);
+    unawaited(_consumeLaunchNotification());
+  }
+
+  Future<void> _consumeLaunchNotification() async {
+    final payload = await _notificationService
+        .consumeLaunchLinuxTerminalSetup();
+    if (payload == null || _disposed) {
+      return;
+    }
+    await _handleNotificationAction(payload);
   }
 
   /// Releases timers/subscriptions.
@@ -282,48 +293,63 @@ class AndroidLinuxTerminalSetupService {
     if (_activeKeyId == null || _activePublicKey == null) {
       return beginSetup();
     }
-    _emit(
-      _state.copyWith(
-        phase: AndroidLinuxTerminalSetupPhase.probing,
-        message: 'Looking for SSH on port $androidLinuxTerminalSetupPort…',
-      ),
-    );
-    final endpoint = await _findReachableEndpoint();
-    if (endpoint == null) {
-      await _notificationService.showLinuxTerminalSetup(
-        title: 'Linux Terminal setup',
-        body:
-            'SSH not reachable yet. In Terminal, run the script and enable port forwarding if needed.',
-      );
-      return _emit(
+    // Serialize concurrent probes (timer + notification + UI) so two
+    // successful lookups cannot both insert a host before either writes.
+    if (_state.phase == AndroidLinuxTerminalSetupPhase.probing ||
+        _state.phase == AndroidLinuxTerminalSetupPhase.succeeded ||
+        _finishInFlight) {
+      return _state;
+    }
+    _finishInFlight = true;
+    _stopProbing();
+    try {
+      _emit(
         _state.copyWith(
-          phase: AndroidLinuxTerminalSetupPhase.waitingForUser,
-          message:
-              'SSH not reachable on port $androidLinuxTerminalSetupPort yet. '
-              'If the VM is isolated, open Terminal port forwarding to $androidLinuxTerminalSetupPort.',
+          phase: AndroidLinuxTerminalSetupPhase.probing,
+          message: 'Looking for SSH on port $androidLinuxTerminalSetupPort…',
         ),
       );
-    }
+      final endpoint = await _findReachableEndpoint();
+      if (endpoint == null) {
+        await _notificationService.showLinuxTerminalSetup(
+          title: 'Linux Terminal setup',
+          body:
+              'SSH not reachable yet. In Terminal, run the script and enable port forwarding if needed.',
+        );
+        final waiting = _emit(
+          _state.copyWith(
+            phase: AndroidLinuxTerminalSetupPhase.waitingForUser,
+            message:
+                'SSH not reachable on port $androidLinuxTerminalSetupPort yet. '
+                'If the VM is isolated, open Terminal port forwarding to $androidLinuxTerminalSetupPort.',
+          ),
+        );
+        _startProbing();
+        return waiting;
+      }
 
-    final hostId = await _createOrUpdateHost(
-      hostname: endpoint.host,
-      port: endpoint.port,
-      keyId: _activeKeyId!,
-    );
-    _stopProbing();
-    await _notificationService.clearLinuxTerminalSetup();
-    return _emit(
-      AndroidLinuxTerminalSetupState(
-        phase: AndroidLinuxTerminalSetupPhase.succeeded,
-        message: 'Added Linux Terminal host ${endpoint.host}:${endpoint.port}.',
-        hostId: hostId,
-        keyId: _activeKeyId,
-        publicKey: _activePublicKey,
-        script: _activeScript,
-        reachableHost: endpoint.host,
-        reachablePort: endpoint.port,
-      ),
-    );
+      final hostId = await _createOrUpdateHost(
+        hostname: endpoint.host,
+        port: endpoint.port,
+        keyId: _activeKeyId!,
+      );
+      await _notificationService.clearLinuxTerminalSetup();
+      return _emit(
+        AndroidLinuxTerminalSetupState(
+          phase: AndroidLinuxTerminalSetupPhase.succeeded,
+          message:
+              'Added Linux Terminal host ${endpoint.host}:${endpoint.port}.',
+          hostId: hostId,
+          keyId: _activeKeyId,
+          publicKey: _activePublicKey,
+          script: _activeScript,
+          reachableHost: endpoint.host,
+          reachablePort: endpoint.port,
+        ),
+      );
+    } finally {
+      _finishInFlight = false;
+    }
   }
 
   /// Cancels an in-progress setup.
@@ -437,25 +463,27 @@ class AndroidLinuxTerminalSetupService {
     required int keyId,
   }) async {
     final hosts = await _hostRepository.getAll();
+    // Only update hosts previously created by this setup flow. Never clobber an
+    // unrelated user host that happens to share localhost/8022.
     for (final host in hosts) {
-      if (isAndroidLinuxTerminalHost(host) ||
-          (host.hostname == hostname && host.port == port)) {
-        await _hostRepository.update(
-          host.copyWith(
-            label: androidLinuxTerminalHostLabel,
-            hostname: hostname,
-            port: port,
-            username: androidLinuxTerminalSetupUsername,
-            keyId: Value(keyId),
-            password: const Value(null),
-            notes: const Value(
-              '$androidLinuxTerminalHostNotesMarker. '
-              'If connect fails, enable port forwarding in the Terminal app.',
-            ),
-          ),
-        );
-        return host.id;
+      if (!isAndroidLinuxTerminalHost(host)) {
+        continue;
       }
+      await _hostRepository.update(
+        host.copyWith(
+          label: androidLinuxTerminalHostLabel,
+          hostname: hostname,
+          port: port,
+          username: androidLinuxTerminalSetupUsername,
+          keyId: Value(keyId),
+          password: const Value(null),
+          notes: const Value(
+            '$androidLinuxTerminalHostNotesMarker. '
+            'If connect fails, enable port forwarding in the Terminal app.',
+          ),
+        ),
+      );
+      return host.id;
     }
 
     return _hostRepository.insert(
@@ -482,16 +510,25 @@ class AndroidLinuxTerminalSetupService {
   }
 
   static Future<bool> _defaultProbeSsh(String host, int port) async {
+    Socket? socket;
     try {
-      final socket = await Socket.connect(
+      socket = await Socket.connect(
         host,
         port,
-        timeout: const Duration(milliseconds: 700),
+        timeout: const Duration(milliseconds: 900),
       );
-      socket.destroy();
-      return true;
+      // Require an SSH identification string so random listeners on 8022 are
+      // not treated as a successful setup.
+      final banner = await socket
+          .timeout(const Duration(milliseconds: 900))
+          .first
+          .timeout(const Duration(milliseconds: 900));
+      final text = String.fromCharCodes(banner);
+      return text.startsWith('SSH-');
     } on Object {
       return false;
+    } finally {
+      socket?.destroy();
     }
   }
 }

--- a/lib/domain/services/android_linux_terminal_setup_service.dart
+++ b/lib/domain/services/android_linux_terminal_setup_service.dart
@@ -19,6 +19,22 @@ const androidLinuxTerminalSetupPort = 8022;
 /// Default username used inside the AVF Debian image.
 const androidLinuxTerminalSetupUsername = 'droid';
 
+/// Label used for hosts created by Linux Terminal setup.
+const androidLinuxTerminalHostLabel = 'Android Linux Terminal';
+
+/// Marker stored in host notes for recovery UX.
+const androidLinuxTerminalHostNotesMarker =
+    'Created by MonkeySSH Linux Terminal setup';
+
+/// Whether [host] was created for Android's AVF Linux Terminal SSH access.
+bool isAndroidLinuxTerminalHost(Host host) {
+  if (host.label.trim() == androidLinuxTerminalHostLabel) {
+    return true;
+  }
+  final notes = host.notes?.trim() ?? '';
+  return notes.contains(androidLinuxTerminalHostNotesMarker);
+}
+
 /// Progress / result of an Android Linux Terminal setup attempt.
 @immutable
 class AndroidLinuxTerminalSetupState {
@@ -245,6 +261,18 @@ class AndroidLinuxTerminalSetupService {
     await _launcher.openDeveloperOptions();
   }
 
+  /// Opens Terminal and shows a lightweight recovery notification after a
+  /// failed SSH connect (does not regenerate keys or rewrite the script).
+  Future<void> prepareConnectRecovery() async {
+    await openTerminalOrSettings();
+    await _notificationService.showLinuxTerminalSetup(
+      title: 'Linux Terminal',
+      body:
+          'Start Linux Terminal, wait for the VM, then return and retry SSH. '
+          'Use port forwarding to $androidLinuxTerminalSetupPort if needed.',
+    );
+  }
+
   /// Opens Terminal port-forward settings when available.
   Future<void> openPortForwardingSettings() =>
       _launcher.openPortForwardingSettings();
@@ -410,18 +438,18 @@ class AndroidLinuxTerminalSetupService {
   }) async {
     final hosts = await _hostRepository.getAll();
     for (final host in hosts) {
-      if (host.label == 'Android Linux Terminal' ||
+      if (isAndroidLinuxTerminalHost(host) ||
           (host.hostname == hostname && host.port == port)) {
         await _hostRepository.update(
           host.copyWith(
-            label: 'Android Linux Terminal',
+            label: androidLinuxTerminalHostLabel,
             hostname: hostname,
             port: port,
             username: androidLinuxTerminalSetupUsername,
             keyId: Value(keyId),
             password: const Value(null),
             notes: const Value(
-              'Created by MonkeySSH Linux Terminal setup. '
+              '$androidLinuxTerminalHostNotesMarker. '
               'If connect fails, enable port forwarding in the Terminal app.',
             ),
           ),
@@ -432,13 +460,13 @@ class AndroidLinuxTerminalSetupService {
 
     return _hostRepository.insert(
       HostsCompanion.insert(
-        label: 'Android Linux Terminal',
+        label: androidLinuxTerminalHostLabel,
         hostname: hostname,
         port: Value(port),
         username: androidLinuxTerminalSetupUsername,
         keyId: Value(keyId),
         notes: const Value(
-          'Created by MonkeySSH Linux Terminal setup. '
+          '$androidLinuxTerminalHostNotesMarker. '
           'If connect fails, enable port forwarding in the Terminal app.',
         ),
       ),

--- a/lib/domain/services/android_linux_terminal_setup_service.dart
+++ b/lib/domain/services/android_linux_terminal_setup_service.dart
@@ -1,0 +1,545 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/database/database.dart';
+import '../../data/repositories/host_repository.dart';
+import '../../data/repositories/key_repository.dart';
+import 'android_linux_terminal_launcher.dart';
+import 'key_service.dart';
+import 'local_notification_service.dart';
+
+/// Default SSH port used by the Linux Terminal setup script.
+const androidLinuxTerminalSetupPort = 8022;
+
+/// Default username used inside the AVF Debian image.
+const androidLinuxTerminalSetupUsername = 'droid';
+
+/// Progress / result of an Android Linux Terminal setup attempt.
+@immutable
+class AndroidLinuxTerminalSetupState {
+  /// Creates a setup state snapshot.
+  const AndroidLinuxTerminalSetupState({
+    required this.phase,
+    required this.message,
+    this.hostId,
+    this.keyId,
+    this.publicKey,
+    this.script,
+    this.reachableHost,
+    this.reachablePort,
+  });
+
+  /// High-level phase for UI.
+  final AndroidLinuxTerminalSetupPhase phase;
+
+  /// User-visible status message (no secrets).
+  final String message;
+
+  /// Host created when setup succeeds.
+  final int? hostId;
+
+  /// SSH key generated for this setup.
+  final int? keyId;
+
+  /// Public key embedded in the setup script.
+  final String? publicKey;
+
+  /// Full setup script currently on the clipboard.
+  final String? script;
+
+  /// Host that answered the SSH probe.
+  final String? reachableHost;
+
+  /// Port that answered the SSH probe.
+  final int? reachablePort;
+
+  /// Idle state.
+  static const idle = AndroidLinuxTerminalSetupState(
+    phase: AndroidLinuxTerminalSetupPhase.idle,
+    message: '',
+  );
+}
+
+/// Phases of the Android Linux Terminal setup flow.
+enum AndroidLinuxTerminalSetupPhase {
+  /// No active setup.
+  idle,
+
+  /// Preparing key/script and launching Terminal.
+  preparing,
+
+  /// Waiting for the user to run the script / enable networking.
+  waitingForUser,
+
+  /// Probing for SSH.
+  probing,
+
+  /// SSH host was created successfully.
+  succeeded,
+
+  /// Setup failed or was cancelled.
+  failed,
+}
+
+/// Coordinates clipboard script + notification + SSH probe for AVF Terminal.
+class AndroidLinuxTerminalSetupService {
+  /// Creates a setup service.
+  AndroidLinuxTerminalSetupService({
+    required HostRepository hostRepository,
+    required KeyRepository keyRepository,
+    required KeyService keyService,
+    required LocalNotificationService notificationService,
+    AndroidLinuxTerminalLauncher? launcher,
+    Future<bool> Function(String host, int port)? probeSsh,
+  }) : _hostRepository = hostRepository,
+       _keyRepository = keyRepository,
+       _keyService = keyService,
+       _notificationService = notificationService,
+       _launcher = launcher ?? AndroidLinuxTerminalLauncher(),
+       _probeSsh = probeSsh ?? _defaultProbeSsh;
+
+  final HostRepository _hostRepository;
+  final KeyRepository _keyRepository;
+  final KeyService _keyService;
+  final LocalNotificationService _notificationService;
+  final AndroidLinuxTerminalLauncher _launcher;
+  final Future<bool> Function(String host, int port) _probeSsh;
+
+  final _stateController =
+      StreamController<AndroidLinuxTerminalSetupState>.broadcast();
+  AndroidLinuxTerminalSetupState _state = AndroidLinuxTerminalSetupState.idle;
+  StreamSubscription<LinuxTerminalSetupNotificationPayload>?
+  _notificationSubscription;
+  Timer? _probeTimer;
+  int? _activeKeyId;
+  String? _activePublicKey;
+  String? _activeScript;
+  bool _disposed = false;
+
+  /// Latest setup state.
+  AndroidLinuxTerminalSetupState get state => _state;
+
+  /// Stream of setup state changes.
+  Stream<AndroidLinuxTerminalSetupState> get states => _stateController.stream;
+
+  /// Whether this flow is available on the current platform.
+  bool get isSupported => _launcher.isSupported;
+
+  /// Starts listening for setup notification actions.
+  void start() {
+    _notificationSubscription ??= _notificationService.linuxTerminalSetupTaps
+        .listen(_handleNotificationAction);
+  }
+
+  /// Releases timers/subscriptions.
+  void dispose() {
+    _disposed = true;
+    _probeTimer?.cancel();
+    unawaited(_notificationSubscription?.cancel());
+    unawaited(_stateController.close());
+  }
+
+  /// Begins setup: generate key, copy script, notify, open Terminal.
+  Future<AndroidLinuxTerminalSetupState> beginSetup() async {
+    if (!isSupported) {
+      return _emit(
+        const AndroidLinuxTerminalSetupState(
+          phase: AndroidLinuxTerminalSetupPhase.failed,
+          message: 'Linux Terminal setup is only available on Android.',
+        ),
+      );
+    }
+
+    _emit(
+      const AndroidLinuxTerminalSetupState(
+        phase: AndroidLinuxTerminalSetupPhase.preparing,
+        message: 'Preparing setup script…',
+      ),
+    );
+
+    final status = await _launcher.getStatus();
+    final key = await _ensureSetupKey();
+    if (key == null) {
+      return _emit(
+        const AndroidLinuxTerminalSetupState(
+          phase: AndroidLinuxTerminalSetupPhase.failed,
+          message: 'Could not create an SSH key for Linux Terminal setup.',
+        ),
+      );
+    }
+
+    final publicKey = _keyService.exportPublicKey(
+      key,
+      comment: 'monkeyssh-android-linux-terminal',
+    );
+    final script = buildAndroidLinuxTerminalSetupScript(
+      publicKey: publicKey,
+      username: androidLinuxTerminalSetupUsername,
+      port: androidLinuxTerminalSetupPort,
+    );
+
+    _activeKeyId = key.id;
+    _activePublicKey = publicKey;
+    _activeScript = script;
+
+    await Clipboard.setData(ClipboardData(text: script));
+    await _notificationService.showLinuxTerminalSetup(
+      title: 'Linux Terminal setup',
+      body: status.canLaunch
+          ? 'Script copied. Paste it in Terminal, then tap Test SSH.'
+          : 'Enable Linux Terminal in Developer options, then open Terminal.',
+    );
+
+    if (status.canLaunch) {
+      await _launcher.openTerminal();
+    } else {
+      await _launcher.openDeveloperOptions();
+    }
+
+    _startProbing();
+    return _emit(
+      AndroidLinuxTerminalSetupState(
+        phase: AndroidLinuxTerminalSetupPhase.waitingForUser,
+        message: status.canLaunch
+            ? 'Paste the script in Linux Terminal, then return here or tap Test SSH.'
+            : 'Turn on Linux development environment, open Terminal, paste the script.',
+        keyId: key.id,
+        publicKey: publicKey,
+        script: script,
+      ),
+    );
+  }
+
+  /// Copies the active setup script to the clipboard again.
+  Future<void> copyScriptAgain() async {
+    final script = _activeScript;
+    if (script == null || script.isEmpty) {
+      await beginSetup();
+      return;
+    }
+    await Clipboard.setData(ClipboardData(text: script));
+    await _notificationService.showLinuxTerminalSetup(
+      title: 'Linux Terminal setup',
+      body: 'Setup script copied again. Paste it in Terminal.',
+    );
+    _emit(
+      _state.copyWith(
+        phase: AndroidLinuxTerminalSetupPhase.waitingForUser,
+        message: 'Setup script copied again. Paste it in Terminal.',
+      ),
+    );
+  }
+
+  /// Opens Terminal or Developer Options.
+  Future<void> openTerminalOrSettings() async {
+    final status = await _launcher.getStatus();
+    if (status.canLaunch) {
+      await _launcher.openTerminal();
+      return;
+    }
+    await _launcher.openDeveloperOptions();
+  }
+
+  /// Opens Terminal port-forward settings when available.
+  Future<void> openPortForwardingSettings() =>
+      _launcher.openPortForwardingSettings();
+
+  /// Probes for SSH and creates a host on success.
+  Future<AndroidLinuxTerminalSetupState> testConnectionAndFinish() async {
+    if (_activeKeyId == null || _activePublicKey == null) {
+      return beginSetup();
+    }
+    _emit(
+      _state.copyWith(
+        phase: AndroidLinuxTerminalSetupPhase.probing,
+        message: 'Looking for SSH on port $androidLinuxTerminalSetupPort…',
+      ),
+    );
+    final endpoint = await _findReachableEndpoint();
+    if (endpoint == null) {
+      await _notificationService.showLinuxTerminalSetup(
+        title: 'Linux Terminal setup',
+        body:
+            'SSH not reachable yet. In Terminal, run the script and enable port forwarding if needed.',
+      );
+      return _emit(
+        _state.copyWith(
+          phase: AndroidLinuxTerminalSetupPhase.waitingForUser,
+          message:
+              'SSH not reachable on port $androidLinuxTerminalSetupPort yet. '
+              'If the VM is isolated, open Terminal port forwarding to $androidLinuxTerminalSetupPort.',
+        ),
+      );
+    }
+
+    final hostId = await _createOrUpdateHost(
+      hostname: endpoint.host,
+      port: endpoint.port,
+      keyId: _activeKeyId!,
+    );
+    _stopProbing();
+    await _notificationService.clearLinuxTerminalSetup();
+    return _emit(
+      AndroidLinuxTerminalSetupState(
+        phase: AndroidLinuxTerminalSetupPhase.succeeded,
+        message: 'Added Linux Terminal host ${endpoint.host}:${endpoint.port}.',
+        hostId: hostId,
+        keyId: _activeKeyId,
+        publicKey: _activePublicKey,
+        script: _activeScript,
+        reachableHost: endpoint.host,
+        reachablePort: endpoint.port,
+      ),
+    );
+  }
+
+  /// Cancels an in-progress setup.
+  Future<void> cancel() async {
+    _stopProbing();
+    await _notificationService.clearLinuxTerminalSetup();
+    _activeKeyId = null;
+    _activePublicKey = null;
+    _activeScript = null;
+    _emit(AndroidLinuxTerminalSetupState.idle);
+  }
+
+  Future<void> _handleNotificationAction(
+    LinuxTerminalSetupNotificationPayload payload,
+  ) async {
+    switch (payload.action) {
+      case linuxTerminalSetupActionCopy:
+        await copyScriptAgain();
+      case linuxTerminalSetupActionOpen:
+        await openTerminalOrSettings();
+      case linuxTerminalSetupActionTest:
+        await testConnectionAndFinish();
+      case linuxTerminalSetupActionCancel:
+        await cancel();
+      case null:
+        // Body tap: bring user back and restate status.
+        await _notificationService.showLinuxTerminalSetup(
+          title: 'Linux Terminal setup',
+          body: _state.message.isEmpty
+              ? 'Continue setup from MonkeySSH.'
+              : _state.message,
+        );
+      default:
+        break;
+    }
+  }
+
+  void _startProbing() {
+    _probeTimer?.cancel();
+    _probeTimer = Timer.periodic(const Duration(seconds: 8), (_) {
+      unawaited(_probeInBackground());
+    });
+  }
+
+  void _stopProbing() {
+    _probeTimer?.cancel();
+    _probeTimer = null;
+  }
+
+  Future<void> _probeInBackground() async {
+    if (_disposed ||
+        _state.phase == AndroidLinuxTerminalSetupPhase.succeeded ||
+        _state.phase == AndroidLinuxTerminalSetupPhase.idle ||
+        _state.phase == AndroidLinuxTerminalSetupPhase.failed) {
+      return;
+    }
+    final endpoint = await _findReachableEndpoint();
+    if (endpoint == null) {
+      return;
+    }
+    await testConnectionAndFinish();
+  }
+
+  Future<({String host, int port})?> _findReachableEndpoint() async {
+    final candidates = await _candidateHosts();
+    for (final host in candidates) {
+      if (await _probeSsh(host, androidLinuxTerminalSetupPort)) {
+        return (host: host, port: androidLinuxTerminalSetupPort);
+      }
+    }
+    return null;
+  }
+
+  Future<List<String>> _candidateHosts() async {
+    final hosts = <String>{'127.0.0.1', 'localhost'};
+    try {
+      final interfaces = await NetworkInterface.list(
+        type: InternetAddressType.IPv4,
+      );
+      for (final interface in interfaces) {
+        for (final address in interface.addresses) {
+          if (!address.isLoopback) {
+            hosts.add(address.address);
+          }
+        }
+      }
+    } on Object {
+      // Best-effort only.
+    }
+    return hosts.toList(growable: false);
+  }
+
+  Future<SshKey?> _ensureSetupKey() async {
+    final existing = await _keyRepository.getAll();
+    for (final key in existing) {
+      if (key.name == 'Android Linux Terminal' &&
+          key.publicKey.trim().isNotEmpty &&
+          key.privateKey.trim().isNotEmpty) {
+        return key;
+      }
+    }
+    return _keyService.generateKey(
+      name: 'Android Linux Terminal',
+      keyType: SshKeyType.ed25519,
+    );
+  }
+
+  Future<int> _createOrUpdateHost({
+    required String hostname,
+    required int port,
+    required int keyId,
+  }) async {
+    final hosts = await _hostRepository.getAll();
+    for (final host in hosts) {
+      if (host.label == 'Android Linux Terminal' ||
+          (host.hostname == hostname && host.port == port)) {
+        await _hostRepository.update(
+          host.copyWith(
+            label: 'Android Linux Terminal',
+            hostname: hostname,
+            port: port,
+            username: androidLinuxTerminalSetupUsername,
+            keyId: Value(keyId),
+            password: const Value(null),
+            notes: const Value(
+              'Created by MonkeySSH Linux Terminal setup. '
+              'If connect fails, enable port forwarding in the Terminal app.',
+            ),
+          ),
+        );
+        return host.id;
+      }
+    }
+
+    return _hostRepository.insert(
+      HostsCompanion.insert(
+        label: 'Android Linux Terminal',
+        hostname: hostname,
+        port: Value(port),
+        username: androidLinuxTerminalSetupUsername,
+        keyId: Value(keyId),
+        notes: const Value(
+          'Created by MonkeySSH Linux Terminal setup. '
+          'If connect fails, enable port forwarding in the Terminal app.',
+        ),
+      ),
+    );
+  }
+
+  AndroidLinuxTerminalSetupState _emit(AndroidLinuxTerminalSetupState next) {
+    _state = next;
+    if (!_stateController.isClosed) {
+      _stateController.add(next);
+    }
+    return next;
+  }
+
+  static Future<bool> _defaultProbeSsh(String host, int port) async {
+    try {
+      final socket = await Socket.connect(
+        host,
+        port,
+        timeout: const Duration(milliseconds: 700),
+      );
+      socket.destroy();
+      return true;
+    } on Object {
+      return false;
+    }
+  }
+}
+
+/// Builds the shell script the user pastes into Android Linux Terminal.
+@visibleForTesting
+String buildAndroidLinuxTerminalSetupScript({
+  required String publicKey,
+  required String username,
+  required int port,
+}) {
+  final normalizedKey = publicKey.trim();
+  return '''
+# MonkeySSH → Android Linux Terminal setup
+# 1) Paste this whole script into Linux Terminal and press Enter
+# 2) If SSH is not reachable from MonkeySSH, open Terminal → Port forwarding
+#    and forward host 127.0.0.1:$port → guest $port
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update
+sudo apt-get install -y openssh-server
+sudo mkdir -p /run/sshd /home/$username/.ssh
+sudo chmod 700 /home/$username/.ssh
+echo ${shellSingleQuote(normalizedKey)} | sudo tee /home/$username/.ssh/authorized_keys >/dev/null
+sudo chown -R $username:$username /home/$username/.ssh
+sudo chmod 600 /home/$username/.ssh/authorized_keys
+if [ -f /etc/ssh/sshd_config ]; then
+  sudo sed -i 's/^#\\?Port .*/Port $port/' /etc/ssh/sshd_config || true
+  grep -q '^Port $port' /etc/ssh/sshd_config || echo 'Port $port' | sudo tee -a /etc/ssh/sshd_config >/dev/null
+  sudo sed -i 's/^#\\?PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config || true
+  sudo sed -i 's/^#\\?PubkeyAuthentication .*/PubkeyAuthentication yes/' /etc/ssh/sshd_config || true
+fi
+sudo ssh-keygen -A
+sudo service ssh restart || sudo systemctl restart ssh || sudo /usr/sbin/sshd
+echo
+echo "MONKEYSSH_AVF_READY user=$username port=$port"
+echo "Next: return to MonkeySSH and tap Test SSH (or wait for auto-detect)."
+''';
+}
+
+/// Shell-single-quotes [value] for embedding in a POSIX script.
+@visibleForTesting
+String shellSingleQuote(String value) =>
+    "'${value.replaceAll("'", "'\"'\"'")}'";
+
+extension on AndroidLinuxTerminalSetupState {
+  AndroidLinuxTerminalSetupState copyWith({
+    AndroidLinuxTerminalSetupPhase? phase,
+    String? message,
+    int? hostId,
+    int? keyId,
+    String? publicKey,
+    String? script,
+    String? reachableHost,
+    int? reachablePort,
+  }) => AndroidLinuxTerminalSetupState(
+    phase: phase ?? this.phase,
+    message: message ?? this.message,
+    hostId: hostId ?? this.hostId,
+    keyId: keyId ?? this.keyId,
+    publicKey: publicKey ?? this.publicKey,
+    script: script ?? this.script,
+    reachableHost: reachableHost ?? this.reachableHost,
+    reachablePort: reachablePort ?? this.reachablePort,
+  );
+}
+
+/// Provider for [AndroidLinuxTerminalSetupService].
+final androidLinuxTerminalSetupServiceProvider =
+    Provider<AndroidLinuxTerminalSetupService>((ref) {
+      final service = AndroidLinuxTerminalSetupService(
+        hostRepository: ref.watch(hostRepositoryProvider),
+        keyRepository: ref.watch(keyRepositoryProvider),
+        keyService: ref.watch(keyServiceProvider),
+        notificationService: ref.watch(localNotificationServiceProvider),
+      )..start();
+      ref.onDispose(service.dispose);
+      return service;
+    });

--- a/lib/domain/services/local_notification_service.dart
+++ b/lib/domain/services/local_notification_service.dart
@@ -384,13 +384,26 @@ class LocalNotificationService {
       autoCancel: !ongoing,
       onlyAlertOnce: true,
       actions: const <AndroidNotificationAction>[
-        AndroidNotificationAction(linuxTerminalSetupActionCopy, 'Copy script'),
+        AndroidNotificationAction(
+          linuxTerminalSetupActionCopy,
+          'Copy script',
+          showsUserInterface: true,
+        ),
         AndroidNotificationAction(
           linuxTerminalSetupActionOpen,
           'Open Terminal',
+          showsUserInterface: true,
         ),
-        AndroidNotificationAction(linuxTerminalSetupActionTest, 'Test SSH'),
-        AndroidNotificationAction(linuxTerminalSetupActionCancel, 'Cancel'),
+        AndroidNotificationAction(
+          linuxTerminalSetupActionTest,
+          'Test SSH',
+          showsUserInterface: true,
+        ),
+        AndroidNotificationAction(
+          linuxTerminalSetupActionCancel,
+          'Cancel',
+          showsUserInterface: true,
+        ),
       ],
     );
 
@@ -538,16 +551,27 @@ class LocalNotificationService {
         ),
       );
       final launchDetails = await _plugin.getNotificationAppLaunchDetails();
-      final launchPayload = (launchDetails?.didNotificationLaunchApp ?? false)
-          ? launchDetails?.notificationResponse?.payload
+      final launchResponse = (launchDetails?.didNotificationLaunchApp ?? false)
+          ? launchDetails?.notificationResponse
           : null;
+      final launchPayload = launchResponse?.payload;
       _launchTmuxAlert = TmuxAlertNotificationPayload.decode(launchPayload);
       _launchTerminalNotification = TerminalNotificationPayload.decode(
         launchPayload,
       );
-      _launchLinuxTerminalSetup = LinuxTerminalSetupNotificationPayload.decode(
-        launchPayload,
-      );
+      // Action buttons put the action in actionId, not the JSON payload.
+      final launchActionId = launchResponse?.actionId;
+      if (launchActionId == linuxTerminalSetupActionCopy ||
+          launchActionId == linuxTerminalSetupActionOpen ||
+          launchActionId == linuxTerminalSetupActionTest ||
+          launchActionId == linuxTerminalSetupActionCancel) {
+        _launchLinuxTerminalSetup = LinuxTerminalSetupNotificationPayload(
+          action: launchActionId,
+        );
+      } else {
+        _launchLinuxTerminalSetup =
+            LinuxTerminalSetupNotificationPayload.decode(launchPayload);
+      }
 
       await _plugin.initialize(
         settings: initializationSettings,

--- a/lib/domain/services/local_notification_service.dart
+++ b/lib/domain/services/local_notification_service.dart
@@ -14,10 +14,29 @@ const tmuxAlertNotificationChannelId = 'tmux-alerts';
 /// Local notification channel used for terminal desktop notifications emitted
 /// by the remote shell (OSC 9 / 777 / 99).
 const terminalNotificationChannelId = 'terminal-notifications';
+
+/// Local notification channel used while setting up Android's Linux Terminal.
+const linuxTerminalSetupNotificationChannelId = 'linux-terminal-setup';
+
+/// Notification action: copy the Linux Terminal setup script again.
+const linuxTerminalSetupActionCopy = 'linux_terminal_copy_script';
+
+/// Notification action: open the Linux Terminal app.
+const linuxTerminalSetupActionOpen = 'linux_terminal_open';
+
+/// Notification action: probe SSH and finish setup.
+const linuxTerminalSetupActionTest = 'linux_terminal_test';
+
+/// Notification action: cancel setup.
+const linuxTerminalSetupActionCancel = 'linux_terminal_cancel';
+
 const _androidNotificationIcon = 'ic_notification_monkey';
 const _disableNotificationsForStoreScreenshots = bool.fromEnvironment(
   'STORE_SCREENSHOT_DISABLE_NOTIFICATIONS',
 );
+
+/// Stable notification id for the Linux Terminal setup flow.
+const linuxTerminalSetupNotificationId = 71001;
 
 /// Payload attached to a tmux alert notification.
 @immutable
@@ -199,6 +218,48 @@ String buildTerminalNotificationLocation(TerminalNotificationPayload payload) =>
       },
     ).toString();
 
+/// Payload attached to Android Linux Terminal setup notifications.
+@immutable
+class LinuxTerminalSetupNotificationPayload {
+  /// Creates a setup notification payload.
+  const LinuxTerminalSetupNotificationPayload({this.action});
+
+  static const _type = 'linux-terminal-setup';
+  static const _version = 1;
+
+  /// Optional action id when a notification action button was pressed.
+  final String? action;
+
+  /// Encodes this payload for the notification plugin.
+  String encode() => jsonEncode(<String, Object>{
+    'type': _type,
+    'version': _version,
+    'action': ?action,
+  });
+
+  /// Decodes a notification payload, returning `null` for other payload types.
+  static LinuxTerminalSetupNotificationPayload? decode(String? payload) {
+    if (payload == null || payload.isEmpty) {
+      return null;
+    }
+    try {
+      final decoded = jsonDecode(payload);
+      if (decoded is! Map<String, Object?> ||
+          decoded['type'] != _type ||
+          decoded['version'] != _version) {
+        return null;
+      }
+      final action = decoded['action'];
+      if (action != null && action is! String) {
+        return null;
+      }
+      return LinuxTerminalSetupNotificationPayload(action: action as String?);
+    } on FormatException {
+      return null;
+    }
+  }
+}
+
 /// Service for showing local notifications inside the app.
 class LocalNotificationService {
   /// Creates a new [LocalNotificationService].
@@ -219,17 +280,29 @@ class LocalNotificationService {
     importance: Importance.high,
   );
 
+  static const _linuxTerminalSetupNotificationChannel =
+      AndroidNotificationChannel(
+        linuxTerminalSetupNotificationChannelId,
+        'Linux Terminal setup',
+        description: 'Setup progress for Android Linux Terminal SSH access.',
+      );
+
   final FlutterLocalNotificationsPlugin _plugin;
   final StreamController<TmuxAlertNotificationPayload> _tmuxAlertTapController =
       StreamController<TmuxAlertNotificationPayload>.broadcast();
   final StreamController<TerminalNotificationPayload>
   _terminalNotificationTapController =
       StreamController<TerminalNotificationPayload>.broadcast();
+  final StreamController<LinuxTerminalSetupNotificationPayload>
+  _linuxTerminalSetupTapController =
+      StreamController<LinuxTerminalSetupNotificationPayload>.broadcast();
   Future<bool>? _initializeFuture;
   TmuxAlertNotificationPayload? _launchTmuxAlert;
   TerminalNotificationPayload? _launchTerminalNotification;
+  LinuxTerminalSetupNotificationPayload? _launchLinuxTerminalSetup;
   bool _didConsumeLaunchTmuxAlert = false;
   bool _didConsumeLaunchTerminalNotification = false;
+  bool _didConsumeLaunchLinuxTerminalSetup = false;
 
   /// Emits whenever the user taps a tmux alert notification.
   Stream<TmuxAlertNotificationPayload> get tmuxAlertTaps =>
@@ -239,6 +312,10 @@ class LocalNotificationService {
   Stream<TerminalNotificationPayload> get terminalNotificationTaps =>
       _terminalNotificationTapController.stream;
 
+  /// Emits whenever the user taps a Linux Terminal setup notification/action.
+  Stream<LinuxTerminalSetupNotificationPayload> get linuxTerminalSetupTaps =>
+      _linuxTerminalSetupTapController.stream;
+
   /// Ensures the underlying notification plugin is initialized.
   Future<bool> initialize() => _initializeFuture ??= _initializeInternal();
 
@@ -246,6 +323,7 @@ class LocalNotificationService {
   void dispose() {
     unawaited(_tmuxAlertTapController.close());
     unawaited(_terminalNotificationTapController.close());
+    unawaited(_linuxTerminalSetupTapController.close());
   }
 
   /// Returns the tmux alert that launched the app, if one has not been consumed.
@@ -268,6 +346,78 @@ class LocalNotificationService {
     }
     _didConsumeLaunchTerminalNotification = true;
     return _launchTerminalNotification;
+  }
+
+  /// Returns the Linux Terminal setup notification that launched the app.
+  Future<LinuxTerminalSetupNotificationPayload?>
+  consumeLaunchLinuxTerminalSetup() async {
+    final didInitialize = await initialize();
+    if (!didInitialize || _didConsumeLaunchLinuxTerminalSetup) {
+      return null;
+    }
+    _didConsumeLaunchLinuxTerminalSetup = true;
+    return _launchLinuxTerminalSetup;
+  }
+
+  /// Shows or refreshes the ongoing Linux Terminal setup notification.
+  Future<void> showLinuxTerminalSetup({
+    required String title,
+    required String body,
+    bool ongoing = true,
+  }) async {
+    final didInitialize = await initialize();
+    if (!didInitialize) {
+      return;
+    }
+    final hasPermission = await _requestNotificationPermission();
+    if (!hasPermission) {
+      return;
+    }
+
+    final androidDetails = AndroidNotificationDetails(
+      linuxTerminalSetupNotificationChannelId,
+      'Linux Terminal setup',
+      channelDescription:
+          'Setup progress for Android Linux Terminal SSH access.',
+      icon: _androidNotificationIcon,
+      ongoing: ongoing,
+      autoCancel: !ongoing,
+      onlyAlertOnce: true,
+      actions: const <AndroidNotificationAction>[
+        AndroidNotificationAction(linuxTerminalSetupActionCopy, 'Copy script'),
+        AndroidNotificationAction(
+          linuxTerminalSetupActionOpen,
+          'Open Terminal',
+        ),
+        AndroidNotificationAction(linuxTerminalSetupActionTest, 'Test SSH'),
+        AndroidNotificationAction(linuxTerminalSetupActionCancel, 'Cancel'),
+      ],
+    );
+
+    try {
+      await _plugin.show(
+        id: linuxTerminalSetupNotificationId,
+        title: title,
+        body: body,
+        notificationDetails: NotificationDetails(android: androidDetails),
+        payload: const LinuxTerminalSetupNotificationPayload().encode(),
+      );
+    } on MissingPluginException {
+      // Widget and unit tests don't register platform notification plugins.
+    }
+  }
+
+  /// Clears the Linux Terminal setup notification.
+  Future<void> clearLinuxTerminalSetup() async {
+    final didInitialize = await initialize();
+    if (!didInitialize) {
+      return;
+    }
+    try {
+      await _plugin.cancel(id: linuxTerminalSetupNotificationId);
+    } on MissingPluginException {
+      // Widget and unit tests don't register platform notification plugins.
+    }
   }
 
   /// Shows or refreshes a tmux alert notification.
@@ -395,6 +545,9 @@ class LocalNotificationService {
       _launchTerminalNotification = TerminalNotificationPayload.decode(
         launchPayload,
       );
+      _launchLinuxTerminalSetup = LinuxTerminalSetupNotificationPayload.decode(
+        launchPayload,
+      );
 
       await _plugin.initialize(
         settings: initializationSettings,
@@ -410,6 +563,9 @@ class LocalNotificationService {
       );
       await androidImplementation?.createNotificationChannel(
         _terminalNotificationChannel,
+      );
+      await androidImplementation?.createNotificationChannel(
+        _linuxTerminalSetupNotificationChannel,
       );
 
       return true;
@@ -453,6 +609,26 @@ class LocalNotificationService {
   }
 
   void _handleNotificationResponse(NotificationResponse response) {
+    final actionId = response.actionId;
+    if (actionId != null &&
+        (actionId == linuxTerminalSetupActionCopy ||
+            actionId == linuxTerminalSetupActionOpen ||
+            actionId == linuxTerminalSetupActionTest ||
+            actionId == linuxTerminalSetupActionCancel)) {
+      _linuxTerminalSetupTapController.add(
+        LinuxTerminalSetupNotificationPayload(action: actionId),
+      );
+      return;
+    }
+
+    final linuxSetupPayload = LinuxTerminalSetupNotificationPayload.decode(
+      response.payload,
+    );
+    if (linuxSetupPayload != null) {
+      _linuxTerminalSetupTapController.add(linuxSetupPayload);
+      return;
+    }
+
     final tmuxPayload = TmuxAlertNotificationPayload.decode(response.payload);
     if (tmuxPayload != null) {
       _tmuxAlertTapController.add(tmuxPayload);

--- a/lib/domain/services/local_terminal_service.dart
+++ b/lib/domain/services/local_terminal_service.dart
@@ -1,0 +1,719 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_pty/flutter_pty.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../../data/database/database.dart';
+import '../models/host_kind.dart';
+
+/// Resolves platform shell executables and spawns local PTY sessions.
+class LocalTerminalService {
+  /// Creates a local terminal service.
+  const LocalTerminalService();
+
+  /// Whether local PTY sessions are available in this runtime.
+  bool get isSupported => isLocalTerminalSupported();
+
+  /// Creates a local SSH-compatible client for [host].
+  Future<LocalTerminalSshClient> createClient(Host host) async {
+    if (!isSupported) {
+      throw UnsupportedError(
+        'Local terminals are not supported on this platform.',
+      );
+    }
+    final shell = await resolveShellExecutable();
+    final workingDirectory = await resolveWorkingDirectory();
+    return LocalTerminalSshClient(
+      host: host,
+      executable: shell.executable,
+      arguments: shell.arguments,
+      workingDirectory: workingDirectory,
+      environment: shell.environment,
+      remoteVersion: shell.remoteVersion,
+    );
+  }
+
+  /// Resolves the interactive shell to launch on this device.
+  @visibleForTesting
+  Future<LocalShellLaunch> resolveShellExecutable() async {
+    if (Platform.isWindows) {
+      return _resolveWindowsShell();
+    }
+    if (Platform.isAndroid) {
+      return _resolveAndroidShell();
+    }
+    return _resolvePosixShell();
+  }
+
+  /// Resolves the initial working directory for local shells.
+  @visibleForTesting
+  Future<String?> resolveWorkingDirectory() async {
+    if (Platform.isAndroid) {
+      final docs = await getApplicationDocumentsDirectory();
+      return docs.path;
+    }
+    final home =
+        Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'];
+    final trimmed = home?.trim();
+    if (trimmed != null && trimmed.isNotEmpty) {
+      return trimmed;
+    }
+    return Directory.current.path;
+  }
+
+  LocalShellLaunch _resolveWindowsShell() {
+    final comSpec = _nonEmpty(Platform.environment['ComSpec']);
+    final candidates = <String>[
+      ?comSpec,
+      r'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe',
+      r'C:\Program Files\PowerShell\7\pwsh.exe',
+      'pwsh.exe',
+      'powershell.exe',
+      'cmd.exe',
+    ];
+    for (final candidate in candidates) {
+      if (_looksExecutable(candidate)) {
+        final isCmd = candidate.toLowerCase().endsWith('cmd.exe');
+        return LocalShellLaunch(
+          executable: candidate,
+          arguments: isCmd ? const ['/K'] : const ['-NoLogo'],
+          environment: _baseEnvironment(
+            remoteVersion: 'SSH-2.0-MonkeySSH_Local_Windows',
+          ),
+        );
+      }
+    }
+    return LocalShellLaunch(
+      executable: 'cmd.exe',
+      arguments: const ['/K'],
+      environment: _baseEnvironment(
+        remoteVersion: 'SSH-2.0-MonkeySSH_Local_Windows',
+      ),
+    );
+  }
+
+  LocalShellLaunch _resolveAndroidShell() {
+    const candidates = <String>[
+      '/system/bin/sh',
+      '/system/xbin/sh',
+      '/bin/sh',
+      'sh',
+    ];
+    final executable = candidates.firstWhere(
+      _looksExecutable,
+      orElse: () => '/system/bin/sh',
+    );
+    final environment = _baseEnvironment(
+      remoteVersion: 'SSH-2.0-MonkeySSH_Local_Android',
+    );
+    final home = _nonEmpty(Platform.environment['HOME']);
+    if (home != null) {
+      environment['HOME'] = home;
+    }
+    environment['PATH'] = _androidPath();
+    return LocalShellLaunch(
+      executable: executable,
+      arguments: const [],
+      environment: environment,
+    );
+  }
+
+  LocalShellLaunch _resolvePosixShell() {
+    final preferred = _nonEmpty(Platform.environment['SHELL']);
+    final candidates = <String>[
+      ?preferred,
+      '/bin/zsh',
+      '/usr/bin/zsh',
+      '/bin/bash',
+      '/usr/bin/bash',
+      '/bin/sh',
+      '/usr/bin/sh',
+    ];
+    final executable = candidates.firstWhere(
+      _looksExecutable,
+      orElse: () => preferred ?? '/bin/sh',
+    );
+    return LocalShellLaunch(
+      executable: executable,
+      arguments: _posixLoginArguments(executable),
+      environment: _baseEnvironment(
+        remoteVersion: Platform.isMacOS
+            ? 'SSH-2.0-MonkeySSH_Local_macOS'
+            : 'SSH-2.0-MonkeySSH_Local_Linux',
+      ),
+    );
+  }
+
+  Map<String, String> _baseEnvironment({required String remoteVersion}) => {
+    'TERM': 'xterm-256color',
+    'COLORTERM': 'truecolor',
+    'TERM_PROGRAM': 'MonkeySSH',
+    'LANG': Platform.environment['LANG'] ?? 'en_US.UTF-8',
+    '_MONKEYSSH_REMOTE_VERSION': remoteVersion,
+  };
+
+  List<String> _posixLoginArguments(String executable) {
+    final base = executable.split(Platform.pathSeparator).last.toLowerCase();
+    if (base == 'zsh' || base == 'bash' || base == 'sh' || base == 'fish') {
+      return const ['-l'];
+    }
+    return const [];
+  }
+
+  String _androidPath() {
+    final existing = _nonEmpty(Platform.environment['PATH']);
+    const defaults =
+        '/system/bin:/system/xbin:/vendor/bin:/product/bin:/apex/com.android.runtime/bin';
+    if (existing == null) {
+      return defaults;
+    }
+    return '$existing:$defaults';
+  }
+
+  bool _looksExecutable(String path) {
+    final trimmed = path.trim();
+    if (trimmed.isEmpty) {
+      return false;
+    }
+    if (!trimmed.contains(Platform.pathSeparator) &&
+        !trimmed.contains('/') &&
+        !trimmed.contains(r'\')) {
+      return true;
+    }
+    try {
+      return File(trimmed).existsSync();
+    } on Object {
+      return false;
+    }
+  }
+
+  String? _nonEmpty(String? value) {
+    final trimmed = value?.trim();
+    if (trimmed == null || trimmed.isEmpty) {
+      return null;
+    }
+    return trimmed;
+  }
+}
+
+/// Resolved shell launch parameters for a local terminal.
+@immutable
+class LocalShellLaunch {
+  /// Creates shell launch parameters.
+  const LocalShellLaunch({
+    required this.executable,
+    required this.arguments,
+    required this.environment,
+  });
+
+  /// Shell executable path or command name.
+  final String executable;
+
+  /// Arguments passed to [executable].
+  final List<String> arguments;
+
+  /// Extra environment variables for the PTY.
+  final Map<String, String> environment;
+
+  /// Fake SSH version string used for platform detection paths.
+  String get remoteVersion =>
+      environment['_MONKEYSSH_REMOTE_VERSION'] ??
+      'SSH-2.0-MonkeySSH_Local_Terminal';
+}
+
+/// Local-device [SSHClient] backed by an interactive PTY shell.
+class LocalTerminalSshClient implements SSHClient {
+  /// Creates a local terminal client.
+  LocalTerminalSshClient({
+    required this.host,
+    required this.executable,
+    required this.arguments,
+    required this.workingDirectory,
+    required this.environment,
+    required this.remoteVersion,
+  });
+
+  /// Host row this client was created for.
+  final Host host;
+
+  /// Shell executable.
+  final String executable;
+
+  /// Shell arguments.
+  final List<String> arguments;
+
+  /// Initial working directory, if known.
+  final String? workingDirectory;
+
+  /// Extra environment for spawned PTYs.
+  final Map<String, String> environment;
+
+  @override
+  final String remoteVersion;
+
+  final _done = Completer<void>();
+  bool _isClosed = false;
+
+  /// Whether this client serves a local terminal host.
+  bool get isLocalTerminal => true;
+
+  @override
+  bool get isClosed => _isClosed;
+
+  @override
+  Future<void> get done => _done.future;
+
+  @override
+  Future<void> get authenticated => Future<void>.value();
+
+  @override
+  String get username => host.username;
+
+  @override
+  Future<SSHSession> shell({
+    SSHPtyConfig? pty = const SSHPtyConfig(),
+    SSHX11Config? x11,
+    Map<String, String>? environment,
+  }) async {
+    _ensureOpen();
+    return LocalTerminalSshSession.interactive(
+      executable: executable,
+      arguments: arguments,
+      workingDirectory: workingDirectory,
+      environment: {...this.environment, ...?environment},
+      pty: pty ?? const SSHPtyConfig(),
+    );
+  }
+
+  @override
+  Future<SSHSession> execute(
+    String command, {
+    SSHPtyConfig? pty,
+    SSHX11Config? x11,
+    Map<String, String>? environment,
+  }) async {
+    _ensureOpen();
+    if (pty != null && _looksLikeLoginShellCommand(command)) {
+      return shell(pty: pty, environment: environment);
+    }
+    return LocalTerminalSshSession.exec(
+      command: command,
+      workingDirectory: workingDirectory,
+      environment: {...this.environment, ...?environment},
+      shellExecutable: executable,
+    );
+  }
+
+  @override
+  Future<SftpClient> sftp() async {
+    throw UnsupportedError('Local terminals do not support SFTP.');
+  }
+
+  @override
+  Future<SSHForwardChannel> forwardLocal(
+    String remoteHost,
+    int remotePort, {
+    String localHost = 'localhost',
+    int localPort = 0,
+  }) async {
+    throw UnsupportedError('Local terminals do not support port forwarding.');
+  }
+
+  @override
+  Future<SSHRemoteForward?> forwardRemote({
+    String? host,
+    int? port,
+    SSHRemoteConnectionFilter? filter,
+  }) async {
+    throw UnsupportedError('Local terminals do not support port forwarding.');
+  }
+
+  @override
+  Future<Uint8List> run(
+    String command, {
+    bool runInPty = false,
+    bool stdout = true,
+    bool stderr = true,
+    Map<String, String>? environment,
+  }) async {
+    final result = await _runProcess(command, environment: environment);
+    final out = StringBuffer();
+    if (stdout) {
+      out.write(result.stdout);
+    }
+    if (stderr && result.stderr.toString().isNotEmpty) {
+      if (out.isNotEmpty) {
+        out.writeln();
+      }
+      out.write(result.stderr);
+    }
+    return Uint8List.fromList(utf8.encode(out.toString()));
+  }
+
+  @override
+  Future<SSHRunResult> runWithResult(
+    String command, {
+    bool runInPty = false,
+    bool stdout = true,
+    bool stderr = true,
+    Map<String, String>? environment,
+  }) async {
+    final result = await _runProcess(command, environment: environment);
+    final stdoutBytes = stdout
+        ? Uint8List.fromList(utf8.encode('${result.stdout}'))
+        : Uint8List(0);
+    final stderrBytes = stderr
+        ? Uint8List.fromList(utf8.encode('${result.stderr}'))
+        : Uint8List(0);
+    final combined = BytesBuilder(copy: false)
+      ..add(stdoutBytes)
+      ..add(stderrBytes);
+    return SSHRunResult(
+      output: combined.takeBytes(),
+      stdout: stdoutBytes,
+      stderr: stderrBytes,
+      exitCode: result.exitCode,
+      exitSignal: null,
+    );
+  }
+
+  Future<ProcessResult> _runProcess(
+    String command, {
+    Map<String, String>? environment,
+  }) {
+    final launch = _commandLaunch(command);
+    return Process.run(
+      launch.executable,
+      launch.arguments,
+      workingDirectory: workingDirectory,
+      environment: {...this.environment, ...?environment},
+      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
+    );
+  }
+
+  ({String executable, List<String> arguments}) _commandLaunch(String command) {
+    if (Platform.isWindows) {
+      final lower = executable.toLowerCase();
+      if (lower.endsWith('cmd.exe') || lower == 'cmd' || lower == 'cmd.exe') {
+        return (executable: executable, arguments: ['/C', command]);
+      }
+      return (
+        executable: executable,
+        arguments: ['-NoLogo', '-Command', command],
+      );
+    }
+    return (executable: executable, arguments: ['-c', command]);
+  }
+
+  @override
+  void close() {
+    if (_isClosed) {
+      return;
+    }
+    _isClosed = true;
+    if (!_done.isCompleted) {
+      _done.complete();
+    }
+  }
+
+  void _ensureOpen() {
+    if (_isClosed) {
+      throw StateError('Local terminal client is closed');
+    }
+  }
+
+  static bool _looksLikeLoginShellCommand(String command) =>
+      command.contains('COLORTERM=truecolor') ||
+      command.contains('TERM_PROGRAM=kitty') ||
+      command.contains('TERM_PROGRAM=MonkeySSH') ||
+      command.contains('/bin/sh -lc') ||
+      command.contains('/bin/bash -lc') ||
+      command.contains('/bin/zsh -lc');
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Interactive or one-shot local shell session implementing [SSHSession].
+class LocalTerminalSshSession implements SSHSession {
+  LocalTerminalSshSession._()
+    : _stdinController = StreamController<Uint8List>(),
+      _stdoutController = StreamController<Uint8List>(),
+      _stderrController = StreamController<Uint8List>() {
+    _stdinSubscription = _stdinController.stream.listen(_handleStdin);
+  }
+
+  /// Starts an interactive local PTY shell.
+  factory LocalTerminalSshSession.interactive({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String> environment,
+    String? workingDirectory,
+    SSHPtyConfig pty = const SSHPtyConfig(),
+  }) {
+    final rows = pty.height > 0 ? pty.height : 24;
+    final cols = pty.width > 0 ? pty.width : 80;
+    final started = Pty.start(
+      executable,
+      arguments: arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      rows: rows,
+      columns: cols,
+    );
+    return LocalTerminalSshSession._().._attachPty(started);
+  }
+
+  /// Runs a short-lived local command without a PTY.
+  static Future<LocalTerminalSshSession> exec({
+    required String command,
+    required Map<String, String> environment,
+    required String shellExecutable,
+    String? workingDirectory,
+  }) async {
+    final args = Platform.isWindows
+        ? _windowsCommandArgs(shellExecutable, command)
+        : <String>['-c', command];
+    final process = await Process.start(
+      shellExecutable,
+      args,
+      workingDirectory: workingDirectory,
+      environment: environment,
+    );
+    return LocalTerminalSshSession._().._attachProcess(process);
+  }
+
+  Pty? _pty;
+  Process? _process;
+  late final StreamSubscription<Uint8List> _stdinSubscription;
+  StreamSubscription<List<int>>? _outputSubscription;
+  StreamSubscription<List<int>>? _stderrSubscription;
+  final StreamController<Uint8List> _stdinController;
+  final StreamController<Uint8List> _stdoutController;
+  final StreamController<Uint8List> _stderrController;
+  final _done = Completer<void>();
+  final _exitCompleter = Completer<int?>();
+  bool _closed = false;
+  int? _exitCode;
+
+  @override
+  int? get exitCode => _exitCode;
+
+  @override
+  SSHSessionExitSignal? get exitSignal => null;
+
+  @override
+  StreamSink<Uint8List> get stdin => _stdinController.sink;
+
+  @override
+  Stream<Uint8List> get stdout => _stdoutController.stream;
+
+  @override
+  Stream<Uint8List> get stderr => _stderrController.stream;
+
+  @override
+  Future<void> get done => _done.future;
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  void write(Uint8List data) {
+    if (_closed) {
+      return;
+    }
+    final pty = _pty;
+    if (pty != null) {
+      pty.write(data);
+      return;
+    }
+    final process = _process;
+    if (process != null) {
+      process.stdin.add(data);
+    }
+  }
+
+  @override
+  void resizeTerminal(
+    int width,
+    int height, [
+    int pixelWidth = 0,
+    int pixelHeight = 0,
+  ]) {
+    final pty = _pty;
+    if (pty == null) {
+      return;
+    }
+    final cols = width > 0 ? width : 80;
+    final rows = height > 0 ? height : 24;
+    pty.resize(rows, cols);
+  }
+
+  @override
+  void close() {
+    unawaited(_finish(exitCode: _exitCode));
+  }
+
+  @override
+  Future<int?> waitForExit({Duration? timeout}) {
+    final future = _exitCompleter.future;
+    return timeout == null
+        ? future
+        : future.timeout(timeout, onTimeout: () => null);
+  }
+
+  @override
+  void kill(SSHSignal signal) {
+    final mapped = _mapSignal(signal);
+    final pty = _pty;
+    if (pty != null) {
+      pty.kill(mapped);
+      return;
+    }
+    final process = _process;
+    if (process != null) {
+      process.kill(mapped);
+    }
+  }
+
+  void _handleStdin(Uint8List data) {
+    write(data);
+  }
+
+  void _attachPty(Pty pty) {
+    _pty = pty;
+    _outputSubscription = pty.output.listen(
+      (chunk) {
+        if (!_stdoutController.isClosed) {
+          _stdoutController.add(chunk);
+        }
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        if (!_stdoutController.isClosed) {
+          _stdoutController.addError(error, stackTrace);
+        }
+      },
+      onDone: () {
+        unawaited(_finishFromPty());
+      },
+    );
+    unawaited(
+      pty.exitCode.then((code) {
+        unawaited(_finish(exitCode: code));
+      }),
+    );
+  }
+
+  void _attachProcess(Process process) {
+    _process = process;
+    _outputSubscription = process.stdout.listen(
+      (chunk) {
+        if (!_stdoutController.isClosed) {
+          _stdoutController.add(Uint8List.fromList(chunk));
+        }
+      },
+      onDone: () {
+        unawaited(_finishFromProcess());
+      },
+    );
+    _stderrSubscription = process.stderr.listen((chunk) {
+      if (!_stderrController.isClosed) {
+        _stderrController.add(Uint8List.fromList(chunk));
+      }
+    });
+    unawaited(
+      process.exitCode.then((code) {
+        unawaited(_finish(exitCode: code));
+      }),
+    );
+  }
+
+  Future<void> _finishFromPty() async {
+    final pty = _pty;
+    if (pty == null) {
+      await _finish(exitCode: _exitCode ?? 0);
+      return;
+    }
+    final code = await pty.exitCode;
+    await _finish(exitCode: code);
+  }
+
+  Future<void> _finishFromProcess() async {
+    final process = _process;
+    if (process == null) {
+      await _finish(exitCode: _exitCode ?? 0);
+      return;
+    }
+    final code = await process.exitCode;
+    await _finish(exitCode: code);
+  }
+
+  Future<void> _finish({required int? exitCode}) async {
+    if (_closed) {
+      return;
+    }
+    _closed = true;
+    _exitCode = exitCode;
+    await _stdinSubscription.cancel();
+    await _outputSubscription?.cancel();
+    await _stderrSubscription?.cancel();
+    final pty = _pty;
+    if (pty != null) {
+      try {
+        pty.kill();
+      } on Object {
+        // Best-effort.
+      }
+    }
+    final process = _process;
+    if (process != null) {
+      try {
+        process.kill();
+      } on Object {
+        // Best-effort.
+      }
+    }
+    if (!_stdinController.isClosed) {
+      await _stdinController.close();
+    }
+    if (!_stdoutController.isClosed) {
+      await _stdoutController.close();
+    }
+    if (!_stderrController.isClosed) {
+      await _stderrController.close();
+    }
+    if (!_exitCompleter.isCompleted) {
+      _exitCompleter.complete(exitCode);
+    }
+    if (!_done.isCompleted) {
+      _done.complete();
+    }
+  }
+
+  ProcessSignal _mapSignal(SSHSignal signal) => switch (signal) {
+    SSHSignal.KILL => ProcessSignal.sigkill,
+    SSHSignal.INT => ProcessSignal.sigint,
+    SSHSignal.HUP => ProcessSignal.sighup,
+    SSHSignal.QUIT => ProcessSignal.sigquit,
+    SSHSignal.USR1 => ProcessSignal.sigusr1,
+    SSHSignal.USR2 => ProcessSignal.sigusr2,
+    _ => ProcessSignal.sigterm,
+  };
+
+  static List<String> _windowsCommandArgs(String executable, String command) {
+    final lower = executable.toLowerCase();
+    if (lower.endsWith('cmd.exe') || lower == 'cmd' || lower == 'cmd.exe') {
+      return ['/C', command];
+    }
+    return ['-NoLogo', '-Command', command];
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/lib/domain/services/local_terminal_service.dart
+++ b/lib/domain/services/local_terminal_service.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -317,8 +316,19 @@ class LocalTerminalSshClient implements SSHClient {
     Map<String, String>? environment,
   }) async {
     _ensureOpen();
-    if (pty != null && _looksLikeLoginShellCommand(command)) {
-      return shell(pty: pty, environment: environment);
+    // Terminal bootstrap always requests a PTY; honor that so startup
+    // commands and truecolor wrappers run under a real TTY, not Process.start.
+    if (pty != null) {
+      final launch = _commandLaunch(command);
+      return _track(
+        LocalTerminalSshSession.interactive(
+          executable: launch.executable,
+          arguments: launch.arguments,
+          workingDirectory: workingDirectory,
+          environment: _mergedEnvironment(environment),
+          pty: pty,
+        ),
+      );
     }
     return _track(
       await LocalTerminalSshSession.exec(
@@ -363,17 +373,14 @@ class LocalTerminalSshClient implements SSHClient {
     Map<String, String>? environment,
   }) async {
     final result = await _runProcess(command, environment: environment);
-    final out = StringBuffer();
+    final builder = BytesBuilder(copy: false);
     if (stdout) {
-      out.write(result.stdout);
+      builder.add(result.stdout as List<int>);
     }
-    if (stderr && result.stderr.toString().isNotEmpty) {
-      if (out.isNotEmpty) {
-        out.writeln();
-      }
-      out.write(result.stderr);
+    if (stderr) {
+      builder.add(result.stderr as List<int>);
     }
-    return Uint8List.fromList(utf8.encode(out.toString()));
+    return builder.takeBytes();
   }
 
   @override
@@ -386,10 +393,10 @@ class LocalTerminalSshClient implements SSHClient {
   }) async {
     final result = await _runProcess(command, environment: environment);
     final stdoutBytes = stdout
-        ? Uint8List.fromList(utf8.encode('${result.stdout}'))
+        ? Uint8List.fromList(result.stdout as List<int>)
         : Uint8List(0);
     final stderrBytes = stderr
-        ? Uint8List.fromList(utf8.encode('${result.stderr}'))
+        ? Uint8List.fromList(result.stderr as List<int>)
         : Uint8List(0);
     final combined = BytesBuilder(copy: false)
       ..add(stdoutBytes)
@@ -408,13 +415,14 @@ class LocalTerminalSshClient implements SSHClient {
     Map<String, String>? environment,
   }) {
     final launch = _commandLaunch(command);
+    // Keep raw bytes so binary command output cannot throw FormatException.
     return Process.run(
       launch.executable,
       launch.arguments,
       workingDirectory: workingDirectory,
       environment: _mergedEnvironment(environment),
-      stdoutEncoding: utf8,
-      stderrEncoding: utf8,
+      stdoutEncoding: null,
+      stderrEncoding: null,
     );
   }
 
@@ -454,14 +462,6 @@ class LocalTerminalSshClient implements SSHClient {
     }
   }
 
-  static bool _looksLikeLoginShellCommand(String command) =>
-      command.contains('COLORTERM=truecolor') ||
-      command.contains('TERM_PROGRAM=kitty') ||
-      command.contains('TERM_PROGRAM=MonkeySSH') ||
-      command.contains('/bin/sh -lc') ||
-      command.contains('/bin/bash -lc') ||
-      command.contains('/bin/zsh -lc');
-
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
@@ -497,6 +497,9 @@ class LocalTerminalSshSession implements SSHSession {
   }
 
   /// Runs a short-lived local command without a PTY.
+  ///
+  /// Returns immediately with a live session so callers can stream output and
+  /// observe exit without waiting for the process to finish first.
   static Future<LocalTerminalSshSession> exec({
     required String command,
     required Map<String, String> environment,
@@ -506,33 +509,25 @@ class LocalTerminalSshSession implements SSHSession {
     final args = Platform.isWindows
         ? _windowsCommandArgs(shellExecutable, command)
         : <String>['-c', command];
-    final result = await Process.run(
+    final process = await Process.start(
       shellExecutable,
       args,
       workingDirectory: workingDirectory,
       // Merge onto the platform environment so PATH/HOME stay intact.
       environment: {...Platform.environment, ...environment},
-      stdoutEncoding: utf8,
-      stderrEncoding: utf8,
     );
-    final session = LocalTerminalSshSession._();
-    final stdoutBytes = utf8.encode('${result.stdout}');
-    final stderrBytes = utf8.encode('${result.stderr}');
-    if (stdoutBytes.isNotEmpty) {
-      session._stdoutController.add(Uint8List.fromList(stdoutBytes));
-    }
-    if (stderrBytes.isNotEmpty) {
-      session._stderrController.add(Uint8List.fromList(stderrBytes));
-    }
-    session._finish(exitCode: result.exitCode, killProcess: false);
-    return session;
+    // Non-interactive exec: close stdin so shells waiting for EOF can exit.
+    unawaited(process.stdin.close());
+    return LocalTerminalSshSession._().._attachProcess(process);
   }
 
   static const _outputDrainTimeout = Duration(seconds: 2);
 
   Pty? _pty;
+  Process? _process;
   late final StreamSubscription<Uint8List> _stdinSubscription;
   StreamSubscription<List<int>>? _outputSubscription;
+  StreamSubscription<List<int>>? _stderrSubscription;
   final StreamController<Uint8List> _stdinController;
   final StreamController<Uint8List> _stdoutController;
   final StreamController<Uint8List> _stderrController;
@@ -568,7 +563,15 @@ class LocalTerminalSshSession implements SSHSession {
     if (_closed) {
       return;
     }
-    _pty?.write(data);
+    final pty = _pty;
+    if (pty != null) {
+      pty.write(data);
+      return;
+    }
+    final process = _process;
+    if (process != null) {
+      process.stdin.add(data);
+    }
   }
 
   @override
@@ -602,11 +605,91 @@ class LocalTerminalSshSession implements SSHSession {
 
   @override
   void kill(SSHSignal signal) {
-    _pty?.kill(_mapSignal(signal));
+    final mapped = _mapSignal(signal);
+    final pty = _pty;
+    if (pty != null) {
+      pty.kill(mapped);
+      return;
+    }
+    _process?.kill(mapped);
   }
 
   void _handleStdin(Uint8List data) {
     write(data);
+  }
+
+  void _attachProcess(Process process) {
+    _process = process;
+    var stdoutDone = false;
+    var stderrDone = false;
+    int? code;
+    void maybeFinish() {
+      if (_finishStarted || code == null || !stdoutDone || !stderrDone) {
+        return;
+      }
+      _finish(exitCode: code, killProcess: false);
+    }
+
+    _outputSubscription = process.stdout.listen(
+      (chunk) {
+        if (!_stdoutController.isClosed) {
+          _stdoutController.add(Uint8List.fromList(chunk));
+        }
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        if (!_stdoutController.isClosed) {
+          _stdoutController.addError(error, stackTrace);
+        }
+        stdoutDone = true;
+        maybeFinish();
+      },
+      onDone: () {
+        stdoutDone = true;
+        maybeFinish();
+      },
+    );
+    _stderrSubscription = process.stderr.listen(
+      (chunk) {
+        if (!_stderrController.isClosed) {
+          _stderrController.add(Uint8List.fromList(chunk));
+        }
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        if (!_stderrController.isClosed) {
+          _stderrController.addError(error, stackTrace);
+        }
+        stderrDone = true;
+        maybeFinish();
+      },
+      onDone: () {
+        stderrDone = true;
+        maybeFinish();
+      },
+    );
+    unawaited(
+      process.exitCode.then(
+        (exitCode) {
+          code = exitCode;
+          maybeFinish();
+          Future<void>.delayed(_outputDrainTimeout, () {
+            stdoutDone = true;
+            stderrDone = true;
+            maybeFinish();
+          });
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          assert(() {
+            // Keep failure visible in debug without crashing release builds.
+            debugPrint('local_terminal process exit failed: $error');
+            return true;
+          }());
+          code ??= -1;
+          stdoutDone = true;
+          stderrDone = true;
+          maybeFinish();
+        },
+      ),
+    );
   }
 
   void _attachPty(Pty pty) {
@@ -639,15 +722,26 @@ class LocalTerminalSshSession implements SSHSession {
       },
     );
     unawaited(
-      pty.exitCode.then((exitCode) {
-        code = exitCode;
-        maybeFinish();
-        // If output stalls after exit, finish after a short drain window.
-        Future<void>.delayed(_outputDrainTimeout, () {
+      pty.exitCode.then(
+        (exitCode) {
+          code = exitCode;
+          maybeFinish();
+          // If output stalls after exit, finish after a short drain window.
+          Future<void>.delayed(_outputDrainTimeout, () {
+            outputDone = true;
+            maybeFinish();
+          });
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          assert(() {
+            debugPrint('local_terminal pty exit failed: $error');
+            return true;
+          }());
+          code ??= -1;
           outputDone = true;
           maybeFinish();
-        });
-      }),
+        },
+      ),
     );
   }
 
@@ -660,11 +754,20 @@ class LocalTerminalSshSession implements SSHSession {
     _exitCode = exitCode;
     unawaited(_stdinSubscription.cancel());
     unawaited(_outputSubscription?.cancel() ?? Future<void>.value());
+    unawaited(_stderrSubscription?.cancel() ?? Future<void>.value());
     if (killProcess) {
       final pty = _pty;
       if (pty != null) {
         try {
           pty.kill();
+        } on Object {
+          // Best-effort.
+        }
+      }
+      final process = _process;
+      if (process != null) {
+        try {
+          process.kill();
         } on Object {
           // Best-effort.
         }

--- a/lib/domain/services/local_terminal_service.dart
+++ b/lib/domain/services/local_terminal_service.dart
@@ -257,6 +257,7 @@ class LocalTerminalSshClient implements SSHClient {
   final String remoteVersion;
 
   final _done = Completer<void>();
+  final _sessions = <LocalTerminalSshSession>{};
   bool _isClosed = false;
 
   /// Whether this client serves a local terminal host.
@@ -274,6 +275,22 @@ class LocalTerminalSshClient implements SSHClient {
   @override
   String get username => host.username;
 
+  Map<String, String> _mergedEnvironment([Map<String, String>? overrides]) => {
+    ...Platform.environment,
+    ...environment,
+    ...?overrides,
+  };
+
+  LocalTerminalSshSession _track(LocalTerminalSshSession session) {
+    _sessions.add(session);
+    unawaited(
+      session.done.whenComplete(() {
+        _sessions.remove(session);
+      }),
+    );
+    return session;
+  }
+
   @override
   Future<SSHSession> shell({
     SSHPtyConfig? pty = const SSHPtyConfig(),
@@ -281,12 +298,14 @@ class LocalTerminalSshClient implements SSHClient {
     Map<String, String>? environment,
   }) async {
     _ensureOpen();
-    return LocalTerminalSshSession.interactive(
-      executable: executable,
-      arguments: arguments,
-      workingDirectory: workingDirectory,
-      environment: {...this.environment, ...?environment},
-      pty: pty ?? const SSHPtyConfig(),
+    return _track(
+      LocalTerminalSshSession.interactive(
+        executable: executable,
+        arguments: arguments,
+        workingDirectory: workingDirectory,
+        environment: _mergedEnvironment(environment),
+        pty: pty ?? const SSHPtyConfig(),
+      ),
     );
   }
 
@@ -301,11 +320,13 @@ class LocalTerminalSshClient implements SSHClient {
     if (pty != null && _looksLikeLoginShellCommand(command)) {
       return shell(pty: pty, environment: environment);
     }
-    return LocalTerminalSshSession.exec(
-      command: command,
-      workingDirectory: workingDirectory,
-      environment: {...this.environment, ...?environment},
-      shellExecutable: executable,
+    return _track(
+      await LocalTerminalSshSession.exec(
+        command: command,
+        workingDirectory: workingDirectory,
+        environment: _mergedEnvironment(environment),
+        shellExecutable: executable,
+      ),
     );
   }
 
@@ -391,7 +412,7 @@ class LocalTerminalSshClient implements SSHClient {
       launch.executable,
       launch.arguments,
       workingDirectory: workingDirectory,
-      environment: {...this.environment, ...?environment},
+      environment: _mergedEnvironment(environment),
       stdoutEncoding: utf8,
       stderrEncoding: utf8,
     );
@@ -417,6 +438,11 @@ class LocalTerminalSshClient implements SSHClient {
       return;
     }
     _isClosed = true;
+    final openSessions = List<LocalTerminalSshSession>.of(_sessions);
+    _sessions.clear();
+    for (final session in openSessions) {
+      session.close();
+    }
     if (!_done.isCompleted) {
       _done.complete();
     }
@@ -480,26 +506,40 @@ class LocalTerminalSshSession implements SSHSession {
     final args = Platform.isWindows
         ? _windowsCommandArgs(shellExecutable, command)
         : <String>['-c', command];
-    final process = await Process.start(
+    final result = await Process.run(
       shellExecutable,
       args,
       workingDirectory: workingDirectory,
-      environment: environment,
+      // Merge onto the platform environment so PATH/HOME stay intact.
+      environment: {...Platform.environment, ...environment},
+      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
     );
-    return LocalTerminalSshSession._().._attachProcess(process);
+    final session = LocalTerminalSshSession._();
+    final stdoutBytes = utf8.encode('${result.stdout}');
+    final stderrBytes = utf8.encode('${result.stderr}');
+    if (stdoutBytes.isNotEmpty) {
+      session._stdoutController.add(Uint8List.fromList(stdoutBytes));
+    }
+    if (stderrBytes.isNotEmpty) {
+      session._stderrController.add(Uint8List.fromList(stderrBytes));
+    }
+    session._finish(exitCode: result.exitCode, killProcess: false);
+    return session;
   }
 
+  static const _outputDrainTimeout = Duration(seconds: 2);
+
   Pty? _pty;
-  Process? _process;
   late final StreamSubscription<Uint8List> _stdinSubscription;
   StreamSubscription<List<int>>? _outputSubscription;
-  StreamSubscription<List<int>>? _stderrSubscription;
   final StreamController<Uint8List> _stdinController;
   final StreamController<Uint8List> _stdoutController;
   final StreamController<Uint8List> _stderrController;
   final _done = Completer<void>();
   final _exitCompleter = Completer<int?>();
   bool _closed = false;
+  bool _finishStarted = false;
   int? _exitCode;
 
   @override
@@ -528,15 +568,7 @@ class LocalTerminalSshSession implements SSHSession {
     if (_closed) {
       return;
     }
-    final pty = _pty;
-    if (pty != null) {
-      pty.write(data);
-      return;
-    }
-    final process = _process;
-    if (process != null) {
-      process.stdin.add(data);
-    }
+    _pty?.write(data);
   }
 
   @override
@@ -557,7 +589,7 @@ class LocalTerminalSshSession implements SSHSession {
 
   @override
   void close() {
-    unawaited(_finish(exitCode: _exitCode));
+    _finish(exitCode: _exitCode);
   }
 
   @override
@@ -570,16 +602,7 @@ class LocalTerminalSshSession implements SSHSession {
 
   @override
   void kill(SSHSignal signal) {
-    final mapped = _mapSignal(signal);
-    final pty = _pty;
-    if (pty != null) {
-      pty.kill(mapped);
-      return;
-    }
-    final process = _process;
-    if (process != null) {
-      process.kill(mapped);
-    }
+    _pty?.kill(_mapSignal(signal));
   }
 
   void _handleStdin(Uint8List data) {
@@ -588,6 +611,15 @@ class LocalTerminalSshSession implements SSHSession {
 
   void _attachPty(Pty pty) {
     _pty = pty;
+    var outputDone = false;
+    int? code;
+    void maybeFinish() {
+      if (_finishStarted || code == null || !outputDone) {
+        return;
+      }
+      _finish(exitCode: code, killProcess: false);
+    }
+
     _outputSubscription = pty.output.listen(
       (chunk) {
         if (!_stdoutController.isClosed) {
@@ -598,95 +630,54 @@ class LocalTerminalSshSession implements SSHSession {
         if (!_stdoutController.isClosed) {
           _stdoutController.addError(error, stackTrace);
         }
+        outputDone = true;
+        maybeFinish();
       },
       onDone: () {
-        unawaited(_finishFromPty());
+        outputDone = true;
+        maybeFinish();
       },
     );
     unawaited(
-      pty.exitCode.then((code) {
-        unawaited(_finish(exitCode: code));
+      pty.exitCode.then((exitCode) {
+        code = exitCode;
+        maybeFinish();
+        // If output stalls after exit, finish after a short drain window.
+        Future<void>.delayed(_outputDrainTimeout, () {
+          outputDone = true;
+          maybeFinish();
+        });
       }),
     );
   }
 
-  void _attachProcess(Process process) {
-    _process = process;
-    _outputSubscription = process.stdout.listen(
-      (chunk) {
-        if (!_stdoutController.isClosed) {
-          _stdoutController.add(Uint8List.fromList(chunk));
-        }
-      },
-      onDone: () {
-        unawaited(_finishFromProcess());
-      },
-    );
-    _stderrSubscription = process.stderr.listen((chunk) {
-      if (!_stderrController.isClosed) {
-        _stderrController.add(Uint8List.fromList(chunk));
-      }
-    });
-    unawaited(
-      process.exitCode.then((code) {
-        unawaited(_finish(exitCode: code));
-      }),
-    );
-  }
-
-  Future<void> _finishFromPty() async {
-    final pty = _pty;
-    if (pty == null) {
-      await _finish(exitCode: _exitCode ?? 0);
+  void _finish({required int? exitCode, bool killProcess = true}) {
+    if (_finishStarted) {
       return;
     }
-    final code = await pty.exitCode;
-    await _finish(exitCode: code);
-  }
-
-  Future<void> _finishFromProcess() async {
-    final process = _process;
-    if (process == null) {
-      await _finish(exitCode: _exitCode ?? 0);
-      return;
-    }
-    final code = await process.exitCode;
-    await _finish(exitCode: code);
-  }
-
-  Future<void> _finish({required int? exitCode}) async {
-    if (_closed) {
-      return;
-    }
+    _finishStarted = true;
     _closed = true;
     _exitCode = exitCode;
-    await _stdinSubscription.cancel();
-    await _outputSubscription?.cancel();
-    await _stderrSubscription?.cancel();
-    final pty = _pty;
-    if (pty != null) {
-      try {
-        pty.kill();
-      } on Object {
-        // Best-effort.
-      }
-    }
-    final process = _process;
-    if (process != null) {
-      try {
-        process.kill();
-      } on Object {
-        // Best-effort.
+    unawaited(_stdinSubscription.cancel());
+    unawaited(_outputSubscription?.cancel() ?? Future<void>.value());
+    if (killProcess) {
+      final pty = _pty;
+      if (pty != null) {
+        try {
+          pty.kill();
+        } on Object {
+          // Best-effort.
+        }
       }
     }
     if (!_stdinController.isClosed) {
-      await _stdinController.close();
+      unawaited(_stdinController.close());
     }
     if (!_stdoutController.isClosed) {
-      await _stdoutController.close();
+      unawaited(_stdoutController.close());
     }
     if (!_stderrController.isClosed) {
-      await _stderrController.close();
+      unawaited(_stderrController.close());
     }
     if (!_exitCompleter.isCompleted) {
       _exitCompleter.complete(exitCode);

--- a/lib/domain/services/port_forward_runtime_service.dart
+++ b/lib/domain/services/port_forward_runtime_service.dart
@@ -74,13 +74,20 @@ bool shouldApplyPortForwardLive({
   required ActiveSessionsNotifier sessions,
   required PortForward portForward,
   PortForward? previous,
-}) =>
-    portForward.autoStart ||
-    (previous != null &&
-        isPortForwardActiveOnConnectedSession(
-          sessions: sessions,
-          portForward: previous,
-        ));
+}) {
+  if (_connectedSessionsForHost(
+    sessions,
+    portForward.hostId,
+  ).any((session) => session.isLocalTerminal)) {
+    return false;
+  }
+  return portForward.autoStart ||
+      (previous != null &&
+          isPortForwardActiveOnConnectedSession(
+            sessions: sessions,
+            portForward: previous,
+          ));
+}
 
 /// Applies [portForward] to an existing connection without reconnecting.
 ///
@@ -132,6 +139,11 @@ Future<PortForwardActivationResult> _activatePortForwardOnConnectedSession({
     sessions,
     portForward.hostId,
   );
+  if (connectedSessions.any((session) => session.isLocalTerminal)) {
+    return const PortForwardActivationResult(
+      status: PortForwardActivationStatus.failed,
+    );
+  }
   final activeOwners = connectedSessions
       .where(
         (session) =>

--- a/lib/domain/services/secure_transfer_service.dart
+++ b/lib/domain/services/secure_transfer_service.dart
@@ -14,6 +14,7 @@ import '../../data/repositories/host_repository.dart';
 import '../../data/repositories/key_repository.dart';
 import '../models/auto_connect_command.dart';
 import '../models/host_cli_launch_preferences.dart';
+import '../models/host_kind.dart';
 import 'diagnostics_log_service.dart';
 import 'host_cli_launch_preferences_service.dart';
 import 'host_key_verification.dart';
@@ -143,6 +144,11 @@ class MigrationPreview {
 
   /// Number of known hosts.
   final int knownHostCount;
+}
+
+String _normalizedImportedHostKind(Object? raw) {
+  final kind = hostKindFromStorage(raw is String ? raw : null);
+  return kind.storageValue;
 }
 
 /// Service that encrypts and imports offline transfer payloads.
@@ -438,7 +444,7 @@ class SecureTransferService {
       final hostId = await _hostRepository.insert(
         HostsCompanion.insert(
           label: _requiredString(hostData, 'label'),
-          hostKind: Value(_optionalString(hostData['hostKind']) ?? 'ssh'),
+          hostKind: Value(_normalizedImportedHostKind(hostData['hostKind'])),
           hostname: _requiredString(hostData, 'hostname'),
           port: Value(_optionalInt(hostData['port']) ?? 22),
           username: _requiredString(hostData, 'username'),
@@ -984,7 +990,7 @@ class SecureTransferService {
       final newId = await _hostRepository.insert(
         HostsCompanion.insert(
           label: _requiredString(item, 'label'),
-          hostKind: Value(_optionalString(item['hostKind']) ?? 'ssh'),
+          hostKind: Value(_normalizedImportedHostKind(item['hostKind'])),
           hostname: _requiredString(item, 'hostname'),
           port: Value(_optionalInt(item['port']) ?? 22),
           username: _requiredString(item, 'username'),

--- a/lib/domain/services/secure_transfer_service.dart
+++ b/lib/domain/services/secure_transfer_service.dart
@@ -438,6 +438,7 @@ class SecureTransferService {
       final hostId = await _hostRepository.insert(
         HostsCompanion.insert(
           label: _requiredString(hostData, 'label'),
+          hostKind: Value(_optionalString(hostData['hostKind']) ?? 'ssh'),
           hostname: _requiredString(hostData, 'hostname'),
           port: Value(_optionalInt(hostData['port']) ?? 22),
           username: _requiredString(hostData, 'username'),
@@ -983,6 +984,7 @@ class SecureTransferService {
       final newId = await _hostRepository.insert(
         HostsCompanion.insert(
           label: _requiredString(item, 'label'),
+          hostKind: Value(_optionalString(item['hostKind']) ?? 'ssh'),
           hostname: _requiredString(item, 'hostname'),
           port: Value(_optionalInt(item['port']) ?? 22),
           username: _requiredString(item, 'username'),

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -16,6 +16,7 @@ import '../../data/repositories/host_repository.dart';
 import '../../data/repositories/key_repository.dart';
 import '../../data/repositories/known_hosts_repository.dart';
 import '../../data/repositories/port_forward_repository.dart';
+import '../models/host_kind.dart';
 import '../models/port_proxy_name.dart';
 import '../models/remote_multiplexer.dart';
 import '../models/terminal_preview.dart';
@@ -28,6 +29,7 @@ import 'host_key_prompt_handler_provider.dart';
 import 'host_key_verification.dart';
 import 'interactive_auth_prompt.dart';
 import 'local_notification_service.dart';
+import 'local_terminal_service.dart';
 import 'port_forward_browser_service.dart';
 import 'settings_service.dart';
 import 'ssh_exec_queue.dart';
@@ -1634,6 +1636,15 @@ class SshService {
         );
       }
 
+      if (isLocalTerminalHost(host)) {
+        return _connectToLocalTerminalHost(
+          host,
+          useHostThemeOverrides: useHostThemeOverrides,
+          onProgress: onProgress,
+          cancellationToken: cancellationToken,
+        );
+      }
+
       List<SshKey>? cachedAutoKeys;
       var didLoadAutoKeys = false;
       Future<List<SshKey>?> loadAutoKeys() async {
@@ -1842,6 +1853,83 @@ class SshService {
         success: false,
         error:
             'Connection setup failed. Check saved credentials and try again.',
+      );
+    }
+  }
+
+  Future<SshConnectionResult> _connectToLocalTerminalHost(
+    Host host, {
+    required bool useHostThemeOverrides,
+    ConnectionProgressCallback? onProgress,
+    SshConnectionCancellationToken? cancellationToken,
+  }) async {
+    onProgress?.call(
+      const ConnectionProgressUpdate(
+        state: SshConnectionState.connecting,
+        message: 'Starting local terminal…',
+      ),
+    );
+    if (cancellationToken?.isCancelled ?? false) {
+      return const SshConnectionResult.userCancelled();
+    }
+    if (!isLocalTerminalSupported()) {
+      return const SshConnectionResult(
+        success: false,
+        error: 'Local terminals are not supported on this platform.',
+      );
+    }
+
+    try {
+      onProgress?.call(
+        const ConnectionProgressUpdate(
+          state: SshConnectionState.authenticating,
+          message: 'Opening local shell…',
+        ),
+      );
+      final client = await const LocalTerminalService().createClient(host);
+      if (cancellationToken?.isCancelled ?? false) {
+        client.close();
+        return const SshConnectionResult.userCancelled();
+      }
+
+      final config = SshConnectionConfig.fromHost(host);
+      final connectionId = _nextConnectionId++;
+      _sessions[connectionId] = SshSession(
+        connectionId: connectionId,
+        hostId: host.id,
+        client: client,
+        config: config,
+        terminalThemeLightId: useHostThemeOverrides
+            ? host.terminalThemeLightId
+            : null,
+        terminalThemeDarkId: useHostThemeOverrides
+            ? host.terminalThemeDarkId
+            : null,
+      );
+      await hostRepository?.updateLastConnected(host.id);
+      DiagnosticsLogService.instance.info(
+        'ssh.connect',
+        'local_terminal_connected',
+        fields: {
+          'hostId': host.id,
+          'connectionId': connectionId,
+          'hostKind': HostKind.local.diagnosticsValue,
+        },
+      );
+      return SshConnectionResult(
+        success: true,
+        client: client,
+        connectionId: connectionId,
+      );
+    } on Object catch (error) {
+      DiagnosticsLogService.instance.error(
+        'ssh.connect',
+        'local_terminal_failed',
+        fields: {'hostId': host.id, 'errorType': error.runtimeType.toString()},
+      );
+      return SshConnectionResult(
+        success: false,
+        error: 'Failed to start local terminal: $error',
       );
     }
   }
@@ -3514,6 +3602,10 @@ class SshSession {
   /// PowerShell `-EncodedCommand` probes respectively).
   bool get remoteIsWindows =>
       remoteVersionIndicatesWindows(remoteSoftwareVersion);
+
+  /// Whether this session is a local device shell rather than a network SSH
+  /// connection.
+  bool get isLocalTerminal => client is LocalTerminalSshClient;
 
   /// The connection configuration.
   final SshConnectionConfig config;

--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -1894,7 +1894,7 @@ class SshService {
 
       final config = SshConnectionConfig.fromHost(host);
       final connectionId = _nextConnectionId++;
-      _sessions[connectionId] = SshSession(
+      final session = SshSession(
         connectionId: connectionId,
         hostId: host.id,
         client: client,
@@ -1906,7 +1906,14 @@ class SshService {
             ? host.terminalThemeDarkId
             : null,
       );
-      await hostRepository?.updateLastConnected(host.id);
+      _sessions[connectionId] = session;
+      try {
+        await hostRepository?.updateLastConnected(host.id);
+      } on Object {
+        _sessions.remove(connectionId);
+        client.close();
+        rethrow;
+      }
       DiagnosticsLogService.instance.info(
         'ssh.connect',
         'local_terminal_connected',

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -883,12 +883,6 @@ class HostsPanel extends ConsumerWidget {
         PanelHeader(
           title: 'hosts',
           actions: [
-            if (isLocalTerminalSupported())
-              _ActionButton(
-                icon: Icons.computer_outlined,
-                label: 'Local',
-                onTap: () => context.push('/hosts/add?kind=local'),
-              ),
             _ActionButton(
               icon: Icons.add,
               label: 'Add Host',
@@ -926,12 +920,6 @@ class HostsPanel extends ConsumerWidget {
       primaryLabel: 'Add Host',
       onPrimary: () => context.push('/hosts/add'),
       secondaryActions: [
-        if (isLocalTerminalSupported())
-          BrandEmptyAction(
-            icon: Icons.computer_outlined,
-            label: 'Add Local Terminal',
-            onTap: () => context.push('/hosts/add?kind=local'),
-          ),
         BrandEmptyAction(
           icon: Icons.content_paste_go_outlined,
           label: 'Paste SSH URL',

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -14,6 +14,7 @@ import '../../data/repositories/key_repository.dart';
 import '../../data/repositories/snippet_repository.dart';
 import '../../domain/commands/duplicate_host_command.dart';
 import '../../domain/models/agent_launch_preset.dart';
+import '../../domain/models/host_kind.dart';
 import '../../domain/models/monetization.dart';
 import '../../domain/models/remote_multiplexer.dart';
 import '../../domain/models/terminal_preview.dart';
@@ -882,6 +883,12 @@ class HostsPanel extends ConsumerWidget {
         PanelHeader(
           title: 'hosts',
           actions: [
+            if (isLocalTerminalSupported())
+              _ActionButton(
+                icon: Icons.computer_outlined,
+                label: 'Local',
+                onTap: () => context.push('/hosts/add?kind=local'),
+              ),
             _ActionButton(
               icon: Icons.add,
               label: 'Add Host',
@@ -919,6 +926,12 @@ class HostsPanel extends ConsumerWidget {
       primaryLabel: 'Add Host',
       onPrimary: () => context.push('/hosts/add'),
       secondaryActions: [
+        if (isLocalTerminalSupported())
+          BrandEmptyAction(
+            icon: Icons.computer_outlined,
+            label: 'Add Local Terminal',
+            onTap: () => context.push('/hosts/add?kind=local'),
+          ),
         BrandEmptyAction(
           icon: Icons.content_paste_go_outlined,
           label: 'Paste SSH URL',
@@ -1158,6 +1171,8 @@ class _HostRow extends ConsumerWidget {
                         Text(
                           _redactStoreScreenshotIdentities
                               ? 'store@local-demo'
+                              : isLocalTerminalHost(host)
+                              ? 'local terminal'
                               : '${host.username}@${host.hostname}',
                           style: FluttyTheme.monoStyle.copyWith(
                             fontSize: 11,

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:collection';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -23,6 +24,7 @@ import '../../domain/models/terminal_themes.dart';
 import '../../domain/models/tmux_state.dart';
 import '../../domain/services/agent_launch_preset_service.dart';
 import '../../domain/services/agent_session_discovery_service.dart';
+import '../../domain/services/android_linux_terminal_setup_service.dart';
 import '../../domain/services/auth_service.dart';
 import '../../domain/services/diagnostics_log_service.dart';
 import '../../domain/services/home_screen_shortcut_service.dart';
@@ -883,6 +885,13 @@ class HostsPanel extends ConsumerWidget {
         PanelHeader(
           title: 'hosts',
           actions: [
+            if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android)
+              _ActionButton(
+                icon: Icons.terminal_outlined,
+                label: 'Linux',
+                onTap: () =>
+                    unawaited(_startAndroidLinuxTerminalSetup(context, ref)),
+              ),
             _ActionButton(
               icon: Icons.add,
               label: 'Add Host',
@@ -909,25 +918,50 @@ class HostsPanel extends ConsumerWidget {
       onRetry: () => ref.invalidate(allHostsProvider),
     ),
     data: (hosts) => hosts.isEmpty
-        ? _buildEmptyState(context)
+        ? _buildEmptyState(context, ref)
         : _buildHostsList(context, ref, hosts),
   );
 
-  Widget _buildEmptyState(BuildContext context) => _buildCenteredHostsState(
-    child: BrandEmptyState(
-      title: 'no hosts yet',
-      message: 'Nothing to connect to — let’s fix that.',
-      primaryLabel: 'Add Host',
-      onPrimary: () => context.push('/hosts/add'),
-      secondaryActions: [
-        BrandEmptyAction(
-          icon: Icons.content_paste_go_outlined,
-          label: 'Paste SSH URL',
-          onTap: () => unawaited(_openPastedSshUrl(context)),
+  Widget _buildEmptyState(BuildContext context, WidgetRef ref) =>
+      _buildCenteredHostsState(
+        child: BrandEmptyState(
+          title: 'no hosts yet',
+          message: 'Nothing to connect to — let’s fix that.',
+          primaryLabel: 'Add Host',
+          onPrimary: () => context.push('/hosts/add'),
+          secondaryActions: [
+            if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android)
+              BrandEmptyAction(
+                icon: Icons.terminal_outlined,
+                label: 'Set up Linux Terminal',
+                onTap: () =>
+                    unawaited(_startAndroidLinuxTerminalSetup(context, ref)),
+              ),
+            BrandEmptyAction(
+              icon: Icons.content_paste_go_outlined,
+              label: 'Paste SSH URL',
+              onTap: () => unawaited(_openPastedSshUrl(context)),
+            ),
+          ],
         ),
-      ],
-    ),
-  );
+      );
+
+  Future<void> _startAndroidLinuxTerminalSetup(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final setup = ref.read(androidLinuxTerminalSetupServiceProvider);
+    final messenger = ScaffoldMessenger.of(context);
+    final state = await setup.beginSetup();
+    if (!context.mounted) {
+      return;
+    }
+    messenger.showSnackBar(SnackBar(content: Text(state.message)));
+    if (state.phase == AndroidLinuxTerminalSetupPhase.succeeded &&
+        state.hostId != null) {
+      ref.invalidate(allHostsProvider);
+    }
+  }
 
   Future<void> _openPastedSshUrl(BuildContext context) async {
     final clipboard = await Clipboard.getData(Clipboard.kTextPlain);

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -212,10 +212,51 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   }
 
   void _applyLocalTerminalDefaults() {
-    _labelController.text = defaultLocalTerminalHostLabel();
+    if (_labelController.text.trim().isEmpty ||
+        _labelController.text.trim() == 'My Server') {
+      _labelController.text = defaultLocalTerminalHostLabel();
+    }
     _hostnameController.text = localTerminalHostname;
     _portController.text = '$localTerminalPort';
-    _usernameController.text = defaultLocalTerminalUsername();
+    if (_usernameController.text.trim().isEmpty) {
+      _usernameController.text = defaultLocalTerminalUsername();
+    }
+    _passwordController.clear();
+    _selectedKeyId = null;
+    _selectedJumpHostId = null;
+    _skipJumpHostOnSsids = const [];
+    _selectedStartupMode = HostStartupMode.none;
+    _selectedAutoConnectMode = AutoConnectCommandMode.none;
+    _autoConnectCommandController.clear();
+    _selectedAutoConnectSnippetId = null;
+    _autoForwardPorts = false;
+  }
+
+  void _applySshHostDefaultsFromLocal() {
+    if (_hostnameController.text.trim() == localTerminalHostname) {
+      _hostnameController.clear();
+    }
+    if (_portController.text.trim() == '$localTerminalPort') {
+      _portController.text = '22';
+    }
+    if (_labelController.text.trim() == defaultLocalTerminalHostLabel()) {
+      _labelController.clear();
+    }
+  }
+
+  void _setLocalTerminalEnabled(bool enabled) {
+    if (!isLocalTerminalSupported() || widget.hostId != null) {
+      return;
+    }
+    setState(() {
+      _hostKind = enabled ? HostKind.local : HostKind.ssh;
+      if (enabled) {
+        _applyLocalTerminalDefaults();
+      } else {
+        _applySshHostDefaultsFromLocal();
+      }
+    });
+    _updateDirtyState();
   }
 
   void _applySshUrl(String rawUrl) {
@@ -498,19 +539,26 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                         ),
                         const SizedBox(height: 16),
 
-                        if (_isLocalHost) ...[
-                          Card(
-                            child: ListTile(
-                              leading: const Icon(Icons.computer_outlined),
-                              title: const Text('Local terminal'),
-                              subtitle: Text(
-                                defaultTargetPlatform == TargetPlatform.android
-                                    ? 'Opens a shell in this app’s sandbox on the device.'
-                                    : 'Opens a shell on this computer without SSH.',
-                              ),
+                        if (isLocalTerminalSupported()) ...[
+                          SwitchListTile(
+                            key: const Key('host-local-terminal-switch'),
+                            contentPadding: EdgeInsets.zero,
+                            secondary: const Icon(Icons.computer_outlined),
+                            title: const Text('Local terminal'),
+                            subtitle: Text(
+                              defaultTargetPlatform == TargetPlatform.android
+                                  ? 'Open a shell in this app’s sandbox instead of SSH.'
+                                  : 'Open a shell on this computer instead of SSH.',
                             ),
+                            value: _isLocalHost,
+                            onChanged: widget.hostId == null
+                                ? _setLocalTerminalEnabled
+                                : null,
                           ),
-                          const SizedBox(height: 16),
+                          const SizedBox(height: 8),
+                        ],
+
+                        if (_isLocalHost) ...[
                           KeyedSubtree(
                             key: _usernameFieldLocationKey,
                             child: TextFormField(

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -119,6 +119,10 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   String? _selectedDarkThemeId;
   String? _selectedFontFamily;
   HostKind _hostKind = HostKind.ssh;
+
+  /// SSH-only draft values preserved while the local-terminal switch is on.
+  _SshDraftSnapshot? _sshDraftSnapshot;
+
   HostStartupMode _selectedStartupMode = HostStartupMode.none;
   AutoConnectCommandMode _selectedAutoConnectMode = AutoConnectCommandMode.none;
   AgentLaunchTool _selectedAgentLaunchTool = AgentLaunchTool.claudeCode;
@@ -196,7 +200,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     } else {
       _hostKind = widget.initialHostKind;
       if (_hostKind == HostKind.local) {
-        _applyLocalTerminalDefaults();
+        _applyLocalTerminalDefaults(preserveSshDraft: false);
       } else if (widget.initialSshUrl?.trim().isNotEmpty ?? false) {
         _applySshUrl(widget.initialSshUrl!.trim());
       }
@@ -211,7 +215,24 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     }
   }
 
-  void _applyLocalTerminalDefaults() {
+  void _applyLocalTerminalDefaults({required bool preserveSshDraft}) {
+    if (preserveSshDraft) {
+      _sshDraftSnapshot = _SshDraftSnapshot(
+        label: _labelController.text,
+        hostname: _hostnameController.text,
+        port: _portController.text,
+        username: _usernameController.text,
+        password: _passwordController.text,
+        selectedKeyId: _selectedKeyId,
+        selectedJumpHostId: _selectedJumpHostId,
+        skipJumpHostOnSsids: _skipJumpHostOnSsids,
+        selectedStartupMode: _selectedStartupMode,
+        selectedAutoConnectMode: _selectedAutoConnectMode,
+        autoConnectCommand: _autoConnectCommandController.text,
+        selectedAutoConnectSnippetId: _selectedAutoConnectSnippetId,
+        autoForwardPorts: _autoForwardPorts,
+      );
+    }
     if (_labelController.text.trim().isEmpty ||
         _labelController.text.trim() == 'My Server') {
       _labelController.text = defaultLocalTerminalHostLabel();
@@ -221,6 +242,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     if (_usernameController.text.trim().isEmpty) {
       _usernameController.text = defaultLocalTerminalUsername();
     }
+    // Hide SSH-only controls while local is selected; values stay in snapshot.
     _passwordController.clear();
     _selectedKeyId = null;
     _selectedJumpHostId = null;
@@ -232,7 +254,25 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     _autoForwardPorts = false;
   }
 
-  void _applySshHostDefaultsFromLocal() {
+  void _restoreSshDraftFromLocal() {
+    final snapshot = _sshDraftSnapshot;
+    if (snapshot != null) {
+      _labelController.text = snapshot.label;
+      _hostnameController.text = snapshot.hostname;
+      _portController.text = snapshot.port;
+      _usernameController.text = snapshot.username;
+      _passwordController.text = snapshot.password;
+      _selectedKeyId = snapshot.selectedKeyId;
+      _selectedJumpHostId = snapshot.selectedJumpHostId;
+      _skipJumpHostOnSsids = snapshot.skipJumpHostOnSsids;
+      _selectedStartupMode = snapshot.selectedStartupMode;
+      _selectedAutoConnectMode = snapshot.selectedAutoConnectMode;
+      _autoConnectCommandController.text = snapshot.autoConnectCommand;
+      _selectedAutoConnectSnippetId = snapshot.selectedAutoConnectSnippetId;
+      _autoForwardPorts = snapshot.autoForwardPorts;
+      _sshDraftSnapshot = null;
+      return;
+    }
     if (_hostnameController.text.trim() == localTerminalHostname) {
       _hostnameController.clear();
     }
@@ -251,9 +291,9 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     setState(() {
       _hostKind = enabled ? HostKind.local : HostKind.ssh;
       if (enabled) {
-        _applyLocalTerminalDefaults();
+        _applyLocalTerminalDefaults(preserveSshDraft: true);
       } else {
-        _applySshHostDefaultsFromLocal();
+        _restoreSshDraftFromLocal();
       }
     });
     _updateDirtyState();
@@ -2984,4 +3024,36 @@ class _SkipJumpHostOnWifiSectionState
       ],
     );
   }
+}
+
+class _SshDraftSnapshot {
+  const _SshDraftSnapshot({
+    required this.label,
+    required this.hostname,
+    required this.port,
+    required this.username,
+    required this.password,
+    required this.selectedKeyId,
+    required this.selectedJumpHostId,
+    required this.skipJumpHostOnSsids,
+    required this.selectedStartupMode,
+    required this.selectedAutoConnectMode,
+    required this.autoConnectCommand,
+    required this.selectedAutoConnectSnippetId,
+    required this.autoForwardPorts,
+  });
+
+  final String label;
+  final String hostname;
+  final String port;
+  final String username;
+  final String password;
+  final int? selectedKeyId;
+  final int? selectedJumpHostId;
+  final List<String> skipJumpHostOnSsids;
+  final HostStartupMode selectedStartupMode;
+  final AutoConnectCommandMode selectedAutoConnectMode;
+  final String autoConnectCommand;
+  final int? selectedAutoConnectSnippetId;
+  final bool autoForwardPorts;
 }

--- a/lib/presentation/screens/host_edit_screen.dart
+++ b/lib/presentation/screens/host_edit_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -12,6 +13,7 @@ import '../../data/repositories/key_repository.dart';
 import '../../data/repositories/port_forward_repository.dart';
 import '../../domain/models/agent_launch_preset.dart';
 import '../../domain/models/auto_connect_command.dart';
+import '../../domain/models/host_kind.dart';
 import '../../domain/models/monetization.dart';
 import '../../domain/models/port_proxy_name.dart';
 import '../../domain/models/remote_multiplexer.dart';
@@ -50,13 +52,21 @@ const _hostStartupModeOptions = <HostStartupMode>[
 /// Screen for adding or editing a host.
 class HostEditScreen extends ConsumerStatefulWidget {
   /// Creates a new [HostEditScreen].
-  const HostEditScreen({this.hostId, this.initialSshUrl, super.key});
+  const HostEditScreen({
+    this.hostId,
+    this.initialSshUrl,
+    this.initialHostKind = HostKind.ssh,
+    super.key,
+  });
 
   /// The host ID to edit, or null for a new host.
   final int? hostId;
 
   /// SSH URL used to prefill a new host.
   final String? initialSshUrl;
+
+  /// Transport kind used when creating a new host.
+  final HostKind initialHostKind;
 
   @override
   ConsumerState<HostEditScreen> createState() => _HostEditScreenState();
@@ -108,6 +118,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
   String? _selectedLightThemeId;
   String? _selectedDarkThemeId;
   String? _selectedFontFamily;
+  HostKind _hostKind = HostKind.ssh;
   HostStartupMode _selectedStartupMode = HostStartupMode.none;
   AutoConnectCommandMode _selectedAutoConnectMode = AutoConnectCommandMode.none;
   AgentLaunchTool _selectedAgentLaunchTool = AgentLaunchTool.claudeCode;
@@ -183,7 +194,10 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
         }
       });
     } else {
-      if (widget.initialSshUrl?.trim().isNotEmpty ?? false) {
+      _hostKind = widget.initialHostKind;
+      if (_hostKind == HostKind.local) {
+        _applyLocalTerminalDefaults();
+      } else if (widget.initialSshUrl?.trim().isNotEmpty ?? false) {
         _applySshUrl(widget.initialSshUrl!.trim());
       }
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -195,6 +209,13 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
             .markInitialDraft(_currentDraft());
       });
     }
+  }
+
+  void _applyLocalTerminalDefaults() {
+    _labelController.text = defaultLocalTerminalHostLabel();
+    _hostnameController.text = localTerminalHostname;
+    _portController.text = '$localTerminalPort';
+    _usernameController.text = defaultLocalTerminalUsername();
   }
 
   void _applySshUrl(String rawUrl) {
@@ -231,6 +252,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     final cliLaunchPreferences = result.cliLaunchPreferences;
     final tmuxExtraFlags = host.tmuxExtraFlags ?? '';
     setState(() {
+      _hostKind = hostKindOf(host);
       _labelController.text = host.label;
       _hostnameController.text = host.hostname;
       _portController.text = host.port.toString();
@@ -335,6 +357,7 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
 
   HostEditDraft _currentDraft() => (
     label: _labelController.text,
+    hostKind: _hostKind,
     hostname: _hostnameController.text,
     port: _portController.text,
     username: _usernameController.text,
@@ -367,6 +390,8 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
     startClisInYoloMode: _startClisInYoloMode,
     autoForwardPorts: _autoForwardPorts,
   );
+
+  bool get _isLocalHost => _hostKind == HostKind.local;
 
   void _closeWithoutUnsavedPrompt(SnackBar snackBar) {
     final messenger = ScaffoldMessenger.of(context);
@@ -473,82 +498,122 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                         ),
                         const SizedBox(height: 16),
 
-                        // Hostname
-                        KeyedSubtree(
-                          key: _hostnameFieldLocationKey,
-                          child: TextFormField(
-                            key: const Key('host-hostname-field'),
-                            controller: _hostnameController,
-                            focusNode: _hostnameFocusNode,
-                            decoration: const InputDecoration(
-                              labelText: 'Hostname',
-                              hintText: 'example.com or 192.168.1.1',
-                              prefixIcon: Icon(Icons.dns),
+                        if (_isLocalHost) ...[
+                          Card(
+                            child: ListTile(
+                              leading: const Icon(Icons.computer_outlined),
+                              title: const Text('Local terminal'),
+                              subtitle: Text(
+                                defaultTargetPlatform == TargetPlatform.android
+                                    ? 'Opens a shell in this app’s sandbox on the device.'
+                                    : 'Opens a shell on this computer without SSH.',
+                              ),
                             ),
-                            keyboardType: TextInputType.url,
-                            textInputAction: TextInputAction.next,
-                            autocorrect: false,
-                            validator: (value) {
-                              if (value == null || value.isEmpty) {
-                                return 'Please enter a hostname';
-                              }
-                              return null;
-                            },
                           ),
-                        ),
-                        const SizedBox(height: 16),
+                          const SizedBox(height: 16),
+                          KeyedSubtree(
+                            key: _usernameFieldLocationKey,
+                            child: TextFormField(
+                              key: const Key('host-username-field'),
+                              controller: _usernameController,
+                              focusNode: _usernameFocusNode,
+                              decoration: const InputDecoration(
+                                labelText: 'Username',
+                                hintText: 'local',
+                                prefixIcon: Icon(Icons.person),
+                                helperText:
+                                    'Display only — the local shell uses your account.',
+                                helperMaxLines: _hostFieldHelperMaxLines,
+                              ),
+                              textInputAction: TextInputAction.next,
+                              autocorrect: false,
+                              validator: (value) {
+                                if (value == null || value.isEmpty) {
+                                  return 'Please enter a username';
+                                }
+                                return null;
+                              },
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                        ] else ...[
+                          // Hostname
+                          KeyedSubtree(
+                            key: _hostnameFieldLocationKey,
+                            child: TextFormField(
+                              key: const Key('host-hostname-field'),
+                              controller: _hostnameController,
+                              focusNode: _hostnameFocusNode,
+                              decoration: const InputDecoration(
+                                labelText: 'Hostname',
+                                hintText: 'example.com or 192.168.1.1',
+                                prefixIcon: Icon(Icons.dns),
+                              ),
+                              keyboardType: TextInputType.url,
+                              textInputAction: TextInputAction.next,
+                              autocorrect: false,
+                              validator: (value) {
+                                if (value == null || value.isEmpty) {
+                                  return 'Please enter a hostname';
+                                }
+                                return null;
+                              },
+                            ),
+                          ),
+                          const SizedBox(height: 16),
 
-                        // Port
-                        KeyedSubtree(
-                          key: _portFieldLocationKey,
-                          child: TextFormField(
-                            key: const Key('host-port-field'),
-                            controller: _portController,
-                            focusNode: _portFocusNode,
-                            decoration: const InputDecoration(
-                              labelText: 'Port',
-                              hintText: '22',
-                              prefixIcon: Icon(Icons.numbers),
+                          // Port
+                          KeyedSubtree(
+                            key: _portFieldLocationKey,
+                            child: TextFormField(
+                              key: const Key('host-port-field'),
+                              controller: _portController,
+                              focusNode: _portFocusNode,
+                              decoration: const InputDecoration(
+                                labelText: 'Port',
+                                hintText: '22',
+                                prefixIcon: Icon(Icons.numbers),
+                              ),
+                              keyboardType: TextInputType.number,
+                              textInputAction: TextInputAction.next,
+                              validator: (value) {
+                                if (value == null || value.isEmpty) {
+                                  return 'Please enter a port';
+                                }
+                                final port = int.tryParse(value);
+                                if (port == null || port < 1 || port > 65535) {
+                                  return 'Port must be between 1 and 65535';
+                                }
+                                return null;
+                              },
                             ),
-                            keyboardType: TextInputType.number,
-                            textInputAction: TextInputAction.next,
-                            validator: (value) {
-                              if (value == null || value.isEmpty) {
-                                return 'Please enter a port';
-                              }
-                              final port = int.tryParse(value);
-                              if (port == null || port < 1 || port > 65535) {
-                                return 'Port must be between 1 and 65535';
-                              }
-                              return null;
-                            },
                           ),
-                        ),
-                        const SizedBox(height: 16),
+                          const SizedBox(height: 16),
 
-                        // Username
-                        KeyedSubtree(
-                          key: _usernameFieldLocationKey,
-                          child: TextFormField(
-                            key: const Key('host-username-field'),
-                            controller: _usernameController,
-                            focusNode: _usernameFocusNode,
-                            decoration: const InputDecoration(
-                              labelText: 'Username',
-                              hintText: 'root',
-                              prefixIcon: Icon(Icons.person),
+                          // Username
+                          KeyedSubtree(
+                            key: _usernameFieldLocationKey,
+                            child: TextFormField(
+                              key: const Key('host-username-field'),
+                              controller: _usernameController,
+                              focusNode: _usernameFocusNode,
+                              decoration: const InputDecoration(
+                                labelText: 'Username',
+                                hintText: 'root',
+                                prefixIcon: Icon(Icons.person),
+                              ),
+                              textInputAction: TextInputAction.next,
+                              autocorrect: false,
+                              validator: (value) {
+                                if (value == null || value.isEmpty) {
+                                  return 'Please enter a username';
+                                }
+                                return null;
+                              },
                             ),
-                            textInputAction: TextInputAction.next,
-                            autocorrect: false,
-                            validator: (value) {
-                              if (value == null || value.isEmpty) {
-                                return 'Please enter a username';
-                              }
-                              return null;
-                            },
                           ),
-                        ),
-                        const SizedBox(height: 16),
+                          const SizedBox(height: 16),
+                        ],
 
                         TextFormField(
                           controller: _tagsController,
@@ -565,249 +630,315 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                         ),
                         const SizedBox(height: 24),
 
-                        // Authentication section
-                        Text(
-                          'authentication',
-                          style: FluttyTheme.displayMono(
-                            fontSize: 15,
-                            color: Theme.of(context).colorScheme.onSurface,
-                          ),
-                        ),
-                        const SizedBox(height: 12),
-
-                        // Password
-                        TextFormField(
-                          controller: _passwordController,
-                          decoration: InputDecoration(
-                            labelText: 'Password (optional)',
-                            hintText: 'Leave empty for key-only auth',
-                            prefixIcon: const Icon(Icons.lock),
-                            suffixIcon: IconButton(
-                              icon: Icon(
-                                _showPassword
-                                    ? Icons.visibility_off
-                                    : Icons.visibility,
-                              ),
-                              onPressed: () => setState(
-                                () => _showPassword = !_showPassword,
-                              ),
+                        if (!_isLocalHost) ...[
+                          // Authentication section
+                          Text(
+                            'authentication',
+                            style: FluttyTheme.displayMono(
+                              fontSize: 15,
+                              color: Theme.of(context).colorScheme.onSurface,
                             ),
                           ),
-                          obscureText: !_showPassword,
-                          textInputAction: TextInputAction.done,
-                        ),
-                        const SizedBox(height: 16),
+                          const SizedBox(height: 12),
 
-                        // SSH Key dropdown
-                        keysAsync.when(
-                          loading: () => const LinearProgressIndicator(),
-                          error: (_, _) => const Text('Error loading keys'),
-                          data: (keys) {
-                            // Validate selected key still exists
-                            final validKeyId =
-                                _selectedKeyId != null &&
-                                    keys.any((k) => k.id == _selectedKeyId)
-                                ? _selectedKeyId
-                                : null;
-                            if (validKeyId != _selectedKeyId) {
-                              // Schedule state update for next frame
-                              WidgetsBinding.instance.addPostFrameCallback((_) {
-                                if (mounted) {
-                                  setState(() => _selectedKeyId = null);
-                                  _updateDirtyState();
-                                }
-                              });
-                            }
-                            return DropdownButtonFormField<int?>(
-                              // ignore: deprecated_member_use
-                              value: validKeyId,
-                              isExpanded: true,
-                              decoration: const InputDecoration(
-                                labelText: 'SSH Key (optional)',
-                                prefixIcon: Icon(Icons.key),
-                                helperText:
-                                    'Auto tries up to 5 installed keys when password is empty',
-                                helperMaxLines: _hostFieldHelperMaxLines,
+                          // Password
+                          TextFormField(
+                            controller: _passwordController,
+                            decoration: InputDecoration(
+                              labelText: 'Password (optional)',
+                              hintText: 'Leave empty for key-only auth',
+                              prefixIcon: const Icon(Icons.lock),
+                              suffixIcon: IconButton(
+                                icon: Icon(
+                                  _showPassword
+                                      ? Icons.visibility_off
+                                      : Icons.visibility,
+                                ),
+                                onPressed: () => setState(
+                                  () => _showPassword = !_showPassword,
+                                ),
                               ),
-                              items: [
-                                const DropdownMenuItem<int?>(
-                                  child: Text('Auto'),
-                                ),
-                                ...keys.map(
-                                  (key) => DropdownMenuItem(
-                                    value: key.id,
-                                    child: Text(
-                                      key.name,
-                                      style: FluttyTheme.monoStyle,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                              onChanged: (value) {
-                                setState(() => _selectedKeyId = value);
-                                _updateDirtyState();
-                              },
-                            );
-                          },
-                        ),
-                        const SizedBox(height: 24),
+                            ),
+                            obscureText: !_showPassword,
+                            textInputAction: TextInputAction.done,
+                          ),
+                          const SizedBox(height: 16),
 
-                        _buildStartupSection(
-                          context: context,
-                          hasAutomationAccess: hasAutomationAccess,
-                          hasAgentPresetAccess: hasAgentPresetAccess,
-                          snippetsAsync: snippetsAsync,
-                        ),
-                        const SizedBox(height: 24),
-
-                        // Advanced section
-                        ExpansionTile(
-                          key: const Key('host-advanced-tile'),
-                          title: const Text('Advanced'),
-                          initiallyExpanded: _selectedJumpHostId != null,
-                          children: [
-                            const SizedBox(height: 8),
-                            // Jump host dropdown
-                            hostsAsync.when(
-                              loading: () => const LinearProgressIndicator(),
-                              error: (_, _) =>
-                                  const Text('Error loading hosts'),
-                              data: (hosts) {
-                                // Filter out current host from jump host options
-                                final availableHosts = hosts
-                                    .where((h) => h.id != widget.hostId)
-                                    .toList();
-                                // Validate selected jump host still exists
-                                final validJumpHostId =
-                                    _selectedJumpHostId != null &&
-                                        availableHosts.any(
-                                          (h) => h.id == _selectedJumpHostId,
-                                        )
-                                    ? _selectedJumpHostId
-                                    : null;
-                                if (validJumpHostId != _selectedJumpHostId) {
-                                  WidgetsBinding.instance.addPostFrameCallback((
-                                    _,
-                                  ) {
-                                    if (mounted) {
-                                      setState(
-                                        () => _selectedJumpHostId = null,
-                                      );
-                                      _updateDirtyState();
-                                    }
-                                  });
-                                }
-                                return DropdownButtonFormField<int?>(
-                                  // ignore: deprecated_member_use
-                                  value: validJumpHostId,
-                                  isExpanded: true,
-                                  decoration: const InputDecoration(
-                                    labelText: 'Jump Host (optional)',
-                                    prefixIcon: Icon(Icons.hub),
-                                    helperText:
-                                        'Connect through another host (bastion)',
-                                    helperMaxLines: _hostFieldHelperMaxLines,
+                          // SSH Key dropdown
+                          keysAsync.when(
+                            loading: () => const LinearProgressIndicator(),
+                            error: (_, _) => const Text('Error loading keys'),
+                            data: (keys) {
+                              // Validate selected key still exists
+                              final validKeyId =
+                                  _selectedKeyId != null &&
+                                      keys.any((k) => k.id == _selectedKeyId)
+                                  ? _selectedKeyId
+                                  : null;
+                              if (validKeyId != _selectedKeyId) {
+                                // Schedule state update for next frame
+                                WidgetsBinding.instance.addPostFrameCallback((
+                                  _,
+                                ) {
+                                  if (mounted) {
+                                    setState(() => _selectedKeyId = null);
+                                    _updateDirtyState();
+                                  }
+                                });
+                              }
+                              return DropdownButtonFormField<int?>(
+                                // ignore: deprecated_member_use
+                                value: validKeyId,
+                                isExpanded: true,
+                                decoration: const InputDecoration(
+                                  labelText: 'SSH Key (optional)',
+                                  prefixIcon: Icon(Icons.key),
+                                  helperText:
+                                      'Auto tries up to 5 installed keys when password is empty',
+                                  helperMaxLines: _hostFieldHelperMaxLines,
+                                ),
+                                items: [
+                                  const DropdownMenuItem<int?>(
+                                    child: Text('Auto'),
                                   ),
-                                  items: [
-                                    const DropdownMenuItem(child: Text('None')),
-                                    ...availableHosts.map(
-                                      (host) => DropdownMenuItem(
-                                        value: host.id,
-                                        child: Text(
-                                          host.label,
-                                          style: FluttyTheme.monoStyle,
-                                        ),
+                                  ...keys.map(
+                                    (key) => DropdownMenuItem(
+                                      value: key.id,
+                                      child: Text(
+                                        key.name,
+                                        style: FluttyTheme.monoStyle,
                                       ),
                                     ),
-                                  ],
-                                  onChanged: (value) {
-                                    setState(() => _selectedJumpHostId = value);
+                                  ),
+                                ],
+                                onChanged: (value) {
+                                  setState(() => _selectedKeyId = value);
+                                  _updateDirtyState();
+                                },
+                              );
+                            },
+                          ),
+                          const SizedBox(height: 24),
+
+                          _buildStartupSection(
+                            context: context,
+                            hasAutomationAccess: hasAutomationAccess,
+                            hasAgentPresetAccess: hasAgentPresetAccess,
+                            snippetsAsync: snippetsAsync,
+                          ),
+                          const SizedBox(height: 24),
+
+                          // Advanced section
+                          ExpansionTile(
+                            key: const Key('host-advanced-tile'),
+                            title: const Text('Advanced'),
+                            initiallyExpanded: _selectedJumpHostId != null,
+                            children: [
+                              const SizedBox(height: 8),
+                              // Jump host dropdown
+                              hostsAsync.when(
+                                loading: () => const LinearProgressIndicator(),
+                                error: (_, _) =>
+                                    const Text('Error loading hosts'),
+                                data: (hosts) {
+                                  // Filter out current/local hosts from jump options
+                                  final availableHosts = hosts
+                                      .where(
+                                        (h) =>
+                                            h.id != widget.hostId &&
+                                            !isLocalTerminalHost(h),
+                                      )
+                                      .toList();
+                                  // Validate selected jump host still exists
+                                  final validJumpHostId =
+                                      _selectedJumpHostId != null &&
+                                          availableHosts.any(
+                                            (h) => h.id == _selectedJumpHostId,
+                                          )
+                                      ? _selectedJumpHostId
+                                      : null;
+                                  if (validJumpHostId != _selectedJumpHostId) {
+                                    WidgetsBinding.instance
+                                        .addPostFrameCallback((_) {
+                                          if (mounted) {
+                                            setState(
+                                              () => _selectedJumpHostId = null,
+                                            );
+                                            _updateDirtyState();
+                                          }
+                                        });
+                                  }
+                                  return DropdownButtonFormField<int?>(
+                                    // ignore: deprecated_member_use
+                                    value: validJumpHostId,
+                                    isExpanded: true,
+                                    decoration: const InputDecoration(
+                                      labelText: 'Jump Host (optional)',
+                                      prefixIcon: Icon(Icons.hub),
+                                      helperText:
+                                          'Connect through another host (bastion)',
+                                      helperMaxLines: _hostFieldHelperMaxLines,
+                                    ),
+                                    items: [
+                                      const DropdownMenuItem(
+                                        child: Text('None'),
+                                      ),
+                                      ...availableHosts.map(
+                                        (host) => DropdownMenuItem(
+                                          value: host.id,
+                                          child: Text(
+                                            host.label,
+                                            style: FluttyTheme.monoStyle,
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                    onChanged: (value) {
+                                      setState(
+                                        () => _selectedJumpHostId = value,
+                                      );
+                                      _updateDirtyState();
+                                    },
+                                  );
+                                },
+                              ),
+                              if (_selectedJumpHostId != null) ...[
+                                const SizedBox(height: 16),
+                                _SkipJumpHostOnWifiSection(
+                                  ssids: _skipJumpHostOnSsids,
+                                  onChanged: (next) {
+                                    setState(() => _skipJumpHostOnSsids = next);
                                     _updateDirtyState();
                                   },
-                                );
-                              },
-                            ),
-                            if (_selectedJumpHostId != null) ...[
-                              const SizedBox(height: 16),
-                              _SkipJumpHostOnWifiSection(
-                                ssids: _skipJumpHostOnSsids,
-                                onChanged: (next) {
-                                  setState(() => _skipJumpHostOnSsids = next);
+                                ),
+                              ],
+                              const SizedBox(height: 24),
+                              // Terminal theme section
+                              Row(
+                                children: [
+                                  Text(
+                                    'terminal theme',
+                                    style: FluttyTheme.displayMono(
+                                      fontSize: 14,
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.onSurface,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 8),
+                                  const PremiumBadge(),
+                                ],
+                              ),
+                              const SizedBox(height: 12),
+                              if (!hasHostThemeAccess) ...[
+                                Text(
+                                  'MonkeySSH Pro unlocks per-host theme overrides. App-wide default themes stay free in Settings.',
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
+                                const SizedBox(height: 12),
+                              ],
+                              // Light mode theme
+                              _ThemeSelectionTile(
+                                label: 'Light Mode Theme',
+                                themeId: _selectedLightThemeId,
+                                themes: terminalThemes,
+                                defaultLabel: 'Use default',
+                                onTap: () =>
+                                    _handleThemeSelectionTap(isLight: true),
+                                onClear: () {
+                                  setState(() {
+                                    _selectedLightThemeId = null;
+                                  });
                                   _updateDirtyState();
                                 },
                               ),
+                              const SizedBox(height: 8),
+                              // Dark mode theme
+                              _ThemeSelectionTile(
+                                label: 'Dark Mode Theme',
+                                themeId: _selectedDarkThemeId,
+                                themes: terminalThemes,
+                                defaultLabel: 'Use default',
+                                onTap: () =>
+                                    _handleThemeSelectionTap(isLight: false),
+                                onClear: () {
+                                  setState(() {
+                                    _selectedDarkThemeId = null;
+                                  });
+                                  _updateDirtyState();
+                                },
+                              ),
+                              const SizedBox(height: 16),
+                              // Terminal font section
+                              _FontSelectionTile(
+                                fontFamily: _selectedFontFamily,
+                                defaultLabel: 'Use default',
+                                onTap: _selectFont,
+                              ),
+                              const SizedBox(height: 16),
                             ],
-                            const SizedBox(height: 24),
-                            // Terminal theme section
-                            Row(
-                              children: [
-                                Text(
-                                  'terminal theme',
-                                  style: FluttyTheme.displayMono(
-                                    fontSize: 14,
-                                    color: Theme.of(
-                                      context,
-                                    ).colorScheme.onSurface,
-                                  ),
-                                ),
-                                const SizedBox(width: 8),
-                                const PremiumBadge(),
-                              ],
+                          ),
+                        ],
+
+                        if (_isLocalHost) ...[
+                          Text(
+                            'terminal theme',
+                            style: FluttyTheme.displayMono(
+                              fontSize: 14,
+                              color: Theme.of(context).colorScheme.onSurface,
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          if (!hasHostThemeAccess) ...[
+                            Text(
+                              'MonkeySSH Pro unlocks per-host theme overrides. App-wide default themes stay free in Settings.',
+                              style: Theme.of(context).textTheme.bodySmall,
                             ),
                             const SizedBox(height: 12),
-                            if (!hasHostThemeAccess) ...[
-                              Text(
-                                'MonkeySSH Pro unlocks per-host theme overrides. App-wide default themes stay free in Settings.',
-                                style: Theme.of(context).textTheme.bodySmall,
-                              ),
-                              const SizedBox(height: 12),
-                            ],
-                            // Light mode theme
-                            _ThemeSelectionTile(
-                              label: 'Light Mode Theme',
-                              themeId: _selectedLightThemeId,
-                              themes: terminalThemes,
-                              defaultLabel: 'Use default',
-                              onTap: () =>
-                                  _handleThemeSelectionTap(isLight: true),
-                              onClear: () {
-                                setState(() {
-                                  _selectedLightThemeId = null;
-                                });
-                                _updateDirtyState();
-                              },
-                            ),
-                            const SizedBox(height: 8),
-                            // Dark mode theme
-                            _ThemeSelectionTile(
-                              label: 'Dark Mode Theme',
-                              themeId: _selectedDarkThemeId,
-                              themes: terminalThemes,
-                              defaultLabel: 'Use default',
-                              onTap: () =>
-                                  _handleThemeSelectionTap(isLight: false),
-                              onClear: () {
-                                setState(() {
-                                  _selectedDarkThemeId = null;
-                                });
-                                _updateDirtyState();
-                              },
-                            ),
-                            const SizedBox(height: 16),
-                            // Terminal font section
-                            _FontSelectionTile(
-                              fontFamily: _selectedFontFamily,
-                              defaultLabel: 'Use default',
-                              onTap: _selectFont,
-                            ),
-                            const SizedBox(height: 16),
                           ],
-                        ),
+                          _ThemeSelectionTile(
+                            label: 'Light Mode Theme',
+                            themeId: _selectedLightThemeId,
+                            themes: terminalThemes,
+                            defaultLabel: 'Use default',
+                            onTap: () =>
+                                _handleThemeSelectionTap(isLight: true),
+                            onClear: () {
+                              setState(() {
+                                _selectedLightThemeId = null;
+                              });
+                              _updateDirtyState();
+                            },
+                          ),
+                          const SizedBox(height: 8),
+                          _ThemeSelectionTile(
+                            label: 'Dark Mode Theme',
+                            themeId: _selectedDarkThemeId,
+                            themes: terminalThemes,
+                            defaultLabel: 'Use default',
+                            onTap: () =>
+                                _handleThemeSelectionTap(isLight: false),
+                            onClear: () {
+                              setState(() {
+                                _selectedDarkThemeId = null;
+                              });
+                              _updateDirtyState();
+                            },
+                          ),
+                          const SizedBox(height: 16),
+                          _FontSelectionTile(
+                            fontFamily: _selectedFontFamily,
+                            defaultLabel: 'Use default',
+                            onTap: _selectFont,
+                          ),
+                        ],
                         const SizedBox(height: 32),
 
-                        // Port Forwards section
-                        _buildPortForwardsSection(context, isEditing),
-                        const SizedBox(height: 32),
+                        if (!_isLocalHost) ...[
+                          // Port Forwards section
+                          _buildPortForwardsSection(context, isEditing),
+                          const SizedBox(height: 32),
+                        ],
 
                         // Save button
                         FilledButton.icon(
@@ -824,14 +955,16 @@ class _HostEditScreenState extends ConsumerState<HostEditScreen> {
                               : const Icon(Icons.save),
                           label: Text(isEditing ? 'Save Changes' : 'Add Host'),
                         ),
-                        const SizedBox(height: 16),
+                        if (!_isLocalHost) ...[
+                          const SizedBox(height: 16),
 
-                        // Test connection button
-                        OutlinedButton.icon(
-                          onPressed: _isBusy ? null : _testConnection,
-                          icon: const Icon(Icons.network_check),
-                          label: const Text('Test Connection'),
-                        ),
+                          // Test connection button
+                          OutlinedButton.icon(
+                            onPressed: _isBusy ? null : _testConnection,
+                            icon: const Icon(Icons.network_check),
+                            label: const Text('Test Connection'),
+                          ),
+                        ],
                       ],
                     ),
                   ),

--- a/lib/presentation/screens/port_forward_edit_screen.dart
+++ b/lib/presentation/screens/port_forward_edit_screen.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import '../../data/database/database.dart';
 import '../../data/repositories/host_repository.dart';
 import '../../data/repositories/port_forward_repository.dart';
+import '../../domain/models/host_kind.dart';
 import '../../domain/services/port_forward_browser_service.dart';
 import '../../domain/services/port_forward_runtime_service.dart';
 import '../../domain/services/ssh_service.dart';
@@ -65,9 +66,17 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
 
   Future<void> _loadHosts() async {
     final hosts = await ref.read(hostRepositoryProvider).getAll();
-    if (mounted) {
-      setState(() => _hosts = hosts);
+    if (!mounted) {
+      return;
     }
+    final sshHosts = hosts.where((host) => !isLocalTerminalHost(host)).toList();
+    setState(() {
+      _hosts = sshHosts;
+      if (_selectedHostId != null &&
+          !sshHosts.any((host) => host.id == _selectedHostId)) {
+        _selectedHostId = null;
+      }
+    });
   }
 
   Future<void> _loadPortForward() async {
@@ -393,6 +402,23 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
 
   Future<void> _savePortForward() async {
     if (!_formKey.currentState!.validate()) return;
+    final selectedHostId = _selectedHostId;
+    if (selectedHostId == null) {
+      return;
+    }
+    final selectedHost = _hosts.cast<Host?>().firstWhere(
+      (host) => host?.id == selectedHostId,
+      orElse: () => null,
+    );
+    if (selectedHost == null || isLocalTerminalHost(selectedHost)) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Port forwards require an SSH host.')),
+      );
+      return;
+    }
     final isRemote = _forwardType == 'remote';
     final bindHost = isRemote
         ? _remoteHostController.text.trim()
@@ -417,7 +443,7 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
         // Update existing port forward
         savedPortForward = previousPortForward.copyWith(
           name: _nameController.text,
-          hostId: _selectedHostId,
+          hostId: selectedHostId,
           forwardType: _forwardType,
           localHost: _localHostController.text,
           localPort: int.parse(_localPortController.text),
@@ -431,7 +457,7 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
         final portForwardId = await repo.insert(
           PortForwardsCompanion.insert(
             name: _nameController.text,
-            hostId: _selectedHostId!,
+            hostId: selectedHostId,
             forwardType: _forwardType,
             localHost: drift.Value(_localHostController.text),
             localPort: int.parse(_localPortController.text),
@@ -443,7 +469,7 @@ class _PortForwardEditScreenState extends ConsumerState<PortForwardEditScreen> {
         savedPortForward = PortForward(
           id: portForwardId,
           name: _nameController.text,
-          hostId: _selectedHostId!,
+          hostId: selectedHostId,
           forwardType: _forwardType,
           localHost: _localHostController.text,
           localPort: int.parse(_localPortController.text),

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -14641,6 +14641,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _runExclusiveTerminalAction(
         _TerminalExclusiveAction.sftpBrowser,
         () async {
+          final activeSession = _connectionId == null
+              ? null
+              : ref
+                    .read(activeSessionsProvider.notifier)
+                    .getSession(_connectionId!);
+          if ((activeSession?.isLocalTerminal ?? false) ||
+              (_host != null && isLocalTerminalHost(_host!))) {
+            _showTerminalLinkMessage(
+              'File browser is not available for local terminals',
+            );
+            return;
+          }
+
           final normalizedPath = trimTerminalFilePathCandidate(path);
           if (!isSupportedTerminalFilePath(normalizedPath)) {
             _showTerminalLinkMessage('Could not open $path');
@@ -15181,6 +15194,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   void _primeTerminalFilePathVerification(String terminalPath) {
     if (!isSupportedTerminalFilePath(terminalPath)) {
+      return;
+    }
+    // Local PTY sessions have no SFTP channel for path verification.
+    final activeSession = _connectionId == null
+        ? null
+        : ref.read(activeSessionsProvider.notifier).getSession(_connectionId!);
+    if ((activeSession?.isLocalTerminal ?? false) ||
+        (_host != null && isLocalTerminalHost(_host!))) {
       return;
     }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -29,6 +29,7 @@ import '../../data/repositories/port_forward_repository.dart';
 import '../../data/repositories/snippet_repository.dart';
 import '../../domain/models/agent_launch_preset.dart';
 import '../../domain/models/auto_connect_command.dart';
+import '../../domain/models/host_kind.dart';
 import '../../domain/models/monetization.dart';
 import '../../domain/models/remote_multiplexer.dart';
 import '../../domain/models/terminal_theme.dart';
@@ -11434,23 +11435,34 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final activeSession = _connectionId == null
         ? null
         : ref.read(activeSessionsProvider.notifier).getSession(_connectionId!);
+    final isLocalTerminalSession =
+        (activeSession?.isLocalTerminal ?? false) ||
+        (_host != null && isLocalTerminalHost(_host!));
     final deviceDebugController = _isAndroidPlatform
         ? _deviceDebugControllerFor(activeSession)
         : null;
     final showsDeviceDebugAction =
         _isAndroidPlatform &&
+        !isLocalTerminalSession &&
         (ref.watch(deviceDebugSupportedProvider).asData?.value ?? false);
     final isConnectedThroughJumpHost =
+        !isLocalTerminalSession &&
         connectionState == SshConnectionState.connected &&
         (_observedSession ?? activeSession)?.config.jumpHost != null;
-    final connectionIdentity = formatTerminalConnectionIdentity(
-      username: _redactStoreScreenshotIdentities ? 'store' : _host?.username,
-      hostname: _redactStoreScreenshotIdentities
-          ? 'local-demo'
-          : _host?.hostname,
-      port: _redactStoreScreenshotIdentities ? null : _host?.port,
-      connectionId: _connectionId,
-    );
+    final connectionIdentity = isLocalTerminalSession
+        ? (_redactStoreScreenshotIdentities
+              ? 'local terminal'
+              : 'local terminal${_connectionId == null ? '' : ' • session #$_connectionId'}')
+        : formatTerminalConnectionIdentity(
+            username: _redactStoreScreenshotIdentities
+                ? 'store'
+                : _host?.username,
+            hostname: _redactStoreScreenshotIdentities
+                ? 'local-demo'
+                : _host?.hostname,
+            port: _redactStoreScreenshotIdentities ? null : _host?.port,
+            connectionId: _connectionId,
+          );
     final titleSubtitleSegments = <String>[];
     if (connectionIdentity != null) {
       titleSubtitleSegments.add(connectionIdentity);
@@ -11564,16 +11576,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                     : _openTmuxNavigator,
                 tooltip: 'tmux windows',
               ),
-            IconButton(
-              icon: const Icon(Icons.folder_outlined),
-              onPressed:
-                  _connectionId == null ||
-                      isOpeningSftpBrowser ||
-                      connectionState != SshConnectionState.connected
-                  ? null
-                  : () => unawaited(_openConnectionFileBrowser()),
-              tooltip: 'Browse files',
-            ),
+            if (!isLocalTerminalSession)
+              IconButton(
+                icon: const Icon(Icons.folder_outlined),
+                onPressed:
+                    _connectionId == null ||
+                        isOpeningSftpBrowser ||
+                        connectionState != SshConnectionState.connected
+                    ? null
+                    : () => unawaited(_openConnectionFileBrowser()),
+                tooltip: 'Browse files',
+              ),
             if (isMobile)
               IconButton(
                 icon: Icon(
@@ -11623,15 +11636,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                   label: 'Change Theme',
                   action: 'change_theme',
                 ),
-                _terminalOverflowMenuItem(
-                  context: context,
-                  icon: Icons.alt_route_rounded,
-                  label: 'Port Forwards',
-                  action: 'port_forwards',
-                  enabled:
-                      _connectionId != null &&
-                      connectionState == SshConnectionState.connected,
-                ),
+                if (!isLocalTerminalSession)
+                  _terminalOverflowMenuItem(
+                    context: context,
+                    icon: Icons.alt_route_rounded,
+                    label: 'Port Forwards',
+                    action: 'port_forwards',
+                    enabled:
+                        _connectionId != null &&
+                        connectionState == SshConnectionState.connected,
+                  ),
                 if (showsDeviceDebugAction)
                   _terminalOverflowSwitchMenuItem(
                     context: context,
@@ -11644,7 +11658,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                         deviceDebugController != null &&
                         connectionState == SshConnectionState.connected,
                   ),
-                if (isPortForwardBrowserSupported())
+                if (!isLocalTerminalSession && isPortForwardBrowserSupported())
                   _terminalOverflowMenuItem(
                     context: context,
                     icon: Icons.open_in_browser_outlined,

--- a/lib/presentation/view_models/host_edit_view_model.dart
+++ b/lib/presentation/view_models/host_edit_view_model.dart
@@ -8,6 +8,7 @@ import '../../domain/commands/save_host_command.dart';
 import '../../domain/models/agent_launch_preset.dart';
 import '../../domain/models/auto_connect_command.dart';
 import '../../domain/models/host_cli_launch_preferences.dart';
+import '../../domain/models/host_kind.dart';
 import '../../domain/models/remote_multiplexer.dart';
 import '../../domain/models/tmux_state.dart';
 import '../../domain/services/agent_launch_preset_service.dart';
@@ -115,6 +116,7 @@ String? resolveTmuxExtraFlags({
 /// Snapshot of all draft values owned by the host edit form.
 typedef HostEditDraft = ({
   String label,
+  HostKind hostKind,
   String hostname,
   String port,
   String username,
@@ -351,6 +353,15 @@ class HostEditViewModel extends Notifier<HostEditState> {
         message: 'Fix label to save this host',
       );
     }
+    if (draft.hostKind == HostKind.local) {
+      if (draft.username.isEmpty) {
+        return const HostEditValidationIssue(
+          target: HostEditValidationTarget.username,
+          message: 'Fix username to save this host',
+        );
+      }
+      return null;
+    }
     if (draft.hostname.isEmpty) {
       return const HostEditValidationIssue(
         target: HostEditValidationTarget.hostname,
@@ -467,11 +478,12 @@ class HostEditViewModel extends Notifier<HostEditState> {
     required bool hasAutomationAccess,
   }) async {
     final existingHost = state.existingHost;
-    final port = int.parse(draft.port);
-    final password = draft.password.isEmpty ? null : draft.password;
+    final isLocal = draft.hostKind == HostKind.local;
+    final port = isLocal ? localTerminalPort : int.parse(draft.port);
+    final password = isLocal || draft.password.isEmpty ? null : draft.password;
     final tags = draft.tags.trim().isEmpty ? null : draft.tags.trim();
     final portProxyName =
-        !draft.autoForwardPorts || draft.portProxyName.trim().isEmpty
+        isLocal || !draft.autoForwardPorts || draft.portProxyName.trim().isEmpty
         ? null
         : normalizePortProxyName(draft.portProxyName);
 
@@ -605,28 +617,30 @@ class HostEditViewModel extends Notifier<HostEditState> {
 
     return SaveHostInput(
       label: draft.label,
-      hostname: draft.hostname,
+      hostKind: draft.hostKind,
+      hostname: isLocal ? localTerminalHostname : draft.hostname,
       port: port,
       username: draft.username,
       password: password,
       tags: tags,
-      keyId: draft.selectedKeyId,
+      keyId: isLocal ? null : draft.selectedKeyId,
       groupId: draft.selectedGroupId,
-      jumpHostId: draft.selectedJumpHostId,
-      skipJumpHostOnSsids: draft.selectedJumpHostId == null
+      jumpHostId: isLocal ? null : draft.selectedJumpHostId,
+      skipJumpHostOnSsids: isLocal || draft.selectedJumpHostId == null
           ? null
           : draft.skipJumpHostOnSsids,
       terminalThemeLightId: draft.selectedLightThemeId,
       terminalThemeDarkId: draft.selectedDarkThemeId,
       terminalFontFamily: draft.selectedFontFamily,
-      autoConnectCommand: normalizedAutoConnectCommand,
-      autoConnectSnippetId: normalizedAutoConnectSnippetId,
-      autoConnectRequiresConfirmation: autoConnectRequiresConfirmation,
-      tmuxSessionName: normalizedTmuxSessionName,
-      tmuxWorkingDirectory: normalizedTmuxWorkingDirectory,
-      tmuxExtraFlags: normalizedTmuxExtraFlags,
-      remoteMuxBackend: normalizedRemoteMuxBackend,
-      autoForwardPorts: draft.autoForwardPorts,
+      autoConnectCommand: isLocal ? null : normalizedAutoConnectCommand,
+      autoConnectSnippetId: isLocal ? null : normalizedAutoConnectSnippetId,
+      autoConnectRequiresConfirmation:
+          !isLocal && autoConnectRequiresConfirmation,
+      tmuxSessionName: isLocal ? null : normalizedTmuxSessionName,
+      tmuxWorkingDirectory: isLocal ? null : normalizedTmuxWorkingDirectory,
+      tmuxExtraFlags: isLocal ? null : normalizedTmuxExtraFlags,
+      remoteMuxBackend: isLocal ? null : normalizedRemoteMuxBackend,
+      autoForwardPorts: !isLocal && draft.autoForwardPorts,
       portProxyName: portProxyName,
       isFavorite: draft.isFavorite,
     );

--- a/lib/presentation/widgets/android_linux_terminal_connect_recovery.dart
+++ b/lib/presentation/widgets/android_linux_terminal_connect_recovery.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/database/database.dart';
+import '../../domain/services/android_linux_terminal_setup_service.dart';
+
+/// User choice after a failed Android Linux Terminal SSH connect.
+enum AndroidLinuxTerminalConnectRecoveryAction {
+  /// Open Terminal (and keep setup helpers warm), then retry connect.
+  openTerminalAndRetry,
+
+  /// Retry connect without launching Terminal again.
+  retry,
+
+  /// Give up.
+  close,
+}
+
+/// Whether failed connects for [host] should offer Linux Terminal recovery.
+bool shouldOfferAndroidLinuxTerminalConnectRecovery(Host host) =>
+    !kIsWeb &&
+    defaultTargetPlatform == TargetPlatform.android &&
+    isAndroidLinuxTerminalHost(host);
+
+/// Shows recovery options when SSH to the Linux Terminal VM is unreachable.
+Future<AndroidLinuxTerminalConnectRecoveryAction>
+showAndroidLinuxTerminalConnectRecoveryDialog({
+  required BuildContext context,
+  required WidgetRef ref,
+  required Host host,
+  String? errorMessage,
+}) async {
+  final setup = ref.read(androidLinuxTerminalSetupServiceProvider);
+  final action =
+      await showDialog<AndroidLinuxTerminalConnectRecoveryAction>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('Linux Terminal not reachable'),
+          content: Text(
+            errorMessage == null || errorMessage.trim().isEmpty
+                ? 'SSH to ${host.username}@${host.hostname}:${host.port} failed. '
+                      'The Linux Terminal app/VM is probably not running, or '
+                      'port forwarding is not set up yet.'
+                : errorMessage,
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(
+                dialogContext,
+              ).pop(AndroidLinuxTerminalConnectRecoveryAction.close),
+              child: const Text('Close'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(
+                dialogContext,
+              ).pop(AndroidLinuxTerminalConnectRecoveryAction.retry),
+              child: const Text('Retry'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(
+                AndroidLinuxTerminalConnectRecoveryAction.openTerminalAndRetry,
+              ),
+              child: const Text('Open Terminal'),
+            ),
+          ],
+        ),
+      ) ??
+      AndroidLinuxTerminalConnectRecoveryAction.close;
+
+  if (action ==
+      AndroidLinuxTerminalConnectRecoveryAction.openTerminalAndRetry) {
+    await setup.prepareConnectRecovery();
+    // Soft wait so the VM can start before the next connect attempt.
+    await Future<void>.delayed(const Duration(seconds: 2));
+  }
+
+  return action;
+}

--- a/lib/presentation/widgets/connection_attempt_dialog.dart
+++ b/lib/presentation/widgets/connection_attempt_dialog.dart
@@ -6,13 +6,58 @@ import '../../data/database/database.dart';
 import '../../domain/models/monetization.dart';
 import '../../domain/services/monetization_service.dart';
 import '../../domain/services/ssh_service.dart';
+import 'android_linux_terminal_connect_recovery.dart';
 
 /// Runs a host connection while showing a live progress dialog.
+///
+/// For Android Linux Terminal hosts, a failed connect offers recovery actions
+/// (open Terminal / retry) before giving up.
 Future<SshConnectionResult> connectToHostWithProgressDialog(
   BuildContext context,
   WidgetRef ref,
   Host host, {
   bool forceNew = true,
+}) async {
+  var attemptForceNew = forceNew;
+  while (true) {
+    final result = await _connectToHostWithProgressDialogOnce(
+      context,
+      ref,
+      host,
+      forceNew: attemptForceNew,
+    );
+    if (result.success ||
+        result.cancelled ||
+        !shouldOfferAndroidLinuxTerminalConnectRecovery(host) ||
+        !context.mounted) {
+      return result;
+    }
+
+    final recovery = await showAndroidLinuxTerminalConnectRecoveryDialog(
+      context: context,
+      ref: ref,
+      host: host,
+      errorMessage: result.error,
+    );
+    if (!context.mounted) {
+      return result;
+    }
+    switch (recovery) {
+      case AndroidLinuxTerminalConnectRecoveryAction.openTerminalAndRetry:
+      case AndroidLinuxTerminalConnectRecoveryAction.retry:
+        attemptForceNew = true;
+        continue;
+      case AndroidLinuxTerminalConnectRecoveryAction.close:
+        return result;
+    }
+  }
+}
+
+Future<SshConnectionResult> _connectToHostWithProgressDialogOnce(
+  BuildContext context,
+  WidgetRef ref,
+  Host host, {
+  required bool forceNew,
 }) async {
   final navigator = Navigator.of(context, rootNavigator: true);
   final sessionsNotifier = ref.read(activeSessionsProvider.notifier);
@@ -50,7 +95,9 @@ Future<SshConnectionResult> connectToHostWithProgressDialog(
   }
 
   final closesDialog =
-      result.cancelled || (result.success && result.connectionId != null);
+      result.cancelled ||
+      (result.success && result.connectionId != null) ||
+      shouldOfferAndroidLinuxTerminalConnectRecovery(host);
   if (closesDialog && navigator.mounted) {
     navigator.pop();
   }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -10,6 +10,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_pty
   jni
 )
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -499,6 +499,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.35"
+  flutter_pty:
+    dependency: "direct main"
+    description:
+      name: flutter_pty
+      sha256: c2f3b3160b519ac820fa3f6ef175361f2dfc52c557465643589542e9f229ad66
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2"
   flutter_riverpod:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -85,6 +85,7 @@ dependencies:
   firebase_core: ^4.12.1
   firebase_analytics: ^12.4.5
   firebase_crashlytics: ^5.2.6
+  flutter_pty: ^0.4.2
 
 dev_dependencies:
   flutter_test:

--- a/test/domain/models/host_kind_test.dart
+++ b/test/domain/models/host_kind_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/models/host_kind.dart';
+
+void main() {
+  group('hostKindFromStorage', () {
+    test('defaults unknown and null values to ssh', () {
+      expect(hostKindFromStorage(null), HostKind.ssh);
+      expect(hostKindFromStorage(''), HostKind.ssh);
+      expect(hostKindFromStorage('mystery'), HostKind.ssh);
+      expect(hostKindFromStorage('ssh'), HostKind.ssh);
+      expect(hostKindFromStorage('LOCAL'), HostKind.local);
+    });
+  });
+
+  group('isLocalTerminalSupported', () {
+    test('supports desktop and Android platforms', () {
+      expect(isLocalTerminalSupported(platform: TargetPlatform.macOS), isTrue);
+      expect(
+        isLocalTerminalSupported(platform: TargetPlatform.windows),
+        isTrue,
+      );
+      expect(isLocalTerminalSupported(platform: TargetPlatform.linux), isTrue);
+      expect(
+        isLocalTerminalSupported(platform: TargetPlatform.android),
+        isTrue,
+      );
+      expect(isLocalTerminalSupported(platform: TargetPlatform.iOS), isFalse);
+    });
+  });
+
+  group('defaultLocalTerminalHostLabel', () {
+    test('uses platform-specific wording', () {
+      expect(
+        defaultLocalTerminalHostLabel(platform: TargetPlatform.macOS),
+        'This Mac',
+      );
+      expect(
+        defaultLocalTerminalHostLabel(platform: TargetPlatform.windows),
+        'This PC',
+      );
+      expect(
+        defaultLocalTerminalHostLabel(platform: TargetPlatform.android),
+        'This Android device',
+      );
+    });
+  });
+}

--- a/test/domain/services/android_linux_terminal_setup_service_test.dart
+++ b/test/domain/services/android_linux_terminal_setup_service_test.dart
@@ -1,8 +1,88 @@
+import 'dart:async';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/data/repositories/key_repository.dart';
+import 'package:monkeyssh/data/security/secret_encryption_service.dart';
+import 'package:monkeyssh/domain/services/android_linux_terminal_launcher.dart';
 import 'package:monkeyssh/domain/services/android_linux_terminal_setup_service.dart';
+import 'package:monkeyssh/domain/services/key_service.dart';
+import 'package:monkeyssh/domain/services/local_notification_service.dart';
+
+class _FakeNotifications extends LocalNotificationService {
+  int showCount = 0;
+  int clearCount = 0;
+  LinuxTerminalSetupNotificationPayload? launchPayload;
+
+  @override
+  Future<void> showLinuxTerminalSetup({
+    required String title,
+    required String body,
+    bool ongoing = true,
+  }) async {
+    showCount += 1;
+  }
+
+  @override
+  Future<void> clearLinuxTerminalSetup() async {
+    clearCount += 1;
+  }
+
+  @override
+  Future<LinuxTerminalSetupNotificationPayload?>
+  consumeLaunchLinuxTerminalSetup() async {
+    final payload = launchPayload;
+    launchPayload = null;
+    return payload;
+  }
+}
+
+class _FakeLauncher extends AndroidLinuxTerminalLauncher {
+  @override
+  bool get isSupported => true;
+
+  @override
+  Future<AndroidLinuxTerminalStatus> getStatus() async =>
+      const AndroidLinuxTerminalStatus(
+        installed: true,
+        enabled: true,
+        canLaunch: true,
+        packageName: 'com.android.virtualization.terminal',
+      );
+
+  @override
+  Future<bool> openTerminal() async => true;
+
+  @override
+  Future<bool> openDeveloperOptions() async => true;
+
+  @override
+  Future<bool> openPortForwardingSettings() async => true;
+}
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method == 'Clipboard.setData' ||
+              call.method == 'Clipboard.getData') {
+            return null;
+          }
+          return null;
+        });
+  });
+
+  tearDownAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
   group('buildAndroidLinuxTerminalSetupScript', () {
     test('embeds the public key and readiness marker', () {
       const publicKey =
@@ -65,5 +145,128 @@ void main() {
       );
       expect(isAndroidLinuxTerminalHost(host(label: 'Prod box')), isFalse);
     });
+  });
+
+  group('AndroidLinuxTerminalSetupService', () {
+    late AppDatabase database;
+    late HostRepository hostRepository;
+    late KeyRepository keyRepository;
+    late KeyService keyService;
+    late _FakeNotifications notifications;
+    late AndroidLinuxTerminalSetupService service;
+
+    setUp(() {
+      database = AppDatabase.forTesting(NativeDatabase.memory());
+      final encryption = SecretEncryptionService.forTesting();
+      hostRepository = HostRepository(database, encryption);
+      keyRepository = KeyRepository(database, encryption);
+      keyService = KeyService(keyRepository);
+      notifications = _FakeNotifications();
+    });
+
+    tearDown(() async {
+      service.dispose();
+      await database.close();
+    });
+
+    AndroidLinuxTerminalSetupService buildService({
+      required Future<bool> Function(String host, int port) probeSsh,
+    }) => AndroidLinuxTerminalSetupService(
+      hostRepository: hostRepository,
+      keyRepository: keyRepository,
+      keyService: keyService,
+      notificationService: notifications,
+      launcher: _FakeLauncher(),
+      probeSsh: probeSsh,
+    );
+
+    test('creates a single host when finish is called concurrently', () async {
+      final gate = Completer<void>();
+      var probeCalls = 0;
+      service = buildService(
+        probeSsh: (host, port) async {
+          probeCalls += 1;
+          await gate.future;
+          return true;
+        },
+      );
+
+      await service.beginSetup();
+      expect(
+        service.state.phase,
+        AndroidLinuxTerminalSetupPhase.waitingForUser,
+      );
+
+      final first = service.testConnectionAndFinish();
+      final second = service.testConnectionAndFinish();
+      gate.complete();
+      final results = await Future.wait([first, second]);
+      expect(
+        results.where(
+          (state) => state.phase == AndroidLinuxTerminalSetupPhase.succeeded,
+        ),
+        isNotEmpty,
+      );
+
+      final hosts = await hostRepository.getAll();
+      expect(hosts.where(isAndroidLinuxTerminalHost), hasLength(1));
+      expect(probeCalls, greaterThanOrEqualTo(1));
+      expect(notifications.clearCount, greaterThanOrEqualTo(1));
+    });
+
+    test(
+      'does not overwrite unrelated localhost hosts on setup success',
+      () async {
+        service = buildService(probeSsh: (host, port) async => true);
+        final unrelatedKey = await keyService.generateKey(
+          name: 'other',
+          keyType: SshKeyType.ed25519,
+        );
+        final unrelatedId = await hostRepository.insert(
+          HostsCompanion.insert(
+            label: 'My local sshd',
+            hostname: '127.0.0.1',
+            port: const Value(androidLinuxTerminalSetupPort),
+            username: 'me',
+            keyId: Value(unrelatedKey!.id),
+          ),
+        );
+
+        await service.beginSetup();
+        final finished = await service.testConnectionAndFinish();
+        expect(finished.phase, AndroidLinuxTerminalSetupPhase.succeeded);
+
+        final hosts = await hostRepository.getAll();
+        final unrelated = hosts.singleWhere((host) => host.id == unrelatedId);
+        expect(unrelated.label, 'My local sshd');
+        expect(unrelated.username, 'me');
+        expect(unrelated.keyId, unrelatedKey.id);
+
+        final linuxHosts = hosts.where(isAndroidLinuxTerminalHost).toList();
+        expect(linuxHosts, hasLength(1));
+        expect(linuxHosts.single.id, isNot(unrelatedId));
+        expect(linuxHosts.single.username, androidLinuxTerminalSetupUsername);
+      },
+    );
+
+    test(
+      'updates existing setup host instead of inserting duplicates',
+      () async {
+        service = buildService(probeSsh: (host, port) async => true);
+        await service.beginSetup();
+        final first = await service.testConnectionAndFinish();
+        expect(first.phase, AndroidLinuxTerminalSetupPhase.succeeded);
+
+        service.dispose();
+        service = buildService(probeSsh: (host, port) async => true);
+        await service.beginSetup();
+        final second = await service.testConnectionAndFinish();
+        expect(second.phase, AndroidLinuxTerminalSetupPhase.succeeded);
+
+        final hosts = await hostRepository.getAll();
+        expect(hosts.where(isAndroidLinuxTerminalHost), hasLength(1));
+        expect(second.hostId, first.hostId);
+      },
+    );
   });
 }

--- a/test/domain/services/android_linux_terminal_setup_service_test.dart
+++ b/test/domain/services/android_linux_terminal_setup_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/data/database/database.dart';
 import 'package:monkeyssh/domain/services/android_linux_terminal_setup_service.dart';
 
 void main() {
@@ -27,7 +28,42 @@ void main() {
 
   group('shellSingleQuote', () {
     test('escapes embedded single quotes', () {
-      expect(shellSingleQuote('a\'b'), equals('\'a\'"\'"\'b\''));
+      expect(shellSingleQuote("a'b"), equals("'a'\"'\"'b'"));
+    });
+  });
+
+  group('isAndroidLinuxTerminalHost', () {
+    Host host({required String label, String? notes}) => Host(
+      id: 1,
+      label: label,
+      hostKind: 'ssh',
+      hostname: '127.0.0.1',
+      port: 8022,
+      username: 'droid',
+      isFavorite: false,
+      autoConnectRequiresConfirmation: false,
+      autoForwardPorts: false,
+      sortOrder: 0,
+      createdAt: DateTime(2026),
+      updatedAt: DateTime(2026),
+      notes: notes,
+    );
+
+    test('matches setup label and notes marker', () {
+      expect(
+        isAndroidLinuxTerminalHost(host(label: androidLinuxTerminalHostLabel)),
+        isTrue,
+      );
+      expect(
+        isAndroidLinuxTerminalHost(
+          host(
+            label: 'Other',
+            notes: '$androidLinuxTerminalHostNotesMarker details',
+          ),
+        ),
+        isTrue,
+      );
+      expect(isAndroidLinuxTerminalHost(host(label: 'Prod box')), isFalse);
     });
   });
 }

--- a/test/domain/services/android_linux_terminal_setup_service_test.dart
+++ b/test/domain/services/android_linux_terminal_setup_service_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/domain/services/android_linux_terminal_setup_service.dart';
+
+void main() {
+  group('buildAndroidLinuxTerminalSetupScript', () {
+    test('embeds the public key and readiness marker', () {
+      const publicKey =
+          'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKey monkeyssh';
+      final script = buildAndroidLinuxTerminalSetupScript(
+        publicKey: publicKey,
+        username: androidLinuxTerminalSetupUsername,
+        port: androidLinuxTerminalSetupPort,
+      );
+
+      expect(script, contains('openssh-server'));
+      expect(script, contains('Port $androidLinuxTerminalSetupPort'));
+      expect(script, contains(publicKey));
+      expect(
+        script,
+        contains(
+          'MONKEYSSH_AVF_READY user=$androidLinuxTerminalSetupUsername port=$androidLinuxTerminalSetupPort',
+        ),
+      );
+      expect(script, contains(shellSingleQuote(publicKey)));
+    });
+  });
+
+  group('shellSingleQuote', () {
+    test('escapes embedded single quotes', () {
+      expect(shellSingleQuote('a\'b'), equals('\'a\'"\'"\'b\''));
+    });
+  });
+}

--- a/test/domain/services/home_screen_shortcut_service_test.dart
+++ b/test/domain/services/home_screen_shortcut_service_test.dart
@@ -16,6 +16,7 @@ Host _buildHost({
   DateTime? lastConnectedAt,
   int port = 22,
 }) => Host(
+  hostKind: 'ssh',
   id: id,
   label: label,
   hostname: '$label.example.com',

--- a/test/domain/services/local_terminal_service_test.dart
+++ b/test/domain/services/local_terminal_service_test.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/data/repositories/host_repository.dart';
+import 'package:monkeyssh/data/security/secret_encryption_service.dart';
+import 'package:monkeyssh/domain/models/host_kind.dart';
+import 'package:monkeyssh/domain/services/local_terminal_service.dart';
+import 'package:monkeyssh/domain/services/ssh_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('LocalTerminalService', () {
+    test('resolves an interactive shell launch on this platform', () async {
+      const service = LocalTerminalService();
+      expect(service.isSupported, isTrue);
+
+      final launch = await service.resolveShellExecutable();
+      expect(launch.executable, isNotEmpty);
+      expect(launch.environment['TERM'], 'xterm-256color');
+      expect(launch.environment['COLORTERM'], 'truecolor');
+      expect(launch.remoteVersion, contains('MonkeySSH_Local'));
+    });
+  });
+
+  group('SshService local terminal connect', () {
+    late AppDatabase database;
+    late SshService sshService;
+    late HostRepository hostRepository;
+
+    setUp(() {
+      database = AppDatabase.forTesting(NativeDatabase.memory());
+      hostRepository = HostRepository(
+        database,
+        SecretEncryptionService.forTesting(),
+      );
+      sshService = SshService(hostRepository: hostRepository);
+    });
+
+    tearDown(() async {
+      await sshService.disconnectAll();
+      await database.close();
+    });
+
+    test(
+      'connectToHost creates a local terminal session without SSH',
+      () async {
+        final hostId = await database
+            .into(database.hosts)
+            .insert(
+              HostsCompanion.insert(
+                label: 'This machine',
+                hostKind: Value(HostKind.local.storageValue),
+                hostname: localTerminalHostname,
+                port: const Value(localTerminalPort),
+                username: defaultLocalTerminalUsername(),
+              ),
+            );
+
+        final result = await sshService.connectToHost(hostId);
+        expect(result.success, isTrue, reason: result.error);
+        expect(result.connectionId, isNotNull);
+
+        final session = sshService.getSession(result.connectionId!);
+        expect(session, isNotNull);
+        expect(session!.isLocalTerminal, isTrue);
+        expect(session.client, isA<LocalTerminalSshClient>());
+        expect(session.remoteSoftwareVersion, contains('MonkeySSH_Local'));
+      },
+      skip:
+          !Platform.isMacOS &&
+          !Platform.isLinux &&
+          !Platform.isWindows &&
+          !Platform.isAndroid,
+    );
+
+    test(
+      'local exec runs a short command without a PTY plugin',
+      () async {
+        final hostId = await database
+            .into(database.hosts)
+            .insert(
+              HostsCompanion.insert(
+                label: 'This machine',
+                hostKind: Value(HostKind.local.storageValue),
+                hostname: localTerminalHostname,
+                port: const Value(localTerminalPort),
+                username: defaultLocalTerminalUsername(),
+              ),
+            );
+        final result = await sshService.connectToHost(hostId);
+        expect(result.success, isTrue, reason: result.error);
+        final session = sshService.getSession(result.connectionId!);
+        final client = session!.client as LocalTerminalSshClient;
+        final output = utf8.decode(await client.run('echo monkey-local-exec'));
+        expect(output, contains('monkey-local-exec'));
+      },
+      skip: !Platform.isMacOS && !Platform.isLinux && !Platform.isWindows,
+    );
+  });
+}

--- a/test/domain/services/local_terminal_service_test.dart
+++ b/test/domain/services/local_terminal_service_test.dart
@@ -11,6 +11,22 @@ import 'package:monkeyssh/domain/models/host_kind.dart';
 import 'package:monkeyssh/domain/services/local_terminal_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 
+bool get _supportsLocalProcess =>
+    Platform.isMacOS || Platform.isLinux || Platform.isWindows;
+
+String get _posixOrWindowsShell => Platform.isWindows
+    ? (Platform.environment['ComSpec'] ?? 'cmd.exe')
+    : '/bin/sh';
+
+String _echoCommand(String message) {
+  if (Platform.isWindows) {
+    return 'echo $message';
+  }
+  return 'printf "$message\\n"';
+}
+
+String get _exitZeroCommand => Platform.isWindows ? 'exit /B 0' : 'exit 0';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -25,6 +41,39 @@ void main() {
       expect(launch.environment['COLORTERM'], 'truecolor');
       expect(launch.remoteVersion, contains('MonkeySSH_Local'));
     });
+  });
+
+  group('LocalTerminalSshSession.exec', () {
+    test(
+      'drains short command stdout before completing',
+      () async {
+        final session = await LocalTerminalSshSession.exec(
+          command: _echoCommand('monkey-local-exec'),
+          environment: const {'TERM': 'xterm-256color'},
+          shellExecutable: _posixOrWindowsShell,
+        );
+        final output = StringBuffer();
+        final stdoutDone = session.stdout.forEach((chunk) {
+          output.write(utf8.decode(chunk));
+        });
+        await session.done.timeout(const Duration(seconds: 5));
+        await stdoutDone.timeout(const Duration(seconds: 1));
+        expect(output.toString(), contains('monkey-local-exec'));
+        expect(session.exitCode, 0);
+      },
+      skip: !_supportsLocalProcess,
+    );
+
+    test('resize is a no-op for non-pty exec sessions', () async {
+      final session = await LocalTerminalSshSession.exec(
+        command: _exitZeroCommand,
+        environment: const {},
+        shellExecutable: _posixOrWindowsShell,
+      );
+      session.resizeTerminal(120, 40);
+      await session.done.timeout(const Duration(seconds: 5));
+      expect(session.exitCode, 0);
+    }, skip: !_supportsLocalProcess);
   });
 
   group('SshService local terminal connect', () {
@@ -70,36 +119,12 @@ void main() {
         expect(session!.isLocalTerminal, isTrue);
         expect(session.client, isA<LocalTerminalSshClient>());
         expect(session.remoteSoftwareVersion, contains('MonkeySSH_Local'));
-      },
-      skip:
-          !Platform.isMacOS &&
-          !Platform.isLinux &&
-          !Platform.isWindows &&
-          !Platform.isAndroid,
-    );
 
-    test(
-      'local exec runs a short command without a PTY plugin',
-      () async {
-        final hostId = await database
-            .into(database.hosts)
-            .insert(
-              HostsCompanion.insert(
-                label: 'This machine',
-                hostKind: Value(HostKind.local.storageValue),
-                hostname: localTerminalHostname,
-                port: const Value(localTerminalPort),
-                username: defaultLocalTerminalUsername(),
-              ),
-            );
-        final result = await sshService.connectToHost(hostId);
-        expect(result.success, isTrue, reason: result.error);
-        final session = sshService.getSession(result.connectionId!);
-        final client = session!.client as LocalTerminalSshClient;
-        final output = utf8.decode(await client.run('echo monkey-local-exec'));
-        expect(output, contains('monkey-local-exec'));
+        final client = session.client as LocalTerminalSshClient;
+        final bytes = await client.run(_echoCommand('monkey-via-client'));
+        expect(utf8.decode(bytes), contains('monkey-via-client'));
       },
-      skip: !Platform.isMacOS && !Platform.isLinux && !Platform.isWindows,
+      skip: !_supportsLocalProcess && !Platform.isAndroid,
     );
   });
 }

--- a/test/domain/services/ssh_service_test.dart
+++ b/test/domain/services/ssh_service_test.dart
@@ -257,6 +257,7 @@ Host _automaticForwardHost({
   String label = 'Dev Box',
   String? portProxyName,
 }) => Host(
+  hostKind: 'ssh',
   id: id,
   label: label,
   hostname: 'dev.example.com',

--- a/test/domain/services/terminal_theme_service_test.dart
+++ b/test/domain/services/terminal_theme_service_test.dart
@@ -46,6 +46,7 @@ void main() {
         final host = Host(
           id: 1,
           label: 'Prod',
+          hostKind: 'ssh',
           hostname: 'prod.example.com',
           port: 22,
           username: 'root',
@@ -72,6 +73,7 @@ void main() {
         final host = Host(
           id: 1,
           label: 'Prod',
+          hostKind: 'ssh',
           hostname: 'prod.example.com',
           port: 22,
           username: 'root',

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -612,6 +612,7 @@ Host _buildHost({
   RemoteMuxBackend? remoteMuxBackend,
   bool autoConnectRequiresConfirmation = false,
 }) => Host(
+  hostKind: 'ssh',
   id: id,
   label: 'Terminal test host',
   hostname: 'terminal.example.com',

--- a/test/presentation/view_models/host_edit_view_model_test.dart
+++ b/test/presentation/view_models/host_edit_view_model_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:monkeyssh/domain/models/agent_launch_preset.dart';
 import 'package:monkeyssh/domain/models/auto_connect_command.dart';
+import 'package:monkeyssh/domain/models/host_kind.dart';
 import 'package:monkeyssh/domain/models/remote_multiplexer.dart';
 import 'package:monkeyssh/presentation/view_models/host_edit_view_model.dart';
 
@@ -25,6 +26,7 @@ HostEditDraft _draft({
   int? snippetId,
 }) => (
   label: label,
+  hostKind: HostKind.ssh,
   hostname: hostname,
   port: port,
   username: username,

--- a/test/unit/database_test.dart
+++ b/test/unit/database_test.dart
@@ -889,6 +889,7 @@ void main() {
           'remote_mux_backend',
           'auto_forward_ports',
           'port_proxy_name',
+          'host_kind',
         ]) {
           expect(
             names,
@@ -896,6 +897,62 @@ void main() {
             reason: 'PRAGMA table_info must include guarded column: $guarded',
           );
         }
+      },
+    );
+
+    test(
+      'v11 migration adds host_kind and defaults existing hosts to ssh',
+      () async {
+        final dbFile = await createTestDbFile('migrate-v10-host-kind');
+
+        // Build a complete current-schema database, then surgically remove
+        // host_kind and roll user_version back to 10 so onUpgrade must add it.
+        final seed = AppDatabase.forTesting(NativeDatabase(dbFile));
+        await seed.select(seed.settings).get();
+        final seededHostId = await seed
+            .into(seed.hosts)
+            .insert(
+              HostsCompanion.insert(
+                label: 'Legacy SSH host',
+                hostname: 'legacy.example.com',
+                username: 'root',
+              ),
+            );
+        final columnRows = await seed
+            .customSelect('PRAGMA table_info(hosts)')
+            .get();
+        final columnNames = columnRows
+            .map((row) => row.read<String>('name'))
+            .where((name) => name != 'host_kind')
+            .toList(growable: false);
+        final quotedColumns = columnNames.map((name) => '"$name"').join(', ');
+        await seed.customStatement(
+          'CREATE TABLE hosts_v10 AS SELECT $quotedColumns FROM hosts;',
+        );
+        await seed.customStatement('DROP TABLE hosts;');
+        await seed.customStatement('ALTER TABLE hosts_v10 RENAME TO hosts;');
+        await seed.customStatement('PRAGMA user_version = 10');
+        await seed.close();
+
+        final upgraded = AppDatabase.forTesting(NativeDatabase(dbFile));
+        addTearDown(() async => upgraded.close());
+
+        final hostColumns = await upgraded
+            .customSelect('PRAGMA table_info(hosts)')
+            .get();
+        final names = hostColumns.map((r) => r.read<String>('name')).toSet();
+        expect(names, contains('host_kind'));
+
+        final host = await (upgraded.select(
+          upgraded.hosts,
+        )..where((h) => h.id.equals(seededHostId))).getSingle();
+        expect(host.hostKind, 'ssh');
+        expect(host.label, 'Legacy SSH host');
+
+        final versionRows = await upgraded
+            .customSelect('PRAGMA user_version')
+            .get();
+        expect(versionRows.first.read<int>('user_version'), 11);
       },
     );
   });

--- a/test/widget/connection_attempt_dialog_test.dart
+++ b/test/widget/connection_attempt_dialog_test.dart
@@ -53,6 +53,7 @@ class _StalledSshService extends SshService {
 Host _host() => Host(
   id: 42,
   label: 'stalled box',
+  hostKind: 'ssh',
   hostname: 'stalled.example.com',
   port: 22,
   username: 'tester',

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -314,6 +314,7 @@ Host _buildHost({
   RemoteMuxBackend? remoteMuxBackend,
   String? tags,
 }) => Host(
+  hostKind: 'ssh',
   id: id,
   label: label,
   hostname: '$label.example.com',

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -1402,8 +1402,18 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 
-        final yoloFinder = find.byKey(const Key('host-cli-yolo-mode-checkbox'));
+        final yoloFinder = find.byKey(
+          const Key('host-cli-yolo-mode-checkbox'),
+          skipOffstage: false,
+        );
         expect(yoloFinder, findsOneWidget);
+        await tester.scrollUntilVisible(
+          yoloFinder,
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.ensureVisible(yoloFinder);
+        await tester.pump();
         expect(tester.widget<CheckboxListTile>(yoloFinder).value, isFalse);
 
         await tester.tap(yoloFinder);

--- a/test/widget/host_edit_screen_test.dart
+++ b/test/widget/host_edit_screen_test.dart
@@ -37,6 +37,7 @@ Host _testHost({
   String? terminalThemeLightId,
   String? terminalThemeDarkId,
 }) => Host(
+  hostKind: 'ssh',
   id: id,
   label: label,
   hostname: 'imported.example.com',

--- a/test/widget/hosts_screen_test.dart
+++ b/test/widget/hosts_screen_test.dart
@@ -76,6 +76,7 @@ Host _buildHost({
   required String label,
   required int sortOrder,
 }) => Host(
+  hostKind: 'ssh',
   id: id,
   label: label,
   hostname: '$label.example.com',

--- a/test/widget/port_forward_edit_screen_test.dart
+++ b/test/widget/port_forward_edit_screen_test.dart
@@ -74,6 +74,7 @@ class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
 }
 
 Host _host() => Host(
+  hostKind: 'ssh',
   id: 10,
   label: 'Dev box',
   hostname: 'example.com',

--- a/test/widget/port_forwards_screen_test.dart
+++ b/test/widget/port_forwards_screen_test.dart
@@ -37,6 +37,7 @@ PortForward _buildPortForward({
 );
 
 Host _buildHost({required int id, required String label}) => Host(
+  hostKind: 'ssh',
   id: id,
   label: label,
   hostname: 'example.com',

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -15,6 +15,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
   flutter_local_notifications_windows
+  flutter_pty
   jni
 )
 


### PR DESCRIPTION
## Summary
- Add a `local` host kind that opens an interactive device shell via PTY (`flutter_pty`) instead of SSH.
- Support macOS, Windows, Linux, and Android sandbox shells; hide SSH-only features (keys, jump hosts, SFTP, port forwards) for local hosts.
- Persist `hostKind` with a schema v11 migration and wire connect/save/UI paths through the existing session stack.

## Test plan
- [x] `flutter analyze` on touched paths (pre-commit)
- [x] Full unit/widget suite via pre-commit (`2937` tests)
- [ ] Manual: Hosts → Local → save → connect on macOS; confirm shell I/O and resize
- [ ] Manual: Android debug build → add local terminal → confirm sandbox shell
- [ ] Manual: SSH host still connects; local host hides SFTP/port-forward actions