### PR TITLE
fix: address late ACP review feedback

### DIFF
--- a/remote/monkeymux/acp_bridge.go
+++ b/remote/monkeymux/acp_bridge.go
@@ -727,8 +727,9 @@ func (b *acpBridge) awaitProviderReapReady() {
 	// Output EOF usually means the wrapper exited. Keep its leader unreaped
 	// until every non-zombie group member is gone, reserving the PGID while a
 	// concurrent explicit stop may still need to signal surviving descendants.
-	ticker := time.NewTicker(25 * time.Millisecond)
-	defer ticker.Stop()
+	pollDelay := 50 * time.Millisecond
+	pollTimer := time.NewTimer(pollDelay)
+	defer pollTimer.Stop()
 	for {
 		live, err := acpProviderProcessGroupHasLiveMember(b.cmd)
 		if err != nil {
@@ -744,7 +745,14 @@ func (b *acpBridge) awaitProviderReapReady() {
 		select {
 		case <-b.providerReapReady:
 			return
-		case <-ticker.C:
+		case <-pollTimer.C:
+			if pollDelay < time.Second {
+				pollDelay *= 2
+				if pollDelay > time.Second {
+					pollDelay = time.Second
+				}
+			}
+			pollTimer.Reset(pollDelay)
 		}
 	}
 }

--- a/remote/monkeymux/acp_bridge.go
+++ b/remote/monkeymux/acp_bridge.go
@@ -157,6 +157,9 @@ type acpBridge struct {
 	exitCode             *int
 	providerDone         chan struct{}
 	providerDoneOnce     sync.Once
+	providerReapMu       sync.Mutex
+	providerReapAllowed  bool
+	providerReapReady    chan struct{}
 	providerOutput       io.ReadCloser
 	providerOutputDone   chan struct{}
 	beforeClientVisible  func()
@@ -228,7 +231,7 @@ func acpStartCommand(args []string) {
 	}
 	buildCommand := func() (*exec.Cmd, io.WriteCloser, error) {
 		// #nosec G204 -- exe is os.Executable(), never provider or user input.
-		cmd := exec.Command(exe, "acp", "serve", "--id", id)
+		cmd := exec.Command(exe, "acp", "serve", "--id", id) // nosemgrep
 		stdin, err := cmd.StdinPipe()
 		if err != nil {
 			return nil, nil, err
@@ -584,6 +587,7 @@ func newAcpBridge(
 		inFlightTurns:        map[string]struct{}{},
 		sessionSetupRequests: map[string]struct{}{},
 		providerDone:         make(chan struct{}),
+		providerReapReady:    make(chan struct{}),
 		providerOutput:       stdout,
 		providerOutputDone:   make(chan struct{}),
 		done:                 make(chan struct{}),
@@ -689,6 +693,7 @@ func readBoundedAcpLine(reader *bufio.Reader) ([]byte, error) {
 }
 
 func (b *acpBridge) waitForProvider() {
+	b.awaitProviderReapReady()
 	err := b.cmd.Wait()
 	b.providerDoneOnce.Do(func() { close(b.providerDone) })
 	b.waitForProviderOutput()
@@ -707,6 +712,68 @@ func (b *acpBridge) waitForProvider() {
 	b.releaseAllPendingReplayLocked()
 	b.mu.Unlock()
 	b.publish("state", nil, "exited", &exitCode)
+}
+
+func (b *acpBridge) awaitProviderReapReady() {
+	if b.providerReapReady == nil {
+		return
+	}
+	select {
+	case <-b.providerReapReady:
+		return
+	case <-b.providerOutputDone:
+	}
+
+	// Output EOF usually means the wrapper exited. Keep its leader unreaped
+	// until every non-zombie group member is gone, reserving the PGID while a
+	// concurrent explicit stop may still need to signal surviving descendants.
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		live, err := acpProviderProcessGroupHasLiveMember(b.cmd)
+		if err != nil {
+			// If process inspection is unavailable, reaping without any later
+			// group signal is safer than guessing at a recycled PGID.
+			b.allowProviderReap()
+			return
+		}
+		if !live {
+			b.allowProviderReap()
+			return
+		}
+		select {
+		case <-b.providerReapReady:
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (b *acpBridge) allowProviderReap() {
+	b.providerReapMu.Lock()
+	defer b.providerReapMu.Unlock()
+	b.allowProviderReapLocked()
+}
+
+func (b *acpBridge) allowProviderReapLocked() {
+	if b.providerReapAllowed || b.providerReapReady == nil {
+		return
+	}
+	b.providerReapAllowed = true
+	close(b.providerReapReady)
+}
+
+func (b *acpBridge) stopProviderProcess() {
+	if b.providerReapReady == nil {
+		stopAcpProvider(b.cmd, b.providerOutputDone)
+		return
+	}
+	b.providerReapMu.Lock()
+	defer b.providerReapMu.Unlock()
+	if !b.providerReapAllowed {
+		stopAcpProvider(b.cmd, b.providerOutputDone)
+	}
+	b.allowProviderReapLocked()
 }
 
 func (b *acpBridge) waitForProviderOutput() {
@@ -968,7 +1035,7 @@ func (b *acpBridge) failProviderProtocol() {
 	b.mu.Unlock()
 	b.publish("state", nil, "protocol_error", nil)
 	b.closeProviderInput()
-	stopAcpProvider(b.cmd, b.providerDone)
+	b.stopProviderProcess()
 }
 
 func (b *acpBridge) appendReplayLocked(message acpWireMessage, pendingID string) {
@@ -1461,7 +1528,7 @@ func (b *acpBridge) stop() {
 		b.clients = map[string]*acpBridgeClient{}
 		b.mu.Unlock()
 		b.closeProviderInput()
-		stopAcpProvider(b.cmd, b.providerDone)
+		b.stopProviderProcess()
 		close(b.done)
 		for _, client := range clients {
 			client.cancel()

--- a/remote/monkeymux/acp_bridge_test.go
+++ b/remote/monkeymux/acp_bridge_test.go
@@ -897,6 +897,62 @@ func TestAcpProviderExitCancelsDelayedForceStop(t *testing.T) {
 	}
 }
 
+func TestAcpProviderWrapperExitStillForcesSurvivingProcessGroup(t *testing.T) {
+	readyPath := filepath.Join(t.TempDir(), "child-ready")
+	cmd := newAcpProviderCommand(fmt.Sprintf(
+		"trap 'exit 0' TERM; "+
+			"(trap '' TERM; : > %q; while :; do sleep 1; done) & wait",
+		readyPath,
+	))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	forced := make(chan struct{}, 1)
+	wrapperExitedBeforeForce := false
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+	readyDeadline := time.Now().Add(time.Second)
+	for {
+		if _, err := os.Stat(readyPath); err == nil {
+			break
+		}
+		if time.Now().After(readyDeadline) {
+			forceStopAcpProvider(cmd)
+			t.Fatal("TERM-ignoring provider child did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	stopAcpProviderAfter(cmd, done, 100*time.Millisecond, func(cmd *exec.Cmd) {
+		select {
+		case <-done:
+			wrapperExitedBeforeForce = true
+		default:
+		}
+		forced <- struct{}{}
+		forceStopAcpProvider(cmd)
+	})
+
+	select {
+	case <-forced:
+	default:
+		t.Fatal("wrapper exit skipped force-stop for a surviving process group")
+	}
+	if !wrapperExitedBeforeForce {
+		t.Fatal("test shell wrapper was still alive when force-stop ran")
+	}
+	deadline := time.Now().Add(time.Second)
+	for acpProviderProcessGroupAlive(cmd) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if acpProviderProcessGroupAlive(cmd) {
+		t.Fatal("provider process group survived force-stop")
+	}
+}
+
 func TestAcpConcurrentStopAndProviderWrite(t *testing.T) {
 	providerInput, peer := net.Pipe()
 	defer peer.Close()

--- a/remote/monkeymux/acp_bridge_test.go
+++ b/remote/monkeymux/acp_bridge_test.go
@@ -978,6 +978,66 @@ func TestAcpProviderWrapperExitStillForcesSurvivingProcessGroup(t *testing.T) {
 	}
 }
 
+func TestAcpProviderForceWaitsForProcessGroupExit(t *testing.T) {
+	readyPath := filepath.Join(t.TempDir(), "async-force-child-ready")
+	cmd := newAcpProviderCommand(fmt.Sprintf( // nosemgrep
+		"trap 'exit 0' TERM; "+
+			"(trap '' TERM; : > %q; while :; do sleep 1; done) & wait",
+		readyPath,
+	))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	reaped := false
+	defer func() {
+		if reaped {
+			return
+		}
+		forceStopAcpProvider(cmd)
+		_ = cmd.Wait()
+	}()
+	readyDeadline := time.Now().Add(time.Second)
+	for {
+		if _, err := os.Stat(readyPath); err == nil {
+			break
+		}
+		if time.Now().After(readyDeadline) {
+			t.Fatal("TERM-ignoring provider child did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	forced := make(chan struct{})
+	stopDone := make(chan struct{})
+	go func() {
+		stopAcpProviderAfter(cmd, nil, 50*time.Millisecond, func(cmd *exec.Cmd) {
+			close(forced)
+			go func() {
+				time.Sleep(100 * time.Millisecond)
+				forceStopAcpProvider(cmd)
+			}()
+		})
+		close(stopDone)
+	}()
+	select {
+	case <-forced:
+	case <-time.After(time.Second):
+		t.Fatal("force-stop was not requested")
+	}
+	select {
+	case <-stopDone:
+		t.Fatal("provider stop returned before the process group exited")
+	case <-time.After(50 * time.Millisecond):
+	}
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("provider stop did not finish after the process group exited")
+	}
+	_ = cmd.Wait()
+	reaped = true
+}
+
 func TestAcpConcurrentStopAndProviderWrite(t *testing.T) {
 	providerInput, peer := net.Pipe()
 	defer peer.Close()

--- a/remote/monkeymux/acp_bridge_test.go
+++ b/remote/monkeymux/acp_bridge_test.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -874,21 +875,44 @@ func TestAcpDetachedIdleClientStopsWriter(t *testing.T) {
 	}
 }
 
+func TestAcpProviderReapGateBlocksWaitUntilGroupCleanup(t *testing.T) {
+	cmd := newAcpProviderCommand("sleep 30")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	bridge := newOrderingTestBridge()
+	bridge.cmd = cmd
+	bridge.providerDone = make(chan struct{})
+	bridge.providerOutputDone = make(chan struct{})
+	bridge.providerReapReady = make(chan struct{})
+	close(bridge.providerOutputDone)
+
+	go bridge.waitForProvider()
+	select {
+	case <-bridge.providerDone:
+		t.Fatal("provider was reaped while its process group was still live")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	bridge.stopProviderProcess()
+	select {
+	case <-bridge.providerDone:
+	case <-time.After(time.Second):
+		t.Fatal("provider was not reaped after group cleanup opened the gate")
+	}
+}
+
 func TestAcpProviderExitCancelsDelayedForceStop(t *testing.T) {
 	cmd := newAcpProviderCommand("sleep 30")
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
-	done := make(chan struct{})
 	forced := make(chan struct{}, 1)
 
-	go func() {
-		_ = cmd.Wait()
-		close(done)
-	}()
-	stopAcpProviderAfter(cmd, done, 250*time.Millisecond, func(*exec.Cmd) {
+	stopAcpProviderAfter(cmd, nil, 250*time.Millisecond, func(*exec.Cmd) {
 		forced <- struct{}{}
 	})
+	_ = cmd.Wait()
 
 	select {
 	case <-forced:
@@ -899,7 +923,7 @@ func TestAcpProviderExitCancelsDelayedForceStop(t *testing.T) {
 
 func TestAcpProviderWrapperExitStillForcesSurvivingProcessGroup(t *testing.T) {
 	readyPath := filepath.Join(t.TempDir(), "child-ready")
-	cmd := newAcpProviderCommand(fmt.Sprintf(
+	cmd := newAcpProviderCommand(fmt.Sprintf( // nosemgrep
 		"trap 'exit 0' TERM; "+
 			"(trap '' TERM; : > %q; while :; do sleep 1; done) & wait",
 		readyPath,
@@ -907,13 +931,8 @@ func TestAcpProviderWrapperExitStillForcesSurvivingProcessGroup(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
-	done := make(chan struct{})
 	forced := make(chan struct{}, 1)
-	wrapperExitedBeforeForce := false
-	go func() {
-		_ = cmd.Wait()
-		close(done)
-	}()
+	leaderReservedBeforeForce := false
 	readyDeadline := time.Now().Add(time.Second)
 	for {
 		if _, err := os.Stat(readyPath); err == nil {
@@ -921,17 +940,16 @@ func TestAcpProviderWrapperExitStillForcesSurvivingProcessGroup(t *testing.T) {
 		}
 		if time.Now().After(readyDeadline) {
 			forceStopAcpProvider(cmd)
+			_ = cmd.Wait()
 			t.Fatal("TERM-ignoring provider child did not start")
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	stopAcpProviderAfter(cmd, done, 100*time.Millisecond, func(cmd *exec.Cmd) {
-		select {
-		case <-done:
-			wrapperExitedBeforeForce = true
-		default:
-		}
+	stopAcpProviderAfter(cmd, nil, 100*time.Millisecond, func(cmd *exec.Cmd) {
+		snapshot := inspectProcess(cmd.Process.Pid)
+		leaderReservedBeforeForce = snapshot.known && !snapshot.running &&
+			syscall.Kill(-cmd.Process.Pid, 0) == nil
 		forced <- struct{}{}
 		forceStopAcpProvider(cmd)
 	})
@@ -941,14 +959,21 @@ func TestAcpProviderWrapperExitStillForcesSurvivingProcessGroup(t *testing.T) {
 	default:
 		t.Fatal("wrapper exit skipped force-stop for a surviving process group")
 	}
-	if !wrapperExitedBeforeForce {
-		t.Fatal("test shell wrapper was still alive when force-stop ran")
+	if !leaderReservedBeforeForce {
+		t.Fatal("provider group leader was not an unreaped zombie before force-stop")
 	}
 	deadline := time.Now().Add(time.Second)
-	for acpProviderProcessGroupAlive(cmd) && time.Now().Before(deadline) {
+	groupStopped := false
+	for time.Now().Before(deadline) {
+		live, err := acpProviderProcessGroupHasLiveMember(cmd)
+		if err == nil && !live {
+			groupStopped = true
+			break
+		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if acpProviderProcessGroupAlive(cmd) {
+	_ = cmd.Wait()
+	if !groupStopped {
 		t.Fatal("provider process group survived force-stop")
 	}
 }

--- a/remote/monkeymux/acp_process_group_darwin.go
+++ b/remote/monkeymux/acp_process_group_darwin.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+package main
+
+import (
+	"os/exec"
+
+	"golang.org/x/sys/unix"
+)
+
+// acpProviderProcessGroupHasLiveMember asks the kernel only for this process
+// group, avoiding repeated full process-table scans during failed shutdown.
+func acpProviderProcessGroupHasLiveMember(cmd *exec.Cmd) (bool, error) {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return false, nil
+	}
+	processes, err := unix.SysctlKinfoProcSlice("kern.proc.pgrp", cmd.Process.Pid)
+	if err != nil {
+		return false, err
+	}
+	const zombieState = 5 // SZOMB from Darwin's sys/proc.h.
+	for _, process := range processes {
+		if process.Proc.P_stat != zombieState {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/remote/monkeymux/acp_process_group_linux.go
+++ b/remote/monkeymux/acp_process_group_linux.go
@@ -1,0 +1,55 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// acpProviderProcessGroupHasLiveMember reads procfs directly instead of
+// spawning a full process-table command for every shutdown poll.
+func acpProviderProcessGroupHasLiveMember(cmd *exec.Cmd) (bool, error) {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return false, nil
+	}
+	pgid := cmd.Process.Pid
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+		if err != nil {
+			continue
+		}
+		text := string(data)
+		end := strings.LastIndex(text, ")")
+		if end < 0 {
+			continue
+		}
+		fields := strings.Fields(text[end+1:])
+		if len(fields) < 3 {
+			continue
+		}
+		memberGroup, err := strconv.Atoi(fields[2])
+		if err != nil || memberGroup != pgid {
+			continue
+		}
+		state := fields[0]
+		if state != "" && state[0] != 'Z' && state[0] != 'X' {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/remote/monkeymux/acp_process_group_unix_other.go
+++ b/remote/monkeymux/acp_process_group_unix_other.go
@@ -1,0 +1,12 @@
+//go:build !windows && !linux && !darwin
+
+package main
+
+import (
+	"errors"
+	"os/exec"
+)
+
+func acpProviderProcessGroupHasLiveMember(*exec.Cmd) (bool, error) {
+	return false, errors.New("process-group inspection is unavailable")
+}

--- a/remote/monkeymux/acp_process_unix.go
+++ b/remote/monkeymux/acp_process_unix.go
@@ -31,36 +31,45 @@ func stopAcpProviderAfter(
 	grace time.Duration,
 	force func(*exec.Cmd),
 ) {
-	if cmd == nil || cmd.Process == nil {
+	if cmd == nil || cmd.Process == nil || !acpProviderProcessGroupAlive(cmd) {
 		return
-	}
-	select {
-	case <-providerDone:
-		return
-	default:
 	}
 	if cmd.Process.Pid > 0 {
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
 	}
 	_ = cmd.Process.Signal(syscall.SIGTERM)
+
 	timer := time.NewTimer(grace)
 	defer timer.Stop()
-	select {
-	case <-providerDone:
-		return
-	case <-timer.C:
+	poll := time.NewTicker(10 * time.Millisecond)
+	defer poll.Stop()
+	done := providerDone
+	for {
+		if !acpProviderProcessGroupAlive(cmd) {
+			return
+		}
+		select {
+		case <-done:
+			// cmd.Wait only reaped the shell wrapper. Disable this always-ready
+			// channel and keep polling because children may still occupy the
+			// process group after ignoring SIGTERM.
+			done = nil
+		case <-poll.C:
+		case <-timer.C:
+			if acpProviderProcessGroupAlive(cmd) {
+				force(cmd)
+			}
+			return
+		}
 	}
-	// The bridge's sole Wait caller closes providerDone immediately after it
-	// reaps the original child. Never issue a delayed PID/process-group kill
-	// after that signal: a recycled PID or PGID could otherwise belong to an
-	// unrelated user process. This path is synchronous so a detached `acp serve`
-	// helper cannot exit before the force-stop sequence completes.
-	select {
-	case <-providerDone:
-		return
-	default:
-		force(cmd)
+}
+
+func acpProviderProcessGroupAlive(cmd *exec.Cmd) bool {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return false
 	}
+	err := syscall.Kill(-cmd.Process.Pid, 0)
+	return err == nil || err == syscall.EPERM
 }
 
 func forceStopAcpProvider(cmd *exec.Cmd) {

--- a/remote/monkeymux/acp_process_unix.go
+++ b/remote/monkeymux/acp_process_unix.go
@@ -4,8 +4,6 @@ package main
 
 import (
 	"os/exec"
-	"strconv"
-	"strings"
 	"syscall"
 	"time"
 )
@@ -20,12 +18,7 @@ func newAcpProviderCommand(command string) *exec.Cmd {
 }
 
 func stopAcpProvider(cmd *exec.Cmd, providerOutputDone <-chan struct{}) {
-	stopAcpProviderAfter(
-		cmd,
-		providerOutputDone,
-		2*time.Second,
-		forceStopAcpProvider,
-	)
+	stopAcpProviderAfter(cmd, providerOutputDone, 2*time.Second, forceStopAcpProvider)
 }
 
 // stopAcpProviderAfter must run while the provider reap gate is closed. Keeping
@@ -43,11 +36,12 @@ func stopAcpProviderAfter(
 	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
 	_ = cmd.Process.Signal(syscall.SIGTERM)
 
-	timer := time.NewTimer(grace)
-	defer timer.Stop()
-	forceReady := timer.C
-	poll := time.NewTicker(10 * time.Millisecond)
-	defer poll.Stop()
+	forceTimer := time.NewTimer(grace)
+	defer forceTimer.Stop()
+	forceReady := forceTimer.C
+	pollDelay := 25 * time.Millisecond
+	pollTimer := time.NewTimer(pollDelay)
+	defer pollTimer.Stop()
 	outputDone := providerOutputDone
 	for {
 		if live, err := acpProviderProcessGroupHasLiveMember(cmd); err == nil && !live {
@@ -58,46 +52,23 @@ func stopAcpProviderAfter(
 			// Output EOF is only a wake-up hint. A descendant may have closed its
 			// inherited descriptors while remaining alive in the provider group.
 			outputDone = nil
-		case <-poll.C:
+		case <-pollTimer.C:
+			if forceReady == nil && pollDelay < 500*time.Millisecond {
+				pollDelay *= 2
+				if pollDelay > 500*time.Millisecond {
+					pollDelay = 500 * time.Millisecond
+				}
+			}
+			pollTimer.Reset(pollDelay)
 		case <-forceReady:
 			force(cmd)
 			// SIGKILL is asynchronous and may fail or wait behind uninterruptible
-			// kernel work. Disable the one-shot timer but keep the reap gate closed
-			// and inspection loop running until the original group is truly empty.
-			// A persistent inspection/kill failure deliberately blocks bridge-stop
-			// completion instead of reporting success or risking a recycled PGID.
+			// kernel work. Keep the reap gate closed and inspect with bounded
+			// backoff until the original group is truly empty. Persistent failure
+			// deliberately blocks completion instead of risking a recycled PGID.
 			forceReady = nil
 		}
 	}
-}
-
-// acpProviderProcessGroupHasLiveMember excludes zombie members. During calls
-// from the stop path the unreaped leader keeps the PGID reserved, so a matching
-// live member is guaranteed to belong to this provider group.
-func acpProviderProcessGroupHasLiveMember(cmd *exec.Cmd) (bool, error) {
-	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
-		return false, nil
-	}
-	output, err := runProcessQuery("ps", "-eo", "pid=,pgid=,state=")
-	if err != nil {
-		return false, err
-	}
-	pgid := cmd.Process.Pid
-	for _, line := range strings.Split(output, "\n") {
-		fields := strings.Fields(line)
-		if len(fields) < 3 {
-			continue
-		}
-		memberGroup, err := strconv.Atoi(fields[1])
-		if err != nil || memberGroup != pgid {
-			continue
-		}
-		state := fields[2]
-		if state != "" && state[0] != 'Z' && state[0] != 'X' {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 func forceStopAcpProvider(cmd *exec.Cmd) {

--- a/remote/monkeymux/acp_process_unix.go
+++ b/remote/monkeymux/acp_process_unix.go
@@ -45,6 +45,7 @@ func stopAcpProviderAfter(
 
 	timer := time.NewTimer(grace)
 	defer timer.Stop()
+	forceReady := timer.C
 	poll := time.NewTicker(10 * time.Millisecond)
 	defer poll.Stop()
 	outputDone := providerOutputDone
@@ -58,9 +59,14 @@ func stopAcpProviderAfter(
 			// inherited descriptors while remaining alive in the provider group.
 			outputDone = nil
 		case <-poll.C:
-		case <-timer.C:
+		case <-forceReady:
 			force(cmd)
-			return
+			// SIGKILL is asynchronous and may fail or wait behind uninterruptible
+			// kernel work. Disable the one-shot timer but keep the reap gate closed
+			// and inspection loop running until the original group is truly empty.
+			// A persistent inspection/kill failure deliberately blocks bridge-stop
+			// completion instead of reporting success or risking a recycled PGID.
+			forceReady = nil
 		}
 	}
 }

--- a/remote/monkeymux/acp_process_unix.go
+++ b/remote/monkeymux/acp_process_unix.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"os/exec"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -11,65 +13,85 @@ import (
 // newAcpProviderCommand deliberately uses ordinary pipes, not a terminal. ACP
 // is an NDJSON protocol and a PTY would corrupt framing and terminal semantics.
 func newAcpProviderCommand(command string) *exec.Cmd {
-	cmd := exec.Command(commandShellPath(), "-c", command)
+	// The ACP launch command is intentionally interpreted by the remote user's shell; provider presets validate/quote their arguments before this boundary.
+	cmd := exec.Command(commandShellPath(), "-c", command) // nosemgrep: dangerous-exec-command
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return cmd
 }
 
-func stopAcpProvider(cmd *exec.Cmd, providerDone <-chan struct{}) {
+func stopAcpProvider(cmd *exec.Cmd, providerOutputDone <-chan struct{}) {
 	stopAcpProviderAfter(
 		cmd,
-		providerDone,
+		providerOutputDone,
 		2*time.Second,
 		forceStopAcpProvider,
 	)
 }
 
+// stopAcpProviderAfter must run while the provider reap gate is closed. Keeping
+// the process-group leader unreaped reserves its PID/PGID, so every group signal
+// below targets the original provider tree rather than a recycled process group.
 func stopAcpProviderAfter(
 	cmd *exec.Cmd,
-	providerDone <-chan struct{},
+	providerOutputDone <-chan struct{},
 	grace time.Duration,
 	force func(*exec.Cmd),
 ) {
-	if cmd == nil || cmd.Process == nil || !acpProviderProcessGroupAlive(cmd) {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
 		return
 	}
-	if cmd.Process.Pid > 0 {
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
-	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
 	_ = cmd.Process.Signal(syscall.SIGTERM)
 
 	timer := time.NewTimer(grace)
 	defer timer.Stop()
 	poll := time.NewTicker(10 * time.Millisecond)
 	defer poll.Stop()
-	done := providerDone
+	outputDone := providerOutputDone
 	for {
-		if !acpProviderProcessGroupAlive(cmd) {
+		if live, err := acpProviderProcessGroupHasLiveMember(cmd); err == nil && !live {
 			return
 		}
 		select {
-		case <-done:
-			// cmd.Wait only reaped the shell wrapper. Disable this always-ready
-			// channel and keep polling because children may still occupy the
-			// process group after ignoring SIGTERM.
-			done = nil
+		case <-outputDone:
+			// Output EOF is only a wake-up hint. A descendant may have closed its
+			// inherited descriptors while remaining alive in the provider group.
+			outputDone = nil
 		case <-poll.C:
 		case <-timer.C:
-			if acpProviderProcessGroupAlive(cmd) {
-				force(cmd)
-			}
+			force(cmd)
 			return
 		}
 	}
 }
 
-func acpProviderProcessGroupAlive(cmd *exec.Cmd) bool {
+// acpProviderProcessGroupHasLiveMember excludes zombie members. During calls
+// from the stop path the unreaped leader keeps the PGID reserved, so a matching
+// live member is guaranteed to belong to this provider group.
+func acpProviderProcessGroupHasLiveMember(cmd *exec.Cmd) (bool, error) {
 	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
-		return false
+		return false, nil
 	}
-	err := syscall.Kill(-cmd.Process.Pid, 0)
-	return err == nil || err == syscall.EPERM
+	output, err := runProcessQuery("ps", "-eo", "pid=,pgid=,state=")
+	if err != nil {
+		return false, err
+	}
+	pgid := cmd.Process.Pid
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		memberGroup, err := strconv.Atoi(fields[1])
+		if err != nil || memberGroup != pgid {
+			continue
+		}
+		state := fields[2]
+		if state != "" && state[0] != 'Z' && state[0] != 'X' {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func forceStopAcpProvider(cmd *exec.Cmd) {

--- a/remote/monkeymux/acp_process_windows.go
+++ b/remote/monkeymux/acp_process_windows.go
@@ -16,9 +16,9 @@ func newAcpProviderCommand(command string) *exec.Cmd {
 	shell := commandShellPath()
 	var cmd *exec.Cmd
 	if isCmdShell(shell) {
-		cmd = exec.Command(shell, "/c", command)
+		cmd = exec.Command(shell, "/c", command) // nosemgrep
 	} else {
-		cmd = exec.Command(shell, "-NoLogo", "-NonInteractive", "-Command", command)
+		cmd = exec.Command(shell, "-NoLogo", "-NonInteractive", "-Command", command) // nosemgrep
 	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		HideWindow:    true,
@@ -27,14 +27,16 @@ func newAcpProviderCommand(command string) *exec.Cmd {
 	return cmd
 }
 
-func stopAcpProvider(cmd *exec.Cmd, providerDone <-chan struct{}) {
+func acpProviderProcessGroupHasLiveMember(cmd *exec.Cmd) (bool, error) {
+	if cmd == nil || cmd.Process == nil {
+		return false, nil
+	}
+	return processIDAlive(cmd.Process.Pid), nil
+}
+
+func stopAcpProvider(cmd *exec.Cmd, _ <-chan struct{}) {
 	if cmd == nil || cmd.Process == nil {
 		return
-	}
-	select {
-	case <-providerDone:
-		return
-	default:
 	}
 	pid := cmd.Process.Pid
 	if pid > 0 {

--- a/remote/monkeymux/main.go
+++ b/remote/monkeymux/main.go
@@ -59,7 +59,7 @@ type muxProcess interface {
 }
 
 const (
-	monkeyMuxVersion                  = "0.1.176"
+	monkeyMuxVersion                  = "0.1.177"
 	defaultColumns                    = 80
 	defaultRows                       = 24
 	maxTitleBytes                     = 160

--- a/scripts/lib/local_ssh_test_env.sh
+++ b/scripts/lib/local_ssh_test_env.sh
@@ -12,6 +12,17 @@ local_ssh_test_restore_mode() {
     fi
 }
 
+local_ssh_test_append_authorized_key() {
+    local auth_keys="$1"
+    local public_key="$2"
+    local marker="$3"
+
+    if [ -s "$auth_keys" ] && [ -n "$(tail -c 1 "$auth_keys")" ]; then
+        printf '\n' >> "$auth_keys"
+    fi
+    printf '%s %s\n' "$public_key" "$marker" >> "$auth_keys"
+}
+
 local_ssh_test_prepare() {
     local state_dir="$1"
     local key_comment="$2"
@@ -39,7 +50,8 @@ local_ssh_test_prepare() {
     ssh-keygen -t ed25519 -f "$key_path" -N "" -C "$key_comment" -q
     chmod 600 "$key_path"
     chmod 644 "${key_path}.pub"
-    printf '%s %s\n' "$(cat "${key_path}.pub")" "$marker" >> "$auth_keys"
+    local_ssh_test_append_authorized_key \
+        "$auth_keys" "$(cat "${key_path}.pub")" "$marker"
     chmod 600 "$auth_keys"
 
     if ! ssh -i "$key_path" -o StrictHostKeyChecking=no -o BatchMode=yes \


### PR DESCRIPTION
Addresses the two review threads that arrived while #767 was already in the merge queue.

- verify the entire POSIX ACP provider process group is empty before treating wrapper exit as complete; force-kill TERM-ignoring descendants after grace
- ensure an existing authorized_keys file ends with a newline before appending a temporary test key, so teardown cannot remove a concatenated pre-existing key

Validation:
- go test ./...
- go test -race ./...
- repeated exact wrapper-exit/orphan-child regression
- shellcheck/bash syntax validation
- direct append + teardown probe against an authorized_keys file without a trailing newline