### PR TITLE
chore: ignore Claude worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ migrate_working_dir/
 
 # Local agent runtime state
 /.pi/
+/.claude/worktrees/
 
 # Local Bundler dependencies
 /vendor/bundle/


### PR DESCRIPTION
## Summary\n\n- ignore repository-local Claude worktrees\n- keep generated worktree contents out of Git status\n\n## Verification\n\n- .gitignore:44:/.claude/worktrees/	.claude/worktrees/fix+bottom-inset-overflow