### PR TITLE
feat: show mux version in terminal info

### DIFF
--- a/lib/domain/services/monkeymux_service.dart
+++ b/lib/domain/services/monkeymux_service.dart
@@ -258,6 +258,38 @@ class MonkeyMuxService implements RemoteMultiplexerService {
       <_MonkeyMuxWatchKey, _AppReviewDemoMonkeyMuxState>{};
   static const _agentSessionMetadataFreshTtl = Duration(seconds: 5);
 
+  @override
+  Future<String?> detectedVersion(
+    SshSession session,
+    String sessionName, {
+    String? extraFlags,
+  }) async {
+    if (isAppReviewDemoSession(session)) {
+      return null;
+    }
+    try {
+      final installation = await _installer.ensureInstalled(session);
+      final status = await runningServerStatus(
+        session,
+        installation,
+        sessionName,
+        priority: SshExecPriority.low,
+      );
+      final version = status?.version?.trim();
+      return version == null || version.isEmpty ? null : version;
+    } on Object catch (error) {
+      DiagnosticsLogService.instance.debug(
+        'monkeymux.status',
+        'version_unavailable',
+        fields: {
+          'connectionId': session.connectionId,
+          'errorType': error.runtimeType,
+        },
+      );
+      return null;
+    }
+  }
+
   /// Clears MonkeyMux caches and watchers for a connection.
   Future<void> clearCache(int connectionId) async {
     DiagnosticsLogService.instance.info(

--- a/lib/domain/services/remote_multiplexer_service.dart
+++ b/lib/domain/services/remote_multiplexer_service.dart
@@ -10,6 +10,16 @@ import 'tmux_service.dart';
 
 /// Common app-side surface for remote terminal multiplexers.
 abstract interface class RemoteMultiplexerService {
+  /// Returns the detected backend version for the active remote multiplexer.
+  ///
+  /// The returned value excludes the backend name and is null when the version
+  /// cannot be determined without disrupting the active terminal.
+  Future<String?> detectedVersion(
+    SshSession session,
+    String sessionName, {
+    String? extraFlags,
+  });
+
   /// Returns the current window list for [sessionName].
   Future<List<TmuxWindow>> listWindows(
     SshSession session,
@@ -114,6 +124,17 @@ class TmuxRemoteMultiplexerService implements RemoteMultiplexerService {
   const TmuxRemoteMultiplexerService(this._tmuxService);
 
   final TmuxService _tmuxService;
+
+  @override
+  Future<String?> detectedVersion(
+    SshSession session,
+    String sessionName, {
+    String? extraFlags,
+  }) => _tmuxService.detectedVersion(
+    session,
+    sessionName,
+    extraFlags: extraFlags,
+  );
 
   @override
   Future<List<TmuxWindow>> listWindows(

--- a/lib/domain/services/tmux_service.dart
+++ b/lib/domain/services/tmux_service.dart
@@ -154,6 +154,35 @@ class TmuxService {
     return 'tmux $optionText$command';
   }
 
+  /// Returns the version reported by the active remote tmux server.
+  Future<String?> detectedVersion(
+    SshSession session,
+    String sessionName, {
+    String? extraFlags,
+  }) async {
+    try {
+      final output = await _execTmuxCommand(
+        session,
+        sessionName,
+        'display-message -p -t ${_shellQuote('$sessionName:')} '
+        '${_shellQuote('#{version}')}',
+        extraFlags: extraFlags,
+        priority: SshExecPriority.low,
+      );
+      return parseTmuxVersionOutput(output);
+    } on Object catch (error) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.query',
+        'version_unavailable',
+        fields: {
+          'connectionId': session.connectionId,
+          'errorType': error.runtimeType,
+        },
+      );
+      return null;
+    }
+  }
+
   /// Returns whether a tmux binary path cache entry exists for [connectionId].
   @visibleForTesting
   static bool hasTmuxPathCacheEntry(int connectionId) =>
@@ -2718,6 +2747,23 @@ String _diagnosticTmuxCommandKind(String command) {
     return 'which_tmux';
   }
   return 'tmux_exec';
+}
+
+/// Parses a version returned by a tmux version probe.
+@visibleForTesting
+String? parseTmuxVersionOutput(String output) {
+  for (final line in const LineSplitter().convert(output).reversed) {
+    final trimmed = line.trim();
+    if (trimmed.isEmpty) {
+      continue;
+    }
+    final match = RegExp(
+      r'^tmux\s+(.+)$',
+      caseSensitive: false,
+    ).firstMatch(trimmed);
+    return match?.group(1)?.trim() ?? trimmed;
+  }
+  return null;
 }
 
 String _buildForegroundTmuxSessionCommand({String? extraFlags}) {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1011,6 +1011,22 @@ String _telemetryMuxBackendName(RemoteMuxBackend backend) => switch (backend) {
   RemoteMuxBackend.monkeyMux => 'monkeymux',
 };
 
+/// Formats a detected remote multiplexer version for terminal metadata.
+@visibleForTesting
+String? formatRemoteMuxVersionLabel(RemoteMuxBackend backend, String? version) {
+  final trimmedVersion = version?.trim();
+  if (trimmedVersion == null || trimmedVersion.isEmpty) {
+    return null;
+  }
+  final backendLabel = backend.label;
+  if (trimmedVersion.toLowerCase().startsWith(
+    '${backendLabel.toLowerCase()} ',
+  )) {
+    return trimmedVersion;
+  }
+  return '$backendLabel $trimmedVersion';
+}
+
 /// Resolves whether the active tmux window requested mouse-wheel input.
 @visibleForTesting
 bool? resolveTmuxBarActiveWindowReportsMouseWheel(
@@ -3502,6 +3518,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   bool _showsTerminalMetadata = false;
   bool _isTmuxActive = false;
   String? _tmuxSessionName;
+  String? _muxVersion;
   String? _monkeyMuxReconnectSessionName;
   bool _monkeyMuxReconnectAttachPending = false;
   int _automaticPortForwardRootSyncGeneration = 0;
@@ -9467,11 +9484,18 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _PreparedRemoteMuxCommand command,
   ) {
     void apply() {
+      final muxContextChanged =
+          _tmuxStateConnectionId != session.connectionId ||
+          _activeMuxBackend != command.backend ||
+          _tmuxSessionName != command.sessionName;
       _activeMuxBackend = command.backend;
       _remoteMuxStartupTool = command.tool;
       session
         ..remoteMuxBackend = command.backend
         ..remoteMuxSessionName = command.sessionName;
+      if (muxContextChanged) {
+        _muxVersion = null;
+      }
       if (command.backend != RemoteMuxBackend.monkeyMux) {
         return;
       }
@@ -9576,6 +9600,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _tmuxDetectionGeneration += 1;
     _isTmuxActive = false;
     _tmuxSessionName = null;
+    _muxVersion = null;
     _activeMuxBackend = RemoteMuxBackend.tmux;
     _tmuxStateConnectionId = null;
     _isTmuxBarExpanded = false;
@@ -9609,6 +9634,58 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     _tmuxForegroundVerificationTimer = null;
     _tmuxForegroundVerificationGeneration += 1;
     _tmuxForegroundVerificationInFlight = false;
+  }
+
+  Future<void> _refreshMuxVersion({
+    required SshSession session,
+    required String sessionName,
+    required RemoteMuxBackend backend,
+    required int detectionGeneration,
+  }) async {
+    try {
+      final version = await _remoteMultiplexerServiceForBackend(backend)
+          .detectedVersion(
+            session,
+            sessionName,
+            extraFlags: backend == RemoteMuxBackend.tmux
+                ? _host?.tmuxExtraFlags
+                : null,
+          );
+      final normalizedVersion = version?.trim();
+      if (!mounted ||
+          _connectionId != session.connectionId ||
+          detectionGeneration != _tmuxDetectionGeneration ||
+          !_isTmuxActive ||
+          _activeMuxBackend != backend ||
+          _tmuxSessionName != sessionName) {
+        return;
+      }
+      final nextVersion = normalizedVersion == null || normalizedVersion.isEmpty
+          ? null
+          : normalizedVersion;
+      if (_muxVersion != nextVersion) {
+        setState(() => _muxVersion = nextVersion);
+      }
+    } on Object catch (error) {
+      DiagnosticsLogService.instance.debug(
+        'tmux.ui',
+        'version_unavailable',
+        fields: {
+          'connectionId': session.connectionId,
+          'backend': backend.storageValue,
+          'errorType': error.runtimeType,
+        },
+      );
+      if (mounted &&
+          _connectionId == session.connectionId &&
+          detectionGeneration == _tmuxDetectionGeneration &&
+          _isTmuxActive &&
+          _activeMuxBackend == backend &&
+          _tmuxSessionName == sessionName &&
+          _muxVersion != null) {
+        setState(() => _muxVersion = null);
+      }
+    }
   }
 
   Future<void> _verifyTmuxForegroundSession(
@@ -9780,6 +9857,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _isTmuxActive = true;
           _tmuxSessionName = candidateSessionName;
           _activeMuxBackend = muxBackend;
+          _muxVersion = null;
           _tmuxStateConnectionId = session.connectionId;
           _tmuxLaunchWorkingDirectory = preferredWorkingDirectory;
           _tmuxWorkingDirectory = preferredWorkingDirectory;
@@ -9789,6 +9867,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           _stopTmuxForegroundVerification();
           _isTmuxActive = false;
           _tmuxSessionName = null;
+          _muxVersion = null;
           _tmuxStateConnectionId = null;
           _tmuxLaunchWorkingDirectory = null;
           _tmuxWorkingDirectory = null;
@@ -9962,6 +10041,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
             tmuxLaunchCwd,
           );
         });
+        unawaited(
+          _refreshMuxVersion(
+            session: session,
+            sessionName: sessionName,
+            backend: muxBackend,
+            detectionGeneration: detectionGeneration,
+          ),
+        );
         session
           ..remoteMuxBackend = muxBackend
           ..remoteMuxSessionName = sessionName;
@@ -11701,6 +11788,15 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
 
   List<Widget> _buildTerminalStatusChips(ThemeData theme) {
     final chipLabels = <({IconData icon, String label, String tooltip})>[
+      if (formatRemoteMuxVersionLabel(_activeMuxBackend, _muxVersion)
+          case final muxVersionLabel? when _isTmuxActive)
+        (
+          icon: Icons.window_outlined,
+          label: muxVersionLabel,
+          tooltip:
+              'Detected ${_activeMuxBackend.label} version for the active '
+              'remote multiplexer.',
+        ),
       if (_workingDirectoryLabel case final workingDirectory?
           when workingDirectory.isNotEmpty)
         (

--- a/test/domain/services/monkeymux_service_test.dart
+++ b/test/domain/services/monkeymux_service_test.dart
@@ -782,6 +782,39 @@ void main() {
     });
   });
 
+  group('MonkeyMuxService.detectedVersion', () {
+    setUpAll(() => registerFallbackValue(Uint8List(0)));
+
+    test('reads the running server version from the control hello', () async {
+      final client = _MockSshClient();
+      final installer = _MockMonkeyMuxInstaller();
+      final session = _buildSession(client, connectionId: 909);
+      final commands = <String>[];
+      when(
+        () => installer.ensureInstalled(session),
+      ).thenAnswer((_) async => _fakeInstallation);
+      when(() => client.execute(any(), pty: any(named: 'pty'))).thenAnswer((
+        invocation,
+      ) async {
+        commands.add(invocation.positionalArguments.single as String);
+        return _buildOutputSession(
+          '{"type":"hello","status":"ok","version":"0.2.4",'
+          '"capabilities":[]}\n',
+        );
+      });
+
+      final version = await MonkeyMuxService(
+        installer: installer,
+      ).detectedVersion(session, 'work');
+
+      expect(version, '0.2.4');
+      expect(
+        commands.single,
+        "'/home/tester/.monkeyssh/bin/monkeymux' control --json 'work'",
+      );
+    });
+  });
+
   group('MonkeyMuxService.installedHelperVersion', () {
     setUpAll(() => registerFallbackValue(Uint8List(0)));
 

--- a/test/domain/services/terminal_connection_backend_service_test.dart
+++ b/test/domain/services/terminal_connection_backend_service_test.dart
@@ -183,6 +183,13 @@ class _FakeRemoteMultiplexerService implements RemoteMultiplexerService {
   final List<String> calls = <String>[];
 
   @override
+  Future<String?> detectedVersion(
+    SshSession session,
+    String sessionName, {
+    String? extraFlags,
+  }) async => null;
+
+  @override
   Future<List<TmuxWindow>> listWindows(
     SshSession session,
     String sessionName, {

--- a/test/domain/services/tmux_service_control_mode_test.dart
+++ b/test/domain/services/tmux_service_control_mode_test.dart
@@ -149,6 +149,47 @@ void main() {
       );
     });
 
+    test('reads the active remote tmux server version', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client, connectionId: 1067);
+      const service = TmuxService();
+      final commands = <String>[];
+
+      when(() => client.execute(any(), pty: any(named: 'pty'))).thenAnswer((
+        invocation,
+      ) async {
+        commands.add(invocation.positionalArguments.single as String);
+        return _buildOpenExecSession(stdout: '3.4\n${_doneMarker()}');
+      });
+
+      final version = await service.detectedVersion(
+        session,
+        'work',
+        extraFlags: '-S /tmp/tmux-socket',
+      );
+
+      expect(version, '3.4');
+      expect(
+        commands.single,
+        contains(
+          "tmux -u -S '/tmp/tmux-socket' display-message -p "
+          "-t 'work:' '#{version}'",
+        ),
+      );
+    });
+
+    test('returns null when the active tmux version is unavailable', () async {
+      final client = _MockSshClient();
+      final session = _buildSession(client, connectionId: 1068);
+      const service = TmuxService();
+
+      when(() => client.execute(any(), pty: any(named: 'pty'))).thenAnswer(
+        (_) => Future<SSHSession>.error(SSHChannelOpenError(2, 'open failed')),
+      );
+
+      expect(await service.detectedVersion(session, 'work'), isNull);
+    });
+
     test('theme refresh command updates pane palette before redraw', () {
       final command = buildTmuxRefreshTerminalThemeCommand(
         "dev's session",

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -156,8 +156,17 @@ class _FakeRemoteAdbCommandRunner implements RemoteAdbCommandRunner {
 }
 
 class _MockTmuxService extends Mock implements TmuxService {
+  String? detectedVersionValue;
+
   @override
   bool isExecChannelCoolingDown(SshSession session) => false;
+
+  @override
+  Future<String?> detectedVersion(
+    SshSession session,
+    String sessionName, {
+    String? extraFlags,
+  }) async => detectedVersionValue;
 }
 
 class _MockMonkeyMuxService extends Mock implements MonkeyMuxService {
@@ -165,6 +174,7 @@ class _MockMonkeyMuxService extends Mock implements MonkeyMuxService {
   Future<MonkeyMuxServerStatus?>? runningStatusFuture;
   MonkeyMuxServerStatus? installedHelpersStatus;
   String? helperVersion;
+  String? detectedVersionValue;
   int installedHelperVersionCalls = 0;
   int runningServerStatusCalls = 0;
   int runningServerStatusFromInstalledHelpersCalls = 0;
@@ -183,6 +193,13 @@ class _MockMonkeyMuxService extends Mock implements MonkeyMuxService {
 
   @override
   bool isExecChannelCoolingDown(SshSession session) => false;
+
+  @override
+  Future<String?> detectedVersion(
+    SshSession session,
+    String sessionName, {
+    String? extraFlags,
+  }) async => detectedVersionValue;
 
   @override
   bool hasLiveControlChannel(SshSession session, String sessionName) =>
@@ -2730,6 +2747,31 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
     }
+
+    testWidgets(
+      'shows the detected tmux version in terminal info',
+      (tester) async {
+        final tmuxService = _MockTmuxService()..detectedVersionValue = '3.4';
+        await pumpTmuxScreen(tester, tmuxService);
+        await tester.pump();
+
+        await openTerminalOverflowSubmenu(tester, 'Options');
+        final showTerminalInfo = terminalMenuItemButton('Show Terminal Info');
+        expect(showTerminalInfo, findsOneWidget);
+
+        await tester.tap(showTerminalInfo);
+        await tester.pumpAndSettle();
+
+        expect(find.text('tmux 3.4'), findsOneWidget);
+        expect(
+          find.byTooltip(
+            'Detected tmux version for the active remote multiplexer.',
+          ),
+          findsOneWidget,
+        );
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
 
     testWidgets(
       'keeps probing for tmux after an initial inactive result',

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -95,6 +95,25 @@ void main() {
       );
     });
 
+    test('formats detected remote multiplexer versions', () {
+      expect(
+        formatRemoteMuxVersionLabel(RemoteMuxBackend.monkeyMux, '0.2.4'),
+        'MonkeyMux 0.2.4',
+      );
+      expect(
+        formatRemoteMuxVersionLabel(RemoteMuxBackend.tmux, '3.4'),
+        'tmux 3.4',
+      );
+      expect(
+        formatRemoteMuxVersionLabel(RemoteMuxBackend.tmux, 'tmux next-3.5'),
+        'tmux next-3.5',
+      );
+      expect(
+        formatRemoteMuxVersionLabel(RemoteMuxBackend.monkeyMux, '  '),
+        isNull,
+      );
+    });
+
     test('terminal identity includes remote host and session id', () {
       expect(
         formatTerminalConnectionIdentity(


### PR DESCRIPTION
## Summary
- detect the active MonkeyMux or tmux server version
- show it as the leading terminal info pill
- clear stale version metadata when mux state changes or probing fails

## Validation
- flutter analyze
- focused mux service, layout, and terminal screen tests