### PR TITLE
fix: prevent Android soft keyboard input garbage

### DIFF
--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
@@ -168,9 +168,33 @@ class MainActivity : FlutterFragmentActivity() {
             channel.invokeMethod(
                 "onPhysicalKeyEvent",
                 mapOf("key" to key, "type" to type),
+                object : MethodChannel.Result {
+                    override fun success(result: Any?) {
+                        redispatchPhysicalKeyEvent(event)
+                    }
+
+                    override fun error(
+                        errorCode: String,
+                        errorMessage: String?,
+                        errorDetails: Any?,
+                    ) {
+                        redispatchPhysicalKeyEvent(event)
+                    }
+
+                    override fun notImplemented() {
+                        redispatchPhysicalKeyEvent(event)
+                    }
+                },
             )
+            return true
         }
         return super.dispatchKeyEvent(event)
+    }
+
+    private fun redispatchPhysicalKeyEvent(event: KeyEvent) {
+        runOnUiThread {
+            super.dispatchKeyEvent(event)
+        }
     }
 
     override fun onResume() {

--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
@@ -7,6 +7,8 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.OpenableColumns
+import android.view.KeyCharacterMap
+import android.view.KeyEvent
 import androidx.core.content.ContextCompat
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
@@ -20,6 +22,8 @@ class MainActivity : FlutterFragmentActivity() {
         private const val MAX_CLIPBOARD_CONTENT_URI_BYTES = 512 * 1024
         private const val MONKEYSSH_TRANSFER_MIME_TYPE = "application/x-monkeyssh-transfer"
         private const val MONKEYSSH_TRANSFER_EXTENSION = ".monkeysshx"
+        private const val TERMINAL_IME_KEY_CHANNEL =
+            "xyz.depollsoft.monkeyssh/terminal_ime_keys"
     }
 
     private val clipboardChannel = "xyz.depollsoft.monkeyssh/clipboard_content"
@@ -27,6 +31,8 @@ class MainActivity : FlutterFragmentActivity() {
     private val maxTransferPayloadBytes = 10 * 1024 * 1024
     private var clipboardMethodChannel: MethodChannel? = null
     private var transferMethodChannel: MethodChannel? = null
+    private var terminalImeKeyMethodChannel: MethodChannel? = null
+    private var terminalImeKeyInterceptionEnabled = false
     private var pendingTransferPayload: String? = null
     private var hasRequestedNotificationPermission = false
 
@@ -99,7 +105,72 @@ class MainActivity : FlutterFragmentActivity() {
             }
         }
 
+        terminalImeKeyMethodChannel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            TERMINAL_IME_KEY_CHANNEL,
+        )
+        terminalImeKeyMethodChannel?.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "setInterceptionEnabled" -> {
+                    terminalImeKeyInterceptionEnabled = call.arguments == true
+                    result.success(null)
+                }
+                else -> result.notImplemented()
+            }
+        }
+        terminalImeKeyMethodChannel?.invokeMethod(
+            "getInterceptionEnabled",
+            null,
+            object : MethodChannel.Result {
+                override fun success(result: Any?) {
+                    terminalImeKeyInterceptionEnabled = result == true
+                }
+
+                override fun error(
+                    errorCode: String,
+                    errorMessage: String?,
+                    errorDetails: Any?,
+                ) {
+                    terminalImeKeyInterceptionEnabled = false
+                }
+
+                override fun notImplemented() {
+                    terminalImeKeyInterceptionEnabled = false
+                }
+            },
+        )
+
         notifyIncomingTransferPayload()
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        val channel = terminalImeKeyMethodChannel
+        val key = terminalImeKeyName(event)
+        val type = when {
+            event.action == KeyEvent.ACTION_UP -> "release"
+            event.action == KeyEvent.ACTION_DOWN && event.repeatCount > 0 -> "repeat"
+            event.action == KeyEvent.ACTION_DOWN -> "press"
+            else -> null
+        }
+        if (
+            terminalImeKeyInterceptionEnabled &&
+            channel != null &&
+            key != null &&
+            type != null
+        ) {
+            if (isVirtualKeyboardEvent(event)) {
+                channel.invokeMethod(
+                    "onVirtualKeyEvent",
+                    mapOf("key" to key, "type" to type),
+                )
+                return true
+            }
+            channel.invokeMethod(
+                "onPhysicalKeyEvent",
+                mapOf("key" to key, "type" to type),
+            )
+        }
+        return super.dispatchKeyEvent(event)
     }
 
     override fun onResume() {
@@ -120,8 +191,22 @@ class MainActivity : FlutterFragmentActivity() {
         clipboardMethodChannel = null
         transferMethodChannel?.setMethodCallHandler(null)
         transferMethodChannel = null
+        terminalImeKeyInterceptionEnabled = false
+        terminalImeKeyMethodChannel?.setMethodCallHandler(null)
+        terminalImeKeyMethodChannel = null
         super.onDestroy()
     }
+
+    private fun terminalImeKeyName(event: KeyEvent): String? = when (event.keyCode) {
+        KeyEvent.KEYCODE_SHIFT_LEFT -> "shiftLeft"
+        KeyEvent.KEYCODE_SHIFT_RIGHT -> "shiftRight"
+        KeyEvent.KEYCODE_DEL -> "backspace"
+        else -> null
+    }
+
+    private fun isVirtualKeyboardEvent(event: KeyEvent): Boolean =
+        event.deviceId == KeyCharacterMap.VIRTUAL_KEYBOARD ||
+            event.device?.isVirtual == true
 
     override fun onRequestPermissionsResult(
         requestCode: Int,

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -767,8 +767,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       return false;
     }
 
-    final isVirtual = _isVirtualTextInputKeyEvent(event);
-    if (!isVirtual) {
+    final isImeOwnedKeyEvent =
+        _isVirtualTextInputKeyEvent(event) || _isAndroidImeShiftKeyEvent(key);
+    if (!isImeOwnedKeyEvent) {
       return false;
     }
 
@@ -854,6 +855,17 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
 
   bool _isVirtualTextInputKeyEvent(KeyEvent event) =>
       event.physicalKey.usbHidUsage >= LogicalKeyboardKey.startOfPlatformPlanes;
+
+  bool _isAndroidImeShiftKeyEvent(TerminalKey key) {
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) {
+      return false;
+    }
+    // Some Android IMEs report their on-screen Shift key with the standard HID
+    // identity. Keep it on the IME path so Kitty modifier reports do not leak.
+    return key == TerminalKey.shiftLeft ||
+        key == TerminalKey.shiftRight ||
+        key == TerminalKey.shift;
+  }
 
   void _trackHandledHardwareCursorKey(
     TerminalKey key, {

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -18,6 +18,9 @@ const _deleteDetectionMarker = '\u200B\u200B';
 final _leadingSwipeNewlineArtifactPattern = RegExp(r'^[\r\n]+ ?(?=\S)');
 final _splitLeadingTokenCandidatePattern = RegExp(r'^\s*\S\s+\S');
 const _enterCommitNewlineSequences = <String>['\r\n', '\n', '\r'];
+const _androidTerminalImeKeyChannel = MethodChannel(
+  'xyz.depollsoft.monkeyssh/terminal_ime_keys',
+);
 
 bool _isAsciiLetterOrDigitCodeUnit(int codeUnit) =>
     (codeUnit >= 0x30 && codeUnit <= 0x39) ||
@@ -70,6 +73,120 @@ DateTime Function()? _modifierChordClockOverride;
 
 DateTime _readModifierChordClock() =>
     (_modifierChordClockOverride ?? DateTime.now).call();
+
+class _AndroidTerminalImeKeyBridge {
+  static _TerminalTextInputHandlerState? _state;
+  static bool _handlerInstalled = false;
+  static final List<({TerminalKey key, TerminalKeyEventType type})>
+  _pendingPhysicalEvents = <({TerminalKey key, TerminalKeyEventType type})>[];
+
+  static void attach() {
+    if (_handlerInstalled) {
+      return;
+    }
+    _handlerInstalled = true;
+    _androidTerminalImeKeyChannel.setMethodCallHandler(_handleMethodCall);
+  }
+
+  static void detach(_TerminalTextInputHandlerState state) {
+    if (identical(_state, state)) {
+      _state = null;
+      _pendingPhysicalEvents.clear();
+    }
+  }
+
+  static void setEnabled(
+    _TerminalTextInputHandlerState state, {
+    required bool enabled,
+  }) {
+    if (enabled) {
+      _state = state;
+    } else if (identical(_state, state)) {
+      _state = null;
+      _pendingPhysicalEvents.clear();
+    } else {
+      return;
+    }
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) {
+      return;
+    }
+    unawaited(_setEnabled(enabled));
+  }
+
+  static Future<void> _setEnabled(bool enabled) async {
+    try {
+      await _androidTerminalImeKeyChannel.invokeMethod<void>(
+        'setInterceptionEnabled',
+        enabled,
+      );
+    } on MissingPluginException {
+      DiagnosticsLogService.instance.warning(
+        'terminal.keyboard',
+        'android_ime_key_bridge_unavailable',
+      );
+    }
+  }
+
+  static Future<Object?> _handleMethodCall(MethodCall call) async {
+    if (call.method == 'getInterceptionEnabled') {
+      return _state != null;
+    }
+    if (call.method != 'onVirtualKeyEvent' &&
+        call.method != 'onPhysicalKeyEvent') {
+      throw MissingPluginException('Unsupported terminal IME key method');
+    }
+    final arguments = call.arguments;
+    if (arguments is! Map<Object?, Object?>) {
+      return null;
+    }
+    final key = switch (arguments['key']) {
+      'shiftLeft' => TerminalKey.shiftLeft,
+      'shiftRight' => TerminalKey.shiftRight,
+      'backspace' => TerminalKey.backspace,
+      _ => null,
+    };
+    final type = switch (arguments['type']) {
+      'press' => TerminalKeyEventType.press,
+      'repeat' => TerminalKeyEventType.repeat,
+      'release' => TerminalKeyEventType.release,
+      _ => null,
+    };
+    if (key == null || type == null) {
+      return null;
+    }
+    if (call.method == 'onPhysicalKeyEvent') {
+      _recordPhysicalEvent(key, type);
+      return null;
+    }
+    _state?._handleAndroidImeKey(key, type);
+    return null;
+  }
+
+  static void _recordPhysicalEvent(TerminalKey key, TerminalKeyEventType type) {
+    _pendingPhysicalEvents.add((key: key, type: type));
+    if (_pendingPhysicalEvents.length > 32) {
+      _pendingPhysicalEvents.removeAt(0);
+    }
+  }
+
+  static bool consumePhysicalEvent(TerminalKey key, TerminalKeyEventType type) {
+    final index = _pendingPhysicalEvents.indexWhere(
+      (event) => event.key == key && event.type == type,
+    );
+    if (index < 0) {
+      return false;
+    }
+    _pendingPhysicalEvents.removeAt(index);
+    return true;
+  }
+
+  static void debugRecordPhysicalEvent(
+    TerminalKey key,
+    TerminalKeyEventType type,
+  ) {
+    _recordPhysicalEvent(key, type);
+  }
+}
 
 /// Overrides the modifier chord clock in tests.
 @visibleForTesting
@@ -185,6 +302,21 @@ class TerminalTextInputHandlerController extends ChangeNotifier {
   /// Resets stale IME context after remote terminal output returns to a prompt.
   void handleExternalTerminalOutput() {
     _state?._handleExternalTerminalOutput();
+  }
+
+  /// Dispatches a native Android IME key event in tests.
+  @visibleForTesting
+  void debugHandleAndroidImeKey(TerminalKey key, TerminalKeyEventType type) {
+    _state?._handleAndroidImeKey(key, type);
+  }
+
+  /// Records a native Android physical-key source marker in tests.
+  @visibleForTesting
+  void debugRecordAndroidPhysicalKey(
+    TerminalKey key,
+    TerminalKeyEventType type,
+  ) {
+    _AndroidTerminalImeKeyBridge.debugRecordPhysicalEvent(key, type);
   }
 }
 
@@ -372,6 +504,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   @override
   void initState() {
     super.initState();
+    _AndroidTerminalImeKeyBridge.attach();
     widget.focusNode.addListener(_onFocusChange);
     widget.controller?._attach(this);
     if (!widget.manageFocus) {
@@ -385,6 +518,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (widget.focusNode != oldWidget.focusNode) {
       oldWidget.focusNode.removeListener(_onFocusChange);
       widget.focusNode.addListener(_onFocusChange);
+      _onFocusChange();
     }
     if (widget.controller != oldWidget.controller) {
       oldWidget.controller?._detach(this);
@@ -436,6 +570,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _touchPointersMovedBeyondTapSlop.clear();
     _touchPointersPressedBeyondLongPressTimeout.clear();
     _closeInputConnectionIfNeeded();
+    _AndroidTerminalImeKeyBridge.detach(this);
     super.dispose();
   }
 
@@ -770,9 +905,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       return false;
     }
 
-    final isImeOwnedKeyEvent =
-        _isVirtualTextInputKeyEvent(event) || _isAndroidImeControlKeyEvent(key);
-    if (!isImeOwnedKeyEvent) {
+    if (!_isVirtualTextInputKeyEvent(event)) {
       return false;
     }
 
@@ -856,45 +989,74 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
   }
 
+  bool _isTerminalModifierKey(TerminalKey key) => switch (key) {
+    TerminalKey.controlLeft ||
+    TerminalKey.controlRight ||
+    TerminalKey.control ||
+    TerminalKey.shiftLeft ||
+    TerminalKey.shiftRight ||
+    TerminalKey.shift ||
+    TerminalKey.altLeft ||
+    TerminalKey.altRight ||
+    TerminalKey.alt ||
+    TerminalKey.metaLeft ||
+    TerminalKey.metaRight ||
+    TerminalKey.meta => true,
+    _ => false,
+  };
+
   bool _isVirtualTextInputKeyEvent(KeyEvent event) =>
       event.physicalKey.usbHidUsage >= LogicalKeyboardKey.startOfPlatformPlanes;
 
-  bool _isAndroidImeControlKeyEvent(TerminalKey key) {
+  bool _isAndroidImeFallbackControlKey(
+    TerminalKey key, {
+    required bool isNativePhysicalEvent,
+    required bool hasShortcutModifier,
+  }) {
     if (kIsWeb ||
         defaultTargetPlatform != TargetPlatform.android ||
+        isNativePhysicalEvent ||
+        hasShortcutModifier ||
         !_isInputConnectionShown ||
         View.of(context).viewInsets.bottom <= 0) {
       return false;
     }
-    // Some Android IMEs report on-screen controls with standard HID identities.
-    // Keep them on the IME path so stale Shift state cannot leak Kitty reports.
-    return switch (key) {
-      TerminalKey.shiftLeft ||
-      TerminalKey.shiftRight ||
-      TerminalKey.shift ||
-      TerminalKey.backspace => true,
-      _ => false,
-    };
+    return key == TerminalKey.shiftLeft ||
+        key == TerminalKey.shiftRight ||
+        key == TerminalKey.backspace;
   }
 
-  bool _handleAndroidImeBackspaceKeyEvent(
-    KeyEvent event,
-    TerminalKey key, {
-    required bool hasShortcutModifier,
+  void _handleAndroidImeKey(TerminalKey key, TerminalKeyEventType type) {
+    if (widget.readOnly ||
+        !widget.focusNode.hasFocus ||
+        !_isInputConnectionShown) {
+      _activeAndroidImeBackspace = null;
+      return;
+    }
+    if (key == TerminalKey.shiftLeft || key == TerminalKey.shiftRight) {
+      return;
+    }
+    if (key != TerminalKey.backspace) {
+      return;
+    }
+    _handleAndroidImeBackspace(
+      type,
+      toolbarModifiers: widget.resolveTerminalKeyModifiers?.call(),
+    );
+  }
+
+  void _handleAndroidImeBackspace(
+    TerminalKeyEventType type, {
     required ({bool ctrl, bool alt, bool shift})? toolbarModifiers,
   }) {
-    if (key != TerminalKey.backspace) {
-      return false;
-    }
-
     final activeBackspace = _activeAndroidImeBackspace;
-    if (event is KeyRepeatEvent && activeBackspace != null) {
+    if (type == TerminalKeyEventType.repeat && activeBackspace != null) {
       if (activeBackspace.raw) {
         _notifyUserInput();
         widget.terminal.textInput('\x7f');
         _pendingAndroidHardwareBackspaces++;
       } else if (_sendHardwareTerminalKey(
-        key,
+        TerminalKey.backspace,
         ctrl: activeBackspace.ctrl,
         alt: activeBackspace.alt,
         shift: activeBackspace.shift,
@@ -904,12 +1066,12 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       )) {
         _pendingAndroidHardwareBackspaces++;
       }
-      return true;
+      return;
     }
-    if (event is KeyUpEvent && activeBackspace != null) {
+    if (type == TerminalKeyEventType.release && activeBackspace != null) {
       if (!activeBackspace.raw) {
         _sendHardwareTerminalKey(
-          key,
+          TerminalKey.backspace,
           ctrl: activeBackspace.ctrl,
           alt: activeBackspace.alt,
           shift: activeBackspace.shift,
@@ -919,13 +1081,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         );
       }
       _activeAndroidImeBackspace = null;
-      return true;
+      return;
     }
-    if (hasShortcutModifier) {
-      return false;
-    }
-    if (event is! KeyDownEvent || !_isAndroidImeControlKeyEvent(key)) {
-      return false;
+    if (type != TerminalKeyEventType.press) {
+      return;
     }
 
     final hasToolbarModifier =
@@ -946,7 +1105,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       // and only use a later IME deletion to synchronize local state.
       widget.terminal.textInput('\x7f');
       _pendingAndroidHardwareBackspaces++;
-      return true;
+      return;
     }
 
     _activeAndroidImeBackspace = (
@@ -956,7 +1115,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       shift: toolbarModifiers.shift,
     );
     final handled = _sendHardwareTerminalKey(
-      key,
+      TerminalKey.backspace,
       ctrl: toolbarModifiers.ctrl,
       alt: toolbarModifiers.alt,
       shift: toolbarModifiers.shift,
@@ -965,11 +1124,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     );
     if (!handled) {
       _activeAndroidImeBackspace = null;
-      return false;
+      return;
     }
     _pendingAndroidHardwareBackspaces++;
     widget.consumeTerminalKeyModifiers?.call();
-    return true;
   }
 
   ({int deletedCount, String appendedText, int deleteCursorOffset})
@@ -996,10 +1154,18 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         ? delta.deletedCount
         : _pendingAndroidHardwareBackspaces;
     _pendingAndroidHardwareBackspaces -= suppressedCount;
-    _lastSentCursorOffset = _clampTextOffset(
-      _lastSentCursorOffset - suppressedCount,
-      _textLengthInGraphemes(_lastSentText),
+    final previousGraphemes = _lastSentText.characters.toList(growable: true);
+    final deletionEnd = _clampTextOffset(
+      delta.deleteCursorOffset,
+      previousGraphemes.length,
     );
+    final deletionStart = _clampTextOffset(
+      deletionEnd - suppressedCount,
+      deletionEnd,
+    );
+    previousGraphemes.removeRange(deletionStart, deletionEnd);
+    _lastSentText = previousGraphemes.join();
+    _lastSentCursorOffset = deletionStart;
     return (
       deletedCount: delta.deletedCount - suppressedCount,
       appendedText: delta.appendedText,
@@ -1071,28 +1237,18 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (key == null) {
       return KeyEventResult.ignored;
     }
-
-    final toolbarModifiers = widget.resolveTerminalKeyModifiers?.call();
-    final hasToolbarModifier =
-        toolbarModifiers != null &&
-        (toolbarModifiers.ctrl ||
-            toolbarModifiers.alt ||
-            toolbarModifiers.shift);
-    if (_handleAndroidImeBackspaceKeyEvent(
-      event,
+    final type = _terminalKeyEventType(event);
+    final isNativePhysicalEvent =
+        _AndroidTerminalImeKeyBridge.consumePhysicalEvent(key, type);
+    if (_isAndroidImeFallbackControlKey(
       key,
+      isNativePhysicalEvent: isNativePhysicalEvent,
       hasShortcutModifier: hasShortcutModifier,
-      toolbarModifiers: toolbarModifiers,
     )) {
+      _handleAndroidImeKey(key, type);
       return KeyEventResult.skipRemainingHandlers;
     }
-    final isAndroidToolbarBackspace =
-        key == TerminalKey.backspace &&
-        _isAndroidImeControlKeyEvent(key) &&
-        hasToolbarModifier;
-    if (!_currentEditingState.composing.isCollapsed &&
-        !hasShortcutModifier &&
-        !isAndroidToolbarBackspace) {
+    if (!_currentEditingState.composing.isCollapsed && !hasShortcutModifier) {
       return KeyEventResult.skipRemainingHandlers;
     }
 
@@ -1111,9 +1267,14 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       return KeyEventResult.skipRemainingHandlers;
     }
 
+    final toolbarModifiers = widget.resolveTerminalKeyModifiers?.call();
+    final hasToolbarModifier =
+        toolbarModifiers != null &&
+        (toolbarModifiers.ctrl ||
+            toolbarModifiers.alt ||
+            toolbarModifiers.shift);
     final isEnter = key == TerminalKey.enter || key == TerminalKey.numpadEnter;
     final isVirtual = _isVirtualTextInputKeyEvent(event);
-    final isAndroidImeControl = _isAndroidImeControlKeyEvent(key);
     // Toolbar modifiers are not mirrored into HardwareKeyboard. Merge them so
     // extended-keyboard Shift/Alt/Ctrl apply on this path.
     final ctrl =
@@ -1128,10 +1289,8 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     // not inherit capitalization Shift (that becomes LF / "newline" in Codex).
     final shift = isEnter
         ? ((toolbarModifiers?.shift ?? false) || (physicalShift && !isVirtual))
-        : ((physicalShift && !isAndroidImeControl) ||
-              (toolbarModifiers?.shift ?? false));
+        : (physicalShift || (toolbarModifiers?.shift ?? false));
     final meta = HardwareKeyboard.instance.isMetaPressed;
-    final type = _terminalKeyEventType(event);
     final useCustomRepeat =
         _shouldUseCustomHardwareKeyRepeat &&
         _isRepeatableHardwareTerminalKey(key);
@@ -1150,7 +1309,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       type: type,
     );
 
-    if (handled && type == TerminalKeyEventType.press && hasToolbarModifier) {
+    if (handled &&
+        type == TerminalKeyEventType.press &&
+        hasToolbarModifier &&
+        !_isTerminalModifierKey(key)) {
       widget.consumeTerminalKeyModifiers?.call();
       if (isEnter) {
         // Soft keyboards often also deliver newline via IME after the key event.
@@ -1300,6 +1462,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       _stopHardwareKeyRepeat();
       _closeInputConnectionIfNeeded();
     }
+    _reconcileAndroidImeKeyBridge();
   }
 
   // -- Input connection management --
@@ -1321,7 +1484,18 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       return;
     }
     _isInputConnectionShown = shown;
+    _reconcileAndroidImeKeyBridge();
     widget.controller?._notifyKeyboardVisibilityChanged();
+  }
+
+  void _reconcileAndroidImeKeyBridge() {
+    _AndroidTerminalImeKeyBridge.setEnabled(
+      this,
+      enabled:
+          _isInputConnectionShown &&
+          widget.focusNode.hasFocus &&
+          !widget.readOnly,
+    );
   }
 
   void _openInputConnection({bool show = true}) {
@@ -3612,6 +3786,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   void connectionClosed() {
     _connection = null;
     _isInputConnectionShown = false;
+    _AndroidTerminalImeKeyBridge.setEnabled(this, enabled: false);
     _stopHardwareKeyRepeat();
     _cancelDeferredTrailingBackspaceImeClear();
     _invalidatePendingEditingUpdates();

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -768,7 +768,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
 
     final isImeOwnedKeyEvent =
-        _isVirtualTextInputKeyEvent(event) || _isAndroidImeShiftKeyEvent(key);
+        _isVirtualTextInputKeyEvent(event) || _isAndroidImeControlKeyEvent(key);
     if (!isImeOwnedKeyEvent) {
       return false;
     }
@@ -798,6 +798,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   /// hardware key that only sees [HardwareKeyboard] state.
   bool _isTextInputManagedTerminalKey(TerminalKey key) {
     if (key == TerminalKey.enter || key == TerminalKey.numpadEnter) {
+      return true;
+    }
+    if (widget.deleteDetection && key == TerminalKey.backspace) {
       return true;
     }
     return _isTextInputManagedCharacterKey(key);
@@ -856,15 +859,19 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   bool _isVirtualTextInputKeyEvent(KeyEvent event) =>
       event.physicalKey.usbHidUsage >= LogicalKeyboardKey.startOfPlatformPlanes;
 
-  bool _isAndroidImeShiftKeyEvent(TerminalKey key) {
+  bool _isAndroidImeControlKeyEvent(TerminalKey key) {
     if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) {
       return false;
     }
-    // Some Android IMEs report their on-screen Shift key with the standard HID
-    // identity. Keep it on the IME path so Kitty modifier reports do not leak.
-    return key == TerminalKey.shiftLeft ||
-        key == TerminalKey.shiftRight ||
-        key == TerminalKey.shift;
+    // Some Android IMEs report on-screen controls with standard HID identities.
+    // Keep them on the IME path so stale Shift state cannot leak Kitty reports.
+    return switch (key) {
+      TerminalKey.shiftLeft ||
+      TerminalKey.shiftRight ||
+      TerminalKey.shift ||
+      TerminalKey.backspace => true,
+      _ => false,
+    };
   }
 
   void _trackHandledHardwareCursorKey(

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -1130,46 +1130,78 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     widget.consumeTerminalKeyModifiers?.call();
   }
 
-  ({int deletedCount, String appendedText, int deleteCursorOffset})
+  ({
+    String currentText,
+    int? cursorOffset,
+    ({int deletedCount, String appendedText, int deleteCursorOffset}) delta,
+  })
   _synchronizeAndroidHardwareBackspace({
+    required String currentText,
+    required int? cursorOffset,
     required ({int deletedCount, String appendedText, int deleteCursorOffset})
     delta,
   }) {
     if (_pendingAndroidHardwareBackspaces == 0) {
-      return delta;
+      return (
+        currentText: currentText,
+        cursorOffset: cursorOffset,
+        delta: delta,
+      );
     }
-    if (delta.deletedCount == 0) {
-      if (delta.appendedText.isNotEmpty) {
-        _pendingAndroidHardwareBackspaces = 0;
-      }
-      return delta;
-    }
-    if (delta.deleteCursorOffset != _lastSentCursorOffset) {
-      _pendingAndroidHardwareBackspaces = 0;
-      return delta;
+    if (delta.deletedCount == 0 && delta.appendedText.isEmpty) {
+      return (
+        currentText: currentText,
+        cursorOffset: cursorOffset,
+        delta: delta,
+      );
     }
 
-    final suppressedCount =
-        delta.deletedCount < _pendingAndroidHardwareBackspaces
-        ? delta.deletedCount
-        : _pendingAndroidHardwareBackspaces;
-    _pendingAndroidHardwareBackspaces -= suppressedCount;
     final previousGraphemes = _lastSentText.characters.toList(growable: true);
     final deletionEnd = _clampTextOffset(
-      delta.deleteCursorOffset,
+      _lastSentCursorOffset,
       previousGraphemes.length,
     );
+    final suppressedCount = _pendingAndroidHardwareBackspaces < deletionEnd
+        ? _pendingAndroidHardwareBackspaces
+        : deletionEnd;
     final deletionStart = _clampTextOffset(
       deletionEnd - suppressedCount,
+      deletionEnd,
+    );
+    final deletedGraphemes = previousGraphemes.sublist(
+      deletionStart,
       deletionEnd,
     );
     previousGraphemes.removeRange(deletionStart, deletionEnd);
     _lastSentText = previousGraphemes.join();
     _lastSentCursorOffset = deletionStart;
+    _pendingAndroidHardwareBackspaces = 0;
+
+    final currentGraphemes = currentText.characters.toList(growable: true);
+    var normalizedCursorOffset = cursorOffset;
+    if (delta.deletedCount == 0 &&
+        deletionEnd <= currentGraphemes.length &&
+        listEquals(
+          currentGraphemes.sublist(deletionStart, deletionEnd),
+          deletedGraphemes,
+        )) {
+      currentGraphemes.removeRange(deletionStart, deletionEnd);
+      if (normalizedCursorOffset != null &&
+          normalizedCursorOffset > deletionStart) {
+        normalizedCursorOffset = _clampTextOffset(
+          normalizedCursorOffset - suppressedCount,
+          currentGraphemes.length,
+        );
+      }
+    }
+    final normalizedCurrentText = currentGraphemes.join();
     return (
-      deletedCount: delta.deletedCount - suppressedCount,
-      appendedText: delta.appendedText,
-      deleteCursorOffset: delta.deleteCursorOffset - suppressedCount,
+      currentText: normalizedCurrentText,
+      cursorOffset: normalizedCursorOffset,
+      delta: _computeTextDelta(
+        normalizedCurrentText,
+        cursorOffsetHint: normalizedCursorOffset,
+      ),
     );
   }
 
@@ -3061,14 +3093,19 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       return false;
     }
 
-    delta = _synchronizeAndroidHardwareBackspace(delta: delta);
+    final synchronizedBackspace = _synchronizeAndroidHardwareBackspace(
+      currentText: currentText,
+      cursorOffset: targetCursorOffset,
+      delta: delta,
+    );
+    delta = synchronizedBackspace.delta;
     if (delta.deletedCount > 0) {
       _notifyUserInput();
     }
-    _sendInputDelta(currentText, delta);
-    if (targetCursorOffset != null &&
-        targetCursorOffset != _lastSentCursorOffset) {
-      _moveTerminalCursorTo(targetCursorOffset);
+    _sendInputDelta(synchronizedBackspace.currentText, delta);
+    if (synchronizedBackspace.cursorOffset != null &&
+        synchronizedBackspace.cursorOffset != _lastSentCursorOffset) {
+      _moveTerminalCursorTo(synchronizedBackspace.cursorOffset!);
     }
     _trimLeadingSuggestionSpaceAfterDelete = true;
     _trimLeadingSwipeSpaceAfterBufferClear = currentText.isEmpty;
@@ -3430,9 +3467,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         normalizedCurrentText,
         cursorOffsetHint: normalizedTargetCursorOffset,
       );
-      final effectiveCurrentText =
+      var effectiveCurrentText =
           deleteResetContinuation?.currentText ?? normalizedCurrentText;
-      final effectiveTargetCursorOffset =
+      var effectiveTargetCursorOffset =
           deleteResetContinuation?.cursorOffset ?? normalizedTargetCursorOffset;
       final deltaPreviousText =
           deleteResetContinuation?.previousText ?? _lastSentText;
@@ -3446,7 +3483,14 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         lastCursorOffsetOverride: deleteResetContinuation?.previousCursorOffset,
       );
       if (deleteResetContinuation == null) {
-        delta = _synchronizeAndroidHardwareBackspace(delta: delta);
+        final synchronizedBackspace = _synchronizeAndroidHardwareBackspace(
+          currentText: effectiveCurrentText,
+          cursorOffset: effectiveTargetCursorOffset,
+          delta: delta,
+        );
+        effectiveCurrentText = synchronizedBackspace.currentText;
+        effectiveTargetCursorOffset = synchronizedBackspace.cursorOffset;
+        delta = synchronizedBackspace.delta;
       } else {
         _pendingAndroidHardwareBackspaces = 0;
       }

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -336,6 +336,8 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   Timer? _hardwareKeyRepeatStartTimer;
   Timer? _hardwareKeyRepeatTimer;
   LogicalKeyboardKey? _hardwareRepeatingLogicalKey;
+  int _pendingAndroidHardwareBackspaces = 0;
+  ({bool raw, bool ctrl, bool alt, bool shift})? _activeAndroidImeBackspace;
   final Set<LogicalKeyboardKey> _textInputHandledHardwareKeys =
       <LogicalKeyboardKey>{};
   ({
@@ -754,6 +756,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _hardwareRepeatingLogicalKey = null;
     _hardwareRepeatInput = null;
     if (logicalKey == null) {
+      _activeAndroidImeBackspace = null;
       _textInputHandledHardwareKeys.clear();
     }
   }
@@ -798,9 +801,6 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   /// hardware key that only sees [HardwareKeyboard] state.
   bool _isTextInputManagedTerminalKey(TerminalKey key) {
     if (key == TerminalKey.enter || key == TerminalKey.numpadEnter) {
-      return true;
-    }
-    if (widget.deleteDetection && key == TerminalKey.backspace) {
       return true;
     }
     return _isTextInputManagedCharacterKey(key);
@@ -860,7 +860,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       event.physicalKey.usbHidUsage >= LogicalKeyboardKey.startOfPlatformPlanes;
 
   bool _isAndroidImeControlKeyEvent(TerminalKey key) {
-    if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) {
+    if (kIsWeb ||
+        defaultTargetPlatform != TargetPlatform.android ||
+        !_isInputConnectionShown ||
+        View.of(context).viewInsets.bottom <= 0) {
       return false;
     }
     // Some Android IMEs report on-screen controls with standard HID identities.
@@ -872,6 +875,136 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       TerminalKey.backspace => true,
       _ => false,
     };
+  }
+
+  bool _handleAndroidImeBackspaceKeyEvent(
+    KeyEvent event,
+    TerminalKey key, {
+    required bool hasShortcutModifier,
+    required ({bool ctrl, bool alt, bool shift})? toolbarModifiers,
+  }) {
+    if (key != TerminalKey.backspace) {
+      return false;
+    }
+
+    final activeBackspace = _activeAndroidImeBackspace;
+    if (event is KeyRepeatEvent && activeBackspace != null) {
+      if (activeBackspace.raw) {
+        _notifyUserInput();
+        widget.terminal.textInput('\x7f');
+        _pendingAndroidHardwareBackspaces++;
+      } else if (_sendHardwareTerminalKey(
+        key,
+        ctrl: activeBackspace.ctrl,
+        alt: activeBackspace.alt,
+        shift: activeBackspace.shift,
+        meta: false,
+        hasShortcutModifier: false,
+        type: TerminalKeyEventType.repeat,
+      )) {
+        _pendingAndroidHardwareBackspaces++;
+      }
+      return true;
+    }
+    if (event is KeyUpEvent && activeBackspace != null) {
+      if (!activeBackspace.raw) {
+        _sendHardwareTerminalKey(
+          key,
+          ctrl: activeBackspace.ctrl,
+          alt: activeBackspace.alt,
+          shift: activeBackspace.shift,
+          meta: false,
+          hasShortcutModifier: false,
+          type: TerminalKeyEventType.release,
+        );
+      }
+      _activeAndroidImeBackspace = null;
+      return true;
+    }
+    if (hasShortcutModifier) {
+      return false;
+    }
+    if (event is! KeyDownEvent || !_isAndroidImeControlKeyEvent(key)) {
+      return false;
+    }
+
+    final hasToolbarModifier =
+        toolbarModifiers != null &&
+        (toolbarModifiers.ctrl ||
+            toolbarModifiers.alt ||
+            toolbarModifiers.shift);
+    if (!hasToolbarModifier) {
+      _activeAndroidImeBackspace = (
+        raw: true,
+        ctrl: false,
+        alt: false,
+        shift: false,
+      );
+      _notifyUserInput();
+      // Some Android IMEs omit the editing-value deletion after emitting a
+      // standard-HID Backspace. Send DEL immediately, bypassing Kitty mode,
+      // and only use a later IME deletion to synchronize local state.
+      widget.terminal.textInput('\x7f');
+      _pendingAndroidHardwareBackspaces++;
+      return true;
+    }
+
+    _activeAndroidImeBackspace = (
+      raw: false,
+      ctrl: toolbarModifiers.ctrl,
+      alt: toolbarModifiers.alt,
+      shift: toolbarModifiers.shift,
+    );
+    final handled = _sendHardwareTerminalKey(
+      key,
+      ctrl: toolbarModifiers.ctrl,
+      alt: toolbarModifiers.alt,
+      shift: toolbarModifiers.shift,
+      meta: false,
+      hasShortcutModifier: false,
+    );
+    if (!handled) {
+      _activeAndroidImeBackspace = null;
+      return false;
+    }
+    _pendingAndroidHardwareBackspaces++;
+    widget.consumeTerminalKeyModifiers?.call();
+    return true;
+  }
+
+  ({int deletedCount, String appendedText, int deleteCursorOffset})
+  _synchronizeAndroidHardwareBackspace({
+    required ({int deletedCount, String appendedText, int deleteCursorOffset})
+    delta,
+  }) {
+    if (_pendingAndroidHardwareBackspaces == 0) {
+      return delta;
+    }
+    if (delta.deletedCount == 0) {
+      if (delta.appendedText.isNotEmpty) {
+        _pendingAndroidHardwareBackspaces = 0;
+      }
+      return delta;
+    }
+    if (delta.deleteCursorOffset != _lastSentCursorOffset) {
+      _pendingAndroidHardwareBackspaces = 0;
+      return delta;
+    }
+
+    final suppressedCount =
+        delta.deletedCount < _pendingAndroidHardwareBackspaces
+        ? delta.deletedCount
+        : _pendingAndroidHardwareBackspaces;
+    _pendingAndroidHardwareBackspaces -= suppressedCount;
+    _lastSentCursorOffset = _clampTextOffset(
+      _lastSentCursorOffset - suppressedCount,
+      _textLengthInGraphemes(_lastSentText),
+    );
+    return (
+      deletedCount: delta.deletedCount - suppressedCount,
+      appendedText: delta.appendedText,
+      deleteCursorOffset: delta.deleteCursorOffset - suppressedCount,
+    );
   }
 
   void _trackHandledHardwareCursorKey(
@@ -933,7 +1066,33 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         hardwareKeyboard.isControlPressed ||
         hardwareKeyboard.isAltPressed ||
         hardwareKeyboard.isMetaPressed;
-    if (!_currentEditingState.composing.isCollapsed && !hasShortcutModifier) {
+
+    final key = keyToTerminalKey(event.logicalKey);
+    if (key == null) {
+      return KeyEventResult.ignored;
+    }
+
+    final toolbarModifiers = widget.resolveTerminalKeyModifiers?.call();
+    final hasToolbarModifier =
+        toolbarModifiers != null &&
+        (toolbarModifiers.ctrl ||
+            toolbarModifiers.alt ||
+            toolbarModifiers.shift);
+    if (_handleAndroidImeBackspaceKeyEvent(
+      event,
+      key,
+      hasShortcutModifier: hasShortcutModifier,
+      toolbarModifiers: toolbarModifiers,
+    )) {
+      return KeyEventResult.skipRemainingHandlers;
+    }
+    final isAndroidToolbarBackspace =
+        key == TerminalKey.backspace &&
+        _isAndroidImeControlKeyEvent(key) &&
+        hasToolbarModifier;
+    if (!_currentEditingState.composing.isCollapsed &&
+        !hasShortcutModifier &&
+        !isAndroidToolbarBackspace) {
       return KeyEventResult.skipRemainingHandlers;
     }
 
@@ -944,11 +1103,6 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       }
     }
 
-    final key = keyToTerminalKey(event.logicalKey);
-    if (key == null) {
-      return KeyEventResult.ignored;
-    }
-
     if (_shouldLetTextInputHandleHardwareKey(
       event,
       key,
@@ -957,9 +1111,9 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       return KeyEventResult.skipRemainingHandlers;
     }
 
-    final toolbarModifiers = widget.resolveTerminalKeyModifiers?.call();
     final isEnter = key == TerminalKey.enter || key == TerminalKey.numpadEnter;
     final isVirtual = _isVirtualTextInputKeyEvent(event);
+    final isAndroidImeControl = _isAndroidImeControlKeyEvent(key);
     // Toolbar modifiers are not mirrored into HardwareKeyboard. Merge them so
     // extended-keyboard Shift/Alt/Ctrl apply on this path.
     final ctrl =
@@ -974,7 +1128,8 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     // not inherit capitalization Shift (that becomes LF / "newline" in Codex).
     final shift = isEnter
         ? ((toolbarModifiers?.shift ?? false) || (physicalShift && !isVirtual))
-        : (physicalShift || (toolbarModifiers?.shift ?? false));
+        : ((physicalShift && !isAndroidImeControl) ||
+              (toolbarModifiers?.shift ?? false));
     final meta = HardwareKeyboard.instance.isMetaPressed;
     final type = _terminalKeyEventType(event);
     final useCustomRepeat =
@@ -995,19 +1150,15 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       type: type,
     );
 
-    if (handled &&
-        isEnter &&
-        type == TerminalKeyEventType.press &&
-        toolbarModifiers != null &&
-        (toolbarModifiers.ctrl ||
-            toolbarModifiers.alt ||
-            toolbarModifiers.shift)) {
+    if (handled && type == TerminalKeyEventType.press && hasToolbarModifier) {
       widget.consumeTerminalKeyModifiers?.call();
-      // Soft keyboards often also deliver newline via IME after the key event.
-      if (_pendingEnterActionSuppressions < 1) {
-        _pendingEnterActionSuppressions = 1;
+      if (isEnter) {
+        // Soft keyboards often also deliver newline via IME after the key event.
+        if (_pendingEnterActionSuppressions < 1) {
+          _pendingEnterActionSuppressions = 1;
+        }
+        _pendingPerformedEnterText = _lastSentText;
       }
-      _pendingPerformedEnterText = _lastSentText;
     }
 
     if (handled && event is KeyDownEvent && useCustomRepeat) {
@@ -1204,6 +1355,8 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       _clearPendingComposingEnterAction();
       _pendingPerformedEnterText = null;
       _pendingEnterActionSuppressions = 0;
+      _pendingAndroidHardwareBackspaces = 0;
+      _activeAndroidImeBackspace = null;
       _currentEditingState = _initEditingState.copyWith();
       _connection!.setEditingState(_initEditingState);
     }
@@ -1257,6 +1410,8 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _clearPendingComposingEnterAction();
     _pendingPerformedEnterText = null;
     _pendingEnterActionSuppressions = 0;
+    _pendingAndroidHardwareBackspaces = 0;
+    _activeAndroidImeBackspace = null;
     _currentEditingState = _initEditingState.copyWith();
   }
 
@@ -1649,6 +1804,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       _pendingPerformedEnterText = null;
     }
     _pendingEnterActionSuppressions = pendingEnterSuppressions;
+    _pendingAndroidHardwareBackspaces = 0;
     _trimLeadingSuggestionSpaceAfterDelete = false;
     _trimLeadingSwipeSpaceAfterBufferClear = false;
     _clearImeAfterNextTouchCursorMove = false;
@@ -2723,7 +2879,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       currentText,
       value,
     );
-    final delta = _computeTextDelta(
+    var delta = _computeTextDelta(
       currentText,
       cursorOffsetHint: targetCursorOffset,
     );
@@ -2731,7 +2887,10 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       return false;
     }
 
-    _notifyUserInput();
+    delta = _synchronizeAndroidHardwareBackspace(delta: delta);
+    if (delta.deletedCount > 0) {
+      _notifyUserInput();
+    }
     _sendInputDelta(currentText, delta);
     if (targetCursorOffset != null &&
         targetCursorOffset != _lastSentCursorOffset) {
@@ -2990,14 +3149,18 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       if (_editingPrefixLength(value.text) < _initEditingState.text.length) {
         final deletedCount = _textLengthInGraphemes(_lastSentText);
         final clearedBufferedInput = deletedCount > 0;
-        _notifyUserInput();
-        _moveTerminalCursorTo(deletedCount);
-        if (clearedBufferedInput) {
-          for (var index = 0; index < deletedCount; index++) {
+        if (_pendingAndroidHardwareBackspaces > 0) {
+          _pendingAndroidHardwareBackspaces--;
+        } else {
+          _notifyUserInput();
+          _moveTerminalCursorTo(deletedCount);
+          if (clearedBufferedInput) {
+            for (var index = 0; index < deletedCount; index++) {
+              widget.terminal.keyInput(TerminalKey.backspace);
+            }
+          } else {
             widget.terminal.keyInput(TerminalKey.backspace);
           }
-        } else {
-          widget.terminal.keyInput(TerminalKey.backspace);
         }
         _sawImeComposition = false;
         _resetCommittedInputState(
@@ -3102,12 +3265,17 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       final deltaPreviousCursorOffset =
           deleteResetContinuation?.previousCursorOffset ??
           _lastSentCursorOffset;
-      final delta = _computeTextDelta(
+      var delta = _computeTextDelta(
         effectiveCurrentText,
         cursorOffsetHint: effectiveTargetCursorOffset,
         previousTextOverride: deleteResetContinuation?.previousText,
         lastCursorOffsetOverride: deleteResetContinuation?.previousCursorOffset,
       );
+      if (deleteResetContinuation == null) {
+        delta = _synchronizeAndroidHardwareBackspace(delta: delta);
+      } else {
+        _pendingAndroidHardwareBackspaces = 0;
+      }
       final pendingEnterActionOwnedBeforeReview =
           revision == _pendingComposingEnterRevision;
       final hadActiveToolbarModifier =
@@ -3461,6 +3629,8 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _allowSplitLeadingTokenNormalization = false;
     _modifierChordResetTime = null;
     _pendingEnterActionSuppressions = 0;
+    _pendingAndroidHardwareBackspaces = 0;
+    _activeAndroidImeBackspace = null;
     _currentEditingState = _initEditingState.copyWith();
   }
 

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -5175,6 +5175,66 @@ void main() {
       focusNode.dispose();
     });
 
+    testWidgets('Android IME HID Shift bypasses Kitty hardware key encoding', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add)
+        ..write('\x1b[>9u');
+      final focusNode = FocusNode();
+
+      try {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: TerminalTextInputHandler(
+                terminal: terminal,
+                focusNode: focusNode,
+                deleteDetection: true,
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+
+        expect(tester.testTextInput.isVisible, isTrue);
+
+        HardwareKeyboard.instance.handleKeyEvent(
+          const KeyDownEvent(
+            logicalKey: LogicalKeyboardKey.shiftLeft,
+            physicalKey: PhysicalKeyboardKey.shiftLeft,
+            timeStamp: Duration.zero,
+          ),
+        );
+        HardwareKeyboard.instance.handleKeyEvent(
+          const KeyUpEvent(
+            logicalKey: LogicalKeyboardKey.shiftLeft,
+            physicalKey: PhysicalKeyboardKey.shiftLeft,
+            timeStamp: Duration.zero,
+          ),
+        );
+        await tester.pump();
+
+        expect(terminalOutput, isEmpty);
+
+        tester.testTextInput.updateEditingValue(
+          _editingValue('C', selectionOffset: 1),
+        );
+        await tester.pump();
+
+        expect(terminalOutput, <String>['C']);
+      } finally {
+        await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+        await tester.pump();
+        focusNode.dispose();
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
     testWidgets('physical shifted text keeps Kitty hardware key encoding', (
       tester,
     ) async {

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -1197,7 +1197,8 @@ Future<_ComparisonResult> _runTerminalSequence(
           terminal: terminal,
           focusNode: focusNode,
           deleteDetection: true,
-          child: const SizedBox.expand(),
+          manageFocus: false,
+          child: Focus(focusNode: focusNode, child: const SizedBox.expand()),
         ),
       ),
     ),
@@ -5280,13 +5281,15 @@ void main() {
     });
 
     testWidgets(
-      'Android external HID Backspace keeps Kitty hardware encoding',
+      'Android external HID Backspace keeps Kitty encoding with visible IME',
       (tester) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        tester.view.viewInsets = const FakeViewPadding(bottom: 300);
         final terminalOutput = <String>[];
         final terminal = Terminal(onOutput: terminalOutput.add)
           ..write('\x1b[>9u');
         final focusNode = FocusNode();
+        final controller = TerminalTextInputHandlerController();
 
         try {
           await tester.pumpWidget(
@@ -5297,6 +5300,7 @@ void main() {
                   child: TerminalTextInputHandler(
                     terminal: terminal,
                     focusNode: focusNode,
+                    controller: controller,
                     deleteDetection: true,
                     manageFocus: false,
                     child: const SizedBox.expand(),
@@ -5310,8 +5314,12 @@ void main() {
           await tester.pump();
 
           expect(tester.testTextInput.isVisible, isTrue);
-          expect(tester.view.viewInsets.bottom, 0);
+          expect(tester.view.viewInsets.bottom, greaterThan(0));
 
+          controller.debugRecordAndroidPhysicalKey(
+            TerminalKey.shiftLeft,
+            TerminalKeyEventType.press,
+          );
           HardwareKeyboard.instance.handleKeyEvent(
             const KeyDownEvent(
               logicalKey: LogicalKeyboardKey.shiftLeft,
@@ -5319,6 +5327,10 @@ void main() {
               timeStamp: Duration.zero,
             ),
           );
+          controller.debugRecordAndroidPhysicalKey(
+            TerminalKey.backspace,
+            TerminalKeyEventType.press,
+          );
           HardwareKeyboard.instance.handleKeyEvent(
             const KeyDownEvent(
               logicalKey: LogicalKeyboardKey.backspace,
@@ -5326,12 +5338,20 @@ void main() {
               timeStamp: Duration.zero,
             ),
           );
+          controller.debugRecordAndroidPhysicalKey(
+            TerminalKey.backspace,
+            TerminalKeyEventType.release,
+          );
           HardwareKeyboard.instance.handleKeyEvent(
             const KeyUpEvent(
               logicalKey: LogicalKeyboardKey.backspace,
               physicalKey: PhysicalKeyboardKey.backspace,
               timeStamp: Duration.zero,
             ),
+          );
+          controller.debugRecordAndroidPhysicalKey(
+            TerminalKey.shiftLeft,
+            TerminalKeyEventType.release,
           );
           HardwareKeyboard.instance.handleKeyEvent(
             const KeyUpEvent(
@@ -5347,20 +5367,24 @@ void main() {
           await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
           await tester.pump();
           focusNode.dispose();
+          controller.dispose();
+          tester.view.resetViewInsets();
           debugDefaultTargetPlatformOverride = null;
         }
       },
     );
 
     testWidgets(
-      'Android IME replacement after HID Backspace does not delete twice',
+      'physical Backspace consumes a toolbar modifier with visible IME',
       (tester) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;
         tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+        var ctrlActive = true;
         final terminalOutput = <String>[];
         final terminal = Terminal(onOutput: terminalOutput.add)
           ..write('\x1b[>1u');
         final focusNode = FocusNode();
+        final controller = TerminalTextInputHandlerController();
 
         try {
           await tester.pumpWidget(
@@ -5371,6 +5395,112 @@ void main() {
                   child: TerminalTextInputHandler(
                     terminal: terminal,
                     focusNode: focusNode,
+                    controller: controller,
+                    deleteDetection: true,
+                    manageFocus: false,
+                    resolveTerminalKeyModifiers: () =>
+                        (ctrl: ctrlActive, alt: false, shift: false),
+                    consumeTerminalKeyModifiers: () => ctrlActive = false,
+                    child: const SizedBox.expand(),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          focusNode.requestFocus();
+          await tester.pump();
+
+          controller.debugRecordAndroidPhysicalKey(
+            TerminalKey.backspace,
+            TerminalKeyEventType.press,
+          );
+          HardwareKeyboard.instance.handleKeyEvent(
+            const KeyDownEvent(
+              logicalKey: LogicalKeyboardKey.backspace,
+              physicalKey: PhysicalKeyboardKey.backspace,
+              timeStamp: Duration.zero,
+            ),
+          );
+          controller.debugRecordAndroidPhysicalKey(
+            TerminalKey.backspace,
+            TerminalKeyEventType.release,
+          );
+          HardwareKeyboard.instance.handleKeyEvent(
+            const KeyUpEvent(
+              logicalKey: LogicalKeyboardKey.backspace,
+              physicalKey: PhysicalKeyboardKey.backspace,
+              timeStamp: Duration.zero,
+            ),
+          );
+          await tester.pump();
+
+          expect(terminalOutput, <String>['\x1b[127;5u']);
+          expect(ctrlActive, isFalse);
+        } finally {
+          await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+          await tester.pump();
+          focusNode.dispose();
+          controller.dispose();
+          tester.view.resetViewInsets();
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testWidgets('replacing focus node closes an unfocused input connection', (
+      tester,
+    ) async {
+      final terminal = Terminal();
+      final firstFocusNode = FocusNode();
+      final replacementFocusNode = FocusNode();
+
+      Widget buildHandler(FocusNode focusNode) => MaterialApp(
+        home: Scaffold(
+          body: TerminalTextInputHandler(
+            terminal: terminal,
+            focusNode: focusNode,
+            deleteDetection: true,
+            child: const SizedBox.expand(),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(buildHandler(firstFocusNode));
+      firstFocusNode.requestFocus();
+      await tester.pump();
+      expect(tester.testTextInput.isVisible, isTrue);
+
+      await tester.pumpWidget(buildHandler(replacementFocusNode));
+      await tester.pump();
+
+      expect(replacementFocusNode.hasFocus, isFalse);
+      expect(tester.testTextInput.isVisible, isFalse);
+
+      firstFocusNode.dispose();
+      replacementFocusNode.dispose();
+    });
+
+    testWidgets(
+      'Android IME replacement after HID Backspace does not delete twice',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add)
+          ..write('\x1b[>1u');
+        final focusNode = FocusNode();
+        final controller = TerminalTextInputHandlerController();
+
+        try {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Focus(
+                  focusNode: focusNode,
+                  child: TerminalTextInputHandler(
+                    terminal: terminal,
+                    focusNode: focusNode,
+                    controller: controller,
                     deleteDetection: true,
                     manageFocus: false,
                     child: const SizedBox.expand(),
@@ -5388,27 +5518,19 @@ void main() {
           await tester.pump();
           terminalOutput.clear();
 
-          HardwareKeyboard.instance.handleKeyEvent(
-            const KeyDownEvent(
-              logicalKey: LogicalKeyboardKey.backspace,
-              physicalKey: PhysicalKeyboardKey.backspace,
-              timeStamp: Duration.zero,
-            ),
-          );
-          HardwareKeyboard.instance.handleKeyEvent(
-            const KeyRepeatEvent(
-              logicalKey: LogicalKeyboardKey.backspace,
-              physicalKey: PhysicalKeyboardKey.backspace,
-              timeStamp: Duration.zero,
-            ),
-          );
-          HardwareKeyboard.instance.handleKeyEvent(
-            const KeyUpEvent(
-              logicalKey: LogicalKeyboardKey.backspace,
-              physicalKey: PhysicalKeyboardKey.backspace,
-              timeStamp: Duration.zero,
-            ),
-          );
+          controller
+            ..debugHandleAndroidImeKey(
+              TerminalKey.backspace,
+              TerminalKeyEventType.press,
+            )
+            ..debugHandleAndroidImeKey(
+              TerminalKey.backspace,
+              TerminalKeyEventType.repeat,
+            )
+            ..debugHandleAndroidImeKey(
+              TerminalKey.backspace,
+              TerminalKeyEventType.release,
+            );
           await tester.pump();
 
           tester.testTextInput.updateEditingValue(
@@ -5421,7 +5543,81 @@ void main() {
           await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
           await tester.pump();
           focusNode.dispose();
-          tester.view.resetViewInsets();
+          controller.dispose();
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testWidgets(
+      'rejected replacement preserves an applied Android IME Backspace',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add)
+          ..write('\x1b[>1u');
+        final focusNode = FocusNode();
+        final controller = TerminalTextInputHandlerController();
+
+        try {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Focus(
+                  focusNode: focusNode,
+                  child: TerminalTextInputHandler(
+                    terminal: terminal,
+                    focusNode: focusNode,
+                    controller: controller,
+                    deleteDetection: true,
+                    manageFocus: false,
+                    onReviewInsertedText: (_) async => false,
+                    child: const SizedBox.expand(),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          focusNode.requestFocus();
+          await tester.pump();
+          tester.testTextInput.updateEditingValue(
+            _editingValue('AB', selectionOffset: 2),
+          );
+          await tester.pump();
+          terminalOutput.clear();
+
+          controller
+            ..debugHandleAndroidImeKey(
+              TerminalKey.backspace,
+              TerminalKeyEventType.press,
+            )
+            ..debugHandleAndroidImeKey(
+              TerminalKey.backspace,
+              TerminalKeyEventType.release,
+            );
+          tester.testTextInput.updateEditingValue(
+            _editingValue('x\ny', selectionOffset: 3),
+          );
+          await tester.pump();
+
+          expect(terminalOutput, <String>['\x7f']);
+          expect(
+            _terminalTextInputClient(tester).currentTextEditingValue,
+            _editingValue('A', selectionOffset: 1),
+          );
+
+          tester.testTextInput.updateEditingValue(
+            _editingValue('AC', selectionOffset: 2),
+          );
+          await tester.pump();
+
+          expect(terminalOutput, <String>['\x7f', 'C']);
+        } finally {
+          await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+          await tester.pump();
+          focusNode.dispose();
+          controller.dispose();
           debugDefaultTargetPlatformOverride = null;
         }
       },
@@ -5431,11 +5627,11 @@ void main() {
       tester,
     ) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
-      tester.view.viewInsets = const FakeViewPadding(bottom: 300);
       final terminalOutput = <String>[];
       final terminal = Terminal(onOutput: terminalOutput.add)
         ..write('\x1b[>1u');
       final focusNode = FocusNode();
+      final controller = TerminalTextInputHandlerController();
 
       try {
         await tester.pumpWidget(
@@ -5446,6 +5642,7 @@ void main() {
                 child: TerminalTextInputHandler(
                   terminal: terminal,
                   focusNode: focusNode,
+                  controller: controller,
                   deleteDetection: true,
                   manageFocus: false,
                   child: const SizedBox.expand(),
@@ -5471,12 +5668,9 @@ void main() {
         await tester.pump();
         terminalOutput.clear();
 
-        HardwareKeyboard.instance.handleKeyEvent(
-          const KeyDownEvent(
-            logicalKey: LogicalKeyboardKey.backspace,
-            physicalKey: PhysicalKeyboardKey.backspace,
-            timeStamp: Duration.zero,
-          ),
+        controller.debugHandleAndroidImeKey(
+          TerminalKey.backspace,
+          TerminalKeyEventType.press,
         );
         await tester.pump();
 
@@ -5493,18 +5687,15 @@ void main() {
 
         expect(terminalOutput, <String>['\x7f']);
 
-        HardwareKeyboard.instance.handleKeyEvent(
-          const KeyUpEvent(
-            logicalKey: LogicalKeyboardKey.backspace,
-            physicalKey: PhysicalKeyboardKey.backspace,
-            timeStamp: Duration.zero,
-          ),
+        controller.debugHandleAndroidImeKey(
+          TerminalKey.backspace,
+          TerminalKeyEventType.release,
         );
       } finally {
         await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
         await tester.pump();
         focusNode.dispose();
-        tester.view.resetViewInsets();
+        controller.dispose();
         debugDefaultTargetPlatformOverride = null;
       }
     });
@@ -5513,12 +5704,12 @@ void main() {
       tester,
     ) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
-      tester.view.viewInsets = const FakeViewPadding(bottom: 300);
       var ctrlActive = true;
       final terminalOutput = <String>[];
       final terminal = Terminal(onOutput: terminalOutput.add)
         ..write('\x1b[>1u');
       final focusNode = FocusNode();
+      final controller = TerminalTextInputHandlerController();
 
       try {
         await tester.pumpWidget(
@@ -5529,6 +5720,7 @@ void main() {
                 child: TerminalTextInputHandler(
                   terminal: terminal,
                   focusNode: focusNode,
+                  controller: controller,
                   deleteDetection: true,
                   manageFocus: false,
                   resolveTerminalKeyModifiers: () =>
@@ -5557,12 +5749,9 @@ void main() {
         await tester.pump();
         terminalOutput.clear();
 
-        HardwareKeyboard.instance.handleKeyEvent(
-          const KeyDownEvent(
-            logicalKey: LogicalKeyboardKey.backspace,
-            physicalKey: PhysicalKeyboardKey.backspace,
-            timeStamp: Duration.zero,
-          ),
+        controller.debugHandleAndroidImeKey(
+          TerminalKey.backspace,
+          TerminalKeyEventType.press,
         );
         await tester.pump();
 
@@ -5580,18 +5769,15 @@ void main() {
 
         expect(terminalOutput, <String>['\x1b[127;5u']);
 
-        HardwareKeyboard.instance.handleKeyEvent(
-          const KeyUpEvent(
-            logicalKey: LogicalKeyboardKey.backspace,
-            physicalKey: PhysicalKeyboardKey.backspace,
-            timeStamp: Duration.zero,
-          ),
+        controller.debugHandleAndroidImeKey(
+          TerminalKey.backspace,
+          TerminalKeyEventType.release,
         );
       } finally {
         await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
         await tester.pump();
         focusNode.dispose();
-        tester.view.resetViewInsets();
+        controller.dispose();
         debugDefaultTargetPlatformOverride = null;
       }
     });
@@ -5600,12 +5786,12 @@ void main() {
       'toolbar modifier keeps Android IME Backspace on hardware path',
       (tester) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;
-        tester.view.viewInsets = const FakeViewPadding(bottom: 300);
         var ctrlActive = true;
         final terminalOutput = <String>[];
         final terminal = Terminal(onOutput: terminalOutput.add)
           ..write('\x1b[>11u');
         final focusNode = FocusNode();
+        final controller = TerminalTextInputHandlerController();
 
         try {
           await tester.pumpWidget(
@@ -5616,6 +5802,7 @@ void main() {
                   child: TerminalTextInputHandler(
                     terminal: terminal,
                     focusNode: focusNode,
+                    controller: controller,
                     deleteDetection: true,
                     manageFocus: false,
                     resolveTerminalKeyModifiers: () =>
@@ -5636,27 +5823,19 @@ void main() {
           await tester.pump();
           terminalOutput.clear();
 
-          HardwareKeyboard.instance.handleKeyEvent(
-            const KeyDownEvent(
-              logicalKey: LogicalKeyboardKey.backspace,
-              physicalKey: PhysicalKeyboardKey.backspace,
-              timeStamp: Duration.zero,
-            ),
-          );
-          HardwareKeyboard.instance.handleKeyEvent(
-            const KeyRepeatEvent(
-              logicalKey: LogicalKeyboardKey.backspace,
-              physicalKey: PhysicalKeyboardKey.backspace,
-              timeStamp: Duration.zero,
-            ),
-          );
-          HardwareKeyboard.instance.handleKeyEvent(
-            const KeyUpEvent(
-              logicalKey: LogicalKeyboardKey.backspace,
-              physicalKey: PhysicalKeyboardKey.backspace,
-              timeStamp: Duration.zero,
-            ),
-          );
+          controller
+            ..debugHandleAndroidImeKey(
+              TerminalKey.backspace,
+              TerminalKeyEventType.press,
+            )
+            ..debugHandleAndroidImeKey(
+              TerminalKey.backspace,
+              TerminalKeyEventType.repeat,
+            )
+            ..debugHandleAndroidImeKey(
+              TerminalKey.backspace,
+              TerminalKeyEventType.release,
+            );
           await tester.pump();
 
           expect(terminalOutput, <String>[
@@ -5680,7 +5859,7 @@ void main() {
           await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
           await tester.pump();
           focusNode.dispose();
-          tester.view.resetViewInsets();
+          controller.dispose();
           debugDefaultTargetPlatformOverride = null;
         }
       },

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -5550,6 +5550,72 @@ void main() {
     );
 
     testWidgets(
+      'Android IME append after omitted Backspace drops stale buffer text',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add)
+          ..write('\x1b[>1u');
+        final focusNode = FocusNode();
+        final controller = TerminalTextInputHandlerController();
+
+        try {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Focus(
+                  focusNode: focusNode,
+                  child: TerminalTextInputHandler(
+                    terminal: terminal,
+                    focusNode: focusNode,
+                    controller: controller,
+                    deleteDetection: true,
+                    manageFocus: false,
+                    child: const SizedBox.expand(),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          focusNode.requestFocus();
+          await tester.pump();
+          tester.testTextInput.updateEditingValue(
+            _editingValue('A', selectionOffset: 1),
+          );
+          await tester.pump();
+          terminalOutput.clear();
+
+          controller
+            ..debugHandleAndroidImeKey(
+              TerminalKey.backspace,
+              TerminalKeyEventType.press,
+            )
+            ..debugHandleAndroidImeKey(
+              TerminalKey.backspace,
+              TerminalKeyEventType.release,
+            );
+          tester.testTextInput.updateEditingValue(
+            _editingValue('AB', selectionOffset: 2),
+          );
+          await tester.pump();
+
+          expect(terminalOutput, <String>['\x7f', 'B']);
+          expect(
+            _terminalTextInputClient(tester).currentTextEditingValue,
+            _editingValue('B', selectionOffset: 1),
+          );
+        } finally {
+          await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+          await tester.pump();
+          focusNode.dispose();
+          controller.dispose();
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testWidgets(
       'rejected replacement preserves an applied Android IME Backspace',
       (tester) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -5021,6 +5021,12 @@ void main() {
         focusNode.requestFocus();
         await tester.pump();
 
+        tester.testTextInput.updateEditingValue(
+          _editingValue('C', selectionOffset: 1),
+        );
+        await tester.pump();
+        terminalOutput.clear();
+
         HardwareKeyboard.instance.handleKeyEvent(
           const KeyDownEvent(
             logicalKey: LogicalKeyboardKey.enter,
@@ -5179,6 +5185,7 @@ void main() {
       tester,
     ) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      tester.view.viewInsets = const FakeViewPadding(bottom: 300);
       final terminalOutput = <String>[];
       final terminal = Terminal(onOutput: terminalOutput.add)
         ..write('\x1b[>1u');
@@ -5188,11 +5195,15 @@ void main() {
         await tester.pumpWidget(
           MaterialApp(
             home: Scaffold(
-              body: TerminalTextInputHandler(
-                terminal: terminal,
+              body: Focus(
                 focusNode: focusNode,
-                deleteDetection: true,
-                child: const SizedBox.expand(),
+                child: TerminalTextInputHandler(
+                  terminal: terminal,
+                  focusNode: focusNode,
+                  deleteDetection: true,
+                  manageFocus: false,
+                  child: const SizedBox.expand(),
+                ),
               ),
             ),
           ),
@@ -5204,7 +5215,7 @@ void main() {
         expect(tester.testTextInput.isVisible, isTrue);
 
         tester.testTextInput.updateEditingValue(
-          _editingValue('C', selectionOffset: 1),
+          _editingValue('CC', selectionOffset: 2),
         );
         await tester.pump();
         terminalOutput.clear();
@@ -5224,6 +5235,13 @@ void main() {
           ),
         );
         HardwareKeyboard.instance.handleKeyEvent(
+          const KeyRepeatEvent(
+            logicalKey: LogicalKeyboardKey.backspace,
+            physicalKey: PhysicalKeyboardKey.backspace,
+            timeStamp: Duration.zero,
+          ),
+        );
+        HardwareKeyboard.instance.handleKeyEvent(
           const KeyUpEvent(
             logicalKey: LogicalKeyboardKey.backspace,
             physicalKey: PhysicalKeyboardKey.backspace,
@@ -5232,7 +5250,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(terminalOutput, isEmpty);
+        expect(terminalOutput, <String>['\x7f', '\x7f']);
 
         tester.testTextInput.updateEditingValue(
           _editingValue('', selectionOffset: 0),
@@ -5241,7 +5259,8 @@ void main() {
 
         expect(
           terminalOutput.join(),
-          _terminalKeyOutput(TerminalKey.backspace),
+          '${_terminalKeyOutput(TerminalKey.backspace)}'
+          '${_terminalKeyOutput(TerminalKey.backspace)}',
         );
 
         HardwareKeyboard.instance.handleKeyEvent(
@@ -5255,9 +5274,417 @@ void main() {
         await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
         await tester.pump();
         focusNode.dispose();
+        tester.view.resetViewInsets();
         debugDefaultTargetPlatformOverride = null;
       }
     });
+
+    testWidgets(
+      'Android external HID Backspace keeps Kitty hardware encoding',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add)
+          ..write('\x1b[>9u');
+        final focusNode = FocusNode();
+
+        try {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Focus(
+                  focusNode: focusNode,
+                  child: TerminalTextInputHandler(
+                    terminal: terminal,
+                    focusNode: focusNode,
+                    deleteDetection: true,
+                    manageFocus: false,
+                    child: const SizedBox.expand(),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          focusNode.requestFocus();
+          await tester.pump();
+
+          expect(tester.testTextInput.isVisible, isTrue);
+          expect(tester.view.viewInsets.bottom, 0);
+
+          HardwareKeyboard.instance.handleKeyEvent(
+            const KeyDownEvent(
+              logicalKey: LogicalKeyboardKey.shiftLeft,
+              physicalKey: PhysicalKeyboardKey.shiftLeft,
+              timeStamp: Duration.zero,
+            ),
+          );
+          HardwareKeyboard.instance.handleKeyEvent(
+            const KeyDownEvent(
+              logicalKey: LogicalKeyboardKey.backspace,
+              physicalKey: PhysicalKeyboardKey.backspace,
+              timeStamp: Duration.zero,
+            ),
+          );
+          HardwareKeyboard.instance.handleKeyEvent(
+            const KeyUpEvent(
+              logicalKey: LogicalKeyboardKey.backspace,
+              physicalKey: PhysicalKeyboardKey.backspace,
+              timeStamp: Duration.zero,
+            ),
+          );
+          HardwareKeyboard.instance.handleKeyEvent(
+            const KeyUpEvent(
+              logicalKey: LogicalKeyboardKey.shiftLeft,
+              physicalKey: PhysicalKeyboardKey.shiftLeft,
+              timeStamp: Duration.zero,
+            ),
+          );
+          await tester.pump();
+
+          expect(terminalOutput.join(), contains('\x1b[127;2u'));
+        } finally {
+          await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+          await tester.pump();
+          focusNode.dispose();
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testWidgets(
+      'Android IME replacement after HID Backspace does not delete twice',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add)
+          ..write('\x1b[>1u');
+        final focusNode = FocusNode();
+
+        try {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Focus(
+                  focusNode: focusNode,
+                  child: TerminalTextInputHandler(
+                    terminal: terminal,
+                    focusNode: focusNode,
+                    deleteDetection: true,
+                    manageFocus: false,
+                    child: const SizedBox.expand(),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          focusNode.requestFocus();
+          await tester.pump();
+          tester.testTextInput.updateEditingValue(
+            _editingValue('CC', selectionOffset: 2),
+          );
+          await tester.pump();
+          terminalOutput.clear();
+
+          HardwareKeyboard.instance.handleKeyEvent(
+            const KeyDownEvent(
+              logicalKey: LogicalKeyboardKey.backspace,
+              physicalKey: PhysicalKeyboardKey.backspace,
+              timeStamp: Duration.zero,
+            ),
+          );
+          HardwareKeyboard.instance.handleKeyEvent(
+            const KeyRepeatEvent(
+              logicalKey: LogicalKeyboardKey.backspace,
+              physicalKey: PhysicalKeyboardKey.backspace,
+              timeStamp: Duration.zero,
+            ),
+          );
+          HardwareKeyboard.instance.handleKeyEvent(
+            const KeyUpEvent(
+              logicalKey: LogicalKeyboardKey.backspace,
+              physicalKey: PhysicalKeyboardKey.backspace,
+              timeStamp: Duration.zero,
+            ),
+          );
+          await tester.pump();
+
+          tester.testTextInput.updateEditingValue(
+            _editingValue('D', selectionOffset: 1),
+          );
+          await tester.pump();
+
+          expect(terminalOutput, <String>['\x7f', '\x7f', 'D']);
+        } finally {
+          await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+          await tester.pump();
+          focusNode.dispose();
+          tester.view.resetViewInsets();
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testWidgets('Android composing IME Backspace sends raw DEL immediately', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add)
+        ..write('\x1b[>1u');
+      final focusNode = FocusNode();
+
+      try {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Focus(
+                focusNode: focusNode,
+                child: TerminalTextInputHandler(
+                  terminal: terminal,
+                  focusNode: focusNode,
+                  deleteDetection: true,
+                  manageFocus: false,
+                  child: const SizedBox.expand(),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+        tester.testTextInput.updateEditingValue(
+          _editingValue('CC', selectionOffset: 2),
+        );
+        await tester.pump();
+        tester.testTextInput.updateEditingValue(
+          _editingValue(
+            'CC',
+            selectionOffset: 2,
+            composing: const TextRange(start: 0, end: 2),
+          ),
+        );
+        await tester.pump();
+        terminalOutput.clear();
+
+        HardwareKeyboard.instance.handleKeyEvent(
+          const KeyDownEvent(
+            logicalKey: LogicalKeyboardKey.backspace,
+            physicalKey: PhysicalKeyboardKey.backspace,
+            timeStamp: Duration.zero,
+          ),
+        );
+        await tester.pump();
+
+        expect(terminalOutput, <String>['\x7f']);
+
+        tester.testTextInput.updateEditingValue(
+          _editingValue(
+            'C',
+            selectionOffset: 1,
+            composing: const TextRange(start: 0, end: 1),
+          ),
+        );
+        await tester.pump();
+
+        expect(terminalOutput, <String>['\x7f']);
+
+        HardwareKeyboard.instance.handleKeyEvent(
+          const KeyUpEvent(
+            logicalKey: LogicalKeyboardKey.backspace,
+            physicalKey: PhysicalKeyboardKey.backspace,
+            timeStamp: Duration.zero,
+          ),
+        );
+      } finally {
+        await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+        await tester.pump();
+        focusNode.dispose();
+        tester.view.resetViewInsets();
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('toolbar modifier applies to composing Android IME Backspace', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+      var ctrlActive = true;
+      final terminalOutput = <String>[];
+      final terminal = Terminal(onOutput: terminalOutput.add)
+        ..write('\x1b[>1u');
+      final focusNode = FocusNode();
+
+      try {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Focus(
+                focusNode: focusNode,
+                child: TerminalTextInputHandler(
+                  terminal: terminal,
+                  focusNode: focusNode,
+                  deleteDetection: true,
+                  manageFocus: false,
+                  resolveTerminalKeyModifiers: () =>
+                      (ctrl: ctrlActive, alt: false, shift: false),
+                  consumeTerminalKeyModifiers: () => ctrlActive = false,
+                  child: const SizedBox.expand(),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        focusNode.requestFocus();
+        await tester.pump();
+        tester.testTextInput.updateEditingValue(
+          _editingValue('CC', selectionOffset: 2),
+        );
+        await tester.pump();
+        tester.testTextInput.updateEditingValue(
+          _editingValue(
+            'CC',
+            selectionOffset: 2,
+            composing: const TextRange(start: 0, end: 2),
+          ),
+        );
+        await tester.pump();
+        terminalOutput.clear();
+
+        HardwareKeyboard.instance.handleKeyEvent(
+          const KeyDownEvent(
+            logicalKey: LogicalKeyboardKey.backspace,
+            physicalKey: PhysicalKeyboardKey.backspace,
+            timeStamp: Duration.zero,
+          ),
+        );
+        await tester.pump();
+
+        expect(terminalOutput, <String>['\x1b[127;5u']);
+        expect(ctrlActive, isFalse);
+
+        tester.testTextInput.updateEditingValue(
+          _editingValue(
+            'C',
+            selectionOffset: 1,
+            composing: const TextRange(start: 0, end: 1),
+          ),
+        );
+        await tester.pump();
+
+        expect(terminalOutput, <String>['\x1b[127;5u']);
+
+        HardwareKeyboard.instance.handleKeyEvent(
+          const KeyUpEvent(
+            logicalKey: LogicalKeyboardKey.backspace,
+            physicalKey: PhysicalKeyboardKey.backspace,
+            timeStamp: Duration.zero,
+          ),
+        );
+      } finally {
+        await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+        await tester.pump();
+        focusNode.dispose();
+        tester.view.resetViewInsets();
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets(
+      'toolbar modifier keeps Android IME Backspace on hardware path',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+        var ctrlActive = true;
+        final terminalOutput = <String>[];
+        final terminal = Terminal(onOutput: terminalOutput.add)
+          ..write('\x1b[>11u');
+        final focusNode = FocusNode();
+
+        try {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Focus(
+                  focusNode: focusNode,
+                  child: TerminalTextInputHandler(
+                    terminal: terminal,
+                    focusNode: focusNode,
+                    deleteDetection: true,
+                    manageFocus: false,
+                    resolveTerminalKeyModifiers: () =>
+                        (ctrl: ctrlActive, alt: false, shift: false),
+                    consumeTerminalKeyModifiers: () => ctrlActive = false,
+                    child: const SizedBox.expand(),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          focusNode.requestFocus();
+          await tester.pump();
+          tester.testTextInput.updateEditingValue(
+            _editingValue('CC', selectionOffset: 2),
+          );
+          await tester.pump();
+          terminalOutput.clear();
+
+          HardwareKeyboard.instance.handleKeyEvent(
+            const KeyDownEvent(
+              logicalKey: LogicalKeyboardKey.backspace,
+              physicalKey: PhysicalKeyboardKey.backspace,
+              timeStamp: Duration.zero,
+            ),
+          );
+          HardwareKeyboard.instance.handleKeyEvent(
+            const KeyRepeatEvent(
+              logicalKey: LogicalKeyboardKey.backspace,
+              physicalKey: PhysicalKeyboardKey.backspace,
+              timeStamp: Duration.zero,
+            ),
+          );
+          HardwareKeyboard.instance.handleKeyEvent(
+            const KeyUpEvent(
+              logicalKey: LogicalKeyboardKey.backspace,
+              physicalKey: PhysicalKeyboardKey.backspace,
+              timeStamp: Duration.zero,
+            ),
+          );
+          await tester.pump();
+
+          expect(terminalOutput, <String>[
+            '\x1b[127;5u',
+            '\x1b[127;5:2u',
+            '\x1b[127;5:3u',
+          ]);
+          expect(ctrlActive, isFalse);
+
+          tester.testTextInput.updateEditingValue(
+            _editingValue('', selectionOffset: 0),
+          );
+          await tester.pump();
+
+          expect(terminalOutput, <String>[
+            '\x1b[127;5u',
+            '\x1b[127;5:2u',
+            '\x1b[127;5:3u',
+          ]);
+        } finally {
+          await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+          await tester.pump();
+          focusNode.dispose();
+          tester.view.resetViewInsets();
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
 
     testWidgets('physical shifted text keeps Kitty hardware key encoding', (
       tester,

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -5175,13 +5175,13 @@ void main() {
       focusNode.dispose();
     });
 
-    testWidgets('Android IME HID Shift bypasses Kitty hardware key encoding', (
+    testWidgets('Android IME HID controls bypass Kitty hardware key encoding', (
       tester,
     ) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
       final terminalOutput = <String>[];
       final terminal = Terminal(onOutput: terminalOutput.add)
-        ..write('\x1b[>9u');
+        ..write('\x1b[>1u');
       final focusNode = FocusNode();
 
       try {
@@ -5203,6 +5203,12 @@ void main() {
 
         expect(tester.testTextInput.isVisible, isTrue);
 
+        tester.testTextInput.updateEditingValue(
+          _editingValue('C', selectionOffset: 1),
+        );
+        await tester.pump();
+        terminalOutput.clear();
+
         HardwareKeyboard.instance.handleKeyEvent(
           const KeyDownEvent(
             logicalKey: LogicalKeyboardKey.shiftLeft,
@@ -5211,9 +5217,16 @@ void main() {
           ),
         );
         HardwareKeyboard.instance.handleKeyEvent(
+          const KeyDownEvent(
+            logicalKey: LogicalKeyboardKey.backspace,
+            physicalKey: PhysicalKeyboardKey.backspace,
+            timeStamp: Duration.zero,
+          ),
+        );
+        HardwareKeyboard.instance.handleKeyEvent(
           const KeyUpEvent(
-            logicalKey: LogicalKeyboardKey.shiftLeft,
-            physicalKey: PhysicalKeyboardKey.shiftLeft,
+            logicalKey: LogicalKeyboardKey.backspace,
+            physicalKey: PhysicalKeyboardKey.backspace,
             timeStamp: Duration.zero,
           ),
         );
@@ -5222,11 +5235,22 @@ void main() {
         expect(terminalOutput, isEmpty);
 
         tester.testTextInput.updateEditingValue(
-          _editingValue('C', selectionOffset: 1),
+          _editingValue('', selectionOffset: 0),
         );
         await tester.pump();
 
-        expect(terminalOutput, <String>['C']);
+        expect(
+          terminalOutput.join(),
+          _terminalKeyOutput(TerminalKey.backspace),
+        );
+
+        HardwareKeyboard.instance.handleKeyEvent(
+          const KeyUpEvent(
+            logicalKey: LogicalKeyboardKey.shiftLeft,
+            physicalKey: PhysicalKeyboardKey.shiftLeft,
+            timeStamp: Duration.zero,
+          ),
+        );
       } finally {
         await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
         await tester.pump();


### PR DESCRIPTION
## Summary
- keep Android software-keyboard Shift events on the IME path even when they use standard HID identities
- route Backspace through IME deletion so stale Shift state cannot produce Kitty escape-sequence garbage
- preserve physical keyboard and toolbar-modifier behavior

## Validation
- `flutter test test/widget/terminal_text_input_handler_test.dart`
- `flutter analyze`
- repository pre-commit checks (full test suite)