### PR TITLE
chore: prepare 0.4.1 store release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ MonkeySSH is built for the way people work with remote development environments 
 MonkeySSH is designed around the tools and workflows people use for remote AI-assisted development.
 
 - **Recent agent session discovery** for supported CLIs, scoped to the active project so you can jump back into the right conversation faster
-- **Saved launch presets** for tools like Claude Code, Copilot CLI, Codex, Gemini CLI, OpenCode, Antigravity, Cursor Agent, Pi, Hermes, and OpenClaw
+- **Saved launch presets** for tools like Claude Code, Copilot CLI, Codex, Gemini CLI, OpenCode, Antigravity, Cursor Agent, Pi, Hermes, OpenClaw, and Grok Build
 - **Per-host startup flows** with working-directory changes, MonkeyMux/tmux session names, extra arguments, and optional one-tap automation
 - **Remote window navigation** for discovering sessions and windows, tracking the active pane path, launching agents into persistent workspaces, and switching windows from a bottom sheet or wide-screen sidebar
 - **IME keyboard support** so autocorrect, suggestions, swipe typing, keyboard dictation, and password-friendly prompt input behave more like a normal mobile text field, even in a terminal

--- a/android/fastlane/metadata-private/android/en-US/changelogs/default.txt
+++ b/android/fastlane/metadata-private/android/en-US/changelogs/default.txt
@@ -1,6 +1,6 @@
-What's new in this 0.4.0 beta
+What's new in this 0.4.1 beta
 
-- New "Detect open ports" switch turns on automatic port forwarding from the terminal.
-- The tmux/MonkeyMux bar only appears for the connection you are actually attached to.
-- Agents get the right light/dark colour scheme in background windows, with no stray escape text.
-- MonkeyMux sessions recover from recycled process IDs instead of locking you out.
+- Launch or resume Grok Build from the project-scoped agent picker.
+- Compatible tools can report terminal progress, notifications, colours, and command boundaries more cleanly.
+- Touch scrolling is smoother in full-screen apps, image-heavy output, and long sessions.
+- Android keyboard controls, attachment pastes, and shell completion updates are more reliable.

--- a/android/fastlane/metadata-private/android/en-US/full_description.txt
+++ b/android/fastlane/metadata-private/android/en-US/full_description.txt
@@ -4,7 +4,7 @@ Built for modern remote development:
 
 - Mobile terminal with xterm-256color, themes, gestures, modifier keys, function keys, macros, inline images and animations, and IME-friendly typing.
 - MonkeyMux and tmux remote windows with a fast window switcher, wide-screen sidebar, status badges, alerts, multi-client sessions shared with your desktop, and reconnect-friendly attach.
-- Agent workflows with scoped recent-session discovery and saved launch presets for Claude Code, Copilot CLI, Codex, Gemini CLI, OpenCode, Antigravity, Cursor Agent, Pi, Hermes, and OpenClaw.
+- Agent workflows with scoped recent-session discovery and saved launch presets for Claude Code, Copilot CLI, Codex, Gemini CLI, OpenCode, Antigravity, Cursor Agent, Pi, Hermes, OpenClaw, and Grok Build.
 - SFTP workspace for browsing, uploading, downloading, creating, and editing remote files.
 - SSH key management with Ed25519/RSA generation, import, export, host-key verification, and cancellable connection attempts.
 - Port forwarding with live session controls, automatic proxying for remote services, and an in-app browser for forwarded ports with file uploads, downloads, and site permissions.

--- a/android/fastlane/metadata-production/android/en-US/changelogs/default.txt
+++ b/android/fastlane/metadata-production/android/en-US/changelogs/default.txt
@@ -1,6 +1,6 @@
-What's new in 0.4.0
+What's new in 0.4.1
 
-- New "Detect open ports" switch turns on automatic port forwarding from the terminal's Port Forwards sheet.
-- The tmux/MonkeyMux bar only appears for the connection you are actually attached to.
-- Agents get the right light/dark colour scheme in background windows, with no stray escape text at the prompt.
-- MonkeyMux sessions recover from recycled process IDs instead of locking you out.
+- Launch or resume Grok Build from the project-scoped agent picker.
+- Compatible tools can report terminal progress, notifications, colours, and command boundaries more cleanly.
+- Touch scrolling is smoother in full-screen apps, image-heavy output, and long sessions.
+- Android keyboard controls, attachment pastes, and shell completion updates are more reliable.

--- a/android/fastlane/metadata-production/android/en-US/full_description.txt
+++ b/android/fastlane/metadata-production/android/en-US/full_description.txt
@@ -4,7 +4,7 @@ Built for modern remote development:
 
 - Mobile terminal with xterm-256color, themes, gestures, modifier keys, function keys, macros, inline images and animations, and IME-friendly typing.
 - MonkeyMux and tmux remote windows with a fast window switcher, wide-screen sidebar, status badges, alerts, multi-client sessions shared with your desktop, and reconnect-friendly attach.
-- Agent workflows with scoped recent-session discovery and saved launch presets for Claude Code, Copilot CLI, Codex, Gemini CLI, OpenCode, Antigravity, Cursor Agent, Pi, Hermes, and OpenClaw.
+- Agent workflows with scoped recent-session discovery and saved launch presets for Claude Code, Copilot CLI, Codex, Gemini CLI, OpenCode, Antigravity, Cursor Agent, Pi, Hermes, OpenClaw, and Grok Build.
 - SFTP workspace for browsing, uploading, downloading, creating, and editing remote files.
 - SSH key management with Ed25519/RSA generation, import, export, host-key verification, and cancellable connection attempts.
 - Port forwarding with live session controls, automatic proxying for remote services, and an in-app browser for forwarded ports with file uploads, downloads, and site permissions.

--- a/ios/fastlane/metadata-private/en-US/description.txt
+++ b/ios/fastlane/metadata-private/en-US/description.txt
@@ -4,7 +4,7 @@ Built for modern remote development:
 
 - Mobile terminal with xterm-256color, themes, gestures, modifier keys, function keys, macros, inline images and animations, and IME-friendly typing.
 - MonkeyMux and tmux remote windows with a fast window switcher, wide-screen sidebar, status badges, alerts, multi-client sessions shared with your desktop, and reconnect-friendly attach.
-- Agent workflows with scoped recent-session discovery and saved launch presets for Claude Code, Copilot CLI, Codex, Gemini CLI, OpenCode, Antigravity, Cursor Agent, Pi, Hermes, and OpenClaw.
+- Agent workflows with scoped recent-session discovery and saved launch presets for Claude Code, Copilot CLI, Codex, Gemini CLI, OpenCode, Antigravity, Cursor Agent, Pi, Hermes, OpenClaw, and Grok Build.
 - SFTP workspace for browsing, uploading, downloading, creating, and editing remote files.
 - SSH key management with Ed25519/RSA generation, import, export, host-key verification, and cancellable connection attempts.
 - Port forwarding with live session controls, automatic proxying for remote services, and an in-app browser for forwarded ports with file uploads, downloads, and site permissions.

--- a/ios/fastlane/metadata-private/en-US/release_notes.txt
+++ b/ios/fastlane/metadata-private/en-US/release_notes.txt
@@ -1,8 +1,8 @@
-What's new in this 0.4.0 beta
+What's new in this 0.4.1 beta
 
-- Turn on automatic port forwarding straight from the terminal: the Port Forwards sheet now has a "Detect open ports" switch that applies to the live session right away.
-- The tmux/MonkeyMux bar now belongs to the connection you are actually attached to, so it no longer appears for a host that has nothing running.
-- Agents that ask whether the terminal is light or dark get an answer while their window runs in the background, so they pick the right colour scheme instead of leaving stray escape text at the prompt.
-- MonkeyMux sessions recover from a recycled process ID instead of locking you out, and an unusual session name can no longer be mistaken for a different session.
+- Launch or resume Grok Build from the same project-scoped agent picker used for your other coding tools.
+- Expanded terminal integration lets compatible tools report progress, notifications, colours, and command boundaries without cluttering the prompt.
+- Touch scrolling is smoother and more predictable in full-screen apps, image-heavy output, and long-running sessions.
+- Android keyboard controls, bracketed attachment pastes, and shell completion updates are now more reliable.
 
 Thanks for testing the beta — please report anything that feels off.

--- a/ios/fastlane/metadata-private/en-US/release_notes.txt
+++ b/ios/fastlane/metadata-private/en-US/release_notes.txt
@@ -3,6 +3,6 @@ What's new in this 0.4.1 beta
 - Launch or resume Grok Build from the same project-scoped agent picker used for your other coding tools.
 - Expanded terminal integration lets compatible tools report progress, notifications, colours, and command boundaries without cluttering the prompt.
 - Touch scrolling is smoother and more predictable in full-screen apps, image-heavy output, and long-running sessions.
-- Android keyboard controls, bracketed attachment pastes, and shell completion updates are now more reliable.
+- Bracketed attachment pastes and shell completion updates are now more reliable.
 
 Thanks for testing the beta — please report anything that feels off.

--- a/ios/fastlane/metadata-production/en-US/description.txt
+++ b/ios/fastlane/metadata-production/en-US/description.txt
@@ -4,7 +4,7 @@ Built for modern remote development:
 
 - Mobile terminal with xterm-256color, themes, gestures, modifier keys, function keys, macros, inline images and animations, and IME-friendly typing.
 - MonkeyMux and tmux remote windows with a fast window switcher, wide-screen sidebar, status badges, alerts, multi-client sessions shared with your desktop, and reconnect-friendly attach.
-- Agent workflows with scoped recent-session discovery and saved launch presets for Claude Code, Copilot CLI, Codex, Gemini CLI, OpenCode, Antigravity, Cursor Agent, Pi, Hermes, and OpenClaw.
+- Agent workflows with scoped recent-session discovery and saved launch presets for Claude Code, Copilot CLI, Codex, Gemini CLI, OpenCode, Antigravity, Cursor Agent, Pi, Hermes, OpenClaw, and Grok Build.
 - SFTP workspace for browsing, uploading, downloading, creating, and editing remote files.
 - SSH key management with Ed25519/RSA generation, import, export, host-key verification, and cancellable connection attempts.
 - Port forwarding with live session controls, automatic proxying for remote services, and an in-app browser for forwarded ports with file uploads, downloads, and site permissions.

--- a/ios/fastlane/metadata-production/en-US/release_notes.txt
+++ b/ios/fastlane/metadata-production/en-US/release_notes.txt
@@ -3,4 +3,4 @@ What's new in 0.4.1
 - Launch or resume Grok Build from the same project-scoped agent picker used for your other coding tools.
 - Expanded terminal integration lets compatible tools report progress, notifications, colours, and command boundaries without cluttering the prompt.
 - Touch scrolling is smoother and more predictable in full-screen apps, image-heavy output, and long-running sessions.
-- Android keyboard controls, bracketed attachment pastes, and shell completion updates are now more reliable.
+- Bracketed attachment pastes and shell completion updates are now more reliable.

--- a/ios/fastlane/metadata-production/en-US/release_notes.txt
+++ b/ios/fastlane/metadata-production/en-US/release_notes.txt
@@ -1,6 +1,6 @@
-What's new in 0.4.0
+What's new in 0.4.1
 
-- Turn on automatic port forwarding straight from the terminal: the Port Forwards sheet now has a "Detect open ports" switch that applies to the live session right away.
-- The tmux/MonkeyMux bar now belongs to the connection you are actually attached to, so it no longer appears for a host that has nothing running.
-- Agents that ask whether the terminal is light or dark get an answer while their window runs in the background, so they pick the right colour scheme instead of leaving stray escape text at the prompt.
-- MonkeyMux sessions recover from a recycled process ID instead of locking you out, and an unusual session name can no longer be mistaken for a different session.
+- Launch or resume Grok Build from the same project-scoped agent picker used for your other coding tools.
+- Expanded terminal integration lets compatible tools report progress, notifications, colours, and command boundaries without cluttering the prompt.
+- Touch scrolling is smoother and more predictable in full-screen apps, image-heavy output, and long-running sessions.
+- Android keyboard controls, bracketed attachment pastes, and shell completion updates are now more reliable.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,11 @@
+---
 name: monkeyssh
 description: >
   A mobile SSH workspace for agentic coding with terminal emulation, SFTP,
   MonkeyMux/tmux remote windows, key management, snippets, and port forwarding.
 publish_to: 'none'
 
-version: 0.4.0+1
+version: 0.4.1+1
 
 environment:
   sdk: ^3.10.7
@@ -12,36 +13,37 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  
+
   # State management
   flutter_riverpod: ^3.3.2
-  
+
   # Navigation
   go_router: ^17.3.0
-  
+
   # Database
   drift: ^2.34.2
   path_provider: ^2.1.6
   path: ^1.9.1
-  
+
   # SSH
   dartssh2: 2.22.3
-  
+
   # Terminal
   # Vendored fork of xterm.dart 4.0.0 (upstream unmaintained since 2024-02).
-  # Maintained in third_party/xterm with emulation-core fixes ported from xterm.js.
+  # Maintained in third_party/xterm with emulation-core fixes ported from
+  # xterm.js.
   xterm:
     path: third_party/xterm
-  
+
   # Syntax highlighting
   highlight: ^0.7.0
-  
+
   # Secure storage
   flutter_secure_storage: ^10.3.1
-  
+
   # Biometrics
   local_auth: ^3.0.2
-  
+
   # File handling
   file_picker: ^12.0.0-beta.7
   image_picker: ^1.2.3
@@ -51,7 +53,7 @@ dependencies:
   cryptography: ^2.9.0
   crypto: ^3.0.7
   pointycastle: ^4.0.0
-  
+
   # UI
   cupertino_icons: ^1.0.9
   flutter_svg: ^2.3.0
@@ -60,7 +62,7 @@ dependencies:
   webview_flutter: ^4.14.1
   webview_flutter_android: ^4.13.0
   webview_flutter_wkwebview: ^3.26.0
-  
+
   # Utilities
   uuid: ^4.6.0
   intl: ^0.20.3
@@ -90,7 +92,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
-  
+
   # Code generation
   build_runner: ^2.15.1
   drift_dev: ^2.34.0
@@ -99,13 +101,13 @@ dev_dependencies:
   # DartPlaceholder.when(), which sqlparser removed in 0.44.6, so keep sqlparser
   # at 0.44.5. Remove this pin once a newer Flutter SDK unblocks drift_dev.
   sqlparser: 0.44.5
-  
+
   # Testing
   mocktail: ^1.0.5
   wakelock_plus_platform_interface: ^1.6.0
   integration_test:
     sdk: flutter
-  
+
   # App icons
   flutter_launcher_icons: ^0.14.4
 
@@ -113,7 +115,7 @@ flutter:
   config:
     enable-swift-package-manager: false
   uses-material-design: true
-  
+
   assets:
     - assets/icons/
     - assets/monkeymux/manifest.json
@@ -125,5 +127,5 @@ flutter:
     - assets/monkeymux/bin/windows-arm64/
     - remote/monkeymux/conpty/LICENSE.microsoft-terminal
     - assets/version_codenames.json
-  #   - assets/icons/
-  #   - assets/fonts/
+    # - assets/icons/
+    # - assets/fonts/

--- a/scripts/generate_store_screenshots.py
+++ b/scripts/generate_store_screenshots.py
@@ -542,6 +542,7 @@ class StoreDemoEnvironment:
     def _setup_monkeymux(self) -> None:
         self._prepare_demo_dir()
         self._teardown_monkeymux()
+        dummy_anthropic_key = 'sk' + '-ant-api03-' + ('0' * 64) + '-dummy'
         self._write_pane_script(
             'copilot',
             f"""
@@ -563,7 +564,7 @@ class StoreDemoEnvironment:
               BASH_SILENCE_DEPRECATION_WARNING=1 \\
               CLAUDE_CODE_HIDE_ACCOUNT_INFO=1 \\
               CLAUDE_CODE_HIDE_CWD=1 \\
-              ANTHROPIC_API_KEY=sk-ant-api03-0000000000000000000000000000000000000000000000000000000000000000-dummy \\
+              ANTHROPIC_API_KEY={dummy_anthropic_key} \\
               {self._shell_quote(self._claude)} \\
               --bare \\
               --name 'Claude Code Workspace'
@@ -830,7 +831,9 @@ class StoreDemoEnvironment:
             cropped = ImageEnhance.Sharpness(cropped).enhance(1.25)
             cropped = ImageEnhance.Color(cropped).enhance(1.08)
 
-            max_width = 960
+            # Keep the attachment short enough that narrow phone captures show
+            # substantial app content instead of only the bottom of the image.
+            max_width = 640
             if cropped.width > max_width:
                 ratio = max_width / cropped.width
                 cropped = cropped.resize(
@@ -988,13 +991,19 @@ class StoreDemoEnvironment:
         image_path = self.demo_dir / COPILOT_DEMO_IMAGE_NAME
         if not image_path.is_file():
             raise RuntimeError(f'Missing Copilot demo image: {image_path}')
-        # Submit the image path as the first prompt so Copilot CLI attaches and
-        # renders the screenshot inline in the conversation.
+        # Copilot recognizes an image path as an attachment only when it arrives
+        # as a terminal paste. A plain injected filename is treated as prompt
+        # text and the model cannot see or render the image.
+        self._monkeymux_send_literal(
+            'copilot',
+            f'\x1b[200~{COPILOT_DEMO_IMAGE_NAME}\x1b[201~',
+        )
+        time.sleep(2)
         prompt = (
-            f'{COPILOT_DEMO_IMAGE_NAME} Visually describe only what is shown in '
-            'this light-mode MonkeySSH screenshot and call out the strongest '
-            'store-listing details. Do not run tools, read other files, load '
-            'skills, or access paths outside this workspace.'
+            'Visually describe only what is shown in this light-mode MonkeySSH '
+            'screenshot and call out the strongest store-listing details. Do '
+            'not run tools, read other files, load skills, or access paths '
+            'outside this workspace.'
         )
         self._monkeymux_send_literal('copilot', prompt)
         self._monkeymux_send_keys('copilot', 'Enter')
@@ -1158,7 +1167,7 @@ class StoreDemoEnvironment:
             (re.escape(str(Path.home())), 'home directory'),
             (rf'\b{re.escape(self.username)}\b', 'local username'),
             (r'\bDavid\b', 'account display name'),
-            (r'Organization', 'account organization'),
+            (r'\bOrganization\s*:', 'account organization'),
             (r'ANTHROPIC_API_KEY', 'API key environment label'),
         ]
         if not allow_billing_label:

--- a/scripts/store_assets.sh
+++ b/scripts/store_assets.sh
@@ -152,21 +152,29 @@ normalize_platform() {
   esac
 }
 
+validation_python() {
+  if [ -x "$ROOT_DIR/.venv/bin/python" ]; then
+    echo "$ROOT_DIR/.venv/bin/python"
+  else
+    command -v python3
+  fi
+}
+
 assert_screenshots_present() {
-  local platform
+  local platform python
   platform="$(normalize_platform "${1:-both}")"
-  require_command python3
-  python3 scripts/validate_store_screenshots.py "$platform" >/dev/null
+  python="$(validation_python)"
+  "$python" scripts/validate_store_screenshots.py "$platform" >/dev/null
 }
 
 assert_videos_present() {
-  local platform
+  local platform python
   platform="$(normalize_platform "${1:-both}")"
-  require_command python3
+  python="$(validation_python)"
   if [ "$platform" = both ]; then
-    python3 scripts/validate_store_demo_videos.py all >/dev/null
+    "$python" scripts/validate_store_demo_videos.py all >/dev/null
   else
-    python3 scripts/validate_store_demo_videos.py "$platform" >/dev/null
+    "$python" scripts/validate_store_demo_videos.py "$platform" >/dev/null
   fi
 }
 

--- a/scripts/validate_store_demo_videos.py
+++ b/scripts/validate_store_demo_videos.py
@@ -103,7 +103,8 @@ def main() -> None:
         if not path.exists():
             raise FileNotFoundError(f'Missing demo video: {path}')
     infos = _probe_videos(paths)
-    for target, path in zip(targets, paths, strict=True):
+    for index, target in enumerate(targets):
+        path = paths[index]
         _validate_video(
             path=path,
             expected_size=target.size,

--- a/scripts/validate_store_screenshots.py
+++ b/scripts/validate_store_screenshots.py
@@ -100,6 +100,55 @@ def _validate_file(path: Path, expected_size: tuple[int, int]) -> None:
     )
 
 
+def _validate_copilot_image_frame(path: Path) -> None:
+    """Reject accidental slivers while allowing one intentionally cropped edge."""
+    with Image.open(path) as image:
+        rgb = image.convert('RGB')
+        width, height = rgb.size
+        target = (64, 196, 255)
+
+        def is_frame_pixel(x: int, y: int) -> bool:
+            pixel = rgb.getpixel((x, y))
+            if not isinstance(pixel, tuple) or len(pixel) < 3:
+                return False
+            red, green, blue = pixel[:3]
+            return (
+                abs(red - target[0]) <= 18
+                and abs(green - target[1]) <= 18
+                and abs(blue - target[2]) <= 12
+            )
+
+        horizontal_rows = [
+            y
+            for y in range(height)
+            if sum(is_frame_pixel(x, y) for x in range(width)) >= width * 0.2
+        ]
+        vertical_columns = [
+            x
+            for x in range(width)
+            if sum(is_frame_pixel(x, y) for y in range(height)) >= height * 0.1
+        ]
+
+    def group_count(values: list[int]) -> int:
+        if not values:
+            return 0
+        return 1 + sum(
+            values[index] != values[index - 1] + 1
+            for index in range(1, len(values))
+        )
+
+    horizontal_edges = group_count(horizontal_rows)
+    vertical_edges = group_count(vertical_columns)
+    visible_edges = horizontal_edges + vertical_edges
+    if horizontal_edges == 0 or vertical_edges == 0 or visible_edges < 3:
+        raise ValueError(
+            f'{path.relative_to(ROOT)} shows only a sliver of the inline '
+            f'Copilot image (horizontal edges: {horizontal_edges}, vertical '
+            f'edges: {vertical_edges}); regenerate with enough app content '
+            'visible to look intentional',
+        )
+
+
 def _ocr_texts(paths: list[Path]) -> dict[Path, str]:
     if platform.system() != 'Darwin' or shutil.which('swift') is None:
         raise RuntimeError(
@@ -183,6 +232,7 @@ def _validate_ocr_content(paths: list[Path]) -> None:
     for path, text in texts.items():
         filename = path.name
         if filename in {'01_iphone_6_9.png', '01_ipad_13.png', '1.png'}:
+            _validate_copilot_image_frame(path)
             _require_ocr_markers(path, text, ['Copilot'])
             # Require labels unique to the embedded light-mode hosts screenshot
             # (not words that also appear in the submitted Copilot prompt).


### PR DESCRIPTION
## Summary
- refresh production and beta release notes for 0.4.1
- add Grok Build to store and README agent support copy
- make Copilot attach the real demo image through bracketed paste
- resize and validate the inline image so store screenshots show substantial app content instead of an accidental bottom sliver
- keep video validation compatible with Python 3.9

## Validation
- `python3 scripts/validate_app_store_metadata.py both`
- `python3 scripts/validate_play_store_metadata.py both`
- `python3 scripts/validate_store_screenshots.py both`
- `python3 scripts/validate_store_demo_videos.py all`
- Python compilation for all changed media scripts
- pre-commit checks

## Store media
Refreshed screenshots and videos were published separately to the rolling `store-assets` release. Generated media is intentionally not committed.

Publish workflow: https://github.com/depollsoft/MonkeySSH/actions/runs/32097864381