### PR TITLE
fix(android): handle release-only Gboard controls

### DIFF
--- a/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
+++ b/android/app/src/main/kotlin/xyz/depollsoft/monkeyssh/MainActivity.kt
@@ -225,6 +225,7 @@ class MainActivity : FlutterFragmentActivity() {
         KeyEvent.KEYCODE_SHIFT_LEFT -> "shiftLeft"
         KeyEvent.KEYCODE_SHIFT_RIGHT -> "shiftRight"
         KeyEvent.KEYCODE_DEL -> "backspace"
+        KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_NUMPAD_ENTER -> "enter"
         else -> null
     }
 

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -3829,7 +3829,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   @override
   void connectionClosed() {
     _connection = null;
-    _isInputConnectionShown = false;
+    _setInputConnectionShown(shown: false);
     _AndroidTerminalImeKeyBridge.setEnabled(this, enabled: false);
     _stopHardwareKeyRepeat();
     _cancelDeferredTrailingBackspaceImeClear();

--- a/lib/presentation/widgets/terminal_text_input_handler.dart
+++ b/lib/presentation/widgets/terminal_text_input_handler.dart
@@ -143,6 +143,7 @@ class _AndroidTerminalImeKeyBridge {
       'shiftLeft' => TerminalKey.shiftLeft,
       'shiftRight' => TerminalKey.shiftRight,
       'backspace' => TerminalKey.backspace,
+      'enter' => TerminalKey.enter,
       _ => null,
     };
     final type = switch (arguments['type']) {
@@ -470,6 +471,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
   LogicalKeyboardKey? _hardwareRepeatingLogicalKey;
   int _pendingAndroidHardwareBackspaces = 0;
   ({bool raw, bool ctrl, bool alt, bool shift})? _activeAndroidImeBackspace;
+  bool _androidImeEnterPressSent = false;
   final Set<LogicalKeyboardKey> _textInputHandledHardwareKeys =
       <LogicalKeyboardKey>{};
   ({
@@ -892,6 +894,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     _hardwareRepeatInput = null;
     if (logicalKey == null) {
       _activeAndroidImeBackspace = null;
+      _androidImeEnterPressSent = false;
       _textInputHandledHardwareKeys.clear();
     }
   }
@@ -1036,13 +1039,54 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     if (key == TerminalKey.shiftLeft || key == TerminalKey.shiftRight) {
       return;
     }
-    if (key != TerminalKey.backspace) {
+    if (key == TerminalKey.enter) {
+      _handleAndroidImeEnter(
+        type,
+        toolbarModifiers: widget.resolveTerminalKeyModifiers?.call(),
+      );
       return;
     }
-    _handleAndroidImeBackspace(
-      type,
-      toolbarModifiers: widget.resolveTerminalKeyModifiers?.call(),
-    );
+    if (key == TerminalKey.backspace) {
+      _handleAndroidImeBackspace(
+        type,
+        toolbarModifiers: widget.resolveTerminalKeyModifiers?.call(),
+      );
+    }
+  }
+
+  void _handleAndroidImeEnter(
+    TerminalKeyEventType type, {
+    required ({bool ctrl, bool alt, bool shift})? toolbarModifiers,
+  }) {
+    if (type == TerminalKeyEventType.press) {
+      _androidImeEnterPressSent = true;
+      _sendAndroidImeEnter(toolbarModifiers);
+      return;
+    }
+    if (type == TerminalKeyEventType.repeat) {
+      _sendAndroidImeEnter(toolbarModifiers);
+      return;
+    }
+    if (type == TerminalKeyEventType.release) {
+      if (!_androidImeEnterPressSent) {
+        // Gboard can expose only the release callback to the platform channel.
+        // Treat it as the missing press, while avoiding a second Enter when
+        // the press callback was already delivered.
+        _sendAndroidImeEnter(toolbarModifiers);
+      }
+      _androidImeEnterPressSent = false;
+    }
+  }
+
+  void _sendAndroidImeEnter(
+    ({bool ctrl, bool alt, bool shift})? toolbarModifiers,
+  ) {
+    final modifiers =
+        toolbarModifiers ?? (ctrl: false, alt: false, shift: false);
+    _sendPerformedEnter(modifiers);
+    if (_pendingEnterActionSuppressions < 1) {
+      _pendingEnterActionSuppressions = 1;
+    }
   }
 
   void _handleAndroidImeBackspace(
@@ -1050,11 +1094,26 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     required ({bool ctrl, bool alt, bool shift})? toolbarModifiers,
   }) {
     final activeBackspace = _activeAndroidImeBackspace;
+    if (type == TerminalKeyEventType.release && activeBackspace == null) {
+      // Gboard can expose only the release callback to the platform channel.
+      // Reconstruct the missing press so the terminal and IME state both move
+      // back once, then immediately finish the synthetic key sequence.
+      _handleAndroidImeBackspace(
+        TerminalKeyEventType.press,
+        toolbarModifiers: toolbarModifiers,
+      );
+      _handleAndroidImeBackspace(
+        TerminalKeyEventType.release,
+        toolbarModifiers: toolbarModifiers,
+      );
+      return;
+    }
     if (type == TerminalKeyEventType.repeat && activeBackspace != null) {
       if (activeBackspace.raw) {
         _notifyUserInput();
         widget.terminal.textInput('\x7f');
         _pendingAndroidHardwareBackspaces++;
+        _syncAndroidImeStateAfterNativeBackspace();
       } else if (_sendHardwareTerminalKey(
         TerminalKey.backspace,
         ctrl: activeBackspace.ctrl,
@@ -1065,6 +1124,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
         type: TerminalKeyEventType.repeat,
       )) {
         _pendingAndroidHardwareBackspaces++;
+        _syncAndroidImeStateAfterNativeBackspace();
       }
       return;
     }
@@ -1105,6 +1165,7 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
       // and only use a later IME deletion to synchronize local state.
       widget.terminal.textInput('\x7f');
       _pendingAndroidHardwareBackspaces++;
+      _syncAndroidImeStateAfterNativeBackspace();
       return;
     }
 
@@ -1128,6 +1189,35 @@ class _TerminalTextInputHandlerState extends State<TerminalTextInputHandler>
     }
     _pendingAndroidHardwareBackspaces++;
     widget.consumeTerminalKeyModifiers?.call();
+    _syncAndroidImeStateAfterNativeBackspace();
+  }
+
+  void _syncAndroidImeStateAfterNativeBackspace() {
+    final currentGraphemes = _lastSentText.characters.toList(growable: true);
+    final deletionEnd = _clampTextOffset(
+      _lastSentCursorOffset,
+      currentGraphemes.length,
+    );
+    final deletionStart = _clampTextOffset(
+      deletionEnd - _pendingAndroidHardwareBackspaces,
+      deletionEnd,
+    );
+    currentGraphemes.removeRange(deletionStart, deletionEnd);
+    final nextText = currentGraphemes.join();
+    final postDeleteCursorOffset = currentGraphemes
+        .take(deletionStart)
+        .join()
+        .length;
+    _syncEditingStateWithUserText(
+      nextText,
+      sourceValue: TextEditingValue(
+        text: '$_deleteDetectionMarker$nextText',
+        selection: TextSelection.collapsed(
+          offset: _deleteDetectionMarker.length + postDeleteCursorOffset,
+        ),
+      ),
+      forceResyncState: true,
+    );
   }
 
   ({

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -4908,6 +4908,52 @@ void main() {
     });
 
     testWidgets(
+      'native Android IME Enter sends one terminal Enter and suppresses a later action',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        final controller = TerminalTextInputHandlerController();
+        final harness = await _pumpTerminalHarness(
+          tester,
+          manageFocus: false,
+          controller: controller,
+        );
+
+        try {
+          tester.testTextInput.updateEditingValue(
+            _editingValue('pwd', selectionOffset: 3),
+          );
+          await tester.pump();
+          harness.terminalOutput.clear();
+
+          controller.debugHandleAndroidImeKey(
+            TerminalKey.enter,
+            TerminalKeyEventType.release,
+          );
+          await tester.pump();
+
+          expect(
+            harness.terminalOutput.join(),
+            _terminalKeyOutput(TerminalKey.enter),
+          );
+
+          _terminalTextInputClient(
+            tester,
+          ).performAction(TextInputAction.newline);
+          await tester.pump();
+
+          expect(
+            harness.terminalOutput.join(),
+            _terminalKeyOutput(TerminalKey.enter),
+          );
+        } finally {
+          await _disposeTerminalHarness(tester, harness);
+          controller.dispose();
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testWidgets(
       'virtual Enter ignores stale soft-keyboard Shift and submits via IME',
       (tester) async {
         const virtualShiftKey = PhysicalKeyboardKey(

--- a/test/widget/terminal_text_input_handler_test.dart
+++ b/test/widget/terminal_text_input_handler_test.dart
@@ -71,7 +71,9 @@ enum _ResetTrigger {
   markerLoss,
 }
 
-int _graphemeLength(String text) => text.characters.length;
+// Flutter text editing offsets are UTF-16 code-unit indexes, not grapheme
+// indexes. Keep grapheme-aware mutations separate from selection math.
+int _textEditingOffset(String text) => text.length;
 
 TextEditingValue _userValue(
   String text, {
@@ -96,12 +98,12 @@ String _dropLastGrapheme(String text) {
 
 _MatrixScenario _insertBeforeMiddleScenario(_SegmentSeed seed) {
   final initial = '${seed.before}${seed.middle}${seed.after}';
-  final insertionOffset = _graphemeLength(seed.before);
+  final insertionOffset = _textEditingOffset(seed.before);
   final updated = '${seed.before}X${seed.middle}${seed.after}';
   return (
     name: '${seed.name}: inserts before the edited segment',
     sequence: [
-      _userValue(initial, selectionBase: _graphemeLength(initial)),
+      _userValue(initial, selectionBase: _textEditingOffset(initial)),
       _userValue(initial, selectionBase: insertionOffset),
       _userValue(updated, selectionBase: insertionOffset + 1),
     ],
@@ -112,12 +114,12 @@ _MatrixScenario _insertBeforeMiddleScenario(_SegmentSeed seed) {
 
 _MatrixScenario _insertAfterMiddleScenario(_SegmentSeed seed) {
   final initial = '${seed.before}${seed.middle}${seed.after}';
-  final insertionOffset = _graphemeLength('${seed.before}${seed.middle}');
+  final insertionOffset = _textEditingOffset('${seed.before}${seed.middle}');
   final updated = '${seed.before}${seed.middle};${seed.after}';
   return (
     name: '${seed.name}: inserts after the edited segment',
     sequence: [
-      _userValue(initial, selectionBase: _graphemeLength(initial)),
+      _userValue(initial, selectionBase: _textEditingOffset(initial)),
       _userValue(initial, selectionBase: insertionOffset),
       _userValue(updated, selectionBase: insertionOffset + 1),
     ],
@@ -128,13 +130,13 @@ _MatrixScenario _insertAfterMiddleScenario(_SegmentSeed seed) {
 
 _MatrixScenario _replaceMiddleScenario(_SegmentSeed seed) {
   final initial = '${seed.before}${seed.middle}${seed.after}';
-  final selectionBase = _graphemeLength(seed.before);
-  final selectionExtent = selectionBase + _graphemeLength(seed.middle);
+  final selectionBase = _textEditingOffset(seed.before);
+  final selectionExtent = selectionBase + _textEditingOffset(seed.middle);
   final updated = '${seed.before}ZX${seed.after}';
   return (
     name: '${seed.name}: replaces the edited segment',
     sequence: [
-      _userValue(initial, selectionBase: _graphemeLength(initial)),
+      _userValue(initial, selectionBase: _textEditingOffset(initial)),
       _userValue(
         initial,
         selectionBase: selectionBase,
@@ -150,16 +152,16 @@ _MatrixScenario _replaceMiddleScenario(_SegmentSeed seed) {
 _MatrixScenario _backspaceWithinMiddleScenario(_SegmentSeed seed) {
   final initial = '${seed.before}${seed.middle}${seed.after}';
   final shortenedMiddle = _dropLastGrapheme(seed.middle);
-  final caretOffset = _graphemeLength('${seed.before}${seed.middle}');
+  final caretOffset = _textEditingOffset('${seed.before}${seed.middle}');
   final updated = '${seed.before}$shortenedMiddle${seed.after}';
   return (
     name: '${seed.name}: backspaces within the edited segment',
     sequence: [
-      _userValue(initial, selectionBase: _graphemeLength(initial)),
+      _userValue(initial, selectionBase: _textEditingOffset(initial)),
       _userValue(initial, selectionBase: caretOffset),
       _userValue(
         updated,
-        selectionBase: _graphemeLength('${seed.before}$shortenedMiddle'),
+        selectionBase: _textEditingOffset('${seed.before}$shortenedMiddle'),
       ),
     ],
     textFieldEchoes: null,
@@ -169,13 +171,13 @@ _MatrixScenario _backspaceWithinMiddleScenario(_SegmentSeed seed) {
 
 _MatrixScenario _deleteMiddleSelectionScenario(_SegmentSeed seed) {
   final initial = '${seed.before}${seed.middle}${seed.after}';
-  final selectionBase = _graphemeLength(seed.before);
-  final selectionExtent = selectionBase + _graphemeLength(seed.middle);
+  final selectionBase = _textEditingOffset(seed.before);
+  final selectionExtent = selectionBase + _textEditingOffset(seed.middle);
   final updated = '${seed.before}${seed.after}';
   return (
     name: '${seed.name}: deletes the edited segment selection',
     sequence: [
-      _userValue(initial, selectionBase: _graphemeLength(initial)),
+      _userValue(initial, selectionBase: _textEditingOffset(initial)),
       _userValue(
         initial,
         selectionBase: selectionBase,
@@ -7178,7 +7180,11 @@ void main() {
       (tester) async {
         final terminal = Terminal();
         final focusNode = FocusNode();
+        final controller = TerminalTextInputHandlerController();
+        var visibilityNotifications = 0;
+        controller.addListener(() => visibilityNotifications++);
         addTearDown(focusNode.dispose);
+        addTearDown(controller.dispose);
 
         await tester.pumpWidget(
           MaterialApp(
@@ -7186,6 +7192,7 @@ void main() {
               body: TerminalTextInputHandler(
                 terminal: terminal,
                 focusNode: focusNode,
+                controller: controller,
                 deleteDetection: true,
                 child: const SizedBox.expand(key: ValueKey('terminal-child')),
               ),
@@ -7198,6 +7205,8 @@ void main() {
 
         expect(focusNode.hasFocus, isTrue);
         expect(tester.testTextInput.isVisible, isTrue);
+        expect(controller.isKeyboardVisible, isTrue);
+        visibilityNotifications = 0;
 
         tester.testTextInput.log.clear();
         (tester.state(find.byType(TerminalTextInputHandler)) as TextInputClient)
@@ -7205,6 +7214,8 @@ void main() {
         await tester.pump();
 
         expect(focusNode.hasFocus, isTrue);
+        expect(controller.isKeyboardVisible, isFalse);
+        expect(visibilityNotifications, 1);
         expect(
           tester.testTextInput.log.where(
             (call) => call.method == 'TextInput.show',


### PR DESCRIPTION
## Summary

- extend the existing native Android IME-key bridge to intercept Enter
- reconstruct Enter or Backspace when Gboard exposes only the release callback
- keep Gboard's editing state synchronized after native Backspace and repeats
- notify keyboard-visibility listeners when the platform closes the input connection
- correct generated Flutter text-editing tests to use UTF-16 code-unit offsets

## Hands-on reproduction and evidence

I reran the disputed behavior inside the real `TerminalScreen`, connected to a live local SSH shell, on Android 16/API 36 with Gboard `15.1.08.726012951-preload-arm64-v8a`.

Temporary instrumentation captured Flutter key/edit/action callbacks, app editing-state writes, terminal output, exact SSH bytes, and the native Android key bridge. It was removed before committing.

### Return

Typing committed `pwd` produced ordinary editing updates and SSH bytes for `p`, `w`, and `d`. Pressing Gboard Return repeatedly produced only the Android virtual key event. There was no `performAction`, newline editing update, or SSH CR. Toolbar Enter emitted byte 13 and executed the command.

The newer `main` branch already introduced a native IME control-key bridge. The trace showed Gboard exposed only the **release** callback through that bridge. This PR extends the bridge to Enter and reconstructs a missing press from release, while suppressing a later duplicate IME action. After the change, one Gboard Return executed `pwd` over live SSH.

### Backspace and stale suggestions

For `teh` followed by three Gboard Backspaces, the terminal received three DEL bytes but Gboard did not provide editing-value deletions. Its private context stayed stale, so retyping generated duplicated candidates and selecting a correction could produce `eth`.

The current main-branch bridge already handles native Backspace and delayed edit reconciliation. This PR additionally:

- reconstructs release-only Backspace sequences
- writes the post-delete editing state back to Gboard after each press/repeat
- preserves the post-delete UTF-16 cursor position

## Validation

- live Gboard Return executed `pwd` over the real SSH terminal after one tap
- `flutter test test/widget/terminal_text_input_handler_test.dart` — 519 passed
- `dart analyze lib/presentation/widgets/terminal_text_input_handler.dart test/widget/terminal_text_input_handler_test.dart`
- repository pre-push analyzer — passed
- independent review performed; repeat tracking and cursor preservation findings were addressed

## Security/privacy

Raw-input tracing was temporary, never routed through repository diagnostics, and never committed. The temporary SSH harness and key defines were removed before the final commit.
