### PR TITLE
fix(monkeymux): resume Claude sessions that moved into a worktree

### DIFF
--- a/remote/monkeymux/README.md
+++ b/remote/monkeymux/README.md
@@ -93,7 +93,13 @@ than risking the wrong conversation. Plain working-directory fallback is used
 only for one live window and one unused session updated during that foreground
 process. Across Copilot, Codex, OpenCode, Claude Code, Gemini, Antigravity, and
 Cursor Agent, argv, open-file, or live-lock identity wins; cwd/history fallback
-only accepts state updated during that foreground process. A carried resume ID
+only accepts state updated during that foreground process. Claude Code's cwd
+fallback follows a session that moved: entering a git worktree relocates the
+JSONL into the worktree's project directory, so that directory's name — which
+encodes where the session lives — decides ownership, not the directory the
+session opened in or the per-message `cwd`, which tracks the agent's own shell
+through any `cd`. Directories the session recorded remain the fallback for a
+project directory name that encoding cannot account for. A carried resume ID
 is revalidated because a failed resume may have fallen back to a fresh agent.
 Stale or ambiguous evidence leaves the restored window fresh instead of
 injecting an older conversation. `--session-dir`,

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -59,7 +59,7 @@ type muxProcess interface {
 }
 
 const (
-	monkeyMuxVersion                  = "0.1.160"
+	monkeyMuxVersion                  = "0.1.161"
 	defaultColumns                    = 80
 	defaultRows                       = 24
 	maxTitleBytes                     = 160
@@ -5086,7 +5086,7 @@ func claudeRecentSessionIDForWorkingDirectory(
 		if err != nil || !sessionUpdatedDuringProcess(info.ModTime(), processStarted) {
 			continue
 		}
-		if normalizedMetadataPath(jsonStringFieldFromFile(path, "cwd")) != workingDirectory {
+		if !claudeSessionMatchesWorkingDirectory(path, workingDirectory) {
 			continue
 		}
 		if sessionID := claudeSessionIDFromProjectFile(path); sessionID != "" {
@@ -5094,6 +5094,75 @@ func claudeRecentSessionIDForWorkingDirectory(
 		}
 	}
 	return ""
+}
+
+// claudeSessionMatchesWorkingDirectory reports whether a project file belongs
+// to a Claude session running in workingDirectory, which the caller has already
+// normalized.
+//
+// The directory the file lives in is the signal to trust. Claude names it by
+// encoding the session's working directory, and entering a git worktree *moves*
+// the file into the worktree's project directory, so the name follows the
+// session. The per-message `cwd` does not: it tracks the agent's shell, so a
+// `cd` inside any tool call leaves the newest records naming a subdirectory,
+// while a relocated session's opening records still name the directory it
+// started in. Matching recorded values alone therefore missed every relocated
+// session — no `--resume` after a helper upgrade — and could hand that session
+// to an unrelated pane left behind in the original directory.
+//
+// Recorded directories stay the fallback for a project directory name this
+// encoding cannot account for: a Claude release that names them differently
+// must not cost every window its resume.
+func claudeSessionMatchesWorkingDirectory(path string, workingDirectory string) bool {
+	if workingDirectory == "" {
+		return false
+	}
+	projectDir := claudeEncodedProjectDirName(filepath.Base(filepath.Dir(path)))
+	if projectDir != "" && projectDir == claudeEncodedProjectDirName(workingDirectory) {
+		return true
+	}
+	recorded := claudeRecordedWorkingDirectories(path)
+	for _, dir := range recorded {
+		// The project directory encodes a directory this very session recorded,
+		// so the name is accounted for and names somewhere else: the session
+		// has moved on from workingDirectory.
+		if projectDir != "" && claudeEncodedProjectDirName(dir) == projectDir {
+			return false
+		}
+	}
+	for _, dir := range recorded {
+		if normalizedMetadataPath(dir) == workingDirectory {
+			return true
+		}
+	}
+	return false
+}
+
+// claudeRecordedWorkingDirectories returns the distinct `cwd` values a session
+// file records, read from its first and last sessionFileScanChunkBytes. A
+// relocated session names its new directory from the move onwards, so the two
+// ends together cover both the directory the session opened in and the one it
+// is using now, however long the transcript in between grew.
+func claudeRecordedWorkingDirectories(path string) []string {
+	return jsonStringFieldValuesFromFileEnds(path, "cwd")
+}
+
+// claudeEncodedProjectDirName mirrors how Claude Code names the directory a
+// session is stored in: every character outside [A-Za-z0-9] becomes "-", so
+// `/work/project` lives in `~/.claude/projects/-work-project`. Encoding an
+// already-encoded name is a no-op, so the same function normalizes both sides
+// of the comparison even if Claude later preserves more characters.
+func claudeEncodedProjectDirName(path string) string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return ""
+	}
+	return strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			return r
+		}
+		return '-'
+	}, trimmed)
 }
 
 func claudeSessionIDFromProjectFile(path string) string {
@@ -5395,6 +5464,54 @@ func jsonStringFieldFromFile(path string, field string) string {
 		}
 	}
 	return ""
+}
+
+// sessionFileScanChunkBytes bounds how much of each end of a session file is
+// read when collecting a field's values. Agent transcripts grow into megabytes
+// of tool output that says nothing about which pane owns the session.
+const sessionFileScanChunkBytes = 256 * 1024
+
+// jsonStringFieldValuesFromFileEnds returns the distinct values of field found
+// in the first and last sessionFileScanChunkBytes of a JSONL file, in the order
+// encountered. A single oversized record (a large tool result) can cut a chunk's
+// scan short; callers treat the result as evidence collected, never as proof
+// that no other value exists.
+func jsonStringFieldValuesFromFileEnds(path string, field string) []string {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil
+	}
+	values := []string{}
+	seen := map[string]bool{}
+	collect := func(reader io.Reader, skipPartialRecord bool) {
+		scanner := bufio.NewScanner(reader)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		if skipPartialRecord && !scanner.Scan() {
+			return
+		}
+		for scanner.Scan() {
+			value := jsonStringFieldFromLine(scanner.Text(), field)
+			if value == "" || seen[value] {
+				continue
+			}
+			seen[value] = true
+			values = append(values, value)
+		}
+	}
+	collect(io.LimitReader(file, sessionFileScanChunkBytes), false)
+	// Below two chunks the head scan already covered the whole file, and a tail
+	// scan would only re-read records it has seen.
+	if info.Size() > 2*sessionFileScanChunkBytes {
+		if _, err := file.Seek(info.Size()-sessionFileScanChunkBytes, io.SeekStart); err == nil {
+			collect(file, true)
+		}
+	}
+	return values
 }
 
 func jsonStringFieldFromLine(line string, field string) string {

--- a/remote/monkeymux/main_test.go
+++ b/remote/monkeymux/main_test.go
@@ -10531,6 +10531,267 @@ func TestDiscoverClaudeSessionIDsFallsBackToRecentProjectFileForCwd(t *testing.T
 	}
 }
 
+// writeClaudeWorktreeSessionFile writes the shape Claude leaves behind after a
+// session enters a git worktree: the file is moved into the worktree's project
+// directory and keeps appending there, so its opening entries still name the
+// directory the session started in and only the later ones name the worktree.
+func writeClaudeWorktreeSessionFile(
+	t *testing.T,
+	home string,
+	sessionID string,
+	originalCwd string,
+	worktreeCwd string,
+) string {
+	t.Helper()
+	projectDir := filepath.Join(
+		home,
+		".claude",
+		"projects",
+		"-work-project--claude-worktrees-feature",
+	)
+	if err := os.MkdirAll(projectDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(projectDir, sessionID+".jsonl")
+	lines := []string{
+		`{"type":"user","cwd":"` + originalCwd + `","sessionId":"` + sessionID + `"}`,
+		`{"type":"worktree-state","worktreeSession":{"originalCwd":"` + originalCwd +
+			`","worktreePath":"` + worktreeCwd + `"},"sessionId":"` + sessionID + `"}`,
+		`{"type":"user","cwd":"` + worktreeCwd + `","sessionId":"` + sessionID + `"}`,
+	}
+	if err := os.WriteFile(
+		path,
+		[]byte(strings.Join(lines, "\n")+"\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestDiscoverClaudeSessionIDsResumesSessionThatMovedIntoWorktree(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalWorkingDirectory := processWorkingDirectoryForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processWorkingDirectoryForMetadata = originalWorkingDirectory
+		processStartedAtForMetadata = originalProcessStart
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sessionID := "b3f0d1c6-2f4f-4d0e-9f0f-2f26f9b1f4c1"
+	worktreeCwd := "/work/project/.claude/worktrees/feature"
+	writeClaudeWorktreeSessionFile(t, home, sessionID, "/work/project", worktreeCwd)
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+	processWorkingDirectoryForMetadata = func(pid int) string {
+		if pid == 200 {
+			return worktreeCwd
+		}
+		return ""
+	}
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return time.Now().Add(-time.Minute)
+		}
+		return time.Time{}
+	}
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "claude", args: "claude"},
+	}
+
+	sessions := discoverClaudeSessionIDs(processes, map[int]struct{}{100: {}})
+
+	if got := sessions[100]; got != sessionID {
+		t.Fatalf("claude session id = %q, want %q", got, sessionID)
+	}
+}
+
+func TestDiscoverClaudeSessionIDsIgnoresSessionThatLeftTheWorkingDirectory(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalWorkingDirectory := processWorkingDirectoryForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processWorkingDirectoryForMetadata = originalWorkingDirectory
+		processStartedAtForMetadata = originalProcessStart
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sessionID := "0d1b2f5c-9a0e-4c1a-8a6a-2b7f5c8d0e11"
+	writeClaudeWorktreeSessionFile(
+		t,
+		home,
+		sessionID,
+		"/work/project",
+		"/work/project/.claude/worktrees/feature",
+	)
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+	processWorkingDirectoryForMetadata = func(pid int) string {
+		if pid == 200 {
+			return "/work/project"
+		}
+		return ""
+	}
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return time.Now().Add(-time.Minute)
+		}
+		return time.Time{}
+	}
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "claude", args: "claude"},
+	}
+
+	sessions := discoverClaudeSessionIDs(processes, map[int]struct{}{100: {}})
+
+	if len(sessions) != 0 {
+		t.Fatalf("relocated Claude session leaked to the original directory: %#v", sessions)
+	}
+}
+
+func TestClaudeSessionMatchesWorkingDirectoryUsesProjectDirWithoutRecordedCwd(t *testing.T) {
+	home := t.TempDir()
+	projectDir := filepath.Join(
+		home,
+		".claude",
+		"projects",
+		"-work-project--claude-worktrees-feature",
+	)
+	if err := os.MkdirAll(projectDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sessionID := "6b1f0f2e-1c3a-4f6b-9d2e-7c4a1b8e5f30"
+	path := filepath.Join(projectDir, sessionID+".jsonl")
+	if err := os.WriteFile(
+		path,
+		[]byte(`{"type":"mode","mode":"normal","sessionId":"`+sessionID+`"}`+"\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	worktreeCwd := "/work/project/.claude/worktrees/feature"
+	if !claudeSessionMatchesWorkingDirectory(path, worktreeCwd) {
+		t.Fatalf("session in %q did not match working directory %q", projectDir, worktreeCwd)
+	}
+	if claudeSessionMatchesWorkingDirectory(path, "/work/project") {
+		t.Fatal("session matched the directory its project folder does not encode")
+	}
+}
+
+// Claude's per-message cwd follows the agent's shell, so a `cd` inside a tool
+// call leaves every later record naming a subdirectory while the pane's process
+// stays where it launched. That must not cost the window its resume.
+func TestDiscoverClaudeSessionIDsResumesAfterAgentChangedDirectory(t *testing.T) {
+	originalOpenFiles := processOpenFilePathsForMetadata
+	originalWorkingDirectory := processWorkingDirectoryForMetadata
+	originalProcessStart := processStartedAtForMetadata
+	t.Cleanup(func() {
+		processOpenFilePathsForMetadata = originalOpenFiles
+		processWorkingDirectoryForMetadata = originalWorkingDirectory
+		processStartedAtForMetadata = originalProcessStart
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sessionID := "8c2e4d17-3b5a-4e7c-9f01-6d3b8a2c5e94"
+	projectDir := filepath.Join(home, ".claude", "projects", "-work-project")
+	if err := os.MkdirAll(projectDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lines := []string{
+		`{"type":"user","cwd":"/work/project","sessionId":"` + sessionID + `"}`,
+		`{"type":"assistant","cwd":"/work/project/server","sessionId":"` + sessionID + `"}`,
+		`{"type":"user","cwd":"/work/project/server","sessionId":"` + sessionID + `"}`,
+	}
+	if err := os.WriteFile(
+		filepath.Join(projectDir, sessionID+".jsonl"),
+		[]byte(strings.Join(lines, "\n")+"\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	processOpenFilePathsForMetadata = func(int) []string { return nil }
+	processWorkingDirectoryForMetadata = func(pid int) string {
+		if pid == 200 {
+			return "/work/project"
+		}
+		return ""
+	}
+	processStartedAtForMetadata = func(pid int) time.Time {
+		if pid == 200 {
+			return time.Now().Add(-time.Minute)
+		}
+		return time.Time{}
+	}
+	processes := map[int]processInfo{
+		100: {pid: 100, ppid: 1, comm: "zsh", args: "zsh"},
+		200: {pid: 200, ppid: 100, comm: "claude", args: "claude"},
+	}
+
+	sessions := discoverClaudeSessionIDs(processes, map[int]struct{}{100: {}})
+
+	if got := sessions[100]; got != sessionID {
+		t.Fatalf("claude session id = %q, want %q", got, sessionID)
+	}
+}
+
+// A project directory this encoding cannot account for — a Claude release that
+// names them differently — must fall back to the directories the session
+// recorded rather than losing the resume outright.
+func TestClaudeSessionMatchesWorkingDirectoryFallsBackForUnknownProjectDirName(t *testing.T) {
+	projectDir := filepath.Join(t.TempDir(), ".claude", "projects", "7f3a9c22e1")
+	if err := os.MkdirAll(projectDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sessionID := "2c7f4e91-5d0b-4a3e-8c16-9b5e2f7a1d40"
+	path := filepath.Join(projectDir, sessionID+".jsonl")
+	if err := os.WriteFile(
+		path,
+		[]byte(`{"type":"user","cwd":"/work/project","sessionId":"`+sessionID+`"}`+"\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if !claudeSessionMatchesWorkingDirectory(path, "/work/project") {
+		t.Fatal("session did not fall back to its recorded working directory")
+	}
+	if claudeSessionMatchesWorkingDirectory(path, "/work/other") {
+		t.Fatal("session matched a directory it never recorded")
+	}
+}
+
+func TestJSONStringFieldValuesFromFileEndsCoversBothEnds(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	filler := strings.Repeat("x", 2*sessionFileScanChunkBytes)
+	lines := []string{
+		`{"type":"user","cwd":"/work/project"}`,
+		`{"type":"user","cwd":"/work/ignored","filler":"` + filler + `"}`,
+		`{"type":"user","cwd":"/work/project/.claude/worktrees/feature"}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := jsonStringFieldValuesFromFileEnds(path, "cwd")
+
+	want := []string{"/work/project", "/work/project/.claude/worktrees/feature"}
+	if len(got) != len(want) {
+		t.Fatalf("cwd values = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("cwd values = %#v, want %#v", got, want)
+		}
+	}
+}
+
 func TestDiscoverClaudeSessionIDsDoesNotResumeSessionFromBeforeFreshProcess(t *testing.T) {
 	originalOpenFiles := processOpenFilePathsForMetadata
 	originalWorkingDirectory := processWorkingDirectoryForMetadata


### PR DESCRIPTION
## Problem

A Claude Code session that has entered a git worktree does not resume after a MonkeyMux helper upgrade — the restore relaunches a bare `claude` instead of `claude --resume <id>`.

Claude stores a session as `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`. Entering a worktree **moves** that file into the worktree's project directory, and `claude` chdirs there, while the file's opening entries still name the directory the session started in:

```
~/.claude/projects/-Users-me-Code-App--claude-worktrees-feature/<id>.jsonl
  line 1:  "cwd":"/Users/me/Code/App"                          ← where it started
  line 2:  {"type":"worktree-state", ...}
  line N:  "cwd":"/Users/me/Code/App/.claude/worktrees/feature"
```

`claudeRecentSessionIDForWorkingDirectory` compared the pane's live working directory against the **first** `cwd` in the file, so a relocated session never matched its own pane. The same stale match could also hand that session to an unrelated pane left behind in the original directory.

## Fix

Ownership is decided by the **project directory name**, which Claude derives from the session's working directory and which the relocation carries along:

1. the project directory name encodes the pane's working directory → match;
2. otherwise, if some directory the session recorded encodes that same project directory name, the name is accounted for and names somewhere else → no match (the session has moved on);
3. otherwise the encoding cannot explain the directory name, so fall back to the directories the session recorded — a Claude release that names them differently degrades to the old behavior instead of costing every window its resume.

The per-message `cwd` deliberately does **not** decide this. It tracks the agent's own shell: a `cd` inside a tool call leaves every later record naming a subdirectory while the pane's process stays put. (Verified on a live transcript here: 253 records name `.../remote/monkeymux` while the `claude` process cwd is still the worktree root.) Recorded directories are read from a bounded 256 KiB at each end of the file, which covers both the directory the session opened in and the one it relocated to.

Checked against the live `~/.claude/projects` tree on a machine with a relocated session: both worktree transcripts match the worktree pane and are correctly refused for the main-repo pane, every main-repo session still matches, and the session that had `cd`'d into a subdirectory still matches its pane.

## Tests

- `TestDiscoverClaudeSessionIDsResumesSessionThatMovedIntoWorktree` — relocated session resumes for a pane in the worktree.
- `TestDiscoverClaudeSessionIDsIgnoresSessionThatLeftTheWorkingDirectory` — that session no longer leaks to a pane in the original directory.
- `TestDiscoverClaudeSessionIDsResumesAfterAgentChangedDirectory` — a session whose newest records name a subdirectory still resumes.
- `TestClaudeSessionMatchesWorkingDirectoryUsesProjectDirWithoutRecordedCwd` / `...FallsBackForUnknownProjectDirName` — both directions of the directory-name rule.
- `TestJSONStringFieldValuesFromFileEndsCoversBothEnds` — bounded head+tail scan, partial records skipped.

The discovery tests fail on the pre-fix logic; `go test ./...` in `remote/monkeymux` passes, `gofmt`/`go vet` clean. Helper version bumped to 0.1.161 so clients pick up the change.

## Other agents

Checked the same shape across the other supported agents: Codex records one constant `cwd` per rollout and starts worktree sessions in the worktree (`~/.codex/worktrees/...`) rather than relocating; Copilot reads its cwd from the `session.start` head and identifies by its inuse lock; OpenCode and Cursor/Antigravity read live store fields, not file position; Gemini matches against a workspace directory list. Pi's relocation is already handled explicitly. Claude Code was the only one affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
