### PR TITLE
fix(monkeymux): force a settled redraw after every window switch

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -7577,6 +7577,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       suppressMonkeyMuxResizeSync: true,
       suppressAutoScroll: !revealLatestOutput,
     );
+    // A MonkeyMux window selection can replay a retained frame before the
+    // foreground TUI has fully repainted at the shared PTY size. A real later
+    // resize (for example opening/closing the software keyboard) reliably heals
+    // the corruption, while switches that happen not to trigger an onResize
+    // callback can remain stale indefinitely. Always schedule the same settled
+    // force-redraw after a window replay; the scheduler coalesces with any real
+    // resize already in flight.
+    _scheduleMonkeyMuxResizeRedrawFollowUp(session);
     _scheduleMonkeyMuxSettledRedrawDisplayRefreshes(
       session,
       reason: 'window_change_replay',

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -3987,6 +3987,11 @@ void main() {
 
         await tester.pump(const Duration(milliseconds: 300));
         await tester.pump();
+        final switchResizeCalls = monkeyMuxService.resizeTerminalCalls
+            .skip(resizeCallsBeforeSwitch)
+            .toList(growable: false);
+        expect(switchResizeCalls, hasLength(1));
+        expect(switchResizeCalls.single.redraw, isTrue);
         final resizeCallsAfterWindowReplay =
             monkeyMuxService.resizeTerminalCalls.length;
         final terminalViewState = tester.state<MonkeyTerminalViewState>(
@@ -4481,8 +4486,9 @@ void main() {
         await tester.pump();
         expect(
           monkeyMuxService.resizeTerminalCalls.length,
-          resizeCountAfterWindowRefresh,
+          resizeCountAfterWindowRefresh + 1,
         );
+        expect(monkeyMuxService.resizeTerminalCalls.last.redraw, isTrue);
         await gesture.up();
 
         final placeholder = String.fromCharCode(


### PR DESCRIPTION
## Problem

Switching MonkeyMux windows after viewing a Kitty image could leave the target
window partially replayed, blank, or visually corrupted. Opening/closing the
Android software keyboard immediately repaired it.

## Evidence

The diagnostics rule out missing images:

- `images=4` throughout
- image decode reports `success=true reused=true`
- no unresolved placeholder IDs during the affected switches

Across six recorded window switches:

- switches that happened to emit
  `monkeymux.resize sync_complete ... redraw=true` settled correctly;
- the final corrupted switch emitted only the delayed
  `monkeymux.redraw display_refresh` ladder and never forced the remote TUI to
  repaint;
- toggling the keyboard produced a real terminal resize/SIGWINCH and healed the
  screen.

`_refreshTerminalAfterMonkeyMuxWindowChange` cancelled the existing 220-ms
resize/redraw timer but did not reliably reschedule it. It therefore depended
on Flutter independently producing an `onResize` callback after the switch.

## Fix

Always schedule the existing coalesced MonkeyMux resize-redraw follow-up after
window replay.

The follow-up:

- runs once at the settled shared terminal size after 220 ms;
- sends `redraw=true` through the MonkeyMux control channel;
- coalesces with an actual keyboard/layout resize if one is already pending;
- keeps the existing delayed display-refresh ladder and scroll-follow behavior.

## Tests

- Window-switch test now requires exactly one forced redraw after replay.
- Active-window-event test requires the same redraw even while touch scroll
  follow is paused.
- All 19 MonkeyMux TerminalScreen tests pass.
- `flutter analyze` is clean.
- Focused code review: approved, no findings.
