### PR TITLE
fix: keep direct terminal scrolling at 1x

### DIFF
--- a/lib/presentation/widgets/monkey_terminal_view.dart
+++ b/lib/presentation/widgets/monkey_terminal_view.dart
@@ -61,9 +61,6 @@ import 'terminal_scroll_mouse_input.dart';
 import 'terminal_selection_text.dart';
 import 'terminal_wheel_scroll_calibrator.dart';
 
-// Match direct pixel scrolling to the conventional multi-row terminal wheel
-// pace.
-const _terminalViewportTouchScrollSensitivity = 3.0;
 const _minimumFaintTextContrast = 4.5;
 const _minimumCursorTextContrast = 4.5;
 const _minimumCellTextContrast = 4.5;
@@ -1600,17 +1597,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
     if (primaryDelta == null || drag == null) {
       return;
     }
-    final scaledDelta = primaryDelta * _terminalViewportTouchScrollSensitivity;
-    drag.update(
-      DragUpdateDetails(
-        sourceTimeStamp: details.sourceTimeStamp,
-        delta: Offset(0, scaledDelta),
-        primaryDelta: scaledDelta,
-        globalPosition: details.globalPosition,
-        localPosition: details.localPosition,
-        kind: details.kind,
-      ),
-    );
+    drag.update(details);
   }
 
   void _onDirectTouchScrollEnd(DragEndDetails details) {
@@ -1622,20 +1609,7 @@ class MonkeyTerminalViewState extends State<MonkeyTerminalView>
     if (drag == null) {
       return;
     }
-    final pixelsPerSecond = details.velocity.pixelsPerSecond;
-    final scaledVelocity =
-        (details.primaryVelocity ?? pixelsPerSecond.dy) *
-        _terminalViewportTouchScrollSensitivity;
-    drag.end(
-      DragEndDetails(
-        globalPosition: details.globalPosition,
-        localPosition: details.localPosition,
-        velocity: Velocity(
-          pixelsPerSecond: Offset(pixelsPerSecond.dx, scaledVelocity),
-        ),
-        primaryVelocity: scaledVelocity,
-      ),
-    );
+    drag.end(details);
     _directTouchScrollDrag = null;
   }
 

--- a/test/widget/monkey_terminal_view_touch_scroll_test.dart
+++ b/test/widget/monkey_terminal_view_touch_scroll_test.dart
@@ -1007,7 +1007,7 @@ void main() {
     },
   );
 
-  testWidgets('direct terminal scrollback accelerates touch drags', (
+  testWidgets('direct terminal scrollback follows touch drags at 1x', (
     tester,
   ) async {
     final terminal = Terminal(maxLines: 200)
@@ -1040,13 +1040,11 @@ void main() {
     await gesture.moveBy(const Offset(0, 20));
     await tester.pump();
 
-    expect(offsetAfterDragStart - scrollController.offset, closeTo(60, 0.01));
+    expect(offsetAfterDragStart - scrollController.offset, closeTo(20, 0.01));
     await gesture.up();
   });
 
-  testWidgets('direct touch fling uses the same accelerated gain', (
-    tester,
-  ) async {
+  testWidgets('direct touch fling preserves platform velocity', (tester) async {
     final terminal = Terminal(maxLines: 200)
       ..write(List.filled(100, 'line\r\n').join());
     final scrollController = ScrollController();
@@ -1080,7 +1078,9 @@ void main() {
 
     expect(ballisticVelocities, isNotEmpty);
     expect(
-      ballisticVelocities.any((velocity) => velocity.abs() > 2000),
+      ballisticVelocities.any(
+        (velocity) => velocity.abs() >= 800 && velocity.abs() <= 1200,
+      ),
       isTrue,
     );
   });


### PR DESCRIPTION
## Summary
- remove the 3× touch-drag multiplier from direct terminal scrollback
- pass drag updates and fling velocity through unchanged so non-alt-buffer shells and agents follow the finger at platform cadence
- keep alternate-buffer adaptive wheel handling unchanged

## Validation
- `flutter analyze --fatal-warnings --fatal-infos --no-pub`
- `flutter test --no-pub test/widget/monkey_terminal_view_touch_scroll_test.dart --plain-name "direct terminal scrollback follows touch drags at 1x"`
- `flutter test --no-pub test/widget/monkey_terminal_view_touch_scroll_test.dart --plain-name "direct touch fling preserves platform velocity"`
- `flutter test --no-pub` — 3,147 tests passed
