### PR TITLE
docs: correct attach wording in Play changelogs

### DIFF
--- a/android/fastlane/metadata-private/android/en-US/changelogs/default.txt
+++ b/android/fastlane/metadata-private/android/en-US/changelogs/default.txt
@@ -3,4 +3,4 @@ What's new in this 0.3.3 beta
 - Windows remotes keep bracketed paste intact.
 - Links no longer render as stray escape text.
 - Escape stays responsive while a paste is arriving.
-- Keystrokes arrive in order when attaching a MonkeyMux window.
+- Keystrokes arrive in order when attaching to a MonkeyMux window.

--- a/android/fastlane/metadata-production/android/en-US/changelogs/default.txt
+++ b/android/fastlane/metadata-production/android/en-US/changelogs/default.txt
@@ -3,7 +3,7 @@ What's new in 0.3.3
 - Windows remotes: bracketed paste survives the round trip, plus session titles, Escape, and Kitty graphics.
 - Links no longer render as stray escape text.
 - Escape stays responsive while a paste is arriving.
-- Keystrokes arrive in order when attaching a MonkeyMux window.
+- Keystrokes arrive in order when attaching to a MonkeyMux window.
 - Launch presets for Pi, Hermes, and OpenClaw.
 - MonkeyMux reconnect preserves your session.
 - Window switching and control-channel stability fixes.


### PR DESCRIPTION
Follow-up to #731. The Play changelogs said "attaching a MonkeyMux window"; the iOS release notes say "attaching to a MonkeyMux window", which is the correct phrasing for the action. Aligns both Play flavors.

`python3 scripts/validate_play_store_metadata.py both` passes.