### PR TITLE
fix: keep terminal chrome above the navigation bar

### DIFF
--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -73,6 +73,7 @@ import '../widgets/device_debug_sheet.dart';
 import '../widgets/keyboard_toolbar.dart';
 import '../widgets/monkey_terminal_view.dart';
 import '../widgets/premium_access.dart';
+import '../widgets/system_bottom_inset.dart';
 import '../widgets/terminal_menu_style.dart';
 import '../widgets/terminal_overlay_focus.dart';
 import '../widgets/terminal_pinch_zoom_gesture_handler.dart';
@@ -793,7 +794,7 @@ EdgeInsets resolveTmuxBarSafeInsets(MediaQueryData mediaQuery) {
   return EdgeInsets.only(
     left: horizontalInsets.left,
     right: horizontalInsets.right,
-    bottom: mediaQuery.padding.bottom,
+    bottom: resolveSystemBottomInset(mediaQuery),
   );
 }
 
@@ -12812,12 +12813,13 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
               children: [
                 Expanded(
                   // The KeyboardToolbar below already absorbs the bottom
-                  // safe-area inset via its own SafeArea, so strip it here to
-                  // prevent the tmux bar from floating above the toolbar.
+                  // system inset, so strip it here to prevent the tmux bar
+                  // from reserving that space a second time.
                   child: showsKeyboardToolbar
-                      ? MediaQuery.removePadding(
-                          context: bodyContext,
-                          removeBottom: true,
+                      ? MediaQuery(
+                          data: removeSystemBottomInset(
+                            MediaQuery.of(bodyContext),
+                          ),
                           child: terminalArea,
                         )
                       : terminalArea,

--- a/lib/presentation/widgets/keyboard_toolbar.dart
+++ b/lib/presentation/widgets/keyboard_toolbar.dart
@@ -4,16 +4,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:xterm/xterm.dart';
 
+import 'system_bottom_inset.dart';
 import 'terminal_key_input.dart';
 import 'terminal_menu_style.dart';
 
-/// Whether the toolbar should keep the bottom safe-area inset.
+/// Resolves the bottom inset the toolbar reserves below its last key row.
 ///
-/// When the system keyboard is visible, the toolbar is already lifted above the
-/// obscured region by the viewport inset. In that state, keeping the bottom
-/// safe-area inset just adds unnecessary extra gap above the keyboard.
-bool shouldKeepToolbarBottomSafeArea(MediaQueryData mediaQuery) =>
-    mediaQuery.viewInsets.bottom == 0;
+/// The toolbar is the bottom-most chrome in the terminal body, so it owns the
+/// gesture handle / navigation bar inset. When the system keyboard lifts the
+/// layout above that bar the inset resolves to zero, which avoids an extra gap
+/// above the keyboard.
+double resolveKeyboardToolbarBottomInset(MediaQueryData mediaQuery) =>
+    resolveSystemBottomInset(mediaQuery);
 
 /// Whether the extra-keys toolbar should collapse to a single row.
 ///
@@ -27,10 +29,8 @@ bool shouldUseSingleRowKeyboardToolbar(MediaQueryData mediaQuery) =>
 /// Resolves the total rendered height of the keyboard toolbar.
 double resolveKeyboardToolbarHeight(MediaQueryData mediaQuery) {
   final rowCount = shouldUseSingleRowKeyboardToolbar(mediaQuery) ? 1 : 2;
-  final bottomInset = shouldKeepToolbarBottomSafeArea(mediaQuery)
-      ? mediaQuery.padding.bottom
-      : 0.0;
-  return rowCount * _KeyRow.height + bottomInset;
+  return rowCount * _KeyRow.height +
+      resolveKeyboardToolbarBottomInset(mediaQuery);
 }
 
 /// Resolves the terminal output sequence for a Tab action.
@@ -343,7 +343,7 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
     final mediaQuery = MediaQuery.of(context);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final keepBottomSafeArea = shouldKeepToolbarBottomSafeArea(mediaQuery);
+    final bottomInset = resolveKeyboardToolbarBottomInset(mediaQuery);
     final useSingleRow = shouldUseSingleRowKeyboardToolbar(mediaQuery);
 
     return DecoratedBox(
@@ -353,13 +353,16 @@ class KeyboardToolbarState extends State<KeyboardToolbar> {
       ),
       child: SafeArea(
         top: false,
-        bottom: keepBottomSafeArea,
-        child: useSingleRow
-            ? _buildLandscapeRow()
-            : Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [_buildModifierRow(), _buildNavigationRow()],
-              ),
+        bottom: false,
+        child: Padding(
+          padding: EdgeInsets.only(bottom: bottomInset),
+          child: useSingleRow
+              ? _buildLandscapeRow()
+              : Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [_buildModifierRow(), _buildNavigationRow()],
+                ),
+        ),
       ),
     );
   }

--- a/lib/presentation/widgets/system_bottom_inset.dart
+++ b/lib/presentation/widgets/system_bottom_inset.dart
@@ -1,0 +1,34 @@
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+
+/// Resolves the bottom system inset (gesture handle or navigation bar) that
+/// bottom-anchored chrome in this subtree still has to clear.
+///
+/// [MediaQueryData.padding] usually answers this on its own: Flutter subtracts
+/// the on-screen keyboard from it, so it is zero exactly while the keyboard
+/// covers the system bar. That only holds when the layout is actually lifted
+/// above the keyboard. [Scaffold] strips the bottom view inset from its body
+/// once it resizes for the keyboard, so a bottom view inset that survives into
+/// this subtree means the layout was *not* lifted — `resizeToAvoidBottomInset`
+/// is off, or the platform is reporting a stale inset after the keyboard
+/// closed. In that state `padding.bottom` is zero while the navigation bar is
+/// still on screen, and bottom chrome would be drawn underneath it.
+double resolveSystemBottomInset(MediaQueryData mediaQuery) {
+  final unliftedInset = mediaQuery.viewInsets.bottom > 0
+      ? mediaQuery.viewPadding.bottom
+      : 0.0;
+  return math.max(mediaQuery.padding.bottom, unliftedInset);
+}
+
+/// Drops the bottom system inset from [mediaQuery].
+///
+/// Use this for content stacked above chrome that already consumed the inset
+/// resolved by [resolveSystemBottomInset], so the inset is not reserved twice.
+/// The bottom view inset is left alone because it still describes the keyboard
+/// for viewport measurements.
+MediaQueryData removeSystemBottomInset(MediaQueryData mediaQuery) =>
+    mediaQuery.copyWith(
+      padding: mediaQuery.padding.copyWith(bottom: 0),
+      viewPadding: mediaQuery.viewPadding.copyWith(bottom: 0),
+    );

--- a/test/widget/keyboard_toolbar_test.dart
+++ b/test/widget/keyboard_toolbar_test.dart
@@ -41,6 +41,7 @@ void main() {
     const mediaQuery = MediaQueryData(
       size: Size(390, 844),
       padding: EdgeInsets.only(bottom: 34),
+      viewPadding: EdgeInsets.only(bottom: 34),
     );
 
     expect(shouldUseSingleRowKeyboardToolbar(mediaQuery), isFalse);
@@ -671,18 +672,71 @@ void main() {
     });
 
     test('keeps bottom safe-area padding when keyboard is closed', () {
-      const mediaQuery = MediaQueryData(padding: EdgeInsets.only(bottom: 34));
+      const mediaQuery = MediaQueryData(
+        padding: EdgeInsets.only(bottom: 34),
+        viewPadding: EdgeInsets.only(bottom: 34),
+      );
 
-      expect(shouldKeepToolbarBottomSafeArea(mediaQuery), isTrue);
+      expect(resolveKeyboardToolbarBottomInset(mediaQuery), 34);
     });
 
     test('drops bottom safe-area padding when keyboard is open', () {
+      // The scaffold lifts the body above the keyboard and strips the bottom
+      // view inset from it, so only the (already zeroed) padding remains.
       const mediaQuery = MediaQueryData(
-        padding: EdgeInsets.only(bottom: 34),
+        viewPadding: EdgeInsets.only(bottom: 34),
+      );
+
+      expect(resolveKeyboardToolbarBottomInset(mediaQuery), 0);
+    });
+
+    test('keeps bottom safe-area padding for an unlifted bottom inset', () {
+      // A bottom view inset that survives into the body means the layout was
+      // never lifted for it (stale platform inset, or
+      // `resizeToAvoidBottomInset: false`), so the navigation bar is still on
+      // screen even though `padding.bottom` reads zero.
+      const mediaQuery = MediaQueryData(
+        viewPadding: EdgeInsets.only(bottom: 34),
         viewInsets: EdgeInsets.only(bottom: 320),
       );
 
-      expect(shouldKeepToolbarBottomSafeArea(mediaQuery), isFalse);
+      expect(resolveKeyboardToolbarBottomInset(mediaQuery), 34);
+      expect(resolveKeyboardToolbarHeight(mediaQuery), 118);
+    });
+
+    testWidgets('stays above the navigation bar for a stale bottom inset', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            // The keyboard is closed but the platform still reports its inset,
+            // so the scaffold never lifted the body: the toolbar has to clear
+            // the navigation bar itself.
+            builder: (context) => MediaQuery(
+              data: MediaQuery.of(context).copyWith(
+                padding: EdgeInsets.zero,
+                viewPadding: const EdgeInsets.only(bottom: 34),
+                viewInsets: const EdgeInsets.only(bottom: 320),
+              ),
+              child: Scaffold(
+                resizeToAvoidBottomInset: false,
+                body: Column(
+                  children: [
+                    const Expanded(child: SizedBox.expand()),
+                    KeyboardToolbar(terminal: terminal),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final bodyBottom = tester.getRect(find.byType(Scaffold)).bottom;
+      final lastRowBottom = tester.getRect(find.byTooltip('Enter')).bottom;
+
+      expect(bodyBottom - lastRowBottom, 34);
     });
 
     testWidgets('arrow keys repeat while held', (tester) async {

--- a/test/widget/system_bottom_inset_test.dart
+++ b/test/widget/system_bottom_inset_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:monkeyssh/presentation/widgets/system_bottom_inset.dart';
+
+void main() {
+  group('resolveSystemBottomInset', () {
+    test('reserves the navigation bar while no keyboard inset applies', () {
+      const mediaQuery = MediaQueryData(
+        padding: EdgeInsets.only(bottom: 34),
+        viewPadding: EdgeInsets.only(bottom: 34),
+      );
+
+      expect(resolveSystemBottomInset(mediaQuery), 34);
+    });
+
+    test('reserves nothing once the layout is lifted above the keyboard', () {
+      // Scaffold strips the bottom view inset from a body it resized, and the
+      // keyboard already covers the navigation bar.
+      const mediaQuery = MediaQueryData(
+        viewPadding: EdgeInsets.only(bottom: 34),
+      );
+
+      expect(resolveSystemBottomInset(mediaQuery), 0);
+    });
+
+    test('reserves the navigation bar for an unlifted bottom inset', () {
+      // The inset survived into this subtree, so nothing lifted the layout for
+      // it: the navigation bar is still on screen even though padding.bottom
+      // has been zeroed out by the (stale) keyboard inset.
+      const mediaQuery = MediaQueryData(
+        viewPadding: EdgeInsets.only(bottom: 34),
+        viewInsets: EdgeInsets.only(bottom: 320),
+      );
+
+      expect(resolveSystemBottomInset(mediaQuery), 34);
+    });
+
+    test('reserves nothing when there is no bottom system bar', () {
+      expect(
+        resolveSystemBottomInset(
+          const MediaQueryData(viewInsets: EdgeInsets.only(bottom: 320)),
+        ),
+        0,
+      );
+      expect(resolveSystemBottomInset(const MediaQueryData()), 0);
+    });
+  });
+
+  group('removeSystemBottomInset', () {
+    test('drops the bottom inset while keeping the keyboard inset', () {
+      const mediaQuery = MediaQueryData(
+        padding: EdgeInsets.fromLTRB(0, 44, 0, 34),
+        viewPadding: EdgeInsets.fromLTRB(0, 44, 0, 34),
+        viewInsets: EdgeInsets.only(bottom: 320),
+      );
+
+      final stripped = removeSystemBottomInset(mediaQuery);
+
+      expect(resolveSystemBottomInset(stripped), 0);
+      expect(stripped.padding.top, 44);
+      expect(stripped.viewPadding.top, 44);
+      expect(stripped.viewInsets.bottom, 320);
+    });
+  });
+}

--- a/test/widget/terminal_screen_layout_test.dart
+++ b/test/widget/terminal_screen_layout_test.dart
@@ -6,6 +6,7 @@ import 'package:monkeyssh/domain/models/tmux_state.dart';
 import 'package:monkeyssh/domain/services/shell_completion_service.dart';
 import 'package:monkeyssh/domain/services/ssh_service.dart';
 import 'package:monkeyssh/presentation/screens/terminal_screen.dart';
+import 'package:monkeyssh/presentation/widgets/system_bottom_inset.dart';
 
 void main() {
   group('terminal layout helpers', () {
@@ -325,7 +326,15 @@ void main() {
         size: Size(390, 844),
         padding: EdgeInsets.only(bottom: 34),
       );
+      // The scaffold lifts the body above the keyboard and strips the bottom
+      // view inset from it, leaving only the already-zeroed bottom padding.
       const portraitKeyboardMediaQuery = MediaQueryData(
+        size: Size(390, 844),
+        viewPadding: EdgeInsets.only(bottom: 34),
+      );
+      // A bottom view inset that survives into the body means the layout was
+      // never lifted for it, so the navigation bar is still on screen.
+      const portraitStaleInsetMediaQuery = MediaQueryData(
         size: Size(390, 844),
         viewPadding: EdgeInsets.only(bottom: 34),
         viewInsets: EdgeInsets.only(bottom: 320),
@@ -342,6 +351,10 @@ void main() {
       expect(
         resolveTmuxBarSafeInsets(portraitKeyboardMediaQuery),
         EdgeInsets.zero,
+      );
+      expect(
+        resolveTmuxBarSafeInsets(portraitStaleInsetMediaQuery),
+        const EdgeInsets.only(bottom: 34),
       );
       expect(
         resolveTmuxBarSafeInsets(landscapeMediaQuery),
@@ -1211,9 +1224,10 @@ void main() {
                 builder: (outerContext) => Column(
                   children: [
                     Expanded(
-                      child: MediaQuery.removePadding(
-                        context: outerContext,
-                        removeBottom: true,
+                      child: MediaQuery(
+                        data: removeSystemBottomInset(
+                          MediaQuery.of(outerContext),
+                        ),
                         child: Builder(
                           builder: (innerContext) {
                             strippedMediaQuery = MediaQuery.of(innerContext);
@@ -1245,6 +1259,48 @@ void main() {
         );
       },
     );
+
+    testWidgets('collapses to zero for a stale unlifted bottom inset', (
+      tester,
+    ) async {
+      late MediaQueryData strippedMediaQuery;
+      await tester.pumpWidget(
+        MediaQuery(
+          // The keyboard is closed but the platform still reports its inset,
+          // so the scaffold never lifted the body and the keyboard toolbar
+          // below absorbs the navigation-bar inset itself.
+          data: const MediaQueryData(
+            viewPadding: EdgeInsets.only(bottom: 34),
+            viewInsets: EdgeInsets.only(bottom: 320),
+          ),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Builder(
+              builder: (outerContext) => Column(
+                children: [
+                  Expanded(
+                    child: MediaQuery(
+                      data: removeSystemBottomInset(
+                        MediaQuery.of(outerContext),
+                      ),
+                      child: Builder(
+                        builder: (innerContext) {
+                          strippedMediaQuery = MediaQuery.of(innerContext);
+                          return const SizedBox.expand();
+                        },
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 118),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(resolveTmuxBarSafeInsets(strippedMediaQuery).bottom, 0);
+    });
   });
 }
 


### PR DESCRIPTION
## Problem

Sometimes the terminal's bottom chrome renders *underneath* the Android gesture handle — the last keyboard-toolbar row sits in the navigation bar strip instead of above it.

The trigger is a stale platform bottom inset. `shouldKeepToolbarBottomSafeArea` dropped the bottom safe area whenever `MediaQuery.viewInsets.bottom != 0`, assuming a bottom view inset always means the layout is already lifted above the keyboard. On Android the platform sometimes keeps reporting the keyboard inset after the keyboard has closed (the screen already guards against this elsewhere — see the `systemKeyboardVisible` comment), and the terminal `Scaffold` only sets `resizeToAvoidBottomInset` when its own input connection agrees the keyboard is up. So in that state:

- nothing lifts the body,
- `padding.bottom` is zeroed out by the stale inset, so a plain `SafeArea` would not help either,
- and the toolbar drops the inset it is supposed to own → it draws under the gesture handle.

## Fix

`Scaffold` strips the bottom view inset from a body it resized for the keyboard, so a bottom view inset that survives into the body means the layout was **not** lifted for it. New shared helper `resolveSystemBottomInset` uses that:

- unlifted bottom inset present → reserve `viewPadding.bottom` (the navigation bar is still on screen),
- otherwise → `padding.bottom`, which is already zero while the keyboard genuinely covers the bar, so no extra gap appears above the keyboard.

The keyboard toolbar and `resolveTmuxBarSafeInsets` both go through it, and the terminal area stacked above the toolbar now strips `padding.bottom` **and** `viewPadding.bottom` (`removeSystemBottomInset`) so the tmux bar can't reserve the same inset a second time.

## Tests

- `test/widget/system_bottom_inset_test.dart` (new) covers the three inset states plus the strip helper.
- `keyboard_toolbar_test.dart`: helper cases rewritten for realistic media queries, plus a widget test asserting the last key row stays exactly `viewPadding.bottom` above the body edge with a stale inset.
- `terminal_screen_layout_test.dart`: tmux safe insets gain a stale-inset case, and the "chrome below absorbs the safe area" test now exercises the production strip helper for both the normal and stale states.

Both new toolbar tests were verified to fail against the previous logic. `flutter analyze` and the full `flutter test` suite (3158 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)