### PR TITLE
fix: resume relocated Pi sessions after MonkeyMux update

### DIFF
--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -3320,7 +3320,10 @@ func discoverPiSessions(
 		provisional := map[int]piSessionEntry{}
 		owners := map[string][]int{}
 		for _, index := range indices {
-			matches := piSessionsCreatedForProcessStart(candidates, processStarts[index])
+			matches := piLeafSessionMatches(
+				piSessionsCreatedForProcessStart(candidates, processStarts[index]),
+				candidates,
+			)
 			if len(matches) != 1 {
 				continue
 			}
@@ -3397,6 +3400,47 @@ func piSessionsCreatedForProcessStart(
 		}
 	}
 	return matches
+}
+
+// piLeafSessionMatches drops matches that another match descends from. Both
+// rotation (/new, /resume) and worktree relocation record the file they came
+// from as parentSession, so a match that a sibling match links back to is a
+// session the pane has already left; the surviving leaf is where it is now.
+// Forks branch from a shared parent without superseding each other, so a
+// branched history keeps every leaf and stays ambiguous.
+func piLeafSessionMatches(matches []piSessionEntry, entries []piSessionEntry) []piSessionEntry {
+	if len(matches) < 2 {
+		return matches
+	}
+	parentByPath := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		parentByPath[entry.path] = entry.parentPath
+	}
+	matchedPaths := make(map[string]struct{}, len(matches))
+	for _, match := range matches {
+		matchedPaths[match.path] = struct{}{}
+	}
+	ancestors := map[string]struct{}{}
+	for _, match := range matches {
+		seen := map[string]struct{}{}
+		for parent := match.parentPath; parent != ""; parent = parentByPath[parent] {
+			if _, ok := seen[parent]; ok {
+				break
+			}
+			seen[parent] = struct{}{}
+			if _, ok := matchedPaths[parent]; ok {
+				ancestors[parent] = struct{}{}
+			}
+		}
+	}
+	leaves := make([]piSessionEntry, 0, len(matches))
+	for _, match := range matches {
+		if _, ok := ancestors[match.path]; ok {
+			continue
+		}
+		leaves = append(leaves, match)
+	}
+	return leaves
 }
 
 // piSessionWasSuperseded prevents the process's initial session from winning

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -59,7 +59,7 @@ type muxProcess interface {
 }
 
 const (
-	monkeyMuxVersion                  = "0.1.156"
+	monkeyMuxVersion                  = "0.1.157"
 	defaultColumns                    = 80
 	defaultRows                       = 24
 	maxTitleBytes                     = 160
@@ -3185,6 +3185,17 @@ type piSessionEntry struct {
 	path      string
 	modTime   time.Time
 	createdAt time.Time
+	// parentPath is the session file this one was rotated or relocated from
+	// (the header's parentSession), which may no longer exist on disk.
+	parentPath string
+	// originDir and originCreatedAt describe the root of the parentSession
+	// chain: the directory name and creation time of the session the pane's
+	// Pi process originally started. Pi's worktree flow relocates a session
+	// to a new cwd-encoded directory with a fresh id and timestamp and
+	// deletes the original file, so only the chain origin still matches the
+	// pane's working directory and process start time.
+	originDir       string
+	originCreatedAt time.Time
 }
 
 var processStartedAtForMetadata = func(pid int) time.Time {
@@ -3289,9 +3300,17 @@ func discoverPiSessions(
 			entries = readPiSessionEntries(key.root)
 			entriesByRoot[key.root] = entries
 		}
+		encodedCwd := piEncodedSessionDirName(key.cwd)
 		candidates := []piSessionEntry{}
 		for _, entry := range entries {
-			if entry.cwd == key.cwd && !used[entry.sessionID] {
+			if used[entry.sessionID] {
+				continue
+			}
+			// A relocated session (Pi's worktree flow) records the pane's
+			// working directory only in the origin of its parentSession
+			// chain, so match either the live cwd or that origin bucket.
+			if entry.cwd == key.cwd ||
+				(encodedCwd != "" && entry.originDir == encodedCwd) {
 				candidates = append(candidates, entry)
 			}
 		}
@@ -3363,11 +3382,17 @@ func piSessionsCreatedForProcessStart(
 	}
 	matches := []piSessionEntry{}
 	for _, entry := range entries {
-		if entry.createdAt.IsZero() {
+		// A relocated session's own timestamp records the relocation, not the
+		// launch, so correlate the process start against the chain origin.
+		createdAt := entry.originCreatedAt
+		if createdAt.IsZero() {
+			createdAt = entry.createdAt
+		}
+		if createdAt.IsZero() {
 			continue
 		}
-		if !entry.createdAt.Before(processStarted.Add(-2*time.Second)) &&
-			!entry.createdAt.After(processStarted.Add(10*time.Second)) {
+		if !createdAt.Before(processStarted.Add(-2*time.Second)) &&
+			!createdAt.After(processStarted.Add(10*time.Second)) {
 			matches = append(matches, entry)
 		}
 	}
@@ -3506,6 +3531,7 @@ func readPiSessionEntries(root string) []piSessionEntry {
 		}
 		return nil
 	})
+	annotatePiSessionOrigins(entries)
 	sort.SliceStable(entries, func(i, j int) bool { return entries[i].modTime.After(entries[j].modTime) })
 	return entries
 }
@@ -3598,10 +3624,11 @@ func readPiSessionEntry(path string) (piSessionEntry, bool) {
 			continue
 		}
 		var header struct {
-			Type      string `json:"type"`
-			ID        string `json:"id"`
-			Timestamp string `json:"timestamp"`
-			Cwd       string `json:"cwd"`
+			Type          string `json:"type"`
+			ID            string `json:"id"`
+			Timestamp     string `json:"timestamp"`
+			Cwd           string `json:"cwd"`
+			ParentSession string `json:"parentSession"`
 		}
 		if json.Unmarshal(scanner.Bytes(), &header) != nil || header.Type != "session" {
 			continue
@@ -3616,15 +3643,107 @@ func readPiSessionEntry(path string) (piSessionEntry, bool) {
 			return piSessionEntry{}, false
 		}
 		createdAt, _ := time.Parse(time.RFC3339Nano, strings.TrimSpace(header.Timestamp))
-		return piSessionEntry{
-			sessionID: sessionID,
-			cwd:       cwd,
-			path:      filepath.Clean(path),
-			modTime:   info.ModTime(),
-			createdAt: createdAt,
-		}, true
+		parentPath := ""
+		if parent := strings.TrimSpace(header.ParentSession); parent != "" {
+			parentPath = filepath.Clean(parent)
+		}
+		entry := piSessionEntry{
+			sessionID:  sessionID,
+			cwd:        cwd,
+			path:       filepath.Clean(path),
+			modTime:    info.ModTime(),
+			createdAt:  createdAt,
+			parentPath: parentPath,
+		}
+		entry.originDir = filepath.Base(filepath.Dir(entry.path))
+		entry.originCreatedAt = createdAt
+		return entry, true
 	}
 	return piSessionEntry{}, false
+}
+
+// piEncodedSessionDirName mirrors Pi's session bucket naming: the resolved
+// cwd with its leading separator stripped and every path separator or drive
+// colon replaced by "-", wrapped in "--". A deleted origin file's bucket name
+// therefore still identifies the working directory it was created in.
+func piEncodedSessionDirName(cwd string) string {
+	resolved := normalizedPiWorkingDirectory(cwd)
+	if resolved == "" {
+		return ""
+	}
+	if resolved[0] == '/' || resolved[0] == '\\' {
+		resolved = resolved[1:]
+	}
+	replaced := strings.NewReplacer("/", "-", "\\", "-", ":", "-").Replace(resolved)
+	return "--" + replaced + "--"
+}
+
+// piSessionFileTimestampPattern matches Pi's session file name prefix
+// (an RFC3339 timestamp with ":" and "." replaced by "-").
+var piSessionFileTimestampPattern = regexp.MustCompile(
+	`^(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z_`,
+)
+
+func piSessionCreatedAtFromFileName(name string) time.Time {
+	match := piSessionFileTimestampPattern.FindStringSubmatch(name)
+	if match == nil {
+		return time.Time{}
+	}
+	fields := make([]int, 0, 7)
+	for _, group := range match[1:] {
+		value, err := strconv.Atoi(group)
+		if err != nil {
+			return time.Time{}
+		}
+		fields = append(fields, value)
+	}
+	return time.Date(
+		fields[0],
+		time.Month(fields[1]),
+		fields[2],
+		fields[3],
+		fields[4],
+		fields[5],
+		fields[6]*int(time.Millisecond),
+		time.UTC,
+	)
+}
+
+// annotatePiSessionOrigins resolves each entry's parentSession chain to its
+// origin. Intermediate links may still exist on disk (rotation via /new keeps
+// the old file) or may be gone (worktree relocation deletes it); a missing
+// link terminates the chain with the directory name and file-name timestamp
+// taken from the dangling path itself.
+func annotatePiSessionOrigins(entries []piSessionEntry) {
+	byPath := map[string]int{}
+	for i := range entries {
+		byPath[entries[i].path] = i
+	}
+	for i := range entries {
+		seen := map[int]struct{}{}
+		current := i
+		for {
+			if _, ok := seen[current]; ok {
+				break
+			}
+			seen[current] = struct{}{}
+			parent := entries[current].parentPath
+			if parent == "" {
+				entries[i].originDir = filepath.Base(filepath.Dir(entries[current].path))
+				entries[i].originCreatedAt = entries[current].createdAt
+				break
+			}
+			if next, ok := byPath[parent]; ok {
+				current = next
+				continue
+			}
+			entries[i].originDir = filepath.Base(filepath.Dir(parent))
+			if createdAt := piSessionCreatedAtFromFileName(filepath.Base(parent)); !createdAt.IsZero() {
+				entries[i].originCreatedAt = createdAt
+			}
+			break
+		}
+	}
 }
 
 func normalizedPiWorkingDirectory(path string) string {

--- a/remote/monkeymux/pi_restore_test.go
+++ b/remote/monkeymux/pi_restore_test.go
@@ -40,6 +40,129 @@ func writePiTestSessionTimes(
 	}
 }
 
+func writePiTestRelocatedSession(
+	t *testing.T,
+	path string,
+	id string,
+	cwd string,
+	parent string,
+	created time.Time,
+	modified time.Time,
+) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	header := fmt.Sprintf(
+		"{\"type\":\"session\",\"id\":%q,\"timestamp\":%q,\"cwd\":%q,\"parentSession\":%q}\n",
+		id,
+		created.UTC().Format(time.RFC3339Nano),
+		cwd,
+		parent,
+	)
+	if err := os.WriteFile(path, []byte(header), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, modified, modified); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Pi's worktree flow relocates a running session into a bucket named for the
+// new worktree cwd and deletes the original file, leaving only the header's
+// parentSession pointing at the pane's working directory. The pane must still
+// resume that session after a helper upgrade rather than launching a fresh Pi.
+func TestDiscoverPiSessionsResumesSessionRelocatedToWorktree(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processStartedAtForMetadata = originalProcessStart
+	})
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+
+	root := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_SESSION_DIR", root)
+	project := filepath.Join(root, "project")
+	worktree := filepath.Join(root, "worktree")
+	started := time.Now().Add(-time.Hour).UTC()
+	originCreated := started.Add(500 * time.Millisecond)
+	// The deleted origin file only survives as the parentSession path.
+	deletedOrigin := filepath.Join(
+		root,
+		piEncodedSessionDirName(project),
+		originCreated.Format("2006-01-02T15-04-05-000Z")+"_origin-session.jsonl",
+	)
+	writePiTestRelocatedSession(
+		t,
+		filepath.Join(root, piEncodedSessionDirName(worktree), "relocated.jsonl"),
+		"relocated-session",
+		worktree,
+		deletedOrigin,
+		started.Add(30*time.Minute),
+		started.Add(45*time.Minute),
+	)
+	processStartedAtForMetadata = func(int) time.Time { return started }
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "pi", args: "pi"},
+	}
+	restore := &serverRestore{Windows: []restoreWindowState{{
+		PanePid: 100, CurrentCommand: "pi", AgentTool: "pi", Cwd: project,
+	}}}
+
+	got := discoverPiSessions(restore, processes, map[int]struct{}{100: {}})[0]
+	if got.sessionID != "relocated-session" {
+		t.Fatalf("relocated Pi session = %#v, want relocated-session", got)
+	}
+	options := createWindowOptionsForRestore(restoreWindowState{
+		CurrentCommand:  "pi",
+		AgentSessionID:  got.sessionID,
+		AgentSessionDir: got.sessionDir,
+	}, false)
+	if !strings.Contains(options.command, "--session relocated-session") {
+		t.Fatalf("relocated restore command = %q, want a resume", options.command)
+	}
+}
+
+func TestPiSessionOriginResolvesChainAndFileNameTimestamp(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	worktree := filepath.Join(root, "worktree")
+	created := time.Date(2026, 8, 15, 6, 56, 17, 353*int(time.Millisecond), time.UTC)
+	origin := filepath.Join(
+		root,
+		piEncodedSessionDirName(project),
+		"2026-08-15T06-56-17-353Z_origin-session.jsonl",
+	)
+	middle := filepath.Join(root, piEncodedSessionDirName(worktree), "middle.jsonl")
+	newest := filepath.Join(root, piEncodedSessionDirName(worktree), "newest.jsonl")
+	writePiTestRelocatedSession(t, middle, "middle-session", worktree, origin, created.Add(time.Minute), created.Add(2*time.Minute))
+	writePiTestRelocatedSession(t, newest, "newest-session", worktree, middle, created.Add(3*time.Minute), created.Add(4*time.Minute))
+
+	entries := readPiSessionEntries(root)
+	if len(entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(entries))
+	}
+	for _, entry := range entries {
+		if entry.originDir != piEncodedSessionDirName(project) {
+			t.Fatalf("%s origin dir = %q, want project bucket", entry.sessionID, entry.originDir)
+		}
+		if !entry.originCreatedAt.Equal(created) {
+			t.Fatalf("%s origin createdAt = %s, want %s", entry.sessionID, entry.originCreatedAt, created)
+		}
+	}
+}
+
+func TestPiEncodedSessionDirNameMatchesPiLayout(t *testing.T) {
+	if got, want := piEncodedSessionDirName("/Users/demo/Code/MonkeySSH"), "--Users-demo-Code-MonkeySSH--"; got != want {
+		t.Fatalf("piEncodedSessionDirName = %q, want %q", got, want)
+	}
+	if got := piEncodedSessionDirName(""); got != "" {
+		t.Fatalf("empty cwd encoding = %q, want empty", got)
+	}
+}
+
 func TestPiAgentToolMappingAndResumeCommand(t *testing.T) {
 	for _, name := range []string{"pi", "/Users/demo/.local/bin/pi"} {
 		if got := agentToolFromCommandName(name); got != "pi" {

--- a/remote/monkeymux/pi_restore_test.go
+++ b/remote/monkeymux/pi_restore_test.go
@@ -154,6 +154,87 @@ func TestPiSessionOriginResolvesChainAndFileNameTimestamp(t *testing.T) {
 	}
 }
 
+// A relocated session that is later rotated (/new) leaves the intermediate
+// file on disk, so the pane's chain has several links that all resolve to the
+// same origin. The pane must resume the leaf it is actually on.
+func TestDiscoverPiSessionsResumesLeafOfRelocatedThenRotatedChain(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processStartedAtForMetadata = originalProcessStart
+	})
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+
+	root := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_SESSION_DIR", root)
+	project := filepath.Join(root, "project")
+	worktree := filepath.Join(root, "worktree")
+	started := time.Now().Add(-time.Hour).UTC()
+	deletedOrigin := filepath.Join(
+		root,
+		piEncodedSessionDirName(project),
+		started.Add(500*time.Millisecond).Format("2006-01-02T15-04-05-000Z")+"_origin-session.jsonl",
+	)
+	middle := filepath.Join(root, piEncodedSessionDirName(worktree), "middle.jsonl")
+	newest := filepath.Join(root, piEncodedSessionDirName(worktree), "newest.jsonl")
+	writePiTestRelocatedSession(t, middle, "middle-session", worktree, deletedOrigin, started.Add(20*time.Minute), started.Add(25*time.Minute))
+	writePiTestRelocatedSession(t, newest, "newest-session", worktree, middle, started.Add(30*time.Minute), started.Add(45*time.Minute))
+
+	processStartedAtForMetadata = func(int) time.Time { return started }
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "pi", args: "pi"},
+	}
+	restore := &serverRestore{Windows: []restoreWindowState{{
+		PanePid: 100, CurrentCommand: "pi", AgentTool: "pi", Cwd: project,
+	}}}
+
+	got := discoverPiSessions(restore, processes, map[int]struct{}{100: {}})[0]
+	if got.sessionID != "newest-session" {
+		t.Fatalf("multi-hop Pi chain = %#v, want newest-session leaf", got)
+	}
+}
+
+// Forks share a parent without superseding each other, so a branched history
+// has no single leaf and must decline rather than guess a conversation.
+func TestDiscoverPiSessionsDeclinesForkedChainBranches(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processStartedAtForMetadata = originalProcessStart
+	})
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+
+	root := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_SESSION_DIR", root)
+	project := filepath.Join(root, "project")
+	worktree := filepath.Join(root, "worktree")
+	started := time.Now().Add(-time.Hour).UTC()
+	deletedOrigin := filepath.Join(
+		root,
+		piEncodedSessionDirName(project),
+		started.Add(500*time.Millisecond).Format("2006-01-02T15-04-05-000Z")+"_origin-session.jsonl",
+	)
+	bucket := piEncodedSessionDirName(worktree)
+	writePiTestRelocatedSession(t, filepath.Join(root, bucket, "branch-a.jsonl"), "branch-a", worktree, deletedOrigin, started.Add(20*time.Minute), started.Add(25*time.Minute))
+	writePiTestRelocatedSession(t, filepath.Join(root, bucket, "branch-b.jsonl"), "branch-b", worktree, deletedOrigin, started.Add(30*time.Minute), started.Add(35*time.Minute))
+
+	processStartedAtForMetadata = func(int) time.Time { return started }
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "pi", args: "pi"},
+	}
+	restore := &serverRestore{Windows: []restoreWindowState{{
+		PanePid: 100, CurrentCommand: "pi", AgentTool: "pi", Cwd: project,
+	}}}
+
+	if got := discoverPiSessions(restore, processes, map[int]struct{}{100: {}}); len(got) != 0 {
+		t.Fatalf("forked Pi chain = %#v, want fresh launch", got)
+	}
+}
+
 func TestPiEncodedSessionDirNameMatchesPiLayout(t *testing.T) {
 	if got, want := piEncodedSessionDirName("/Users/demo/Code/MonkeySSH"), "--Users-demo-Code-MonkeySSH--"; got != want {
 		t.Fatalf("piEncodedSessionDirName = %q, want %q", got, want)


### PR DESCRIPTION
## Problem

After a MonkeyMux helper update, a restored Pi window relaunched a bare `pi` instead of resuming its conversation.

Restore matches each pane against Pi session files by the `cwd` recorded in the session header. Pi's worktree flow rewrites a running session into a bucket named for a *new* working directory, gives it a fresh id and timestamp, and deletes the original file — the previous path survives only as `parentSession` in the new header.

So for a pane sitting in `~/Code/MonkeySSH` whose session had been relocated into a worktree bucket, no candidate matched the pane's cwd, discovery found nothing, and the window fell back to a fresh launch.

Verified against a live upgraded helper: the pane's session file was gone from its own cwd bucket, and the live file in the worktree bucket pointed back at that deleted path via `parentSession`.

## Fix

- Parse `parentSession` and resolve each session's chain to its **origin** (bucket name + creation time).
- Match a pane against the origin bucket as well as the live `cwd`, using Pi's own cwd-to-directory encoding.
- Correlate process start against the origin timestamp, since a relocated file's own timestamp records the relocation rather than the launch.
- A dangling origin link still yields its bucket name and file-name timestamp — the case that matters, because relocation deletes the file.

Ambiguity guards are unchanged: an unresolvable or contested match still declines and launches fresh rather than resuming the wrong conversation.

## Testing

- `go test ./...` in `remote/monkeymux` passes (helper bumped to 0.1.157 so running servers pick up the fix).
- New regression tests cover the relocation resume, multi-hop chain resolution, and the directory encoding. Verified red/green: `TestDiscoverPiSessionsResumesSessionRelocatedToWorktree` fails without the matching change.
