### PR TITLE
fix(terminal): preserve queued wheel and anchor events

### DIFF
--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -4,6 +4,7 @@
 // ignore_for_file: implementation_imports, public_member_api_docs, directives_ordering, always_put_required_named_parameters_first, cast_nullable_to_non_nullable, prefer_expression_function_bodies, sort_child_properties_last, use_if_null_to_convert_nulls_to_bools, avoid_bool_literals_in_conditional_expressions, avoid_setters_without_getters, prefer_int_literals, cascade_invocations, unnecessary_null_checks, invalid_use_of_internal_member
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:math' as math;
 import 'dart:ui';
 
@@ -789,6 +790,10 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
   String? _composingText;
   Offset _lastTouchScrollPosition = Offset.zero;
   double _touchScrollRemainder = 0;
+  final ListQueue<
+    ({TerminalMouseButton button, CellOffset position, int count})
+  >
+  _pendingTouchScrollRuns = ListQueue();
   bool _touchScrollDrainScheduled = false;
   int _touchScrollDispatchGeneration = 0;
   late final Ticker _touchScrollInertiaTicker;
@@ -1474,7 +1479,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
   void _onTouchScrollStart(DragStartDetails details) {
     _stopTouchScrollInertia();
     _lastTouchScrollPosition = details.localPosition;
-    _touchScrollRemainder = 0;
+    _resetTouchScrollDispatch();
   }
 
   void _onTouchScrollUpdate(DragUpdateDetails details) {
@@ -1515,48 +1520,80 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
       return;
     }
     _touchScrollRemainder += delta;
+    final position = _resolveViewportMousePosition(_lastTouchScrollPosition);
+    while (_touchScrollRemainder.abs() >= stepHeight) {
+      final scrollUp = _touchScrollRemainder > 0;
+      _enqueueTouchScrollRun(
+        scrollUp ? TerminalMouseButton.wheelUp : TerminalMouseButton.wheelDown,
+        position,
+      );
+      _touchScrollRemainder += scrollUp ? -stepHeight : stepHeight;
+    }
     _drainTouchScrollInput();
   }
 
-  void _drainTouchScrollInput() {
-    if (_touchScrollDrainScheduled) {
-      return;
-    }
-    final stepHeight = _touchScrollStepHeight;
-    if (stepHeight <= 0) {
-      return;
-    }
-
-    while (_touchScrollRemainder.abs() >= stepHeight) {
-      final scrollUp = _touchScrollRemainder > 0;
-      final canBatchSgr =
-          widget.forceSgrTouchScroll ||
-          (widget.terminal.mouseMode.reportScroll &&
-              widget.terminal.mouseReportMode == MouseReportMode.sgr);
-      final queuedSteps = canBatchSgr
-          ? (_touchScrollRemainder.abs() / stepHeight).floor().clamp(1, 6)
-          : 1;
-      final handled = _sendTouchScrollMouseInput(
-        scrollUp ? TerminalMouseButton.wheelUp : TerminalMouseButton.wheelDown,
-        _resolveViewportMousePosition(_lastTouchScrollPosition),
-        repeatCount: canBatchSgr ? queuedSteps : 1,
-      );
-      final consumedDistance = stepHeight * queuedSteps;
-      _touchScrollRemainder += scrollUp ? -consumedDistance : consumedDistance;
-
-      if (handled) {
-        if (canBatchSgr) {
-          // Lock the frame-wide report budget even when this update consumed
-          // its entire remainder; another pointer update in the same frame must
-          // wait for the scheduled reset.
-          _scheduleTouchScrollDrain();
-          return;
-        }
-        continue;
+  void _enqueueTouchScrollRun(TerminalMouseButton button, CellOffset position) {
+    if (_pendingTouchScrollRuns.isNotEmpty) {
+      final last = _pendingTouchScrollRuns.last;
+      if (last.button == button &&
+          last.position.x == position.x &&
+          last.position.y == position.y) {
+        _pendingTouchScrollRuns
+          ..removeLast()
+          ..add((button: button, position: position, count: last.count + 1));
+        return;
       }
-      if (widget.simulateScroll) {
+    }
+    _pendingTouchScrollRuns.add((button: button, position: position, count: 1));
+  }
+
+  void _consumeTouchScrollRun(int count) {
+    final run = _pendingTouchScrollRuns.removeFirst();
+    if (run.count > count) {
+      _pendingTouchScrollRuns.addFirst((
+        button: run.button,
+        position: run.position,
+        count: run.count - count,
+      ));
+    }
+  }
+
+  void _drainTouchScrollInput() {
+    if (_touchScrollDrainScheduled || _pendingTouchScrollRuns.isEmpty) {
+      return;
+    }
+    final canBatchSgr =
+        widget.forceSgrTouchScroll ||
+        (widget.terminal.mouseMode.reportScroll &&
+            widget.terminal.mouseReportMode == MouseReportMode.sgr);
+    if (canBatchSgr) {
+      var budget = 6;
+      while (budget > 0 && _pendingTouchScrollRuns.isNotEmpty) {
+        final run = _pendingTouchScrollRuns.first;
+        final count = math.min(run.count, budget);
+        _sendTouchScrollMouseInput(
+          run.button,
+          run.position,
+          repeatCount: count,
+        );
+        _consumeTouchScrollRun(count);
+        budget -= count;
+      }
+      // Lock the frame-wide budget even when the queue is empty; pointer updates
+      // received before this callback only append runs for the next frame.
+      _scheduleTouchScrollDrain();
+      return;
+    }
+
+    while (_pendingTouchScrollRuns.isNotEmpty) {
+      final run = _pendingTouchScrollRuns.first;
+      final handled = _sendTouchScrollMouseInput(run.button, run.position);
+      _consumeTouchScrollRun(1);
+      if (!handled && widget.simulateScroll) {
         widget.terminal.keyInput(
-          scrollUp ? TerminalKey.arrowUp : TerminalKey.arrowDown,
+          run.button == TerminalMouseButton.wheelUp
+              ? TerminalKey.arrowUp
+              : TerminalKey.arrowDown,
         );
       }
     }
@@ -1583,6 +1620,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
   void _resetTouchScrollDispatch() {
     _touchScrollDispatchGeneration += 1;
     _touchScrollDrainScheduled = false;
+    _pendingTouchScrollRuns.clear();
     _touchScrollRemainder = 0;
   }
 

--- a/test/widget/monkey_terminal_view_touch_scroll_test.dart
+++ b/test/widget/monkey_terminal_view_touch_scroll_test.dart
@@ -232,24 +232,31 @@ void main() {
       detector.onTouchScrollUpdate!(
         DragUpdateDetails(
           kind: PointerDeviceKind.touch,
-          globalPosition: Offset(150, 100 - lineHeight * 12),
-          localPosition: Offset(150, 100 - lineHeight * 12),
-          delta: Offset(0, -lineHeight * 12),
+          globalPosition: const Offset(150, 180),
+          localPosition: const Offset(150, 180),
+          delta: Offset(0, lineHeight * 12),
         ),
       );
 
-      // Fourteen original wheel thresholds across two pointer updates are
-      // preserved, but the frame-wide budget permits only six reports before
-      // the next local frame.
+      // Ten down events followed by four up events are preserved across the
+      // direction reversal, but only six reports fit in one local frame.
       expect(output, hasLength(1));
       expect(_countOccurrences(output.single, '\u001b[<65;'), 6);
       await tester.pump();
-      expect(output, hasLength(2));
-      expect(_countOccurrences(output.last, '\u001b[<65;'), 6);
-      await tester.pump();
       expect(output, hasLength(3));
-      expect(_countOccurrences(output.last, '\u001b[<65;'), 2);
-      expect(_countOccurrences(output.join(), '\u001b[<65;'), 14);
+      expect(_countOccurrences(output[1], '\u001b[<65;'), 4);
+      expect(_countOccurrences(output[2], '\u001b[<64;'), 2);
+      await tester.pump();
+      expect(output, hasLength(4));
+      expect(_countOccurrences(output.last, '\u001b[<64;'), 2);
+      final joined = output.join();
+      expect(_countOccurrences(joined, '\u001b[<65;'), 10);
+      expect(_countOccurrences(joined, '\u001b[<64;'), 4);
+      final down = RegExp(r'\x1b\[<65;\d+;(\d+)M').firstMatch(joined);
+      final up = RegExp(r'\x1b\[<64;\d+;(\d+)M').firstMatch(joined);
+      expect(down, isNotNull);
+      expect(up, isNotNull);
+      expect(down!.group(1), isNot(up!.group(1)));
     },
   );
 

--- a/third_party/xterm/lib/src/core/buffer/line.dart
+++ b/third_party/xterm/lib/src/core/buffer/line.dart
@@ -201,8 +201,7 @@ class BufferLine with IndexedItem {
     }
 
     // Update anchors, remove anchors that are inside the removed range.
-    for (var i = 0; i < _anchors.length; i++) {
-      final anchor = _anchors[i];
+    for (final anchor in _anchors.toList()) {
       if (anchor.x >= start) {
         if (anchor.x < start + count) {
           anchor.dispose();
@@ -240,9 +239,8 @@ class BufferLine with IndexedItem {
     }
 
     // Update anchors, move anchors that are after the inserted range.
-    for (var i = 0; i < _anchors.length; i++) {
-      final anchor = _anchors[i];
-      if (anchor.x >= start + count) {
+    for (final anchor in _anchors.toList()) {
+      if (anchor.x >= start) {
         anchor.reposition(anchor.x + count);
 
         // Remove anchors that are now outside the buffer.

--- a/third_party/xterm/test/src/core/graphics_viewport_index_test.dart
+++ b/third_party/xterm/test/src/core/graphics_viewport_index_test.dart
@@ -212,26 +212,32 @@ void main() {
       final terminal = Terminal(maxLines: 100)..resize(12, 6);
       final graphics = terminal.graphics;
       final line = terminal.buffer.lines[0];
-      graphics.addPlaceholder(
-        imageId: 1,
+      for (var column = 2; column <= 3; column++) {
+        graphics.addPlaceholder(
+          imageId: column,
+          imageIdBitWidth: 24,
+          anchor: line.createAnchor(column),
+          row: 0,
+          col: column - 2,
+        );
+      }
+
+      line.removeCells(2, 2);
+      expect(graphics.placeholderCount, 0);
+      expect(graphics.placeholderGridCount, 0);
+
+      final moved = graphics.addPlaceholder(
+        imageId: 4,
         imageIdBitWidth: 24,
         anchor: line.createAnchor(2),
         row: 0,
         col: 0,
       );
+      line.insertCells(2, 1);
+      expect(moved.anchor.x, 3);
+      expect(graphics.placeholderCount, 1);
 
-      line.removeCells(2, 1);
-      expect(graphics.placeholderCount, 0);
-      expect(graphics.placeholderGridCount, 0);
-
-      graphics.addPlaceholder(
-        imageId: 2,
-        imageIdBitWidth: 24,
-        anchor: line.createAnchor(11),
-        row: 0,
-        col: 0,
-      );
-      line.insertCells(0, 1);
+      line.insertCells(0, 10);
       expect(graphics.placeholderCount, 0);
       expect(graphics.placeholderGridCount, 0);
     });


### PR DESCRIPTION
## Summary

- preserve generated touch-wheel events as directional, positioned runs instead of allowing opposite-direction deltas to cancel queued reports
- enforce the six-report frame budget while draining runs in exact generation order
- iterate BufferLine anchor snapshots during cell deletion so adjacent disposed anchors are not skipped
- shift every anchor at or after an insertion point, disposing anchors that move outside the line

## Review context

Follow-up to #760 for comments that appeared while the original PR was already in the merge queue:

- https://github.com/depollsoft/MonkeySSH/pull/760#discussion_r3797853558
- https://github.com/depollsoft/MonkeySSH/pull/760#discussion_r3797853598

## Validation

- Flutter/xterm analysis clean
- focused wheel direction/position regression passed
- focused adjacent-anchor and viewport-index tests passed
- 191 vendored graphics/buffer/reflow/circular-buffer tests passed during final #760 validation
