### PR TITLE
Fix color escape spew in Windows raw terminals

### DIFF
--- a/lib/domain/services/ssh_service.dart
+++ b/lib/domain/services/ssh_service.dart
@@ -3700,6 +3700,17 @@ class SshSession {
   /// foreground app.
   bool get terminalWin32InputMode => _runtime.terminalWin32InputMode;
 
+  /// Whether the current shell queried its ANSI palette at or after [instant].
+  ///
+  /// ConPTY forwards OSC 4 palette queries from foreground TUIs even when it
+  /// consumes their OSC 10/11 default-color queries. A bare Windows shell does
+  /// not interrogate the palette, so this is safe evidence that a delayed
+  /// default-color report belongs to a TUI rather than the command prompt.
+  bool hasTerminalPaletteQuerySince(DateTime instant) {
+    final lastQueryAt = _lastTerminalPaletteQueryAt;
+    return lastQueryAt != null && !lastQueryAt.isBefore(instant);
+  }
+
   /// Tracks OSC 8 hyperlinks rendered in the persistent terminal.
   final terminalHyperlinkTracker = TerminalHyperlinkTracker();
 
@@ -4167,6 +4178,7 @@ class SshSession {
     _terminalPreview = null;
     _terminalPreviewSnapshot = null;
     _windowTitle = null;
+    _lastTerminalPaletteQueryAt = null;
     _lastVolunteeredThemeDefaultsAt = null;
     if (hadMetadata || hadRemoteColors) {
       _notifyMetadataChanged();
@@ -4175,6 +4187,7 @@ class SshSession {
     }
   }
 
+  DateTime? _lastTerminalPaletteQueryAt;
   DateTime? _lastVolunteeredThemeDefaultsAt;
 
   /// A color interrogation arrives as a burst of palette queries; volunteer
@@ -4229,6 +4242,9 @@ class SshSession {
 
   void _handlePrivateOsc(String code, List<String> args) {
     final hasThemeQuery = args.any((arg) => arg.trim() == '?');
+    if (hasThemeQuery && code == '4') {
+      _lastTerminalPaletteQueryAt = DateTime.now();
+    }
     if (hasThemeQuery &&
         (code == '4' ||
             code == '10' ||

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -4995,6 +4995,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
   }) {
     _cancelTerminalThemeRefreshTimers();
     final refreshGeneration = ++_terminalThemeRefreshGeneration;
+    final refreshStartedAt = DateTime.now();
     final plainTuiRefreshAllowed = _shouldRefreshPlainTerminalTui(session);
     final terminalViewReady = _isTerminalThemeRefreshViewReady;
     final tmuxStateBelongsToSession =
@@ -5110,9 +5111,11 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     // foreground TUI. Codex treats those bytes as user input, and its crossterm
     // color re-query can also be disrupted by unrelated terminal reports.
     // Always send a synthetic focus transition so focus-aware TUIs re-query OSC
-    // 10/11 through the normal path. Also push default-color reports when the
-    // app requested DEC 2031 updates or when Windows ConPTY is active: ConPTY
-    // consumes the OSC 10/11 queries Copilot CLI uses to repaint its composer.
+    // 10/11 through the normal path. Apps that requested DEC 2031 updates can
+    // receive default-color reports directly. Under Windows ConPTY, wait until
+    // the foreground TUI responds by querying its palette. ConPTY enables focus
+    // reporting for a bare command prompt too, where unsolicited color reports
+    // are echoed as typed input.
     final includeThemeModeReport = session.terminalColorSchemeUpdatesMode;
     final includeDefaultColorReports =
         includeThemeModeReport || session.terminalWin32InputMode;
@@ -5145,6 +5148,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
           includeFocusReport: false,
           includeThemeModeReport: false,
           includeDefaultColorReports: true,
+          requirePaletteQuerySince: includeThemeModeReport
+              ? null
+              : refreshStartedAt,
           reason: '${reason}_plain_defaults',
         );
       }
@@ -6160,6 +6166,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
     bool includeColorReports = false,
     bool includeDefaultColorReports = false,
     bool includeFocusReport = true,
+    DateTime? requirePaletteQuerySince,
     String reason = 'unspecified',
   }) {
     late final Timer timer;
@@ -6170,6 +6177,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen>
         session: session,
         refreshGeneration: refreshGeneration,
       )) {
+        return;
+      }
+      if (includeDefaultColorReports &&
+          requirePaletteQuerySince != null &&
+          !session.hasTerminalPaletteQuerySince(requirePaletteQuerySince)) {
+        DiagnosticsLogService.instance.info(
+          'terminal.theme',
+          'defaults_skipped_no_palette_query',
+          fields: {'reason': reason, 'connectionId': session.connectionId},
+        );
         return;
       }
       if (_isTmuxActive &&

--- a/test/presentation/screens/terminal_screen_test.dart
+++ b/test/presentation/screens/terminal_screen_test.dart
@@ -2607,7 +2607,7 @@ void main() {
     );
 
     testWidgets(
-      'pushes updated default colors through Windows ConPTY on theme changes',
+      'does not push default colors into an idle Windows ConPTY shell',
       (tester) async {
         await pumpScreen(tester);
         shellStdoutController.add(
@@ -2633,6 +2633,47 @@ void main() {
           RegExp(r'\x1b\[0;0;(\d+);1;0;1_'),
           (match) => String.fromCharCode(int.parse(match.group(1)!)),
         );
+        expect(decodedWin32Input, contains('\x1b[O\x1b[I'));
+        expect(decodedWin32Input, isNot(contains('\x1b]10;')));
+        expect(decodedWin32Input, isNot(contains('\x1b]11;')));
+        expect(decodedWin32Input, isNot(contains('\x1b[?997;1n')));
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets(
+      'pushes updated default colors through Windows ConPTY for a TUI',
+      (tester) async {
+        await pumpScreen(tester);
+        shellStdoutController.add(
+          Uint8List.fromList(utf8.encode('\x1b[?9001h\x1b[?1004h')),
+        );
+        await tester.pump(const Duration(milliseconds: 20));
+        expect(session.terminalWin32InputMode, isTrue);
+        shellWrites.clear();
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(TerminalScreen)),
+        );
+        await container
+            .read(themeModeNotifierProvider.notifier)
+            .setThemeMode(ThemeMode.dark);
+        await tester.pump();
+
+        shellStdoutController.add(
+          Uint8List.fromList(utf8.encode('\x1b]4;0;?\x1b\\')),
+        );
+        await tester.pump(const Duration(milliseconds: 20));
+        shellWrites.clear();
+        await tester.pump(const Duration(milliseconds: 500));
+
+        final writtenShellText = utf8.decode(
+          shellWrites.expand((chunk) => chunk).toList(growable: false),
+        );
+        final decodedWin32Input = writtenShellText.replaceAllMapped(
+          RegExp(r'\x1b\[0;0;(\d+);1;0;1_'),
+          (match) => String.fromCharCode(int.parse(match.group(1)!)),
+        );
         expect(
           decodedWin32Input,
           contains(
@@ -2641,7 +2682,6 @@ void main() {
             ),
           ),
         );
-        expect(decodedWin32Input, contains('\x1b[O\x1b[I'));
         expect(decodedWin32Input, isNot(contains('\x1b[?997;1n')));
       },
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),


### PR DESCRIPTION
## Summary

- stop sending unsolicited OSC 10/11 color reports to idle Windows ConPTY shells
- use OSC 4 palette queries as evidence that a foreground TUI requested a theme refresh
- preserve delayed color updates for Copilot and other palette-querying TUIs

## Tests

- `flutter analyze lib/domain/services/ssh_service.dart lib/presentation/screens/terminal_screen.dart test/presentation/screens/terminal_screen_test.dart`
- `flutter test test/presentation/screens/terminal_screen_test.dart --plain-name "Windows ConPTY"`
- `flutter test test/domain/services/ssh_service_test.dart --plain-name "volunteers default color reports"`