### PR TITLE
fix: harden bracketed paste handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     outputs:
       run_check: ${{ steps.filter.outputs.run_check }}
       go: ${{ steps.filter.outputs.go }}
@@ -41,7 +41,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          fetch-depth: 0
+          # The checked-out PR/merge commit contains both diff parents. Avoid
+          # fetching the binary-heavy full history just to classify changed files.
+          fetch-depth: 2
 
       - name: Detect platform changes
         id: filter

--- a/lib/domain/services/remote_file_service.dart
+++ b/lib/domain/services/remote_file_service.dart
@@ -340,7 +340,14 @@ const _bracketedPasteEnd = '\x1b[201~';
 bool _isTerminalSafeAttachmentPath(String path) =>
     !_terminalControlCharacterPattern.hasMatch(path);
 
-bool _isBracketedAttachmentPath(String path, {required bool windows}) {
+bool _isUnquotedAttachmentPath(String path, {required bool windows}) {
+  final safePathPattern = windows
+      ? RegExp(r'^[A-Za-z0-9._/\\:-]+$')
+      : RegExp(r'^[A-Za-z0-9._/-]+$');
+  return safePathPattern.hasMatch(path);
+}
+
+bool _isRawAgentAttachmentPath(String path, {required bool windows}) {
   final safePathPattern = windows
       ? RegExp(r'^[A-Za-z0-9._/\\: -]+$')
       : RegExp(r'^[A-Za-z0-9._/ -]+$');
@@ -356,9 +363,9 @@ String _shellEscapeAttachmentPath(String path, {required bool windows}) =>
 /// When [bracketedPasteMode] is true, each path containing only normal path
 /// characters (including spaces) is returned as its own bracketed-paste segment
 /// (`CSI 200~ <path> CSI 201~ ` with a trailing space). The raw path stays
-/// unquoted inside the framing because agent CLIs require the real filesystem
-/// path to recognise it as an attachment. Shell metacharacters and terminal
-/// controls are omitted so the payload remains safe if a shell owns the mode.
+/// unquoted for paths that are shell-safe, and also for space-containing paths
+/// when [preferRawAgentPaths] confirms an agent CLI owns the pane. Other
+/// printable paths are shell-escaped inside the framing.
 ///
 /// When bracketed paste is not requested, paths are shell-escaped for the
 /// current remote shell and returned as one segment. Paths containing terminal
@@ -372,14 +379,12 @@ List<String> buildTerminalAttachmentPasteSegments(
   Iterable<String> remotePaths, {
   required bool bracketedPasteMode,
   bool windows = false,
+  bool preferRawAgentPaths = false,
 }) {
   final paths = remotePaths
       .where(
         (remotePath) =>
-            remotePath.isNotEmpty &&
-            _isTerminalSafeAttachmentPath(remotePath) &&
-            (!bracketedPasteMode ||
-                _isBracketedAttachmentPath(remotePath, windows: windows)),
+            remotePath.isNotEmpty && _isTerminalSafeAttachmentPath(remotePath),
       )
       .toList();
   if (paths.isEmpty) {
@@ -390,11 +395,27 @@ List<String> buildTerminalAttachmentPasteSegments(
       '${paths.map((path) => _shellEscapeAttachmentPath(path, windows: windows)).join(' ')} ',
     ];
   }
-  return [
-    for (final remotePath in paths)
-      '$_bracketedPasteStart$remotePath$_bracketedPasteEnd ',
-  ];
+  return paths.map((remotePath) {
+    final useRawPath =
+        _isUnquotedAttachmentPath(remotePath, windows: windows) ||
+        (preferRawAgentPaths &&
+            _isRawAgentAttachmentPath(remotePath, windows: windows));
+    final payload = useRawPath
+        ? remotePath
+        : _shellEscapeAttachmentPath(remotePath, windows: windows);
+    return '$_bracketedPasteStart$payload$_bracketedPasteEnd ';
+  }).toList();
 }
+
+/// Counts paths that can be safely represented as terminal attachment input.
+int countTerminalAttachmentPastePaths(Iterable<String> remotePaths) =>
+    remotePaths
+        .where(
+          (remotePath) =>
+              remotePath.isNotEmpty &&
+              _isTerminalSafeAttachmentPath(remotePath),
+        )
+        .length;
 
 /// Shared helpers for remote file transfers over SFTP.
 final remoteFileServiceProvider = Provider<RemoteFileService>(

--- a/lib/domain/services/remote_file_service.dart
+++ b/lib/domain/services/remote_file_service.dart
@@ -337,21 +337,15 @@ String shellEscapeWindows(String value) {
 const _bracketedPasteStart = '\x1b[200~';
 const _bracketedPasteEnd = '\x1b[201~';
 
-/// Whether [path] is safe to paste unquoted (only path separators and the
-/// strict upload-filename allowlist). Windows shell paths also allow `:`
-/// drive prefixes and `\` separators.
-/// Uploaded filenames are sanitized, but the directory prefix derives from the
-/// remote home directory, which a hostile or misconfigured server could fill
-/// with spaces or shell metacharacters.
-bool _isUnquotedSafeAttachmentPath(String path, {required bool windows}) {
-  final safePathPattern = windows
-      ? RegExp(r'^[A-Za-z0-9._/\\:-]+$')
-      : RegExp(r'^[A-Za-z0-9._/-]+$');
-  return safePathPattern.hasMatch(path);
-}
-
 bool _isTerminalSafeAttachmentPath(String path) =>
     !_terminalControlCharacterPattern.hasMatch(path);
+
+bool _isBracketedAttachmentPath(String path, {required bool windows}) {
+  final safePathPattern = windows
+      ? RegExp(r'^[A-Za-z0-9._/\\: -]+$')
+      : RegExp(r'^[A-Za-z0-9._/ -]+$');
+  return safePathPattern.hasMatch(path);
+}
 
 String _shellEscapeAttachmentPath(String path, {required bool windows}) =>
     windows ? shellEscapeWindows(path) : shellEscapePosix(path);
@@ -359,13 +353,12 @@ String _shellEscapeAttachmentPath(String path, {required bool windows}) =>
 /// Builds the terminal-input segments that reference uploaded [remotePaths]
 /// after a paste upload.
 ///
-/// When [bracketedPasteMode] is true, each terminal-safe path is returned as
-/// its own bracketed-paste segment (`CSI 200~ <path> CSI 201~ ` with a trailing
-/// space). Paths that are unsafe unquoted are shell-escaped inside the framing,
-/// so one quoted path no longer disables bracketed paste for the whole batch.
-/// The caller must write these segments sequentially with a short delay: an
-/// agent CLI such as Copilot CLI only recognises each path as a separate
-/// attachment when the bracketed pastes arrive as distinct reads.
+/// When [bracketedPasteMode] is true, each path containing only normal path
+/// characters (including spaces) is returned as its own bracketed-paste segment
+/// (`CSI 200~ <path> CSI 201~ ` with a trailing space). The raw path stays
+/// unquoted inside the framing because agent CLIs require the real filesystem
+/// path to recognise it as an attachment. Shell metacharacters and terminal
+/// controls are omitted so the payload remains safe if a shell owns the mode.
 ///
 /// When bracketed paste is not requested, paths are shell-escaped for the
 /// current remote shell and returned as one segment. Paths containing terminal
@@ -383,7 +376,10 @@ List<String> buildTerminalAttachmentPasteSegments(
   final paths = remotePaths
       .where(
         (remotePath) =>
-            remotePath.isNotEmpty && _isTerminalSafeAttachmentPath(remotePath),
+            remotePath.isNotEmpty &&
+            _isTerminalSafeAttachmentPath(remotePath) &&
+            (!bracketedPasteMode ||
+                _isBracketedAttachmentPath(remotePath, windows: windows)),
       )
       .toList();
   if (paths.isEmpty) {
@@ -394,12 +390,10 @@ List<String> buildTerminalAttachmentPasteSegments(
       '${paths.map((path) => _shellEscapeAttachmentPath(path, windows: windows)).join(' ')} ',
     ];
   }
-  return paths.map((remotePath) {
-    final payload = _isUnquotedSafeAttachmentPath(remotePath, windows: windows)
-        ? remotePath
-        : _shellEscapeAttachmentPath(remotePath, windows: windows);
-    return '$_bracketedPasteStart$payload$_bracketedPasteEnd ';
-  }).toList();
+  return [
+    for (final remotePath in paths)
+      '$_bracketedPasteStart$remotePath$_bracketedPasteEnd ',
+  ];
 }
 
 /// Shared helpers for remote file transfers over SFTP.

--- a/lib/domain/services/remote_file_service.dart
+++ b/lib/domain/services/remote_file_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path/path.dart' as path;
 
 final _sftpWindowsDriveRootPattern = RegExp(r'^/?[A-Za-z]:(?:/|$)');
+final _terminalControlCharacterPattern = RegExp(r'[\x00-\x1f\x7f-\x9f]');
 
 /// Display path for files pasted directly into a terminal session.
 const remoteClipboardUploadDirectoryDisplay = '~/.cache/monkeyssh/uploads';
@@ -349,27 +350,27 @@ bool _isUnquotedSafeAttachmentPath(String path, {required bool windows}) {
   return safePathPattern.hasMatch(path);
 }
 
+bool _isTerminalSafeAttachmentPath(String path) =>
+    !_terminalControlCharacterPattern.hasMatch(path);
+
 String _shellEscapeAttachmentPath(String path, {required bool windows}) =>
     windows ? shellEscapeWindows(path) : shellEscapePosix(path);
 
 /// Builds the terminal-input segments that reference uploaded [remotePaths]
 /// after a paste upload.
 ///
-/// When [bracketedPasteMode] is true *and* every path is safe to paste
-/// unquoted, each path is returned as its own bracketed-paste segment
-/// (`CSI 200~ <path> CSI 201~ ` with a trailing space). The caller must write
-/// these segments sequentially with a short delay between them: an agent CLI
-/// such as Copilot CLI only recognises each path as a separate attachment —
-/// rendering a preview chip per file — when the bracketed pastes arrive as
-/// distinct reads. The trailing space also keeps the paths usable as distinct
-/// shell arguments.
+/// When [bracketedPasteMode] is true, each terminal-safe path is returned as
+/// its own bracketed-paste segment (`CSI 200~ <path> CSI 201~ ` with a trailing
+/// space). Paths that are unsafe unquoted are shell-escaped inside the framing,
+/// so one quoted path no longer disables bracketed paste for the whole batch.
+/// The caller must write these segments sequentially with a short delay: an
+/// agent CLI such as Copilot CLI only recognises each path as a separate
+/// attachment when the bracketed pastes arrive as distinct reads.
 ///
-/// Otherwise — when bracketed paste is not requested, or when a path contains
-/// characters that would be unsafe unquoted (e.g. a remote home directory with
-/// spaces or shell metacharacters) — the paths are shell-escaped for the current
-/// remote shell and returned as a single segment. That form shows no preview (a
-/// path with spaces would not produce a chip anyway) but keeps the inserted text
-/// quoted for the active remote shell.
+/// When bracketed paste is not requested, paths are shell-escaped for the
+/// current remote shell and returned as one segment. Paths containing terminal
+/// control characters are omitted in either mode because they cannot be safely
+/// represented as terminal input.
 ///
 /// Segments must be written straight to the session input sink (e.g.
 /// `Terminal.onOutput`), not through `Terminal.paste`, which would strip the
@@ -380,26 +381,25 @@ List<String> buildTerminalAttachmentPasteSegments(
   bool windows = false,
 }) {
   final paths = remotePaths
-      .where((remotePath) => remotePath.isNotEmpty)
+      .where(
+        (remotePath) =>
+            remotePath.isNotEmpty && _isTerminalSafeAttachmentPath(remotePath),
+      )
       .toList();
   if (paths.isEmpty) {
     return const [];
   }
-  final canRenderChips =
-      bracketedPasteMode &&
-      paths.every(
-        (remotePath) =>
-            _isUnquotedSafeAttachmentPath(remotePath, windows: windows),
-      );
-  if (!canRenderChips) {
+  if (!bracketedPasteMode) {
     return [
       '${paths.map((path) => _shellEscapeAttachmentPath(path, windows: windows)).join(' ')} ',
     ];
   }
-  return [
-    for (final remotePath in paths)
-      '$_bracketedPasteStart$remotePath$_bracketedPasteEnd ',
-  ];
+  return paths.map((remotePath) {
+    final payload = _isUnquotedSafeAttachmentPath(remotePath, windows: windows)
+        ? remotePath
+        : _shellEscapeAttachmentPath(remotePath, windows: windows);
+    return '$_bracketedPasteStart$payload$_bracketedPasteEnd ';
+  }).toList();
 }
 
 /// Shared helpers for remote file transfers over SFTP.

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -962,11 +962,12 @@ void pasteTerminalTextWithBracketedPasteMode({
 bool shouldRetryTerminalPasteModeSettle({
   required bool refreshAttempted,
   required bool refreshSucceeded,
+  required bool hasActiveWindow,
   required bool modeReliable,
   required bool targetsCurrentWindow,
 }) {
-  if (refreshAttempted && !refreshSucceeded) {
-    return false;
+  if (refreshAttempted) {
+    return refreshSucceeded && (!hasActiveWindow || !targetsCurrentWindow);
   }
   return !modeReliable || !targetsCurrentWindow;
 }
@@ -3560,6 +3561,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   /// Monotonically-increasing counter; incremented whenever the terminal
   /// buffer changes content. Used to invalidate per-row snapshot caches.
   int _terminalContentGeneration = 0;
+  int _terminalUserInputGeneration = 0;
 
   /// Cache of [_TerminalPathTapSnapshot] objects keyed by the canonical start
   /// row of each wrapped-line group. Invalidated when
@@ -4277,6 +4279,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     required String title,
     required String Function(TerminalCommandReview review) messageBuilder,
     required String confirmLabel,
+    VoidCallback? onReviewShown,
   }) async {
     while (mounted) {
       final review = buildReview(_terminalCommandAfterInsertion(insertedText));
@@ -4284,6 +4287,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         return true;
       }
 
+      onReviewShown?.call();
       final shouldInsert = await _confirmCommandInsertion(
         title: title,
         message: messageBuilder(review),
@@ -5236,12 +5240,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (!stillOwnsTerminalContext()) {
       return null;
     }
+    _syncTerminalModesFromActiveMuxWindow();
+    final fallbackActiveWindowBracketedPasteMode =
+        resolveTmuxBarActiveWindowBracketedPasteMode(
+          _currentTmuxWindowsSnapshot,
+        );
     return (
       activeWindowKey: resolveTmuxBarActiveWindowKey(
         _currentTmuxWindowsSnapshot,
       ),
       bracketedPasteMode: terminal.bracketedPasteMode,
-      bracketedPasteModeKnown: currentActiveWindowBracketedPasteMode != null,
+      bracketedPasteModeKnown: fallbackActiveWindowBracketedPasteMode != null,
       connectionId: connectionId,
       isMuxActive: isMuxActive,
       muxBackend: muxBackend,
@@ -5263,6 +5272,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         pasteMode.activeWindowKey != null;
   }
 
+  bool _terminalPasteModeCanUseResolvedState(_TerminalPasteMode pasteMode) =>
+      _terminalPasteModeIsReliable(pasteMode) ||
+      (pasteMode.isMuxActive &&
+          pasteMode.muxBackend == RemoteMuxBackend.monkeyMux &&
+          pasteMode.bracketedPasteModeKnown &&
+          pasteMode.activeWindowKey != null &&
+          _terminalPasteModeTargetsCurrentWindow(pasteMode));
+
   Future<_TerminalPasteMode?> _resolveSettledTerminalPasteMode() async {
     _TerminalPasteMode? pasteMode;
     for (
@@ -5283,6 +5300,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       if (!shouldRetryTerminalPasteModeSettle(
         refreshAttempted: pasteMode.refreshAttempted,
         refreshSucceeded: pasteMode.refreshSucceeded,
+        hasActiveWindow: pasteMode.activeWindowKey != null,
         modeReliable: modeReliable,
         targetsCurrentWindow: targetsCurrentWindow,
       )) {
@@ -7458,6 +7476,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           fields: {'connectionId': session.connectionId},
         );
         return;
+      }
+      if (!_terminalMouseReportOutputPattern.hasMatch(output) &&
+          !_terminalFocusReportOutputPattern.hasMatch(output)) {
+        _terminalUserInputGeneration++;
       }
       _clearDetectedSensitiveKeyboardPromptAfterInput(output);
       _handleTerminalOutputForShellCompletion(output);
@@ -15632,6 +15654,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }
 
   Future<void> _pasteClipboard() async {
+    final inputGeneration = _terminalUserInputGeneration;
     try {
       if (_isAndroidPlatform) {
         final imageBytes = await Pasteboard.image;
@@ -15689,14 +15712,25 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
         return;
       }
+      if (!_terminalPasteModeCanUseResolvedState(pasteMode)) {
+        DiagnosticsLogService.instance.warning(
+          'terminal.clipboard',
+          'text_input_skipped_mode_unavailable',
+          fields: {'connectionId': _connectionId},
+        );
+        _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+        _showClipboardMessage(
+          'Could not verify bracketed paste mode. Try again.',
+        );
+        return;
+      }
 
       final requiredReview = _shouldReviewTerminalCommandInsertion;
-      var reviewedBracketedPasteMode =
-          _terminalPasteModeIsReliable(pasteMode) &&
-          pasteMode.bracketedPasteMode;
+      var reviewedBracketedPasteMode = pasteMode.bracketedPasteMode;
       if (requiredReview) {
         var modeStableAfterReview = false;
         for (var reviewAttempt = 0; reviewAttempt < 2; reviewAttempt++) {
+          var reviewShown = false;
           final shouldPaste = await _confirmTerminalInsertionIfNeeded(
             insertedText: text,
             buildReview: (commandText) => assessClipboardPasteCommand(
@@ -15708,10 +15742,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 ? 'This clipboard content looks risky even with bracketed paste enabled.'
                 : 'This clipboard content could execute multiple or reshaped commands.',
             confirmLabel: 'Paste anyway',
+            onReviewShown: () => reviewShown = true,
           );
           if (!shouldPaste) {
             _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
             return;
+          }
+          if (!reviewShown) {
+            modeStableAfterReview = true;
+            break;
           }
 
           final refreshedPasteMode = await _resolveSettledTerminalPasteMode();
@@ -15722,19 +15761,30 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             return;
           }
           if (!_sameTerminalPasteContext(pasteMode, refreshedPasteMode) ||
+              refreshedPasteMode.activeWindowKey != pasteMode.activeWindowKey ||
               !_terminalPasteModeOwnsCurrentContext(refreshedPasteMode)) {
             DiagnosticsLogService.instance.warning(
               'terminal.clipboard',
-              'text_input_skipped_context_changed',
+              'text_input_skipped_window_changed',
               fields: {'connectionId': _connectionId},
             );
             _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
             return;
           }
           pasteMode = refreshedPasteMode;
-          final refreshedBracketedPasteMode =
-              _terminalPasteModeIsReliable(pasteMode) &&
-              pasteMode.bracketedPasteMode;
+          if (!_terminalPasteModeCanUseResolvedState(pasteMode)) {
+            DiagnosticsLogService.instance.warning(
+              'terminal.clipboard',
+              'text_input_skipped_mode_unavailable',
+              fields: {'connectionId': _connectionId},
+            );
+            _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+            _showClipboardMessage(
+              'Could not verify bracketed paste mode. Try again.',
+            );
+            return;
+          }
+          final refreshedBracketedPasteMode = pasteMode.bracketedPasteMode;
           if (refreshedBracketedPasteMode == reviewedBracketedPasteMode) {
             modeStableAfterReview = true;
             break;
@@ -15771,8 +15821,20 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         return;
       }
 
+      if (_terminalUserInputGeneration != inputGeneration) {
+        DiagnosticsLogService.instance.warning(
+          'terminal.clipboard',
+          'text_input_skipped_intervening_input',
+          fields: {'connectionId': _connectionId},
+        );
+        _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+        _showClipboardMessage('Paste canceled because terminal input changed.');
+        return;
+      }
+
       final modeReliable = _terminalPasteModeIsReliable(pasteMode);
-      final usedBracketedPaste = modeReliable && pasteMode.bracketedPasteMode;
+      final modeUsable = _terminalPasteModeCanUseResolvedState(pasteMode);
+      final usedBracketedPaste = pasteMode.bracketedPasteMode;
       _followLiveOutput();
       pasteTerminalTextWithBracketedPasteMode(
         terminal: pasteMode.terminal,
@@ -15787,6 +15849,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           'bracketedPasteMode': pasteMode.bracketedPasteMode,
           'bracketedPasteModeKnown': pasteMode.bracketedPasteModeKnown,
           'modeReliable': modeReliable,
+          'modeUsable': modeUsable,
           'usedBracketedPaste': usedBracketedPaste,
           'modeRefreshAttempted': pasteMode.refreshAttempted,
           'modeRefreshSucceeded': pasteMode.refreshSucceeded,
@@ -16175,28 +16238,29 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   /// attachment. The pre-built segments are written straight to the session
   /// input via [Terminal.onOutput]; they must not go through [Terminal.paste],
   /// which would strip the bracketed-paste markers.
-  Future<void> _insertUploadedFileReferences(
+  Future<bool> _insertUploadedFileReferences(
     List<String> remotePaths, {
     required bool windows,
   }) async {
+    var inputGeneration = _terminalUserInputGeneration;
     final pathCount = remotePaths
         .where((remotePath) => remotePath.isNotEmpty)
         .length;
     if (pathCount == 0) {
-      return;
+      return true;
     }
     final initialPasteMode = await _resolveSettledTerminalPasteMode();
     if (initialPasteMode == null || !mounted) {
-      return;
+      return false;
     }
-    var pasteMode = initialPasteMode;
+    final pasteMode = initialPasteMode;
     if (!_terminalPasteModeOwnsCurrentContext(pasteMode)) {
       DiagnosticsLogService.instance.warning(
         'terminal.clipboard',
         'attachment_input_skipped_context_changed',
         fields: {'connectionId': _connectionId, 'pathCount': pathCount},
       );
-      return;
+      return false;
     }
     if (!_terminalPasteModeTargetsCurrentWindow(pasteMode)) {
       _syncTerminalModesFromActiveMuxWindow();
@@ -16205,10 +16269,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         'attachment_input_skipped_window_changed',
         fields: {'connectionId': _connectionId, 'pathCount': pathCount},
       );
-      return;
+      return false;
     }
     final modeReliable = _terminalPasteModeIsReliable(pasteMode);
-    final usedBracketedPaste = modeReliable && pasteMode.bracketedPasteMode;
+    final modeUsable = _terminalPasteModeCanUseResolvedState(pasteMode);
+    if (!modeUsable) {
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'attachment_input_skipped_mode_unavailable',
+        fields: {'connectionId': _connectionId, 'pathCount': pathCount},
+      );
+      return false;
+    }
+    final usedBracketedPaste = pasteMode.bracketedPasteMode;
     final terminalSafePathCount = buildTerminalAttachmentPasteSegments(
       remotePaths,
       bracketedPasteMode: true,
@@ -16220,7 +16293,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         'attachment_input_skipped_unsafe_paths',
         fields: {'connectionId': _connectionId, 'pathCount': pathCount},
       );
-      return;
+      return false;
     }
     final segments = buildTerminalAttachmentPasteSegments(
       remotePaths,
@@ -16238,6 +16311,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         'bracketedPasteMode': pasteMode.bracketedPasteMode,
         'bracketedPasteModeKnown': pasteMode.bracketedPasteModeKnown,
         'modeReliable': modeReliable,
+        'modeUsable': modeUsable,
         'usedBracketedPaste': usedBracketedPaste,
         'modeRefreshAttempted': pasteMode.refreshAttempted,
         'modeRefreshSucceeded': pasteMode.refreshSucceeded,
@@ -16245,19 +16319,19 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
     for (var i = 0; i < segments.length; i++) {
       if (!mounted) {
-        return;
+        return false;
       }
       if (i > 0) {
-        final currentPasteMode = await _resolveSettledTerminalPasteMode();
-        if (currentPasteMode == null || !mounted) {
-          return;
-        }
-        final currentUsedBracketedPaste =
-            _terminalPasteModeIsReliable(currentPasteMode) &&
-            currentPasteMode.bracketedPasteMode;
-        if (!_sameTerminalPasteContext(pasteMode, currentPasteMode) ||
-            currentPasteMode.activeWindowKey != pasteMode.activeWindowKey ||
-            currentUsedBracketedPaste != usedBracketedPaste) {
+        _syncTerminalModesFromActiveMuxWindow();
+        final activeWindowBracketedPasteMode =
+            resolveTmuxBarActiveWindowBracketedPasteMode(
+              _currentTmuxWindowsSnapshot,
+            );
+        final modeChanged = pasteMode.isMuxActive
+            ? activeWindowBracketedPasteMode != null &&
+                  activeWindowBracketedPasteMode != usedBracketedPaste
+            : pasteMode.terminal.bracketedPasteMode != usedBracketedPaste;
+        if (modeChanged) {
           DiagnosticsLogService.instance.warning(
             'terminal.clipboard',
             'attachment_input_stopped_mode_changed',
@@ -16267,9 +16341,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
               'sentCount': i,
             },
           );
-          return;
+          return false;
         }
-        pasteMode = currentPasteMode;
       }
       if (!_terminalPasteModeOwnsCurrentContext(pasteMode)) {
         DiagnosticsLogService.instance.warning(
@@ -16281,7 +16354,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             'sentCount': i,
           },
         );
-        return;
+        return false;
       }
       if (!_terminalPasteModeTargetsCurrentWindow(pasteMode)) {
         _syncTerminalModesFromActiveMuxWindow();
@@ -16294,13 +16367,27 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             'sentCount': i,
           },
         );
-        return;
+        return false;
+      }
+      if (_terminalUserInputGeneration != inputGeneration) {
+        DiagnosticsLogService.instance.warning(
+          'terminal.clipboard',
+          'attachment_input_stopped_intervening_input',
+          fields: {
+            'connectionId': _connectionId,
+            'pathCount': pathCount,
+            'sentCount': i,
+          },
+        );
+        return false;
       }
       pasteMode.terminal.onOutput?.call(segments[i]);
+      inputGeneration = _terminalUserInputGeneration;
       if (i < segments.length - 1) {
         await Future<void>.delayed(_uploadedAttachmentPasteStagger);
       }
     }
+    return true;
   }
 
   Future<void> _pasteClipboardFiles(List<String> clipboardFiles) async {
@@ -16381,25 +16468,29 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     });
 
     _followLiveOutput();
-    await _insertUploadedFileReferences(
+    final pathsInserted = await _insertUploadedFileReferences(
       remotePaths.paths,
       windows: remotePaths.windows,
     );
     if (!mounted) {
       return;
     }
-    unawaited(
-      ref
-          .read(telemetryServiceProvider)
-          .logTerminalPasteUsed(
-            source: 'clipboard_files',
-            requiredReview: true,
-          ),
-    );
+    if (pathsInserted) {
+      unawaited(
+        ref
+            .read(telemetryServiceProvider)
+            .logTerminalPasteUsed(
+              source: 'clipboard_files',
+              requiredReview: true,
+            ),
+      );
+    }
     _terminalController.clearSelection();
     _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
     _showClipboardMessage(
-      'Uploaded ${remotePaths.paths.length} file${remotePaths.paths.length == 1 ? '' : 's'} to $_clipboardUploadDirectoryDisplay',
+      pathsInserted
+          ? 'Uploaded ${remotePaths.paths.length} file${remotePaths.paths.length == 1 ? '' : 's'} to $_clipboardUploadDirectoryDisplay'
+          : 'Uploaded ${remotePaths.paths.length} file${remotePaths.paths.length == 1 ? '' : 's'}, but could not paste ${remotePaths.paths.length == 1 ? 'its path' : 'their paths'}',
     );
   }
 
@@ -16490,25 +16581,31 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       );
     }, uploadBaseDirectory: uploadBaseDirectory);
     _followLiveOutput();
-    await _insertUploadedFileReferences([
+    final pathInserted = await _insertUploadedFileReferences([
       remotePath.path,
     ], windows: remotePath.windows);
     if (!mounted) {
       return;
     }
-    unawaited(
-      ref
-          .read(telemetryServiceProvider)
-          .logTerminalPasteUsed(
-            source: 'clipboard_image',
-            requiredReview: true,
-          ),
-    );
+    if (pathInserted) {
+      unawaited(
+        ref
+            .read(telemetryServiceProvider)
+            .logTerminalPasteUsed(
+              source: 'clipboard_image',
+              requiredReview: true,
+            ),
+      );
+    }
     _terminalController.clearSelection();
     _restoreTerminalFocus(
       showSystemKeyboard: showKeyboardAfterPaste && _isMobilePlatform,
     );
-    _showClipboardMessage('Uploaded clipboard image to ${remotePath.path}');
+    _showClipboardMessage(
+      pathInserted
+          ? 'Uploaded clipboard image to ${remotePath.path}'
+          : 'Uploaded clipboard image, but could not paste its path',
+    );
   }
 
   Future<void> _pasteSelectedFiles(
@@ -16585,22 +16682,26 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     });
 
     _followLiveOutput();
-    await _insertUploadedFileReferences(
+    final pathsInserted = await _insertUploadedFileReferences(
       remotePaths.paths,
       windows: remotePaths.windows,
     );
     if (!mounted) {
       return;
     }
-    unawaited(
-      ref
-          .read(telemetryServiceProvider)
-          .logTerminalPasteUsed(source: 'picked_files', requiredReview: true),
-    );
+    if (pathsInserted) {
+      unawaited(
+        ref
+            .read(telemetryServiceProvider)
+            .logTerminalPasteUsed(source: 'picked_files', requiredReview: true),
+      );
+    }
     _terminalController.clearSelection();
     _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
     _showClipboardMessage(
-      'Uploaded ${selectedFiles.length == 1 ? 'selected $itemLabelSingular' : '${remotePaths.paths.length} $itemLabelPlural'} to $_clipboardUploadDirectoryDisplay',
+      pathsInserted
+          ? 'Uploaded ${selectedFiles.length == 1 ? 'selected $itemLabelSingular' : '${remotePaths.paths.length} $itemLabelPlural'} to $_clipboardUploadDirectoryDisplay'
+          : 'Uploaded ${selectedFiles.length == 1 ? 'selected $itemLabelSingular' : '${remotePaths.paths.length} $itemLabelPlural'}, but could not paste ${remotePaths.paths.length == 1 ? 'its path' : 'their paths'}',
     );
   }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -5267,10 +5267,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         pasteMode.muxBackend != RemoteMuxBackend.monkeyMux) {
       return true;
     }
-    return pasteMode.refreshSucceeded &&
-        pasteMode.bracketedPasteModeKnown &&
-        pasteMode.activeWindowKey != null;
+    return pasteMode.refreshSucceeded && pasteMode.activeWindowKey != null;
   }
+
+  bool _effectiveTerminalBracketedPasteMode(_TerminalPasteMode pasteMode) =>
+      pasteMode.bracketedPasteModeKnown && pasteMode.bracketedPasteMode;
 
   bool _terminalPasteModeCanUseResolvedState(_TerminalPasteMode pasteMode) =>
       _terminalPasteModeIsReliable(pasteMode) ||
@@ -6291,6 +6292,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _queueTerminalScrollToBottom();
   }
 
+  void _handleTerminalUserInput() {
+    _terminalUserInputGeneration++;
+    _followLiveOutput();
+  }
+
   void _followNextLiveOutputWithoutScrolling() {
     _setShouldFollowLiveOutput(true);
   }
@@ -6905,7 +6911,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (text.isNotEmpty) {
       _terminal.textInput(text);
     }
-    _followLiveOutput();
+    _handleTerminalUserInput();
     _terminalTextInputController.clearImeBuffer();
   }
 
@@ -7476,10 +7482,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           fields: {'connectionId': session.connectionId},
         );
         return;
-      }
-      if (!_terminalMouseReportOutputPattern.hasMatch(output) &&
-          !_terminalFocusReportOutputPattern.hasMatch(output)) {
-        _terminalUserInputGeneration++;
       }
       _clearDetectedSensitiveKeyboardPromptAfterInput(output);
       _handleTerminalOutputForShellCompletion(output);
@@ -12089,7 +12091,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 _toolbarController.isShiftActive,
           ),
     );
-    _followLiveOutput();
+    _handleTerminalUserInput();
     _terminalTextInputController.clearImeBuffer();
   }
 
@@ -12691,6 +12693,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       forceSgrTouchScroll: _forceSgrTouchScroll,
       onInsertText: isMobile ? null : _confirmDesktopInsertedText,
       onPasteText: _pasteClipboard,
+      onUserInput: _handleTerminalUserInput,
       onTapDown: (_, _) => _claimActiveMonkeyMuxClientFocus(),
     );
 
@@ -12808,7 +12811,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       controller: _terminalTextInputController,
       deleteDetection: true,
       keyboardAppearance: keyboardAppearance,
-      onUserInput: _followLiveOutput,
+      onUserInput: _handleTerminalUserInput,
       onReviewInsertedText: _confirmKeyboardInsertion,
       buildReviewTextForInsertedText: _terminalCommandAfterInputDelta,
       resolveTextBeforeCursor: _terminalTextBeforeCursor,
@@ -15726,7 +15729,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       }
 
       final requiredReview = _shouldReviewTerminalCommandInsertion;
-      var reviewedBracketedPasteMode = pasteMode.bracketedPasteMode;
+      var reviewedBracketedPasteMode = _effectiveTerminalBracketedPasteMode(
+        pasteMode,
+      );
       if (requiredReview) {
         var modeStableAfterReview = false;
         for (var reviewAttempt = 0; reviewAttempt < 2; reviewAttempt++) {
@@ -15784,7 +15789,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             );
             return;
           }
-          final refreshedBracketedPasteMode = pasteMode.bracketedPasteMode;
+          final refreshedBracketedPasteMode =
+              _effectiveTerminalBracketedPasteMode(pasteMode);
           if (refreshedBracketedPasteMode == reviewedBracketedPasteMode) {
             modeStableAfterReview = true;
             break;
@@ -15834,13 +15840,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
       final modeReliable = _terminalPasteModeIsReliable(pasteMode);
       final modeUsable = _terminalPasteModeCanUseResolvedState(pasteMode);
-      final usedBracketedPaste = pasteMode.bracketedPasteMode;
+      final usedBracketedPaste = _effectiveTerminalBracketedPasteMode(
+        pasteMode,
+      );
       _followLiveOutput();
       pasteTerminalTextWithBracketedPasteMode(
         terminal: pasteMode.terminal,
         text: text,
         bracketedPasteMode: usedBracketedPaste,
       );
+      _terminalUserInputGeneration++;
       DiagnosticsLogService.instance.info(
         'terminal.clipboard',
         'text_input',
@@ -16281,13 +16290,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       );
       return false;
     }
-    final usedBracketedPaste = pasteMode.bracketedPasteMode;
-    final terminalSafePathCount = buildTerminalAttachmentPasteSegments(
+    final usedBracketedPaste = _effectiveTerminalBracketedPasteMode(pasteMode);
+    final segments = buildTerminalAttachmentPasteSegments(
       remotePaths,
-      bracketedPasteMode: true,
+      bracketedPasteMode: usedBracketedPaste,
       windows: windows,
-    ).length;
-    if (terminalSafePathCount == 0) {
+    );
+    if (segments.isEmpty) {
       DiagnosticsLogService.instance.warning(
         'terminal.clipboard',
         'attachment_input_skipped_unsafe_paths',
@@ -16295,11 +16304,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       );
       return false;
     }
-    final segments = buildTerminalAttachmentPasteSegments(
-      remotePaths,
-      bracketedPasteMode: usedBracketedPaste,
-      windows: windows,
-    );
     DiagnosticsLogService.instance.debug(
       'terminal.clipboard',
       'attachment_input',
@@ -16307,7 +16311,6 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         'connectionId': _connectionId,
         'pathCount': pathCount,
         'segmentCount': segments.length,
-        'skippedUnsafePathCount': pathCount - terminalSafePathCount,
         'bracketedPasteMode': pasteMode.bracketedPasteMode,
         'bracketedPasteModeKnown': pasteMode.bracketedPasteModeKnown,
         'modeReliable': modeReliable,
@@ -16382,6 +16385,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         return false;
       }
       pasteMode.terminal.onOutput?.call(segments[i]);
+      _terminalUserInputGeneration++;
       inputGeneration = _terminalUserInputGeneration;
       if (i < segments.length - 1) {
         await Future<void>.delayed(_uploadedAttachmentPasteStagger);
@@ -16510,12 +16514,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   Future<void> _pasteStoreDemoImage() async {
     final pasteCompleter = storeDemoImagePasteCompleter;
     try {
-      await _pasteClipboardImage(
+      final pathInserted = await _pasteClipboardImage(
         _storeDemoClipboardImageBytes,
         autoConfirmAfter: const Duration(milliseconds: 4200),
         showKeyboardAfterPaste: false,
         uploadBaseDirectory: _workingDirectoryPath,
       );
+      if (!pathInserted) {
+        throw StateError('Demo image path was not inserted into the terminal');
+      }
       if (!mounted) {
         return;
       }
@@ -16538,7 +16545,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
   }
 
-  Future<void> _pasteClipboardImage(
+  Future<bool> _pasteClipboardImage(
     Uint8List imageBytes, {
     bool confirm = true,
     Duration? autoConfirmAfter,
@@ -16556,7 +16563,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       );
       if (!shouldUpload) {
         _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
-        return;
+        return false;
       }
     }
 
@@ -16585,7 +16592,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       remotePath.path,
     ], windows: remotePath.windows);
     if (!mounted) {
-      return;
+      return false;
     }
     if (pathInserted) {
       unawaited(
@@ -16606,6 +16613,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           ? 'Uploaded clipboard image to ${remotePath.path}'
           : 'Uploaded clipboard image, but could not paste its path',
     );
+    return pathInserted;
   }
 
   Future<void> _pasteSelectedFiles(
@@ -16806,7 +16814,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
 
-    _followLiveOutput();
+    _handleTerminalUserInput();
     _terminal.paste(substitution.command);
     _terminalController.clearSelection();
     _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
@@ -16950,7 +16958,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
         return;
       }
-      _followLiveOutput();
+      _handleTerminalUserInput();
       // Insert the command into terminal
       _terminal.paste(result.command);
       // Track usage

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -342,6 +342,8 @@ typedef _TerminalPasteMode = ({
   Terminal terminal,
 });
 
+typedef _AttachmentPasteResult = ({int requestedCount, int sentCount});
+
 /// Resolves the retry schedule used for tmux detection after connect.
 @visibleForTesting
 List<Duration> resolveTmuxDetectionRetrySchedule({bool skipDelay = false}) =>
@@ -12812,6 +12814,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       deleteDetection: true,
       keyboardAppearance: keyboardAppearance,
       onUserInput: _handleTerminalUserInput,
+      onPasteText: _pasteClipboard,
       onReviewInsertedText: _confirmKeyboardInsertion,
       buildReviewTextForInsertedText: _terminalCommandAfterInputDelta,
       resolveTextBeforeCursor: _terminalTextBeforeCursor,
@@ -16247,7 +16250,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   /// attachment. The pre-built segments are written straight to the session
   /// input via [Terminal.onOutput]; they must not go through [Terminal.paste],
   /// which would strip the bracketed-paste markers.
-  Future<bool> _insertUploadedFileReferences(
+  Future<_AttachmentPasteResult> _insertUploadedFileReferences(
     List<String> remotePaths, {
     required bool windows,
   }) async {
@@ -16255,12 +16258,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     final pathCount = remotePaths
         .where((remotePath) => remotePath.isNotEmpty)
         .length;
+    _AttachmentPasteResult result(int sentCount) =>
+        (requestedCount: pathCount, sentCount: sentCount);
     if (pathCount == 0) {
-      return true;
+      return result(0);
     }
+    var sentCount = 0;
     final initialPasteMode = await _resolveSettledTerminalPasteMode();
     if (initialPasteMode == null || !mounted) {
-      return false;
+      return result(sentCount);
     }
     final pasteMode = initialPasteMode;
     if (!_terminalPasteModeOwnsCurrentContext(pasteMode)) {
@@ -16269,7 +16275,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         'attachment_input_skipped_context_changed',
         fields: {'connectionId': _connectionId, 'pathCount': pathCount},
       );
-      return false;
+      return result(sentCount);
     }
     if (!_terminalPasteModeTargetsCurrentWindow(pasteMode)) {
       _syncTerminalModesFromActiveMuxWindow();
@@ -16278,7 +16284,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         'attachment_input_skipped_window_changed',
         fields: {'connectionId': _connectionId, 'pathCount': pathCount},
       );
-      return false;
+      return result(sentCount);
     }
     final modeReliable = _terminalPasteModeIsReliable(pasteMode);
     final modeUsable = _terminalPasteModeCanUseResolvedState(pasteMode);
@@ -16288,13 +16294,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         'attachment_input_skipped_mode_unavailable',
         fields: {'connectionId': _connectionId, 'pathCount': pathCount},
       );
-      return false;
+      return result(sentCount);
     }
     final usedBracketedPaste = _effectiveTerminalBracketedPasteMode(pasteMode);
+    final sendablePathCount = countTerminalAttachmentPastePaths(remotePaths);
     final segments = buildTerminalAttachmentPasteSegments(
       remotePaths,
       bracketedPasteMode: usedBracketedPaste,
       windows: windows,
+      preferRawAgentPaths: _isAgentToolActive,
     );
     if (segments.isEmpty) {
       DiagnosticsLogService.instance.warning(
@@ -16302,7 +16310,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         'attachment_input_skipped_unsafe_paths',
         fields: {'connectionId': _connectionId, 'pathCount': pathCount},
       );
-      return false;
+      return result(sentCount);
     }
     DiagnosticsLogService.instance.debug(
       'terminal.clipboard',
@@ -16322,30 +16330,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
     for (var i = 0; i < segments.length; i++) {
       if (!mounted) {
-        return false;
-      }
-      if (i > 0) {
-        _syncTerminalModesFromActiveMuxWindow();
-        final activeWindowBracketedPasteMode =
-            resolveTmuxBarActiveWindowBracketedPasteMode(
-              _currentTmuxWindowsSnapshot,
-            );
-        final modeChanged = pasteMode.isMuxActive
-            ? activeWindowBracketedPasteMode != null &&
-                  activeWindowBracketedPasteMode != usedBracketedPaste
-            : pasteMode.terminal.bracketedPasteMode != usedBracketedPaste;
-        if (modeChanged) {
-          DiagnosticsLogService.instance.warning(
-            'terminal.clipboard',
-            'attachment_input_stopped_mode_changed',
-            fields: {
-              'connectionId': _connectionId,
-              'pathCount': pathCount,
-              'sentCount': i,
-            },
-          );
-          return false;
-        }
+        return result(sentCount);
       }
       if (!_terminalPasteModeOwnsCurrentContext(pasteMode)) {
         DiagnosticsLogService.instance.warning(
@@ -16357,7 +16342,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             'sentCount': i,
           },
         );
-        return false;
+        return result(sentCount);
       }
       if (!_terminalPasteModeTargetsCurrentWindow(pasteMode)) {
         _syncTerminalModesFromActiveMuxWindow();
@@ -16370,7 +16355,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             'sentCount': i,
           },
         );
-        return false;
+        return result(sentCount);
       }
       if (_terminalUserInputGeneration != inputGeneration) {
         DiagnosticsLogService.instance.warning(
@@ -16382,16 +16367,17 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             'sentCount': i,
           },
         );
-        return false;
+        return result(sentCount);
       }
       pasteMode.terminal.onOutput?.call(segments[i]);
       _terminalUserInputGeneration++;
       inputGeneration = _terminalUserInputGeneration;
+      sentCount = usedBracketedPaste ? sentCount + 1 : sendablePathCount;
       if (i < segments.length - 1) {
         await Future<void>.delayed(_uploadedAttachmentPasteStagger);
       }
     }
-    return true;
+    return result(sentCount);
   }
 
   Future<void> _pasteClipboardFiles(List<String> clipboardFiles) async {
@@ -16472,14 +16458,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     });
 
     _followLiveOutput();
-    final pathsInserted = await _insertUploadedFileReferences(
+    final pasteResult = await _insertUploadedFileReferences(
       remotePaths.paths,
       windows: remotePaths.windows,
     );
     if (!mounted) {
       return;
     }
-    if (pathsInserted) {
+    if (pasteResult.sentCount > 0) {
       unawaited(
         ref
             .read(telemetryServiceProvider)
@@ -16491,9 +16477,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
     _terminalController.clearSelection();
     _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+    final pathsInserted = pasteResult.sentCount == pasteResult.requestedCount;
     _showClipboardMessage(
       pathsInserted
           ? 'Uploaded ${remotePaths.paths.length} file${remotePaths.paths.length == 1 ? '' : 's'} to $_clipboardUploadDirectoryDisplay'
+          : pasteResult.sentCount > 0
+          ? 'Uploaded ${remotePaths.paths.length} files and pasted ${pasteResult.sentCount} of ${pasteResult.requestedCount} paths'
           : 'Uploaded ${remotePaths.paths.length} file${remotePaths.paths.length == 1 ? '' : 's'}, but could not paste ${remotePaths.paths.length == 1 ? 'its path' : 'their paths'}',
     );
   }
@@ -16588,12 +16577,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       );
     }, uploadBaseDirectory: uploadBaseDirectory);
     _followLiveOutput();
-    final pathInserted = await _insertUploadedFileReferences([
+    final pasteResult = await _insertUploadedFileReferences([
       remotePath.path,
     ], windows: remotePath.windows);
     if (!mounted) {
       return false;
     }
+    final pathInserted = pasteResult.sentCount == 1;
     if (pathInserted) {
       unawaited(
         ref
@@ -16690,14 +16680,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     });
 
     _followLiveOutput();
-    final pathsInserted = await _insertUploadedFileReferences(
+    final pasteResult = await _insertUploadedFileReferences(
       remotePaths.paths,
       windows: remotePaths.windows,
     );
     if (!mounted) {
       return;
     }
-    if (pathsInserted) {
+    if (pasteResult.sentCount > 0) {
       unawaited(
         ref
             .read(telemetryServiceProvider)
@@ -16706,9 +16696,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
     _terminalController.clearSelection();
     _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+    final pathsInserted = pasteResult.sentCount == pasteResult.requestedCount;
     _showClipboardMessage(
       pathsInserted
           ? 'Uploaded ${selectedFiles.length == 1 ? 'selected $itemLabelSingular' : '${remotePaths.paths.length} $itemLabelPlural'} to $_clipboardUploadDirectoryDisplay'
+          : pasteResult.sentCount > 0
+          ? 'Uploaded ${remotePaths.paths.length} $itemLabelPlural and pasted ${pasteResult.sentCount} of ${pasteResult.requestedCount} paths'
           : 'Uploaded ${selectedFiles.length == 1 ? 'selected $itemLabelSingular' : '${remotePaths.paths.length} $itemLabelPlural'}, but could not paste ${remotePaths.paths.length == 1 ? 'its path' : 'their paths'}',
     );
   }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -957,6 +957,20 @@ void pasteTerminalTextWithBracketedPasteMode({
   }
 }
 
+/// Whether paste-mode settling should request another mux snapshot.
+@visibleForTesting
+bool shouldRetryTerminalPasteModeSettle({
+  required bool refreshAttempted,
+  required bool refreshSucceeded,
+  required bool modeReliable,
+  required bool targetsCurrentWindow,
+}) {
+  if (refreshAttempted && !refreshSucceeded) {
+    return false;
+  }
+  return !modeReliable || !targetsCurrentWindow;
+}
+
 int? _compareMonkeyMuxVersions(String? left, String? right) {
   final leftVersion = _parseMonkeyMuxVersion(left);
   final rightVersion = _parseMonkeyMuxVersion(right);
@@ -5262,8 +5276,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           !_terminalPasteModeOwnsCurrentContext(pasteMode)) {
         return pasteMode;
       }
-      if (_terminalPasteModeIsReliable(pasteMode) &&
-          _terminalPasteModeTargetsCurrentWindow(pasteMode)) {
+      final modeReliable = _terminalPasteModeIsReliable(pasteMode);
+      final targetsCurrentWindow = _terminalPasteModeTargetsCurrentWindow(
+        pasteMode,
+      );
+      if (!shouldRetryTerminalPasteModeSettle(
+        refreshAttempted: pasteMode.refreshAttempted,
+        refreshSucceeded: pasteMode.refreshSucceeded,
+        modeReliable: modeReliable,
+        targetsCurrentWindow: targetsCurrentWindow,
+      )) {
         return pasteMode;
       }
       if (attempt < _terminalPasteModeSettleAttempts - 1) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -328,9 +328,10 @@ class _ClipboardUploadTarget {
       remoteShellPathForSftpPath(sftpPath, windows: windows);
 }
 
-typedef _UploadedAttachmentPasteMode = ({
+typedef _TerminalPasteMode = ({
   String? activeWindowKey,
   bool bracketedPasteMode,
+  bool bracketedPasteModeKnown,
   int? connectionId,
   bool isMuxActive,
   RemoteMuxBackend muxBackend,
@@ -915,21 +916,45 @@ bool inheritTerminalBracketedPasteModeFromMuxWindow({
 
 /// Refreshes [terminal] from the active window in a fresh mux snapshot.
 @visibleForTesting
-Future<({bool bracketedPasteMode, String? activeWindowKey})>
+Future<
+  ({
+    bool bracketedPasteMode,
+    bool bracketedPasteModeKnown,
+    String? activeWindowKey,
+  })
+>
 refreshTerminalBracketedPasteModeFromMuxWindows({
   required Terminal terminal,
   required Future<Iterable<TmuxWindow>> Function() loadWindows,
 }) async {
   final windows = await loadWindows();
+  final activeWindowBracketedPasteMode =
+      resolveTmuxBarActiveWindowBracketedPasteMode(windows);
   inheritTerminalBracketedPasteModeFromMuxWindow(
     terminal: terminal,
-    activeWindowBracketedPasteMode:
-        resolveTmuxBarActiveWindowBracketedPasteMode(windows),
+    activeWindowBracketedPasteMode: activeWindowBracketedPasteMode,
   );
   return (
     bracketedPasteMode: terminal.bracketedPasteMode,
+    bracketedPasteModeKnown: activeWindowBracketedPasteMode != null,
     activeWindowKey: resolveTmuxBarActiveWindowKey(windows),
   );
+}
+
+/// Pastes [text] using an explicitly resolved bracketed-paste mode.
+@visibleForTesting
+void pasteTerminalTextWithBracketedPasteMode({
+  required Terminal terminal,
+  required String text,
+  required bool bracketedPasteMode,
+}) {
+  final previousBracketedPasteMode = terminal.bracketedPasteMode;
+  terminal.setBracketedPasteMode(bracketedPasteMode);
+  try {
+    terminal.paste(text);
+  } finally {
+    terminal.setBracketedPasteMode(previousBracketedPasteMode);
+  }
 }
 
 int? _compareMonkeyMuxVersions(String? left, String? right) {
@@ -5087,14 +5112,20 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
   }
 
-  Future<_UploadedAttachmentPasteMode?>
-  _resolveUploadedAttachmentPasteMode() async {
+  static const _terminalPasteModeSettleAttempts = 3;
+  static const _terminalPasteModeSettleDelay = Duration(milliseconds: 75);
+
+  Future<_TerminalPasteMode?> _resolveTerminalPasteMode() async {
     _syncTerminalModesFromActiveMuxWindow();
     final terminal = _terminal;
     final connectionId = _connectionId;
     final muxBackend = _activeMuxBackend;
     final activeSession = _activeSession();
     final isMuxActive = _isTmuxActive && _tmuxStateConnectionId == connectionId;
+    final currentActiveWindowBracketedPasteMode =
+        resolveTmuxBarActiveWindowBracketedPasteMode(
+          _currentTmuxWindowsSnapshot,
+        );
     final currentActiveWindowKey = isMuxActive
         ? resolveTmuxBarActiveWindowKey(_currentTmuxWindowsSnapshot)
         : null;
@@ -5103,6 +5134,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return (
         activeWindowKey: currentActiveWindowKey,
         bracketedPasteMode: terminal.bracketedPasteMode,
+        bracketedPasteModeKnown: true,
         connectionId: connectionId,
         isMuxActive: isMuxActive,
         muxBackend: muxBackend,
@@ -5124,6 +5156,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _currentTmuxWindowsSnapshot,
         ),
         bracketedPasteMode: terminal.bracketedPasteMode,
+        bracketedPasteModeKnown: currentActiveWindowBracketedPasteMode != null,
         connectionId: connectionId,
         isMuxActive: isMuxActive,
         muxBackend: muxBackend,
@@ -5166,6 +5199,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return (
         activeWindowKey: refreshedMode.activeWindowKey,
         bracketedPasteMode: refreshedMode.bracketedPasteMode,
+        bracketedPasteModeKnown: refreshedMode.bracketedPasteModeKnown,
         connectionId: connectionId,
         isMuxActive: isMuxActive,
         muxBackend: muxBackend,
@@ -5176,13 +5210,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         terminal: terminal,
       );
     } on TimeoutException catch (error) {
-      _logAttachmentPasteModeRefreshFailure(session, error);
+      _logTerminalPasteModeRefreshFailure(session, error);
     } on MonkeyMuxInstallException catch (error) {
-      _logAttachmentPasteModeRefreshFailure(session, error);
+      _logTerminalPasteModeRefreshFailure(session, error);
     } on SSHError catch (error) {
-      _logAttachmentPasteModeRefreshFailure(session, error);
+      _logTerminalPasteModeRefreshFailure(session, error);
     } on IOException catch (error) {
-      _logAttachmentPasteModeRefreshFailure(session, error);
+      _logTerminalPasteModeRefreshFailure(session, error);
     }
 
     if (!stillOwnsTerminalContext()) {
@@ -5193,6 +5227,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         _currentTmuxWindowsSnapshot,
       ),
       bracketedPasteMode: terminal.bracketedPasteMode,
+      bracketedPasteModeKnown: currentActiveWindowBracketedPasteMode != null,
       connectionId: connectionId,
       isMuxActive: isMuxActive,
       muxBackend: muxBackend,
@@ -5204,9 +5239,41 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
   }
 
-  bool _uploadedAttachmentPasteModeOwnsCurrentTerminalContext(
-    _UploadedAttachmentPasteMode pasteMode,
-  ) {
+  bool _terminalPasteModeIsReliable(_TerminalPasteMode pasteMode) {
+    if (!pasteMode.isMuxActive ||
+        pasteMode.muxBackend != RemoteMuxBackend.monkeyMux) {
+      return true;
+    }
+    return pasteMode.refreshSucceeded &&
+        pasteMode.bracketedPasteModeKnown &&
+        pasteMode.activeWindowKey != null;
+  }
+
+  Future<_TerminalPasteMode?> _resolveSettledTerminalPasteMode() async {
+    _TerminalPasteMode? pasteMode;
+    for (
+      var attempt = 0;
+      attempt < _terminalPasteModeSettleAttempts;
+      attempt++
+    ) {
+      pasteMode = await _resolveTerminalPasteMode();
+      if (pasteMode == null ||
+          !mounted ||
+          !_terminalPasteModeOwnsCurrentContext(pasteMode)) {
+        return pasteMode;
+      }
+      if (_terminalPasteModeIsReliable(pasteMode) &&
+          _terminalPasteModeTargetsCurrentWindow(pasteMode)) {
+        return pasteMode;
+      }
+      if (attempt < _terminalPasteModeSettleAttempts - 1) {
+        await Future<void>.delayed(_terminalPasteModeSettleDelay);
+      }
+    }
+    return pasteMode;
+  }
+
+  bool _terminalPasteModeOwnsCurrentContext(_TerminalPasteMode pasteMode) {
     if (!mounted ||
         _connectionId != pasteMode.connectionId ||
         !identical(_activeSession(), pasteMode.session) ||
@@ -5230,9 +5297,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         : _tmuxSessionName == pasteMode.muxSessionName;
   }
 
-  bool _sameUploadedAttachmentTerminalContext(
-    _UploadedAttachmentPasteMode previous,
-    _UploadedAttachmentPasteMode next,
+  bool _sameTerminalPasteContext(
+    _TerminalPasteMode previous,
+    _TerminalPasteMode next,
   ) =>
       previous.connectionId == next.connectionId &&
       identical(previous.session, next.session) &&
@@ -5241,9 +5308,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       previous.muxBackend == next.muxBackend &&
       previous.muxSessionName == next.muxSessionName;
 
-  bool _uploadedAttachmentPasteModeTargetsCurrentWindow(
-    _UploadedAttachmentPasteMode pasteMode,
-  ) {
+  bool _terminalPasteModeTargetsCurrentWindow(_TerminalPasteMode pasteMode) {
     final activeWindowKey = pasteMode.activeWindowKey;
     if (!pasteMode.isMuxActive) {
       return true;
@@ -5258,10 +5323,10 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     );
   }
 
-  void _logAttachmentPasteModeRefreshFailure(SshSession session, Object error) {
+  void _logTerminalPasteModeRefreshFailure(SshSession session, Object error) {
     DiagnosticsLogService.instance.warning(
       'terminal.clipboard',
-      'attachment_mode_refresh_failed',
+      'mode_refresh_failed',
       fields: {
         'connectionId': session.connectionId,
         'errorType': error.runtimeType,
@@ -12581,7 +12646,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       touchScrollToTerminal: routeTouchScrollToTerminal,
       forceSgrTouchScroll: _forceSgrTouchScroll,
       onInsertText: isMobile ? null : _confirmDesktopInsertedText,
-      onPasteText: isMobile ? null : _pasteClipboard,
+      onPasteText: _pasteClipboard,
       onTapDown: (_, _) => _claimActiveMonkeyMuxClientFocus(),
     );
 
@@ -15575,14 +15640,46 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         return;
       }
 
+      final initialPasteMode = await _resolveSettledTerminalPasteMode();
+      if (initialPasteMode == null || !mounted) {
+        if (mounted) {
+          _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+        }
+        return;
+      }
+      var pasteMode = initialPasteMode;
+      if (!_terminalPasteModeOwnsCurrentContext(pasteMode)) {
+        DiagnosticsLogService.instance.warning(
+          'terminal.clipboard',
+          'text_input_skipped_context_changed',
+          fields: {'connectionId': _connectionId},
+        );
+        _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+        return;
+      }
+      if (!_terminalPasteModeTargetsCurrentWindow(pasteMode)) {
+        _syncTerminalModesFromActiveMuxWindow();
+        DiagnosticsLogService.instance.warning(
+          'terminal.clipboard',
+          'text_input_skipped_window_changed',
+          fields: {'connectionId': _connectionId},
+        );
+        _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+        return;
+      }
+
       final requiredReview = _shouldReviewTerminalCommandInsertion;
-      final shouldPaste =
-          !requiredReview ||
-          await _confirmTerminalInsertionIfNeeded(
+      var reviewedBracketedPasteMode =
+          _terminalPasteModeIsReliable(pasteMode) &&
+          pasteMode.bracketedPasteMode;
+      if (requiredReview) {
+        var modeStableAfterReview = false;
+        for (var reviewAttempt = 0; reviewAttempt < 2; reviewAttempt++) {
+          final shouldPaste = await _confirmTerminalInsertionIfNeeded(
             insertedText: text,
             buildReview: (commandText) => assessClipboardPasteCommand(
               commandText,
-              bracketedPasteModeEnabled: _terminal.bracketedPasteMode,
+              bracketedPasteModeEnabled: reviewedBracketedPasteMode,
             ),
             title: 'Review clipboard paste',
             messageBuilder: (review) => review.bracketedPasteModeEnabled
@@ -15590,13 +15687,89 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
                 : 'This clipboard content could execute multiple or reshaped commands.',
             confirmLabel: 'Paste anyway',
           );
-      if (!shouldPaste) {
+          if (!shouldPaste) {
+            _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+            return;
+          }
+
+          final refreshedPasteMode = await _resolveSettledTerminalPasteMode();
+          if (refreshedPasteMode == null || !mounted) {
+            if (mounted) {
+              _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+            }
+            return;
+          }
+          if (!_sameTerminalPasteContext(pasteMode, refreshedPasteMode) ||
+              !_terminalPasteModeOwnsCurrentContext(refreshedPasteMode)) {
+            DiagnosticsLogService.instance.warning(
+              'terminal.clipboard',
+              'text_input_skipped_context_changed',
+              fields: {'connectionId': _connectionId},
+            );
+            _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+            return;
+          }
+          pasteMode = refreshedPasteMode;
+          final refreshedBracketedPasteMode =
+              _terminalPasteModeIsReliable(pasteMode) &&
+              pasteMode.bracketedPasteMode;
+          if (refreshedBracketedPasteMode == reviewedBracketedPasteMode) {
+            modeStableAfterReview = true;
+            break;
+          }
+          reviewedBracketedPasteMode = refreshedBracketedPasteMode;
+        }
+        if (!modeStableAfterReview) {
+          DiagnosticsLogService.instance.warning(
+            'terminal.clipboard',
+            'text_input_skipped_mode_changed',
+            fields: {'connectionId': _connectionId},
+          );
+          _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+          return;
+        }
+      }
+      if (!_terminalPasteModeOwnsCurrentContext(pasteMode)) {
+        DiagnosticsLogService.instance.warning(
+          'terminal.clipboard',
+          'text_input_skipped_context_changed',
+          fields: {'connectionId': _connectionId},
+        );
+        _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
+        return;
+      }
+      if (!_terminalPasteModeTargetsCurrentWindow(pasteMode)) {
+        _syncTerminalModesFromActiveMuxWindow();
+        DiagnosticsLogService.instance.warning(
+          'terminal.clipboard',
+          'text_input_skipped_window_changed',
+          fields: {'connectionId': _connectionId},
+        );
         _restoreTerminalFocus(showSystemKeyboard: _isMobilePlatform);
         return;
       }
 
+      final modeReliable = _terminalPasteModeIsReliable(pasteMode);
+      final usedBracketedPaste = modeReliable && pasteMode.bracketedPasteMode;
       _followLiveOutput();
-      _terminal.paste(text);
+      pasteTerminalTextWithBracketedPasteMode(
+        terminal: pasteMode.terminal,
+        text: text,
+        bracketedPasteMode: usedBracketedPaste,
+      );
+      DiagnosticsLogService.instance.info(
+        'terminal.clipboard',
+        'text_input',
+        fields: {
+          'connectionId': pasteMode.connectionId,
+          'bracketedPasteMode': pasteMode.bracketedPasteMode,
+          'bracketedPasteModeKnown': pasteMode.bracketedPasteModeKnown,
+          'modeReliable': modeReliable,
+          'usedBracketedPaste': usedBracketedPaste,
+          'modeRefreshAttempted': pasteMode.refreshAttempted,
+          'modeRefreshSucceeded': pasteMode.refreshSucceeded,
+        },
+      );
       unawaited(
         ref
             .read(telemetryServiceProvider)
@@ -15990,11 +16163,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     if (pathCount == 0) {
       return;
     }
-    var pasteMode = await _resolveUploadedAttachmentPasteMode();
-    if (pasteMode == null || !mounted) {
+    final initialPasteMode = await _resolveSettledTerminalPasteMode();
+    if (initialPasteMode == null || !mounted) {
       return;
     }
-    if (!_uploadedAttachmentPasteModeOwnsCurrentTerminalContext(pasteMode)) {
+    var pasteMode = initialPasteMode;
+    if (!_terminalPasteModeOwnsCurrentContext(pasteMode)) {
       DiagnosticsLogService.instance.warning(
         'terminal.clipboard',
         'attachment_input_skipped_context_changed',
@@ -16002,43 +16176,34 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       );
       return;
     }
-    if (!_uploadedAttachmentPasteModeTargetsCurrentWindow(pasteMode)) {
-      final refreshedPasteMode = await _resolveUploadedAttachmentPasteMode();
-      if (refreshedPasteMode == null || !mounted) {
-        return;
-      }
-      if (!_sameUploadedAttachmentTerminalContext(
-            pasteMode,
-            refreshedPasteMode,
-          ) ||
-          !_uploadedAttachmentPasteModeOwnsCurrentTerminalContext(
-            refreshedPasteMode,
-          )) {
-        DiagnosticsLogService.instance.warning(
-          'terminal.clipboard',
-          'attachment_input_skipped_context_changed',
-          fields: {'connectionId': _connectionId, 'pathCount': pathCount},
-        );
-        return;
-      }
-      pasteMode = refreshedPasteMode;
-      if (!_uploadedAttachmentPasteModeTargetsCurrentWindow(pasteMode)) {
-        _syncTerminalModesFromActiveMuxWindow();
-        DiagnosticsLogService.instance.warning(
-          'terminal.clipboard',
-          'attachment_input_skipped_window_changed',
-          fields: {'connectionId': _connectionId, 'pathCount': pathCount},
-        );
-        return;
-      }
+    if (!_terminalPasteModeTargetsCurrentWindow(pasteMode)) {
+      _syncTerminalModesFromActiveMuxWindow();
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'attachment_input_skipped_window_changed',
+        fields: {'connectionId': _connectionId, 'pathCount': pathCount},
+      );
+      return;
+    }
+    final modeReliable = _terminalPasteModeIsReliable(pasteMode);
+    final usedBracketedPaste = modeReliable && pasteMode.bracketedPasteMode;
+    final terminalSafePathCount = buildTerminalAttachmentPasteSegments(
+      remotePaths,
+      bracketedPasteMode: true,
+      windows: windows,
+    ).length;
+    if (terminalSafePathCount == 0) {
+      DiagnosticsLogService.instance.warning(
+        'terminal.clipboard',
+        'attachment_input_skipped_unsafe_paths',
+        fields: {'connectionId': _connectionId, 'pathCount': pathCount},
+      );
+      return;
     }
     final segments = buildTerminalAttachmentPasteSegments(
       remotePaths,
-      bracketedPasteMode: pasteMode.bracketedPasteMode,
+      bracketedPasteMode: usedBracketedPaste,
       windows: windows,
-    );
-    final usedBracketedPaste = segments.any(
-      (segment) => segment.startsWith('\x1b[200~'),
     );
     DiagnosticsLogService.instance.debug(
       'terminal.clipboard',
@@ -16046,7 +16211,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       fields: {
         'connectionId': _connectionId,
         'pathCount': pathCount,
+        'segmentCount': segments.length,
+        'skippedUnsafePathCount': pathCount - terminalSafePathCount,
         'bracketedPasteMode': pasteMode.bracketedPasteMode,
+        'bracketedPasteModeKnown': pasteMode.bracketedPasteModeKnown,
+        'modeReliable': modeReliable,
         'usedBracketedPaste': usedBracketedPaste,
         'modeRefreshAttempted': pasteMode.refreshAttempted,
         'modeRefreshSucceeded': pasteMode.refreshSucceeded,
@@ -16056,7 +16225,31 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       if (!mounted) {
         return;
       }
-      if (!_uploadedAttachmentPasteModeOwnsCurrentTerminalContext(pasteMode)) {
+      if (i > 0) {
+        final currentPasteMode = await _resolveSettledTerminalPasteMode();
+        if (currentPasteMode == null || !mounted) {
+          return;
+        }
+        final currentUsedBracketedPaste =
+            _terminalPasteModeIsReliable(currentPasteMode) &&
+            currentPasteMode.bracketedPasteMode;
+        if (!_sameTerminalPasteContext(pasteMode, currentPasteMode) ||
+            currentPasteMode.activeWindowKey != pasteMode.activeWindowKey ||
+            currentUsedBracketedPaste != usedBracketedPaste) {
+          DiagnosticsLogService.instance.warning(
+            'terminal.clipboard',
+            'attachment_input_stopped_mode_changed',
+            fields: {
+              'connectionId': _connectionId,
+              'pathCount': pathCount,
+              'sentCount': i,
+            },
+          );
+          return;
+        }
+        pasteMode = currentPasteMode;
+      }
+      if (!_terminalPasteModeOwnsCurrentContext(pasteMode)) {
         DiagnosticsLogService.instance.warning(
           'terminal.clipboard',
           'attachment_input_stopped_context_changed',
@@ -16068,7 +16261,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         );
         return;
       }
-      if (!_uploadedAttachmentPasteModeTargetsCurrentWindow(pasteMode)) {
+      if (!_terminalPasteModeTargetsCurrentWindow(pasteMode)) {
         _syncTerminalModesFromActiveMuxWindow();
         DiagnosticsLogService.instance.warning(
           'terminal.clipboard',
@@ -16081,7 +16274,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         );
         return;
       }
-      _terminal.onOutput?.call(segments[i]);
+      pasteMode.terminal.onOutput?.call(segments[i]);
       if (i < segments.length - 1) {
         await Future<void>.delayed(_uploadedAttachmentPasteStagger);
       }

--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -592,6 +592,7 @@ class MonkeyTerminalView extends StatefulWidget {
     this.onSystemSelectionChanged,
     this.onInsertText,
     this.onPasteText,
+    this.onUserInput,
     this.inlineUnderlines = const <TerminalTextUnderline>[],
   });
 
@@ -752,6 +753,9 @@ class MonkeyTerminalView extends StatefulWidget {
 
   /// Called to handle paste shortcuts before xterm pastes clipboard text.
   final Future<void> Function()? onPasteText;
+
+  /// Called immediately before accepted user input is sent to the terminal.
+  final VoidCallback? onUserInput;
 
   /// Cell ranges that should be painted with inline text underlines.
   final List<TerminalTextUnderline> inlineUnderlines;
@@ -1600,6 +1604,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
     }
 
     final key = charToTerminalKey(text.trim());
+    widget.onUserInput?.call();
 
     // On mobile platforms there is no guarantee that virtual keyboard will
     // generate hardware key events. So we need first try to send the key
@@ -1667,6 +1672,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
           );
 
     if (handled) {
+      widget.onUserInput?.call();
       _scrollToBottom();
     }
 
@@ -1697,12 +1703,14 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
 
   void _onDelete() {
     _scrollToBottom();
+    widget.onUserInput?.call();
     widget.terminal.keyInput(TerminalKey.backspace);
   }
 
   void _onTextInputAction(TextInputAction action) {
     _scrollToBottom();
     if (action == TextInputAction.done) {
+      widget.onUserInput?.call();
       widget.terminal.keyInput(TerminalKey.enter);
     }
   }

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -208,6 +208,7 @@ class TerminalTextInputHandler extends StatefulWidget {
     this.deleteDetection = false,
     this.keyboardAppearance = Brightness.dark,
     this.onUserInput,
+    this.onPasteText,
     this.onReviewInsertedText,
     this.buildReviewTextForInsertedText,
     this.resolveTextBeforeCursor,
@@ -243,6 +244,9 @@ class TerminalTextInputHandler extends StatefulWidget {
 
   /// Called when user input has been accepted for sending to the terminal.
   final VoidCallback? onUserInput;
+
+  /// Handles hardware-keyboard paste shortcuts before they reach the terminal.
+  final FutureOr<void> Function()? onPasteText;
 
   /// Called before suspicious multi-character IME insertions are sent.
   final TerminalTextInputReviewCallback? onReviewInsertedText;
@@ -892,10 +896,24 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       return KeyEventResult.ignored;
     }
 
+    final hardwareKeyboard = HardwareKeyboard.instance;
+    final isPasteShortcut =
+        widget.onPasteText != null &&
+        event.logicalKey == LogicalKeyboardKey.keyV &&
+        !hardwareKeyboard.isAltPressed &&
+        (hardwareKeyboard.isControlPressed || hardwareKeyboard.isMetaPressed);
+    if (isPasteShortcut) {
+      _stopHardwareKeyRepeat();
+      if (event is KeyDownEvent) {
+        unawaited(Future<void>.sync(widget.onPasteText!));
+      }
+      return KeyEventResult.handled;
+    }
+
     final hasShortcutModifier =
-        HardwareKeyboard.instance.isControlPressed ||
-        HardwareKeyboard.instance.isAltPressed ||
-        HardwareKeyboard.instance.isMetaPressed;
+        hardwareKeyboard.isControlPressed ||
+        hardwareKeyboard.isAltPressed ||
+        hardwareKeyboard.isMetaPressed;
     if (!_currentEditingState.composing.isCollapsed && !hasShortcutModifier) {
       return KeyEventResult.skipRemainingHandlers;
     }

--- a/test/domain/services/remote_file_service_test.dart
+++ b/test/domain/services/remote_file_service_test.dart
@@ -240,13 +240,11 @@ void main() {
           bracketedPasteMode: true,
           windows: true,
         ),
-        [
-          '$start${r'"C:\Users\John Smith\.cache\monkeyssh\uploads\a.png"'}$end ',
-        ],
+        ['$start${r'C:\Users\John Smith\.cache\monkeyssh\uploads\a.png'}$end '],
       );
     });
 
-    test('keeps unsafe printable paths inside separate bracketed pastes', () {
+    test('keeps printable paths raw inside separate bracketed pastes', () {
       const start = '\x1b[200~';
       const end = '\x1b[201~';
       expect(
@@ -255,7 +253,7 @@ void main() {
           '/home/u/.cache/monkeyssh/uploads/b.png',
         ], bracketedPasteMode: true),
         [
-          "$start'/home/john smith/.cache/monkeyssh/uploads/a.png'$end ",
+          '$start/home/john smith/.cache/monkeyssh/uploads/a.png$end ',
           '$start/home/u/.cache/monkeyssh/uploads/b.png$end ',
         ],
       );
@@ -263,7 +261,7 @@ void main() {
         buildTerminalAttachmentPasteSegments([
           r'/home/u/$(reboot)/a.png',
         ], bracketedPasteMode: true),
-        ["$start'/home/u/\$(reboot)/a.png'$end "],
+        isEmpty,
       );
     });
 

--- a/test/domain/services/remote_file_service_test.dart
+++ b/test/domain/services/remote_file_service_test.dart
@@ -240,11 +240,22 @@ void main() {
           bracketedPasteMode: true,
           windows: true,
         ),
+        [
+          '$start${r'"C:\Users\John Smith\.cache\monkeyssh\uploads\a.png"'}$end ',
+        ],
+      );
+      expect(
+        buildTerminalAttachmentPasteSegments(
+          [r'C:\Users\John Smith\.cache\monkeyssh\uploads\a.png'],
+          bracketedPasteMode: true,
+          windows: true,
+          preferRawAgentPaths: true,
+        ),
         ['$start${r'C:\Users\John Smith\.cache\monkeyssh\uploads\a.png'}$end '],
       );
     });
 
-    test('keeps printable paths raw inside separate bracketed pastes', () {
+    test('keeps agent paths raw and shell paths escaped when needed', () {
       const start = '\x1b[200~';
       const end = '\x1b[201~';
       expect(
@@ -253,15 +264,23 @@ void main() {
           '/home/u/.cache/monkeyssh/uploads/b.png',
         ], bracketedPasteMode: true),
         [
-          '$start/home/john smith/.cache/monkeyssh/uploads/a.png$end ',
+          "$start'/home/john smith/.cache/monkeyssh/uploads/a.png'$end ",
           '$start/home/u/.cache/monkeyssh/uploads/b.png$end ',
         ],
+      );
+      expect(
+        buildTerminalAttachmentPasteSegments(
+          ['/home/john smith/.cache/monkeyssh/uploads/a.png'],
+          bracketedPasteMode: true,
+          preferRawAgentPaths: true,
+        ),
+        ['$start/home/john smith/.cache/monkeyssh/uploads/a.png$end '],
       );
       expect(
         buildTerminalAttachmentPasteSegments([
           r'/home/u/$(reboot)/a.png',
         ], bracketedPasteMode: true),
-        isEmpty,
+        ["$start'/home/u/\$(reboot)/a.png'$end "],
       );
     });
 

--- a/test/domain/services/remote_file_service_test.dart
+++ b/test/domain/services/remote_file_service_test.dart
@@ -240,25 +240,41 @@ void main() {
           bracketedPasteMode: true,
           windows: true,
         ),
-        [r'"C:\Users\John Smith\.cache\monkeyssh\uploads\a.png" '],
+        [
+          '$start${r'"C:\Users\John Smith\.cache\monkeyssh\uploads\a.png"'}$end ',
+        ],
       );
     });
 
-    test('falls back to shell-escaping when a path is not unquoted-safe', () {
-      // A remote home directory with a space (or shell metacharacters) must not
-      // be pasted raw: it would split/inject in a shell. Such a path would not
-      // produce a preview chip anyway, so a safe shell-escaped segment is used.
+    test('keeps unsafe printable paths inside separate bracketed pastes', () {
+      const start = '\x1b[200~';
+      const end = '\x1b[201~';
       expect(
         buildTerminalAttachmentPasteSegments([
           '/home/john smith/.cache/monkeyssh/uploads/a.png',
+          '/home/u/.cache/monkeyssh/uploads/b.png',
         ], bracketedPasteMode: true),
-        ["'/home/john smith/.cache/monkeyssh/uploads/a.png' "],
+        [
+          "$start'/home/john smith/.cache/monkeyssh/uploads/a.png'$end ",
+          '$start/home/u/.cache/monkeyssh/uploads/b.png$end ',
+        ],
       );
       expect(
         buildTerminalAttachmentPasteSegments([
           r'/home/u/$(reboot)/a.png',
         ], bracketedPasteMode: true),
-        [r"'/home/u/$(reboot)/a.png' "],
+        ["$start'/home/u/\$(reboot)/a.png'$end "],
+      );
+    });
+
+    test('omits paths containing terminal control characters', () {
+      expect(
+        buildTerminalAttachmentPasteSegments([
+          '/tmp/safe.png',
+          '/tmp/bad\x1b[201~\n.png',
+          '/tmp/c1\u009b201~.png',
+        ], bracketedPasteMode: true),
+        const ['\x1b[200~/tmp/safe.png\x1b[201~ '],
       );
     });
 

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -615,6 +615,7 @@ void main() {
         shouldRetryTerminalPasteModeSettle(
           refreshAttempted: true,
           refreshSucceeded: false,
+          hasActiveWindow: true,
           modeReliable: false,
           targetsCurrentWindow: false,
         ),
@@ -622,11 +623,22 @@ void main() {
       );
     });
 
-    test('retries successful snapshots until mode and window settle', () {
+    test('only retries successful snapshots for window settling', () {
       expect(
         shouldRetryTerminalPasteModeSettle(
           refreshAttempted: true,
           refreshSucceeded: true,
+          hasActiveWindow: true,
+          modeReliable: false,
+          targetsCurrentWindow: true,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldRetryTerminalPasteModeSettle(
+          refreshAttempted: true,
+          refreshSucceeded: true,
+          hasActiveWindow: false,
           modeReliable: false,
           targetsCurrentWindow: true,
         ),
@@ -636,6 +648,7 @@ void main() {
         shouldRetryTerminalPasteModeSettle(
           refreshAttempted: true,
           refreshSucceeded: true,
+          hasActiveWindow: true,
           modeReliable: true,
           targetsCurrentWindow: false,
         ),
@@ -645,6 +658,7 @@ void main() {
         shouldRetryTerminalPasteModeSettle(
           refreshAttempted: true,
           refreshSucceeded: true,
+          hasActiveWindow: true,
           modeReliable: true,
           targetsCurrentWindow: true,
         ),

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -464,33 +464,40 @@ void main() {
   });
 
   group('refreshTerminalBracketedPasteModeFromMuxWindows', () {
-    test(
-      'refreshes a stale disabled mode before attachment insertion',
-      () async {
-        final terminal = Terminal();
-        final windows = Completer<Iterable<TmuxWindow>>();
-        final refresh = refreshTerminalBracketedPasteModeFromMuxWindows(
-          terminal: terminal,
-          loadWindows: () => windows.future,
-        );
+    test('refreshes a stale disabled mode before terminal paste', () async {
+      final output = <String>[];
+      final terminal = Terminal(onOutput: output.add);
+      final windows = Completer<Iterable<TmuxWindow>>();
+      final refresh = refreshTerminalBracketedPasteModeFromMuxWindows(
+        terminal: terminal,
+        loadWindows: () => windows.future,
+      );
 
-        expect(terminal.bracketedPasteMode, isFalse);
-        windows.complete(const [
-          TmuxWindow(
-            index: 0,
-            name: 'copilot',
-            isActive: true,
-            terminalBracketedPasteMode: true,
-          ),
-        ]);
+      expect(terminal.bracketedPasteMode, isFalse);
+      windows.complete(const [
+        TmuxWindow(
+          index: 0,
+          name: 'copilot',
+          isActive: true,
+          terminalBracketedPasteMode: true,
+        ),
+      ]);
 
-        expect(await refresh, (
-          bracketedPasteMode: true,
-          activeWindowKey: '#0',
-        ));
-        expect(terminal.bracketedPasteMode, isTrue);
-      },
-    );
+      expect(await refresh, (
+        bracketedPasteMode: true,
+        bracketedPasteModeKnown: true,
+        activeWindowKey: '#0',
+      ));
+      expect(terminal.bracketedPasteMode, isTrue);
+
+      pasteTerminalTextWithBracketedPasteMode(
+        terminal: terminal,
+        text: 'clipboard text',
+        bracketedPasteMode: true,
+      );
+
+      expect(output, ['\x1b[200~clipboard text\x1b[201~']);
+    });
 
     test('applies known disabled mode and preserves unknown mode', () async {
       final terminal = Terminal()..setBracketedPasteMode(true);
@@ -507,7 +514,11 @@ void main() {
             ),
           ],
         ),
-        (bracketedPasteMode: false, activeWindowKey: '#0'),
+        (
+          bracketedPasteMode: false,
+          bracketedPasteModeKnown: true,
+          activeWindowKey: '#0',
+        ),
       );
 
       terminal.setBracketedPasteMode(true);
@@ -518,7 +529,11 @@ void main() {
             TmuxWindow(index: 0, name: 'legacy', isActive: true),
           ],
         ),
-        (bracketedPasteMode: true, activeWindowKey: '#0'),
+        (
+          bracketedPasteMode: true,
+          bracketedPasteModeKnown: false,
+          activeWindowKey: '#0',
+        ),
       );
     });
 
@@ -538,8 +553,27 @@ void main() {
             ),
           ],
         ),
-        (bracketedPasteMode: true, activeWindowKey: '@9'),
+        (
+          bracketedPasteMode: true,
+          bracketedPasteModeKnown: true,
+          activeWindowKey: '@9',
+        ),
       );
+    });
+
+    test('can conservatively paste without mutating cached terminal mode', () {
+      final output = <String>[];
+      final terminal = Terminal(onOutput: output.add)
+        ..setBracketedPasteMode(true);
+
+      pasteTerminalTextWithBracketedPasteMode(
+        terminal: terminal,
+        text: 'clipboard text',
+        bracketedPasteMode: false,
+      );
+
+      expect(output, ['clipboard text']);
+      expect(terminal.bracketedPasteMode, isTrue);
     });
   });
 

--- a/test/widget/terminal_screen_selection_test.dart
+++ b/test/widget/terminal_screen_selection_test.dart
@@ -609,6 +609,50 @@ void main() {
     });
   });
 
+  group('shouldRetryTerminalPasteModeSettle', () {
+    test('does not retry a failed refresh', () {
+      expect(
+        shouldRetryTerminalPasteModeSettle(
+          refreshAttempted: true,
+          refreshSucceeded: false,
+          modeReliable: false,
+          targetsCurrentWindow: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('retries successful snapshots until mode and window settle', () {
+      expect(
+        shouldRetryTerminalPasteModeSettle(
+          refreshAttempted: true,
+          refreshSucceeded: true,
+          modeReliable: false,
+          targetsCurrentWindow: true,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldRetryTerminalPasteModeSettle(
+          refreshAttempted: true,
+          refreshSucceeded: true,
+          modeReliable: true,
+          targetsCurrentWindow: false,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldRetryTerminalPasteModeSettle(
+          refreshAttempted: true,
+          refreshSucceeded: true,
+          modeReliable: true,
+          targetsCurrentWindow: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('enableAndroidPhotoPickerForTerminalMedia', () {
     test('enables the existing Android image picker implementation', () {
       final imagePicker = ImagePickerAndroid();

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -6885,6 +6885,43 @@ void main() {
       otherFocusNode.dispose();
     });
 
+    testWidgets('routes hardware paste shortcuts through the paste callback', (
+      tester,
+    ) async {
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add);
+      final focusNode = FocusNode();
+      var pasteCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TerminalTextInputHandler(
+              terminal: terminal,
+              focusNode: focusNode,
+              deleteDetection: true,
+              onPasteText: () => pasteCount++,
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyV);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.keyV);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      expect(pasteCount, 1);
+      expect(terminalOutput, isEmpty);
+
+      focusNode.dispose();
+    });
+
     testWidgets('consumes composing hardware keys when the child owns focus', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary
- refresh and settle MonkeyMux bracketed-paste mode before text and attachment input
- preserve separate bracketed attachment segments for quoted paths and mixed batches
- use conservative unframed fallback when mode metadata is unknown, and stop staggered batches on context or mode changes
- route mobile hardware-keyboard paste shortcuts through the same refreshed path
- add privacy-safe paste mode diagnostics and reject terminal-control bytes in remote paths

## Testing
- flutter analyze on the changed implementation and tests
- flutter test test/domain/services/remote_file_service_test.dart test/widget/terminal_screen_selection_test.dart