### PR TITLE
chore: prepare v0.3.3 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,12 @@ permissions:
 jobs:
   compute-version:
     name: Compute Version
+    # `store-assets` is a rolling prerelease that re-hosts regenerated store
+    # media. Publishing it fires `release: published`, but it is not an app
+    # release and its tag is not an x.y.z version, so skip the deploy entirely.
+    if: >-
+      github.event_name != 'release' ||
+      github.event.release.tag_name != 'store-assets'
     runs-on: ubuntu-latest
     outputs:
       build-name: ${{ steps.version.outputs.build-name }}

--- a/android/fastlane/metadata-private/android/en-US/changelogs/default.txt
+++ b/android/fastlane/metadata-private/android/en-US/changelogs/default.txt
@@ -1,8 +1,6 @@
-What's new in this 0.3.2 beta
+What's new in this 0.3.3 beta
 
-- Launch presets for Pi, Hermes, and OpenClaw.
-- Mux version shown in terminal info.
-- MonkeyMux reconnect preserves your session.
-- Windows remotes: titles, Escape, Kitty graphics, steadier redraws.
-- More reliable paste and capability handling.
-- Window switching and control-channel stability fixes.
+- Windows remotes keep bracketed paste intact.
+- Links no longer render as stray escape text.
+- Escape stays responsive while a paste is arriving.
+- Keystrokes arrive in order when attaching a MonkeyMux window.

--- a/android/fastlane/metadata-production/android/en-US/changelogs/default.txt
+++ b/android/fastlane/metadata-production/android/en-US/changelogs/default.txt
@@ -1,8 +1,9 @@
-What's new in 0.3.2
+What's new in 0.3.3
 
+- Windows remotes: bracketed paste survives the round trip, plus session titles, Escape, and Kitty graphics.
+- Links no longer render as stray escape text.
+- Escape stays responsive while a paste is arriving.
+- Keystrokes arrive in order when attaching a MonkeyMux window.
 - Launch presets for Pi, Hermes, and OpenClaw.
-- Mux version shown in terminal info.
 - MonkeyMux reconnect preserves your session.
-- Windows remotes: titles, Escape, Kitty graphics, steadier redraws.
-- More reliable paste and capability handling.
 - Window switching and control-channel stability fixes.

--- a/ios/fastlane/metadata-private/en-US/release_notes.txt
+++ b/ios/fastlane/metadata-private/en-US/release_notes.txt
@@ -1,10 +1,8 @@
-What's new in this 0.3.2 beta
+What's new in this 0.3.3 beta
 
-- Launch presets for Pi, Hermes, and OpenClaw join the existing agent family.
-- Terminal info now shows the active MonkeyMux helper version.
-- MonkeyMux reconnect keeps your session instead of starting over.
-- Windows remotes: session titles, Escape key, Kitty graphics, and steadier redraws.
-- Bracketed paste and terminal capability handling are more reliable.
-- Stability fixes for window switching, control-channel recovery, and agent detection.
+- Pasting into Windows remotes keeps bracketed paste intact, so editors and agents treat it as a paste instead of typed keystrokes.
+- Links no longer show up as stray escape text in the terminal.
+- Escape stays responsive while a paste is still arriving.
+- Keystrokes arrive in order when attaching to a MonkeyMux window.
 
 Thanks for testing the beta — please report anything that feels off.

--- a/ios/fastlane/metadata-production/en-US/release_notes.txt
+++ b/ios/fastlane/metadata-production/en-US/release_notes.txt
@@ -1,8 +1,6 @@
-What's new in 0.3.2
+What's new in 0.3.3
 
-- Launch presets for Pi, Hermes, and OpenClaw join the existing agent family.
-- Terminal info now shows the active MonkeyMux helper version.
-- MonkeyMux reconnect keeps your session instead of starting over.
-- Windows remotes: session titles, Escape key, Kitty graphics, and steadier redraws.
-- Bracketed paste and terminal capability handling are more reliable.
-- Stability fixes for window switching, control-channel recovery, and agent detection.
+- Pasting into Windows remotes keeps bracketed paste intact, so editors and agents treat it as a paste instead of typed keystrokes.
+- Links no longer show up as stray escape text in the terminal.
+- Escape stays responsive while a paste is still arriving.
+- Keystrokes arrive in order when attaching to a MonkeyMux window.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
   MonkeyMux/tmux remote windows, key management, snippets, and port forwarding.
 publish_to: 'none'
 
-version: 0.3.2+1
+version: 0.3.3+1
 
 environment:
   sdk: ^3.10.7


### PR DESCRIPTION
Prepares the v0.3.3 production release.

## Version

Bumps `pubspec.yaml` to `0.3.3+1`. Nothing in `lib/` changed since 0.3.2, but the
bundled MonkeyMux helper (`assets/monkeymux/bin/...`) picked up four user-facing
fixes, so they ship as an app update:

- bracketed paste preserved through ConPTY on Windows remotes
- a duplicated ESC no longer prints OSC 8 hyperlinks as literal text
- paste-prefix classification and Escape semantics preserved
- ordered attach input queuing

## Release notes

iOS notes cover 0.3.3 only. The **Play production changelog also carries the
0.3.2 highlights forward**, because the 0.3.2 Android rollout failed
(`Google Api Error: Invalid request - This Edit has been deleted.`, run
[30929241207](https://github.com/depollsoft/MonkeySSH/actions/runs/30929241207))
and Play production is still on 0.3.1. iOS did ship 0.3.2 successfully.

## CI fix

`release.yml` triggers on any `release: published`, so publishing the rolling
`store-assets` prerelease started a production deploy that failed in Compute
Version because `store-assets` is not an `x.y.z` tag (run
[30934054820](https://github.com/depollsoft/MonkeySSH/actions/runs/30934054820)).
Guards `compute-version` so media publishes no longer trigger a failing release.

## Validation

- `python3 scripts/validate_app_store_metadata.py both` — pass
- `python3 scripts/validate_play_store_metadata.py both` — pass
- `python3 scripts/validate_store_screenshots.py both` — pass (against the published `store-assets` archive)
- `python3 scripts/validate_store_demo_videos.py all` — pass

Store media was **not** regenerated: no UI code changed since the Aug 4
`store-assets` publish, and the existing archive validates clean.