### PR TITLE
Fix held toolbar arrows in raw terminals

### DIFF
--- a/lib/presentation/widgets/keyboard_toolbar.dart
+++ b/lib/presentation/widgets/keyboard_toolbar.dart
@@ -459,7 +459,6 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
         '\x1b[5~',
         withHaptic: false,
         consumeOneShot: false,
-        type: TerminalKeyEventType.repeat,
       ),
       tooltip: 'Page Up',
     ),
@@ -474,7 +473,6 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
         '\x1b[6~',
         withHaptic: false,
         consumeOneShot: false,
-        type: TerminalKeyEventType.repeat,
       ),
       tooltip: 'Page Down',
     ),
@@ -488,7 +486,6 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
         '\x1b[H',
         withHaptic: false,
         consumeOneShot: false,
-        type: TerminalKeyEventType.repeat,
       ),
       tooltip: 'Home',
     ),
@@ -502,7 +499,6 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
         '\x1b[F',
         withHaptic: false,
         consumeOneShot: false,
-        type: TerminalKeyEventType.repeat,
       ),
       tooltip: 'End',
     ),
@@ -514,12 +510,8 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
       label: '',
       onTap: () => _sendArrow(_Arrow.left),
       onLongPressStart: () => _sendArrow(_Arrow.left),
-      onLongPressRepeat: () => _sendArrow(
-        _Arrow.left,
-        withHaptic: false,
-        consumeOneShot: false,
-        type: TerminalKeyEventType.repeat,
-      ),
+      onLongPressRepeat: () =>
+          _sendArrow(_Arrow.left, withHaptic: false, consumeOneShot: false),
       tooltip: 'Left',
     ),
     _ToolbarButton(
@@ -527,12 +519,8 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
       label: '',
       onTap: () => _sendArrow(_Arrow.right),
       onLongPressStart: () => _sendArrow(_Arrow.right),
-      onLongPressRepeat: () => _sendArrow(
-        _Arrow.right,
-        withHaptic: false,
-        consumeOneShot: false,
-        type: TerminalKeyEventType.repeat,
-      ),
+      onLongPressRepeat: () =>
+          _sendArrow(_Arrow.right, withHaptic: false, consumeOneShot: false),
       tooltip: 'Right',
     ),
     _ToolbarButton(
@@ -540,12 +528,8 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
       label: '',
       onTap: () => _sendArrow(_Arrow.up),
       onLongPressStart: () => _sendArrow(_Arrow.up),
-      onLongPressRepeat: () => _sendArrow(
-        _Arrow.up,
-        withHaptic: false,
-        consumeOneShot: false,
-        type: TerminalKeyEventType.repeat,
-      ),
+      onLongPressRepeat: () =>
+          _sendArrow(_Arrow.up, withHaptic: false, consumeOneShot: false),
       tooltip: 'Up',
     ),
     _ToolbarButton(
@@ -553,12 +537,8 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
       label: '',
       onTap: () => _sendArrow(_Arrow.down),
       onLongPressStart: () => _sendArrow(_Arrow.down),
-      onLongPressRepeat: () => _sendArrow(
-        _Arrow.down,
-        withHaptic: false,
-        consumeOneShot: false,
-        type: TerminalKeyEventType.repeat,
-      ),
+      onLongPressRepeat: () =>
+          _sendArrow(_Arrow.down, withHaptic: false, consumeOneShot: false),
       tooltip: 'Down',
     ),
   ];

--- a/test/widget/keyboard_toolbar_test.dart
+++ b/test/widget/keyboard_toolbar_test.dart
@@ -706,7 +706,7 @@ void main() {
       expect(output.where((value) => value == '\x1b[A').length, greaterThan(1));
     });
 
-    testWidgets('arrow key repeats use Kitty event type when enabled', (
+    testWidgets('arrow holds avoid Kitty event types in raw terminals', (
       tester,
     ) async {
       final output = <String>[];
@@ -728,8 +728,8 @@ void main() {
       await gesture.up();
       await tester.pump();
 
-      expect(output, contains('\x1b[A'));
-      expect(output.where((value) => value == '\x1b[1;1:2A'), isNotEmpty);
+      expect(output.where((value) => value == '\x1b[A').length, greaterThan(1));
+      expect(output.where((value) => value.contains(':2')), isEmpty);
     });
 
     testWidgets(
@@ -756,7 +756,7 @@ void main() {
       },
     );
 
-    testWidgets('series navigation repeats use Kitty event type when enabled', (
+    testWidgets('series navigation holds avoid Kitty event types', (
       tester,
     ) async {
       final output = <String>[];
@@ -778,8 +778,11 @@ void main() {
       await gesture.up();
       await tester.pump();
 
-      expect(output, contains('\x1b[5~'));
-      expect(output.where((value) => value == '\x1b[5;1:2~'), isNotEmpty);
+      expect(
+        output.where((value) => value == '\x1b[5~').length,
+        greaterThan(1),
+      );
+      expect(output.where((value) => value.contains(':2')), isEmpty);
     });
 
     testWidgets('repeating navigation stops when gesture is cancelled', (


### PR DESCRIPTION
## Summary
- treat extended-keyboard hold timers as repeated press events instead of Kitty repeat events
- prevent `:2` Kitty event-type suffixes from leaking into raw MonkeyMux shell input
- cover arrow and series-navigation holds with regression tests

## Testing
- `dart format --output=none --set-exit-if-changed lib/presentation/widgets/keyboard_toolbar.dart test/widget/keyboard_toolbar_test.dart`
- `flutter analyze lib/presentation/widgets/keyboard_toolbar.dart test/widget/keyboard_toolbar_test.dart`
- `flutter test test/widget/keyboard_toolbar_test.dart`
