### PR TITLE
fix(terminal): stop a duplicated ESC from printing OSC 8 hyperlinks as text

### DIFF
--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -7525,6 +7525,7 @@ func (s *muxServer) resumePausedAttachForwarding(
 			window.redrawForwardingFallbackHistory,
 		) && len(fallbackReplay) > 0 {
 			replay = nil
+			window.discardDeliveredAttachOscBufferLocked()
 			buffered = append(
 				append([]byte(nil), fallbackReplay...),
 				queryData...,
@@ -7771,6 +7772,7 @@ func (s *muxServer) replayBytesLockedWithSkip(
 	} else {
 		history = trimReplayHistoryForAttachWithParser(history, historyStart)
 		history = stripTerminalQueriesFromReplay(history)
+		window.discardDeliveredAttachOscBufferLocked()
 	}
 	return buildWindowReplay(window, history)
 }
@@ -10069,6 +10071,25 @@ func (w *muxWindow) storeAttachPartialOscLocked(data []byte) bool {
 	}
 	w.attachOscBuffer = append(w.attachOscBuffer[:0], data...)
 	return true
+}
+
+// discardDeliveredAttachOscBufferLocked drops the partial OSC that
+// stripLocallyAnsweredThemeQueriesLocked held back from the live stream once a
+// history replay has delivered those same bytes.
+//
+// The buffer exists so a colour query split across two PTY reads can still be
+// recognised (and stripped) when its tail arrives, which means the leading
+// bytes are withheld from the forwarded output until then. appendHistoryLocked
+// always records the whole chunk, so a replay that lands in that window sends
+// the withheld bytes to the client — and forwarding them again with the next
+// chunk would duplicate them. A duplicated `ESC` is not cosmetic: `ESC ESC ] 8
+// ; ...` makes the terminal consume both escapes and print the rest of the
+// hyperlink introducer as literal text.
+func (w *muxWindow) discardDeliveredAttachOscBufferLocked() {
+	if w == nil {
+		return
+	}
+	w.attachOscBuffer = nil
 }
 
 func stripTerminalQueriesFromReplay(data []byte) []byte {

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -7525,7 +7525,6 @@ func (s *muxServer) resumePausedAttachForwarding(
 			window.redrawForwardingFallbackHistory,
 		) && len(fallbackReplay) > 0 {
 			replay = nil
-			window.discardDeliveredAttachOscBufferLocked()
 			buffered = append(
 				append([]byte(nil), fallbackReplay...),
 				queryData...,
@@ -7772,7 +7771,7 @@ func (s *muxServer) replayBytesLockedWithSkip(
 	} else {
 		history = trimReplayHistoryForAttachWithParser(history, historyStart)
 		history = stripTerminalQueriesFromReplay(history)
-		window.discardDeliveredAttachOscBufferLocked()
+		history = window.withheldAttachOscSuffixTrimmedLocked(history)
 	}
 	return buildWindowReplay(window, history)
 }
@@ -7829,6 +7828,7 @@ func (s *muxServer) foregroundHistoryFallbackReplayLocked(
 		return nil
 	}
 	images := window.kittyImageReplayLocked(nil)
+	history = window.withheldAttachOscSuffixTrimmedLocked(history)
 	replayHistory := make([]byte, 0, len(images)+len(history))
 	replayHistory = append(replayHistory, images...)
 	replayHistory = append(replayHistory, history...)
@@ -10073,23 +10073,35 @@ func (w *muxWindow) storeAttachPartialOscLocked(data []byte) bool {
 	return true
 }
 
-// discardDeliveredAttachOscBufferLocked drops the partial OSC that
-// stripLocallyAnsweredThemeQueriesLocked held back from the live stream once a
-// history replay has delivered those same bytes.
+// withheldAttachOscSuffixTrimmedLocked removes from a replay the partial OSC
+// that stripLocallyAnsweredThemeQueriesLocked is still holding back from the
+// live stream, so the replay ends exactly where the live stream did.
 //
 // The buffer exists so a colour query split across two PTY reads can still be
-// recognised (and stripped) when its tail arrives, which means the leading
+// recognised (and stripped) when its tail arrives, which means its leading
 // bytes are withheld from the forwarded output until then. appendHistoryLocked
-// always records the whole chunk, so a replay that lands in that window sends
-// the withheld bytes to the client — and forwarding them again with the next
-// chunk would duplicate them. A duplicated `ESC` is not cosmetic: `ESC ESC ] 8
-// ; ...` makes the terminal consume both escapes and print the rest of the
-// hyperlink introducer as literal text.
-func (w *muxWindow) discardDeliveredAttachOscBufferLocked() {
-	if w == nil {
-		return
+// records the whole chunk regardless, so a replay built straight from history
+// would hand the client bytes the live stream is about to send again. A
+// duplicated `ESC` is not cosmetic: `ESC ESC ] 8 ; ...` makes the terminal
+// consume both escapes and print the rest of the hyperlink introducer as
+// literal text.
+//
+// Trimming the replay rather than dropping the buffer keeps this correct for
+// every client. A replay is built per client, so releasing window-global state
+// when one client reattaches would strand the clients that never saw it, and a
+// replay whose history was trimmed away entirely (which
+// trimReplayHistoryForAttachWithParser does when it finds no terminal ground
+// state — the very case that fills this buffer) would strand all of them.
+func (w *muxWindow) withheldAttachOscSuffixTrimmedLocked(
+	history []byte,
+) []byte {
+	if w == nil || len(w.attachOscBuffer) == 0 {
+		return history
 	}
-	w.attachOscBuffer = nil
+	if !bytes.HasSuffix(history, w.attachOscBuffer) {
+		return history
+	}
+	return history[:len(history)-len(w.attachOscBuffer)]
 }
 
 func stripTerminalQueriesFromReplay(data []byte) []byte {

--- a/remote/monkeymux/main_test.go
+++ b/remote/monkeymux/main_test.go
@@ -12061,3 +12061,48 @@ func (a testAddr) Network() string {
 func (a testAddr) String() string {
 	return string(a)
 }
+
+func TestReplayDropsAttachOscBufferAlreadyDeliveredByHistory(t *testing.T) {
+	// stripLocallyAnsweredThemeQueriesLocked withholds a partial OSC from the
+	// live stream until its tail arrives, but appendHistoryLocked keeps the
+	// whole chunk. A replay landing in that window delivers the withheld bytes,
+	// so forwarding them again with the next chunk duplicated them. For the ESC
+	// that opens an OSC 8 hyperlink that meant the client received
+	// "\x1b\x1b]8;id=..." and printed the introducer as literal text.
+	server := &muxServer{}
+	window := &muxWindow{id: "@1"}
+
+	chunkA := []byte("Seeded release: \x1b")
+	window.appendHistoryLocked(chunkA)
+	forwardedA := window.stripLocallyAnsweredThemeQueriesLocked(chunkA, nil)
+	if string(forwardedA) != "Seeded release: " {
+		t.Fatalf("forwarded first chunk = %q, want the ESC withheld", forwardedA)
+	}
+	if string(window.attachOscBuffer) != "\x1b" {
+		t.Fatalf("attach OSC buffer = %q, want the withheld ESC", window.attachOscBuffer)
+	}
+
+	replay := server.replayBytesLocked(window)
+	if !bytes.Contains(replay, chunkA) {
+		t.Fatalf("replay = %q, want it to contain the full history %q", replay, chunkA)
+	}
+	if len(window.attachOscBuffer) != 0 {
+		t.Fatalf("attach OSC buffer = %q, want dropped after replay",
+			window.attachOscBuffer)
+	}
+
+	chunkB := []byte("]8;id=md-7nao1v;https://example.com/x\x1b\\label\x1b]8;;\x1b\\")
+	window.appendHistoryLocked(chunkB)
+	forwardedB := window.stripLocallyAnsweredThemeQueriesLocked(chunkB, nil)
+
+	if string(forwardedB) != string(chunkB) {
+		t.Fatalf("forwarded second chunk = %q, want %q without the replayed ESC",
+			forwardedB, chunkB)
+	}
+	if got := string(replay) + string(forwardedB); strings.Contains(
+		got,
+		"\x1b\x1b]8;",
+	) {
+		t.Fatalf("replay+live stream = %q, want no duplicated ESC", got)
+	}
+}

--- a/remote/monkeymux/main_test.go
+++ b/remote/monkeymux/main_test.go
@@ -12062,13 +12062,13 @@ func (a testAddr) String() string {
 	return string(a)
 }
 
-func TestReplayDropsAttachOscBufferAlreadyDeliveredByHistory(t *testing.T) {
+func TestReplayOmitsTheAttachOscTailStillWithheldFromLiveOutput(t *testing.T) {
 	// stripLocallyAnsweredThemeQueriesLocked withholds a partial OSC from the
 	// live stream until its tail arrives, but appendHistoryLocked keeps the
-	// whole chunk. A replay landing in that window delivers the withheld bytes,
-	// so forwarding them again with the next chunk duplicated them. For the ESC
-	// that opens an OSC 8 hyperlink that meant the client received
-	// "\x1b\x1b]8;id=..." and printed the introducer as literal text.
+	// whole chunk. A replay built straight from history would hand the client
+	// bytes the live stream is about to send again; for the ESC that opens an
+	// OSC 8 hyperlink that means the client receives "\x1b\x1b]8;id=..." and
+	// prints the introducer as literal text.
 	server := &muxServer{}
 	window := &muxWindow{id: "@1"}
 
@@ -12083,26 +12083,82 @@ func TestReplayDropsAttachOscBufferAlreadyDeliveredByHistory(t *testing.T) {
 	}
 
 	replay := server.replayBytesLocked(window)
-	if !bytes.Contains(replay, chunkA) {
-		t.Fatalf("replay = %q, want it to contain the full history %q", replay, chunkA)
+	if !bytes.Contains(replay, []byte("Seeded release: ")) {
+		t.Fatalf("replay = %q, want it to carry the delivered history", replay)
 	}
-	if len(window.attachOscBuffer) != 0 {
-		t.Fatalf("attach OSC buffer = %q, want dropped after replay",
+
+	withheld := window.attachOscBuffer
+	window.attachOscBuffer = nil
+	untrimmed := server.replayBytesLocked(window)
+	window.attachOscBuffer = withheld
+	if len(untrimmed)-len(replay) != len(withheld) {
+		t.Fatalf("replay = %q (%d bytes), untrimmed = %d bytes; want %d fewer",
+			replay, len(replay), len(untrimmed), len(withheld))
+	}
+	// The buffer is window-global while replays are per client, so it must
+	// survive: the live stream still owes those bytes to every attached client.
+	if string(window.attachOscBuffer) != "\x1b" {
+		t.Fatalf("attach OSC buffer = %q, want it kept for the live stream",
 			window.attachOscBuffer)
 	}
 
 	chunkB := []byte("]8;id=md-7nao1v;https://example.com/x\x1b\\label\x1b]8;;\x1b\\")
 	window.appendHistoryLocked(chunkB)
 	forwardedB := window.stripLocallyAnsweredThemeQueriesLocked(chunkB, nil)
-
-	if string(forwardedB) != string(chunkB) {
-		t.Fatalf("forwarded second chunk = %q, want %q without the replayed ESC",
-			forwardedB, chunkB)
+	if !bytes.HasPrefix(forwardedB, []byte("\x1b]8;")) {
+		t.Fatalf("forwarded second chunk = %q, want it to lead with the ESC", forwardedB)
 	}
 	if got := string(replay) + string(forwardedB); strings.Contains(
 		got,
 		"\x1b\x1b]8;",
 	) {
 		t.Fatalf("replay+live stream = %q, want no duplicated ESC", got)
+	}
+}
+
+func TestReplayKeepsWithheldTailWhenHistoryIsTrimmedAway(t *testing.T) {
+	// trimReplayHistoryForAttachWithParser returns nil when it finds no
+	// terminal ground state after the size-based cut, which is exactly the
+	// condition that fills attachOscBuffer: history ending mid-sequence. There
+	// is then nothing to trim, and the buffer must still be owed to the client.
+	window := &muxWindow{}
+	window.history = bytes.Repeat(
+		[]byte("\x1b_Ga=T,f=100;AAAA"),
+		1+windowReplayLimitBytes/16,
+	)
+	window.attachOscBuffer = []byte("\x1b")
+
+	history, historyStart := window.historyTailWithParserLocked()
+	trimmed := trimReplayHistoryForAttachWithParser(history, historyStart)
+	if len(trimmed) != 0 {
+		t.Skipf("replay retained history (%d bytes); nothing to assert", len(trimmed))
+	}
+
+	if got := window.withheldAttachOscSuffixTrimmedLocked(trimmed); len(got) != 0 {
+		t.Fatalf("trimmed replay = %q, want it left empty", got)
+	}
+	if string(window.attachOscBuffer) != "\x1b" {
+		t.Fatalf("attach OSC buffer = %q, want it kept when the replay omits it",
+			window.attachOscBuffer)
+	}
+}
+
+func TestWithheldAttachOscSuffixTrimmedRequiresSuffixMatch(t *testing.T) {
+	window := &muxWindow{attachOscBuffer: []byte("\x1b]11;?")}
+
+	// A snapshot taken before the partial arrived has nothing to trim.
+	if got := window.withheldAttachOscSuffixTrimmedLocked(
+		[]byte("earlier frame"),
+	); string(got) != "earlier frame" {
+		t.Fatalf("trimmed replay = %q, want it unchanged", got)
+	}
+
+	if got := window.withheldAttachOscSuffixTrimmedLocked(
+		[]byte("earlier frame\x1b]11;?"),
+	); string(got) != "earlier frame" {
+		t.Fatalf("trimmed replay = %q, want the withheld tail removed", got)
+	}
+	if string(window.attachOscBuffer) != "\x1b]11;?" {
+		t.Fatalf("attach OSC buffer = %q, want it left intact", window.attachOscBuffer)
 	}
 }

--- a/test/domain/services/terminal_hyperlink_tracker_test.dart
+++ b/test/domain/services/terminal_hyperlink_tracker_test.dart
@@ -44,6 +44,27 @@ void main() {
       );
     });
 
+    test('renders a link whose introducer is preceded by a stray ESC', () {
+      // A MonkeyMux replay could deliver the ESC that opens an OSC 8 sequence
+      // and then have the live stream forward it a second time. The duplicated
+      // ESC must not make the terminal print the introducer as text
+      // (`]8;id=md-...;https://...`) instead of following the hyperlink.
+      const url = 'https://github.com/depollsoft/MonkeySSH/releases/tag/x';
+      terminal.write(
+        [
+          'Seeded release: ',
+          '\u001b\u001b]8;id=md-7nao1v;$url\u001b\\',
+          url,
+          '\u001b]8;;\u001b\\',
+        ].join(),
+      );
+
+      final firstLine = terminal.buffer.lines[0].toString();
+      expect(firstLine, startsWith('Seeded release: $url'));
+      expect(firstLine, isNot(contains(']8;')));
+      expect(tracker.resolveLinkAt(const CellOffset(20, 0)), url);
+    });
+
     test('resolves OSC 8 links terminated with ST (ESC backslash)', () {
       terminal.write(
         [

--- a/third_party/xterm/lib/src/core/escape/handler.dart
+++ b/third_party/xterm/lib/src/core/escape/handler.dart
@@ -263,4 +263,11 @@ abstract class EscapeHandler {
 
   /// End of the current Kitty graphics command (final chunk received).
   void graphicsCommandEnd();
+
+  /// A Kitty graphics command was cut short by an ESC before its terminator.
+  ///
+  /// Any transmission still open from an earlier `m=1` chunk is unrecoverable
+  /// at that point, so it must be discarded rather than left active for the
+  /// next command to be appended to.
+  void graphicsCommandAbort();
 }

--- a/third_party/xterm/lib/src/core/escape/parser.dart
+++ b/third_party/xterm/lib/src/core/escape/parser.dart
@@ -190,35 +190,31 @@ class EscapeParser {
     return true;
   }
 
-  bool _escHandleDesignateCharset0() {
+  /// `ESC ( / ) / * / +  <name>` Designate character set (SCS).
+  ///
+  /// An ESC in the name slot re-enters the escape state instead of being taken
+  /// as the charset name, so a stray or duplicated ESC cannot swallow the
+  /// introducer of the sequence that follows.
+  bool _escHandleDesignateCharset(int g) {
     if (_queue.isEmpty) return false;
-    int name = _queue.consume();
-    handler.designateCharset(0, name);
+    final name = _queue.consume();
+    if (name == Ascii.ESC) {
+      _queue.rollback();
+      return true;
+    }
+    handler.designateCharset(g, name);
     return true;
   }
 
-  bool _escHandleDesignateCharset1() {
-    if (_queue.isEmpty) return false;
-    int name = _queue.consume();
-    handler.designateCharset(1, name);
-    return true;
-  }
+  bool _escHandleDesignateCharset0() => _escHandleDesignateCharset(0);
+
+  bool _escHandleDesignateCharset1() => _escHandleDesignateCharset(1);
 
   /// `ESC * <name>` Designate G2 Character Set (SCS)
-  bool _escHandleDesignateCharset2() {
-    if (_queue.isEmpty) return false;
-    int name = _queue.consume();
-    handler.designateCharset(2, name);
-    return true;
-  }
+  bool _escHandleDesignateCharset2() => _escHandleDesignateCharset(2);
 
   /// `ESC + <name>` Designate G3 Character Set (SCS)
-  bool _escHandleDesignateCharset3() {
-    if (_queue.isEmpty) return false;
-    int name = _queue.consume();
-    handler.designateCharset(3, name);
-    return true;
-  }
+  bool _escHandleDesignateCharset3() => _escHandleDesignateCharset(3);
 
   /// `ESC =` Set Application Keypad Mode (DECKPAM)
   ///
@@ -1436,13 +1432,19 @@ class EscapeParser {
     final args = <String, String>{};
     final argsResult = _parseGraphicsArgs(args);
     if (argsResult == _ApcParse.incomplete) return false;
-    if (argsResult == _ApcParse.aborted) return true;
+    if (argsResult == _ApcParse.aborted) {
+      handler.graphicsCommandAbort();
+      return true;
+    }
 
     final payload = <int>[];
     if (argsResult == _ApcParse.payloadFollows) {
       final payloadResult = _parseGraphicsPayload(payload);
       if (payloadResult == _SeqParse.incomplete) return false;
-      if (payloadResult == _SeqParse.aborted) return true;
+      if (payloadResult == _SeqParse.aborted) {
+        handler.graphicsCommandAbort();
+        return true;
+      }
     }
 
     // The full command is buffered before dispatching so an incomplete payload

--- a/third_party/xterm/lib/src/core/escape/parser.dart
+++ b/third_party/xterm/lib/src/core/escape/parser.dart
@@ -70,6 +70,18 @@ class EscapeParser {
     if (_queue.isEmpty) return false;
 
     final escapeChar = _queue.consume();
+
+    // ECMA-48/VT500: ESC re-enters the escape state from anywhere, so `ESC ESC`
+    // abandons the first introducer and starts a fresh sequence rather than
+    // consuming the second ESC as this sequence's final byte. Roll it back so
+    // the main loop dispatches it; without this a stray or duplicated ESC makes
+    // the whole following sequence (e.g. `ESC ESC ] 8 ; id=...`) render as
+    // literal text.
+    if (escapeChar == Ascii.ESC) {
+      _queue.rollback();
+      return true;
+    }
+
     final escapeHandler = _escHandlers[escapeChar];
 
     if (escapeHandler == null) {
@@ -78,6 +90,23 @@ class EscapeParser {
     }
 
     return escapeHandler();
+  }
+
+  /// Consumes the terminator of a string sequence (OSC/DCS/APC/SOS/PM) once its
+  /// leading ESC has already been consumed.
+  ///
+  /// Returns [_SeqParse.complete] for a full ST (`ESC \`), [_SeqParse.incomplete]
+  /// when the byte after ESC has not arrived yet, and [_SeqParse.aborted] for
+  /// any other byte — in which case the ESC is rolled back so it can start a new
+  /// sequence, as ECMA-48 requires.
+  _SeqParse _consumeStringTerminator() {
+    if (_queue.isEmpty) return _SeqParse.incomplete;
+    if (_queue.peek() == Ascii.backslash) {
+      _queue.consume();
+      return _SeqParse.complete;
+    }
+    _queue.rollback();
+    return _SeqParse.aborted;
   }
 
   late final _sbcHandlers = FastLookupTable<_SbcHandler>({
@@ -208,8 +237,9 @@ class EscapeParser {
   }
 
   bool _escHandleCSI() {
-    final consumed = _consumeCsi();
-    if (!consumed) return false;
+    final result = _consumeCsi();
+    if (result == _SeqParse.incomplete) return false;
+    if (result == _SeqParse.aborted) return true;
 
     if (_csi.finalByte == Ascii.u && _handleKittyKeyboardProtocol()) {
       return true;
@@ -251,11 +281,12 @@ class EscapeParser {
   /// object allocations.
   final _csi = _Csi(finalByte: 0, params: []);
 
-  /// Parse a CSI from the head of the queue. Return false if the CSI isn't
-  /// complete. After a CSI is successfully parsed, [_csi] is updated.
-  bool _consumeCsi() {
+  /// Parse a CSI from the head of the queue. Returns [_SeqParse.incomplete] if
+  /// the CSI isn't complete and [_SeqParse.aborted] if an ESC cut it short.
+  /// After a CSI is successfully parsed, [_csi] is updated.
+  _SeqParse _consumeCsi() {
     if (_queue.isEmpty) {
-      return false;
+      return _SeqParse.incomplete;
     }
 
     _csi.params.clear();
@@ -298,10 +329,18 @@ class EscapeParser {
     while (true) {
       // The sequence isn't completed, just ignore it.
       if (_queue.isEmpty) {
-        return false;
+        return _SeqParse.incomplete;
       }
 
       final char = _queue.consume();
+
+      // ESC aborts the CSI and starts a new sequence. Without this the ESC
+      // falls into the intermediate-byte range below and is silently absorbed,
+      // letting a truncated CSI swallow the sequence that follows it.
+      if (char == Ascii.ESC) {
+        _queue.rollback();
+        return _SeqParse.aborted;
+      }
 
       if (char == Ascii.semicolon) {
         commitParam(emptyAsZero: true);
@@ -347,7 +386,7 @@ class EscapeParser {
         commitParam(emptyAsZero: pendingEmptyParam);
 
         _csi.finalByte = char;
-        return true;
+        return _SeqParse.complete;
       }
     }
   }
@@ -1256,9 +1295,14 @@ class EscapeParser {
   /// Parse a OSC sequence from the queue. Returns true if a sequence was
   /// found and handled.
   bool _escHandleOSC() {
-    final consumed = _consumeOsc();
-    if (!consumed) {
+    final result = _consumeOsc();
+    if (result == _SeqParse.incomplete) {
       return false;
+    }
+    // An ESC cut the OSC short, so its parameters are truncated (a hyperlink
+    // URL, a title, ...). Discard them rather than acting on a partial payload.
+    if (result == _SeqParse.aborted) {
+      return true;
     }
 
     if (_osc.isEmpty) {
@@ -1292,13 +1336,13 @@ class EscapeParser {
 
   final _osc = <String>[];
 
-  bool _consumeOsc() {
+  _SeqParse _consumeOsc() {
     _osc.clear();
     final param = StringBuffer();
 
     while (true) {
       if (_queue.isEmpty) {
-        return false;
+        return _SeqParse.incomplete;
       }
 
       final char = _queue.consume();
@@ -1306,20 +1350,16 @@ class EscapeParser {
       // OSC terminates with BEL
       if (char == Ascii.BEL) {
         _osc.add(param.toString());
-        return true;
+        return _SeqParse.complete;
       }
 
       /// OSC terminates with ST
       if (char == Ascii.ESC) {
-        if (_queue.isEmpty) {
-          return false;
-        }
-
-        if (_queue.consume() == Ascii.backslash) {
+        final terminator = _consumeStringTerminator();
+        if (terminator == _SeqParse.complete) {
           _osc.add(param.toString());
         }
-
-        return true;
+        return terminator;
       }
 
       /// Parse next parameter
@@ -1351,9 +1391,11 @@ class EscapeParser {
 
       // DCS terminates with ST (`ESC \`).
       if (char == Ascii.ESC) {
-        if (_queue.isEmpty) return false;
-        if (_queue.consume() == Ascii.backslash) break;
-        continue;
+        final terminator = _consumeStringTerminator();
+        if (terminator == _SeqParse.complete) break;
+        // Incomplete: wait for more data. Aborted: the ESC starts a new
+        // sequence and this DCS is discarded without reporting.
+        return terminator != _SeqParse.incomplete;
       }
       // BEL is tolerated as a terminator for robustness.
       if (char == Ascii.BEL) break;
@@ -1394,10 +1436,13 @@ class EscapeParser {
     final args = <String, String>{};
     final argsResult = _parseGraphicsArgs(args);
     if (argsResult == _ApcParse.incomplete) return false;
+    if (argsResult == _ApcParse.aborted) return true;
 
     final payload = <int>[];
     if (argsResult == _ApcParse.payloadFollows) {
-      if (!_parseGraphicsPayload(payload)) return false;
+      final payloadResult = _parseGraphicsPayload(payload);
+      if (payloadResult == _SeqParse.incomplete) return false;
+      if (payloadResult == _SeqParse.aborted) return true;
     }
 
     // The full command is buffered before dispatching so an incomplete payload
@@ -1437,12 +1482,14 @@ class EscapeParser {
         return _ApcParse.payloadFollows;
       }
       if (char == Ascii.ESC) {
-        if (_queue.isEmpty) return _ApcParse.incomplete;
-        if (_queue.consume() == Ascii.backslash) {
+        final terminator = _consumeStringTerminator();
+        if (terminator == _SeqParse.complete) {
           flush();
           return _ApcParse.terminated;
         }
-        continue;
+        return terminator == _SeqParse.aborted
+            ? _ApcParse.aborted
+            : _ApcParse.incomplete;
       }
       if (char == Ascii.BEL) {
         flush();
@@ -1475,18 +1522,18 @@ class EscapeParser {
   /// the payload decode, the sooner the screen repaints. Non-base64 bytes
   /// (whitespace, stray padding) are skipped, matching the previous lenient
   /// decoder.
-  bool _parseGraphicsPayload(List<int> out) {
+  _SeqParse _parseGraphicsPayload(List<int> out) {
     var accumulator = 0;
     var bits = 0;
 
     while (true) {
-      if (_queue.isEmpty) return false;
+      if (_queue.isEmpty) return _SeqParse.incomplete;
       final char = _queue.consume();
 
       if (char == Ascii.ESC) {
-        if (_queue.isEmpty) return false;
-        if (_queue.consume() == Ascii.backslash) break;
-        continue;
+        final terminator = _consumeStringTerminator();
+        if (terminator == _SeqParse.complete) break;
+        return terminator;
       }
       if (char == Ascii.BEL) break;
 
@@ -1501,7 +1548,7 @@ class EscapeParser {
       }
     }
 
-    return true;
+    return _SeqParse.complete;
   }
 
   /// Skips an unrecognized string sequence up to ST. Returns false when the
@@ -1511,9 +1558,9 @@ class EscapeParser {
       if (_queue.isEmpty) return false;
       final char = _queue.consume();
       if (char == Ascii.ESC) {
-        if (_queue.isEmpty) return false;
-        if (_queue.consume() == Ascii.backslash) return true;
-        continue;
+        final terminator = _consumeStringTerminator();
+        // Aborted counts as handled: the rolled-back ESC starts a new sequence.
+        return terminator != _SeqParse.incomplete;
       }
       if (char == Ascii.BEL) return true;
     }
@@ -1537,7 +1584,15 @@ List<int> _buildBase64DecodeTable() {
 }
 
 /// Result of parsing the key/value header of an APC graphics command.
-enum _ApcParse { incomplete, payloadFollows, terminated }
+enum _ApcParse { incomplete, payloadFollows, terminated, aborted }
+
+/// Outcome of parsing a sequence whose end is only known once its terminator
+/// arrives.
+///
+/// [aborted] means an ESC appeared where the terminator was expected. ECMA-48
+/// treats that ESC as the start of a new sequence, so the consumer rolls it
+/// back and discards whatever it had gathered.
+enum _SeqParse { complete, incomplete, aborted }
 
 class _Csi {
   _Csi({

--- a/third_party/xterm/lib/src/terminal.dart
+++ b/third_party/xterm/lib/src/terminal.dart
@@ -1430,6 +1430,16 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
   }
 
   @override
+  void graphicsCommandAbort() {
+    // An ESC ended the command before its terminator, so whatever an earlier
+    // `m=1` chunk opened can never be completed. Dropping it keeps the next
+    // real image from being swallowed as a continuation of this one.
+    if (!_graphicsActive) return;
+    _graphicsActive = false;
+    _graphicsData.clear();
+  }
+
+  @override
   void graphicsCommandEnd() {
     if (!_graphicsActive) return;
     _graphicsActive = false;

--- a/third_party/xterm/lib/src/utils/debugger.dart
+++ b/third_party/xterm/lib/src/utils/debugger.dart
@@ -683,4 +683,9 @@ class _TerminalDebuggerHandler implements EscapeHandler {
   void graphicsCommandEnd() {
     onCommand('graphicsCommandEnd');
   }
+
+  @override
+  void graphicsCommandAbort() {
+    onCommand('graphicsCommandAbort');
+  }
 }

--- a/third_party/xterm/test/src/core/escape/parser_test.dart
+++ b/third_party/xterm/test/src/core/escape/parser_test.dart
@@ -311,6 +311,27 @@ void main() {
         verifyNever(handler.sendTermcapReport(any));
       });
 
+      test('ESC is not taken as a charset designation name', () {
+        final handler = MockEscapeHandler();
+        EscapeParser(handler).write('\x1b(\x1b]2;title\x07');
+        verify(handler.setTitle('title')).called(1);
+        verifyNever(handler.designateCharset(any, any));
+      });
+
+      test('an aborted APC cancels an open m=1 graphics transmission', () {
+        // Without the cancel, `_graphicsActive` stays set and Terminal swallows
+        // the next image's args as a continuation of the broken transmission.
+        final handler = MockEscapeHandler();
+        final parser = EscapeParser(handler)
+          ..write('\x1b_Ga=T,f=100,m=1;AAAA\x1b\\')
+          ..write('\x1b_Gm=0;BBBB\x1b[0m');
+        verify(handler.graphicsCommandAbort()).called(1);
+        verifyNever(handler.graphicsCommandEnd());
+
+        parser.write('\x1b_Ga=T,f=100;CCCC\x1b\\');
+        verify(handler.graphicsCommandEnd()).called(1);
+      });
+
       test('a trailing lone ESC is still buffered across writes', () {
         final handler = MockEscapeHandler();
         EscapeParser(handler)

--- a/third_party/xterm/test/src/core/escape/parser_test.dart
+++ b/third_party/xterm/test/src/core/escape/parser_test.dart
@@ -250,5 +250,74 @@ void main() {
         verify(handler.graphicsCommandEnd()).called(1);
       });
     });
+
+    group('ESC re-enters the escape state', () {
+      // ECMA-48/VT500: an ESC aborts whatever sequence is being collected and
+      // starts a new one. Swallowing it instead lets a duplicated or stray ESC
+      // turn the sequence that follows into visible garbage, e.g. `ESC ESC ] 8
+      // ; id=...` printing the hyperlink introducer as literal text.
+      test('duplicated ESC still dispatches the OSC that follows', () {
+        final handler = MockEscapeHandler();
+        EscapeParser(handler).write(
+          '\x1b\x1b]8;id=md-7nao1v;https://example.com/x\x1b\\',
+        );
+        verify(
+          handler.unknownOSC('8', ['id=md-7nao1v', 'https://example.com/x']),
+        ).called(1);
+        verifyNever(handler.writeChar(0x5d)); // ']'
+      });
+
+      test('duplicated ESC still dispatches the CSI that follows', () {
+        final handler = MockEscapeHandler();
+        EscapeParser(handler).write('\x1b\x1b[38;5;214m');
+        verify(handler.setForegroundColor256(214)).called(1);
+        verifyNever(handler.writeChar(0x5b)); // '['
+      });
+
+      test('ESC ends a truncated CSI instead of being absorbed by it', () {
+        final handler = MockEscapeHandler();
+        EscapeParser(handler).write('\x1b[38;5\x1b]0;title\x07');
+        verify(handler.setTitle('title')).called(1);
+      });
+
+      test('ESC ends a truncated OSC instead of swallowing the next escape',
+          () {
+        final handler = MockEscapeHandler();
+        EscapeParser(handler).write('\x1b]0;trunc\x1b]2;title\x07');
+        verify(handler.setTitle('title')).called(1);
+        verifyNever(handler.setTitle('trunc'));
+      });
+
+      test('a truncated OSC does not dispatch its partial parameters', () {
+        final handler = MockEscapeHandler();
+        EscapeParser(handler).write('\x1b]8;id=x;https://cut\x1b[38;5;214m');
+        verifyNever(handler.unknownOSC(any, any));
+        verify(handler.setForegroundColor256(214)).called(1);
+      });
+
+      test('ESC ends a truncated APC instead of swallowing the next escape',
+          () {
+        final handler = MockEscapeHandler();
+        EscapeParser(handler).write('\x1b_Ga=T;aGk\x1b]2;title\x07');
+        verify(handler.setTitle('title')).called(1);
+        verifyNever(handler.graphicsCommandStart(captureAny));
+      });
+
+      test('ESC ends a truncated DCS instead of swallowing the next escape',
+          () {
+        final handler = MockEscapeHandler();
+        EscapeParser(handler).write('\x1bP+q544\x1b]2;title\x07');
+        verify(handler.setTitle('title')).called(1);
+        verifyNever(handler.sendTermcapReport(any));
+      });
+
+      test('a trailing lone ESC is still buffered across writes', () {
+        final handler = MockEscapeHandler();
+        EscapeParser(handler)
+          ..write('\x1b\x1b')
+          ..write(']2;title\x07');
+        verify(handler.setTitle('title')).called(1);
+      });
+    });
   });
 }

--- a/third_party/xterm/test/src/core/escape/parser_test.mocks.dart
+++ b/third_party/xterm/test/src/core/escape/parser_test.mocks.dart
@@ -1169,4 +1169,13 @@ class MockEscapeHandler extends _i1.Mock implements _i2.EscapeHandler {
         ),
         returnValueForMissingStub: null,
       );
+
+  @override
+  void graphicsCommandAbort() => super.noSuchMethod(
+        Invocation.method(
+          #graphicsCommandAbort,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }


### PR DESCRIPTION
## Problem

A rendered line could show the raw OSC 8 hyperlink introducer instead of a link:

```
• Seeded release: ]8;id=md-7nao1v;https://github.com/depollsoft
  SH/releases/tag/store-assetshttps://github.com/depollsoft/Mon
  eySSH/releases/tag/store-assets
```

Reported from a live Copilot CLI session over MonkeyMux. Two defects combine to produce it.

## Root cause

**1. MonkeyMux duplicated an ESC.**

`stripLocallyAnsweredThemeQueriesLocked` withholds a partial OSC from the live stream until its tail arrives, so a colour query split across two PTY reads can still be recognised and stripped. `appendHistoryLocked` records the whole chunk regardless.

A replay landing in that window (re-attach, window switch, app resume — routine on mobile) therefore delivers the withheld bytes, and the next chunk forwards them a second time. When the withheld byte is the ESC that opens an OSC 8 sequence, the client receives `ESC ESC ] 8 ; ...`.

**2. The vendored xterm parser turned that duplicate into visible garbage.**

It consumed `ESC ESC` as an unknown two-byte escape, leaving `]8;id=...` to print as text. ECMA-48/VT500 — and xterm.js — instead treat ESC as re-entering the escape state from *anywhere*, aborting whatever sequence is being collected.

Reproduced exactly before fixing:

```
row0: Seeded release: ]8;id=md-7nao1v;https://github.com/depollsoft/M
```

## Fix

- **`remote/monkeymux`**: drop `attachOscBuffer` once a history replay has delivered those bytes, so they are never forwarded twice. This also stops the client being left holding a dangling, never-terminated partial OSC in the same scenario.
- **`third_party/xterm`**: apply the ESC re-entry rule to the escape, CSI, OSC, DCS, APC and Kitty-graphics consumers. A stray or duplicated ESC now ends the pending sequence instead of swallowing the one that follows.

Two related defects fall out of the same change: a truncated CSI no longer absorbs ESC as an intermediate byte, and an aborted OSC no longer dispatches its partial parameters (a truncated hyperlink URL or window title).

## Validation

- Full app suite: 2991 tests pass
- MonkeyMux Go suite: `gofmt -l`, `go vet ./...`, `go test ./...` clean
- Vendored xterm suite passes (the 2 `terminal_view_test.dart` `textScaler` failures are pre-existing on `main`)
- `flutter analyze`: no issues

New regression tests at three levels:
- `remote/monkeymux/main_test.go` — replay + live stream contains no duplicated ESC
- `third_party/xterm/test/src/core/escape/parser_test.dart` — 8 cases covering ESC re-entry for OSC/CSI/DCS/APC, truncated-sequence abort, and a lone ESC buffered across writes
- `test/domain/services/terminal_hyperlink_tracker_test.dart` — a link preceded by a stray ESC renders and stays tappable