### PR TITLE
Fix stale Android keyboard inset after app switching

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -12171,7 +12171,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       _stopSharedClipboardSync();
       _syncTerminalWakeLock();
     } else if (state == AppLifecycleState.resumed && _wasBackgrounded) {
-      final shouldRestoreKeyboard = _restoreKeyboardAfterAppResume;
+      // Android dismisses the IME when the app loses its window. Asking it
+      // to show again from the first resumed callback can be ignored while the
+      // old bottom inset remains, leaving a keyboard-sized blank region. Keep
+      // the keyboard closed there; an explicit terminal tap can reopen it once
+      // the resumed window is ready. iOS continues restoring it automatically.
+      final shouldRestoreKeyboard =
+          _restoreKeyboardAfterAppResume && !_isAndroidPlatform;
       _restoreKeyboardAfterAppResume = false;
       _wasBackgrounded = false;
       _syncTerminalWakeLock();

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -3496,6 +3496,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   late FocusNode _terminalFocusNode;
   final _terminalTextInputController = TerminalTextInputHandlerController();
   bool _keyboardVisibilityRebuildScheduled = false;
+  int _terminalFocusRestoreGeneration = 0;
   final _toolbarController = KeyboardToolbarController();
   SSHSession? _shell;
   StreamSubscription<void>? _doneSubscription;
@@ -12160,6 +12161,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.inactive) {
+      _terminalFocusRestoreGeneration += 1;
       final shouldRestoreKeyboard = state == AppLifecycleState.paused
           ? _dismissTerminalKeyboardForAppBackground()
           : _shouldRestoreTerminalKeyboardAfterTemporaryDismissal;
@@ -12174,10 +12176,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       // Android dismisses the IME when the app loses its window. Asking it
       // to show again from the first resumed callback can be ignored while the
       // old bottom inset remains, leaving a keyboard-sized blank region. Keep
-      // the keyboard closed there; an explicit terminal tap can reopen it once
-      // the resumed window is ready. iOS continues restoring it automatically.
+      // the keyboard closed there while restoring terminal focus for hardware
+      // input. iOS continues restoring both focus and the keyboard.
+      final shouldRestoreTerminalFocus = _restoreKeyboardAfterAppResume;
       final shouldRestoreKeyboard =
-          _restoreKeyboardAfterAppResume && !_isAndroidPlatform;
+          shouldRestoreTerminalFocus && !_isAndroidPlatform;
       _restoreKeyboardAfterAppResume = false;
       _wasBackgrounded = false;
       _syncTerminalWakeLock();
@@ -12211,7 +12214,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           reason: 'app_resumed',
         );
       }
-      _restoreTemporarilyDismissedTerminalKeyboard(shouldRestoreKeyboard);
+      if (shouldRestoreTerminalFocus) {
+        _restoreTerminalFocus(forceShowSystemKeyboard: shouldRestoreKeyboard);
+      }
     }
   }
 
@@ -12780,8 +12785,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
       return;
     }
     _dismissNativeSelectionOverlayForEditing();
+    final restoreGeneration = _terminalFocusRestoreGeneration;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) {
+      if (!mounted || restoreGeneration != _terminalFocusRestoreGeneration) {
         return;
       }
       _terminalTextInputController.resetImeCompletions();

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -9266,6 +9266,56 @@ void main() {
     );
 
     testWidgets(
+      'Android app resume leaves a system-dismissed keyboard closed',
+      (tester) async {
+        // Android can retain the previous IME inset after app switching even
+        // though the system keyboard itself has been dismissed.
+        tester.view
+          ..physicalSize = const Size(390, 844)
+          ..devicePixelRatio = 1
+          ..viewInsets = const FakeViewPadding(bottom: 500);
+        addTearDown(() {
+          tester.view
+            ..resetPhysicalSize()
+            ..resetDevicePixelRatio()
+            ..resetViewInsets();
+        });
+
+        await pumpScreen(tester);
+        await tester.tap(find.byType(MonkeyTerminalView));
+        await tester.pump();
+        await tester.pump();
+
+        expect(tester.testTextInput.isVisible, isTrue);
+        expect(tester.getBottomLeft(find.byType(KeyboardToolbar)).dy, 344);
+
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+        await tester.pump();
+
+        expect(tester.testTextInput.isVisible, isFalse);
+
+        tester.testTextInput.log.clear();
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(
+          tester.testTextInput.log.where(
+            (call) => call.method == 'TextInput.show',
+          ),
+          isEmpty,
+        );
+        expect(tester.testTextInput.isVisible, isFalse);
+        expect(find.byTooltip('Show system keyboard'), findsOneWidget);
+        expect(find.byTooltip('Hide system keyboard'), findsNothing);
+        expect(tester.getBottomLeft(find.byType(KeyboardToolbar)).dy, 844);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
       'terminal overflow menu preserves the visible mobile keyboard',
       (tester) async {
         await pumpScreen(tester);

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -9311,6 +9311,49 @@ void main() {
         expect(find.byTooltip('Show system keyboard'), findsOneWidget);
         expect(find.byTooltip('Hide system keyboard'), findsNothing);
         expect(tester.getBottomLeft(find.byType(KeyboardToolbar)).dy, 844);
+        final inputHandler = tester.widget<TerminalTextInputHandler>(
+          find.byType(TerminalTextInputHandler),
+        );
+        expect(inputHandler.focusNode.hasFocus, isTrue);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'Android app background invalidates a queued keyboard request',
+      (tester) async {
+        tester.view
+          ..physicalSize = const Size(390, 844)
+          ..devicePixelRatio = 1
+          ..viewInsets = const FakeViewPadding(bottom: 500);
+        addTearDown(() {
+          tester.view
+            ..resetPhysicalSize()
+            ..resetDevicePixelRatio()
+            ..resetViewInsets();
+        });
+
+        await pumpScreen(tester);
+        tester.testTextInput.log.clear();
+
+        // Queue the post-frame keyboard request, then background the app before
+        // Flutter can run it. It must not replay in the resumed window.
+        await tester.tap(find.byTooltip('Show system keyboard'));
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(
+          tester.testTextInput.log.where(
+            (call) => call.method == 'TextInput.show',
+          ),
+          isEmpty,
+        );
+        expect(tester.testTextInput.isVisible, isFalse);
+        expect(tester.getBottomLeft(find.byType(KeyboardToolbar)).dy, 844);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );


### PR DESCRIPTION
## Summary

- Keep Android's system keyboard closed when returning from another app so a stale IME inset cannot leave a keyboard-sized blank region.
- Restore terminal focus without reopening the Android IME, preserving hardware-keyboard input.
- Invalidate queued post-frame keyboard requests when the app backgrounds.
- Preserve automatic keyboard restoration on iOS.
- Add Android regressions for stale insets, focus restoration, and queued keyboard requests.

## Tests

- `flutter test test/presentation/screens/terminal_screen_test.dart --plain-name "Android app resume leaves a system-dismissed keyboard closed"`
- `flutter test test/presentation/screens/terminal_screen_test.dart --plain-name "Android app background invalidates a queued keyboard request"`
- `flutter test test/presentation/screens/terminal_screen_test.dart --plain-name "keyboard button shows the keyboard despite a stale bottom inset"`
- `flutter test test/presentation/screens/terminal_screen_test.dart --plain-name "app resume restores the mobile keyboard when it was visible"`
- `flutter analyze lib/presentation/screens/terminal_screen.dart test/presentation/screens/terminal_screen_test.dart`
