### PR TITLE
Fix Pi session discovery in tmux menu

### DIFF
--- a/lib/domain/services/agent_session_discovery_service.dart
+++ b/lib/domain/services/agent_session_discovery_service.dart
@@ -3723,30 +3723,17 @@ print(json.dumps(sessions))
               maximum: 12,
             )
           : calculateRecentSessionMetadataReadLimit(max);
-      final output = session.remoteIsWindows
-          ? await _execWindowsPowerShell(
-              session,
-              windowsListNewestFilesScript(
-                relativeRoot: '.pi/agent/sessions',
-                includeGlobs: const ['*.jsonl'],
-                limit: scanLimit,
-              ),
-            )
-          : await _exec(
-              session,
-              'find ~/.pi/agent/sessions -name "*.jsonl" -type f '
-              '-exec ls -1t {} + 2>/dev/null | head -n $scanLimit',
-            );
-      if (output.trim().isEmpty) {
+      final sessionPaths = await _listPiSessionPaths(
+        session,
+        workingDirectory,
+        relatedWorkingDirectories,
+        scanLimit: scanLimit,
+        prioritizedCount: metadataReadLimit,
+        previewOnly: previewOnly,
+      );
+      if (sessionPaths.isEmpty) {
         return const _ToolDiscoveryResult.success('Pi', []);
       }
-
-      final sessionPaths = output
-          .trim()
-          .split('\n')
-          .map((line) => line.trim())
-          .where((line) => line.isNotEmpty)
-          .toList(growable: false);
       final recentSessionPaths = sessionPaths
           .take(metadataReadLimit)
           .toList(growable: false);
@@ -3829,6 +3816,86 @@ print(json.dumps(sessions))
     } on Object {
       return const _ToolDiscoveryResult.failure('Pi');
     }
+  }
+
+  /// Lists Pi candidates from the active project buckets before the global
+  /// history. Pi users often have enough sessions across worktrees that a small
+  /// global preview scan never reaches the active project's files.
+  Future<List<String>> _listPiSessionPaths(
+    SshSession session,
+    String? workingDirectory,
+    List<String> relatedWorkingDirectories, {
+    required int scanLimit,
+    required int prioritizedCount,
+    required bool previewOnly,
+  }) async {
+    List<String> parsePaths(String output) => output
+        .trim()
+        .split('\n')
+        .map((line) => line.trim())
+        .where((line) => line.isNotEmpty)
+        .toList(growable: false);
+
+    final scopeDirectories = relatedWorkingDirectories.isNotEmpty
+        ? relatedWorkingDirectories
+        : workingDirectory == null || workingDirectory.isEmpty
+        ? const <String>[]
+        : <String>[workingDirectory];
+    final buckets = scopeDirectories
+        .map(piEncodedSessionDirectoryName)
+        .whereType<String>()
+        .toSet()
+        .toList(growable: false);
+
+    var scopedPaths = const <String>[];
+    if (buckets.isNotEmpty) {
+      final scopedOutput = session.remoteIsWindows
+          ? await _execWindowsPowerShell(
+              session,
+              windowsListNewestFilesScript(
+                relativeRoot: '.pi/agent/sessions/${buckets.first}',
+                additionalRelativeRoots: buckets
+                    .skip(1)
+                    .map((bucket) => '.pi/agent/sessions/$bucket')
+                    .toList(growable: false),
+                includeGlobs: const ['*.jsonl'],
+                limit: scanLimit,
+              ),
+            )
+          : await _exec(
+              session,
+              'find ${buckets.map((bucket) => '"\$HOME"/.pi/agent/sessions/${_shellQuote(bucket)}').join(' ')} '
+              '-maxdepth 1 -name "*.jsonl" -type f '
+              '-exec ls -1t {} + 2>/dev/null | head -n $scanLimit',
+            );
+      scopedPaths = parsePaths(scopedOutput);
+      // The provider menu only needs one in-scope row. Avoid a second remote
+      // scan once that row is known, and likewise stop when the full picker has
+      // enough prioritized candidates to fill its metadata budget.
+      if ((previewOnly && scopedPaths.isNotEmpty) ||
+          scopedPaths.length >= prioritizedCount) {
+        return scopedPaths.take(scanLimit).toList(growable: false);
+      }
+    }
+
+    final globalOutput = session.remoteIsWindows
+        ? await _execWindowsPowerShell(
+            session,
+            windowsListNewestFilesScript(
+              relativeRoot: '.pi/agent/sessions',
+              includeGlobs: const ['*.jsonl'],
+              limit: scanLimit,
+            ),
+          )
+        : await _exec(
+            session,
+            'find ~/.pi/agent/sessions -name "*.jsonl" -type f '
+            '-exec ls -1t {} + 2>/dev/null | head -n $scanLimit',
+          );
+    return <String>{
+      ...scopedPaths,
+      ...parsePaths(globalOutput),
+    }.take(scanLimit).toList(growable: false);
   }
 
   /// Keeps Pi sessions recorded in scope, plus sessions Pi has since relocated

--- a/test/domain/services/agent_session_discovery_service_test.dart
+++ b/test/domain/services/agent_session_discovery_service_test.dart
@@ -2329,6 +2329,60 @@ branch refs/heads/main
     });
 
     test(
+      'Pi provider preview prioritizes the scope over newer unrelated files',
+      () async {
+        final client = _MockSshClient();
+        const projectPath =
+            '/Users/demo/.pi/agent/sessions/--Users-depoll-Code-flutty--/'
+            '2026-04-12T21-07-44-781Z_01JYX7ABCD.jsonl';
+        final unrelatedPaths = List<String>.generate(
+          7,
+          (index) =>
+              '/Users/demo/.pi/agent/sessions/--Users-depoll-Code-other--/'
+              '2026-04-13T00-00-0$index-000Z_OTHER$index.jsonl',
+        );
+
+        when(() => client.execute(any())).thenAnswer((invocation) async {
+          final command = invocation.positionalArguments.first as String;
+          if (command.contains(projectPath)) {
+            return _buildExecSession(
+              stdout: _remoteSnapshotLine(projectPath, '''
+{"type":"session","version":3,"id":"01JYX7ABCD","timestamp":"2026-04-12T21:07:44.781Z","cwd":"/Users/depoll/Code/flutty"}
+{"type":"message","message":{"role":"user","content":"Scoped Pi session"}}
+'''),
+            );
+          }
+          if (command.contains('--Users-depoll-Code-flutty--')) {
+            return _buildExecSession(stdout: projectPath);
+          }
+          if (command.contains('find ~/.pi/agent/sessions')) {
+            return _buildExecSession(
+              stdout: <String>[...unrelatedPaths, projectPath].join('\n'),
+            );
+          }
+          return _buildExecSession();
+        });
+
+        final discovery = AgentSessionDiscoveryService();
+        final snapshots = await discovery
+            .discoverSessionsStream(
+              _buildDiscoverySession(client),
+              workingDirectory: '/Users/depoll/Code/flutty',
+              maxPerTool: 1,
+            )
+            .toList();
+        final piPreviews = snapshots
+            .expand((snapshot) => snapshot.sessions)
+            .where((session) => session.toolName == 'Pi')
+            .toList(growable: false);
+
+        expect(piPreviews, isNotEmpty);
+        expect(piPreviews.first.sessionId, '01JYX7ABCD');
+        expect(piPreviews.first.summary, 'Scoped Pi session');
+      },
+    );
+
+    test(
       'Pi discovery keeps a session relocated out of the scoped directory',
       () async {
         final client = _MockSshClient();


### PR DESCRIPTION
## Summary
- prioritize Pi session buckets for the active project and related worktrees before scanning global history
- keep global fallback candidates for relocated sessions and empty scopes
- add a regression test for the incremental tmux provider menu when newer unrelated Pi sessions fill the global scan

## Validation
- `dart analyze lib/domain/services/agent_session_discovery_service.dart test/domain/services/agent_session_discovery_service_test.dart`
- `flutter test test/domain/services/agent_session_discovery_service_test.dart`