### PR TITLE
fix: stop MonkeyMux window list from hanging on a spinner

### DIFF
--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -28,6 +28,23 @@ const _oneShotControlResponseTimeout = Duration(seconds: 10);
 const _oneShotRunCommandResponseTimeout = Duration(seconds: 25);
 const _monkeyMuxSessionStdinCloseTimeout = Duration(milliseconds: 250);
 
+/// Last-resort deadline for a shared window-list query.
+///
+/// The in-flight request is handed to every later caller, so a query that never
+/// settles would pin the window switcher on a spinner for the rest of the
+/// connection instead of retrying.
+const _windowListWatchdogTimeout = Duration(seconds: 30);
+
+var _controlRequestSequence = 0;
+
+/// Returns a process-unique id for a MonkeyMux control request.
+///
+/// Raw microsecond timestamps are not unique: two commands created in the same
+/// microsecond collided in the pending-request map, so the overwritten request
+/// never received a response and stalled its caller forever.
+String _nextControlRequestId() =>
+    '${DateTime.now().microsecondsSinceEpoch}-${_controlRequestSequence++}';
+
 /// MonkeyMux-backed implementation of [RemoteMultiplexerService].
 final monkeyMuxServiceProvider = Provider<MonkeyMuxService>(
   (ref) =>
@@ -311,7 +328,19 @@ class MonkeyMuxService implements RemoteMultiplexerService {
     String sessionName,
     _MonkeyMuxWatchKey key,
   ) {
-    final request = _listWindows(session, sessionName, key);
+    final request = _listWindows(session, sessionName, key).timeout(
+      _controlResponseTimeout == null
+          ? _windowListWatchdogTimeout
+          : _controlResponseTimeout * 3,
+      onTimeout: () {
+        DiagnosticsLogService.instance.warning(
+          'monkeymux.watch',
+          'window_list_watchdog',
+          fields: {'connectionId': session.connectionId},
+        );
+        throw TimeoutException('MonkeyMux window list timed out.');
+      },
+    );
     _windowListRequests[key] = request;
     request.whenComplete(() {
       if (identical(_windowListRequests[key], request)) {
@@ -346,42 +375,7 @@ class MonkeyMuxService implements RemoteMultiplexerService {
       scheduleMicrotask(state.emitWindowList);
       return state.stream;
     }
-    final observer = _observers.putIfAbsent(
-      key,
-      () => _MonkeyMuxWindowChangeObserver(
-        session: session,
-        sessionName: sessionName,
-        installer: _installer,
-        onWindowList: (windows) {
-          _cacheWindows(key, windows);
-          _scheduleAgentMetadataRefresh(session, sessionName, key, windows);
-        },
-        onWindowSnapshot: (window) {
-          final cachedWindows = _windowSnapshotCache[key];
-          final forceAgentMetadataRefresh =
-              shouldForceAgentSessionMetadataRefreshForSnapshot(
-                cachedWindows ?? const <TmuxWindow>[],
-                window,
-              );
-          _cacheWindowSnapshot(key, window);
-          final windows = _windowSnapshotCache[key];
-          if (windows != null) {
-            _scheduleAgentMetadataRefresh(
-              session,
-              sessionName,
-              key,
-              windows,
-              force: forceAgentMetadataRefresh,
-            );
-          }
-        },
-        onDispose: () {
-          _observers.remove(key);
-          _cancelAgentMetadataPeriodicRefresh(key);
-        },
-        controlResponseTimeoutOverride: _controlResponseTimeout,
-      ),
-    );
+    final observer = _resolveObserver(session, sessionName, key);
     final cachedWindows = _windowSnapshotCache[key];
     if (cachedWindows != null) {
       _scheduleAgentMetadataRefresh(session, sessionName, key, cachedWindows);
@@ -395,6 +389,61 @@ class MonkeyMuxService implements RemoteMultiplexerService {
       },
     );
     return observer.stream;
+  }
+
+  /// Returns the live observer for [key], replacing a disposed one.
+  ///
+  /// Disposal finishes asynchronously, so a disposed observer keeps its map
+  /// entry for a moment. Reusing it would hand the caller a closed stream and a
+  /// control channel that can never run another command.
+  _MonkeyMuxWindowChangeObserver _resolveObserver(
+    SshSession session,
+    String sessionName,
+    _MonkeyMuxWatchKey key,
+  ) {
+    final existing = _observers[key];
+    if (existing != null && !existing.isDisposed) {
+      return existing;
+    }
+    late final _MonkeyMuxWindowChangeObserver observer;
+    observer = _MonkeyMuxWindowChangeObserver(
+      session: session,
+      sessionName: sessionName,
+      installer: _installer,
+      onWindowList: (windows) {
+        _cacheWindows(key, windows);
+        _scheduleAgentMetadataRefresh(session, sessionName, key, windows);
+      },
+      onWindowSnapshot: (window) {
+        final cachedWindows = _windowSnapshotCache[key];
+        final forceAgentMetadataRefresh =
+            shouldForceAgentSessionMetadataRefreshForSnapshot(
+              cachedWindows ?? const <TmuxWindow>[],
+              window,
+            );
+        _cacheWindowSnapshot(key, window);
+        final windows = _windowSnapshotCache[key];
+        if (windows != null) {
+          _scheduleAgentMetadataRefresh(
+            session,
+            sessionName,
+            key,
+            windows,
+            force: forceAgentMetadataRefresh,
+          );
+        }
+      },
+      onDispose: () {
+        // A newer observer may already own this key, and dropping its entry
+        // would orphan a live control channel.
+        if (!identical(_observers[key], observer)) return;
+        _observers.remove(key);
+        _cancelAgentMetadataPeriodicRefresh(key);
+      },
+      controlResponseTimeoutOverride: _controlResponseTimeout,
+    );
+    _observers[key] = observer;
+    return observer;
   }
 
   @override
@@ -857,7 +906,7 @@ class MonkeyMuxService implements RemoteMultiplexerService {
   }) async {
     final observer =
         _observers[_MonkeyMuxWatchKey(session.connectionId, sessionName)];
-    if (observer != null) {
+    if (observer != null && !observer.isDisposed) {
       return observer.runCommand(command, priority: priority);
     }
     final installation = await _installer.ensureInstalled(
@@ -868,7 +917,7 @@ class MonkeyMuxService implements RemoteMultiplexerService {
       installation,
       sessionName,
     );
-    final commandId = DateTime.now().microsecondsSinceEpoch.toString();
+    final commandId = _nextControlRequestId();
     final request = <String, Object?>{'id': commandId, ...command};
     return session.runQueuedExec(
       () => _runOneShotControlCommand(session, controlCommand, request),
@@ -1405,6 +1454,9 @@ class _MonkeyMuxWindowChangeObserver {
   bool get isControlChannelReady =>
       !_disposed && !_controller.isClosed && _controlSession != null;
 
+  /// Whether this observer has been torn down and can no longer run commands.
+  bool get isDisposed => _disposed;
+
   void emitWindowList(List<TmuxWindow> windows) {
     if (_disposed || _controller.isClosed || windows.isEmpty) {
       return;
@@ -1422,21 +1474,39 @@ class _MonkeyMuxWindowChangeObserver {
         'MonkeyMux control channel unavailable.',
       );
     }
-    await _ensureStarted();
-    if (_disposed || _controlSession == null) {
-      throw const MonkeyMuxInstallException(
-        'MonkeyMux control channel unavailable.',
-      );
-    }
     final request = _MonkeyMuxControlRequest(command);
+    // Arm the deadline before the channel is negotiated. Opening the control
+    // session is unbounded, and a request that is disposed or dropped while
+    // still queued never reaches the write path, so a timeout armed only when
+    // the command is written would leave the caller awaiting forever.
+    request.scheduleTimeout(
+      controlResponseTimeoutOverride ??
+          _oneShotResponseTimeout(request.payload),
+      () => _handleRequestTimeout(request),
+    );
     switch (priority) {
       case SshExecPriority.normal:
         _normalCommandQueue.add(request);
       case SshExecPriority.low:
         _lowCommandQueue.add(request);
     }
-    _drainCommands();
+    unawaited(_flushQueuedCommands(request));
     return request.future;
+  }
+
+  Future<void> _flushQueuedCommands(_MonkeyMuxControlRequest request) async {
+    await _ensureStarted();
+    if (request.isCompleted) return;
+    if (_disposed || _controlSession == null) {
+      _failPending(
+        const MonkeyMuxInstallException(
+          'MonkeyMux control channel unavailable.',
+        ),
+        StackTrace.current,
+      );
+      return;
+    }
+    _drainCommands();
   }
 
   Future<void> _ensureStarted() {
@@ -1502,35 +1572,40 @@ class _MonkeyMuxWindowChangeObserver {
       _pendingCommands[request.id] = request;
       try {
         controlSession.write(utf8.encode('${jsonEncode(request.payload)}\n'));
-        request.scheduleTimeout(
-          controlResponseTimeoutOverride ??
-              _oneShotResponseTimeout(request.payload),
-          () => _handleRequestTimeout(request),
-        );
       } on Object catch (error, stackTrace) {
         _pendingCommands.remove(request.id);
+        request.completeError(error, stackTrace);
+        // Recycling the channel also fails everything still queued behind this
+        // command, so there is nothing left to drain.
         _handleError(error, stackTrace);
-        Error.throwWithStackTrace(error, stackTrace);
+        return;
       }
     }
   }
 
   void _handleRequestTimeout(_MonkeyMuxControlRequest request) {
-    if (_disposed) return;
-    if (!_pendingCommands.containsKey(request.id)) return;
+    if (request.isCompleted) return;
     DiagnosticsLogService.instance.warning(
       'monkeymux.watch',
       'request_timeout',
-      fields: {'connectionId': session.connectionId},
+      fields: {
+        'connectionId': session.connectionId,
+        'sent': _pendingCommands.containsKey(request.id),
+        'disposed': _disposed,
+      },
     );
+    final error = TimeoutException('MonkeyMux control command timed out.');
+    final stackTrace = StackTrace.current;
     // A missing response means the shared control channel is wedged: further
     // commands would also stall. Fail the in-flight requests and recycle the
     // channel so the next command runs on a fresh session instead of leaving
     // the UI stuck on a perpetual spinner.
-    _handleError(
-      TimeoutException('MonkeyMux control command timed out.'),
-      StackTrace.current,
-    );
+    if (!_disposed) {
+      _handleError(error, stackTrace);
+    }
+    // Nothing else completes a request that is still queued or that outlived
+    // its observer, so always settle it here.
+    request.completeError(error, stackTrace);
   }
 
   void _handleLine(String line) {
@@ -1675,6 +1750,13 @@ class _MonkeyMuxWindowChangeObserver {
     _disposed = true;
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
+    // Queued and in-flight commands can never receive a response once the
+    // channel is gone. Leaving them pending strands their callers — including
+    // the window switcher, which then spins forever on a dead reload future.
+    _failPending(
+      const MonkeyMuxInstallException('MonkeyMux control channel closed.'),
+      StackTrace.current,
+    );
     await _cleanup();
     if (!_controller.isClosed) {
       await _controller.close();
@@ -1685,7 +1767,7 @@ class _MonkeyMuxWindowChangeObserver {
 
 class _MonkeyMuxControlRequest {
   _MonkeyMuxControlRequest(Map<String, Object?> command)
-    : this._(DateTime.now().microsecondsSinceEpoch.toString(), command);
+    : this._(_nextControlRequestId(), command);
 
   _MonkeyMuxControlRequest._(this.id, Map<String, Object?> command)
     : payload = {'id': id, ...command};
@@ -1696,6 +1778,9 @@ class _MonkeyMuxControlRequest {
   Timer? _timeoutTimer;
 
   Future<_MonkeyMuxControlResponse> get future => _completer.future;
+
+  /// Whether this request already resolved with a response or an error.
+  bool get isCompleted => _completer.isCompleted;
 
   /// Arms a one-shot timer that fires when no response arrives in time.
   ///

--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -35,6 +35,12 @@ const _monkeyMuxSessionStdinCloseTimeout = Duration(milliseconds: 250);
 /// connection instead of retrying.
 const _windowListWatchdogTimeout = Duration(seconds: 30);
 
+/// Deadline for opening the shared control channel.
+///
+/// An SSH channel open carries no deadline of its own, so a wedged open would
+/// otherwise leave every later command awaiting the same dead start attempt.
+const _controlChannelOpenTimeout = Duration(seconds: 20);
+
 var _controlRequestSequence = 0;
 
 /// Returns a process-unique id for a MonkeyMux control request.
@@ -1448,8 +1454,16 @@ class _MonkeyMuxWindowChangeObserver {
   MonkeyMuxInstallation? _installation;
   bool _disposed = false;
   int _reconnectAttempts = 0;
+  int _startGeneration = 0;
 
   Stream<TmuxWindowChangeEvent> get stream => _controller.stream;
+
+  /// Deadline for negotiating the control channel, scaled down under the test
+  /// override so recovery after a wedged open stays observable.
+  Duration get _channelOpenTimeout {
+    final override = controlResponseTimeoutOverride;
+    return override == null ? _controlChannelOpenTimeout : override * 2;
+  }
 
   bool get isControlChannelReady =>
       !_disposed && !_controller.isClosed && _controlSession != null;
@@ -1515,7 +1529,7 @@ class _MonkeyMuxWindowChangeObserver {
     _reconnectTimer = null;
     final existingStart = _startFuture;
     if (existingStart != null) return existingStart;
-    final start = _start();
+    final start = _start(++_startGeneration);
     _startFuture = start;
     unawaited(
       start.whenComplete(() {
@@ -1527,15 +1541,39 @@ class _MonkeyMuxWindowChangeObserver {
     return start;
   }
 
-  Future<void> _start() async {
+  /// Drops the in-flight start attempt so the next command opens a new channel.
+  ///
+  /// Bumping the generation makes the abandoned attempt discard whatever it
+  /// eventually produces, so a channel that opens late is closed instead of
+  /// being installed over a newer one.
+  void _abandonStartAttempt() {
+    if (_startFuture == null) return;
+    _startGeneration += 1;
+    _startFuture = null;
+  }
+
+  Future<void> _start(int generation) async {
     try {
       final installation = _installation ??= await installer.ensureInstalled(
         session,
       );
-      if (_disposed) return;
+      if (_disposed || generation != _startGeneration) return;
       final command = _buildMonkeyMuxControlCommand(installation, sessionName);
-      final controlSession = await session.execute(command);
-      if (_disposed) {
+      final open = session.execute(command);
+      final controlSession = await open.timeout(
+        _channelOpenTimeout,
+        onTimeout: () {
+          unawaited(
+            open.then(
+              (late) =>
+                  _closeControlSession(late, operation: 'start_open_timeout'),
+              onError: (Object _) {},
+            ),
+          );
+          throw TimeoutException('MonkeyMux control channel open timed out.');
+        },
+      );
+      if (_disposed || generation != _startGeneration) {
         await _closeControlSession(controlSession, operation: 'start_disposed');
         return;
       }
@@ -1558,6 +1596,7 @@ class _MonkeyMuxWindowChangeObserver {
         fields: {'connectionId': session.connectionId},
       );
     } on Object catch (error, stackTrace) {
+      if (generation != _startGeneration) return;
       _handleError(error, stackTrace);
     }
   }
@@ -1658,6 +1697,10 @@ class _MonkeyMuxWindowChangeObserver {
       },
     );
     _failPending(error, stackTrace);
+    // A start attempt still in flight may never finish, and every later command
+    // would await that same dead future. Abandoning it lets the reconnect below
+    // — and the next command — negotiate a fresh channel.
+    _abandonStartAttempt();
     unawaited(_cleanup().whenComplete(_scheduleReconnect));
   }
 

--- a/test/domain/services/monkeymux_service_test.dart
+++ b/test/domain/services/monkeymux_service_test.dart
@@ -641,7 +641,7 @@ void main() {
       },
     );
 
-    test('listWindows fails when the control channel never opens', () async {
+    test('listWindows recovers after the control channel never opens', () async {
       final client = _MockSshClient();
       final installer = _MockMonkeyMuxInstaller();
       final session = _buildSession(client, connectionId: 903);
@@ -667,6 +667,31 @@ void main() {
         throwsA(isA<TimeoutException>()),
       );
 
+      // The wedged start attempt must not be reused: every later reload would
+      // await the same dead future and time out without opening a channel.
+      final reconnectController = StreamController<Uint8List>();
+      final reconnectSession = _buildRespondingControlSession(
+        reconnectController,
+        window: _fakeWindowJson,
+      );
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) async => reconnectSession);
+
+      final windows = await service.listWindows(session, 'work');
+      expect(windows, hasLength(1));
+      expect(windows.single.name, 'Codex');
+
+      // A channel that opens after its attempt was abandoned is closed rather
+      // than installed over the live one.
+      final abandoned = _buildSilentControlSession(
+        StreamController<Uint8List>(),
+      );
+      neverOpens.complete(abandoned);
+      await pumpEventQueue();
+      verify(abandoned.close).called(1);
+
+      await reconnectController.close();
       await service.clearCache(903);
     });
 

--- a/test/domain/services/monkeymux_service_test.dart
+++ b/test/domain/services/monkeymux_service_test.dart
@@ -582,7 +582,142 @@ void main() {
         await service.clearCache(901);
       },
     );
+    test(
+      'listWindows fails instead of hanging when the watcher is disposed',
+      () async {
+        final client = _MockSshClient();
+        final installer = _MockMonkeyMuxInstaller();
+        final session = _buildSession(client, connectionId: 902);
+        final stdoutController = StreamController<Uint8List>();
+        final controlSession = _buildSilentControlSession(stdoutController);
+
+        when(
+          () => installer.ensureInstalled(session),
+        ).thenAnswer((_) async => _fakeInstallation);
+        when(
+          () => client.execute(any(), pty: any(named: 'pty')),
+        ).thenAnswer((_) async => controlSession);
+
+        final service = MonkeyMuxService(
+          installer: installer,
+          agentSessionMetadataPeriodicRefreshInterval: Duration.zero,
+        );
+        final subscription = service
+            .watchWindowChanges(session, 'work')
+            .listen((_) {});
+        final stuckReload = service.listWindows(session, 'work');
+        final reloadFailed = expectLater(
+          stuckReload,
+          throwsA(isA<MonkeyMuxInstallException>()),
+        );
+        await pumpEventQueue();
+
+        // Tearing down the last window-change listener disposes the shared
+        // control channel. The in-flight reload used to stay pending forever,
+        // and because it is cached as the shared window-list request every
+        // later reload reused it, leaving the switcher on a perpetual spinner.
+        await subscription.cancel();
+        await reloadFailed;
+
+        final reconnectController = StreamController<Uint8List>();
+        when(() => client.execute(any(), pty: any(named: 'pty'))).thenAnswer(
+          (_) async => _buildRespondingControlSession(
+            reconnectController,
+            window: _fakeWindowJson,
+          ),
+        );
+        final resubscribed = service
+            .watchWindowChanges(session, 'work')
+            .listen((_) {});
+
+        final windows = await service.listWindows(session, 'work');
+        expect(windows, hasLength(1));
+        expect(windows.single.name, 'Codex');
+
+        await resubscribed.cancel();
+        await reconnectController.close();
+        await stdoutController.close();
+        await service.clearCache(902);
+      },
+    );
+
+    test('listWindows fails when the control channel never opens', () async {
+      final client = _MockSshClient();
+      final installer = _MockMonkeyMuxInstaller();
+      final session = _buildSession(client, connectionId: 903);
+      final neverOpens = Completer<SSHSession>();
+
+      when(
+        () => installer.ensureInstalled(session),
+      ).thenAnswer((_) async => _fakeInstallation);
+      // A channel open that never resolves used to block runCommand before the
+      // request deadline was armed, so no timeout could ever fire.
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) => neverOpens.future);
+
+      final service = MonkeyMuxService(
+        installer: installer,
+        agentSessionMetadataPeriodicRefreshInterval: Duration.zero,
+        controlResponseTimeout: const Duration(milliseconds: 80),
+      )..watchWindowChanges(session, 'work');
+
+      await expectLater(
+        service.listWindows(session, 'work'),
+        throwsA(isA<TimeoutException>()),
+      );
+
+      await service.clearCache(903);
+    });
+
+    test('gives every queued control command a distinct id', () async {
+      final client = _MockSshClient();
+      final installer = _MockMonkeyMuxInstaller();
+      final session = _buildSession(client, connectionId: 904);
+      final stdoutController = StreamController<Uint8List>();
+      final controlSession = _buildSilentControlSession(stdoutController);
+      final requests = <Map<String, Object?>>[];
+
+      when(
+        () => installer.ensureInstalled(session),
+      ).thenAnswer((_) async => _fakeInstallation);
+      when(
+        () => client.execute(any(), pty: any(named: 'pty')),
+      ).thenAnswer((_) async => controlSession);
+      when(() => controlSession.write(any())).thenAnswer((invocation) {
+        final data = invocation.positionalArguments.single as List<int>;
+        requests.add(jsonDecode(utf8.decode(data)) as Map<String, Object?>);
+      });
+
+      final service = MonkeyMuxService(
+        installer: installer,
+        agentSessionMetadataPeriodicRefreshInterval: Duration.zero,
+      )..watchWindowChanges(session, 'work');
+      // Commands created in the same tick used to share a microsecond
+      // timestamp id, so the second overwrote the first in the pending map and
+      // the first caller never received a response.
+      final windowList = service.listWindows(session, 'work');
+      final panePath = service.currentPanePath(session, 'work');
+      await pumpEventQueue();
+
+      expect(requests, hasLength(2));
+      expect(requests.first['id'], isNot(requests.last['id']));
+
+      for (final request in requests) {
+        _respondToWindowListRequest(
+          stdoutController,
+          request,
+          terminalBracketedPasteMode: false,
+        );
+      }
+      await windowList;
+      await panePath;
+
+      await stdoutController.close();
+      await service.clearCache(904);
+    });
   });
+
   group('MonkeyMuxService.installedHelperVersion', () {
     setUpAll(() => registerFallbackValue(Uint8List(0)));
 


### PR DESCRIPTION
## Problem

The MonkeyMux window switcher sometimes never populates after connecting — the menu just shows a spinner forever.

The diagnostics log from the report shows the signature clearly for the new connection:

```
tmux.ui bar_reload_start connectionId=10 generation=1
...16 seconds pass...
tmux.ui bar_reload_queued connectionId=10
tmux.ui bar_reload_queued connectionId=10
```

No `bar_reload_result`, no `bar_reload_failed`, and no `monkeymux.watch request_timeout`. The shared `list_windows` future never settled. Because `MonkeyMuxService` caches the in-flight query in `_windowListRequests`, that dead future was then handed to **every** later reload for the rest of the connection, and `_TmuxExpandableBar._loadWindows` stayed wedged with `_loadingWindows = true` — hence the endless `bar_reload_queued` and the permanent spinner.

## Root causes

Three separate ways a control request could stall forever:

1. **Colliding request ids.** `_MonkeyMuxControlRequest` used `DateTime.now().microsecondsSinceEpoch` as its id. Two commands created in the same tick got the same id, so the second overwrote the first in `_pendingCommands` and the first never received a response. Its timeout then bailed out early because `_pendingCommands.containsKey(id)` was still true for the *other* request. This is not theoretical — the new regression test reproduces it on the unfixed code, with both commands getting id `1785700600252651`.
2. **No deadline until the command was written.** `scheduleTimeout` was only armed inside `_drainCommands`. A request queued while the control channel was still opening had no deadline, and `runCommand` awaited `_ensureStarted()` (install probe + channel open) with no bound at all.
3. **Dispose stranded in-flight requests.** `_dispose()` closed the channel without calling `_failPending`, so tearing down the last window-change listener left every queued and pending request unresolved. Their timers then hit the `if (_disposed) return;` early-out and logged nothing.

## Fix

- Give every control request a process-unique id (`<micros>-<counter>`), used by both the shared channel and the one-shot path.
- Arm the response deadline at enqueue time, and always settle the request when it fires — including when the observer is already disposed or the command was never written. `runCommand` now returns the request future immediately and flushes the queue in the background, so a wedged channel open can no longer block the caller.
- Fail queued and pending requests on `dispose()`.
- Never reuse a disposed observer: `watchWindowChanges` replaces it, `_runControlCommand` skips it, and the map entry is only removed if it still belongs to the disposing observer (disposal is async, so a newer observer could otherwise be orphaned).
- Add a watchdog to the shared window-list request so the `_windowListRequests` cache entry can never outlive its query.

## Tests

Three new regression tests in `test/domain/services/monkeymux_service_test.dart`, each verified to fail without the fix:

- `listWindows fails instead of hanging when the watcher is disposed` — hung for 30s before, and a follow-up reload now recovers.
- `listWindows fails when the control channel never opens` — hung for 30s before.
- `gives every queued control command a distinct id` — reproduced the real id collision before.

`flutter analyze` is clean. Full `flutter test` passes apart from a pre-existing, unrelated Windows-only failure in `ssh_service_test.dart` (`builds a valid persistent POSIX watcher command` shells out to `/bin/sh`), confirmed failing on a clean tree too.
