### PR TITLE
Fix migration imports with invalid jump hosts

### DIFF
--- a/lib/domain/services/secure_transfer_service.dart
+++ b/lib/domain/services/secure_transfer_service.dart
@@ -279,6 +279,25 @@ class SecureTransferService {
             .get();
     final rawPortForwards = await _db.select(_db.portForwards).get();
     final exportedHostIds = hosts.map((host) => host.id).toSet();
+    var removedJumpHostReferenceCount = 0;
+    final exportedHosts = hosts
+        .map((host) {
+          final hostData = Map<String, dynamic>.from(host.toJson());
+          final jumpHostId = host.jumpHostId;
+          if (jumpHostId != null && !exportedHostIds.contains(jumpHostId)) {
+            hostData['jumpHostId'] = null;
+            removedJumpHostReferenceCount += 1;
+          }
+          return hostData;
+        })
+        .toList(growable: false);
+    if (removedJumpHostReferenceCount > 0) {
+      _diagnosticsLogger.warning(
+        'secure_transfer',
+        'migration_export_jump_host_references_removed',
+        fields: {'removedCount': removedJumpHostReferenceCount},
+      );
+    }
     final portForwards = rawPortForwards
         .where((portForward) => exportedHostIds.contains(portForward.hostId))
         .toList(growable: false);
@@ -303,7 +322,7 @@ class SecureTransferService {
       'settings': filteredSettings,
       'groups': _sortedJsonRecords(groups.map((item) => item.toJson())),
       'keys': _sortedJsonRecords(keys.map((item) => item.toJson())),
-      'hosts': _sortedJsonRecords(hosts.map((item) => item.toJson())),
+      'hosts': _sortedJsonRecords(exportedHosts),
       'snippetFolders': _sortedJsonRecords(
         snippetFolders.map((item) => item.toJson()),
       ),
@@ -937,6 +956,7 @@ class SecureTransferService {
   }) async {
     final idMapping = <int, int>{};
     final jumpMapping = <int, int?>{};
+    var removedJumpHostReferenceCount = 0;
 
     for (final item in rawHosts) {
       final oldId = _optionalInt(item['id']);
@@ -1036,12 +1056,18 @@ class SecureTransferService {
       }
       final mappedJumpId = idMapping[oldJumpId];
       if (mappedJumpId == null) {
-        throw const FormatException(
-          'Invalid jump host reference in migration payload',
-        );
+        removedJumpHostReferenceCount += 1;
+        continue;
       }
       await (_db.update(_db.hosts)..where((tbl) => tbl.id.equals(newHostId)))
           .write(HostsCompanion(jumpHostId: Value(mappedJumpId)));
+    }
+    if (removedJumpHostReferenceCount > 0) {
+      _diagnosticsLogger.warning(
+        'secure_transfer',
+        'migration_import_jump_host_references_removed',
+        fields: {'removedCount': removedJumpHostReferenceCount},
+      );
     }
 
     return idMapping;

--- a/test/domain/services/secure_transfer_service_test.dart
+++ b/test/domain/services/secure_transfer_service_test.dart
@@ -198,6 +198,51 @@ void main() {
     );
 
     test(
+      'full migration removes missing jump hosts and remains importable',
+      () async {
+        await db.customStatement('PRAGMA foreign_keys = OFF');
+        await db
+            .into(db.hosts)
+            .insert(
+              HostsCompanion.insert(
+                label: 'Production',
+                hostname: 'prod.example.com',
+                username: 'root',
+                jumpHostId: const Value(999),
+              ),
+            );
+
+        final encodedPayload = await transferService.createFullMigrationPayload(
+          transferPassphrase: '1234',
+        );
+
+        final importedDb = AppDatabase.forTesting(NativeDatabase.memory());
+        addTearDown(importedDb.close);
+        final importedEncryptionService = SecretEncryptionService.forTesting();
+        final importedTransferService = SecureTransferService(
+          importedDb,
+          KeyRepository(importedDb, importedEncryptionService),
+          HostRepository(importedDb, importedEncryptionService),
+        );
+        final payload = await importedTransferService.decryptPayload(
+          encodedPayload: encodedPayload,
+          transferPassphrase: '1234',
+        );
+
+        await importedTransferService.importFullMigrationPayload(
+          payload: payload,
+          mode: MigrationImportMode.replace,
+        );
+
+        final importedHost = await importedDb
+            .select(importedDb.hosts)
+            .getSingle();
+        expect(importedHost.label, 'Production');
+        expect(importedHost.jumpHostId, isNull);
+      },
+    );
+
+    test(
       'createMigrationData excludes port forwards for missing hosts',
       () async {
         final hostId = await hostRepository.insert(
@@ -730,6 +775,45 @@ void main() {
         ),
         throwsFormatException,
       );
+    });
+
+    test('removes missing jump host references during import', () async {
+      final diagnosticsLogger = _RecordingDiagnosticsLogger();
+      final service = SecureTransferService(
+        db,
+        keyRepository,
+        hostRepository,
+        diagnosticsLogger: diagnosticsLogger,
+      );
+      final payload = TransferPayload(
+        type: TransferPayloadType.fullMigration,
+        schemaVersion: 1,
+        createdAt: DateTime.now().toUtc(),
+        data: {
+          'hosts': [
+            {
+              'id': 1,
+              'label': 'Host',
+              'hostname': 'example.com',
+              'username': 'root',
+              'jumpHostId': 999,
+            },
+          ],
+        },
+      );
+
+      await service.importFullMigrationPayload(
+        payload: payload,
+        mode: MigrationImportMode.merge,
+      );
+
+      final importedHost = await db.select(db.hosts).getSingle();
+      expect(importedHost.jumpHostId, isNull);
+      final warning = diagnosticsLogger.events.singleWhere(
+        (event) =>
+            event.message == 'migration_import_jump_host_references_removed',
+      );
+      expect(warning.fields, {'removedCount': 1});
     });
 
     test(

--- a/test/domain/services/secure_transfer_service_test.dart
+++ b/test/domain/services/secure_transfer_service_test.dart
@@ -212,9 +212,15 @@ void main() {
               ),
             );
 
-        final encodedPayload = await transferService.createFullMigrationPayload(
-          transferPassphrase: '1234',
+        final diagnosticsLogger = _RecordingDiagnosticsLogger();
+        final exportingService = SecureTransferService(
+          db,
+          keyRepository,
+          hostRepository,
+          diagnosticsLogger: diagnosticsLogger,
         );
+        final encodedPayload = await exportingService
+            .createFullMigrationPayload(transferPassphrase: '1234');
 
         final importedDb = AppDatabase.forTesting(NativeDatabase.memory());
         addTearDown(importedDb.close);
@@ -228,6 +234,16 @@ void main() {
           encodedPayload: encodedPayload,
           transferPassphrase: '1234',
         );
+        final exportedHosts = payload.data['hosts'] as List;
+        final exportedHost = Map<String, dynamic>.from(
+          exportedHosts.single as Map,
+        );
+        expect(exportedHost['jumpHostId'], isNull);
+        final warning = diagnosticsLogger.events.singleWhere(
+          (event) =>
+              event.message == 'migration_export_jump_host_references_removed',
+        );
+        expect(warning.fields, {'removedCount': 1});
 
         await importedTransferService.importFullMigrationPayload(
           payload: payload,


### PR DESCRIPTION
## Summary
- strip dangling jump-host references from full migration exports so generated packages remain importable
- gracefully ignore invalid jump-host references in incoming migration payloads while preserving the host
- record sanitized count-only diagnostics for both paths

## Tests
- `flutter test test/domain/services/secure_transfer_service_test.dart`
- `flutter analyze lib/domain/services/secure_transfer_service.dart test/domain/services/secure_transfer_service_test.dart`
- pre-push full-project analyzer