### PR TITLE
ci: run the MonkeyMux Go suite on Linux and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     timeout-minutes: 2
     outputs:
       run_check: ${{ steps.filter.outputs.run_check }}
+      go: ${{ steps.filter.outputs.go }}
       android: ${{ steps.filter.outputs.android }}
       ios: ${{ steps.filter.outputs.ios }}
       macos: ${{ steps.filter.outputs.macos }}
@@ -62,6 +63,7 @@ jobs:
           else
             # Fallback for first pushes or missing history — run the full suite.
             echo "run_check=true" >> "$GITHUB_OUTPUT"
+            echo "go=true" >> "$GITHUB_OUTPUT"
             for p in android ios macos windows linux; do
               echo "$p=true" >> "$GITHUB_OUTPUT"
             done
@@ -71,6 +73,7 @@ jobs:
           if ! changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null); then
             echo "::warning::git diff failed — building all platforms as a safety net"
             echo "run_check=true" >> "$GITHUB_OUTPUT"
+            echo "go=true" >> "$GITHUB_OUTPUT"
             for p in android ios macos windows linux; do
               echo "$p=true" >> "$GITHUB_OUTPUT"
             done
@@ -78,6 +81,13 @@ jobs:
           fi
 
           matches() { echo "$changed" | grep -qE "$1" && echo "true" || echo "false"; }
+
+          # The MonkeyMux helper is a standalone Go module shipped to remote
+          # hosts as the prebuilt binaries under assets/monkeymux/, so asset
+          # changes are in scope too: version_consistency_test.go pins the
+          # bundled manifest to the compiled monkeyMuxVersion.
+          go_changed=$(matches '(^remote/monkeymux/|^assets/monkeymux/|^\.github/workflows/ci\.yml$|^scripts/build_monkeymux_assets\.sh$)')
+          echo "go=$go_changed" >> "$GITHUB_OUTPUT"
 
           run_check=$(matches '(\.dart$|^pubspec\.(yaml|lock)$|^analysis_options\.yaml$|^\.github/workflows/|^scripts/|^assets/|^(android|ios|macos|windows|linux|web)/)')
           echo "run_check=$run_check" >> "$GITHUB_OUTPUT"
@@ -105,7 +115,7 @@ jobs:
   noop:
     name: No-op
     needs: changes
-    if: needs.changes.outputs.run_check != 'true'
+    if: needs.changes.outputs.run_check != 'true' && needs.changes.outputs.go != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -167,6 +177,91 @@ jobs:
 
       - name: Run tests
         run: flutter test --no-pub --total-shards 4 --shard-index ${{ matrix.shard-index }}
+
+  # ---------------------------------------------------------------------------
+  # MonkeyMux helper (Go) — a standalone module under remote/monkeymux that is
+  # shipped to remote hosts as the prebuilt binaries in assets/monkeymux/.
+  #
+  # Runs on both Linux and Windows because the helper supports both as a remote
+  # host and the two platforms cover disjoint test sets: the bulk of the suite
+  # is //go:build !windows (it needs creack/pty and the unixPty type), while the
+  # ConPTY backend tests are //go:build windows.
+  # ---------------------------------------------------------------------------
+  go-test:
+    name: Go Tests (${{ matrix.name }})
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux
+            os: ubuntu-latest
+          - name: windows
+            os: windows-2025
+    defaults:
+      run:
+        shell: bash
+        working-directory: remote/monkeymux
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: remote/monkeymux/go.mod
+          cache-dependency-path: remote/monkeymux/go.sum
+
+      # Checked on Linux only: the repository has no .gitattributes, so a
+      # Windows runner checks out CRLF and gofmt would flag every file.
+      - name: Check formatting
+        if: matrix.name == 'linux'
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "::error::gofmt reported unformatted files:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      # The race detector needs cgo and a C toolchain, which is dependable on
+      # the Linux runner but not on Windows; run the Windows set without it
+      # rather than make the job depend on a preinstalled gcc.
+      - name: Test
+        run: |
+          if [ "${{ matrix.name }}" = "linux" ]; then
+            go test -race ./...
+          else
+            go test ./...
+          fi
+
+      # The helper ships as prebuilt binaries for six platform pairs. Building
+      # each one keeps a platform-gated compile error from reaching the release
+      # script, which is the only place they are otherwise built.
+      - name: Cross-compile release targets
+        if: matrix.name == 'linux'
+        run: |
+          for target in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64 windows/arm64; do
+            echo "building $target"
+            GOOS="${target%/*}" GOARCH="${target#*/}" CGO_ENABLED=0 \
+              go build -trimpath -ldflags="-s -w" -o /dev/null .
+          done
+
+      # Vet the platform-gated sources (including their tests) that this
+      # runner's own GOOS excludes from the checks above.
+      - name: Vet other platforms
+        if: matrix.name == 'linux'
+        run: |
+          for goos in darwin windows; do
+            echo "vetting $goos"
+            GOOS="$goos" go vet ./...
+          done
 
   # ---------------------------------------------------------------------------
   # Platform builds — conditional on detected changes.
@@ -467,7 +562,7 @@ jobs:
   ci:
     name: CI
     if: ${{ always() && !cancelled() }}
-    needs: [changes, check, test, build-android, build-ios, build-macos, build-windows, build-linux]
+    needs: [changes, check, test, go-test, build-android, build-ios, build-macos, build-windows, build-linux]
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -476,6 +571,7 @@ jobs:
           CHANGES_RESULT: ${{ needs.changes.result }}
           CHECK_RESULT: ${{ needs.check.result }}
           TEST_RESULT: ${{ needs.test.result }}
+          GO_TEST_RESULT: ${{ needs.go-test.result }}
           ANDROID_RESULT: ${{ needs.build-android.result }}
           IOS_RESULT: ${{ needs.build-ios.result }}
           MACOS_RESULT: ${{ needs.build-macos.result }}
@@ -487,6 +583,7 @@ jobs:
             "changes:$CHANGES_RESULT" \
             "check:$CHECK_RESULT" \
             "test:$TEST_RESULT" \
+            "go-test:$GO_TEST_RESULT" \
             "build-android:$ANDROID_RESULT" \
             "build-ios:$IOS_RESULT" \
             "build-macos:$MACOS_RESULT" \

--- a/remote/monkeymux/copilot_restore_fallback_test.go
+++ b/remote/monkeymux/copilot_restore_fallback_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,8 +24,21 @@ func writeCopilotSession(
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	events := `{"type":"session.start","data":{"sessionId":"` + id +
-		`","context":{"cwd":"` + cwd + `"}}}` + "\n"
+	// Marshal rather than concatenate: a Windows cwd such as
+	// C:\Users\...\project is full of backslashes that would otherwise become
+	// invalid JSON escapes, so the events log would not parse at all.
+	event := map[string]any{
+		"type": "session.start",
+		"data": map[string]any{
+			"sessionId": id,
+			"context":   map[string]any{"cwd": cwd},
+		},
+	}
+	encoded, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := string(encoded) + "\n"
 	eventsPath := filepath.Join(dir, "events.jsonl")
 	if err := os.WriteFile(eventsPath, []byte(events), 0o600); err != nil {
 		t.Fatal(err)
@@ -66,7 +80,7 @@ func itoaPositive(n int) string {
 // pane.
 func TestDiscoverCopilotSessionIDsPrefersFreshSessionOnStaleLock(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHomeDir(t, home)
 	stateDir := filepath.Join(home, ".copilot", "session-state")
 
 	now := time.Now()
@@ -92,7 +106,7 @@ func TestDiscoverCopilotSessionIDsPrefersFreshSessionOnStaleLock(t *testing.T) {
 // instead of relaunching blank.
 func TestEnrichRestoreCopilotFallsBackToCwd(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHomeDir(t, home)
 	stateDir := filepath.Join(home, ".copilot", "session-state")
 	project := filepath.Join(home, "project")
 	if err := os.MkdirAll(project, 0o755); err != nil {
@@ -125,7 +139,7 @@ func TestEnrichRestoreCopilotFallsBackToCwd(t *testing.T) {
 // that a session already claimed elsewhere is never reused.
 func TestAssignCopilotSessionsByWorkingDirectoryDedups(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHomeDir(t, home)
 	stateDir := filepath.Join(home, ".copilot", "session-state")
 	project := filepath.Join(home, "shared")
 	if err := os.MkdirAll(project, 0o755); err != nil {
@@ -163,7 +177,7 @@ func TestAssignCopilotSessionsByWorkingDirectoryDedups(t *testing.T) {
 // cwd and a session cwd match through ~ expansion and symlink resolution.
 func TestAssignCopilotSessionsByWorkingDirectoryNormalizesPaths(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHomeDir(t, home)
 	stateDir := filepath.Join(home, ".copilot", "session-state")
 
 	realDir := filepath.Join(home, "real-project")

--- a/remote/monkeymux/test_home_test.go
+++ b/remote/monkeymux/test_home_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"runtime"
+	"testing"
+)
+
+// setTestHomeDir points os.UserHomeDir at dir for the duration of the test.
+//
+// os.UserHomeDir reads a different variable per platform (USERPROFILE on
+// Windows, HOME elsewhere), so a test that only sets HOME silently keeps
+// resolving the real user profile on Windows and reads whatever agent state
+// happens to exist there. Setting every variable the lookup consults keeps
+// agent-session discovery tests hermetic on all platforms.
+func setTestHomeDir(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", dir)
+	}
+}


### PR DESCRIPTION
## Why

`remote/monkeymux` is a standalone Go module shipped to remote hosts as the prebuilt binaries in `assets/monkeymux/`. **No CI job ever built or tested it.**

That is exactly how the stale `monkeyMuxVersion` in #716 reached a merge: `version_consistency_test.go` pins the bundled manifest to the compiled constant and would have caught it, but nothing ran it.

## The job

New `go-test` job gated on a new `go` change output. The output is computed **before** the `run_check` early exit, so a Go-only change (which does not match the Flutter `run_check` pattern) still triggers it. It is wired into the required `ci` gate.

| | linux | windows |
|---|---|---|
| `gofmt -l` | ✅ | — |
| `go vet ./...` | ✅ | ✅ |
| `go test` | ✅ `-race` | ✅ |
| cross-compile ×6 | ✅ | — |
| `go vet` darwin + windows | ✅ | — |

Two runners because the platforms cover **disjoint** test sets — 355 tests are `//go:build !windows`, and the ConPTY backend tests are `//go:build windows`.

The cross-compile step builds all six released platform pairs so a platform-gated compile error cannot reach `scripts/build_monkeymux_assets.sh`, which is otherwise the only place they are built.

`gofmt` and `-race` are Linux-only on purpose: the repo has no `.gitattributes`, so a Windows runner checks out CRLF and `gofmt` would flag every file; `-race` needs cgo plus a C toolchain, which is not dependable on the Windows runner.

## "Is there a reason we can't run the Go tests on Windows?"

Partly. Windows currently runs **17 of 372** tests, and 4 of those were failing before this PR:

- **`HOME` vs `USERPROFILE`** — the tests set `HOME`, but `os.UserHomeDir()` reads `USERPROFILE` on Windows, so they were silently reading the real user profile instead of the temp dir. Added a `setTestHomeDir` helper that sets both.
- **JSON built by concatenation** — `writeCopilotSession` interpolated a cwd straight into a JSON string. A Windows `C:\Users\...` path turns into invalid `\U`, `\A`, `\T` escapes, so the events log never parsed. Now marshaled with `encoding/json`.

Both were latent test-harness portability bugs, not production bugs. With them fixed the Windows suite is green.

The remaining **355** tests stay `//go:build !windows` for a real reason: they are built on `github.com/creack/pty` (`pty.Open`, `pty.GetsizeFull`) and the `unixPty` type. Windows has no equivalent that can wrap an arbitrary pipe — `winPty` wraps a real ConPTY created via `CreatePseudoConsole` — and a set of them shell out to `/bin/sh`. Porting those is a genuine refactor of a 369 KB test file, not a build-tag change, so this PR does not attempt it.

## Verification

Run locally on Windows:
- `go test ./...` — green, 17 tests (was 4 failures)
- `go vet ./...` for `GOOS=linux`, `darwin`, `windows` — all clean
- all six cross-compile targets build
- whole module `gofmt`-clean when LF-normalized (confirms the new gofmt gate passes)
- change-detection regex checked against go-source, asset, ci.yml, build-script, dart-only, docs-only and unrelated-path inputs
- workflow YAML parses; gate `needs` and matrix confirmed
