### PR TITLE
fix: replace kitty placements sharing an image and placement id

### DIFF
--- a/third_party/xterm/lib/src/core/graphics_manager.dart
+++ b/third_party/xterm/lib/src/core/graphics_manager.dart
@@ -1761,6 +1761,23 @@ class GraphicsManager {
     int xOffset = 0,
     int yOffset = 0,
   }) {
+    // Kitty: a placement is uniquely identified by (image id, placement id),
+    // and re-sending one with the same pair replaces the first — this is how
+    // clients move or resize a displayed image without flicker (e.g. the Grok
+    // CLI re-places its inline image with the same p= at a new cursor position
+    // on every scroll repaint). Appending instead of replacing left a stale
+    // copy behind at every scroll step. Placements without a client id (p=0)
+    // always accumulate, per the spec.
+    if (clientPlacementId > 0) {
+      _placements.removeWhere((existing) {
+        if (existing.imageId != imageId ||
+            existing.clientPlacementId != clientPlacementId) {
+          return false;
+        }
+        existing.dispose();
+        return true;
+      });
+    }
     final placement = TerminalImagePlacement(
       placementId: _nextPlacementId++,
       imageId: imageId,

--- a/third_party/xterm/test/src/core/graphics_test.dart
+++ b/third_party/xterm/test/src/core/graphics_test.dart
@@ -2425,6 +2425,115 @@ void main() {
     });
   });
 
+  testWidgets('re-placing with the same image and placement id replaces', (
+    tester,
+  ) async {
+    await tester.runAsync(() async {
+      final pngBase64 = await _buildPngBase64(4, 4);
+      final terminal = Terminal()..resize(80, 24);
+      terminal.write('\x1b_Ga=t,f=100,i=77,q=2;$pngBase64\x1b\\');
+      terminal.graphics.imageForPlacement(77);
+      await _awaitImage(terminal, 77);
+
+      // A client moving an inline image during a scroll repaint (e.g. Grok
+      // CLI) re-places it with the same p= at the new cursor position on
+      // every frame. Each re-place must replace the previous placement, not
+      // leave a stale copy one row behind.
+      terminal
+        ..write('\x1b[3;1H')
+        ..write('\x1b_Ga=p,i=77,p=5,c=4,r=2,z=0,C=1,q=2\x1b\\')
+        ..write('\x1b[6;2H')
+        ..write('\x1b_Ga=p,i=77,p=5,c=4,r=2,z=0,C=1,q=2\x1b\\');
+
+      final placement = terminal.graphics.placements
+          .where((placement) => placement.imageId == 77)
+          .single;
+      expect(placement.clientPlacementId, 5);
+      expect(placement.row, 5);
+      expect(placement.col, 1);
+    });
+  });
+
+  testWidgets('distinct placement ids of one image are all kept', (
+    tester,
+  ) async {
+    await tester.runAsync(() async {
+      final pngBase64 = await _buildPngBase64(4, 4);
+      final terminal = Terminal()..resize(80, 24);
+      terminal.write('\x1b_Ga=t,f=100,i=78,q=2;$pngBase64\x1b\\');
+      terminal.graphics.imageForPlacement(78);
+      await _awaitImage(terminal, 78);
+
+      terminal
+        ..write('\x1b_Ga=p,i=78,p=1,c=2,r=1,C=1,q=2\x1b\\')
+        ..write('\x1b[5;1H')
+        ..write('\x1b_Ga=p,i=78,p=2,c=2,r=1,C=1,q=2\x1b\\');
+
+      expect(
+        terminal.graphics.placements
+            .where((placement) => placement.imageId == 78)
+            .map((placement) => placement.clientPlacementId),
+        unorderedEquals([1, 2]),
+      );
+    });
+  });
+
+  testWidgets('placements without a placement id accumulate', (tester) async {
+    await tester.runAsync(() async {
+      final pngBase64 = await _buildPngBase64(4, 4);
+      final terminal = Terminal()..resize(80, 24);
+      terminal.write('\x1b_Ga=t,f=100,i=79,q=2;$pngBase64\x1b\\');
+      terminal.graphics.imageForPlacement(79);
+      await _awaitImage(terminal, 79);
+
+      terminal
+        ..write('\x1b_Ga=p,i=79,c=2,r=1,C=1,q=2\x1b\\')
+        ..write('\x1b[5;1H')
+        ..write('\x1b_Ga=p,i=79,c=2,r=1,C=1,q=2\x1b\\');
+
+      expect(
+        terminal.graphics.placements
+            .where((placement) => placement.imageId == 79)
+            .length,
+        2,
+      );
+    });
+  });
+
+  testWidgets('a=T with the same image and placement id replaces', (
+    tester,
+  ) async {
+    await tester.runAsync(() async {
+      final pngBase64 = await _buildPngBase64(4, 4);
+      final terminal = Terminal()..resize(80, 24);
+
+      terminal
+        ..write('\x1b[2;1H')
+        ..write('\x1b_Ga=T,f=100,i=80,p=3,c=2,r=1,C=1,q=2;$pngBase64\x1b\\');
+      await _awaitImage(terminal, 80);
+      terminal
+        ..write('\x1b[7;1H')
+        ..write('\x1b_Ga=T,f=100,i=80,p=3,c=2,r=1,C=1,q=2;$pngBase64\x1b\\');
+      var waited = 0;
+      bool moved() {
+        final placements = terminal.graphics.placements
+            .where((placement) => placement.imageId == 80)
+            .toList();
+        return placements.length == 1 && placements.single.row == 6;
+      }
+
+      while (!moved() && waited < 2000) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        waited += 20;
+      }
+
+      final placement = terminal.graphics.placements
+          .where((placement) => placement.imageId == 80)
+          .single;
+      expect(placement.row, 6);
+    });
+  });
+
   testWidgets('invalid graphics payload is ignored without placing', (
     tester,
   ) async {


### PR DESCRIPTION
## Problem

When Grok CLI displays an image inline and the transcript scrolls, the image smears into a scalloped trail of stale copies, painting over surrounding text (reported with video + screenshot from a MonkeySSH Android preview build).

## Root cause

The kitty graphics spec defines a placement as uniquely identified by the **(image id, placement id)** pair:

> If you send two placements with the same image id and placement id the second one will replace the first. This can be used to resize or move placements around the screen, without flicker.

Grok CLI relies on exactly this. A live capture of the real `grok` binary (driven in a PTY with `TERM=xterm-kitty`, mirroring the reported `imagine-edit` flow) shows it transmit the image once (`a=t,f=100,i=2`) and then re-send

```
a=p,i=2,p=2,c=50,r=13,z=-1,x=0,y=319,w=1136,h=592,C=1,q=2
```

**151 times** during scrolling, with shifting crops, never deleting between frames (its per-frame `a=d,d=i` deletes target a different slot id).

Our vendored xterm's `GraphicsManager.placeImage` appended unconditionally, so every scroll repaint left a stale copy one row behind the previous one - the scalloped smear.

## Fix

`placeImage` now removes any existing placement with the same `(imageId, clientPlacementId)` pair before adding the new one when a client placement id (`p=` > 0) is present. Placements without a client id (`p=0`) still accumulate, per the spec.

## Validation

- Replaying the captured 353 KB grok session byte stream through the emulator: **151 accumulated placements before, exactly 1 after** the fix.
- New regression tests using grok's exact key patterns: same-`p=` re-place replaces (for both `a=p` and `a=T`), distinct `p=` ids are all kept, and `p=`-less placements still accumulate.
- `third_party/xterm`: full `flutter test` passes (the two `TerminalView.textScaler` failures pre-exist on `main`); `flutter analyze` matches `main` (13 pre-existing infos).
