### PR TITLE
feat: toggle automatic port forwarding from the terminal sheet

### DIFF
--- a/lib/data/repositories/host_repository.dart
+++ b/lib/data/repositories/host_repository.dart
@@ -325,6 +325,14 @@ class HostRepository {
     return update(host.copyWith(isFavorite: !host.isFavorite));
   }
 
+  /// Enable or disable automatic forwarding of newly opened remote ports.
+  Future<bool> setAutoForwardPorts(int id, {required bool enabled}) async {
+    final host = await getById(id);
+    if (host == null) return false;
+    if (host.autoForwardPorts == enabled) return true;
+    return update(host.copyWith(autoForwardPorts: enabled));
+  }
+
   /// Update last connected timestamp.
   Future<bool> updateLastConnected(int id) async {
     final host = await getById(id);

--- a/lib/data/repositories/host_repository.dart
+++ b/lib/data/repositories/host_repository.dart
@@ -100,6 +100,14 @@ class HostRepository {
     return _decryptHost(host);
   }
 
+  /// Watch a single host by ID.
+  Stream<Host?> watchById(int id) =>
+      (_db.select(
+        _db.hosts,
+      )..where((h) => h.id.equals(id))).watchSingleOrNull().asyncMap(
+        (host) => host == null ? Future.value() : _decryptHost(host),
+      );
+
   /// Resolves this host's collision-free custom or generated proxy name.
   Future<String> resolveProxyName({
     required int hostId,
@@ -325,13 +333,26 @@ class HostRepository {
     return update(host.copyWith(isFavorite: !host.isFavorite));
   }
 
-  /// Enable or disable automatic forwarding of newly opened remote ports.
-  Future<bool> setAutoForwardPorts(int id, {required bool enabled}) async {
-    final host = await getById(id);
-    if (host == null) return false;
-    if (host.autoForwardPorts == enabled) return true;
-    return update(host.copyWith(autoForwardPorts: enabled));
+  /// Applies a partial column update to a single host.
+  ///
+  /// Unlike [update], this never rewrites columns the caller did not set, so a
+  /// stale in-memory [Host] snapshot cannot clobber fields changed elsewhere.
+  /// The `password` column is always left untouched here; use [update] for
+  /// credential changes so the secret is encrypted and cached correctly.
+  Future<bool> updateFields(int id, HostsCompanion changes) async {
+    final updatedRows =
+        await (_db.update(_db.hosts)..where((h) => h.id.equals(id))).write(
+          changes.copyWith(
+            id: const Value.absent(),
+            password: const Value.absent(),
+          ),
+        );
+    return updatedRows > 0;
   }
+
+  /// Enable or disable automatic forwarding of newly opened remote ports.
+  Future<bool> setAutoForwardPorts(int id, {required bool enabled}) =>
+      updateFields(id, HostsCompanion(autoForwardPorts: Value(enabled)));
 
   /// Update last connected timestamp.
   Future<bool> updateLastConnected(int id) async {

--- a/lib/presentation/providers/entity_list_providers.dart
+++ b/lib/presentation/providers/entity_list_providers.dart
@@ -16,6 +16,12 @@ final allHostsProvider = StreamProvider<List<Host>>((ref) {
   return repo.watchAll();
 });
 
+/// Stream of a single saved host, or `null` when it no longer exists.
+final hostByIdProvider = StreamProvider.family<Host?, int>((ref, hostId) {
+  final repo = ref.watch(hostRepositoryProvider);
+  return repo.watchById(hostId);
+});
+
 /// Shared stream of all saved SSH keys for presentation screens.
 final allKeysProvider = StreamProvider<List<SshKey>>((ref) {
   final repo = ref.watch(keyRepositoryProvider);

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -9077,7 +9077,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         final updatedHost = host.copyWith(
           autoConnectRequiresConfirmation: false,
         );
-        await ref.read(hostRepositoryProvider).update(updatedHost);
+        await ref
+            .read(hostRepositoryProvider)
+            .updateFields(
+              updatedHost.id,
+              const HostsCompanion(
+                autoConnectRequiresConfirmation: drift.Value(false),
+              ),
+            );
         _host = updatedHost;
       }
     }
@@ -9125,7 +9132,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         final updatedHost = host.copyWith(
           autoConnectRequiresConfirmation: false,
         );
-        await ref.read(hostRepositoryProvider).update(updatedHost);
+        await ref
+            .read(hostRepositoryProvider)
+            .updateFields(
+              updatedHost.id,
+              const HostsCompanion(
+                autoConnectRequiresConfirmation: drift.Value(false),
+              ),
+            );
         _host = updatedHost;
       }
     }
@@ -9770,7 +9784,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         final updatedHost = host.copyWith(
           autoConnectRequiresConfirmation: false,
         );
-        await ref.read(hostRepositoryProvider).update(updatedHost);
+        await ref
+            .read(hostRepositoryProvider)
+            .updateFields(
+              updatedHost.id,
+              const HostsCompanion(
+                autoConnectRequiresConfirmation: drift.Value(false),
+              ),
+            );
         _host = updatedHost;
       }
     }
@@ -13078,7 +13099,12 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         ? _host!.copyWith(terminalThemeDarkId: drift.Value(theme.id))
         : _host!.copyWith(terminalThemeLightId: drift.Value(theme.id));
 
-    await hostRepo.update(updatedHost);
+    await hostRepo.updateFields(
+      updatedHost.id,
+      isDark
+          ? HostsCompanion(terminalThemeDarkId: drift.Value(theme.id))
+          : HostsCompanion(terminalThemeLightId: drift.Value(theme.id)),
+    );
     _host = updatedHost;
 
     if (mounted) {

--- a/lib/presentation/widgets/terminal_port_forwards_sheet.dart
+++ b/lib/presentation/widgets/terminal_port_forwards_sheet.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../app/theme.dart';
 import '../../data/database/database.dart';
+import '../../data/repositories/host_repository.dart';
 import '../../domain/services/ssh_service.dart';
 import '../providers/entity_list_providers.dart';
 import 'brand_empty_state.dart';
@@ -65,11 +66,22 @@ class _TerminalPortForwardsSheet extends ConsumerStatefulWidget {
 class _TerminalPortForwardsSheetState
     extends ConsumerState<_TerminalPortForwardsSheet> {
   final Set<int> _pendingPortForwardIds = {};
+  bool _isUpdatingAutoForwardPorts = false;
 
   @override
   Widget build(BuildContext context) {
     final portForwards = ref.watch(portForwardsForHostProvider(widget.hostId));
     final activeSessionStates = ref.watch(activeSessionsProvider);
+    final autoForwardPorts = ref.watch(
+      allHostsProvider.select((hosts) {
+        for (final host in hosts.asData?.value ?? const <Host>[]) {
+          if (host.id == widget.hostId) {
+            return host.autoForwardPorts;
+          }
+        }
+        return null;
+      }),
+    );
     final isConnected =
         activeSessionStates[widget.connectionId] ==
         SshConnectionState.connected;
@@ -163,17 +175,27 @@ class _TerminalPortForwardsSheetState
                 onRetry: () =>
                     ref.invalidate(portForwardsForHostProvider(widget.hostId)),
               ),
-              data: (forwards) {
-                if (forwards.isEmpty && automaticTunnels.isEmpty) {
-                  return _buildEmptyState(context);
-                }
-                return _buildForwardList(
-                  context,
-                  forwards: forwards,
-                  automaticTunnels: automaticTunnels,
-                  isConnected: isConnected,
-                );
-              },
+              data: (forwards) => ListView(
+                controller: widget.scrollController,
+                padding: const EdgeInsets.only(bottom: FluttyTheme.spacingSm),
+                children: [
+                  _buildAutoForwardToggle(
+                    context,
+                    autoForwardPorts: autoForwardPorts,
+                    hasAutomaticTunnels: automaticTunnels.isNotEmpty,
+                  ),
+                  const Divider(height: 1),
+                  if (forwards.isEmpty && automaticTunnels.isEmpty)
+                    _buildEmptyState(context)
+                  else
+                    ..._buildForwardRows(
+                      context,
+                      forwards: forwards,
+                      automaticTunnels: automaticTunnels,
+                      isConnected: isConnected,
+                    ),
+                ],
+              ),
             ),
           ),
         ),
@@ -197,56 +219,128 @@ class _TerminalPortForwardsSheetState
     );
   }
 
-  Widget _buildEmptyState(BuildContext context) => Center(
-    child: SingleChildScrollView(
-      controller: widget.scrollController,
-      padding: const EdgeInsets.all(FluttyTheme.spacingLg),
-      child: BrandEmptyState(
-        title: 'no forwards for this host',
-        message: 'Add a rule, then start it without leaving the terminal.',
-        primaryLabel: 'Add Forward',
-        onPrimary: _addForward,
-      ),
+  Widget _buildAutoForwardToggle(
+    BuildContext context, {
+    required bool? autoForwardPorts,
+    required bool hasAutomaticTunnels,
+  }) {
+    final theme = Theme.of(context);
+    final isEnabled = autoForwardPorts ?? false;
+    return SwitchListTile.adaptive(
+      key: const Key('terminal-auto-forward-ports-switch'),
+      secondary: _isUpdatingAutoForwardPorts
+          ? const SizedBox.square(
+              dimension: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : Icon(
+              Icons.radar_rounded,
+              color: isEnabled
+                  ? theme.colorScheme.primary
+                  : theme.colorScheme.onSurfaceVariant,
+            ),
+      title: const Text('Detect open ports'),
+      subtitle: Text(switch ((isEnabled, hasAutomaticTunnels)) {
+        (false, _) => 'Automatically proxy new remote listeners on this host',
+        (true, true) => 'Proxying new remote listeners while connected',
+        (true, false) => 'Watching this host for new remote listeners',
+      }, style: theme.textTheme.bodySmall),
+      value: isEnabled,
+      onChanged: autoForwardPorts == null || _isUpdatingAutoForwardPorts
+          ? null
+          : (enabled) => unawaited(_setAutoForwardPorts(enabled: enabled)),
+    );
+  }
+
+  Future<void> _setAutoForwardPorts({required bool enabled}) async {
+    if (_isUpdatingAutoForwardPorts) {
+      return;
+    }
+    setState(() => _isUpdatingAutoForwardPorts = true);
+    try {
+      final updated = await ref
+          .read(hostRepositoryProvider)
+          .setAutoForwardPorts(widget.hostId, enabled: enabled);
+      if (!updated) {
+        if (mounted) {
+          _showMessage('Could not update automatic port detection.');
+        }
+        return;
+      }
+      await ref
+          .read(activeSessionsProvider.notifier)
+          .reconfigureAutomaticPortForwardingForHost(widget.hostId);
+      if (mounted) {
+        _showMessage(
+          enabled
+              ? 'Detecting open ports on this host.'
+              : 'Stopped detecting open ports on this host.',
+        );
+      }
+    } on Object catch (error, stackTrace) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          library: 'port forwards',
+          context: ErrorDescription(
+            'while changing automatic port forwarding for a host',
+          ),
+        ),
+      );
+      if (mounted) {
+        _showMessage('Could not update automatic port detection.');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isUpdatingAutoForwardPorts = false);
+      }
+    }
+  }
+
+  Widget _buildEmptyState(BuildContext context) => Padding(
+    padding: const EdgeInsets.all(FluttyTheme.spacingLg),
+    child: BrandEmptyState(
+      title: 'no forwards for this host',
+      message: 'Add a rule, then start it without leaving the terminal.',
+      primaryLabel: 'Add Forward',
+      onPrimary: _addForward,
     ),
   );
 
-  Widget _buildForwardList(
+  List<Widget> _buildForwardRows(
     BuildContext context, {
     required List<PortForward> forwards,
     required List<ActiveTunnelInfo> automaticTunnels,
     required bool isConnected,
-  }) => ListView(
-    controller: widget.scrollController,
-    padding: const EdgeInsets.symmetric(vertical: FluttyTheme.spacingSm),
-    children: [
-      if (automaticTunnels.any((tunnel) => tunnel.isShellRelated)) ...[
-        _buildGroupLabel(context, 'This saved host'),
-        for (final tunnel in automaticTunnels.where(
-          (tunnel) => tunnel.isShellRelated,
-        )) ...[
-          _buildAutomaticForwardRow(context, tunnel),
-          const Divider(height: 1),
-        ],
-      ],
-      if (automaticTunnels.any((tunnel) => !tunnel.isShellRelated)) ...[
-        _buildGroupLabel(context, 'Shared host services'),
-        for (final tunnel in automaticTunnels.where(
-          (tunnel) => !tunnel.isShellRelated,
-        )) ...[
-          _buildAutomaticForwardRow(context, tunnel),
-          const Divider(height: 1),
-        ],
-      ],
-      if (forwards.isNotEmpty) ...[
-        if (automaticTunnels.isNotEmpty)
-          _buildGroupLabel(context, 'Saved forwards'),
-        for (var index = 0; index < forwards.length; index++) ...[
-          _buildForwardRow(context, forwards[index], isConnected: isConnected),
-          if (index < forwards.length - 1) const Divider(height: 1),
-        ],
+  }) => [
+    if (automaticTunnels.any((tunnel) => tunnel.isShellRelated)) ...[
+      _buildGroupLabel(context, 'This saved host'),
+      for (final tunnel in automaticTunnels.where(
+        (tunnel) => tunnel.isShellRelated,
+      )) ...[
+        _buildAutomaticForwardRow(context, tunnel),
+        const Divider(height: 1),
       ],
     ],
-  );
+    if (automaticTunnels.any((tunnel) => !tunnel.isShellRelated)) ...[
+      _buildGroupLabel(context, 'Shared host services'),
+      for (final tunnel in automaticTunnels.where(
+        (tunnel) => !tunnel.isShellRelated,
+      )) ...[
+        _buildAutomaticForwardRow(context, tunnel),
+        const Divider(height: 1),
+      ],
+    ],
+    if (forwards.isNotEmpty) ...[
+      if (automaticTunnels.isNotEmpty)
+        _buildGroupLabel(context, 'Saved forwards'),
+      for (var index = 0; index < forwards.length; index++) ...[
+        _buildForwardRow(context, forwards[index], isConnected: isConnected),
+        if (index < forwards.length - 1) const Divider(height: 1),
+      ],
+    ],
+  ];
 
   Widget _buildGroupLabel(BuildContext context, String label) => Padding(
     padding: const EdgeInsets.fromLTRB(
@@ -434,6 +528,7 @@ class _TerminalPortForwardsSheetState
                               : 'Start ${portForward.name}',
                           toggled: isActive,
                           child: Switch(
+                            key: Key('port-forward-switch-${portForward.id}'),
                             value: isActive,
                             onChanged: !isConnected
                                 ? null

--- a/lib/presentation/widgets/terminal_port_forwards_sheet.dart
+++ b/lib/presentation/widgets/terminal_port_forwards_sheet.dart
@@ -73,14 +73,9 @@ class _TerminalPortForwardsSheetState
     final portForwards = ref.watch(portForwardsForHostProvider(widget.hostId));
     final activeSessionStates = ref.watch(activeSessionsProvider);
     final autoForwardPorts = ref.watch(
-      allHostsProvider.select((hosts) {
-        for (final host in hosts.asData?.value ?? const <Host>[]) {
-          if (host.id == widget.hostId) {
-            return host.autoForwardPorts;
-          }
-        }
-        return null;
-      }),
+      hostByIdProvider(
+        widget.hostId,
+      ).select((host) => host.asData?.value?.autoForwardPorts),
     );
     final isConnected =
         activeSessionStates[widget.connectionId] ==
@@ -164,6 +159,13 @@ class _TerminalPortForwardsSheetState
               ],
             ),
           ),
+        _buildAutoForwardToggle(
+          context,
+          autoForwardPorts: autoForwardPorts,
+          hasAutomaticTunnels: automaticTunnels.isNotEmpty,
+          isConnected: isConnected,
+        ),
+        const Divider(height: 1),
         Expanded(
           child: StreamBuilder<void>(
             stream: widget.session.portForwardChanges,
@@ -175,27 +177,17 @@ class _TerminalPortForwardsSheetState
                 onRetry: () =>
                     ref.invalidate(portForwardsForHostProvider(widget.hostId)),
               ),
-              data: (forwards) => ListView(
-                controller: widget.scrollController,
-                padding: const EdgeInsets.only(bottom: FluttyTheme.spacingSm),
-                children: [
-                  _buildAutoForwardToggle(
-                    context,
-                    autoForwardPorts: autoForwardPorts,
-                    hasAutomaticTunnels: automaticTunnels.isNotEmpty,
-                  ),
-                  const Divider(height: 1),
-                  if (forwards.isEmpty && automaticTunnels.isEmpty)
-                    _buildEmptyState(context)
-                  else
-                    ..._buildForwardRows(
-                      context,
-                      forwards: forwards,
-                      automaticTunnels: automaticTunnels,
-                      isConnected: isConnected,
-                    ),
-                ],
-              ),
+              data: (forwards) {
+                if (forwards.isEmpty && automaticTunnels.isEmpty) {
+                  return _buildEmptyState(context);
+                }
+                return _buildForwardList(
+                  context,
+                  forwards: forwards,
+                  automaticTunnels: automaticTunnels,
+                  isConnected: isConnected,
+                );
+              },
             ),
           ),
         ),
@@ -223,11 +215,13 @@ class _TerminalPortForwardsSheetState
     BuildContext context, {
     required bool? autoForwardPorts,
     required bool hasAutomaticTunnels,
+    required bool isConnected,
   }) {
     final theme = Theme.of(context);
     final isEnabled = autoForwardPorts ?? false;
     return SwitchListTile.adaptive(
       key: const Key('terminal-auto-forward-ports-switch'),
+      dense: true,
       secondary: _isUpdatingAutoForwardPorts
           ? const SizedBox.square(
               dimension: 20,
@@ -240,10 +234,13 @@ class _TerminalPortForwardsSheetState
                   : theme.colorScheme.onSurfaceVariant,
             ),
       title: const Text('Detect open ports'),
-      subtitle: Text(switch ((isEnabled, hasAutomaticTunnels)) {
-        (false, _) => 'Automatically proxy new remote listeners on this host',
-        (true, true) => 'Proxying new remote listeners while connected',
-        (true, false) => 'Watching this host for new remote listeners',
+      subtitle: Text(switch ((isEnabled, isConnected, hasAutomaticTunnels)) {
+        (false, _, _) =>
+          'Automatically proxy new remote listeners on this host',
+        (true, false, _) =>
+          'Will watch for new remote listeners once connected',
+        (true, true, true) => 'Proxying new remote listeners while connected',
+        (true, true, false) => 'Watching this host for new remote listeners',
       }, style: theme.textTheme.bodySmall),
       value: isEnabled,
       onChanged: autoForwardPorts == null || _isUpdatingAutoForwardPorts
@@ -256,20 +253,23 @@ class _TerminalPortForwardsSheetState
     if (_isUpdatingAutoForwardPorts) {
       return;
     }
+    // Captured before the first await so dismissing the sheet mid-save still
+    // applies the change to live sessions.
+    final hostRepository = ref.read(hostRepositoryProvider);
+    final sessions = ref.read(activeSessionsProvider.notifier);
     setState(() => _isUpdatingAutoForwardPorts = true);
     try {
-      final updated = await ref
-          .read(hostRepositoryProvider)
-          .setAutoForwardPorts(widget.hostId, enabled: enabled);
+      final updated = await hostRepository.setAutoForwardPorts(
+        widget.hostId,
+        enabled: enabled,
+      );
       if (!updated) {
         if (mounted) {
           _showMessage('Could not update automatic port detection.');
         }
         return;
       }
-      await ref
-          .read(activeSessionsProvider.notifier)
-          .reconfigureAutomaticPortForwardingForHost(widget.hostId);
+      await sessions.reconfigureAutomaticPortForwardingForHost(widget.hostId);
       if (mounted) {
         _showMessage(
           enabled
@@ -298,49 +298,56 @@ class _TerminalPortForwardsSheetState
     }
   }
 
-  Widget _buildEmptyState(BuildContext context) => Padding(
-    padding: const EdgeInsets.all(FluttyTheme.spacingLg),
-    child: BrandEmptyState(
-      title: 'no forwards for this host',
-      message: 'Add a rule, then start it without leaving the terminal.',
-      primaryLabel: 'Add Forward',
-      onPrimary: _addForward,
+  Widget _buildEmptyState(BuildContext context) => Center(
+    child: SingleChildScrollView(
+      controller: widget.scrollController,
+      padding: const EdgeInsets.all(FluttyTheme.spacingLg),
+      child: BrandEmptyState(
+        title: 'no forwards for this host',
+        message: 'Add a rule, then start it without leaving the terminal.',
+        primaryLabel: 'Add Forward',
+        onPrimary: _addForward,
+      ),
     ),
   );
 
-  List<Widget> _buildForwardRows(
+  Widget _buildForwardList(
     BuildContext context, {
     required List<PortForward> forwards,
     required List<ActiveTunnelInfo> automaticTunnels,
     required bool isConnected,
-  }) => [
-    if (automaticTunnels.any((tunnel) => tunnel.isShellRelated)) ...[
-      _buildGroupLabel(context, 'This saved host'),
-      for (final tunnel in automaticTunnels.where(
-        (tunnel) => tunnel.isShellRelated,
-      )) ...[
-        _buildAutomaticForwardRow(context, tunnel),
-        const Divider(height: 1),
+  }) => ListView(
+    controller: widget.scrollController,
+    padding: const EdgeInsets.symmetric(vertical: FluttyTheme.spacingSm),
+    children: [
+      if (automaticTunnels.any((tunnel) => tunnel.isShellRelated)) ...[
+        _buildGroupLabel(context, 'This saved host'),
+        for (final tunnel in automaticTunnels.where(
+          (tunnel) => tunnel.isShellRelated,
+        )) ...[
+          _buildAutomaticForwardRow(context, tunnel),
+          const Divider(height: 1),
+        ],
+      ],
+      if (automaticTunnels.any((tunnel) => !tunnel.isShellRelated)) ...[
+        _buildGroupLabel(context, 'Shared host services'),
+        for (final tunnel in automaticTunnels.where(
+          (tunnel) => !tunnel.isShellRelated,
+        )) ...[
+          _buildAutomaticForwardRow(context, tunnel),
+          const Divider(height: 1),
+        ],
+      ],
+      if (forwards.isNotEmpty) ...[
+        if (automaticTunnels.isNotEmpty)
+          _buildGroupLabel(context, 'Saved forwards'),
+        for (var index = 0; index < forwards.length; index++) ...[
+          _buildForwardRow(context, forwards[index], isConnected: isConnected),
+          if (index < forwards.length - 1) const Divider(height: 1),
+        ],
       ],
     ],
-    if (automaticTunnels.any((tunnel) => !tunnel.isShellRelated)) ...[
-      _buildGroupLabel(context, 'Shared host services'),
-      for (final tunnel in automaticTunnels.where(
-        (tunnel) => !tunnel.isShellRelated,
-      )) ...[
-        _buildAutomaticForwardRow(context, tunnel),
-        const Divider(height: 1),
-      ],
-    ],
-    if (forwards.isNotEmpty) ...[
-      if (automaticTunnels.isNotEmpty)
-        _buildGroupLabel(context, 'Saved forwards'),
-      for (var index = 0; index < forwards.length; index++) ...[
-        _buildForwardRow(context, forwards[index], isConnected: isConnected),
-        if (index < forwards.length - 1) const Divider(height: 1),
-      ],
-    ],
-  ];
+  );
 
   Widget _buildGroupLabel(BuildContext context, String label) => Padding(
     padding: const EdgeInsets.fromLTRB(

--- a/test/data/repositories/host_repository_test.dart
+++ b/test/data/repositories/host_repository_test.dart
@@ -899,6 +899,35 @@ void main() {
       expect(result, isFalse);
     });
 
+    test('setAutoForwardPorts persists automatic port detection', () async {
+      final id = await repository.insert(
+        HostsCompanion.insert(
+          label: 'Test Server',
+          hostname: '192.168.1.2',
+          username: 'admin',
+        ),
+      );
+
+      var host = await repository.getById(id);
+      expect(host!.autoForwardPorts, isFalse);
+
+      expect(await repository.setAutoForwardPorts(id, enabled: true), isTrue);
+
+      host = await repository.getById(id);
+      expect(host!.autoForwardPorts, isTrue);
+
+      // A no-op update still reports success without rewriting the row.
+      expect(await repository.setAutoForwardPorts(id, enabled: true), isTrue);
+      expect(await repository.setAutoForwardPorts(id, enabled: false), isTrue);
+
+      host = await repository.getById(id);
+      expect(host!.autoForwardPorts, isFalse);
+    });
+
+    test('setAutoForwardPorts returns false when host not exists', () async {
+      expect(await repository.setAutoForwardPorts(999, enabled: true), isFalse);
+    });
+
     test('getFavorites returns only favorite hosts', () async {
       await repository.insert(
         HostsCompanion.insert(

--- a/test/data/repositories/host_repository_test.dart
+++ b/test/data/repositories/host_repository_test.dart
@@ -916,12 +916,89 @@ void main() {
       host = await repository.getById(id);
       expect(host!.autoForwardPorts, isTrue);
 
-      // A no-op update still reports success without rewriting the row.
-      expect(await repository.setAutoForwardPorts(id, enabled: true), isTrue);
       expect(await repository.setAutoForwardPorts(id, enabled: false), isTrue);
 
       host = await repository.getById(id);
       expect(host!.autoForwardPorts, isFalse);
+    });
+
+    test('setAutoForwardPorts leaves the stored password untouched', () async {
+      const plaintextPassword = 'auto-forward-pass';
+      final id = await repository.insert(
+        HostsCompanion.insert(
+          label: 'Host',
+          hostname: '10.0.0.9',
+          username: 'admin',
+          password: const Value(plaintextPassword),
+        ),
+      );
+
+      Future<String?> storedPassword() async => (await (db.select(
+        db.hosts,
+      )..where((h) => h.id.equals(id))).getSingle()).password;
+
+      final ciphertextBefore = await storedPassword();
+      expect(ciphertextBefore, startsWith('ENCv1:'));
+
+      await repository.setAutoForwardPorts(id, enabled: true);
+
+      // The column write must not re-encrypt (or double-encrypt) the secret.
+      expect(await storedPassword(), ciphertextBefore);
+      expect((await repository.getById(id))!.password, plaintextPassword);
+    });
+
+    test(
+      'setAutoForwardPorts does not clobber concurrent field edits',
+      () async {
+        final id = await repository.insert(
+          HostsCompanion.insert(
+            label: 'Host',
+            hostname: '10.0.0.10',
+            username: 'admin',
+          ),
+        );
+
+        // Simulates a stale snapshot held elsewhere in the app.
+        final staleHost = (await repository.getById(id))!;
+
+        await repository.setAutoForwardPorts(id, enabled: true);
+        await repository.updateFields(
+          id,
+          const HostsCompanion(label: Value('Renamed')),
+        );
+
+        final host = await repository.getById(id);
+        expect(host!.autoForwardPorts, isTrue);
+        expect(host.label, 'Renamed');
+        expect(staleHost.autoForwardPorts, isFalse);
+      },
+    );
+
+    test('updateFields ignores password changes', () async {
+      const plaintextPassword = 'field-update-pass';
+      final id = await repository.insert(
+        HostsCompanion.insert(
+          label: 'Host',
+          hostname: '10.0.0.11',
+          username: 'admin',
+          password: const Value(plaintextPassword),
+        ),
+      );
+
+      await repository.updateFields(
+        id,
+        const HostsCompanion(
+          label: Value('Renamed'),
+          password: Value('plaintext-leak'),
+        ),
+      );
+
+      final rawHost = await (db.select(
+        db.hosts,
+      )..where((h) => h.id.equals(id))).getSingle();
+      expect(rawHost.label, 'Renamed');
+      expect(rawHost.password, startsWith('ENCv1:'));
+      expect((await repository.getById(id))!.password, plaintextPassword);
     });
 
     test('setAutoForwardPorts returns false when host not exists', () async {

--- a/test/widget/terminal_port_forwards_sheet_test.dart
+++ b/test/widget/terminal_port_forwards_sheet_test.dart
@@ -13,6 +13,7 @@ import 'package:monkeyssh/data/repositories/port_forward_repository.dart';
 import 'package:monkeyssh/domain/services/port_forward_browser_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/presentation/providers/entity_list_providers.dart';
+import 'package:monkeyssh/presentation/widgets/brand_list_skeleton.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_port_forwards_sheet.dart';
 
 class _MockPortForwardRepository extends Mock
@@ -99,15 +100,18 @@ class _LiveTestSession extends SshSession {
 }
 
 class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
-  _TestActiveSessionsNotifier(this.sessions);
+  _TestActiveSessionsNotifier(
+    this.sessions, {
+    this.connectionState = SshConnectionState.connected,
+  });
 
   final List<SshSession> sessions;
+  final SshConnectionState connectionState;
   final List<int> reconfiguredHostIds = [];
 
   @override
   Map<int, SshConnectionState> build() => {
-    for (final session in sessions)
-      session.connectionId: SshConnectionState.connected,
+    for (final session in sessions) session.connectionId: connectionState,
   };
 
   @override
@@ -144,6 +148,39 @@ Host _host({bool autoForwardPorts = false}) => Host(
   isFavorite: false,
   autoConnectRequiresConfirmation: false,
   sortOrder: 0,
+);
+
+Widget _buildSheetHost({
+  required _LiveTestSession session,
+  required _TestActiveSessionsNotifier notifier,
+  required PortForwardRepository portForwardRepository,
+  required HostRepository hostRepository,
+  required Stream<Host?> hostStream,
+}) => ProviderScope(
+  overrides: [
+    portForwardRepositoryProvider.overrideWithValue(portForwardRepository),
+    hostRepositoryProvider.overrideWithValue(hostRepository),
+    hostByIdProvider(session.hostId).overrideWith((ref) => hostStream),
+    activeSessionsProvider.overrideWith(() => notifier),
+  ],
+  child: MaterialApp(
+    home: Scaffold(
+      body: Builder(
+        builder: (context) => FilledButton(
+          onPressed: () => unawaited(
+            showTerminalPortForwardsSheet(
+              context: context,
+              hostId: session.hostId,
+              connectionId: session.connectionId,
+              session: session,
+              onOpenInBrowser: (_) async {},
+            ),
+          ),
+          child: const Text('Open'),
+        ),
+      ),
+    ),
+  ),
 );
 
 PortForward _portForward() => PortForward(
@@ -233,7 +270,9 @@ void main() {
       ProviderScope(
         overrides: [
           portForwardRepositoryProvider.overrideWithValue(repository),
-          allHostsProvider.overrideWith((ref) => Stream.value([_host()])),
+          hostByIdProvider(
+            session.hostId,
+          ).overrideWith((ref) => Stream.value(_host())),
           activeSessionsProvider.overrideWith(
             () => _TestActiveSessionsNotifier([session, automaticOwner]),
           ),
@@ -373,7 +412,7 @@ void main() {
         client: _MockSshClient(),
       );
       addTearDown(session.changes.close);
-      final hosts = StreamController<List<Host>>.broadcast();
+      final hosts = StreamController<Host?>.broadcast();
       addTearDown(hosts.close);
       final notifier = _TestActiveSessionsNotifier([session]);
 
@@ -386,7 +425,7 @@ void main() {
           enabled: any(named: 'enabled'),
         ),
       ).thenAnswer((_) async {
-        hosts.add([_host(autoForwardPorts: true)]);
+        hosts.add(_host(autoForwardPorts: true));
         return true;
       });
 
@@ -397,8 +436,8 @@ void main() {
               portForwardRepository,
             ),
             hostRepositoryProvider.overrideWithValue(hostRepository),
-            allHostsProvider.overrideWith((ref) async* {
-              yield [_host()];
+            hostByIdProvider(session.hostId).overrideWith((ref) async* {
+              yield _host();
               yield* hosts.stream;
             }),
             activeSessionsProvider.overrideWith(() => notifier),
@@ -452,4 +491,146 @@ void main() {
       expect(find.text('Detecting open ports on this host.'), findsOneWidget);
     },
   );
+
+  testWidgets('auto-forward switch stays usable while saved forwards load', (
+    tester,
+  ) async {
+    final portForwardRepository = _MockPortForwardRepository();
+    final hostRepository = _MockHostRepository();
+    final session = _LiveTestSession(
+      connectionId: 7,
+      hostId: 10,
+      client: _MockSshClient(),
+    );
+    addTearDown(session.changes.close);
+    final notifier = _TestActiveSessionsNotifier([session]);
+
+    // Saved forwards never resolve, so the sheet stays in its loading state.
+    when(
+      () => portForwardRepository.watchByHostId(session.hostId),
+    ).thenAnswer((_) => const Stream<List<PortForward>>.empty());
+    when(
+      () => hostRepository.setAutoForwardPorts(
+        any(),
+        enabled: any(named: 'enabled'),
+      ),
+    ).thenAnswer((_) async => true);
+
+    await tester.pumpWidget(
+      _buildSheetHost(
+        session: session,
+        notifier: notifier,
+        portForwardRepository: portForwardRepository,
+        hostRepository: hostRepository,
+        hostStream: Stream.value(_host()),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BrandListSkeleton), findsOneWidget);
+    final autoSwitch = find.byKey(
+      const Key('terminal-auto-forward-ports-switch'),
+    );
+    expect(autoSwitch, findsOneWidget);
+
+    await tester.tap(autoSwitch);
+    await tester.pumpAndSettle();
+
+    verify(
+      () => hostRepository.setAutoForwardPorts(10, enabled: true),
+    ).called(1);
+    expect(notifier.reconfiguredHostIds, [10]);
+  });
+
+  testWidgets('auto-forward subtitle reflects a disconnected session', (
+    tester,
+  ) async {
+    final portForwardRepository = _MockPortForwardRepository();
+    final hostRepository = _MockHostRepository();
+    final session = _LiveTestSession(
+      connectionId: 7,
+      hostId: 10,
+      client: _MockSshClient(),
+    );
+    addTearDown(session.changes.close);
+
+    when(
+      () => portForwardRepository.watchByHostId(session.hostId),
+    ).thenAnswer((_) => Stream.value([_portForward()]));
+
+    await tester.pumpWidget(
+      _buildSheetHost(
+        session: session,
+        notifier: _TestActiveSessionsNotifier([
+          session,
+        ], connectionState: SshConnectionState.disconnected),
+        portForwardRepository: portForwardRepository,
+        hostRepository: hostRepository,
+        hostStream: Stream.value(_host(autoForwardPorts: true)),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Will watch for new remote listeners once connected'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('dismissing the sheet mid-save still reconfigures sessions', (
+    tester,
+  ) async {
+    final portForwardRepository = _MockPortForwardRepository();
+    final hostRepository = _MockHostRepository();
+    final session = _LiveTestSession(
+      connectionId: 7,
+      hostId: 10,
+      client: _MockSshClient(),
+    );
+    addTearDown(session.changes.close);
+    final notifier = _TestActiveSessionsNotifier([session]);
+    final saveCompleter = Completer<bool>();
+
+    when(
+      () => portForwardRepository.watchByHostId(session.hostId),
+    ).thenAnswer((_) => Stream.value([_portForward()]));
+    when(
+      () => hostRepository.setAutoForwardPorts(
+        any(),
+        enabled: any(named: 'enabled'),
+      ),
+    ).thenAnswer((_) => saveCompleter.future);
+
+    await tester.pumpWidget(
+      _buildSheetHost(
+        session: session,
+        notifier: notifier,
+        portForwardRepository: portForwardRepository,
+        hostRepository: hostRepository,
+        hostStream: Stream.value(_host()),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const Key('terminal-auto-forward-ports-switch')),
+    );
+    await tester.pump();
+
+    // Dismiss the sheet while the write is still in flight.
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+    expect(find.text('Detect open ports'), findsNothing);
+
+    saveCompleter.complete(true);
+    await tester.pumpAndSettle();
+
+    expect(notifier.reconfiguredHostIds, [10]);
+  });
 }

--- a/test/widget/terminal_port_forwards_sheet_test.dart
+++ b/test/widget/terminal_port_forwards_sheet_test.dart
@@ -8,13 +8,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:monkeyssh/data/database/database.dart';
+import 'package:monkeyssh/data/repositories/host_repository.dart';
 import 'package:monkeyssh/data/repositories/port_forward_repository.dart';
 import 'package:monkeyssh/domain/services/port_forward_browser_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
+import 'package:monkeyssh/presentation/providers/entity_list_providers.dart';
 import 'package:monkeyssh/presentation/widgets/terminal_port_forwards_sheet.dart';
 
 class _MockPortForwardRepository extends Mock
     implements PortForwardRepository {}
+
+class _MockHostRepository extends Mock implements HostRepository {}
 
 class _MockSshClient extends Mock implements SSHClient {}
 
@@ -98,6 +102,7 @@ class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
   _TestActiveSessionsNotifier(this.sessions);
 
   final List<SshSession> sessions;
+  final List<int> reconfiguredHostIds = [];
 
   @override
   Map<int, SshConnectionState> build() => {
@@ -116,11 +121,30 @@ class _TestActiveSessionsNotifier extends ActiveSessionsNotifier {
   }
 
   @override
+  Future<void> reconfigureAutomaticPortForwardingForHost(int hostId) async {
+    reconfiguredHostIds.add(hostId);
+  }
+
+  @override
   List<int> getConnectionsForHost(int hostId) => sessions
       .where((session) => session.hostId == hostId)
       .map((session) => session.connectionId)
       .toList(growable: false);
 }
+
+Host _host({bool autoForwardPorts = false}) => Host(
+  id: 10,
+  label: 'Dev box',
+  hostname: 'example.com',
+  port: 22,
+  username: 'user',
+  createdAt: DateTime(2026),
+  updatedAt: DateTime(2026),
+  autoForwardPorts: autoForwardPorts,
+  isFavorite: false,
+  autoConnectRequiresConfirmation: false,
+  sortOrder: 0,
+);
 
 PortForward _portForward() => PortForward(
   id: 1,
@@ -209,6 +233,7 @@ void main() {
       ProviderScope(
         overrides: [
           portForwardRepositoryProvider.overrideWithValue(repository),
+          allHostsProvider.overrideWith((ref) => Stream.value([_host()])),
           activeSessionsProvider.overrideWith(
             () => _TestActiveSessionsNotifier([session, automaticOwner]),
           ),
@@ -249,28 +274,34 @@ void main() {
     expect(find.text('Web preview'), findsOneWidget);
     expect(find.text('Stopped • Auto-start'), findsOneWidget);
 
+    await tester.ensureVisible(find.text('Port 3000'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('Port 3000'));
     await tester.pump();
 
     expect(openedTunnels.map((tunnel) => tunnel.portForwardId), [-3000]);
 
+    await tester.ensureVisible(find.text('Web preview'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('Web preview'));
     await tester.pump();
 
     expect(openedTunnels.map((tunnel) => tunnel.portForwardId), [-3000]);
 
-    await tester.tap(find.byType(Switch));
+    await tester.tap(find.byKey(const Key('port-forward-switch-1')));
     await tester.pumpAndSettle();
 
     expect(session.starts, [1]);
     expect(find.text('Active now • Auto-start'), findsOneWidget);
 
+    await tester.ensureVisible(find.text('Web preview'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('Web preview'));
     await tester.pump();
 
     expect(openedTunnels.map((tunnel) => tunnel.portForwardId), [-3000, 1]);
 
-    await tester.tap(find.byType(Switch));
+    await tester.tap(find.byKey(const Key('port-forward-switch-1')));
     await tester.pumpAndSettle();
 
     expect(session.stops, [1]);
@@ -322,4 +353,103 @@ void main() {
             as PortForwardsCompanion;
     expect(inserted.forwardType.value, 'remote');
   });
+
+  testWidgets(
+    'auto-forward switch persists the host setting and reconfigures',
+    (tester) async {
+      tester.view
+        ..physicalSize = const Size(390, 844)
+        ..devicePixelRatio = 1;
+      addTearDown(() {
+        tester.view
+          ..resetPhysicalSize()
+          ..resetDevicePixelRatio();
+      });
+      final portForwardRepository = _MockPortForwardRepository();
+      final hostRepository = _MockHostRepository();
+      final session = _LiveTestSession(
+        connectionId: 7,
+        hostId: 10,
+        client: _MockSshClient(),
+      );
+      addTearDown(session.changes.close);
+      final hosts = StreamController<List<Host>>.broadcast();
+      addTearDown(hosts.close);
+      final notifier = _TestActiveSessionsNotifier([session]);
+
+      when(
+        () => portForwardRepository.watchByHostId(session.hostId),
+      ).thenAnswer((_) => Stream.value([_portForward()]));
+      when(
+        () => hostRepository.setAutoForwardPorts(
+          any(),
+          enabled: any(named: 'enabled'),
+        ),
+      ).thenAnswer((_) async {
+        hosts.add([_host(autoForwardPorts: true)]);
+        return true;
+      });
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            portForwardRepositoryProvider.overrideWithValue(
+              portForwardRepository,
+            ),
+            hostRepositoryProvider.overrideWithValue(hostRepository),
+            allHostsProvider.overrideWith((ref) async* {
+              yield [_host()];
+              yield* hosts.stream;
+            }),
+            activeSessionsProvider.overrideWith(() => notifier),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => FilledButton(
+                  onPressed: () => unawaited(
+                    showTerminalPortForwardsSheet(
+                      context: context,
+                      hostId: session.hostId,
+                      connectionId: session.connectionId,
+                      session: session,
+                      onOpenInBrowser: (_) async {},
+                    ),
+                  ),
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      final autoSwitch = find.byKey(
+        const Key('terminal-auto-forward-ports-switch'),
+      );
+      expect(autoSwitch, findsOneWidget);
+      expect(
+        find.text('Automatically proxy new remote listeners on this host'),
+        findsOneWidget,
+      );
+      expect(tester.widget<SwitchListTile>(autoSwitch).value, isFalse);
+
+      await tester.tap(autoSwitch);
+      await tester.pumpAndSettle();
+
+      verify(
+        () => hostRepository.setAutoForwardPorts(10, enabled: true),
+      ).called(1);
+      expect(notifier.reconfiguredHostIds, [10]);
+      expect(tester.widget<SwitchListTile>(autoSwitch).value, isTrue);
+      expect(
+        find.text('Watching this host for new remote listeners'),
+        findsOneWidget,
+      );
+      expect(find.text('Detecting open ports on this host.'), findsOneWidget);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Automatic port forwarding (`hosts.autoForwardPorts`) could previously only be enabled from the host editor. This adds a **Detect open ports** switch to the terminal's Port Forwards sheet so it can be turned on for the connected host without leaving the terminal.

## Changes

- **`terminal_port_forwards_sheet.dart`** — new switch at the top of the sheet. It reflects the host's saved setting, persists on toggle, immediately calls `reconfigureAutomaticPortForwardingForHost` so the live session starts/stops proxying, shows a spinner while saving, and reports failures via snackbar. The subtitle reflects state (off / watching / actively proxying).
  - The saved-forward list and empty state were folded into a single scroll view so the new row scrolls with content instead of permanently shrinking the list viewport.
  - Per-forward switches gained stable keys (`port-forward-switch-<id>`).
- **`host_repository.dart`** — new `setAutoForwardPorts(id, enabled:)`, mirroring `toggleFavorite`; skips the write when the value is unchanged to avoid needless password re-encryption.

## Testing

- New widget test: toggling persists the host setting, triggers reconfiguration, and updates the switch/subtitle/snackbar.
- New repository tests for `setAutoForwardPorts` (persist, no-op, missing host).
- `flutter analyze` clean; full `flutter test` suite passes (2994 tests) via the pre-commit hook.