### PR TITLE
Fix unreliable shell completion refreshes

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -6420,10 +6420,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     }
 
     _trackShellCompletionOptimisticInput(output);
-    if (_filterVisibleShellCompletionsForCurrentInput()) {
-      return;
+    // Keep matching rows visible, but still refresh for the narrower prefix.
+    // Returning here leaves the capped source result stale for later input.
+    final keptVisibleSuggestions =
+        _filterVisibleShellCompletionsForCurrentInput();
+    if (!keptVisibleSuggestions) {
+      _showCachedShellCompletionsIfAvailable();
     }
-    _showCachedShellCompletionsIfAvailable();
     _primeShellCompletionHistory();
     _queueShellCompletionRefresh();
   }

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -436,9 +436,14 @@ class _RecordingLocalNotificationService extends LocalNotificationService {
 }
 
 class _TestShellCompletionService extends ShellCompletionService {
-  _TestShellCompletionService({required this.cachedSuggestions});
+  _TestShellCompletionService({
+    required this.cachedSuggestions,
+    this.completionSuggestions =
+        const <String, List<ShellCompletionSuggestion>>{},
+  });
 
   final List<ShellCompletionSuggestion> cachedSuggestions;
+  final Map<String, List<ShellCompletionSuggestion>> completionSuggestions;
   final cachedInvocations = <ShellCompletionInvocation>[];
   final completeInvocations = <ShellCompletionInvocation>[];
 
@@ -462,7 +467,8 @@ class _TestShellCompletionService extends ShellCompletionService {
     ShellCompletionInvocation invocation,
   ) async {
     completeInvocations.add(invocation);
-    return const <ShellCompletionSuggestion>[];
+    return completionSuggestions[invocation.token] ??
+        const <ShellCompletionSuggestion>[];
   }
 }
 
@@ -6129,6 +6135,77 @@ void main() {
 
         expect(find.text('checkout'), findsOneWidget);
         expect(completionService.completeInvocations, isEmpty);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'keeps suggestions visible while refreshing the latest typed prefix',
+      (tester) async {
+        final completionService = _TestShellCompletionService(
+          cachedSuggestions: const <ShellCompletionSuggestion>[
+            ShellCompletionSuggestion(
+              label: 'checkout',
+              replacement: 'checkout',
+              replacementStart: 4,
+              replacementEnd: 6,
+              kind: ShellCompletionSuggestionKind.history,
+              commitSuffix: ' ',
+            ),
+          ],
+          completionSuggestions:
+              const <String, List<ShellCompletionSuggestion>>{
+                'che': <ShellCompletionSuggestion>[
+                  ShellCompletionSuggestion(
+                    label: 'cherry-pick',
+                    replacement: 'cherry-pick',
+                    replacementStart: 4,
+                    replacementEnd: 7,
+                    kind: ShellCompletionSuggestionKind.history,
+                    commitSuffix: ' ',
+                  ),
+                ],
+              },
+        );
+
+        session.terminal!.write('root@host ~ % git c');
+        await pumpScreen(tester, shellCompletionService: completionService);
+
+        session.terminal!.textInput('h');
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('checkout'), findsOneWidget);
+
+        await tester.pump(const Duration(milliseconds: 250));
+        await tester.pump();
+
+        expect(
+          completionService.completeInvocations.map(
+            (invocation) => invocation.token,
+          ),
+          ['ch'],
+        );
+        expect(find.text('checkout'), findsOneWidget);
+
+        session.terminal!.textInput('e');
+        await tester.pump();
+
+        // Keep the still-valid cached row visible while the latest prefix is
+        // debounced and resolved instead of flashing the popup away.
+        expect(find.text('checkout'), findsOneWidget);
+
+        await tester.pump(const Duration(milliseconds: 250));
+        await tester.pump();
+
+        expect(
+          completionService.completeInvocations.map(
+            (invocation) => invocation.token,
+          ),
+          ['ch', 'che'],
+        );
+        expect(find.text('checkout'), findsNothing);
+        expect(find.text('cherry-pick'), findsOneWidget);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.android),
     );


### PR DESCRIPTION
## Summary
- keep still-matching completion rows visible while the user continues typing
- debounce a fresh lookup for every latest input prefix instead of treating a filtered popup as final
- add a widget regression covering cached-to-fresh suggestion replacement

## Diagnosis
The terminal input path returned early whenever the currently visible suggestions could be filtered for the new prefix. That kept the popup on screen, but it also skipped the debounced refresh. The request generation therefore stayed tied to an older prefix, leaving a capped/stale result set as the final answer; suggestions could disappear once that old set stopped matching without ever resolving the narrower prefix.

The fix separates visual stability from data freshness: matching rows remain visible, while the normal debounce/request state machine still advances for the latest input.

## Proof
The new widget test types from `ch` to `che`. Against the old behavior it fails with only `['ch']` requested; with this patch it observes `['ch', 'che']`, keeps `checkout` visible during the refresh, then replaces it with the fresh `cherry-pick` result.

## Tests
- `flutter analyze lib/presentation/screens/terminal_screen.dart test/presentation/screens/terminal_screen_test.dart`
- `flutter test test/domain/services/shell_completion_service_test.dart test/widget/terminal_screen_layout_test.dart` (76 tests)
- `flutter test test/presentation/screens/terminal_screen_test.dart --name 'shell completion|latest typed prefix'` (3 widget tests)
