### PR TITLE
chore: bump version to 0.4.0 and refresh release notes

### DIFF
--- a/android/fastlane/metadata-private/android/en-US/changelogs/default.txt
+++ b/android/fastlane/metadata-private/android/en-US/changelogs/default.txt
@@ -1,6 +1,6 @@
-What's new in this 0.3.3 beta
+What's new in this 0.4.0 beta
 
-- Windows remotes keep bracketed paste intact.
-- Links no longer render as stray escape text.
-- Escape stays responsive while a paste is arriving.
-- Keystrokes arrive in order when attaching to a MonkeyMux window.
+- New "Detect open ports" switch turns on automatic port forwarding from the terminal.
+- The tmux/MonkeyMux bar only appears for the connection you are actually attached to.
+- Agents get the right light/dark colour scheme in background windows, with no stray escape text.
+- MonkeyMux sessions recover from recycled process IDs instead of locking you out.

--- a/android/fastlane/metadata-production/android/en-US/changelogs/default.txt
+++ b/android/fastlane/metadata-production/android/en-US/changelogs/default.txt
@@ -1,9 +1,6 @@
-What's new in 0.3.3
+What's new in 0.4.0
 
-- Windows remotes: bracketed paste survives the round trip, plus session titles, Escape, and Kitty graphics.
-- Links no longer render as stray escape text.
-- Escape stays responsive while a paste is arriving.
-- Keystrokes arrive in order when attaching to a MonkeyMux window.
-- Launch presets for Pi, Hermes, and OpenClaw.
-- MonkeyMux reconnect preserves your session.
-- Window switching and control-channel stability fixes.
+- New "Detect open ports" switch turns on automatic port forwarding from the terminal's Port Forwards sheet.
+- The tmux/MonkeyMux bar only appears for the connection you are actually attached to.
+- Agents get the right light/dark colour scheme in background windows, with no stray escape text at the prompt.
+- MonkeyMux sessions recover from recycled process IDs instead of locking you out.

--- a/ios/fastlane/metadata-private/en-US/release_notes.txt
+++ b/ios/fastlane/metadata-private/en-US/release_notes.txt
@@ -1,8 +1,8 @@
-What's new in this 0.3.3 beta
+What's new in this 0.4.0 beta
 
-- Pasting into Windows remotes keeps bracketed paste intact, so editors and agents treat it as a paste instead of typed keystrokes.
-- Links no longer show up as stray escape text in the terminal.
-- Escape stays responsive while a paste is still arriving.
-- Keystrokes arrive in order when attaching to a MonkeyMux window.
+- Turn on automatic port forwarding straight from the terminal: the Port Forwards sheet now has a "Detect open ports" switch that applies to the live session right away.
+- The tmux/MonkeyMux bar now belongs to the connection you are actually attached to, so it no longer appears for a host that has nothing running.
+- Agents that ask whether the terminal is light or dark get an answer while their window runs in the background, so they pick the right colour scheme instead of leaving stray escape text at the prompt.
+- MonkeyMux sessions recover from a recycled process ID instead of locking you out, and an unusual session name can no longer be mistaken for a different session.
 
 Thanks for testing the beta — please report anything that feels off.

--- a/ios/fastlane/metadata-production/en-US/release_notes.txt
+++ b/ios/fastlane/metadata-production/en-US/release_notes.txt
@@ -1,6 +1,6 @@
-What's new in 0.3.3
+What's new in 0.4.0
 
-- Pasting into Windows remotes keeps bracketed paste intact, so editors and agents treat it as a paste instead of typed keystrokes.
-- Links no longer show up as stray escape text in the terminal.
-- Escape stays responsive while a paste is still arriving.
-- Keystrokes arrive in order when attaching to a MonkeyMux window.
+- Turn on automatic port forwarding straight from the terminal: the Port Forwards sheet now has a "Detect open ports" switch that applies to the live session right away.
+- The tmux/MonkeyMux bar now belongs to the connection you are actually attached to, so it no longer appears for a host that has nothing running.
+- Agents that ask whether the terminal is light or dark get an answer while their window runs in the background, so they pick the right colour scheme instead of leaving stray escape text at the prompt.
+- MonkeyMux sessions recover from a recycled process ID instead of locking you out, and an unusual session name can no longer be mistaken for a different session.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
   MonkeyMux/tmux remote windows, key management, snippets, and port forwarding.
 publish_to: 'none'
 
-version: 0.3.3+1
+version: 0.4.0+1
 
 environment:
   sdk: ^3.10.7


### PR DESCRIPTION
Release prep for **v0.4.0** (production, iOS + Android).

## Changes

- Bump `pubspec.yaml` to `0.4.0+1`
- Refresh App Store release notes (production + beta)
- Refresh Play changelogs (production + beta)

## What 0.4.0 covers

Since `v0.3.3`:

- **New:** "Detect open ports" switch in the terminal Port Forwards sheet, so automatic port forwarding can be enabled for the connected host without leaving the terminal (#733)
- **Fix:** the tmux/MonkeyMux bar is scoped to the SSH connection that actually owns the multiplexer client, so it no longer appears for a host running nothing (#736)
- **Fix:** colour-scheme probes are answered from the cached theme hint, so background agents pick the right light/dark scheme and no longer leave stray escape text at the prompt (#735)
- **Fix:** MonkeyMux proves session ownership from the server's own command line, recovers from stale/recycled session pid files, and emits the session token before the user-supplied name so a crafted session name cannot shadow another session (#734)

## Store media

Not regenerated. Nothing store-facing changed visually since the existing `store-assets` archive, which the successful `v0.3.3` production deploy already consumed on both platforms.

## Validation

- `python3 scripts/validate_app_store_metadata.py both` — pass
- `python3 scripts/validate_play_store_metadata.py both` — pass
- Play changelogs are 412 / 386 chars, under the 500-char Console cap

Merging this, then cutting tag `v0.4.0` to trigger the production `release.yml` deploy.
