### PR TITLE
fix(terminal): sync applicable KTerm 1.5.5 changes

### DIFF
--- a/third_party/xterm/CHANGELOG.md
+++ b/third_party/xterm/CHANGELOG.md
@@ -63,6 +63,18 @@ out of scope.
     is now private, `IndexAwareCircularBuffer.operator []=` has an explicit `void`
     return type, the unused `TerminalSnapshot` plus dead `main()`/commented
     scaffolding were removed, and `TerminalSize` is exported from `ui.dart`.
+* kterm.dart 1.5.0 -> 1.5.5 reconciliation. Applicable upstream fixes are
+  ported without replacing MonkeySSH's divergent parser, renderer, Kitty
+  keyboard, or graphics manager:
+  * Full-buffer insertion at index zero now inserts at the front instead of
+    silently dropping the item, and `swap` validates its index.
+  * Truncated keytab records throw `ParseError` instead of a null-check error;
+    observable listeners may safely mutate subscriptions during notification;
+    and detached `CellAnchor` coordinates throw explicit `StateError`s.
+  * ZMODEM callbacks no longer dereference a session that was reset while an
+    asynchronous transfer was in flight.
+  * DECANM (`CSI ? 2 h/l`) tracks ANSI/VT52 mode and selects the existing
+    keytab's VT52 arrow and tab mappings.
 
 ### Evaluated but intentionally not ported
 * Synchronized output (`DECSET 2026`) needs a timeout safeguard (a dropped end
@@ -87,6 +99,15 @@ out of scope.
   prefix (`=` set / `>` push / `<` pop / `?` query) and accumulates graphics
   payload across all chunks, deferring `graphicsCommandEnd` until the final
   (`m != 1`) chunk.
+* kterm.dart 1.5.3's plain-text `Terminal.write` bypass is not safe for this
+  fork. MonkeySSH accepts arbitrary stream slices (including slices in the
+  middle of OSC/APC/DCS sequences), and every printable rune must pass through
+  `Terminal.writeChar` to assemble Kitty Unicode placeholders. Bypassing the
+  stateful parser based only on the current slice would corrupt both cases.
+* kterm.dart 1.5.5's controller-search catch narrowing does not apply because
+  this vendored API predates and does not expose KTerm's search controller.
+  Its `GraphicsManager` export was already present here; renderer/focus
+  deduplication and documentation-only commits do not change behavior.
 * Upstream's 1.4.2 painter run-batching and 1.5.0 htop spurious-underline
   cache-key fix do not apply: MonkeySSH renders through `MonkeyTerminalPainter` /
   `MonkeyRenderTerminal`, and our foreground paragraph cache key already folds in

--- a/third_party/xterm/lib/src/base/observable.dart
+++ b/third_party/xterm/lib/src/base/observable.dart
@@ -10,7 +10,8 @@ mixin Observable {
   }
 
   void notifyListeners() {
-    for (var listener in _listeners) {
+    // Snapshot the set so callbacks can safely add or remove listeners.
+    for (var listener in List.of(_listeners)) {
       listener();
     }
   }

--- a/third_party/xterm/lib/src/core/buffer/line.dart
+++ b/third_party/xterm/lib/src/core/buffer/line.dart
@@ -400,13 +400,19 @@ class CellAnchor {
   }
 
   int get y {
-    assert(attached);
-    return _owner!.index;
+    final owner = _owner;
+    if (owner == null || !owner.attached) {
+      throw StateError('Cannot access y on detached CellAnchor');
+    }
+    return owner.index;
   }
 
   CellOffset get offset {
-    assert(attached);
-    return CellOffset(_offset, _owner!.index);
+    final owner = _owner;
+    if (owner == null || !owner.attached) {
+      throw StateError('Cannot access offset on detached CellAnchor');
+    }
+    return CellOffset(_offset, owner.index);
   }
 
   BufferLine? _owner;

--- a/third_party/xterm/lib/src/core/escape/handler.dart
+++ b/third_party/xterm/lib/src/core/escape/handler.dart
@@ -129,6 +129,8 @@ abstract class EscapeHandler {
 
   void setCursorKeysMode(bool enabled);
 
+  void setAnsiMode(bool enabled);
+
   void setReverseDisplayMode(bool enabled);
 
   void setOriginMode(bool enabled);

--- a/third_party/xterm/lib/src/core/escape/parser.dart
+++ b/third_party/xterm/lib/src/core/escape/parser.dart
@@ -1201,6 +1201,8 @@ class EscapeParser {
     switch (mode) {
       case 1:
         return handler.setCursorKeysMode(enabled);
+      case 2:
+        return handler.setAnsiMode(enabled);
       case 3:
         return handler.setColumnMode(enabled);
       case 5:

--- a/third_party/xterm/lib/src/core/input/handler.dart
+++ b/third_party/xterm/lib/src/core/input/handler.dart
@@ -149,6 +149,7 @@ class KeytabInputHandler implements TerminalInputHandler {
       appKeyPad: event.state.appKeypadMode,
       appScreen: event.altBuffer,
       macos: event.platform == TerminalTargetPlatform.macos,
+      ansi: event.state.ansiMode,
     );
 
     if (record == null) {

--- a/third_party/xterm/lib/src/core/input/keytab/keytab.dart
+++ b/third_party/xterm/lib/src/core/input/keytab/keytab.dart
@@ -33,6 +33,7 @@ class Keytab {
     bool keyPad = false,
     bool appScreen = false,
     bool macos = false,
+    bool ansi = true,
     // bool meta,
   }) {
     for (var record in records) {
@@ -87,8 +88,7 @@ class Keytab {
         continue;
       }
 
-      // TODO: support VT52
-      if (record.ansi == false) {
+      if (record.ansi != null && record.ansi != ansi) {
         continue;
       }
 

--- a/third_party/xterm/lib/src/core/input/keytab/keytab_parse.dart
+++ b/third_party/xterm/lib/src/core/input/keytab/keytab_parse.dart
@@ -30,6 +30,14 @@ class KeytabParser {
   String? _name;
   final _records = <KeytabRecord>[];
 
+  KeytabToken _takeRequired(TokensReader reader) {
+    final token = reader.take();
+    if (token == null) {
+      throw ParseError();
+    }
+    return token;
+  }
+
   void addTokens(List<KeytabToken> tokens) {
     final reader = TokensReader(tokens);
 
@@ -53,11 +61,11 @@ class KeytabParser {
   }
 
   void _parseName(TokensReader reader) {
-    if (reader.take()!.type != KeytabTokenType.keyboard) {
+    if (_takeRequired(reader).type != KeytabTokenType.keyboard) {
       throw ParseError();
     }
 
-    final name = reader.take()!;
+    final name = _takeRequired(reader);
     if (name.type != KeytabTokenType.input) {
       throw ParseError();
     }
@@ -66,11 +74,11 @@ class KeytabParser {
   }
 
   void _parseKeyDefine(TokensReader reader) {
-    if (reader.take()!.type != KeytabTokenType.keyDefine) {
+    if (_takeRequired(reader).type != KeytabTokenType.keyDefine) {
       throw ParseError();
     }
 
-    final keyName = reader.take()!;
+    final keyName = _takeRequired(reader);
 
     if (keyName.type != KeytabTokenType.keyName) {
       throw ParseError();
@@ -93,9 +101,9 @@ class KeytabParser {
     bool? newLine;
     bool? mac;
 
-    while (reader.peek()!.type == KeytabTokenType.modeStatus) {
+    while (reader.peek()?.type == KeytabTokenType.modeStatus) {
       bool modeStatus;
-      switch (reader.take()!.value) {
+      switch (_takeRequired(reader).value) {
         case '+':
           modeStatus = true;
           break;
@@ -106,8 +114,8 @@ class KeytabParser {
           throw ParseError();
       }
 
-      final mode = reader.take();
-      if (mode!.type != KeytabTokenType.mode) {
+      final mode = _takeRequired(reader);
+      if (mode.type != KeytabTokenType.mode) {
         throw ParseError();
       }
 
@@ -150,11 +158,11 @@ class KeytabParser {
       }
     }
 
-    if (reader.take()!.type != KeytabTokenType.colon) {
+    if (_takeRequired(reader).type != KeytabTokenType.colon) {
       throw ParseError();
     }
 
-    final actionToken = reader.take()!;
+    final actionToken = _takeRequired(reader);
     KeytabAction action;
     if (actionToken.type == KeytabTokenType.input) {
       action = KeytabAction(KeytabActionType.input, actionToken.value);

--- a/third_party/xterm/lib/src/core/state.dart
+++ b/third_party/xterm/lib/src/core/state.dart
@@ -20,6 +20,9 @@ abstract class TerminalState {
 
   bool get cursorKeysMode;
 
+  /// Whether DECANM is enabled. When false, keytab input uses VT52 mappings.
+  bool get ansiMode;
+
   bool get reverseDisplayMode;
 
   bool get originMode;

--- a/third_party/xterm/lib/src/terminal.dart
+++ b/third_party/xterm/lib/src/terminal.dart
@@ -228,6 +228,8 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
 
   bool _cursorKeysMode = false;
 
+  bool _ansiMode = true;
+
   bool _reverseDisplayMode = false;
 
   bool _originMode = false;
@@ -275,6 +277,9 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
 
   @override
   bool get cursorKeysMode => _cursorKeysMode;
+
+  @override
+  bool get ansiMode => _ansiMode;
 
   @override
   bool get reverseDisplayMode => _reverseDisplayMode;
@@ -1103,6 +1108,11 @@ class Terminal with Observable implements TerminalState, EscapeHandler {
   @override
   void setCursorKeysMode(bool enabled) {
     _cursorKeysMode = enabled;
+  }
+
+  @override
+  void setAnsiMode(bool enabled) {
+    _ansiMode = enabled;
   }
 
   @override

--- a/third_party/xterm/lib/src/utils/circular_buffer.dart
+++ b/third_party/xterm/lib/src/utils/circular_buffer.dart
@@ -212,11 +212,11 @@ class IndexAwareCircularBuffer<T extends IndexedItem> {
       insert(index, items[i]);
       // when the list is full then we have to move the index down
       // as newly inserted values remove values with a lower index
-      if (_length >= _array.length) {
+      if (_length >= _array.length && index > 0) {
+        // Generic full-buffer insertion evicts a lower index, so move left for
+        // the next item. At zero, insertion now drops the last item instead;
+        // keep inserting at zero to preserve every leading input item.
         index--;
-        if (index < 0) {
-          return;
-        }
       }
     }
   }

--- a/third_party/xterm/lib/src/utils/circular_buffer.dart
+++ b/third_party/xterm/lib/src/utils/circular_buffer.dart
@@ -183,8 +183,12 @@ class IndexAwareCircularBuffer<T extends IndexedItem> {
     }
 
     if (index == 0 && _length >= _array.length) {
-      // when something is inserted at index 0 and the list is full then
-      // the new value immediately gets removed => nothing changes
+      // Put the new item at the logical front and discard the old last item.
+      // The generic full-buffer path below rotates in the opposite direction
+      // and would place this item at the end.
+      _startIndex = (_startIndex - 1 + _array.length) % _array.length;
+      _absoluteStartIndex--;
+      _adoptChild(0, item);
       return;
     }
 
@@ -260,8 +264,9 @@ class IndexAwareCircularBuffer<T extends IndexedItem> {
   }
 
   /// Replaces the element at [index] with [value] and returns the replaced
-  /// item.
+  /// item. Throws if [index] is out of bounds.
   T swap(int index, T value) {
+    RangeError.checkValueInInterval(index, 0, length - 1, 'index');
     final result = _getChild(index);
     _adoptChild(index, value);
     return result!;

--- a/third_party/xterm/lib/src/utils/debugger.dart
+++ b/third_party/xterm/lib/src/utils/debugger.dart
@@ -391,6 +391,11 @@ class _TerminalDebuggerHandler implements EscapeHandler {
   }
 
   @override
+  void setAnsiMode(bool enabled) {
+    onCommand('setAnsiMode($enabled)');
+  }
+
+  @override
   void setReverseDisplayMode(bool enabled) {
     onCommand('setReverseDisplayMode($enabled)');
   }

--- a/third_party/xterm/lib/zmodem.dart
+++ b/third_party/xterm/lib/zmodem.dart
@@ -135,7 +135,11 @@ class ZModemMux {
   }
 
   Future<void> _handleZModem(Uint8List chunk) async {
-    for (final event in _session!.receive(chunk)) {
+    final session = _session;
+    if (session == null) {
+      return;
+    }
+    for (final event in session.receive(chunk)) {
       /// remote is sz
       if (event is ZFileOfferedEvent) {
         _handleZFileOfferedEvent(event);
@@ -164,9 +168,13 @@ class ZModemMux {
 
   void _handleZFileOfferedEvent(ZFileOfferedEvent event) {
     final onFileOffer = this.onFileOffer;
+    final session = _session;
+    if (session == null) {
+      return;
+    }
 
     if (onFileOffer == null) {
-      _session!.skipFile();
+      session.skipFile();
       return;
     }
 
@@ -193,6 +201,10 @@ class ZModemMux {
   }
 
   Future<void> _handleFileAcceptedEvent(ZFileAcceptedEvent event) async {
+    final session = _session;
+    if (session == null) {
+      return;
+    }
     final data = _fileOffers!.current.accept(event.offset);
     var bytesSent = 0;
 
@@ -200,15 +212,21 @@ class ZModemMux {
       data.transform(
         StreamTransformer<Uint8List, Uint8List>.fromHandlers(
           handleData: (chunk, sink) {
+            if (!identical(_session, session)) {
+              return;
+            }
             bytesSent += chunk.length;
-            _session!.sendFileData(chunk);
-            sink.add(_session!.dataToSend());
+            session.sendFileData(chunk);
+            sink.add(session.dataToSend());
           },
         ),
       ),
     );
 
-    _session!.finishSending(event.offset + bytesSent);
+    if (!identical(_session, session)) {
+      return;
+    }
+    session.finishSending(event.offset + bytesSent);
   }
 
   void _handleFileSkippedEvent(ZFileSkippedEvent event) {
@@ -218,12 +236,16 @@ class ZModemMux {
 
   /// Sends next file offer if available, or closes the session if not.
   void _moveToNextOffer() {
+    final session = _session;
+    if (session == null) {
+      return;
+    }
     if (_fileOffers?.moveNext() != true) {
       _closeSession();
       return;
     }
 
-    _session!.offerFile(_fileOffers!.current.info);
+    session.offerFile(_fileOffers!.current.info);
   }
 
   /// Creates a [ZModemOffer] ƒrom the info from remote peer that can be used
@@ -232,14 +254,22 @@ class ZModemMux {
     return ZModemCallbackOffer(
       fileInfo,
       onAccept: (offset) {
-        _session!.acceptFile(offset);
+        final session = _session;
+        if (session == null) {
+          return _receiveSink?.stream ?? const Stream<Uint8List>.empty();
+        }
+        session.acceptFile(offset);
         _flush();
 
         _createReceiveSink();
         return _receiveSink!.stream;
       },
       onSkip: () {
-        _session!.skipFile();
+        final session = _session;
+        if (session == null) {
+          return;
+        }
+        session.skipFile();
         _flush();
       },
     );
@@ -264,7 +294,11 @@ class ZModemMux {
 
   /// Requests remote to close the session.
   void _closeSession() {
-    _session!.finishSession();
+    final session = _session;
+    if (session == null) {
+      return;
+    }
+    session.finishSession();
   }
 
   /// Clears all ZModem state.

--- a/third_party/xterm/lib/zmodem.dart
+++ b/third_party/xterm/lib/zmodem.dart
@@ -149,6 +149,9 @@ class ZModemMux {
         await _handleZFileEndEvent(event);
       } else if (event is ZSessionFinishedEvent) {
         await _handleZSessionFinishedEvent(event);
+        // Reset closes the receive sink and invalidates every remaining event
+        // yielded for this chunk. Never dispatch trailing events into it.
+        return;
       }
 
       /// remote is rz
@@ -178,7 +181,7 @@ class ZModemMux {
       return;
     }
 
-    onFileOffer(_createRemoteOffer(event.fileInfo));
+    onFileOffer(_createRemoteOffer(event.fileInfo, session));
   }
 
   void _handleZFileDataEvent(ZFileDataEvent event) {
@@ -250,26 +253,27 @@ class ZModemMux {
 
   /// Creates a [ZModemOffer] ƒrom the info from remote peer that can be used
   /// by local client to accept or skip the file.
-  ZModemOffer _createRemoteOffer(ZModemFileInfo fileInfo) {
+  ZModemOffer _createRemoteOffer(
+    ZModemFileInfo fileInfo,
+    ZModemCore originatingSession,
+  ) {
     return ZModemCallbackOffer(
       fileInfo,
       onAccept: (offset) {
-        final session = _session;
-        if (session == null) {
-          return _receiveSink?.stream ?? const Stream<Uint8List>.empty();
+        if (!identical(_session, originatingSession)) {
+          return const Stream<Uint8List>.empty();
         }
-        session.acceptFile(offset);
+        originatingSession.acceptFile(offset);
         _flush();
 
         _createReceiveSink();
         return _receiveSink!.stream;
       },
       onSkip: () {
-        final session = _session;
-        if (session == null) {
+        if (!identical(_session, originatingSession)) {
           return;
         }
-        session.skipFile();
+        originatingSession.skipFile();
         _flush();
       },
     );

--- a/third_party/xterm/test/src/base/observable_test.dart
+++ b/third_party/xterm/test/src/base/observable_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/src/base/observable.dart';
+
+class _TestObservable with Observable {}
+
+void main() {
+  test('listeners may be added and removed during notification', () {
+    final observable = _TestObservable();
+    var removedCalls = 0;
+    var addedCalls = 0;
+
+    void removed() => removedCalls++;
+    void added() => addedCalls++;
+
+    observable
+      ..addListener(removed)
+      ..addListener(() {
+        observable
+          ..removeListener(removed)
+          ..addListener(added);
+      });
+
+    observable.notifyListeners();
+    expect(removedCalls, 1);
+    expect(addedCalls, 0);
+
+    observable.notifyListeners();
+    expect(removedCalls, 1);
+    expect(addedCalls, 1);
+  });
+}

--- a/third_party/xterm/test/src/core/buffer/line_test.dart
+++ b/third_party/xterm/test/src/core/buffer/line_test.dart
@@ -117,6 +117,8 @@ void main() {
       terminal.buffer.clear();
       expect(line.attached, false);
       expect(anchor.attached, false);
+      expect(() => anchor.y, throwsStateError);
+      expect(() => anchor.offset, throwsStateError);
     });
   });
 }

--- a/third_party/xterm/test/src/core/escape/parser_test.mocks.dart
+++ b/third_party/xterm/test/src/core/escape/parser_test.mocks.dart
@@ -560,6 +560,15 @@ class MockEscapeHandler extends _i1.Mock implements _i2.EscapeHandler {
       );
 
   @override
+  void setAnsiMode(bool? enabled) => super.noSuchMethod(
+        Invocation.method(
+          #setAnsiMode,
+          [enabled],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   void setReverseDisplayMode(bool? enabled) => super.noSuchMethod(
         Invocation.method(
           #setReverseDisplayMode,

--- a/third_party/xterm/test/src/core/input/handler_test.dart
+++ b/third_party/xterm/test/src/core/input/handler_test.dart
@@ -10,6 +10,26 @@ void main() {
       terminal.keyInput(TerminalKey.numpadEnter);
       expect(output, ['\r']);
     });
+
+    test('uses VT52 key mappings while DECANM is reset', () {
+      final output = <String>[];
+      final terminal = Terminal(onOutput: output.add);
+
+      terminal.keyInput(TerminalKey.arrowUp);
+      expect(output.last, '\x1b[A');
+
+      terminal.write('\x1b[?2l');
+      expect(terminal.ansiMode, isFalse);
+      terminal.keyInput(TerminalKey.arrowUp);
+      expect(output.last, '\x1bA');
+      terminal.keyInput(TerminalKey.tab, shift: true);
+      expect(output.last, '\t');
+
+      terminal.write('\x1b[?2h');
+      expect(terminal.ansiMode, isTrue);
+      terminal.keyInput(TerminalKey.arrowUp);
+      expect(output.last, '\x1b[A');
+    });
   });
 
   group('KeytabInputHandler', () {

--- a/third_party/xterm/test/src/core/input/keytab/keytab_parse_test.dart
+++ b/third_party/xterm/test/src/core/input/keytab/keytab_parse_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/src/core/input/keytab/keytab_parse.dart';
+import 'package:xterm/src/core/input/keytab/keytab_token.dart';
+
+void main() {
+  group('KeytabParser truncated input', () {
+    test('keyboard declaration without a name throws ParseError', () {
+      expect(
+        () => KeytabParser().addTokens([
+          KeytabToken(KeytabTokenType.keyboard, ''),
+        ]),
+        throwsA(isA<ParseError>()),
+      );
+    });
+
+    test('key declaration without a key name throws ParseError', () {
+      expect(
+        () => KeytabParser().addTokens([
+          KeytabToken(KeytabTokenType.keyDefine, ''),
+        ]),
+        throwsA(isA<ParseError>()),
+      );
+    });
+
+    test('mode declaration without a colon throws ParseError', () {
+      expect(
+        () => KeytabParser().addTokens([
+          KeytabToken(KeytabTokenType.keyDefine, ''),
+          KeytabToken(KeytabTokenType.keyName, 'Home'),
+          KeytabToken(KeytabTokenType.modeStatus, '+'),
+          KeytabToken(KeytabTokenType.mode, 'Control'),
+        ]),
+        throwsA(isA<ParseError>()),
+      );
+    });
+
+    test('key declaration without an action throws ParseError', () {
+      expect(
+        () => KeytabParser().addTokens([
+          KeytabToken(KeytabTokenType.keyDefine, ''),
+          KeytabToken(KeytabTokenType.keyName, 'Home'),
+          KeytabToken(KeytabTokenType.colon, ':'),
+        ]),
+        throwsA(isA<ParseError>()),
+      );
+    });
+  });
+}

--- a/third_party/xterm/test/src/core/input/keytab/keytab_test.dart
+++ b/third_party/xterm/test/src/core/input/keytab/keytab_test.dart
@@ -12,5 +12,35 @@ void main() {
       final record1 = keytab.find(TerminalKey.home);
       expect(record1, isNull);
     });
+
+    test('matches ANSI and VT52 records for the requested mode', () {
+      final keytab = Keytab.parse(r'''
+key Home -Ansi : "VT52"
+key Home +Ansi : "ANSI"
+''');
+
+      expect(keytab.find(TerminalKey.home)!.action.unescapedValue(), 'ANSI');
+      expect(
+        keytab.find(TerminalKey.home, ansi: false)!.action.unescapedValue(),
+        'VT52',
+      );
+    });
+
+    test('default keytab exposes VT52 arrow mappings', () {
+      expect(
+        Keytab.defaultKeytab
+            .find(TerminalKey.arrowUp, ansi: false)!
+            .action
+            .unescapedValue(),
+        '\x1bA',
+      );
+      expect(
+        Keytab.defaultKeytab
+            .find(TerminalKey.tab, shift: true, ansi: false)!
+            .action
+            .unescapedValue(),
+        '\t',
+      );
+    });
   });
 }

--- a/third_party/xterm/test/src/utils/circular_buffer_test.dart
+++ b/third_party/xterm/test/src/utils/circular_buffer_test.dart
@@ -269,8 +269,17 @@ void main() {
       cl.insert(0, IndexedValue(100));
 
       expect(cl.length, 10);
-      expect(cl[0], 0.indexed); //the inserted 100 fell over immediately
-      expect(cl[1], 1.indexed);
+      expect(cl[0], 100.indexed);
+      expect(cl[1], 0.indexed);
+      expect(cl[9], 8.indexed);
+    });
+
+    test('swap rejects an out-of-range index', () {
+      final cl = IndexAwareCircularBuffer<IndexedValue<int>>(2)
+        ..push(IndexedValue(1));
+
+      expect(() => cl.swap(-1, IndexedValue(2)), throwsRangeError);
+      expect(() => cl.swap(1, IndexedValue(2)), throwsRangeError);
     });
 
     test("insert all works", () {
@@ -405,8 +414,6 @@ void main() {
       expect(item3.index, 2);
 
       cl.remove(0, 2);
-
-      print(cl.debugDump());
 
       expect(item11.attached, false);
       expect(item2.attached, false);

--- a/third_party/xterm/test/src/utils/circular_buffer_test.dart
+++ b/third_party/xterm/test/src/utils/circular_buffer_test.dart
@@ -282,6 +282,19 @@ void main() {
       expect(() => cl.swap(1, IndexedValue(2)), throwsRangeError);
     });
 
+    test('insert all at the front of a full buffer keeps every input item', () {
+      final cl = IndexAwareCircularBuffer<IndexedValue<int>>(5)
+        ..pushAll(
+          List<int>.generate(5, (index) => index).map(IndexedValue.new),
+        );
+
+      cl.insertAll(0, [IndexedValue(10), IndexedValue(11)]);
+
+      expect(cl.length, 5);
+      expect(cl.toList(),
+          [10.indexed, 11.indexed, 0.indexed, 1.indexed, 2.indexed]);
+    });
+
     test("insert all works", () {
       final cl = IndexAwareCircularBuffer<IndexedValue<int>>(10);
       cl.pushAll(

--- a/third_party/xterm/test/src/zmodem_test.dart
+++ b/third_party/xterm/test/src/zmodem_test.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/zmodem.dart' as xterm;
+import 'package:zmodem/zmodem.dart';
+
+void main() {
+  test('an offer retained from an ended session cannot mutate a new session',
+      () async {
+    final muxInput = StreamController<Uint8List>();
+    final muxOutput = StreamController<List<int>>();
+    final outputQueue = <List<int>>[];
+    final offers = <xterm.ZModemOffer>[];
+    final outputSubscription = muxOutput.stream.listen(outputQueue.add);
+    xterm.ZModemMux(
+      stdin: muxOutput.sink,
+      stdout: muxInput.stream,
+    ).onFileOffer = offers.add;
+
+    addTearDown(() async {
+      await muxInput.close();
+      await outputSubscription.cancel();
+      await muxOutput.close();
+    });
+
+    // zmodem 0.0.6's parser expects the escaped LF byte (0x8a) after a
+    // hex header while its own encoder emits LF (0x0a). Real lrzsz traffic uses
+    // the escaped form; normalize test-core output at hex-header boundaries.
+    Uint8List parserCompatible(Iterable<int> bytes) {
+      final result = Uint8List.fromList(bytes.toList());
+      for (var index = 1; index < result.length; index++) {
+        if (result[index - 1] == 0x0d && result[index] == 0x0a) {
+          result[index] = 0x8a;
+        }
+      }
+      return result;
+    }
+
+    Future<T> takeNext<T>(List<T> queue, String phase) async {
+      for (var attempt = 0; attempt < 1000; attempt++) {
+        if (queue.isNotEmpty) {
+          return queue.removeAt(0);
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+      }
+      throw TimeoutException('Timed out waiting for $phase');
+    }
+
+    Future<void> beginSession(ZModemCore remote) async {
+      remote.initiateSend();
+      muxInput.add(parserCompatible(remote.dataToSend()));
+      final events = remote
+          .receive(
+            parserCompatible(
+              await takeNext(outputQueue, 'session handshake'),
+            ),
+          )
+          .toList();
+      expect(events, [isA<ZReadyToSendEvent>()]);
+    }
+
+    final firstRemote = ZModemCore();
+    await beginSession(firstRemote);
+    firstRemote.offerFile(ZModemFileInfo(pathname: 'first', length: 1));
+    muxInput.add(parserCompatible(firstRemote.dataToSend()));
+    final staleOffer = await takeNext(offers, 'first file offer');
+
+    staleOffer.skip();
+    expect(
+      firstRemote
+          .receive(
+            parserCompatible(
+              await takeNext(outputQueue, 'file skip response'),
+            ),
+          )
+          .toList(),
+      [isA<ZFileSkippedEvent>()],
+    );
+
+    firstRemote.finishSession();
+    muxInput.add(parserCompatible(firstRemote.dataToSend()));
+    expect(
+      firstRemote
+          .receive(
+            parserCompatible(
+              await takeNext(outputQueue, 'session finish response'),
+            ),
+          )
+          .toList(),
+      [isA<ZSessionFinishedEvent>()],
+    );
+
+    final secondRemote = ZModemCore();
+    await beginSession(secondRemote);
+
+    expect(await staleOffer.accept(0).toList(), isEmpty);
+    expect(staleOffer.skip, returnsNormally);
+
+    secondRemote.offerFile(ZModemFileInfo(pathname: 'second', length: 1));
+    muxInput.add(parserCompatible(secondRemote.dataToSend()));
+    final currentOffer = await takeNext(offers, 'second file offer');
+    expect(currentOffer.info.pathname, 'second');
+  });
+}


### PR DESCRIPTION
## Summary

- audit `lbp0200/kterm.dart` changes from v1.5.0 through v1.5.5 and document the reconciliation in `third_party/xterm/CHANGELOG.md`
- port applicable buffer, keytab parser, observable, detached-anchor, and ZMODEM safety fixes
- add DECANM state and select the vendored keytab's existing VT52 mappings for arrows and Shift+Tab
- retain MonkeySSH's divergent parser/graphics implementation instead of adopting KTerm's unsafe plain-text bypass; document other already-covered or non-applicable changes
- add focused regression coverage for the imported behavior

## Testing

- `cd third_party/xterm && flutter test <all tests except test/src/terminal_view_test.dart>` — 315 passed
- `flutter test test/unit/terminal_cursor_keys_mode_test.dart test/presentation/widgets/terminal_key_input_test.dart test/widget/monkey_terminal_graphics_test.dart test/widget/monkey_terminal_view_layout_test.dart` — 76 passed
- pre-push `flutter analyze` — no issues

The complete vendored suite was also run. Its only failures were the two pre-existing `TerminalView.textScaler` golden tests: current rendering differs from the checked-in PNGs by 0.06–0.13%; all non-golden tests pass.
