### PR TITLE
fix(monkeymux): restore agent sessions safely across upgrades

### DIFF
--- a/remote/monkeymux/README.md
+++ b/remote/monkeymux/README.md
@@ -89,13 +89,14 @@ stay ambiguous. MonkeyMux otherwise correlates a unique session-header creation
 time with the live process start and relaunches a matched session by its exact
 file path. A later unowned write in the same working directory marks that match
 ambiguous (including `/new` and `/resume` rotation), so it launches fresh rather
-than risking the wrong conversation. Plain
-working-directory fallback is used only for one window and one unused session.
-Across Copilot, Codex, OpenCode, Claude Code, Gemini, Antigravity, and Cursor Agent,
-argv, open-file, or live-lock identity wins; cwd/history fallback only accepts state
-updated during that foreground process. A carried resume ID is revalidated because a
-failed resume may have fallen back to a fresh agent. Stale or ambiguous evidence leaves
-the restored window fresh instead of injecting an older conversation. `--session-dir`,
+than risking the wrong conversation. Plain working-directory fallback is used
+only for one live window and one unused session updated during that foreground
+process. Across Copilot, Codex, OpenCode, Claude Code, Gemini, Antigravity, and
+Cursor Agent, argv, open-file, or live-lock identity wins; cwd/history fallback
+only accepts state updated during that foreground process. A carried resume ID
+is revalidated because a failed resume may have fallen back to a fresh agent.
+Stale or ambiguous evidence leaves the restored window fresh instead of
+injecting an older conversation. `--session-dir`,
 environment, and global/project `settings.json` session directories are honored,
 while nested child-agent stores are excluded. The server inherits the environment from
 the shell that launched it exactly, so profile-managed values such as `PATH`

--- a/remote/monkeymux/README.md
+++ b/remote/monkeymux/README.md
@@ -90,9 +90,12 @@ time with the live process start and relaunches a matched session by its exact
 file path. A later unowned write in the same working directory marks that match
 ambiguous (including `/new` and `/resume` rotation), so it launches fresh rather
 than risking the wrong conversation. Plain
-working-directory fallback is used only for one window and one unused session. Claude
-Code cwd fallback likewise only considers files written during the current Claude
-process, so a fresh empty window cannot inherit an older conversation. `--session-dir`,
+working-directory fallback is used only for one window and one unused session.
+Across Copilot, Codex, OpenCode, Claude Code, Gemini, Antigravity, and Cursor Agent,
+argv, open-file, or live-lock identity wins; cwd/history fallback only accepts state
+updated during that foreground process. A carried resume ID is revalidated because a
+failed resume may have fallen back to a fresh agent. Stale or ambiguous evidence leaves
+the restored window fresh instead of injecting an older conversation. `--session-dir`,
 environment, and global/project `settings.json` session directories are honored,
 while nested child-agent stores are excluded. The server inherits the environment from
 the shell that launched it exactly, so profile-managed values such as `PATH`

--- a/remote/monkeymux/README.md
+++ b/remote/monkeymux/README.md
@@ -82,11 +82,14 @@ record even when large image records appear earlier in the JSONL. This remains
 reliable when Pi creates the JSONL only after its first assistant response or
 several restored processes started at once. A validated exact identity is kept
 on the live window for later helper upgrades, including unnamed sessions on
-Windows where process arguments cannot recover it. MonkeyMux otherwise
-correlates a unique session-header creation time with the live process start
-and relaunches a matched session by its exact file path. A later unowned write in the same
-working directory marks that match ambiguous (including `/new` and `/resume`
-rotation), so it launches fresh rather than risking the wrong conversation. Plain
+Windows where process arguments cannot recover it. For unnamed same-directory
+windows inherited from an older helper, MonkeyMux pairs a unique JSONL write
+time with that window's most recent terminal output; overlapping timestamps
+stay ambiguous. MonkeyMux otherwise correlates a unique session-header creation
+time with the live process start and relaunches a matched session by its exact
+file path. A later unowned write in the same working directory marks that match
+ambiguous (including `/new` and `/resume` rotation), so it launches fresh rather
+than risking the wrong conversation. Plain
 working-directory fallback is used only for one window and one unused session. `--session-dir`,
 environment, and global/project `settings.json` session directories are honored,
 while nested child-agent stores are excluded. The server inherits the environment from

--- a/remote/monkeymux/README.md
+++ b/remote/monkeymux/README.md
@@ -90,7 +90,9 @@ time with the live process start and relaunches a matched session by its exact
 file path. A later unowned write in the same working directory marks that match
 ambiguous (including `/new` and `/resume` rotation), so it launches fresh rather
 than risking the wrong conversation. Plain
-working-directory fallback is used only for one window and one unused session. `--session-dir`,
+working-directory fallback is used only for one window and one unused session. Claude
+Code cwd fallback likewise only considers files written during the current Claude
+process, so a fresh empty window cannot inherit an older conversation. `--session-dir`,
 environment, and global/project `settings.json` session directories are honored,
 while nested child-agent stores are excluded. The server inherits the environment from
 the shell that launched it exactly, so profile-managed values such as `PATH`

--- a/remote/monkeymux/copilot_restore_fallback_test.go
+++ b/remote/monkeymux/copilot_restore_fallback_test.go
@@ -114,7 +114,11 @@ func TestDiscoverCopilotSessionIDsPrefersFreshSessionOnStaleLock(t *testing.T) {
 // instead of relaunching blank.
 func TestEnrichRestoreCopilotFallsBackToCwd(t *testing.T) {
 	originalProcessStart := processStartedAtForMetadata
-	t.Cleanup(func() { processStartedAtForMetadata = originalProcessStart })
+	originalProcessTable := processTableForMetadata
+	t.Cleanup(func() {
+		processStartedAtForMetadata = originalProcessStart
+		processTableForMetadata = originalProcessTable
+	})
 	home := t.TempDir()
 	setTestHomeDir(t, home)
 	stateDir := filepath.Join(home, ".copilot", "session-state")
@@ -125,10 +129,16 @@ func TestEnrichRestoreCopilotFallsBackToCwd(t *testing.T) {
 
 	now := time.Now()
 	processStartedAtForMetadata = func(pid int) time.Time {
-		if pid == 200 {
+		if pid == 201 {
 			return now.Add(-time.Minute)
 		}
 		return time.Time{}
+	}
+	processTableForMetadata = func() map[int]processInfo {
+		return map[int]processInfo{
+			200: {pid: 200, ppid: 1, comm: "cmd.exe", args: "cmd.exe"},
+			201: {pid: 201, ppid: 200, comm: "copilot", args: "copilot"},
+		}
 	}
 	writeCopilotSession(t, stateDir, "old-session", project, 0, now.Add(-48*time.Hour))
 	writeCopilotSession(t, stateDir, "recent-session", project, 0, now)
@@ -188,11 +198,18 @@ func TestAssignCopilotSessionsByWorkingDirectoryDedups(t *testing.T) {
 			// Already resolved by the process table — must be left untouched and
 			// not reused for the other windows.
 			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: project, AgentSessionID: "sess-middle"},
-			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: project, PanePid: 201},
-			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: project, PanePid: 202},
+			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: project, PanePid: 201, LastActivityEpochSeconds: now.Unix()},
+			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: project, PanePid: 202, LastActivityEpochSeconds: now.Add(-2 * time.Hour).Unix()},
 		},
 	}
-	assignCopilotSessionsByWorkingDirectory(restore)
+	assignCopilotSessionsByWorkingDirectory(
+		restore,
+		map[int]processInfo{
+			201: {pid: 201, ppid: 1, comm: "copilot", args: "copilot"},
+			202: {pid: 202, ppid: 1, comm: "copilot", args: "copilot"},
+		},
+		map[int]struct{}{201: {}, 202: {}},
+	)
 
 	if restore.Windows[0].AgentSessionID != "sess-middle" {
 		t.Fatalf("window 0 changed to %q, want untouched sess-middle", restore.Windows[0].AgentSessionID)
@@ -207,6 +224,19 @@ func TestAssignCopilotSessionsByWorkingDirectoryDedups(t *testing.T) {
 
 // TestAssignCopilotSessionsByWorkingDirectoryNormalizesPaths confirms a window
 // cwd and a session cwd match through ~ expansion and symlink resolution.
+
+func TestCopilotActivityAssignmentsRejectPartialOverlap(t *testing.T) {
+	now := time.Now()
+	a := copilotSessionEntry{id: "a", updatedAt: now}
+	b := copilotSessionEntry{id: "b", updatedAt: now.Add(10 * time.Second)}
+	got := uniqueCopilotSessionAssignments(map[int][]copilotSessionEntry{
+		0: {a},
+		1: {a, b},
+	})
+	if len(got) != 0 {
+		t.Fatalf("partial-overlap Copilot assignments = %#v, want none", got)
+	}
+}
 
 func TestCopilotCwdFallbackDoesNotResumeSessionFromBeforeFreshProcess(t *testing.T) {
 	originalProcessStart := processStartedAtForMetadata
@@ -227,7 +257,11 @@ func TestCopilotCwdFallbackDoesNotResumeSessionFromBeforeFreshProcess(t *testing
 		Name: "Copilot CLI", AgentTool: "copilot", Cwd: project, PanePid: 200,
 	}}}
 
-	assignCopilotSessionsByWorkingDirectory(restore)
+	assignCopilotSessionsByWorkingDirectory(
+		restore,
+		map[int]processInfo{200: {pid: 200, ppid: 1, comm: "copilot", args: "copilot"}},
+		map[int]struct{}{200: {}},
+	)
 
 	if got := restore.Windows[0].AgentSessionID; got != "" {
 		t.Fatalf("fresh Copilot process inherited stale session %q", got)
@@ -263,7 +297,11 @@ func TestAssignCopilotSessionsByWorkingDirectoryNormalizesPaths(t *testing.T) {
 			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: linkDir, PanePid: 200},
 		},
 	}
-	assignCopilotSessionsByWorkingDirectory(restore)
+	assignCopilotSessionsByWorkingDirectory(
+		restore,
+		map[int]processInfo{200: {pid: 200, ppid: 1, comm: "copilot", args: "copilot"}},
+		map[int]struct{}{200: {}},
+	)
 	if got := restore.Windows[0].AgentSessionID; got != "linked-session" {
 		t.Fatalf("session id = %q, want linked-session via symlink normalization", got)
 	}

--- a/remote/monkeymux/copilot_restore_fallback_test.go
+++ b/remote/monkeymux/copilot_restore_fallback_test.go
@@ -79,11 +79,19 @@ func itoaPositive(n int) string {
 // later. Discovery keeps the freshest (most recently locked) session for a
 // pane.
 func TestDiscoverCopilotSessionIDsPrefersFreshSessionOnStaleLock(t *testing.T) {
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() { processStartedAtForMetadata = originalProcessStart })
 	home := t.TempDir()
 	setTestHomeDir(t, home)
 	stateDir := filepath.Join(home, ".copilot", "session-state")
 
 	now := time.Now()
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 201 {
+			return now.Add(-time.Minute)
+		}
+		return time.Time{}
+	}
 	// The live session was locked seconds ago; the stale dir (whose lock PID
 	// 201 was reused) was locked long ago but sorts AFTER the live one.
 	writeCopilotSession(t, stateDir, "aaa-live", "/work", 201, now)

--- a/remote/monkeymux/copilot_restore_fallback_test.go
+++ b/remote/monkeymux/copilot_restore_fallback_test.go
@@ -105,6 +105,8 @@ func TestDiscoverCopilotSessionIDsPrefersFreshSessionOnStaleLock(t *testing.T) {
 // window still resumes the most recent copilot session recorded for its cwd
 // instead of relaunching blank.
 func TestEnrichRestoreCopilotFallsBackToCwd(t *testing.T) {
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() { processStartedAtForMetadata = originalProcessStart })
 	home := t.TempDir()
 	setTestHomeDir(t, home)
 	stateDir := filepath.Join(home, ".copilot", "session-state")
@@ -114,13 +116,19 @@ func TestEnrichRestoreCopilotFallsBackToCwd(t *testing.T) {
 	}
 
 	now := time.Now()
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return now.Add(-time.Minute)
+		}
+		return time.Time{}
+	}
 	writeCopilotSession(t, stateDir, "old-session", project, 0, now.Add(-48*time.Hour))
 	writeCopilotSession(t, stateDir, "recent-session", project, 0, now)
 	writeCopilotSession(t, stateDir, "other-dir", filepath.Join(home, "elsewhere"), 0, now)
 
 	restore := &serverRestore{
 		Windows: []restoreWindowState{
-			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: project},
+			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: project, PanePid: 200},
 		},
 	}
 	enrichRestoreWithAgentSessionIDs(restore)
@@ -138,6 +146,8 @@ func TestEnrichRestoreCopilotFallsBackToCwd(t *testing.T) {
 // windows sharing a directory receive distinct sessions (most recent first) and
 // that a session already claimed elsewhere is never reused.
 func TestAssignCopilotSessionsByWorkingDirectoryDedups(t *testing.T) {
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() { processStartedAtForMetadata = originalProcessStart })
 	home := t.TempDir()
 	setTestHomeDir(t, home)
 	stateDir := filepath.Join(home, ".copilot", "session-state")
@@ -147,6 +157,16 @@ func TestAssignCopilotSessionsByWorkingDirectoryDedups(t *testing.T) {
 	}
 
 	now := time.Now()
+	processStartedAtForMetadata = func(pid int) time.Time {
+		switch pid {
+		case 201:
+			return now.Add(-10 * time.Minute)
+		case 202:
+			return now.Add(-3 * time.Hour)
+		default:
+			return time.Time{}
+		}
+	}
 	writeCopilotSession(t, stateDir, "sess-newest", project, 0, now)
 	writeCopilotSession(t, stateDir, "sess-middle", project, 0, now.Add(-time.Hour))
 	writeCopilotSession(t, stateDir, "sess-oldest", project, 0, now.Add(-2*time.Hour))
@@ -156,8 +176,8 @@ func TestAssignCopilotSessionsByWorkingDirectoryDedups(t *testing.T) {
 			// Already resolved by the process table — must be left untouched and
 			// not reused for the other windows.
 			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: project, AgentSessionID: "sess-middle"},
-			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: project},
-			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: project},
+			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: project, PanePid: 201},
+			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: project, PanePid: 202},
 		},
 	}
 	assignCopilotSessionsByWorkingDirectory(restore)
@@ -175,7 +195,42 @@ func TestAssignCopilotSessionsByWorkingDirectoryDedups(t *testing.T) {
 
 // TestAssignCopilotSessionsByWorkingDirectoryNormalizesPaths confirms a window
 // cwd and a session cwd match through ~ expansion and symlink resolution.
+
+func TestCopilotCwdFallbackDoesNotResumeSessionFromBeforeFreshProcess(t *testing.T) {
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() { processStartedAtForMetadata = originalProcessStart })
+	home := t.TempDir()
+	setTestHomeDir(t, home)
+	project := filepath.Join(home, "project")
+	stateDir := filepath.Join(home, ".copilot", "session-state")
+	processStarted := time.Now().UTC().Truncate(time.Second)
+	writeCopilotSession(t, stateDir, "stale-session", project, 0, processStarted.Add(-time.Hour))
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return processStarted
+		}
+		return time.Time{}
+	}
+	restore := &serverRestore{Windows: []restoreWindowState{{
+		Name: "Copilot CLI", AgentTool: "copilot", Cwd: project, PanePid: 200,
+	}}}
+
+	assignCopilotSessionsByWorkingDirectory(restore)
+
+	if got := restore.Windows[0].AgentSessionID; got != "" {
+		t.Fatalf("fresh Copilot process inherited stale session %q", got)
+	}
+}
+
 func TestAssignCopilotSessionsByWorkingDirectoryNormalizesPaths(t *testing.T) {
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() { processStartedAtForMetadata = originalProcessStart })
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return time.Now().Add(-time.Minute)
+		}
+		return time.Time{}
+	}
 	home := t.TempDir()
 	setTestHomeDir(t, home)
 	stateDir := filepath.Join(home, ".copilot", "session-state")
@@ -193,7 +248,7 @@ func TestAssignCopilotSessionsByWorkingDirectoryNormalizesPaths(t *testing.T) {
 
 	restore := &serverRestore{
 		Windows: []restoreWindowState{
-			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: linkDir},
+			{Name: "Copilot CLI", AgentTool: "copilot", Cwd: linkDir, PanePid: 200},
 		},
 	}
 	assignCopilotSessionsByWorkingDirectory(restore)

--- a/remote/monkeymux/copilot_restore_fallback_test.go
+++ b/remote/monkeymux/copilot_restore_fallback_test.go
@@ -145,8 +145,12 @@ func TestEnrichRestoreCopilotFallsBackToCwd(t *testing.T) {
 		t.Fatalf("session id = %q, want most-recent session for cwd (recent-session)", got)
 	}
 	options := createWindowOptionsForRestore(restore.Windows[0], false)
-	if options.command != "copilot --resume 'recent-session' || copilot" {
-		t.Fatalf("command = %q, want copilot resume with fresh fallback", options.command)
+	want := agentResumeCommandWithFreshFallback(
+		agentResumeCommand("copilot", "recent-session", false),
+		agentLaunchCommand("copilot", false),
+	)
+	if options.command != want {
+		t.Fatalf("command = %q, want %q", options.command, want)
 	}
 }
 

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -2894,7 +2894,7 @@ func enrichRestoreWithAgentSessionIDs(restore *serverRestore) {
 	}
 	processes := map[int]processInfo{}
 	if len(panePids) > 0 {
-		processes = readProcessTable()
+		processes = processTableForMetadata()
 	}
 	piSessions := map[int]piRestoreSession{}
 	if hasPiWindows {
@@ -2957,7 +2957,7 @@ func applyPiRestoreSessions(restore *serverRestore, sessions map[int]piRestoreSe
 		restore.Windows[i].AgentSessionID = ""
 		restore.Windows[i].AgentSessionDir = ""
 		restore.Windows[i].AgentSessionPath = ""
-		if session, ok := sessions[i]; ok {
+		if session, ok := sessions[i]; ok && agentToolForRestore(restore.Windows[i]) == "pi" {
 			restore.Windows[i].AgentSessionID = session.sessionID
 			restore.Windows[i].AgentSessionDir = session.sessionDir
 			restore.Windows[i].AgentSessionPath = session.sessionPath
@@ -3013,10 +3013,6 @@ func readAntigravityHistoryEntries() []antigravityHistoryEntry {
 		return nil
 	}
 	defer file.Close()
-	info, err := file.Stat()
-	if err != nil {
-		return nil
-	}
 
 	scanner := bufio.NewScanner(file)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -3025,6 +3021,7 @@ func readAntigravityHistoryEntries() []antigravityHistoryEntry {
 		var raw struct {
 			ConversationID string `json:"conversationId"`
 			Workspace      string `json:"workspace"`
+			Timestamp      int64  `json:"timestamp"`
 		}
 		if err := json.Unmarshal(scanner.Bytes(), &raw); err != nil {
 			continue
@@ -3036,7 +3033,7 @@ func readAntigravityHistoryEntries() []antigravityHistoryEntry {
 		entries = append(entries, antigravityHistoryEntry{
 			conversationID: sessionID,
 			workspace:      normalizedAntigravityWorkspacePath(raw.Workspace),
-			updatedAt:      info.ModTime(),
+			updatedAt:      unixDatabaseTime(strconv.FormatInt(raw.Timestamp, 10)),
 		})
 	}
 	return entries
@@ -3255,6 +3252,8 @@ var processStartedAtForMetadata = func(pid int) time.Time {
 	return inspectProcess(pid).started
 }
 
+var processTableForMetadata = readProcessTable
+
 type piRestoreSession struct {
 	sessionID   string
 	sessionDir  string
@@ -3278,7 +3277,7 @@ func discoverPiSessions(
 	}
 	used := map[string]bool{}
 	for _, window := range restore.Windows {
-		if agentToolCandidateForRestore(window) == "pi" {
+		if agentToolForRestore(window) == "pi" {
 			continue
 		}
 		if id := strings.TrimSpace(window.AgentSessionID); id != "" {
@@ -3305,6 +3304,9 @@ func discoverPiSessions(
 			continue
 		}
 		process, hasProcess := piProcesses[window.PanePid]
+		if agentToolForRestore(window) != "pi" && !hasProcess {
+			continue
+		}
 		if hasProcess {
 			restore.Windows[i].AgentToolConfirmed = true
 			livePiWindows[i] = true
@@ -3403,6 +3405,10 @@ func discoverPiSessions(
 			indices,
 			candidates,
 		) {
+			if !livePiWindows[index] ||
+				!sessionUpdatedDuringProcess(candidate.modTime, processStarts[index]) {
+				continue
+			}
 			sessions[index] = piRestoreSession{
 				sessionID:   candidate.sessionID,
 				sessionDir:  filepath.Dir(candidate.path),
@@ -3427,12 +3433,26 @@ func discoverPiSessions(
 		// latest terminal output still brackets the JSONL append for that turn,
 		// which gives upgrades a one-to-one signal even after /new or /resume
 		// made process-start correlation stale. Fail closed if timestamps overlap.
-		for index, candidate := range uniquePiSessionsByWindowActivity(
+		activityMatches := uniquePiSessionsByWindowActivity(
 			restore,
 			remainingIndices,
 			remainingCandidates,
 			livePiWindows,
-		) {
+		)
+		activityOwnedSessionIDs := map[string]bool{}
+		for _, candidate := range activityMatches {
+			activityOwnedSessionIDs[candidate.sessionID] = true
+		}
+		for index, candidate := range activityMatches {
+			if !sessionUpdatedDuringProcess(candidate.modTime, processStarts[index]) ||
+				piSessionWasSuperseded(
+					remainingCandidates,
+					candidate,
+					processStarts[index],
+					activityOwnedSessionIDs,
+				) {
+				continue
+			}
 			sessions[index] = piRestoreSession{
 				sessionID:   candidate.sessionID,
 				sessionDir:  filepath.Dir(candidate.path),
@@ -3455,29 +3475,20 @@ func discoverPiSessions(
 
 		// Compute every pane's process-time match before reserving any session.
 		// A greedy pass can let an earlier pane steal a later pane's only match.
-		provisional := map[int]piSessionEntry{}
-		owners := map[string][]int{}
+		processMatchesByWindow := map[int][]piSessionEntry{}
 		for _, index := range remainingIndices {
-			matches := piLeafSessionMatches(
+			processMatchesByWindow[index] = piLeafSessionMatches(
 				piSessionsCreatedForProcessStart(
 					remainingCandidates,
 					processStarts[index],
 				),
 				remainingCandidates,
 			)
-			if len(matches) != 1 {
-				continue
-			}
-			provisional[index] = matches[0]
-			owners[matches[0].sessionID] = append(owners[matches[0].sessionID], index)
 		}
+		provisional := uniquePiSessionAssignments(processMatchesByWindow)
 		ownedSessionIDs := map[string]bool{}
-		for index, candidate := range provisional {
-			if len(owners[candidate.sessionID]) == 1 {
-				ownedSessionIDs[candidate.sessionID] = true
-			} else {
-				delete(provisional, index)
-			}
+		for _, candidate := range provisional {
+			ownedSessionIDs[candidate.sessionID] = true
 		}
 		accepted := map[int]piSessionEntry{}
 		for index, candidate := range provisional {
@@ -3562,10 +3573,18 @@ func discoverPiSessions(
 		// Preserve the old cwd fallback only for a genuinely one-to-one
 		// bucket. Never hand a leftover session to a pane after a multi-pane
 		// process match was rejected as ambiguous.
-		if len(remainingIndices) == 1 && len(remainingCandidates) == 1 {
-			index := remainingIndices[0]
-			if _, ok := sessions[index]; !ok {
-				candidate := remainingCandidates[0]
+		if len(indices) == 1 && len(candidates) == 1 {
+			index := indices[0]
+			candidate := candidates[0]
+			if _, ok := sessions[index]; !ok &&
+				livePiWindows[index] &&
+				sessionUpdatedDuringProcess(candidate.modTime, processStarts[index]) &&
+				!piSessionWasSuperseded(
+					candidates,
+					candidate,
+					processStarts[index],
+					map[string]bool{candidate.sessionID: true},
+				) {
 				sessions[index] = piRestoreSession{
 					sessionID:   candidate.sessionID,
 					sessionDir:  filepath.Dir(candidate.path),
@@ -3584,8 +3603,7 @@ func uniquePiSessionsByWindowActivity(
 	candidates []piSessionEntry,
 	livePiWindows map[int]bool,
 ) map[int]piSessionEntry {
-	provisional := map[int]piSessionEntry{}
-	owners := map[string][]int{}
+	matchesByWindow := map[int][]piSessionEntry{}
 	for _, index := range indices {
 		if !livePiWindows[index] {
 			continue
@@ -3608,19 +3626,28 @@ func uniquePiSessionsByWindowActivity(
 				matches = append(matches, candidate)
 			}
 		}
-		matches = piLeafSessionMatches(matches, candidates)
-		if len(matches) != 1 {
+		matchesByWindow[index] = piLeafSessionMatches(matches, candidates)
+	}
+	return uniquePiSessionAssignments(matchesByWindow)
+}
+
+func uniquePiSessionAssignments(
+	matchesByWindow map[int][]piSessionEntry,
+) map[int]piSessionEntry {
+	claimants := map[string]int{}
+	for _, matches := range matchesByWindow {
+		for _, candidate := range matches {
+			claimants[candidate.sessionID]++
+		}
+	}
+	assignments := map[int]piSessionEntry{}
+	for index, matches := range matchesByWindow {
+		if len(matches) != 1 || claimants[matches[0].sessionID] != 1 {
 			continue
 		}
-		provisional[index] = matches[0]
-		owners[matches[0].sessionID] = append(owners[matches[0].sessionID], index)
+		assignments[index] = matches[0]
 	}
-	for index, candidate := range provisional {
-		if len(owners[candidate.sessionID]) != 1 {
-			delete(provisional, index)
-		}
-	}
-	return provisional
+	return assignments
 }
 
 func uniquePiSessionsByPaneTitle(
@@ -3628,8 +3655,7 @@ func uniquePiSessionsByPaneTitle(
 	indices []int,
 	candidates []piSessionEntry,
 ) map[int]piSessionEntry {
-	provisional := map[int]piSessionEntry{}
-	owners := map[string][]int{}
+	matchesByWindow := map[int][]piSessionEntry{}
 	for _, index := range indices {
 		matches := []piSessionEntry{}
 		for _, candidate := range candidates {
@@ -3637,19 +3663,9 @@ func uniquePiSessionsByPaneTitle(
 				matches = append(matches, candidate)
 			}
 		}
-		matches = piLeafSessionMatches(matches, candidates)
-		if len(matches) != 1 {
-			continue
-		}
-		provisional[index] = matches[0]
-		owners[matches[0].sessionID] = append(owners[matches[0].sessionID], index)
+		matchesByWindow[index] = piLeafSessionMatches(matches, candidates)
 	}
-	for index, candidate := range provisional {
-		if len(owners[candidate.sessionID]) != 1 {
-			delete(provisional, index)
-		}
-	}
-	return provisional
+	return uniquePiSessionAssignments(matchesByWindow)
 }
 
 func piSessionsWithLatestNamesForTitles(
@@ -4320,6 +4336,9 @@ func discoverCopilotSessionIDs(
 			// one so a restored window resumes the live session rather than an
 			// abandoned one.
 			modTime := copilotLockModTime(lock)
+			if !sessionUpdatedDuringProcess(modTime, processStartedAtForMetadata(pid)) {
+				continue
+			}
 			if previous, exists := chosenModTime[panePid]; exists && !modTime.After(previous) {
 				continue
 			}
@@ -4514,6 +4533,46 @@ func assignCopilotSessionsByWorkingDirectory(restore *serverRestore) {
 	}
 }
 
+func agentProcessesByPane(
+	processes map[int]processInfo,
+	panePids map[int]struct{},
+	tool string,
+) map[int]processInfo {
+	selected := map[int]processInfo{}
+	minimumDepth := map[int]int{}
+	minimumDepthCount := map[int]int{}
+	for _, process := range processes {
+		panePid := ancestorPanePID(processes, process.pid, panePids)
+		if panePid <= 0 {
+			continue
+		}
+		command := commandNameFromProcessFields(process.comm, process.args)
+		if agentToolFromCommandName(command) != tool {
+			continue
+		}
+		depth := processDepthFromAncestor(processes, process.pid, panePid)
+		if depth < 0 {
+			continue
+		}
+		priorDepth, exists := minimumDepth[panePid]
+		if !exists || depth < priorDepth {
+			minimumDepth[panePid] = depth
+			minimumDepthCount[panePid] = 1
+			selected[panePid] = process
+			continue
+		}
+		if depth == priorDepth {
+			minimumDepthCount[panePid]++
+		}
+	}
+	for panePid, count := range minimumDepthCount {
+		if count != 1 {
+			delete(selected, panePid)
+		}
+	}
+	return selected
+}
+
 func discoverCodexSessionIDs(
 	processes map[int]processInfo,
 	panePids map[int]struct{},
@@ -4527,14 +4586,14 @@ func discoverCodexSessionIDs(
 	unresolved := []unresolvedCodexProcess{}
 	unresolvedPanes := map[int]struct{}{}
 	workingDirectoryCounts := map[string]int{}
-	for _, process := range processes {
-		panePid := ancestorPanePID(processes, process.pid, panePids)
-		if panePid <= 0 || sessions[panePid] != "" {
-			continue
-		}
-		command := commandNameFromProcessFields(process.comm, process.args)
-		if agentToolFromCommandName(command) != "codex" {
-			continue
+	countedWorkingDirectoryPanes := map[int]bool{}
+	for panePid, process := range agentProcessesByPane(processes, panePids, "codex") {
+		workingDirectory := normalizedMetadataPath(
+			processWorkingDirectoryForMetadata(process.pid),
+		)
+		if workingDirectory != "" && !countedWorkingDirectoryPanes[panePid] {
+			workingDirectoryCounts[workingDirectory]++
+			countedWorkingDirectoryPanes[panePid] = true
 		}
 		if sessionID := agentSessionIDFromArgs("codex", process.args); sessionID != "" {
 			sessions[panePid] = sessionID
@@ -4544,9 +4603,6 @@ func discoverCodexSessionIDs(
 			sessions[panePid] = sessionID
 			continue
 		}
-		workingDirectory := normalizedMetadataPath(
-			processWorkingDirectoryForMetadata(process.pid),
-		)
 		processStarted := processStartedAtForMetadata(process.pid)
 		if workingDirectory == "" || processStarted.IsZero() {
 			continue
@@ -4560,7 +4616,6 @@ func discoverCodexSessionIDs(
 			workingDirectory: workingDirectory,
 			processStarted:   processStarted,
 		})
-		workingDirectoryCounts[workingDirectory]++
 	}
 	for _, candidate := range unresolved {
 		if sessions[candidate.panePid] != "" ||
@@ -4716,22 +4771,19 @@ func discoverOpenCodeSessionIDs(
 	unresolved := []unresolvedOpenCodeProcess{}
 	unresolvedPanes := map[int]struct{}{}
 	workingDirectoryCounts := map[string]int{}
-	for _, process := range processes {
-		panePid := ancestorPanePID(processes, process.pid, panePids)
-		if panePid <= 0 || sessions[panePid] != "" {
-			continue
-		}
-		command := commandNameFromProcessFields(process.comm, process.args)
-		if agentToolFromCommandName(command) != "opencode" {
-			continue
+	countedWorkingDirectoryPanes := map[int]bool{}
+	for panePid, process := range agentProcessesByPane(processes, panePids, "opencode") {
+		workingDirectory := normalizedMetadataPath(
+			processWorkingDirectoryForMetadata(process.pid),
+		)
+		if workingDirectory != "" && !countedWorkingDirectoryPanes[panePid] {
+			workingDirectoryCounts[workingDirectory]++
+			countedWorkingDirectoryPanes[panePid] = true
 		}
 		if sessionID := agentSessionIDFromArgs("opencode", process.args); sessionID != "" {
 			sessions[panePid] = sessionID
 			continue
 		}
-		workingDirectory := normalizedMetadataPath(
-			processWorkingDirectoryForMetadata(process.pid),
-		)
 		if workingDirectory == "" {
 			continue
 		}
@@ -4748,7 +4800,6 @@ func discoverOpenCodeSessionIDs(
 			workingDirectory: workingDirectory,
 			processStarted:   processStarted,
 		})
-		workingDirectoryCounts[workingDirectory]++
 	}
 	if len(unresolved) == 0 {
 		return sessions
@@ -4881,14 +4932,14 @@ func discoverClaudeSessionIDs(
 	unresolved := []unresolvedClaudeProcess{}
 	unresolvedPanes := map[int]struct{}{}
 	workingDirectoryCounts := map[string]int{}
-	for _, process := range processes {
-		panePid := ancestorPanePID(processes, process.pid, panePids)
-		if panePid <= 0 || sessions[panePid] != "" {
-			continue
-		}
-		command := commandNameFromProcessFields(process.comm, process.args)
-		if agentToolFromCommandName(command) != "claude" {
-			continue
+	countedWorkingDirectoryPanes := map[int]bool{}
+	for panePid, process := range agentProcessesByPane(processes, panePids, "claude") {
+		workingDirectory := normalizedMetadataPath(
+			processWorkingDirectoryForMetadata(process.pid),
+		)
+		if workingDirectory != "" && !countedWorkingDirectoryPanes[panePid] {
+			workingDirectoryCounts[workingDirectory]++
+			countedWorkingDirectoryPanes[panePid] = true
 		}
 		if sessionID := agentSessionIDFromArgs("claude", process.args); sessionID != "" {
 			sessions[panePid] = sessionID
@@ -4898,9 +4949,6 @@ func discoverClaudeSessionIDs(
 			sessions[panePid] = sessionID
 			continue
 		}
-		workingDirectory := normalizedMetadataPath(
-			processWorkingDirectoryForMetadata(process.pid),
-		)
 		processStarted := processStartedAtForMetadata(process.pid)
 		if workingDirectory == "" || processStarted.IsZero() {
 			continue
@@ -4914,7 +4962,6 @@ func discoverClaudeSessionIDs(
 			workingDirectory: workingDirectory,
 			processStarted:   processStarted,
 		})
-		workingDirectoryCounts[workingDirectory]++
 	}
 	for _, candidate := range unresolved {
 		if sessions[candidate.panePid] != "" ||
@@ -5022,14 +5069,14 @@ func discoverGeminiSessionIDs(
 	unresolved := []unresolvedGeminiProcess{}
 	unresolvedPanes := map[int]struct{}{}
 	workingDirectoryCounts := map[string]int{}
-	for _, process := range processes {
-		panePid := ancestorPanePID(processes, process.pid, panePids)
-		if panePid <= 0 || sessions[panePid] != "" {
-			continue
-		}
-		command := commandNameFromProcessFields(process.comm, process.args)
-		if agentToolFromCommandName(command) != "gemini" {
-			continue
+	countedWorkingDirectoryPanes := map[int]bool{}
+	for panePid, process := range agentProcessesByPane(processes, panePids, "gemini") {
+		workingDirectory := normalizedMetadataPath(
+			processWorkingDirectoryForMetadata(process.pid),
+		)
+		if workingDirectory != "" && !countedWorkingDirectoryPanes[panePid] {
+			workingDirectoryCounts[workingDirectory]++
+			countedWorkingDirectoryPanes[panePid] = true
 		}
 		if sessionID := agentSessionIDFromArgs("gemini", process.args); sessionID != "" {
 			sessions[panePid] = sessionID
@@ -5039,9 +5086,6 @@ func discoverGeminiSessionIDs(
 			sessions[panePid] = sessionID
 			continue
 		}
-		workingDirectory := normalizedMetadataPath(
-			processWorkingDirectoryForMetadata(process.pid),
-		)
 		if workingDirectory == "" {
 			continue
 		}
@@ -5058,7 +5102,6 @@ func discoverGeminiSessionIDs(
 			workingDirectory: workingDirectory,
 			processStarted:   processStarted,
 		})
-		workingDirectoryCounts[workingDirectory]++
 	}
 	for _, candidate := range unresolved {
 		if sessions[candidate.panePid] != "" ||
@@ -14705,7 +14748,10 @@ func piResumeCommand(sessionID string, sessionDir string, sessionPath string) st
 }
 
 func agentResumeCommand(tool string, sessionID string, startInYoloMode bool) string {
-	quotedSessionID := shellQuote(sessionID)
+	quotedSessionID, ok := shellArgument(sessionID)
+	if !ok {
+		return ""
+	}
 	switch tool {
 	case "claude":
 		if startInYoloMode {
@@ -14788,15 +14834,7 @@ func canonicalAgentCommandName(command string) string {
 // the shell before it can reach the fallback, so closing a window never
 // relaunches the agent.
 func agentResumeCommandWithFreshFallback(resume string, launch string) string {
-	resume = strings.TrimSpace(resume)
-	launch = strings.TrimSpace(launch)
-	if resume == "" {
-		return launch
-	}
-	if launch == "" || launch == resume {
-		return resume
-	}
-	return resume + " || " + launch
+	return piResumeCommandWithFreshFallback(resume, launch)
 }
 
 func agentToolFromTerminalTitle(title string) string {

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -2872,6 +2872,7 @@ func enrichRestoreWithAgentSessionIDs(restore *serverRestore) {
 		return
 	}
 	panePids := map[int]struct{}{}
+	paneWorkingDirectories := map[int]string{}
 	hasAntigravityWindows := false
 	hasCursorWindows := false
 	hasPiWindows := false
@@ -2891,6 +2892,7 @@ func enrichRestoreWithAgentSessionIDs(restore *serverRestore) {
 		}
 		if tool != "" && window.PanePid > 0 {
 			panePids[window.PanePid] = struct{}{}
+			paneWorkingDirectories[window.PanePid] = window.Cwd
 		}
 	}
 	processes := map[int]processInfo{}
@@ -2914,10 +2916,10 @@ func enrichRestoreWithAgentSessionIDs(restore *serverRestore) {
 	if len(processes) > 0 {
 		processDiscoveredSessions = map[string]map[int]string{
 			"copilot":  discoverCopilotSessionIDs(processes, panePids),
-			"codex":    discoverCodexSessionIDs(processes, panePids),
-			"opencode": discoverOpenCodeSessionIDs(processes, panePids),
-			"claude":   discoverClaudeSessionIDs(processes, panePids),
-			"gemini":   discoverGeminiSessionIDs(processes, panePids),
+			"codex":    discoverCodexSessionIDs(processes, panePids, paneWorkingDirectories),
+			"opencode": discoverOpenCodeSessionIDs(processes, panePids, paneWorkingDirectories),
+			"claude":   discoverClaudeSessionIDs(processes, panePids, paneWorkingDirectories),
+			"gemini":   discoverGeminiSessionIDs(processes, panePids, paneWorkingDirectories),
 		}
 	}
 	for i := range restore.Windows {
@@ -4627,9 +4629,26 @@ func agentProcessesByPane(
 	return selected
 }
 
+func agentWorkingDirectoryForMetadata(
+	processPID int,
+	panePID int,
+	fallbackWorkingDirectories []map[int]string,
+) string {
+	if workingDirectory := normalizedMetadataPath(
+		processWorkingDirectoryForMetadata(processPID),
+	); workingDirectory != "" {
+		return workingDirectory
+	}
+	if len(fallbackWorkingDirectories) == 0 {
+		return ""
+	}
+	return normalizedMetadataPath(fallbackWorkingDirectories[0][panePID])
+}
+
 func discoverCodexSessionIDs(
 	processes map[int]processInfo,
 	panePids map[int]struct{},
+	fallbackWorkingDirectories ...map[int]string,
 ) map[int]string {
 	type unresolvedCodexProcess struct {
 		panePid          int
@@ -4642,8 +4661,10 @@ func discoverCodexSessionIDs(
 	workingDirectoryCounts := map[string]int{}
 	countedWorkingDirectoryPanes := map[int]bool{}
 	for panePid, process := range agentProcessesByPane(processes, panePids, "codex") {
-		workingDirectory := normalizedMetadataPath(
-			processWorkingDirectoryForMetadata(process.pid),
+		workingDirectory := agentWorkingDirectoryForMetadata(
+			process.pid,
+			panePid,
+			fallbackWorkingDirectories,
 		)
 		if workingDirectory != "" && !countedWorkingDirectoryPanes[panePid] {
 			workingDirectoryCounts[workingDirectory]++
@@ -4815,6 +4836,7 @@ var openCodeSessionEntriesReader = defaultOpenCodeSessionEntries
 func discoverOpenCodeSessionIDs(
 	processes map[int]processInfo,
 	panePids map[int]struct{},
+	fallbackWorkingDirectories ...map[int]string,
 ) map[int]string {
 	type unresolvedOpenCodeProcess struct {
 		panePid          int
@@ -4827,8 +4849,10 @@ func discoverOpenCodeSessionIDs(
 	workingDirectoryCounts := map[string]int{}
 	countedWorkingDirectoryPanes := map[int]bool{}
 	for panePid, process := range agentProcessesByPane(processes, panePids, "opencode") {
-		workingDirectory := normalizedMetadataPath(
-			processWorkingDirectoryForMetadata(process.pid),
+		workingDirectory := agentWorkingDirectoryForMetadata(
+			process.pid,
+			panePid,
+			fallbackWorkingDirectories,
 		)
 		if workingDirectory != "" && !countedWorkingDirectoryPanes[panePid] {
 			workingDirectoryCounts[workingDirectory]++
@@ -4976,6 +5000,7 @@ var claudeSessionIDPattern = regexp.MustCompile(
 func discoverClaudeSessionIDs(
 	processes map[int]processInfo,
 	panePids map[int]struct{},
+	fallbackWorkingDirectories ...map[int]string,
 ) map[int]string {
 	type unresolvedClaudeProcess struct {
 		panePid          int
@@ -4988,8 +5013,10 @@ func discoverClaudeSessionIDs(
 	workingDirectoryCounts := map[string]int{}
 	countedWorkingDirectoryPanes := map[int]bool{}
 	for panePid, process := range agentProcessesByPane(processes, panePids, "claude") {
-		workingDirectory := normalizedMetadataPath(
-			processWorkingDirectoryForMetadata(process.pid),
+		workingDirectory := agentWorkingDirectoryForMetadata(
+			process.pid,
+			panePid,
+			fallbackWorkingDirectories,
 		)
 		if workingDirectory != "" && !countedWorkingDirectoryPanes[panePid] {
 			workingDirectoryCounts[workingDirectory]++
@@ -5113,6 +5140,7 @@ type geminiSessionMetadata struct {
 func discoverGeminiSessionIDs(
 	processes map[int]processInfo,
 	panePids map[int]struct{},
+	fallbackWorkingDirectories ...map[int]string,
 ) map[int]string {
 	type unresolvedGeminiProcess struct {
 		panePid          int
@@ -5125,8 +5153,10 @@ func discoverGeminiSessionIDs(
 	workingDirectoryCounts := map[string]int{}
 	countedWorkingDirectoryPanes := map[int]bool{}
 	for panePid, process := range agentProcessesByPane(processes, panePids, "gemini") {
-		workingDirectory := normalizedMetadataPath(
-			processWorkingDirectoryForMetadata(process.pid),
+		workingDirectory := agentWorkingDirectoryForMetadata(
+			process.pid,
+			panePid,
+			fallbackWorkingDirectories,
 		)
 		if workingDirectory != "" && !countedWorkingDirectoryPanes[panePid] {
 			workingDirectoryCounts[workingDirectory]++

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -1971,6 +1971,15 @@ func acquireSessionLock(session string) (func(), error) {
 	var nextStaleCheck time.Time
 	for clears := 0; ; {
 		record, acquired, err := installSessionLockFile(path)
+		if errors.Is(err, os.ErrNotExist) && time.Now().Before(deadline) {
+			// A concurrent cleanup may remove the per-user runtime directory
+			// after the initial MkdirAll. Recreate it and retry the same lock
+			// generation instead of failing an otherwise valid contender.
+			if mkdirErr := os.MkdirAll(filepath.Dir(path), 0o700); mkdirErr != nil {
+				return nil, mkdirErr
+			}
+			continue
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -66,7 +66,7 @@ const (
 	piSessionMetadataRecordLimitBytes = 1024 * 1024
 	piSessionHeaderScanLimitBytes     = 1024 * 1024
 	piSessionActivityMatchTolerance   = 15 * time.Second
-	claudeSessionStartTolerance       = 2 * time.Second
+	agentSessionStartTolerance        = 2 * time.Second
 	oscBufferLimitBytes               = 4096
 	processMetadataTimeout            = 500 * time.Millisecond
 	processMetadataInterval           = 500 * time.Millisecond
@@ -2874,9 +2874,6 @@ func enrichRestoreWithAgentSessionIDs(restore *serverRestore) {
 				panePids[window.PanePid] = struct{}{}
 			}
 		}
-		if strings.TrimSpace(window.AgentSessionID) != "" {
-			continue
-		}
 		switch tool {
 		case "antigravity":
 			hasAntigravityWindows = true
@@ -2904,21 +2901,6 @@ func enrichRestoreWithAgentSessionIDs(restore *serverRestore) {
 		piSessions = discoverPiSessions(restore, processes, panePids)
 		applyPiRestoreSessions(restore, piSessions)
 	}
-	if len(panePids) == 0 {
-		for i, sessionID := range antigravitySessions {
-			restore.Windows[i].AgentSessionID = sessionID
-		}
-		for i, sessionID := range cursorSessions {
-			restore.Windows[i].AgentSessionID = sessionID
-		}
-		for i, session := range piSessions {
-			restore.Windows[i].AgentSessionID = session.sessionID
-			restore.Windows[i].AgentSessionDir = session.sessionDir
-			restore.Windows[i].AgentSessionPath = session.sessionPath
-		}
-		assignCopilotSessionsByWorkingDirectory(restore)
-		return
-	}
 	processDiscoveredSessions := map[string]map[int]string{}
 	if len(processes) > 0 {
 		processDiscoveredSessions = map[string]map[int]string{
@@ -2930,9 +2912,6 @@ func enrichRestoreWithAgentSessionIDs(restore *serverRestore) {
 		}
 	}
 	for i := range restore.Windows {
-		if strings.TrimSpace(restore.Windows[i].AgentSessionID) != "" {
-			continue
-		}
 		tool := agentToolForRestore(restore.Windows[i])
 		panePid := restore.Windows[i].PanePid
 		if tool == "" {
@@ -2944,28 +2923,28 @@ func enrichRestoreWithAgentSessionIDs(restore *serverRestore) {
 			// discovery and lose the exact path.
 			continue
 		}
+		discoveredSessionID := ""
 		if panePid > 0 {
-			if sessionID := processDiscoveredSessions[tool][panePid]; sessionID != "" {
-				restore.Windows[i].AgentSessionID = sessionID
-				continue
-			}
+			discoveredSessionID = processDiscoveredSessions[tool][panePid]
 		}
-		if panePid > 0 && len(processes) > 0 {
-			if sessionID := sessionIDFromDescendantProcessArgs(processes, panePid, tool); sessionID != "" {
-				restore.Windows[i].AgentSessionID = sessionID
-				continue
-			}
+		if discoveredSessionID == "" && panePid > 0 && len(processes) > 0 {
+			discoveredSessionID = sessionIDFromDescendantProcessArgs(
+				processes,
+				panePid,
+				tool,
+			)
 		}
-		if tool == "antigravity" {
-			if sessionID := antigravitySessions[i]; sessionID != "" {
-				restore.Windows[i].AgentSessionID = sessionID
-			}
+		if discoveredSessionID == "" && tool == "antigravity" {
+			discoveredSessionID = antigravitySessions[i]
 		}
-		if tool == "cursor-agent" {
-			if sessionID := cursorSessions[i]; sessionID != "" {
-				restore.Windows[i].AgentSessionID = sessionID
-			}
+		if discoveredSessionID == "" && tool == "cursor-agent" {
+			discoveredSessionID = cursorSessions[i]
 		}
+		// A carried ID describes what MonkeyMux tried to resume, not proof that
+		// the resume succeeded. If the command fell back to a fresh agent, its
+		// live argv/open file/store has no matching identity, so clear the stale
+		// ID instead of forcing that old conversation again on the next upgrade.
+		restore.Windows[i].AgentSessionID = discoveredSessionID
 	}
 	assignCopilotSessionsByWorkingDirectory(restore)
 }
@@ -2989,6 +2968,7 @@ func applyPiRestoreSessions(restore *serverRestore, sessions map[int]piRestoreSe
 type antigravityHistoryEntry struct {
 	conversationID string
 	workspace      string
+	updatedAt      time.Time
 }
 
 func discoverAntigravitySessionIDs(restore *serverRestore) map[int]string {
@@ -2996,37 +2976,31 @@ func discoverAntigravitySessionIDs(restore *serverRestore) map[int]string {
 	if len(entries) == 0 {
 		return nil
 	}
-	latestSessionID := latestAntigravitySessionID(entries)
-	needsFallback := antigravityRestoreWindowCount(restore) == 1
+	workspaceCounts := map[string]int{}
+	for _, window := range restore.Windows {
+		if agentToolForRestore(window) == "antigravity" {
+			workspaceCounts[normalizedAntigravityWorkspacePath(window.Cwd)]++
+		}
+	}
 	sessions := map[int]string{}
 	for i, window := range restore.Windows {
-		if strings.TrimSpace(window.AgentSessionID) != "" ||
-			agentToolForRestore(window) != "antigravity" {
+		if agentToolForRestore(window) != "antigravity" {
 			continue
 		}
-		if sessionID := antigravitySessionIDForWorkspace(entries, window.Cwd); sessionID != "" {
+		workspace := normalizedAntigravityWorkspacePath(window.Cwd)
+		if workspace == "" || workspaceCounts[workspace] != 1 {
+			continue
+		}
+		processStarted := processStartedAtForMetadata(window.PanePid)
+		if sessionID := antigravitySessionIDForWorkspace(
+			entries,
+			workspace,
+			processStarted,
+		); sessionID != "" {
 			sessions[i] = sessionID
-			continue
-		}
-		if needsFallback && latestSessionID != "" {
-			sessions[i] = latestSessionID
 		}
 	}
 	return sessions
-}
-
-func antigravityRestoreWindowCount(restore *serverRestore) int {
-	if restore == nil {
-		return 0
-	}
-	count := 0
-	for _, window := range restore.Windows {
-		if strings.TrimSpace(window.AgentSessionID) == "" &&
-			agentToolForRestore(window) == "antigravity" {
-			count++
-		}
-	}
-	return count
 }
 
 func readAntigravityHistoryEntries() []antigravityHistoryEntry {
@@ -3039,6 +3013,10 @@ func readAntigravityHistoryEntries() []antigravityHistoryEntry {
 		return nil
 	}
 	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil
+	}
 
 	scanner := bufio.NewScanner(file)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -3058,30 +3036,24 @@ func readAntigravityHistoryEntries() []antigravityHistoryEntry {
 		entries = append(entries, antigravityHistoryEntry{
 			conversationID: sessionID,
 			workspace:      normalizedAntigravityWorkspacePath(raw.Workspace),
+			updatedAt:      info.ModTime(),
 		})
 	}
 	return entries
 }
 
-func latestAntigravitySessionID(entries []antigravityHistoryEntry) string {
-	for i := len(entries) - 1; i >= 0; i-- {
-		if sessionID := strings.TrimSpace(entries[i].conversationID); sessionID != "" {
-			return sessionID
-		}
-	}
-	return ""
-}
-
 func antigravitySessionIDForWorkspace(
 	entries []antigravityHistoryEntry,
 	workspace string,
+	processStarted time.Time,
 ) string {
 	normalizedWorkspace := normalizedAntigravityWorkspacePath(workspace)
 	if normalizedWorkspace == "" {
 		return ""
 	}
 	for i := len(entries) - 1; i >= 0; i-- {
-		if entries[i].workspace == normalizedWorkspace {
+		if entries[i].workspace == normalizedWorkspace &&
+			sessionUpdatedDuringProcess(entries[i].updatedAt, processStarted) {
 			return entries[i].conversationID
 		}
 	}
@@ -3106,9 +3078,9 @@ func normalizedAntigravityWorkspacePath(value string) string {
 
 // ── Cursor Agent ─────────────────────────────────────────────────────────────
 // Cursor persists chats under ~/.cursor/chats/<workspaceHash>/<chatId>/meta.json.
-// A fresh `cursor-agent` launch carries no resumable id in its process args, so
-// after a MonkeyMux helper update recreates its windows the id is recovered from
-// the chat store keyed by the pane's working directory (matching meta.json cwd).
+// A fresh `cursor-agent` launch carries no resumable id in its process args.
+// Restore only a unique chat for the pane's workspace that was updated during
+// the current Cursor process; older chats leave a fresh window fresh.
 
 type cursorChatEntry struct {
 	chatID    string
@@ -3121,37 +3093,31 @@ func discoverCursorSessionIDs(restore *serverRestore) map[int]string {
 	if len(entries) == 0 {
 		return nil
 	}
-	latestSessionID := latestCursorSessionID(entries)
-	needsFallback := cursorRestoreWindowCount(restore) == 1
+	workspaceCounts := map[string]int{}
+	for _, window := range restore.Windows {
+		if agentToolForRestore(window) == "cursor-agent" {
+			workspaceCounts[normalizedCursorWorkspacePath(window.Cwd)]++
+		}
+	}
 	sessions := map[int]string{}
 	for i, window := range restore.Windows {
-		if strings.TrimSpace(window.AgentSessionID) != "" ||
-			agentToolForRestore(window) != "cursor-agent" {
+		if agentToolForRestore(window) != "cursor-agent" {
 			continue
 		}
-		if sessionID := cursorSessionIDForWorkspace(entries, window.Cwd); sessionID != "" {
+		workspace := normalizedCursorWorkspacePath(window.Cwd)
+		if workspace == "" || workspaceCounts[workspace] != 1 {
+			continue
+		}
+		processStarted := processStartedAtForMetadata(window.PanePid)
+		if sessionID := cursorSessionIDForWorkspace(
+			entries,
+			workspace,
+			processStarted,
+		); sessionID != "" {
 			sessions[i] = sessionID
-			continue
-		}
-		if needsFallback && latestSessionID != "" {
-			sessions[i] = latestSessionID
 		}
 	}
 	return sessions
-}
-
-func cursorRestoreWindowCount(restore *serverRestore) int {
-	if restore == nil {
-		return 0
-	}
-	count := 0
-	for _, window := range restore.Windows {
-		if strings.TrimSpace(window.AgentSessionID) == "" &&
-			agentToolForRestore(window) == "cursor-agent" {
-			count++
-		}
-	}
-	return count
 }
 
 // readCursorChatEntries reads recent Cursor chat metadata, ordered oldest to
@@ -3228,22 +3194,19 @@ func readCursorChatMeta(path string, chatID string) (cursorChatEntry, bool) {
 	}, true
 }
 
-func latestCursorSessionID(entries []cursorChatEntry) string {
-	for i := len(entries) - 1; i >= 0; i-- {
-		if sessionID := strings.TrimSpace(entries[i].chatID); sessionID != "" {
-			return sessionID
-		}
-	}
-	return ""
-}
-
-func cursorSessionIDForWorkspace(entries []cursorChatEntry, workspace string) string {
+func cursorSessionIDForWorkspace(
+	entries []cursorChatEntry,
+	workspace string,
+	processStarted time.Time,
+) string {
 	normalizedWorkspace := normalizedCursorWorkspacePath(workspace)
 	if normalizedWorkspace == "" {
 		return ""
 	}
 	for i := len(entries) - 1; i >= 0; i-- {
-		if entries[i].cwd == normalizedWorkspace {
+		updatedAt := time.UnixMilli(entries[i].updatedAt)
+		if entries[i].cwd == normalizedWorkspace &&
+			sessionUpdatedDuringProcess(updatedAt, processStarted) {
 			return entries[i].chatID
 		}
 	}
@@ -4376,13 +4339,16 @@ func copilotLockModTime(lock string) time.Time {
 	return time.Time{}
 }
 
+type copilotSessionEntry struct {
+	id        string
+	updatedAt time.Time
+}
+
 // copilotSessionsByWorkingDirectory groups on-disk copilot sessions by the
 // working directory recorded in each session's events log, most recently
-// active first. It is the on-disk fallback used when the live process table no
-// longer maps a restored copilot window to its session (the helper upgrade
-// already reaped the process, ps timed out, or the inuse lock had been
-// cleared) so the window can still resume the right conversation.
-func copilotSessionsByWorkingDirectory() map[string][]string {
+// active first. It supplements authoritative inuse-lock discovery only with
+// sessions updated during the window's current process lifetime.
+func copilotSessionsByWorkingDirectory() map[string][]copilotSessionEntry {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil
@@ -4392,11 +4358,7 @@ func copilotSessionsByWorkingDirectory() map[string][]string {
 	if err != nil {
 		return nil
 	}
-	type sessionEntry struct {
-		id      string
-		modTime time.Time
-	}
-	byDirectory := map[string][]sessionEntry{}
+	byDirectory := map[string][]copilotSessionEntry{}
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -4412,21 +4374,15 @@ func copilotSessionsByWorkingDirectory() map[string][]string {
 		}
 		byDirectory[workingDirectory] = append(
 			byDirectory[workingDirectory],
-			sessionEntry{id: entry.Name(), modTime: modTime},
+			copilotSessionEntry{id: entry.Name(), updatedAt: modTime},
 		)
 	}
-	result := map[string][]string{}
-	for workingDirectory, list := range byDirectory {
+	for _, list := range byDirectory {
 		sort.SliceStable(list, func(i, j int) bool {
-			return list[i].modTime.After(list[j].modTime)
+			return list[i].updatedAt.After(list[j].updatedAt)
 		})
-		ids := make([]string, 0, len(list))
-		for _, session := range list {
-			ids = append(ids, session.id)
-		}
-		result[workingDirectory] = ids
 	}
-	return result
+	return byDirectory
 }
 
 // copilotSessionWorkingDirectory returns the normalized working directory a
@@ -4483,12 +4439,10 @@ func normalizedCopilotWorkingDirectory(path string) string {
 }
 
 // assignCopilotSessionsByWorkingDirectory is the on-disk fallback for restored
-// copilot windows the live process table no longer maps to a session. Each such
-// window resumes the most recent copilot session recorded for its working
-// directory instead of relaunching blank, so a helper upgrade keeps the
-// conversation open in every copilot window. Sessions already claimed by
-// another window (via the process table or an earlier fallback) are never
-// reused, so windows sharing a directory get distinct sessions.
+// Copilot windows whose inuse lock could not identify a session. It considers
+// only sessions updated during that window process and uses terminal activity
+// to disambiguate multiple candidates. Stale or overlapping evidence stays
+// fresh; sessions claimed by another window are never reused.
 func assignCopilotSessionsByWorkingDirectory(restore *serverRestore) {
 	if restore == nil {
 		return
@@ -4521,13 +4475,41 @@ func assignCopilotSessionsByWorkingDirectory(restore *serverRestore) {
 		if workingDirectory == "" {
 			continue
 		}
-		for _, id := range sessionsByDirectory[workingDirectory] {
-			if used[id] {
+		processStarted := processStartedAtForMetadata(restore.Windows[i].PanePid)
+		candidates := []copilotSessionEntry{}
+		for _, session := range sessionsByDirectory[workingDirectory] {
+			if used[session.id] ||
+				!sessionUpdatedDuringProcess(session.updatedAt, processStarted) {
 				continue
 			}
-			restore.Windows[i].AgentSessionID = id
-			used[id] = true
-			break
+			candidates = append(candidates, session)
+		}
+		if len(candidates) == 0 {
+			continue
+		}
+		selected := ""
+		if len(candidates) == 1 {
+			selected = candidates[0].id
+		} else if restore.Windows[i].LastActivityEpochSeconds > 0 {
+			activity := time.Unix(restore.Windows[i].LastActivityEpochSeconds, 0)
+			for _, candidate := range candidates {
+				delta := candidate.updatedAt.Sub(activity)
+				if delta < 0 {
+					delta = -delta
+				}
+				if delta > piSessionActivityMatchTolerance {
+					continue
+				}
+				if selected != "" {
+					selected = ""
+					break
+				}
+				selected = candidate.id
+			}
+		}
+		if selected != "" {
+			restore.Windows[i].AgentSessionID = selected
+			used[selected] = true
 		}
 	}
 }
@@ -4539,6 +4521,7 @@ func discoverCodexSessionIDs(
 	type unresolvedCodexProcess struct {
 		panePid          int
 		workingDirectory string
+		processStarted   time.Time
 	}
 	sessions := map[int]string{}
 	unresolved := []unresolvedCodexProcess{}
@@ -4564,7 +4547,8 @@ func discoverCodexSessionIDs(
 		workingDirectory := normalizedMetadataPath(
 			processWorkingDirectoryForMetadata(process.pid),
 		)
-		if workingDirectory == "" {
+		processStarted := processStartedAtForMetadata(process.pid)
+		if workingDirectory == "" || processStarted.IsZero() {
 			continue
 		}
 		if _, ok := unresolvedPanes[panePid]; ok {
@@ -4574,6 +4558,7 @@ func discoverCodexSessionIDs(
 		unresolved = append(unresolved, unresolvedCodexProcess{
 			panePid:          panePid,
 			workingDirectory: workingDirectory,
+			processStarted:   processStarted,
 		})
 		workingDirectoryCounts[workingDirectory]++
 	}
@@ -4582,7 +4567,10 @@ func discoverCodexSessionIDs(
 			workingDirectoryCounts[candidate.workingDirectory] != 1 {
 			continue
 		}
-		if sessionID := codexRecentSessionIDForWorkingDirectory(candidate.workingDirectory); sessionID != "" {
+		if sessionID := codexRecentSessionIDForWorkingDirectory(
+			candidate.workingDirectory,
+			candidate.processStarted,
+		); sessionID != "" {
 			sessions[candidate.panePid] = sessionID
 		}
 	}
@@ -4598,9 +4586,12 @@ func codexSessionIDFromOpenFiles(pid int) string {
 	return ""
 }
 
-func codexRecentSessionIDForWorkingDirectory(workingDirectory string) string {
+func codexRecentSessionIDForWorkingDirectory(
+	workingDirectory string,
+	processStarted time.Time,
+) string {
 	workingDirectory = normalizedMetadataPath(workingDirectory)
-	if workingDirectory == "" {
+	if workingDirectory == "" || processStarted.IsZero() {
 		return ""
 	}
 	home, err := os.UserHomeDir()
@@ -4609,6 +4600,10 @@ func codexRecentSessionIDForWorkingDirectory(workingDirectory string) string {
 	}
 	sessionsDir := filepath.Join(home, ".codex", "sessions")
 	for _, path := range recentCodexRolloutFiles(sessionsDir, 30) {
+		info, err := os.Stat(path)
+		if err != nil || !sessionUpdatedDuringProcess(info.ModTime(), processStarted) {
+			continue
+		}
 		if normalizedMetadataPath(codexRolloutWorkingDirectory(path)) != workingDirectory {
 			continue
 		}
@@ -4695,12 +4690,13 @@ func codexSessionIDFromRolloutName(name string) string {
 // ── OpenCode ───────────────────────────────────────────────────────────────
 // OpenCode persists sessions in a SQLite store keyed by working directory, so
 // a session launched fresh (`opencode`, no `--session`) carries no resumable
-// ID in its process arguments. Recover the most recent session for the pane's
-// working directory so it keeps resuming after a MonkeyMux helper update.
+// ID in its process arguments. Recover only a same-directory row updated during
+// the current OpenCode process so an older project session is never injected.
 
 type openCodeSessionEntry struct {
 	sessionID string
 	directory string
+	updatedAt time.Time
 }
 
 // openCodeSessionEntriesReader is overridable in tests so the SQLite-backed
@@ -4714,6 +4710,7 @@ func discoverOpenCodeSessionIDs(
 	type unresolvedOpenCodeProcess struct {
 		panePid          int
 		workingDirectory string
+		processStarted   time.Time
 	}
 	sessions := map[int]string{}
 	unresolved := []unresolvedOpenCodeProcess{}
@@ -4742,9 +4739,14 @@ func discoverOpenCodeSessionIDs(
 			continue
 		}
 		unresolvedPanes[panePid] = struct{}{}
+		processStarted := processStartedAtForMetadata(process.pid)
+		if processStarted.IsZero() {
+			continue
+		}
 		unresolved = append(unresolved, unresolvedOpenCodeProcess{
 			panePid:          panePid,
 			workingDirectory: workingDirectory,
+			processStarted:   processStarted,
 		})
 		workingDirectoryCounts[workingDirectory]++
 	}
@@ -4763,6 +4765,7 @@ func discoverOpenCodeSessionIDs(
 		if sessionID := openCodeSessionIDForWorkingDirectory(
 			entries,
 			candidate.workingDirectory,
+			candidate.processStarted,
 		); sessionID != "" {
 			sessions[candidate.panePid] = sessionID
 		}
@@ -4777,14 +4780,16 @@ func readOpenCodeSessionEntries() []openCodeSessionEntry {
 func openCodeSessionIDForWorkingDirectory(
 	entries []openCodeSessionEntry,
 	workingDirectory string,
+	processStarted time.Time,
 ) string {
 	workingDirectory = normalizedMetadataPath(workingDirectory)
-	if workingDirectory == "" {
+	if workingDirectory == "" || processStarted.IsZero() {
 		return ""
 	}
 	// entries are ordered most-recently-updated first.
 	for _, entry := range entries {
-		if entry.directory == workingDirectory {
+		if entry.directory == workingDirectory &&
+			sessionUpdatedDuringProcess(entry.updatedAt, processStarted) {
 			return entry.sessionID
 		}
 	}
@@ -4809,7 +4814,7 @@ func defaultOpenCodeSessionEntries() []openCodeSessionEntry {
 		return nil
 	}
 	const separator = "\x1f"
-	query := "SELECT id, directory FROM session " +
+	query := "SELECT id, directory, time_updated FROM session " +
 		"WHERE parent_id IS NULL AND time_archived IS NULL " +
 		"ORDER BY time_updated DESC LIMIT 200;"
 	ctx, cancel := context.WithTimeout(context.Background(), processMetadataTimeout)
@@ -4830,7 +4835,7 @@ func defaultOpenCodeSessionEntries() []openCodeSessionEntry {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		parts := strings.SplitN(line, separator, 2)
+		parts := strings.SplitN(line, separator, 3)
 		sessionID := strings.TrimSpace(parts[0])
 		if sessionID == "" {
 			continue
@@ -4839,9 +4844,14 @@ func defaultOpenCodeSessionEntries() []openCodeSessionEntry {
 		if len(parts) > 1 {
 			directory = normalizedMetadataPath(parts[1])
 		}
+		updatedAt := time.Time{}
+		if len(parts) > 2 {
+			updatedAt = unixDatabaseTime(parts[2])
+		}
 		entries = append(entries, openCodeSessionEntry{
 			sessionID: sessionID,
 			directory: directory,
+			updatedAt: updatedAt,
 		})
 	}
 	return entries
@@ -4945,7 +4955,7 @@ func claudeRecentSessionIDForWorkingDirectory(
 	projectsDir := filepath.Join(home, ".claude", "projects")
 	for _, path := range recentAgentSessionFiles(projectsDir, 60, isClaudeProjectSessionPath) {
 		info, err := os.Stat(path)
-		if err != nil || info.ModTime().Before(processStarted.Add(-claudeSessionStartTolerance)) {
+		if err != nil || !sessionUpdatedDuringProcess(info.ModTime(), processStarted) {
 			continue
 		}
 		if normalizedMetadataPath(jsonStringFieldFromFile(path, "cwd")) != workingDirectory {
@@ -4983,9 +4993,8 @@ func isClaudeProjectSessionPath(path string) bool {
 // ── Gemini CLI ───────────────────────────────────────────────────────────────
 // Gemini stores chats at `~/.gemini/tmp/<project>/chats/session-*.json`, with
 // the resumable `sessionId` and the project `directories` recorded inside the
-// file. Recover the session from the chat file the process holds open, or the
-// most recent non-subagent chat whose directories include the pane's working
-// directory.
+// file. Recover the session from the chat file the process holds open, or a
+// non-subagent chat for the pane's directory updated during this process.
 
 var (
 	geminiSessionIDFieldPattern   = regexp.MustCompile(`"sessionId"\s*:\s*"((?:\\.|[^"\\])*)"`)
@@ -5007,6 +5016,7 @@ func discoverGeminiSessionIDs(
 	type unresolvedGeminiProcess struct {
 		panePid          int
 		workingDirectory string
+		processStarted   time.Time
 	}
 	sessions := map[int]string{}
 	unresolved := []unresolvedGeminiProcess{}
@@ -5039,9 +5049,14 @@ func discoverGeminiSessionIDs(
 			continue
 		}
 		unresolvedPanes[panePid] = struct{}{}
+		processStarted := processStartedAtForMetadata(process.pid)
+		if processStarted.IsZero() {
+			continue
+		}
 		unresolved = append(unresolved, unresolvedGeminiProcess{
 			panePid:          panePid,
 			workingDirectory: workingDirectory,
+			processStarted:   processStarted,
 		})
 		workingDirectoryCounts[workingDirectory]++
 	}
@@ -5052,6 +5067,7 @@ func discoverGeminiSessionIDs(
 		}
 		if sessionID := geminiRecentSessionIDForWorkingDirectory(
 			candidate.workingDirectory,
+			candidate.processStarted,
 		); sessionID != "" {
 			sessions[candidate.panePid] = sessionID
 		}
@@ -5072,9 +5088,12 @@ func geminiSessionIDFromOpenFiles(pid int) string {
 	return ""
 }
 
-func geminiRecentSessionIDForWorkingDirectory(workingDirectory string) string {
+func geminiRecentSessionIDForWorkingDirectory(
+	workingDirectory string,
+	processStarted time.Time,
+) string {
 	workingDirectory = normalizedMetadataPath(workingDirectory)
-	if workingDirectory == "" {
+	if workingDirectory == "" || processStarted.IsZero() {
 		return ""
 	}
 	home, err := os.UserHomeDir()
@@ -5083,6 +5102,10 @@ func geminiRecentSessionIDForWorkingDirectory(workingDirectory string) string {
 	}
 	tmpDir := filepath.Join(home, ".gemini", "tmp")
 	for _, path := range recentAgentSessionFiles(tmpDir, 60, isGeminiChatSessionPath) {
+		info, err := os.Stat(path)
+		if err != nil || !sessionUpdatedDuringProcess(info.ModTime(), processStarted) {
+			continue
+		}
 		metadata := readGeminiSessionMetadata(path)
 		if metadata.sessionID == "" || metadata.isSubagent {
 			continue
@@ -5154,6 +5177,32 @@ func geminiDirectoriesFromText(text string) []string {
 }
 
 // ── Shared agent session-file helpers ────────────────────────────────────────
+
+// sessionUpdatedDuringProcess is the common safety boundary for cwd/history
+// fallback. A store record from before the foreground process started cannot
+// describe a fresh agent launched by that process.
+func sessionUpdatedDuringProcess(updatedAt time.Time, processStarted time.Time) bool {
+	return !updatedAt.IsZero() &&
+		!processStarted.IsZero() &&
+		!updatedAt.Before(processStarted.Add(-agentSessionStartTolerance))
+}
+
+func unixDatabaseTime(value string) time.Time {
+	raw, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	if err != nil || raw <= 0 {
+		return time.Time{}
+	}
+	switch {
+	case raw >= 100_000_000_000_000_000:
+		return time.Unix(0, raw)
+	case raw >= 100_000_000_000_000:
+		return time.UnixMicro(raw)
+	case raw >= 100_000_000_000:
+		return time.UnixMilli(raw)
+	default:
+		return time.Unix(raw, 0)
+	}
+}
 
 // recentAgentSessionFiles returns up to limit matching files under root,
 // ordered most-recently-modified first.

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -66,6 +66,7 @@ const (
 	piSessionMetadataRecordLimitBytes = 1024 * 1024
 	piSessionHeaderScanLimitBytes     = 1024 * 1024
 	piSessionActivityMatchTolerance   = 15 * time.Second
+	claudeSessionStartTolerance       = 2 * time.Second
 	oscBufferLimitBytes               = 4096
 	processMetadataTimeout            = 500 * time.Millisecond
 	processMetadataInterval           = 500 * time.Millisecond
@@ -4850,8 +4851,8 @@ func defaultOpenCodeSessionEntries() []openCodeSessionEntry {
 // Claude Code stores each session as
 // `~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl`. A freshly launched
 // `claude` carries no `--resume` argument, so recover the session from the
-// rollout file the process holds open, or the most recent project file whose
-// `cwd` matches the pane's working directory.
+// rollout file the process holds open, or a project file whose `cwd` matches
+// the pane and which was written during this Claude process's lifetime.
 
 var claudeSessionIDPattern = regexp.MustCompile(
 	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`,
@@ -4864,6 +4865,7 @@ func discoverClaudeSessionIDs(
 	type unresolvedClaudeProcess struct {
 		panePid          int
 		workingDirectory string
+		processStarted   time.Time
 	}
 	sessions := map[int]string{}
 	unresolved := []unresolvedClaudeProcess{}
@@ -4889,7 +4891,8 @@ func discoverClaudeSessionIDs(
 		workingDirectory := normalizedMetadataPath(
 			processWorkingDirectoryForMetadata(process.pid),
 		)
-		if workingDirectory == "" {
+		processStarted := processStartedAtForMetadata(process.pid)
+		if workingDirectory == "" || processStarted.IsZero() {
 			continue
 		}
 		if _, ok := unresolvedPanes[panePid]; ok {
@@ -4899,6 +4902,7 @@ func discoverClaudeSessionIDs(
 		unresolved = append(unresolved, unresolvedClaudeProcess{
 			panePid:          panePid,
 			workingDirectory: workingDirectory,
+			processStarted:   processStarted,
 		})
 		workingDirectoryCounts[workingDirectory]++
 	}
@@ -4909,6 +4913,7 @@ func discoverClaudeSessionIDs(
 		}
 		if sessionID := claudeRecentSessionIDForWorkingDirectory(
 			candidate.workingDirectory,
+			candidate.processStarted,
 		); sessionID != "" {
 			sessions[candidate.panePid] = sessionID
 		}
@@ -4925,9 +4930,12 @@ func claudeSessionIDFromOpenFiles(pid int) string {
 	return ""
 }
 
-func claudeRecentSessionIDForWorkingDirectory(workingDirectory string) string {
+func claudeRecentSessionIDForWorkingDirectory(
+	workingDirectory string,
+	processStarted time.Time,
+) string {
 	workingDirectory = normalizedMetadataPath(workingDirectory)
-	if workingDirectory == "" {
+	if workingDirectory == "" || processStarted.IsZero() {
 		return ""
 	}
 	home, err := os.UserHomeDir()
@@ -4936,6 +4944,10 @@ func claudeRecentSessionIDForWorkingDirectory(workingDirectory string) string {
 	}
 	projectsDir := filepath.Join(home, ".claude", "projects")
 	for _, path := range recentAgentSessionFiles(projectsDir, 60, isClaudeProjectSessionPath) {
+		info, err := os.Stat(path)
+		if err != nil || info.ModTime().Before(processStarted.Add(-claudeSessionStartTolerance)) {
+			continue
+		}
 		if normalizedMetadataPath(jsonStringFieldFromFile(path, "cwd")) != workingDirectory {
 			continue
 		}

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -3845,6 +3845,7 @@ func piProcessesByPane(
 ) map[int]processInfo {
 	selected := map[int]processInfo{}
 	depths := map[int]int{}
+	minimumDepthCount := map[int]int{}
 	for _, process := range processes {
 		panePid := ancestorPanePID(processes, process.pid, panePids)
 		if panePid <= 0 {
@@ -3860,11 +3861,21 @@ func piProcessesByPane(
 		if depth < 0 {
 			continue
 		}
-		if prior, ok := depths[panePid]; ok && prior <= depth {
+		prior, exists := depths[panePid]
+		if !exists || depth < prior {
+			selected[panePid] = process
+			depths[panePid] = depth
+			minimumDepthCount[panePid] = 1
 			continue
 		}
-		selected[panePid] = process
-		depths[panePid] = depth
+		if depth == prior {
+			minimumDepthCount[panePid]++
+		}
+	}
+	for panePid, count := range minimumDepthCount {
+		if count != 1 {
+			delete(selected, panePid)
+		}
 	}
 	return selected
 }

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -2893,17 +2893,17 @@ func enrichRestoreWithAgentSessionIDs(restore *serverRestore) {
 			panePids[window.PanePid] = struct{}{}
 		}
 	}
-	antigravitySessions := map[int]string{}
-	if hasAntigravityWindows {
-		antigravitySessions = discoverAntigravitySessionIDs(restore)
-	}
-	cursorSessions := map[int]string{}
-	if hasCursorWindows {
-		cursorSessions = discoverCursorSessionIDs(restore)
-	}
 	processes := map[int]processInfo{}
 	if len(panePids) > 0 {
 		processes = processTableForMetadata()
+	}
+	antigravitySessions := map[int]string{}
+	if hasAntigravityWindows {
+		antigravitySessions = discoverAntigravitySessionIDs(restore, processes, panePids)
+	}
+	cursorSessions := map[int]string{}
+	if hasCursorWindows {
+		cursorSessions = discoverCursorSessionIDs(restore, processes, panePids)
 	}
 	piSessions := map[int]piRestoreSession{}
 	if hasPiWindows {
@@ -2937,7 +2937,7 @@ func enrichRestoreWithAgentSessionIDs(restore *serverRestore) {
 			discoveredSessionID = processDiscoveredSessions[tool][panePid]
 		}
 		if discoveredSessionID == "" && panePid > 0 && len(processes) > 0 {
-			discoveredSessionID = sessionIDFromDescendantProcessArgs(
+			discoveredSessionID = sessionIDFromSelectedAgentProcessArgs(
 				processes,
 				panePid,
 				tool,
@@ -2955,7 +2955,7 @@ func enrichRestoreWithAgentSessionIDs(restore *serverRestore) {
 		// ID instead of forcing that old conversation again on the next upgrade.
 		restore.Windows[i].AgentSessionID = discoveredSessionID
 	}
-	assignCopilotSessionsByWorkingDirectory(restore)
+	assignCopilotSessionsByWorkingDirectory(restore, processes, panePids)
 }
 
 func applyPiRestoreSessions(restore *serverRestore, sessions map[int]piRestoreSession) {
@@ -2980,7 +2980,11 @@ type antigravityHistoryEntry struct {
 	updatedAt      time.Time
 }
 
-func discoverAntigravitySessionIDs(restore *serverRestore) map[int]string {
+func discoverAntigravitySessionIDs(
+	restore *serverRestore,
+	processes map[int]processInfo,
+	panePids map[int]struct{},
+) map[int]string {
 	entries := readAntigravityHistoryEntries()
 	if len(entries) == 0 {
 		return nil
@@ -2992,6 +2996,7 @@ func discoverAntigravitySessionIDs(restore *serverRestore) map[int]string {
 		}
 	}
 	sessions := map[int]string{}
+	liveProcesses := agentProcessesByPane(processes, panePids, "antigravity")
 	for i, window := range restore.Windows {
 		if agentToolForRestore(window) != "antigravity" {
 			continue
@@ -3000,7 +3005,11 @@ func discoverAntigravitySessionIDs(restore *serverRestore) map[int]string {
 		if workspace == "" || workspaceCounts[workspace] != 1 {
 			continue
 		}
-		processStarted := processStartedAtForMetadata(window.PanePid)
+		process, ok := liveProcesses[window.PanePid]
+		if !ok {
+			continue
+		}
+		processStarted := processStartedAtForMetadata(process.pid)
 		if sessionID := antigravitySessionIDForWorkspace(
 			entries,
 			workspace,
@@ -3094,7 +3103,11 @@ type cursorChatEntry struct {
 	updatedAt int64
 }
 
-func discoverCursorSessionIDs(restore *serverRestore) map[int]string {
+func discoverCursorSessionIDs(
+	restore *serverRestore,
+	processes map[int]processInfo,
+	panePids map[int]struct{},
+) map[int]string {
 	entries := readCursorChatEntries()
 	if len(entries) == 0 {
 		return nil
@@ -3106,6 +3119,7 @@ func discoverCursorSessionIDs(restore *serverRestore) map[int]string {
 		}
 	}
 	sessions := map[int]string{}
+	liveProcesses := agentProcessesByPane(processes, panePids, "cursor-agent")
 	for i, window := range restore.Windows {
 		if agentToolForRestore(window) != "cursor-agent" {
 			continue
@@ -3114,7 +3128,11 @@ func discoverCursorSessionIDs(restore *serverRestore) map[int]string {
 		if workspace == "" || workspaceCounts[workspace] != 1 {
 			continue
 		}
-		processStarted := processStartedAtForMetadata(window.PanePid)
+		process, ok := liveProcesses[window.PanePid]
+		if !ok {
+			continue
+		}
+		processStarted := processStartedAtForMetadata(process.pid)
 		if sessionID := cursorSessionIDForWorkspace(
 			entries,
 			workspace,
@@ -3448,18 +3466,22 @@ func discoverPiSessions(
 			remainingCandidates,
 			livePiWindows,
 		)
+		freshActivityMatches := map[int]piSessionEntry{}
 		activityOwnedSessionIDs := map[string]bool{}
-		for _, candidate := range activityMatches {
+		for index, candidate := range activityMatches {
+			if !sessionUpdatedDuringProcess(candidate.modTime, processStarts[index]) {
+				continue
+			}
+			freshActivityMatches[index] = candidate
 			activityOwnedSessionIDs[candidate.sessionID] = true
 		}
-		for index, candidate := range activityMatches {
-			if !sessionUpdatedDuringProcess(candidate.modTime, processStarts[index]) ||
-				piSessionWasSuperseded(
-					remainingCandidates,
-					candidate,
-					processStarts[index],
-					activityOwnedSessionIDs,
-				) {
+		for index, candidate := range freshActivityMatches {
+			if piSessionWasSuperseded(
+				remainingCandidates,
+				candidate,
+				processStarts[index],
+				activityOwnedSessionIDs,
+			) {
 				continue
 			}
 			sessions[index] = piRestoreSession{
@@ -3546,7 +3568,8 @@ func discoverPiSessions(
 				matches = append(matches, candidate)
 			}
 			matches = piLeafSessionMatches(matches, remainingCandidates)
-			if len(matches) != 1 {
+			if len(matches) != 1 ||
+				!sessionUpdatedDuringProcess(matches[0].modTime, processStarts[index]) {
 				continue
 			}
 			persisted[index] = matches[0]
@@ -4471,21 +4494,12 @@ func normalizedCopilotWorkingDirectory(path string) string {
 // only sessions updated during that window process and uses terminal activity
 // to disambiguate multiple candidates. Stale or overlapping evidence stays
 // fresh; sessions claimed by another window are never reused.
-func assignCopilotSessionsByWorkingDirectory(restore *serverRestore) {
+func assignCopilotSessionsByWorkingDirectory(
+	restore *serverRestore,
+	processes map[int]processInfo,
+	panePids map[int]struct{},
+) {
 	if restore == nil {
-		return
-	}
-	needing := []int{}
-	for i := range restore.Windows {
-		if strings.TrimSpace(restore.Windows[i].AgentSessionID) != "" {
-			continue
-		}
-		if agentToolForRestore(restore.Windows[i]) != "copilot" {
-			continue
-		}
-		needing = append(needing, i)
-	}
-	if len(needing) == 0 {
 		return
 	}
 	sessionsByDirectory := copilotSessionsByWorkingDirectory()
@@ -4498,12 +4512,22 @@ func assignCopilotSessionsByWorkingDirectory(restore *serverRestore) {
 			used[id] = true
 		}
 	}
-	for _, i := range needing {
+	liveProcesses := agentProcessesByPane(processes, panePids, "copilot")
+	matchesByWindow := map[int][]copilotSessionEntry{}
+	for i := range restore.Windows {
+		if strings.TrimSpace(restore.Windows[i].AgentSessionID) != "" ||
+			agentToolForRestore(restore.Windows[i]) != "copilot" {
+			continue
+		}
+		process, ok := liveProcesses[restore.Windows[i].PanePid]
+		if !ok {
+			continue
+		}
 		workingDirectory := normalizedCopilotWorkingDirectory(restore.Windows[i].Cwd)
 		if workingDirectory == "" {
 			continue
 		}
-		processStarted := processStartedAtForMetadata(restore.Windows[i].PanePid)
+		processStarted := processStartedAtForMetadata(process.pid)
 		candidates := []copilotSessionEntry{}
 		for _, session := range sessionsByDirectory[workingDirectory] {
 			if used[session.id] ||
@@ -4512,34 +4536,44 @@ func assignCopilotSessionsByWorkingDirectory(restore *serverRestore) {
 			}
 			candidates = append(candidates, session)
 		}
-		if len(candidates) == 0 {
-			continue
-		}
-		selected := ""
-		if len(candidates) == 1 {
-			selected = candidates[0].id
-		} else if restore.Windows[i].LastActivityEpochSeconds > 0 {
+		if len(candidates) > 1 && restore.Windows[i].LastActivityEpochSeconds > 0 {
 			activity := time.Unix(restore.Windows[i].LastActivityEpochSeconds, 0)
+			activityMatches := candidates[:0]
 			for _, candidate := range candidates {
 				delta := candidate.updatedAt.Sub(activity)
 				if delta < 0 {
 					delta = -delta
 				}
-				if delta > piSessionActivityMatchTolerance {
-					continue
+				if delta <= piSessionActivityMatchTolerance {
+					activityMatches = append(activityMatches, candidate)
 				}
-				if selected != "" {
-					selected = ""
-					break
-				}
-				selected = candidate.id
 			}
+			candidates = activityMatches
 		}
-		if selected != "" {
-			restore.Windows[i].AgentSessionID = selected
-			used[selected] = true
+		matchesByWindow[i] = candidates
+	}
+	for index, session := range uniqueCopilotSessionAssignments(matchesByWindow) {
+		restore.Windows[index].AgentSessionID = session.id
+	}
+}
+
+func uniqueCopilotSessionAssignments(
+	matchesByWindow map[int][]copilotSessionEntry,
+) map[int]copilotSessionEntry {
+	claimants := map[string]int{}
+	for _, matches := range matchesByWindow {
+		for _, candidate := range matches {
+			claimants[candidate.id]++
 		}
 	}
+	assignments := map[int]copilotSessionEntry{}
+	for index, matches := range matchesByWindow {
+		if len(matches) != 1 || claimants[matches[0].id] != 1 {
+			continue
+		}
+		assignments[index] = matches[0]
+	}
+	return assignments
 }
 
 func agentProcessesByPane(
@@ -5450,25 +5484,21 @@ func ancestorPanePID(
 	return 0
 }
 
-func sessionIDFromDescendantProcessArgs(
+func sessionIDFromSelectedAgentProcessArgs(
 	processes map[int]processInfo,
 	panePid int,
 	tool string,
 ) string {
-	targetPanePids := map[int]struct{}{panePid: struct{}{}}
-	for _, process := range processes {
-		if ancestorPanePID(processes, process.pid, targetPanePids) != panePid {
-			continue
-		}
-		command := commandNameFromProcessFields(process.comm, process.args)
-		if agentToolFromCommandName(command) != tool {
-			continue
-		}
-		if sessionID := agentSessionIDFromArgs(tool, process.args); sessionID != "" {
-			return sessionID
-		}
+	selected := agentProcessesByPane(
+		processes,
+		map[int]struct{}{panePid: {}},
+		tool,
+	)
+	process, ok := selected[panePid]
+	if !ok {
+		return ""
 	}
-	return ""
+	return agentSessionIDFromArgs(tool, process.args)
 }
 
 func agentSessionIDFromArgs(tool string, args string) string {

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -59,12 +59,13 @@ type muxProcess interface {
 }
 
 const (
-	monkeyMuxVersion                  = "0.1.159"
+	monkeyMuxVersion                  = "0.1.160"
 	defaultColumns                    = 80
 	defaultRows                       = 24
 	maxTitleBytes                     = 160
 	piSessionMetadataRecordLimitBytes = 1024 * 1024
 	piSessionHeaderScanLimitBytes     = 1024 * 1024
+	piSessionActivityMatchTolerance   = 15 * time.Second
 	oscBufferLimitBytes               = 4096
 	processMetadataTimeout            = 500 * time.Millisecond
 	processMetadataInterval           = 500 * time.Millisecond
@@ -559,6 +560,7 @@ type restoreWindowState struct {
 	AgentSessionID           string                    `json:"agentSessionId,omitempty"`
 	AgentSessionDir          string                    `json:"agentSessionDir,omitempty"`
 	AgentSessionPath         string                    `json:"agentSessionPath,omitempty"`
+	LastActivityEpochSeconds int64                     `json:"lastActivityEpochSeconds,omitempty"`
 	HistoryBase64            string                    `json:"historyBase64,omitempty"`
 	HistoryStartsAtGround    bool                      `json:"historyStartsAtGround,omitempty"`
 	CursorVisible            bool                      `json:"cursorVisible,omitempty"`
@@ -2487,8 +2489,61 @@ func collectServerRestore(session string, status runningServerStatus) *serverRes
 		restore = restoreFromWindowSnapshots(windows)
 		enrichRestoreWithCapturedShellHistory(session, restore)
 	}
+	if restore != nil && restoreNeedsWindowActivity(restore) {
+		if windows, err := queryServerWindows(session); err == nil {
+			enrichRestoreWithWindowActivity(restore, windows)
+		}
+	}
 	enrichRestoreWithAgentSessionIDs(restore)
 	return restore
+}
+
+func restoreNeedsWindowActivity(restore *serverRestore) bool {
+	if restore == nil {
+		return false
+	}
+	for _, window := range restore.Windows {
+		if agentToolCandidateForRestore(window) == "pi" &&
+			strings.TrimSpace(window.AgentSessionPath) == "" &&
+			window.LastActivityEpochSeconds <= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func enrichRestoreWithWindowActivity(
+	restore *serverRestore,
+	windows []windowSnapshot,
+) {
+	if restore == nil || len(windows) == 0 {
+		return
+	}
+	byID := make(map[string]int64, len(windows))
+	byIndex := make(map[int]int64, len(windows))
+	for _, window := range windows {
+		if window.LastActivityEpochSeconds <= 0 {
+			continue
+		}
+		if id := strings.TrimSpace(window.ID); id != "" {
+			byID[id] = window.LastActivityEpochSeconds
+		}
+		byIndex[window.Index] = window.LastActivityEpochSeconds
+	}
+	for i := range restore.Windows {
+		if restore.Windows[i].LastActivityEpochSeconds > 0 {
+			continue
+		}
+		if id := strings.TrimSpace(restore.Windows[i].ID); id != "" {
+			if activity := byID[id]; activity > 0 {
+				restore.Windows[i].LastActivityEpochSeconds = activity
+			}
+			continue
+		}
+		if activity := byIndex[restore.Windows[i].Index]; activity > 0 {
+			restore.Windows[i].LastActivityEpochSeconds = activity
+		}
+	}
 }
 
 func requestServerRestore(session string) (*serverRestore, error) {
@@ -2590,21 +2645,22 @@ func restoreFromWindowSnapshots(windows []windowSnapshot) *serverRestore {
 	}
 	for _, window := range windows {
 		restore.Windows = append(restore.Windows, restoreWindowState{
-			ID:                 window.ID,
-			Index:              window.Index,
-			Name:               window.Name,
-			Cwd:                window.CurrentPath,
-			CurrentCommand:     window.CurrentCommand,
-			PanePid:            window.PanePid,
-			PaneTitle:          window.PaneTitle,
-			AgentTool:          window.AgentTool,
-			AgentToolConfirmed: window.AgentToolConfirmed,
-			AgentSessionID:     window.AgentSessionID,
-			AgentSessionDir:    window.AgentSessionDir,
-			AgentSessionPath:   window.AgentSessionPath,
-			PrivateModes:       privateModesFromWindowSnapshot(window),
-			TerminalProgress:   copyTerminalProgressSnapshot(window.TerminalProgress),
-			Active:             window.Active,
+			ID:                       window.ID,
+			Index:                    window.Index,
+			Name:                     window.Name,
+			Cwd:                      window.CurrentPath,
+			CurrentCommand:           window.CurrentCommand,
+			PanePid:                  window.PanePid,
+			PaneTitle:                window.PaneTitle,
+			AgentTool:                window.AgentTool,
+			AgentToolConfirmed:       window.AgentToolConfirmed,
+			AgentSessionID:           window.AgentSessionID,
+			AgentSessionDir:          window.AgentSessionDir,
+			AgentSessionPath:         window.AgentSessionPath,
+			LastActivityEpochSeconds: window.LastActivityEpochSeconds,
+			PrivateModes:             privateModesFromWindowSnapshot(window),
+			TerminalProgress:         copyTerminalProgressSnapshot(window.TerminalProgress),
+			Active:                   window.Active,
 		})
 	}
 	return restore
@@ -3403,6 +3459,36 @@ func discoverPiSessions(
 			}
 		}
 
+		// Unnamed Pi windows all publish the same `Pi - <cwd>` title. Their
+		// latest terminal output still brackets the JSONL append for that turn,
+		// which gives upgrades a one-to-one signal even after /new or /resume
+		// made process-start correlation stale. Fail closed if timestamps overlap.
+		for index, candidate := range uniquePiSessionsByWindowActivity(
+			restore,
+			remainingIndices,
+			remainingCandidates,
+			livePiWindows,
+		) {
+			sessions[index] = piRestoreSession{
+				sessionID:   candidate.sessionID,
+				sessionDir:  filepath.Dir(candidate.path),
+				sessionPath: candidate.path,
+			}
+			used[candidate.sessionID] = true
+		}
+		remainingIndices = remainingIndices[:0]
+		for _, index := range indices {
+			if _, ok := sessions[index]; !ok {
+				remainingIndices = append(remainingIndices, index)
+			}
+		}
+		remainingCandidates = remainingCandidates[:0]
+		for _, candidate := range candidates {
+			if !used[candidate.sessionID] {
+				remainingCandidates = append(remainingCandidates, candidate)
+			}
+		}
+
 		// Compute every pane's process-time match before reserving any session.
 		// A greedy pass can let an earlier pane steal a later pane's only match.
 		provisional := map[int]piSessionEntry{}
@@ -3526,6 +3612,51 @@ func discoverPiSessions(
 		}
 	}
 	return sessions
+}
+
+func uniquePiSessionsByWindowActivity(
+	restore *serverRestore,
+	indices []int,
+	candidates []piSessionEntry,
+	livePiWindows map[int]bool,
+) map[int]piSessionEntry {
+	provisional := map[int]piSessionEntry{}
+	owners := map[string][]int{}
+	for _, index := range indices {
+		if !livePiWindows[index] {
+			continue
+		}
+		epoch := restore.Windows[index].LastActivityEpochSeconds
+		if epoch <= 0 {
+			continue
+		}
+		activity := time.Unix(epoch, 0)
+		matches := []piSessionEntry{}
+		for _, candidate := range candidates {
+			if candidate.modTime.IsZero() {
+				continue
+			}
+			delta := candidate.modTime.Sub(activity)
+			if delta < 0 {
+				delta = -delta
+			}
+			if delta <= piSessionActivityMatchTolerance {
+				matches = append(matches, candidate)
+			}
+		}
+		matches = piLeafSessionMatches(matches, candidates)
+		if len(matches) != 1 {
+			continue
+		}
+		provisional[index] = matches[0]
+		owners[matches[0].sessionID] = append(owners[matches[0].sessionID], index)
+	}
+	for index, candidate := range provisional {
+		if len(owners[candidate.sessionID]) != 1 {
+			delete(provisional, index)
+		}
+	}
+	return provisional
 }
 
 func uniquePiSessionsByPaneTitle(
@@ -8420,6 +8551,7 @@ func (s *muxServer) restoreSnapshot() *serverRestore {
 			AgentSessionID:           window.agentSessionID,
 			AgentSessionDir:          window.agentSessionDir,
 			AgentSessionPath:         window.agentSessionPath,
+			LastActivityEpochSeconds: window.lastActivity.Unix(),
 			CursorVisible:            window.cursorVisible,
 			CursorVisibilityKnown:    window.cursorVisibilityKnown,
 			PrivateModes:             copyPrivateModes(window.privateModes),

--- a/remote/monkeymux/main_test.go
+++ b/remote/monkeymux/main_test.go
@@ -11059,9 +11059,14 @@ func TestEnrichRestoreWithAgentSessionIDsUsesAntigravityHistory(t *testing.T) {
 		processTableForMetadata = originalProcessTable
 	})
 	now := time.Now().UTC().Truncate(time.Second)
-	processTableForMetadata = func() map[int]processInfo { return nil }
+	processTableForMetadata = func() map[int]processInfo {
+		return map[int]processInfo{
+			200: {pid: 200, ppid: 1, comm: "cmd.exe", args: "cmd.exe"},
+			201: {pid: 201, ppid: 200, comm: "agy", args: "agy"},
+		}
+	}
 	processStartedAtForMetadata = func(pid int) time.Time {
-		if pid == 200 {
+		if pid == 201 {
 			return now.Add(-time.Minute)
 		}
 		return time.Time{}
@@ -11115,13 +11120,18 @@ func TestEnrichRestoreAntigravityRejectsOtherWorkspaceFileMtime(t *testing.T) {
 		processStartedAtForMetadata = originalProcessStart
 		processTableForMetadata = originalProcessTable
 	})
-	processTableForMetadata = func() map[int]processInfo { return nil }
+	processTableForMetadata = func() map[int]processInfo {
+		return map[int]processInfo{
+			200: {pid: 200, ppid: 1, comm: "cmd.exe", args: "cmd.exe"},
+			201: {pid: 201, ppid: 200, comm: "agy", args: "agy"},
+		}
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	project := filepath.Join(home, "project")
 	now := time.Now().UTC().Truncate(time.Second)
 	processStartedAtForMetadata = func(pid int) time.Time {
-		if pid == 200 {
+		if pid == 201 {
 			return now.Add(-time.Minute)
 		}
 		return time.Time{}
@@ -11186,13 +11196,23 @@ func TestCursorAgentToolMapping(t *testing.T) {
 
 func TestEnrichRestoreWithAgentSessionIDsUsesCursorChatStore(t *testing.T) {
 	originalProcessStart := processStartedAtForMetadata
-	t.Cleanup(func() { processStartedAtForMetadata = originalProcessStart })
+	originalProcessTable := processTableForMetadata
+	t.Cleanup(func() {
+		processStartedAtForMetadata = originalProcessStart
+		processTableForMetadata = originalProcessTable
+	})
 	now := time.Now()
 	processStartedAtForMetadata = func(pid int) time.Time {
-		if pid == 200 {
+		if pid == 201 {
 			return now.Add(-time.Minute)
 		}
 		return time.Time{}
+	}
+	processTableForMetadata = func() map[int]processInfo {
+		return map[int]processInfo{
+			200: {pid: 200, ppid: 1, comm: "cmd.exe", args: "cmd.exe"},
+			201: {pid: 201, ppid: 200, comm: "cursor-agent", args: "cursor-agent"},
+		}
 	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/remote/monkeymux/main_test.go
+++ b/remote/monkeymux/main_test.go
@@ -10351,9 +10351,11 @@ func TestDiscoverClaudeSessionIDsUsesOpenProjectFile(t *testing.T) {
 func TestDiscoverClaudeSessionIDsFallsBackToRecentProjectFileForCwd(t *testing.T) {
 	originalOpenFiles := processOpenFilePathsForMetadata
 	originalWorkingDirectory := processWorkingDirectoryForMetadata
+	originalProcessStart := processStartedAtForMetadata
 	t.Cleanup(func() {
 		processOpenFilePathsForMetadata = originalOpenFiles
 		processWorkingDirectoryForMetadata = originalWorkingDirectory
+		processStartedAtForMetadata = originalProcessStart
 	})
 
 	home := t.TempDir()
@@ -10377,6 +10379,12 @@ func TestDiscoverClaudeSessionIDsFallsBackToRecentProjectFileForCwd(t *testing.T
 		}
 		return ""
 	}
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return time.Now().Add(-time.Minute)
+		}
+		return time.Time{}
+	}
 	processes := map[int]processInfo{
 		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
 		200: {pid: 200, ppid: 100, comm: "claude", args: "claude"},
@@ -10386,6 +10394,61 @@ func TestDiscoverClaudeSessionIDsFallsBackToRecentProjectFileForCwd(t *testing.T
 
 	if got := sessions[100]; got != sessionID {
 		t.Fatalf("claude session id = %q, want %q", got, sessionID)
+	}
+}
+
+func TestDiscoverClaudeSessionIDsDoesNotResumeSessionFromBeforeFreshProcess(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalWorkingDirectory := processWorkingDirectoryForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processWorkingDirectoryForMetadata = originalWorkingDirectory
+		processStartedAtForMetadata = originalProcessStart
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sessionID := "a69d705a-1822-49de-83ba-c86bd51932bb"
+	projectDir := filepath.Join(home, ".claude", "projects", "-work-project")
+	if err := os.MkdirAll(projectDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sessionPath := filepath.Join(projectDir, sessionID+".jsonl")
+	if err := os.WriteFile(
+		sessionPath,
+		[]byte(`{"type":"user","cwd":"/work/project","sessionId":"`+sessionID+`"}`+"\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	processStarted := time.Now().UTC().Truncate(time.Second)
+	oldActivity := processStarted.Add(-time.Hour)
+	if err := os.Chtimes(sessionPath, oldActivity, oldActivity); err != nil {
+		t.Fatal(err)
+	}
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+	processWorkingDirectoryForMetadata = func(pid int) string {
+		if pid == 200 {
+			return "/work/project"
+		}
+		return ""
+	}
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return processStarted
+		}
+		return time.Time{}
+	}
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "claude", args: "claude"},
+	}
+
+	sessions := discoverClaudeSessionIDs(processes, map[int]struct{}{100: {}})
+
+	if len(sessions) != 0 {
+		t.Fatalf("fresh Claude process inherited stale sessions %#v, want none", sessions)
 	}
 }
 

--- a/remote/monkeymux/main_test.go
+++ b/remote/monkeymux/main_test.go
@@ -10123,10 +10123,12 @@ func TestDiscoverCodexSessionIDsFallsBackToRecentRolloutForCwd(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	originalOpenFiles := processOpenFilePathsForMetadata
 	originalWorkingDirectory := processWorkingDirectoryForMetadata
+	originalProcessStart := processStartedAtForMetadata
 	t.Cleanup(func() {
 		_ = os.Setenv("HOME", originalHome)
 		processOpenFilePathsForMetadata = originalOpenFiles
 		processWorkingDirectoryForMetadata = originalWorkingDirectory
+		processStartedAtForMetadata = originalProcessStart
 	})
 
 	home := t.TempDir()
@@ -10155,6 +10157,12 @@ func TestDiscoverCodexSessionIDsFallsBackToRecentRolloutForCwd(t *testing.T) {
 			return "/work/project"
 		}
 		return ""
+	}
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return time.Now().Add(-time.Minute)
+		}
+		return time.Time{}
 	}
 	processes := map[int]processInfo{
 		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
@@ -10224,6 +10232,22 @@ func TestDiscoverCodexSessionIDsSkipsAmbiguousCwdFallback(t *testing.T) {
 	}
 }
 
+func TestUnixDatabaseTimeSupportsCommonPrecisions(t *testing.T) {
+	want := time.Unix(1_787_030_000, 0)
+	for name, value := range map[string]string{
+		"seconds":      "1787030000",
+		"milliseconds": "1787030000000",
+		"microseconds": "1787030000000000",
+		"nanoseconds":  "1787030000000000000",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := unixDatabaseTime(value); !got.Equal(want) {
+				t.Fatalf("unixDatabaseTime(%s) = %s, want %s", value, got, want)
+			}
+		})
+	}
+}
+
 func TestDiscoverOpenCodeSessionIDsUsesProcessArgs(t *testing.T) {
 	originalReader := openCodeSessionEntriesReader
 	originalWorkingDirectory := processWorkingDirectoryForMetadata
@@ -10252,14 +10276,17 @@ func TestDiscoverOpenCodeSessionIDsUsesProcessArgs(t *testing.T) {
 func TestDiscoverOpenCodeSessionIDsUsesWorkingDirectory(t *testing.T) {
 	originalReader := openCodeSessionEntriesReader
 	originalWorkingDirectory := processWorkingDirectoryForMetadata
+	originalProcessStart := processStartedAtForMetadata
 	t.Cleanup(func() {
 		openCodeSessionEntriesReader = originalReader
 		processWorkingDirectoryForMetadata = originalWorkingDirectory
+		processStartedAtForMetadata = originalProcessStart
 	})
+	now := time.Now()
 	openCodeSessionEntriesReader = func() []openCodeSessionEntry {
 		return []openCodeSessionEntry{
-			{sessionID: "ses_new", directory: "/work/project"},
-			{sessionID: "ses_other", directory: "/tmp/other"},
+			{sessionID: "ses_new", directory: "/work/project", updatedAt: now},
+			{sessionID: "ses_other", directory: "/tmp/other", updatedAt: now},
 		}
 	}
 	processWorkingDirectoryForMetadata = func(pid int) string {
@@ -10267,6 +10294,12 @@ func TestDiscoverOpenCodeSessionIDsUsesWorkingDirectory(t *testing.T) {
 			return "/work/project"
 		}
 		return ""
+	}
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return now.Add(-time.Minute)
+		}
+		return time.Time{}
 	}
 	processes := map[int]processInfo{
 		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
@@ -10498,9 +10531,11 @@ func TestDiscoverGeminiSessionIDsUsesOpenChatFile(t *testing.T) {
 func TestDiscoverGeminiSessionIDsFallsBackToRecentChatForCwd(t *testing.T) {
 	originalOpenFiles := processOpenFilePathsForMetadata
 	originalWorkingDirectory := processWorkingDirectoryForMetadata
+	originalProcessStart := processStartedAtForMetadata
 	t.Cleanup(func() {
 		processOpenFilePathsForMetadata = originalOpenFiles
 		processWorkingDirectoryForMetadata = originalWorkingDirectory
+		processStartedAtForMetadata = originalProcessStart
 	})
 
 	home := t.TempDir()
@@ -10523,6 +10558,12 @@ func TestDiscoverGeminiSessionIDsFallsBackToRecentChatForCwd(t *testing.T) {
 			return "/work/project"
 		}
 		return ""
+	}
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return time.Now().Add(-time.Minute)
+		}
+		return time.Time{}
 	}
 	processes := map[int]processInfo{
 		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
@@ -10573,6 +10614,69 @@ func TestDiscoverGeminiSessionIDsSkipsSubagentChats(t *testing.T) {
 
 	if len(sessions) != 0 {
 		t.Fatalf("gemini sessions = %#v, want none for subagent chats", sessions)
+	}
+}
+
+
+func TestAgentStoreFallbacksRejectSessionsFromBeforeProcess(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	project := filepath.Join(home, "project")
+	processStarted := time.Now().UTC().Truncate(time.Second)
+	stale := processStarted.Add(-time.Hour)
+
+	if got := openCodeSessionIDForWorkingDirectory(
+		[]openCodeSessionEntry{{sessionID: "stale-opencode", directory: project, updatedAt: stale}},
+		project,
+		processStarted,
+	); got != "" {
+		t.Fatalf("fresh OpenCode process inherited stale session %q", got)
+	}
+	if got := antigravitySessionIDForWorkspace(
+		[]antigravityHistoryEntry{{conversationID: "stale-antigravity", workspace: project, updatedAt: stale}},
+		project,
+		processStarted,
+	); got != "" {
+		t.Fatalf("fresh Antigravity process inherited stale session %q", got)
+	}
+	if got := cursorSessionIDForWorkspace(
+		[]cursorChatEntry{{chatID: "stale-cursor", cwd: project, updatedAt: stale.UnixMilli()}},
+		project,
+		processStarted,
+	); got != "" {
+		t.Fatalf("fresh Cursor process inherited stale session %q", got)
+	}
+
+	codexID := "123e4567-e89b-12d3-a456-426614174099"
+	codexDir := filepath.Join(home, ".codex", "sessions", "2026", "08")
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	codexPath := filepath.Join(codexDir, "rollout-2026-08-18T00-00-00-"+codexID+".jsonl")
+	if err := os.WriteFile(codexPath, []byte(`{"cwd":`+fmt.Sprintf("%q", project)+`,"id":"`+codexID+`"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(codexPath, stale, stale); err != nil {
+		t.Fatal(err)
+	}
+	if got := codexRecentSessionIDForWorkingDirectory(project, processStarted); got != "" {
+		t.Fatalf("fresh Codex process inherited stale session %q", got)
+	}
+
+	geminiDir := filepath.Join(home, ".gemini", "tmp", "project", "chats")
+	if err := os.MkdirAll(geminiDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	geminiPath := filepath.Join(geminiDir, "session-stale.json")
+	geminiData := fmt.Sprintf(`{"sessionId":"stale-gemini","kind":"main","directories":[%q]}`, project)
+	if err := os.WriteFile(geminiPath, []byte(geminiData), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(geminiPath, stale, stale); err != nil {
+		t.Fatal(err)
+	}
+	if got := geminiRecentSessionIDForWorkingDirectory(project, processStarted); got != "" {
+		t.Fatalf("fresh Gemini process inherited stale session %q", got)
 	}
 }
 
@@ -10809,6 +10913,30 @@ func TestCreateWindowOptionsForRestoreDropsIncompleteTrailingAPC(t *testing.T) {
 	}
 }
 
+
+func TestEnrichRestoreClearsUnvalidatedCarriedAgentSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	restore := &serverRestore{Windows: []restoreWindowState{
+		{Name: "Copilot CLI", AgentTool: "copilot", AgentSessionID: "stale-copilot"},
+		{Name: "Codex", AgentTool: "codex", AgentSessionID: "stale-codex"},
+		{Name: "OpenCode", AgentTool: "opencode", AgentSessionID: "stale-opencode"},
+		{Name: "Claude Code", AgentTool: "claude", AgentSessionID: "stale-claude"},
+		{Name: "Gemini", AgentTool: "gemini", AgentSessionID: "stale-gemini"},
+		{Name: "Antigravity", AgentTool: "antigravity", AgentSessionID: "stale-antigravity"},
+		{Name: "Cursor Agent", AgentTool: "cursor-agent", AgentSessionID: "stale-cursor"},
+		{Name: "Pi", AgentTool: "pi", AgentSessionID: "stale-pi"},
+	}}
+
+	enrichRestoreWithAgentSessionIDs(restore)
+
+	for i, window := range restore.Windows {
+		if window.AgentSessionID != "" {
+			t.Fatalf("window %d (%s) kept unvalidated session %q", i, window.AgentTool, window.AgentSessionID)
+		}
+	}
+}
+
 func TestCreateWindowOptionsForRestoreBuildsAgentResumeCommand(t *testing.T) {
 	state := restoreWindowState{
 		Name:           "Copilot CLI",
@@ -10833,6 +10961,14 @@ func TestCreateWindowOptionsForRestoreBuildsAgentResumeCommand(t *testing.T) {
 }
 
 func TestEnrichRestoreWithAgentSessionIDsUsesAntigravityHistory(t *testing.T) {
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() { processStartedAtForMetadata = originalProcessStart })
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return time.Now().Add(-time.Minute)
+		}
+		return time.Time{}
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	project := filepath.Join(home, "project")
@@ -10858,6 +10994,7 @@ func TestEnrichRestoreWithAgentSessionIDsUsesAntigravityHistory(t *testing.T) {
 				Name:           "Antigravity",
 				Cwd:            project,
 				CurrentCommand: "agy",
+				PanePid:        200,
 				AgentTool:      "antigravity",
 			},
 		},
@@ -10906,6 +11043,15 @@ func TestCursorAgentToolMapping(t *testing.T) {
 }
 
 func TestEnrichRestoreWithAgentSessionIDsUsesCursorChatStore(t *testing.T) {
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() { processStartedAtForMetadata = originalProcessStart })
+	now := time.Now()
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return now.Add(-time.Minute)
+		}
+		return time.Time{}
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	project := filepath.Join(home, "project")
@@ -10929,9 +11075,9 @@ func TestEnrichRestoreWithAgentSessionIDsUsesCursorChatStore(t *testing.T) {
 		}
 	}
 
-	writeChat("old-chat", project, 1000)
-	writeChat("new-chat", project, 2000)
-	writeChat("other-chat", "/tmp/other", 3000)
+	writeChat("old-chat", project, now.Add(-30*time.Second).UnixMilli())
+	writeChat("new-chat", project, now.UnixMilli())
+	writeChat("other-chat", "/tmp/other", now.Add(time.Second).UnixMilli())
 
 	restore := &serverRestore{
 		Windows: []restoreWindowState{
@@ -10939,6 +11085,7 @@ func TestEnrichRestoreWithAgentSessionIDsUsesCursorChatStore(t *testing.T) {
 				Name:           "Cursor Agent",
 				Cwd:            project,
 				CurrentCommand: "cursor-agent",
+				PanePid:        200,
 				AgentTool:      "cursor-agent",
 			},
 		},

--- a/remote/monkeymux/main_test.go
+++ b/remote/monkeymux/main_test.go
@@ -10257,8 +10257,13 @@ func TestDiscoverCodexSessionIDsFallsBackToRecentRolloutForCwd(t *testing.T) {
 		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
 		200: {pid: 200, ppid: 100, comm: "codex", args: "codex"},
 	}
+	processWorkingDirectoryForMetadata = func(int) string { return "" }
 
-	sessions := discoverCodexSessionIDs(processes, map[int]struct{}{100: {}})
+	sessions := discoverCodexSessionIDs(
+		processes,
+		map[int]struct{}{100: {}},
+		map[int]string{100: "/work/project"},
+	)
 
 	if got := sessions[100]; got != sessionID {
 		t.Fatalf("codex session id = %q, want %q", got, sessionID)
@@ -10395,7 +10400,12 @@ func TestDiscoverOpenCodeSessionIDsUsesWorkingDirectory(t *testing.T) {
 		200: {pid: 200, ppid: 100, comm: "opencode", args: "opencode"},
 	}
 
-	sessions := discoverOpenCodeSessionIDs(processes, map[int]struct{}{100: {}})
+	processWorkingDirectoryForMetadata = func(int) string { return "" }
+	sessions := discoverOpenCodeSessionIDs(
+		processes,
+		map[int]struct{}{100: {}},
+		map[int]string{100: "/work/project"},
+	)
 
 	if got := sessions[100]; got != "ses_new" {
 		t.Fatalf("opencode session id = %q, want ses_new", got)

--- a/remote/monkeymux/main_test.go
+++ b/remote/monkeymux/main_test.go
@@ -10081,6 +10081,93 @@ func TestAgentSessionIDFromArgsParsesResumeCommands(t *testing.T) {
 	}
 }
 
+func TestAgentProcessesByPaneSelectsUniqueShallowestProcess(t *testing.T) {
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "claude", args: "claude --resume outer"},
+		300: {pid: 300, ppid: 200, comm: "claude", args: "claude --resume nested"},
+	}
+	got := agentProcessesByPane(processes, map[int]struct{}{100: {}}, "claude")
+	if got[100].pid != 200 {
+		t.Fatalf("selected process = %#v, want shallow pid 200", got)
+	}
+	processes[201] = processInfo{pid: 201, ppid: 100, comm: "claude", args: "claude --resume tie"}
+	if got := agentProcessesByPane(processes, map[int]struct{}{100: {}}, "claude"); len(got) != 0 {
+		t.Fatalf("same-depth process tie = %#v, want fail closed", got)
+	}
+}
+
+func TestDiscoverCodexSessionIDsReservesArgvOwnedSiblingSession(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalWorkingDirectory := processWorkingDirectoryForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processWorkingDirectoryForMetadata = originalWorkingDirectory
+		processStartedAtForMetadata = originalProcessStart
+	})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sessionID := "123e4567-e89b-12d3-a456-426614174055"
+	rolloutDir := filepath.Join(home, ".codex", "sessions", "2026", "08")
+	if err := os.MkdirAll(rolloutDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(rolloutDir, "rollout-2026-08-18T00-00-00-"+sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte(`{"cwd":"/work/project","id":"`+sessionID+`"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+	processWorkingDirectoryForMetadata = func(int) string { return "/work/project" }
+	processStartedAtForMetadata = func(int) time.Time { return time.Now().Add(-time.Minute) }
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		101: {pid: 101, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "codex", args: "codex resume " + sessionID},
+		201: {pid: 201, ppid: 101, comm: "codex", args: "codex"},
+	}
+
+	got := discoverCodexSessionIDs(processes, map[int]struct{}{100: {}, 101: {}})
+	if got[100] != sessionID || got[101] != "" {
+		t.Fatalf("Codex sibling assignments = %#v, want only argv-owned pane", got)
+	}
+}
+
+func TestDiscoverClaudeSessionIDsReservesArgvOwnedSiblingSession(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalWorkingDirectory := processWorkingDirectoryForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processWorkingDirectoryForMetadata = originalWorkingDirectory
+		processStartedAtForMetadata = originalProcessStart
+	})
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sessionID := "de4e84a3-cf16-4cc2-8ba7-34587e984d4a"
+	projectDir := filepath.Join(home, ".claude", "projects", "-work-project")
+	if err := os.MkdirAll(projectDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, sessionID+".jsonl"), []byte(`{"cwd":"/work/project","sessionId":"`+sessionID+`"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+	processWorkingDirectoryForMetadata = func(int) string { return "/work/project" }
+	processStartedAtForMetadata = func(int) time.Time { return time.Now().Add(-time.Minute) }
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		101: {pid: 101, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "claude", args: "claude --resume " + sessionID},
+		201: {pid: 201, ppid: 101, comm: "claude", args: "claude"},
+	}
+
+	got := discoverClaudeSessionIDs(processes, map[int]struct{}{100: {}, 101: {}})
+	if got[100] != sessionID || got[101] != "" {
+		t.Fatalf("Claude sibling assignments = %#v, want only argv-owned pane", got)
+	}
+}
+
 func TestDiscoverCodexSessionIDsUsesOpenRolloutFile(t *testing.T) {
 	originalOpenFiles := processOpenFilePathsForMetadata
 	originalWorkingDirectory := processWorkingDirectoryForMetadata
@@ -10099,7 +10186,9 @@ func TestDiscoverCodexSessionIDsUsesOpenRolloutFile(t *testing.T) {
 		}
 	}
 	processWorkingDirectoryForMetadata = func(pid int) string {
-		t.Fatalf("processWorkingDirectoryForMetadata(%d) was called; open file match should win", pid)
+		if pid == 200 {
+			return "/work/project"
+		}
 		return ""
 	}
 	processes := map[int]processInfo{
@@ -10366,7 +10455,9 @@ func TestDiscoverClaudeSessionIDsUsesOpenProjectFile(t *testing.T) {
 		}
 	}
 	processWorkingDirectoryForMetadata = func(pid int) string {
-		t.Fatalf("processWorkingDirectoryForMetadata(%d) called; open file match should win", pid)
+		if pid == 200 {
+			return "/work/project"
+		}
 		return ""
 	}
 	processes := map[int]processInfo{
@@ -10513,7 +10604,9 @@ func TestDiscoverGeminiSessionIDsUsesOpenChatFile(t *testing.T) {
 		return []string{chatPath}
 	}
 	processWorkingDirectoryForMetadata = func(pid int) string {
-		t.Fatalf("processWorkingDirectoryForMetadata(%d) called; open file match should win", pid)
+		if pid == 200 {
+			return "/work/project"
+		}
 		return ""
 	}
 	processes := map[int]processInfo{
@@ -10616,7 +10709,6 @@ func TestDiscoverGeminiSessionIDsSkipsSubagentChats(t *testing.T) {
 		t.Fatalf("gemini sessions = %#v, want none for subagent chats", sessions)
 	}
 }
-
 
 func TestAgentStoreFallbacksRejectSessionsFromBeforeProcess(t *testing.T) {
 	home := t.TempDir()
@@ -10913,7 +11005,6 @@ func TestCreateWindowOptionsForRestoreDropsIncompleteTrailingAPC(t *testing.T) {
 	}
 }
 
-
 func TestEnrichRestoreClearsUnvalidatedCarriedAgentSessions(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -10962,10 +11053,16 @@ func TestCreateWindowOptionsForRestoreBuildsAgentResumeCommand(t *testing.T) {
 
 func TestEnrichRestoreWithAgentSessionIDsUsesAntigravityHistory(t *testing.T) {
 	originalProcessStart := processStartedAtForMetadata
-	t.Cleanup(func() { processStartedAtForMetadata = originalProcessStart })
+	originalProcessTable := processTableForMetadata
+	t.Cleanup(func() {
+		processStartedAtForMetadata = originalProcessStart
+		processTableForMetadata = originalProcessTable
+	})
+	now := time.Now().UTC().Truncate(time.Second)
+	processTableForMetadata = func() map[int]processInfo { return nil }
 	processStartedAtForMetadata = func(pid int) time.Time {
 		if pid == 200 {
-			return time.Now().Add(-time.Minute)
+			return now.Add(-time.Minute)
 		}
 		return time.Time{}
 	}
@@ -10977,9 +11074,9 @@ func TestEnrichRestoreWithAgentSessionIDsUsesAntigravityHistory(t *testing.T) {
 		t.Fatal(err)
 	}
 	history := strings.Join([]string{
-		`{"conversationId":"old-session","workspace":"` + project + `","display":"Old"}`,
-		`{"conversationId":"new-session","workspace":"` + project + `","display":"New"}`,
-		`{"conversationId":"other-session","workspace":"/tmp/other","display":"Other"}`,
+		fmt.Sprintf(`{"conversationId":"old-session","workspace":%q,"timestamp":%d}`, project, now.Add(-30*time.Second).UnixMilli()),
+		fmt.Sprintf(`{"conversationId":"new-session","workspace":%q,"timestamp":%d}`, project, now.UnixMilli()),
+		fmt.Sprintf(`{"conversationId":"other-session","workspace":"/tmp/other","timestamp":%d}`, now.UnixMilli()),
 	}, "\n")
 	if err := os.WriteFile(
 		filepath.Join(historyDir, "history.jsonl"),
@@ -11008,6 +11105,51 @@ func TestEnrichRestoreWithAgentSessionIDsUsesAntigravityHistory(t *testing.T) {
 	options := createWindowOptionsForRestore(restore.Windows[0], true)
 	if got := options.command; got != "agy --dangerously-skip-permissions --conversation 'new-session' || agy --dangerously-skip-permissions" {
 		t.Fatalf("command = %q, want Antigravity resume command with fresh fallback", got)
+	}
+}
+
+func TestEnrichRestoreAntigravityRejectsOtherWorkspaceFileMtime(t *testing.T) {
+	originalProcessStart := processStartedAtForMetadata
+	originalProcessTable := processTableForMetadata
+	t.Cleanup(func() {
+		processStartedAtForMetadata = originalProcessStart
+		processTableForMetadata = originalProcessTable
+	})
+	processTableForMetadata = func() map[int]processInfo { return nil }
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	project := filepath.Join(home, "project")
+	now := time.Now().UTC().Truncate(time.Second)
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return now.Add(-time.Minute)
+		}
+		return time.Time{}
+	}
+	historyDir := filepath.Join(home, ".gemini", "antigravity-cli")
+	if err := os.MkdirAll(historyDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	history := fmt.Sprintf(
+		"{\"conversationId\":\"stale-project\",\"workspace\":%q,\"timestamp\":%d}\n"+
+			"{\"conversationId\":\"current-other\",\"workspace\":\"/tmp/other\",\"timestamp\":%d}\n",
+		project, now.Add(-time.Hour).UnixMilli(), now.UnixMilli(),
+	)
+	path := filepath.Join(historyDir, "history.jsonl")
+	if err := os.WriteFile(path, []byte(history), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatal(err)
+	}
+	restore := &serverRestore{Windows: []restoreWindowState{{
+		Name: "Antigravity", Cwd: project, CurrentCommand: "agy", PanePid: 200, AgentTool: "antigravity",
+	}}}
+
+	enrichRestoreWithAgentSessionIDs(restore)
+
+	if got := restore.Windows[0].AgentSessionID; got != "" {
+		t.Fatalf("fresh Antigravity pane inherited stale session %q", got)
 	}
 }
 

--- a/remote/monkeymux/pi_restore_test.go
+++ b/remote/monkeymux/pi_restore_test.go
@@ -951,7 +951,7 @@ func TestPiSessionIdentitySurvivesSecondUpgradeAndRejectsRotation(t *testing.T) 
 		100: {pid: 100, ppid: 1, comm: "pi.exe", args: "pi.exe"},
 		101: {pid: 101, ppid: 1, comm: "pi.exe", args: "pi.exe"},
 	}
-	processStartedAtForMetadata = func(int) time.Time { return started }
+	processStartedAtForMetadata = func(int) time.Time { return started.Add(-3 * time.Hour) }
 	got := discoverPiSessions(restore, processes, map[int]struct{}{100: {}, 101: {}})
 	if got[0].sessionPath != firstPath || got[1].sessionPath != secondPath {
 		t.Fatalf("second-upgrade sessions = %#v, want persisted exact paths", got)
@@ -962,6 +962,40 @@ func TestPiSessionIdentitySurvivesSecondUpgradeAndRejectsRotation(t *testing.T) 
 	got = discoverPiSessions(restore, processes, map[int]struct{}{100: {}, 101: {}})
 	if len(got) != 0 {
 		t.Fatalf("sessions after unowned rotation = %#v, want fresh launch", got)
+	}
+}
+
+func TestDiscoverPiSessionsRejectsPersistedPathWithoutCurrentProcessWrite(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processStartedAtForMetadata = originalProcessStart
+	})
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+	root := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_SESSION_DIR", root)
+	project := filepath.Join(root, "project")
+	started := time.Now().UTC().Truncate(time.Second)
+	path := filepath.Join(root, "project", "stale.jsonl")
+	writePiTestSessionTimes(t, path, "stale-session", project, started.Add(-2*time.Hour), started.Add(-time.Hour))
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return started
+		}
+		return time.Time{}
+	}
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "pi", args: "pi"},
+	}
+	restore := &serverRestore{Windows: []restoreWindowState{{
+		PanePid: 100, CurrentCommand: "pi", AgentTool: "pi", Cwd: project,
+		AgentSessionID: "stale-session", AgentSessionDir: filepath.Dir(path), AgentSessionPath: path,
+	}}}
+
+	if got := discoverPiSessions(restore, processes, map[int]struct{}{100: {}}); len(got) != 0 {
+		t.Fatalf("persisted path without current-process write restored: %#v", got)
 	}
 }
 

--- a/remote/monkeymux/pi_restore_test.go
+++ b/remote/monkeymux/pi_restore_test.go
@@ -956,3 +956,123 @@ func TestPiSessionIdentitySurvivesSecondUpgradeAndRejectsRotation(t *testing.T) 
 		t.Fatalf("sessions after unowned rotation = %#v, want fresh launch", got)
 	}
 }
+
+func TestDiscoverPiSessionsUsesWindowActivityForUnnamedSameCwdSessions(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processStartedAtForMetadata = originalProcessStart
+	})
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+
+	root := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_SESSION_DIR", root)
+	project := filepath.Join(root, "project")
+	started := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	activities := []time.Time{
+		started.Add(25 * time.Minute),
+		started.Add(50 * time.Minute),
+		started.Add(75 * time.Minute),
+	}
+	paths := make([]string, len(activities))
+	for i, activity := range activities {
+		paths[i] = filepath.Join(root, "project", fmt.Sprintf("session-%d.jsonl", i))
+		// These sessions were selected with /resume after Pi started, so process
+		// creation time cannot identify them. Their final writes still coincide
+		// with output activity in the owning MonkeyMux window.
+		writePiTestSessionTimes(
+			t,
+			paths[i],
+			fmt.Sprintf("session-%d", i),
+			project,
+			started.Add(-time.Duration(i+1)*time.Hour),
+			activity,
+		)
+	}
+	processStartedAtForMetadata = func(int) time.Time { return started }
+	processes := map[int]processInfo{}
+	restore := &serverRestore{Windows: make([]restoreWindowState, len(activities))}
+	panePids := map[int]struct{}{}
+	for i, activity := range activities {
+		panePID := 100 + i
+		processPID := 200 + i
+		processes[panePID] = processInfo{pid: panePID, ppid: 1, comm: "zsh", args: "zsh"}
+		processes[processPID] = processInfo{pid: processPID, ppid: panePID, comm: "pi", args: "pi"}
+		panePids[panePID] = struct{}{}
+		restore.Windows[i] = restoreWindowState{
+			PanePid:                  panePID,
+			CurrentCommand:           "pi",
+			AgentTool:                "pi",
+			Cwd:                      project,
+			LastActivityEpochSeconds: activity.Unix(),
+		}
+	}
+
+	got := discoverPiSessions(restore, processes, panePids)
+	if len(got) != len(activities) {
+		t.Fatalf("activity-correlated Pi sessions = %#v, want all %d sessions", got, len(activities))
+	}
+	for i, path := range paths {
+		if got[i].sessionPath != path {
+			t.Fatalf("window %d session = %#v, want exact path %q", i, got[i], path)
+		}
+		options := createWindowOptionsForRestore(restoreWindowState{
+			CurrentCommand:   "pi",
+			AgentSessionID:   got[i].sessionID,
+			AgentSessionDir:  got[i].sessionDir,
+			AgentSessionPath: got[i].sessionPath,
+		}, false)
+		want := piResumeCommandWithFreshFallback(
+			piResumeCommand(got[i].sessionID, got[i].sessionDir, path),
+			piLaunchCommand(got[i].sessionDir),
+		)
+		if options.command != want {
+			t.Fatalf("window %d restore command = %q, want exact-path command %q", i, options.command, want)
+		}
+	}
+}
+
+func TestPiWindowActivityCorrelationRejectsAmbiguity(t *testing.T) {
+	activity := time.Now().UTC().Truncate(time.Second)
+	restore := &serverRestore{Windows: []restoreWindowState{
+		{LastActivityEpochSeconds: activity.Unix()},
+		{LastActivityEpochSeconds: activity.Add(time.Second).Unix()},
+	}}
+	candidates := []piSessionEntry{
+		{sessionID: "one", path: "one.jsonl", modTime: activity},
+		{sessionID: "two", path: "two.jsonl", modTime: activity.Add(2 * time.Second)},
+	}
+	got := uniquePiSessionsByWindowActivity(
+		restore,
+		[]int{0, 1},
+		candidates,
+		map[int]bool{0: true, 1: true},
+	)
+	if len(got) != 0 {
+		t.Fatalf("overlapping activity matches = %#v, want no assignments", got)
+	}
+}
+
+func TestEnrichRestoreWithWindowActivityUsesStableWindowIdentity(t *testing.T) {
+	restore := &serverRestore{Windows: []restoreWindowState{
+		{ID: "@2", Index: 0, AgentTool: "pi"},
+		{Index: 0, AgentTool: "pi"},
+	}}
+	if !restoreNeedsWindowActivity(restore) {
+		t.Fatal("legacy Pi restore did not request window activity")
+	}
+	enrichRestoreWithWindowActivity(restore, []windowSnapshot{
+		{ID: "@1", Index: 0, LastActivityEpochSeconds: 10},
+		{ID: "@2", Index: 1, LastActivityEpochSeconds: 20},
+	})
+	if got := restore.Windows[0].LastActivityEpochSeconds; got != 20 {
+		t.Fatalf("ID-matched activity = %d, want 20", got)
+	}
+	if got := restore.Windows[1].LastActivityEpochSeconds; got != 10 {
+		t.Fatalf("legacy index-matched activity = %d, want 10", got)
+	}
+	if restoreNeedsWindowActivity(restore) {
+		t.Fatal("enriched Pi restore still requests window activity")
+	}
+}

--- a/remote/monkeymux/pi_restore_test.go
+++ b/remote/monkeymux/pi_restore_test.go
@@ -709,6 +709,22 @@ func TestDiscoverPiSessionsDeclinesOverlappingProcessStarts(t *testing.T) {
 	}
 }
 
+func TestPiProcessesByPaneRejectsMinimumDepthTie(t *testing.T) {
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "pi", args: "pi --session first"},
+		201: {pid: 201, ppid: 100, comm: "pi", args: "pi --session second"},
+	}
+	if got := piProcessesByPane(processes, map[int]struct{}{100: {}}, map[int]struct{}{100: {}}); len(got) != 0 {
+		t.Fatalf("same-depth Pi process tie = %#v, want fail closed", got)
+	}
+	delete(processes, 201)
+	processes[300] = processInfo{pid: 300, ppid: 200, comm: "pi", args: "pi --session nested"}
+	if got := piProcessesByPane(processes, map[int]struct{}{100: {}}, map[int]struct{}{100: {}}); got[100].pid != 200 {
+		t.Fatalf("Pi process selection = %#v, want shallow pid 200", got)
+	}
+}
+
 func TestDiscoverPiSessionsUsesLiveOpenFileAndSkipsNestedPiProcess(t *testing.T) {
 	originalOpenFiles := processOpenFilePathsForMetadata
 	t.Cleanup(func() { processOpenFilePathsForMetadata = originalOpenFiles })

--- a/remote/monkeymux/pi_restore_test.go
+++ b/remote/monkeymux/pi_restore_test.go
@@ -433,7 +433,7 @@ func TestPiResumeCommandRejectsShellMetacharacters(t *testing.T) {
 	}
 }
 
-func TestEnrichRestoreWithAgentSessionIDsUsesUnambiguousPiSession(t *testing.T) {
+func TestEnrichRestoreWithAgentSessionIDsKeepsFreshPiWindowFresh(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("PI_CODING_AGENT_SESSION_DIR", root)
 	project := filepath.Join(root, "project")
@@ -448,14 +448,11 @@ func TestEnrichRestoreWithAgentSessionIDsUsesUnambiguousPiSession(t *testing.T) 
 	}}}
 	enrichRestoreWithAgentSessionIDs(restore)
 
-	if got := restore.Windows[0].AgentSessionID; got != "primary-session" {
-		t.Fatalf("Pi session = %q, want primary-session", got)
+	if got := restore.Windows[0].AgentSessionID; got != "" {
+		t.Fatalf("fresh Pi window inherited session %q", got)
 	}
-	if got := restore.Windows[0].AgentSessionDir; got != filepath.Join(root, "project") {
-		t.Fatalf("Pi session dir = %q, want project bucket", got)
-	}
-	if got := restore.Windows[0].AgentSessionPath; got != primaryPath {
-		t.Fatalf("Pi session path = %q, want %q", got, primaryPath)
+	if restore.Windows[0].AgentSessionDir != "" || restore.Windows[0].AgentSessionPath != "" {
+		t.Fatalf("fresh Pi window kept restore metadata: %#v", restore.Windows[0])
 	}
 }
 
@@ -750,11 +747,22 @@ func TestDiscoverPiSessionsUsesLiveOpenFileAndSkipsNestedPiProcess(t *testing.T)
 
 func TestDiscoverPiSessionsHonorsProcessSessionDir(t *testing.T) {
 	originalOpenFiles := processOpenFilePathsForMetadata
-	t.Cleanup(func() { processOpenFilePathsForMetadata = originalOpenFiles })
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processStartedAtForMetadata = originalProcessStart
+	})
 	processOpenFilePathsForMetadata = func(int) []string { return nil }
 	project := t.TempDir()
 	custom := filepath.Join(project, ".sessions")
-	writePiTestSession(t, filepath.Join(custom, "current.jsonl"), "custom-session", project, time.Now())
+	now := time.Now()
+	writePiTestSession(t, filepath.Join(custom, "current.jsonl"), "custom-session", project, now)
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return now.Add(-time.Minute)
+		}
+		return time.Time{}
+	}
 	processes := map[int]processInfo{
 		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
 		200: {pid: 200, ppid: 100, comm: "pi", args: "pi --session-dir .sessions"},
@@ -1051,6 +1059,153 @@ func TestPiWindowActivityCorrelationRejectsAmbiguity(t *testing.T) {
 	)
 	if len(got) != 0 {
 		t.Fatalf("overlapping activity matches = %#v, want no assignments", got)
+	}
+}
+
+func TestDiscoverPiSessionsUsesSingleCurrentCwdFallback(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processStartedAtForMetadata = originalProcessStart
+	})
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+	root := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_SESSION_DIR", root)
+	project := filepath.Join(root, "project")
+	started := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	path := filepath.Join(root, "project", "resumed.jsonl")
+	writePiTestSessionTimes(t, path, "resumed-session", project, started.Add(-time.Hour), started.Add(30*time.Minute))
+	processStartedAtForMetadata = func(int) time.Time { return started }
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "pi", args: "pi"},
+	}
+	restore := &serverRestore{Windows: []restoreWindowState{{
+		PanePid: 100, CurrentCommand: "pi", AgentTool: "pi", Cwd: project,
+	}}}
+
+	got := discoverPiSessions(restore, processes, map[int]struct{}{100: {}})
+	if got[0].sessionPath != path {
+		t.Fatalf("current-process cwd fallback = %#v, want %q", got, path)
+	}
+}
+
+func TestDiscoverPiSessionsActivityDeclinesLaterUnownedSession(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processStartedAtForMetadata = originalProcessStart
+	})
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+	root := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_SESSION_DIR", root)
+	project := filepath.Join(root, "project")
+	started := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	activity := started.Add(30 * time.Minute)
+	writePiTestSessionTimes(t, filepath.Join(root, "project", "abandoned.jsonl"), "abandoned", project, started.Add(-time.Hour), activity)
+	writePiTestSessionTimes(t, filepath.Join(root, "project", "later.jsonl"), "later", project, started.Add(-30*time.Minute), activity.Add(time.Minute))
+	processStartedAtForMetadata = func(int) time.Time { return started }
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "pi", args: "pi"},
+	}
+	restore := &serverRestore{Windows: []restoreWindowState{{
+		PanePid: 100, CurrentCommand: "pi", AgentTool: "pi", Cwd: project,
+		LastActivityEpochSeconds: activity.Unix(),
+	}}}
+
+	if got := discoverPiSessions(restore, processes, map[int]struct{}{100: {}}); len(got) != 0 {
+		t.Fatalf("activity restored superseded session: %#v", got)
+	}
+}
+
+func TestPiActivityAssignmentsRejectPartialOverlap(t *testing.T) {
+	activity := time.Now().UTC().Truncate(time.Second)
+	restore := &serverRestore{Windows: []restoreWindowState{
+		{LastActivityEpochSeconds: activity.Unix()},
+		{LastActivityEpochSeconds: activity.Add(10 * time.Second).Unix()},
+	}}
+	candidates := []piSessionEntry{
+		{sessionID: "a", modTime: activity},
+		{sessionID: "b", modTime: activity.Add(20 * time.Second)},
+	}
+	got := uniquePiSessionsByWindowActivity(restore, []int{0, 1}, candidates, map[int]bool{0: true, 1: true})
+	if len(got) != 0 {
+		t.Fatalf("partial-overlap activity assignments = %#v, want none", got)
+	}
+}
+
+func TestDiscoverPiSessionsDoesNotCollapseMultiPaneCwdFallback(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processStartedAtForMetadata = originalProcessStart
+	})
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+	root := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_SESSION_DIR", root)
+	project := filepath.Join(root, "project")
+	started := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	activity := started.Add(time.Hour)
+	firstPath := filepath.Join(root, "project", "first.jsonl")
+	writePiTestSessionTimes(t, firstPath, "first", project, started.Add(-2*time.Hour), activity)
+	writePiTestSessionTimes(t, filepath.Join(root, "project", "second.jsonl"), "second", project, started.Add(-time.Hour), activity.Add(-time.Minute))
+	processStartedAtForMetadata = func(int) time.Time { return started }
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		101: {pid: 101, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "pi", args: "pi"},
+		201: {pid: 201, ppid: 101, comm: "pi", args: "pi"},
+	}
+	restore := &serverRestore{Windows: []restoreWindowState{
+		{PanePid: 100, CurrentCommand: "pi", AgentTool: "pi", Cwd: project, LastActivityEpochSeconds: activity.Unix()},
+		{PanePid: 101, CurrentCommand: "pi", AgentTool: "pi", Cwd: project},
+	}}
+
+	got := discoverPiSessions(restore, processes, map[int]struct{}{100: {}, 101: {}})
+	if len(got) != 1 || got[0].sessionPath != firstPath {
+		t.Fatalf("collapsed multi-pane fallback = %#v, want only pane 0", got)
+	}
+}
+
+func TestDiscoverPiSessionsIgnoresUnconfirmedShellPane(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processStartedAtForMetadata = originalProcessStart
+	})
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+	root := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_SESSION_DIR", root)
+	project := filepath.Join(root, "project")
+	path := filepath.Join(root, "project", "named.jsonl")
+	now := time.Now()
+	writePiTestSession(t, path, "named-session", project, now)
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 201 {
+			return now.Add(-time.Minute)
+		}
+		return time.Time{}
+	}
+	appendPiTestSessionName(t, path, "work")
+	title := "Pi - work - " + filepath.Base(project)
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		101: {pid: 101, ppid: 1, comm: "zsh", args: "zsh"},
+		201: {pid: 201, ppid: 101, comm: "pi", args: "pi"},
+	}
+	restore := &serverRestore{Windows: []restoreWindowState{
+		{PanePid: 100, CurrentCommand: "zsh", AgentTool: "pi", PaneTitle: title, Cwd: project},
+		{PanePid: 101, CurrentCommand: "pi", AgentTool: "pi", PaneTitle: title, Cwd: project},
+	}}
+
+	got := discoverPiSessions(restore, processes, map[int]struct{}{100: {}, 101: {}})
+	if _, ok := got[0]; ok || got[1].sessionPath != path {
+		t.Fatalf("Pi-like shell consumed session: %#v", got)
 	}
 }
 

--- a/remote/monkeymux/pi_restore_windows_test.go
+++ b/remote/monkeymux/pi_restore_windows_test.go
@@ -27,6 +27,28 @@ func TestPiRestoreTreatsWindowsShellsAsShells(t *testing.T) {
 	}
 }
 
+func TestAgentRestoreCommandUsesWindowsShellSyntax(t *testing.T) {
+	t.Setenv("ComSpec", "cmd.exe")
+	t.Setenv("MONKEYMUX_SHELL", "cmd.exe")
+	if got := agentResumeCommand("claude", "session id", false); got != `claude --resume "session id"` {
+		t.Fatalf("cmd resume command = %q", got)
+	}
+	if got := agentResumeCommandWithFreshFallback(`claude --resume "session id"`, "claude"); got != `claude --resume "session id" || claude` {
+		t.Fatalf("cmd fallback command = %q", got)
+	}
+	if got := agentResumeCommand("claude", "session%id", false); got != "" {
+		t.Fatalf("unsafe cmd resume command = %q", got)
+	}
+
+	t.Setenv("MONKEYMUX_SHELL", "powershell.exe")
+	if got := agentResumeCommand("claude", "session's id", false); got != `claude --resume 'session''s id'` {
+		t.Fatalf("PowerShell resume command = %q", got)
+	}
+	if got := agentResumeCommandWithFreshFallback("claude --resume session-id", "claude"); got != "claude --resume session-id; if (-not $?) { claude }" {
+		t.Fatalf("PowerShell fallback command = %q", got)
+	}
+}
+
 func TestPiRestoreCommandIsSafeForCmd(t *testing.T) {
 	t.Setenv("ComSpec", "cmd.exe")
 	t.Setenv("MONKEYMUX_SHELL", "cmd.exe")

--- a/remote/monkeymux/platform_windows.go
+++ b/remote/monkeymux/platform_windows.go
@@ -862,14 +862,15 @@ func defaultShellPath() string {
 }
 
 func shellCommand(shell string) *exec.Cmd {
-	return exec.Command(shell)
+	// The shell path is explicit user-owned MONKEYMUX_SHELL/ComSpec configuration.
+	return exec.Command(shell) // nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
 }
 
 func shellCommandForScript(shell string, command string) *exec.Cmd {
 	if isCmdShell(shell) {
-		return exec.Command(shell, "/c", command)
+		return exec.Command(shell, "/c", command) // nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
 	}
-	return exec.Command(shell, "-NoLogo", "-Command", command)
+	return exec.Command(shell, "-NoLogo", "-Command", command) // nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
 }
 
 func isCmdShell(shell string) bool {


### PR DESCRIPTION
## Summary
- preserve per-window activity timestamps in MonkeyMux upgrade snapshots, including compatibility with older helpers
- restore unnamed same-directory Pi panes by unique window-output/session-write timing
- apply one safe restore contract to every resumable agent: live argv/open-file/lock evidence wins; cwd/history fallback must have been updated during the current foreground process
- revalidate carried resume IDs because a failed resume may already have fallen back to a fresh agent
- leave stale or ambiguous windows fresh instead of injecting an older conversation
- bump the packaged helper to 0.1.160

## Supported-agent audit
| Agent | Authoritative evidence | Guarded fallback |
| --- | --- | --- |
| Copilot CLI | process-bound `inuse` lock / argv | cwd event log updated during this process; activity disambiguates |
| Codex | resume argv / open rollout | same-cwd rollout updated during this process |
| OpenCode | session argv | same-directory DB row updated during this process |
| Claude Code | resume argv / open project JSONL | same-cwd JSONL updated during this process |
| Gemini CLI | resume argv / open non-subagent chat | same-directory chat updated during this process |
| Antigravity | conversation argv | unique workspace history updated during this process |
| Cursor Agent | persisted/current chat metadata | unique workspace chat updated during this process |
| Pi | explicit argv / open JSONL / named title | exact process/activity/path correlation with ambiguity rejection |

Agents without resumable session support are relaunched fresh and do not participate in session fallback.

## Reproduction
### Pi sessions
The reported 0.1.159 workspace had four confirmed Pi windows in one working directory after an upgrade. Only one retained an exact session path; three relaunched as bare `pi`. The regression fails on the previous implementation with zero restored sessions and now maps all three to exact JSONL paths and exact-path resume commands.

### Fresh Claude window
The live restored Claude foreground process had been relaunched with `--resume` even though it was fresh before the upgrade. The old cwd fallback selected an older project JSONL whenever no live identity existed. The regression reproduces that false assignment and now keeps the window fresh.

### All-agent safety
New regressions verify stale pre-process records are rejected for Copilot, Codex, OpenCode, Claude Code, Gemini, Antigravity, Cursor Agent, and Pi. A separate enrichment regression verifies unvalidated IDs carried from a previous failed resume are cleared for all eight agents. Existing positive tests still prove argv, open-file, lock, current-process store, exact-path, path-normalization, and multi-window behavior.

## Validation
- `cd remote/monkeymux && go test -race ./...`
- explicit positive/negative restore matrix for all eight agents
- `GOOS=windows GOARCH=amd64 go test -c`
- `flutter test test/domain/services/monkeymux_assets_test.dart`
- primary LSP diagnostics on touched Go files: clean
- regenerated ignored MonkeyMux assets; packaged binaries report 0.1.160
