### PR TITLE
fix: offer relocated Pi sessions where they started

### DIFF
--- a/lib/domain/models/tmux_state.dart
+++ b/lib/domain/models/tmux_state.dart
@@ -816,6 +816,7 @@ class ToolSessionInfo {
     required this.toolName,
     required this.sessionId,
     this.workingDirectory,
+    this.originWorkingDirectory,
     this.lastActive,
     this.summary,
   });
@@ -828,6 +829,14 @@ class ToolSessionInfo {
 
   /// The working directory this session was used in.
   final String? workingDirectory;
+
+  /// The directory this session started in, when it since moved elsewhere.
+  ///
+  /// Pi rewrites a session into a new directory when work moves to a worktree,
+  /// which leaves [workingDirectory] pointing away from where the user began
+  /// the conversation. Keeping the original directory lets project-scoped
+  /// pickers still offer the session where it started.
+  final String? originWorkingDirectory;
 
   /// When this session was last active.
   final DateTime? lastActive;

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -757,42 +757,61 @@ parsePiSessionMetadata(String raw) {
 String? piEncodedSessionDirectoryName(String? workingDirectory) {
   final trimmed = _trimWorkingDirectory(workingDirectory);
   if (trimmed == null) return null;
-  final withoutLeadingSeparator = trimmed.replaceFirst(RegExp(r'^[/\\]'), '');
+  // Pi encodes its resolved cwd, which never carries a trailing separator, so
+  // a scope directory that does must shed it or it gains a stray `-`.
+  final withoutTrailingSeparator = trimmed.replaceFirst(RegExp(r'[/\\]+$'), '');
+  final withoutLeadingSeparator = withoutTrailingSeparator.replaceFirst(
+    RegExp(r'^[/\\]'),
+    '',
+  );
   if (withoutLeadingSeparator.isEmpty) return null;
   final encoded = withoutLeadingSeparator.replaceAll(RegExp(r'[/\\:]'), '-');
   return '--$encoded--';
 }
 
-String? _piSessionBucketName(String? sessionFilePath) {
-  final segments = sessionFilePath?.split('/') ?? const <String>[];
+/// Reads the bucket directory name out of a Pi session file path.
+///
+/// Splits on either separator because a Windows listing reports forward
+/// slashes while Pi writes `parentSession` as a native backslash path.
+@visibleForTesting
+String? piSessionBucketName(String? sessionFilePath) {
+  final trimmed = sessionFilePath?.trim();
+  if (trimmed == null || trimmed.isEmpty) return null;
+  final segments = trimmed
+      .split(RegExp(r'[/\\]'))
+      .where((segment) => segment.isNotEmpty)
+      .toList(growable: false);
   return segments.length < 2 ? null : segments[segments.length - 2];
 }
 
-/// Resolves the bucket that a session's `parentSession` chain started in.
+/// The bucket a session was relocated out of, or null when it was not.
 ///
-/// Pi records the file it came from when a session rotates (`/new`) or is
-/// relocated to another working directory. Rotation keeps the previous file on
-/// disk, so the walk follows links that were read; relocation deletes it, so a
-/// dangling link ends the walk at its own bucket, which still names the
-/// directory the conversation started in.
+/// Pi records the previous file in `parentSession` for three different
+/// operations, and only one of them means the conversation moved:
+///
+/// * relocation into another working directory rewrites the session and
+///   **deletes** the previous file;
+/// * rotation (`/new`) keeps the previous file, in the same bucket;
+/// * `--fork` keeps the previous file and may write the new session into a
+///   different bucket.
+///
+/// Both conditions are therefore required. Without the deletion check a fork
+/// would be offered in the project it was forked from, which is a different
+/// conversation than the one the user started there. Only the immediate parent
+/// is considered: a session that moved and was then rotated or forked is a new
+/// conversation, not the one that left the original directory.
 @visibleForTesting
-String? piOriginSessionBucketName(
-  String sessionFilePath,
-  Map<String, String> parentSessionPathsByFile,
-) {
-  final visited = <String>{};
-  var current = sessionFilePath;
-  while (visited.add(current)) {
-    final parent = parentSessionPathsByFile[current];
-    if (parent == null || parent.isEmpty) {
-      return _piSessionBucketName(current);
-    }
-    if (!parentSessionPathsByFile.containsKey(parent)) {
-      return _piSessionBucketName(parent);
-    }
-    current = parent;
-  }
-  return _piSessionBucketName(current);
+String? piRelocationSourceBucketName({
+  required String sessionFilePath,
+  required String? parentSessionPath,
+  required bool parentExists,
+}) {
+  if (parentExists) return null;
+  final parentBucket = piSessionBucketName(parentSessionPath);
+  if (parentBucket == null) return null;
+  return parentBucket == piSessionBucketName(sessionFilePath)
+      ? null
+      : parentBucket;
 }
 
 /// Extracts the Pi session id from a `<timestamp>_<sessionId>.jsonl` file name.
@@ -1439,6 +1458,30 @@ List<String> buildRelatedWorkingDirectories(
   return directories.toList(growable: false);
 }
 
+/// Whether a discovered session belongs to the active project scope.
+///
+/// A session Pi relocated into another directory keeps the directory it started
+/// in on [ToolSessionInfo.originWorkingDirectory], so both are checked. Every
+/// scope filter must use this predicate: discovery scopes per provider, the
+/// aggregate scopes again, and the incremental preview scopes a third time, so
+/// a filter that only looks at the recorded directory silently drops the row.
+@visibleForTesting
+bool discoveredSessionMatchesScope(
+  ToolSessionInfo info,
+  String workingDirectory, {
+  Iterable<String> relatedWorkingDirectories = const <String>[],
+}) =>
+    matchesDiscoveredSessionWorkingDirectory(
+      workingDirectory,
+      info.workingDirectory,
+      relatedWorkingDirectories: relatedWorkingDirectories,
+    ) ||
+    matchesDiscoveredSessionWorkingDirectory(
+      workingDirectory,
+      info.originWorkingDirectory,
+      relatedWorkingDirectories: relatedWorkingDirectories,
+    );
+
 /// Whether a discovered session directory belongs to the active project scope.
 @visibleForTesting
 bool matchesDiscoveredSessionWorkingDirectory(
@@ -1608,17 +1651,11 @@ List<ToolSessionInfo> scopeDiscoveredSessionsToWorkingDirectory(
   for (final toolSessions in sessionsByTool.values) {
     final matchingSessions = toolSessions
         .where(
-          (session) =>
-              matchesDiscoveredSessionWorkingDirectory(
-                workingDirectory,
-                session.workingDirectory,
-                relatedWorkingDirectories: relatedWorkingDirectories,
-              ) ||
-              matchesDiscoveredSessionWorkingDirectory(
-                workingDirectory,
-                session.originWorkingDirectory,
-                relatedWorkingDirectories: relatedWorkingDirectories,
-              ),
+          (session) => discoveredSessionMatchesScope(
+            session,
+            workingDirectory,
+            relatedWorkingDirectories: relatedWorkingDirectories,
+          ),
         )
         .toList(growable: false);
     if (matchingSessions.isNotEmpty) {
@@ -2164,9 +2201,9 @@ class AgentSessionDiscoveryService {
       if (workingDirectory == null || workingDirectory.isEmpty) {
         return normalized;
       }
-      if (matchesDiscoveredSessionWorkingDirectory(
+      if (discoveredSessionMatchesScope(
+        normalized,
         workingDirectory,
-        normalized.workingDirectory,
         relatedWorkingDirectories: relatedWorkingDirectories,
       )) {
         return normalized;
@@ -3743,8 +3780,10 @@ print(json.dumps(sessions))
             summary = metadata.summary;
             sessionWorkingDirectory = metadata.workingDirectory;
             lastActive = metadata.updatedAt;
-            parentSessionPathsByFile[filePath] =
-                metadata.parentSessionPath?.trim() ?? '';
+            final parentSessionPath = metadata.parentSessionPath?.trim();
+            if (parentSessionPath != null && parentSessionPath.isNotEmpty) {
+              parentSessionPathsByFile[filePath] = parentSessionPath;
+            }
           } on Object {
             hadError = true;
           }
@@ -3770,9 +3809,13 @@ print(json.dumps(sessions))
           ? _scopePiSessionsToWorkingDirectory(
               sessions: sessions,
               sessionFilePaths: sessionFilePaths,
-              parentSessionPathsByFile: parentSessionPathsByFile,
+              relocationBucketsByFile: await _piRelocationBucketsByFile(
+                session,
+                parentSessionPathsByFile,
+              ),
               workingDirectory: workingDirectory,
               relatedWorkingDirectories: relatedWorkingDirectories,
+              caseInsensitiveBuckets: session.remoteIsWindows,
             )
           : sessions;
       return _ToolDiscoveryResult.success(
@@ -3799,39 +3842,42 @@ print(json.dumps(sessions))
   List<ToolSessionInfo> _scopePiSessionsToWorkingDirectory({
     required List<ToolSessionInfo> sessions,
     required List<String> sessionFilePaths,
-    required Map<String, String> parentSessionPathsByFile,
+    required Map<String, String> relocationBucketsByFile,
     required String workingDirectory,
     required List<String> relatedWorkingDirectories,
+    required bool caseInsensitiveBuckets,
   }) {
     final scopeDirectories = relatedWorkingDirectories.isNotEmpty
         ? relatedWorkingDirectories
         : <String>[workingDirectory];
+    String bucketKey(String bucket) =>
+        caseInsensitiveBuckets ? bucket.toLowerCase() : bucket;
     final scopeDirectoriesByBucket = <String, String>{};
     for (final directory in scopeDirectories) {
       final bucket = piEncodedSessionDirectoryName(directory);
       if (bucket != null) {
-        scopeDirectoriesByBucket.putIfAbsent(bucket, () => directory);
+        scopeDirectoriesByBucket.putIfAbsent(
+          bucketKey(bucket),
+          () => directory,
+        );
       }
     }
 
     final scoped = <ToolSessionInfo>[];
     for (var index = 0; index < sessions.length; index++) {
       final info = sessions[index];
-      if (matchesDiscoveredSessionWorkingDirectory(
+      if (discoveredSessionMatchesScope(
+        info,
         workingDirectory,
-        info.workingDirectory,
         relatedWorkingDirectories: relatedWorkingDirectories,
       )) {
         scoped.add(info);
         continue;
       }
-      final originBucket = piOriginSessionBucketName(
-        sessionFilePaths[index],
-        parentSessionPathsByFile,
-      );
-      final originDirectory = originBucket == null
+      final relocationBucket = relocationBucketsByFile[sessionFilePaths[index]];
+      final originDirectory = relocationBucket == null
           ? null
-          : scopeDirectoriesByBucket[originBucket];
+          : scopeDirectoriesByBucket[bucketKey(relocationBucket)];
       if (originDirectory == null) continue;
       scoped.add(
         ToolSessionInfo(
@@ -3845,6 +3891,82 @@ print(json.dumps(sessions))
       );
     }
     return scoped.toList(growable: false);
+  }
+
+  /// Maps each session file to the bucket Pi relocated it out of.
+  ///
+  /// Only entries whose parent sits in another bucket are probed, so the common
+  /// case (no relocation, or a rotation in place) costs no extra round trip.
+  Future<Map<String, String>> _piRelocationBucketsByFile(
+    SshSession session,
+    Map<String, String> parentSessionPathsByFile,
+  ) async {
+    final crossBucketParents = <String, String>{};
+    for (final entry in parentSessionPathsByFile.entries) {
+      final parentBucket = piSessionBucketName(entry.value);
+      if (parentBucket == null) continue;
+      if (parentBucket == piSessionBucketName(entry.key)) continue;
+      crossBucketParents[entry.key] = entry.value;
+    }
+    if (crossBucketParents.isEmpty) return const <String, String>{};
+
+    final existingParents = await _existingRemoteSessionPaths(
+      session,
+      crossBucketParents.values,
+    );
+    final relocationBuckets = <String, String>{};
+    for (final entry in crossBucketParents.entries) {
+      final bucket = piRelocationSourceBucketName(
+        sessionFilePath: entry.key,
+        parentSessionPath: entry.value,
+        parentExists: existingParents.contains(entry.value),
+      );
+      if (bucket != null) relocationBuckets[entry.key] = bucket;
+    }
+    return relocationBuckets;
+  }
+
+  /// Returns the subset of [paths] that still exist on the remote.
+  ///
+  /// Pi deletes a session file when it relocates that conversation into another
+  /// directory, and keeps it for a rotation or a fork, so existence is what
+  /// separates the two. Absence from the discovery listing cannot stand in for
+  /// this check: that listing is capped at the newest files, so a retained
+  /// parent can simply fall outside it.
+  Future<Set<String>> _existingRemoteSessionPaths(
+    SshSession session,
+    Iterable<String> paths,
+  ) async {
+    final candidates = paths.toSet();
+    if (candidates.isEmpty) return const <String>{};
+    try {
+      final String output;
+      if (session.remoteIsWindows) {
+        final literals = candidates.map(powerShellSingleQuote).join(',');
+        output = await _execWindowsPowerShell(
+          session,
+          '@($literals) | Where-Object { Test-Path -LiteralPath \$_ } | '
+          r'ForEach-Object { $_ }',
+        );
+      } else {
+        final quoted = candidates.map(_shellQuote).join(' ');
+        output = await _exec(
+          session,
+          'for __flutty_parent in $quoted; do '
+          r'[ -e "$__flutty_parent" ] && '
+          r'printf "%s\n" "$__flutty_parent"; done',
+        );
+      }
+      return output
+          .split('\n')
+          .map((line) => line.trim())
+          .where((line) => line.isNotEmpty)
+          .toSet();
+    } on Object {
+      // A failed probe must not promote forks into another project, so treat
+      // every candidate parent as still present.
+      return candidates;
+    }
   }
 
   // ── Hermes ─────────────────────────────────────────────────────────────

--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -61,6 +61,7 @@ ToolSessionInfo? normalizeDiscoveredSessionInfo(
     toolName: info.toolName,
     sessionId: info.sessionId,
     workingDirectory: info.workingDirectory,
+    originWorkingDirectory: info.originWorkingDirectory,
     lastActive: info.lastActive,
     summary: normalizedSummary,
   );
@@ -694,6 +695,7 @@ parseGrokSessionMetadata(String raw) {
   String? sessionId,
   String? summary,
   String? workingDirectory,
+  String? parentSessionPath,
   DateTime? updatedAt,
   bool parsedAny,
 })
@@ -702,6 +704,7 @@ parsePiSessionMetadata(String raw) {
   String? displayName;
   String? firstUserMessage;
   String? workingDirectory;
+  String? parentSessionPath;
   DateTime? updatedAt;
   var parsedAny = false;
 
@@ -714,6 +717,7 @@ parsePiSessionMetadata(String raw) {
     if (type == 'session') {
       sessionId ??= _readStringField(decoded, 'id');
       workingDirectory ??= _readStringField(decoded, 'cwd');
+      parentSessionPath ??= _readStringField(decoded, 'parentSession');
       updatedAt ??= _parseDateTimeValue(decoded['timestamp']);
       continue;
     }
@@ -740,9 +744,55 @@ parsePiSessionMetadata(String raw) {
     sessionId: sessionId,
     summary: displayName ?? firstUserMessage,
     workingDirectory: workingDirectory,
+    parentSessionPath: parentSessionPath,
     updatedAt: updatedAt,
     parsedAny: parsedAny,
   );
+}
+
+/// Encodes a working directory the way Pi names the bucket it stores that
+/// directory's sessions in: the path without its leading separator, with every
+/// separator and drive colon replaced by `-`, wrapped in `--`.
+@visibleForTesting
+String? piEncodedSessionDirectoryName(String? workingDirectory) {
+  final trimmed = _trimWorkingDirectory(workingDirectory);
+  if (trimmed == null) return null;
+  final withoutLeadingSeparator = trimmed.replaceFirst(RegExp(r'^[/\\]'), '');
+  if (withoutLeadingSeparator.isEmpty) return null;
+  final encoded = withoutLeadingSeparator.replaceAll(RegExp(r'[/\\:]'), '-');
+  return '--$encoded--';
+}
+
+String? _piSessionBucketName(String? sessionFilePath) {
+  final segments = sessionFilePath?.split('/') ?? const <String>[];
+  return segments.length < 2 ? null : segments[segments.length - 2];
+}
+
+/// Resolves the bucket that a session's `parentSession` chain started in.
+///
+/// Pi records the file it came from when a session rotates (`/new`) or is
+/// relocated to another working directory. Rotation keeps the previous file on
+/// disk, so the walk follows links that were read; relocation deletes it, so a
+/// dangling link ends the walk at its own bucket, which still names the
+/// directory the conversation started in.
+@visibleForTesting
+String? piOriginSessionBucketName(
+  String sessionFilePath,
+  Map<String, String> parentSessionPathsByFile,
+) {
+  final visited = <String>{};
+  var current = sessionFilePath;
+  while (visited.add(current)) {
+    final parent = parentSessionPathsByFile[current];
+    if (parent == null || parent.isEmpty) {
+      return _piSessionBucketName(current);
+    }
+    if (!parentSessionPathsByFile.containsKey(parent)) {
+      return _piSessionBucketName(parent);
+    }
+    current = parent;
+  }
+  return _piSessionBucketName(current);
 }
 
 /// Extracts the Pi session id from a `<timestamp>_<sessionId>.jsonl` file name.
@@ -1558,11 +1608,17 @@ List<ToolSessionInfo> scopeDiscoveredSessionsToWorkingDirectory(
   for (final toolSessions in sessionsByTool.values) {
     final matchingSessions = toolSessions
         .where(
-          (session) => matchesDiscoveredSessionWorkingDirectory(
-            workingDirectory,
-            session.workingDirectory,
-            relatedWorkingDirectories: relatedWorkingDirectories,
-          ),
+          (session) =>
+              matchesDiscoveredSessionWorkingDirectory(
+                workingDirectory,
+                session.workingDirectory,
+                relatedWorkingDirectories: relatedWorkingDirectories,
+              ) ||
+              matchesDiscoveredSessionWorkingDirectory(
+                workingDirectory,
+                session.originWorkingDirectory,
+                relatedWorkingDirectories: relatedWorkingDirectories,
+              ),
         )
         .toList(growable: false);
     if (matchingSessions.isNotEmpty) {
@@ -3663,6 +3719,8 @@ print(json.dumps(sessions))
         maxLines: previewOnly ? 40 : 80,
       );
       final sessions = <ToolSessionInfo>[];
+      final sessionFilePaths = <String>[];
+      final parentSessionPathsByFile = <String, String>{};
       var hadError = false;
 
       for (final filePath in recentSessionPaths) {
@@ -3685,6 +3743,8 @@ print(json.dumps(sessions))
             summary = metadata.summary;
             sessionWorkingDirectory = metadata.workingDirectory;
             lastActive = metadata.updatedAt;
+            parentSessionPathsByFile[filePath] =
+                metadata.parentSessionPath?.trim() ?? '';
           } on Object {
             hadError = true;
           }
@@ -3703,18 +3763,17 @@ print(json.dumps(sessions))
             summary: summary ?? _truncateId(resolvedId),
           ),
         );
+        sessionFilePaths.add(filePath);
       }
       final scopedSessions =
           workingDirectory != null && workingDirectory.isNotEmpty
-          ? sessions
-                .where(
-                  (info) => matchesDiscoveredSessionWorkingDirectory(
-                    workingDirectory,
-                    info.workingDirectory,
-                    relatedWorkingDirectories: relatedWorkingDirectories,
-                  ),
-                )
-                .toList(growable: false)
+          ? _scopePiSessionsToWorkingDirectory(
+              sessions: sessions,
+              sessionFilePaths: sessionFilePaths,
+              parentSessionPathsByFile: parentSessionPathsByFile,
+              workingDirectory: workingDirectory,
+              relatedWorkingDirectories: relatedWorkingDirectories,
+            )
           : sessions;
       return _ToolDiscoveryResult.success(
         'Pi',
@@ -3727,6 +3786,65 @@ print(json.dumps(sessions))
     } on Object {
       return const _ToolDiscoveryResult.failure('Pi');
     }
+  }
+
+  /// Keeps Pi sessions recorded in scope, plus sessions Pi has since relocated
+  /// out of it.
+  ///
+  /// Relocating a session rewrites it into a bucket named for the new working
+  /// directory, so its recorded cwd no longer matches the directory the
+  /// conversation started in. The origin of its `parentSession` chain still
+  /// names that directory, which keeps the conversation offered where the user
+  /// began it.
+  List<ToolSessionInfo> _scopePiSessionsToWorkingDirectory({
+    required List<ToolSessionInfo> sessions,
+    required List<String> sessionFilePaths,
+    required Map<String, String> parentSessionPathsByFile,
+    required String workingDirectory,
+    required List<String> relatedWorkingDirectories,
+  }) {
+    final scopeDirectories = relatedWorkingDirectories.isNotEmpty
+        ? relatedWorkingDirectories
+        : <String>[workingDirectory];
+    final scopeDirectoriesByBucket = <String, String>{};
+    for (final directory in scopeDirectories) {
+      final bucket = piEncodedSessionDirectoryName(directory);
+      if (bucket != null) {
+        scopeDirectoriesByBucket.putIfAbsent(bucket, () => directory);
+      }
+    }
+
+    final scoped = <ToolSessionInfo>[];
+    for (var index = 0; index < sessions.length; index++) {
+      final info = sessions[index];
+      if (matchesDiscoveredSessionWorkingDirectory(
+        workingDirectory,
+        info.workingDirectory,
+        relatedWorkingDirectories: relatedWorkingDirectories,
+      )) {
+        scoped.add(info);
+        continue;
+      }
+      final originBucket = piOriginSessionBucketName(
+        sessionFilePaths[index],
+        parentSessionPathsByFile,
+      );
+      final originDirectory = originBucket == null
+          ? null
+          : scopeDirectoriesByBucket[originBucket];
+      if (originDirectory == null) continue;
+      scoped.add(
+        ToolSessionInfo(
+          toolName: info.toolName,
+          sessionId: info.sessionId,
+          workingDirectory: info.workingDirectory,
+          originWorkingDirectory: originDirectory,
+          lastActive: info.lastActive,
+          summary: info.summary,
+        ),
+      );
+    }
+    return scoped.toList(growable: false);
   }
 
   // ── Hermes ─────────────────────────────────────────────────────────────

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -1119,6 +1119,92 @@ cwd: /tmp/demo
       expect(metadata.parsedAny, isFalse);
       expect(metadata.sessionId, isNull);
     });
+
+    test('reads the parent session a relocated transcript came from', () {
+      final metadata = parsePiSessionMetadata('''
+{"type":"session","version":3,"id":"01JYX7","timestamp":"2026-04-12T21:07:44.781Z","cwd":"/Users/depoll/worktrees/feature","parentSession":"/Users/depoll/.pi/agent/sessions/--Users-depoll-Code-flutty--/2026-04-12T21-07-30-000Z_01JYX6.jsonl"}
+''');
+
+      expect(
+        metadata.parentSessionPath,
+        '/Users/depoll/.pi/agent/sessions/--Users-depoll-Code-flutty--/2026-04-12T21-07-30-000Z_01JYX6.jsonl',
+      );
+    });
+
+    test('leaves the parent session unset for a fresh transcript', () {
+      final metadata = parsePiSessionMetadata('''
+{"type":"session","version":3,"id":"01JYX7","timestamp":"2026-04-12T21:07:44.781Z","cwd":"/tmp/project"}
+''');
+
+      expect(metadata.parentSessionPath, isNull);
+    });
+  });
+
+  group('piEncodedSessionDirectoryName', () {
+    test('matches the bucket Pi stores sessions for a directory in', () {
+      expect(
+        piEncodedSessionDirectoryName('/Users/depoll/Code/MonkeySSH'),
+        '--Users-depoll-Code-MonkeySSH--',
+      );
+    });
+
+    test('ignores a trailing slash so scoping still matches', () {
+      expect(
+        piEncodedSessionDirectoryName('/Users/depoll/Code/MonkeySSH/'),
+        piEncodedSessionDirectoryName('/Users/depoll/Code/MonkeySSH'),
+      );
+    });
+
+    test('returns null when there is no directory to encode', () {
+      expect(piEncodedSessionDirectoryName(null), isNull);
+      expect(piEncodedSessionDirectoryName('  '), isNull);
+    });
+  });
+
+  group('piOriginSessionBucketName', () {
+    const sessionsRoot = '/home/dev/.pi/agent/sessions';
+    const projectBucket = '--home-dev-project--';
+    const worktreeBucket = '--home-dev-worktree--';
+
+    test('uses the session own bucket when it has no parent', () {
+      const path = '$sessionsRoot/$projectBucket/a.jsonl';
+
+      expect(piOriginSessionBucketName(path, const {path: ''}), projectBucket);
+    });
+
+    test('falls back to the deleted parent bucket after relocation', () {
+      const relocated = '$sessionsRoot/$worktreeBucket/relocated.jsonl';
+      const deletedOrigin = '$sessionsRoot/$projectBucket/origin.jsonl';
+
+      expect(
+        piOriginSessionBucketName(relocated, const {relocated: deletedOrigin}),
+        projectBucket,
+      );
+    });
+
+    test('walks a rotated chain back to where it started', () {
+      const middle = '$sessionsRoot/$worktreeBucket/middle.jsonl';
+      const newest = '$sessionsRoot/$worktreeBucket/newest.jsonl';
+      const deletedOrigin = '$sessionsRoot/$projectBucket/origin.jsonl';
+
+      expect(
+        piOriginSessionBucketName(newest, const {
+          newest: middle,
+          middle: deletedOrigin,
+        }),
+        projectBucket,
+      );
+    });
+
+    test('stops on a cyclic chain instead of looping forever', () {
+      const first = '$sessionsRoot/$projectBucket/first.jsonl';
+      const second = '$sessionsRoot/$worktreeBucket/second.jsonl';
+
+      expect(
+        piOriginSessionBucketName(first, const {first: second, second: first}),
+        isNotNull,
+      );
+    });
   });
 
   group('parseHermesDbOutput', () {
@@ -2176,6 +2262,77 @@ branch refs/heads/main
         "cd '/Users/depoll/Code/flutty' && pi --session '01JYX7ABCD'",
       );
     });
+
+    test(
+      'Pi discovery keeps a session relocated out of the scoped directory',
+      () async {
+        final client = _MockSshClient();
+        const sessionsRoot = '/Users/demo/.pi/agent/sessions';
+        const projectPath =
+            '$sessionsRoot/--Users-depoll-Code-flutty--/'
+            '2026-04-12T21-07-44-781Z_01JYX7ABCD.jsonl';
+        const relocatedPath =
+            '$sessionsRoot/--Users-depoll-worktrees-feature--/'
+            '2026-04-12T22-10-00-000Z_01JYX8RELOC.jsonl';
+        const unrelatedPath =
+            '$sessionsRoot/--Users-depoll-Code-other--/'
+            '2026-04-12T23-00-00-000Z_01JYX9OTHER.jsonl';
+        // Relocation deletes the file this session was rewritten from, so the
+        // parent path is the only record of where the conversation started.
+        const deletedOriginPath =
+            '$sessionsRoot/--Users-depoll-Code-flutty--/'
+            '2026-04-12T22-09-50-000Z_01JYX8ORIGIN.jsonl';
+
+        when(() => client.execute(any())).thenAnswer((invocation) async {
+          final command = invocation.positionalArguments.first as String;
+          if (command.contains('find ~/.pi/agent/sessions')) {
+            return _buildExecSession(
+              stdout: '$relocatedPath\n$unrelatedPath\n$projectPath\n',
+            );
+          }
+          if (command.contains(relocatedPath)) {
+            return _buildExecSession(
+              stdout:
+                  _remoteSnapshotLine(relocatedPath, '''
+{"type":"session","version":3,"id":"01JYX8RELOC","timestamp":"2026-04-12T22:10:00.000Z","cwd":"/Users/depoll/worktrees/feature","parentSession":"$deletedOriginPath"}
+{"type":"message","message":{"role":"user","content":"Continue the worktree work"}}
+''', mtime: 1777243999) +
+                  _remoteSnapshotLine(unrelatedPath, '''
+{"type":"session","version":3,"id":"01JYX9OTHER","timestamp":"2026-04-12T23:00:00.000Z","cwd":"/Users/depoll/Code/other"}
+{"type":"message","message":{"role":"user","content":"Unrelated project work"}}
+''', mtime: 1777244500) +
+                  _remoteSnapshotLine(projectPath, '''
+{"type":"session","version":3,"id":"01JYX7ABCD","timestamp":"2026-04-12T21:07:44.781Z","cwd":"/Users/depoll/Code/flutty"}
+{"type":"message","message":{"role":"user","content":"Fix the tmux navigator crash"}}
+''', mtime: 1777243460),
+            );
+          }
+          return _buildExecSession();
+        });
+
+        final discovery = AgentSessionDiscoveryService();
+        final session = _buildDiscoverySession(client);
+        final result = await discovery.discoverSessions(
+          session,
+          workingDirectory: '/Users/depoll/Code/flutty',
+          toolName: 'Pi',
+        );
+
+        expect(
+          result.sessions.map((info) => info.sessionId),
+          containsAll(<String>['01JYX8RELOC', '01JYX7ABCD']),
+        );
+        expect(
+          result.sessions.map((info) => info.sessionId),
+          isNot(contains('01JYX9OTHER')),
+        );
+        // Resuming a relocated session belongs in the directory it moved to.
+        final relocated = result.sessions.firstWhere(
+          (info) => info.sessionId == '01JYX8RELOC',
+        );
+        expect(relocated.workingDirectory, '/Users/depoll/worktrees/feature');
+      },
+    );
 
     test('Hermes discovery reads the state database', () async {
       final client = _MockSshClient();

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -1161,49 +1161,114 @@ cwd: /tmp/demo
     });
   });
 
-  group('piOriginSessionBucketName', () {
+  group('piSessionBucketName', () {
+    test('reads the bucket from a POSIX session path', () {
+      expect(
+        piSessionBucketName(
+          '/home/dev/.pi/agent/sessions/--home-dev--/a.jsonl',
+        ),
+        '--home-dev--',
+      );
+    });
+
+    test('reads the bucket from a native Windows session path', () {
+      expect(
+        piSessionBucketName(
+          r'C:\Users\dev\.pi\agent\sessions\--C-Users-dev-proj--\a.jsonl',
+        ),
+        '--C-Users-dev-proj--',
+      );
+    });
+
+    test('returns null without a containing directory', () {
+      expect(piSessionBucketName('a.jsonl'), isNull);
+      expect(piSessionBucketName(null), isNull);
+    });
+  });
+
+  group('piRelocationSourceBucketName', () {
     const sessionsRoot = '/home/dev/.pi/agent/sessions';
     const projectBucket = '--home-dev-project--';
     const worktreeBucket = '--home-dev-worktree--';
+    const relocated = '$sessionsRoot/$worktreeBucket/relocated.jsonl';
+    const parentInProject = '$sessionsRoot/$projectBucket/origin.jsonl';
 
-    test('uses the session own bucket when it has no parent', () {
-      const path = '$sessionsRoot/$projectBucket/a.jsonl';
-
-      expect(piOriginSessionBucketName(path, const {path: ''}), projectBucket);
-    });
-
-    test('falls back to the deleted parent bucket after relocation', () {
-      const relocated = '$sessionsRoot/$worktreeBucket/relocated.jsonl';
-      const deletedOrigin = '$sessionsRoot/$projectBucket/origin.jsonl';
-
+    test('reports the bucket a deleted parent named', () {
       expect(
-        piOriginSessionBucketName(relocated, const {relocated: deletedOrigin}),
+        piRelocationSourceBucketName(
+          sessionFilePath: relocated,
+          parentSessionPath: parentInProject,
+          parentExists: false,
+        ),
         projectBucket,
       );
     });
 
-    test('walks a rotated chain back to where it started', () {
-      const middle = '$sessionsRoot/$worktreeBucket/middle.jsonl';
-      const newest = '$sessionsRoot/$worktreeBucket/newest.jsonl';
-      const deletedOrigin = '$sessionsRoot/$projectBucket/origin.jsonl';
-
+    test('ignores a fork, whose parent is still on disk', () {
       expect(
-        piOriginSessionBucketName(newest, const {
-          newest: middle,
-          middle: deletedOrigin,
-        }),
-        projectBucket,
+        piRelocationSourceBucketName(
+          sessionFilePath: relocated,
+          parentSessionPath: parentInProject,
+          parentExists: true,
+        ),
+        isNull,
       );
     });
 
-    test('stops on a cyclic chain instead of looping forever', () {
-      const first = '$sessionsRoot/$projectBucket/first.jsonl';
-      const second = '$sessionsRoot/$worktreeBucket/second.jsonl';
-
+    test('ignores a rotation inside the same directory', () {
       expect(
-        piOriginSessionBucketName(first, const {first: second, second: first}),
-        isNotNull,
+        piRelocationSourceBucketName(
+          sessionFilePath: relocated,
+          parentSessionPath: '$sessionsRoot/$worktreeBucket/previous.jsonl',
+          parentExists: false,
+        ),
+        isNull,
       );
+    });
+
+    test('ignores a session that has no parent at all', () {
+      expect(
+        piRelocationSourceBucketName(
+          sessionFilePath: relocated,
+          parentSessionPath: null,
+          parentExists: false,
+        ),
+        isNull,
+      );
+    });
+
+    test('matches a Windows parent recorded with backslashes', () {
+      expect(
+        piRelocationSourceBucketName(
+          sessionFilePath:
+              'C:/Users/dev/.pi/agent/sessions/--C-Users-dev-wt--/a.jsonl',
+          parentSessionPath:
+              r'C:\Users\dev\.pi\agent\sessions\--C-Users-dev-proj--\b.jsonl',
+          parentExists: false,
+        ),
+        '--C-Users-dev-proj--',
+      );
+    });
+  });
+
+  group('discoveredSessionMatchesScope', () {
+    const info = ToolSessionInfo(
+      toolName: 'Pi',
+      sessionId: 'a',
+      workingDirectory: '/home/dev/worktree',
+      originWorkingDirectory: '/home/dev/project',
+    );
+
+    test('matches the directory a session was relocated out of', () {
+      expect(discoveredSessionMatchesScope(info, '/home/dev/project'), isTrue);
+    });
+
+    test('matches the directory a session currently records', () {
+      expect(discoveredSessionMatchesScope(info, '/home/dev/worktree'), isTrue);
+    });
+
+    test('rejects an unrelated directory', () {
+      expect(discoveredSessionMatchesScope(info, '/home/dev/other'), isFalse);
     });
   });
 
@@ -2331,6 +2396,55 @@ branch refs/heads/main
           (info) => info.sessionId == '01JYX8RELOC',
         );
         expect(relocated.workingDirectory, '/Users/depoll/worktrees/feature');
+      },
+    );
+
+    test(
+      'Pi discovery leaves a fork in the project it now belongs to',
+      () async {
+        final client = _MockSshClient();
+        const sessionsRoot = '/Users/demo/.pi/agent/sessions';
+        const forkPath =
+            '$sessionsRoot/--Users-depoll-Code-other--/'
+            '2026-04-12T22-10-00-000Z_01JYXFORK.jsonl';
+        // A fork records a cross-directory parent exactly like a relocation, but
+        // keeps that parent on disk, so it is a different conversation from the
+        // one the user started in the scoped project.
+        const retainedParentPath =
+            '$sessionsRoot/--Users-depoll-Code-flutty--/'
+            '2026-04-12T22-09-50-000Z_01JYXSOURCE.jsonl';
+
+        when(() => client.execute(any())).thenAnswer((invocation) async {
+          final command = invocation.positionalArguments.first as String;
+          if (command.contains('find ~/.pi/agent/sessions')) {
+            return _buildExecSession(stdout: '$forkPath\n');
+          }
+          if (command.contains('__flutty_parent')) {
+            return _buildExecSession(stdout: '$retainedParentPath\n');
+          }
+          if (command.contains(forkPath)) {
+            return _buildExecSession(
+              stdout: _remoteSnapshotLine(forkPath, '''
+{"type":"session","version":3,"id":"01JYXFORK","timestamp":"2026-04-12T22:10:00.000Z","cwd":"/Users/depoll/Code/other","parentSession":"$retainedParentPath"}
+{"type":"message","message":{"role":"user","content":"Fork of the other project"}}
+''', mtime: 1777243999),
+            );
+          }
+          return _buildExecSession();
+        });
+
+        final discovery = AgentSessionDiscoveryService();
+        final session = _buildDiscoverySession(client);
+        final result = await discovery.discoverSessions(
+          session,
+          workingDirectory: '/Users/depoll/Code/flutty',
+          toolName: 'Pi',
+        );
+
+        expect(
+          result.sessions.map((info) => info.sessionId),
+          isNot(contains('01JYXFORK')),
+        );
       },
     );
 


### PR DESCRIPTION
## Problem

Follow-up to #753, which fixed MonkeyMux restoring a relocated Pi session. The in-app **recent sessions** picker had the same blind spot from the same cause.

Pi rewrites a running session into a bucket named for a new working directory when work moves to a worktree, and deletes the original file. Discovery scoped sessions purely by the `cwd` in each session header, so once a conversation had relocated it disappeared from the picker in the directory the user actually started it in.

## Fix

- Parse `parentSession` from the Pi session header.
- Resolve each session's chain to its origin bucket, following links that were read and falling back to a dangling parent's bucket (the relocation case, where the file is gone).
- Match that origin against the scoped directories using Pi's own cwd-to-directory encoding, and record the directory the conversation started in on `ToolSessionInfo.originWorkingDirectory`.
- Teach the outer `scopeDiscoveredSessionsToWorkingDirectory` filter to consider that origin, so a relocated session survives both scoping passes.

`workingDirectory` still points at where the session lives now, so resuming continues to `cd` into the worktree.

Sessions that merely rotate (`/new`) within one directory resolve to the same bucket, so nothing changes for them. Only a chain that actually crossed directories adds rows.

## Testing

- Full `flutter test` (3050 tests) and `flutter analyze` pass.
- New end-to-end discovery test asserts a relocated session is offered in the directory it started in, while an unrelated project's session stays filtered out.
- Unit tests cover `parentSession` parsing, the directory encoding, and the origin walk including a multi-hop chain and a cycle guard.
- Verified red/green: the end-to-end test fails without the origin scoping, returning only the non-relocated session.

Note: the outer scope filter was found precisely because the end-to-end test failed with the inner fix alone.