### PR TITLE
Fix intermittent home screen insets

### DIFF
--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -469,6 +469,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   }
 
   Widget _buildMobileLayout() => Scaffold(
+    // This shell has no text input. Ignore stale IME insets left behind by
+    // input-heavy routes.
+    resizeToAvoidBottomInset: false,
     appBar: AppBar(
       title: Row(
         mainAxisSize: MainAxisSize.min,
@@ -494,6 +497,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     ),
     body: _buildContent(),
     bottomNavigationBar: NavigationBar(
+      // Keep destinations clear of edge-to-edge system navigation while an
+      // IME inset temporarily reduces MediaQuery.padding.
+      maintainBottomViewPadding: true,
       selectedIndex: _selectedIndex,
       onDestinationSelected: (index) => setState(() => _selectedIndex = index),
       labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,

--- a/test/widget/home_screen_test.dart
+++ b/test/widget/home_screen_test.dart
@@ -417,6 +417,7 @@ void main() {
     required AppDatabase db,
     required List overrides,
     Size size = const Size(400, 800),
+    MediaQueryData mediaQueryData = const MediaQueryData(),
   }) => ProviderScope(
     overrides: [
       databaseProvider.overrideWithValue(db),
@@ -432,10 +433,80 @@ void main() {
       ...overrides,
     ],
     child: MediaQuery(
-      data: MediaQueryData(size: size),
+      data: mediaQueryData.copyWith(size: size),
       child: const MaterialApp(home: HomeScreen()),
     ),
   );
+
+  group('HomeScreen mobile insets', () {
+    const systemNavigationBarHeight = 24.0;
+    const staleKeyboardInset = 240.0;
+    const insetMediaQueryData = MediaQueryData(
+      padding: EdgeInsets.zero,
+      viewPadding: EdgeInsets.only(bottom: systemNavigationBarHeight),
+      viewInsets: EdgeInsets.only(bottom: staleKeyboardInset),
+    );
+
+    testWidgets('keeps navigation destinations above the system bar', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      await tester.pumpWidget(
+        buildMobileHomeScreen(
+          db: db,
+          mediaQueryData: insetMediaQueryData,
+          overrides: [
+            activeSessionsProvider.overrideWith(
+              _TestActiveSessionsNotifier.new,
+            ),
+            allHostsProvider.overrideWith(
+              (ref) => Stream.value(const <Host>[]),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      final scaffoldRect = tester.getRect(find.byType(Scaffold).first);
+      final hostsDestinationRect = tester.getRect(find.text('Hosts').last);
+
+      expect(
+        hostsDestinationRect.bottom,
+        lessThanOrEqualTo(scaffoldRect.bottom - systemNavigationBarHeight),
+      );
+    });
+
+    testWidgets('does not shrink the home content for a stale keyboard inset', (
+      tester,
+    ) async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      await tester.pumpWidget(
+        buildMobileHomeScreen(
+          db: db,
+          mediaQueryData: insetMediaQueryData,
+          overrides: [
+            activeSessionsProvider.overrideWith(
+              _TestActiveSessionsNotifier.new,
+            ),
+            allHostsProvider.overrideWith(
+              (ref) => Stream.value(const <Host>[]),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      final scaffold = tester.widget<Scaffold>(find.byType(Scaffold).first);
+      final bodyRect = tester.getRect(find.byWidget(scaffold.body!));
+      final navigationBarRect = tester.getRect(find.byType(NavigationBar));
+
+      expect(bodyRect.bottom, closeTo(navigationBarRect.top, 0.01));
+    });
+  });
 
   group('HomeScreen reorder affordance', () {
     testWidgets('shows reorder handles and persists host order on mobile', (


### PR DESCRIPTION
## Summary

- keep the mobile home shell from resizing around stale Android IME insets
- preserve the bottom system navigation inset for NavigationBar destinations in edge-to-edge mode
- add widget regressions that reproduce both failures with simultaneous view padding and stale keyboard insets

## Reproduction

The regression fixture reports a 24dp bottom system inset with a stale 240dp IME inset. Before the fix, the home body ended 175dp above the navigation bar and the navigation content lost its 24dp system-bar clearance.

## Verification

- `flutter test test/widget/home_screen_test.dart`
- `flutter analyze lib/presentation/screens/home_screen.dart test/widget/home_screen_test.dart`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home flutter build apk --debug --flavor private -t lib/main.dart`
- installed and visually checked the APK on an Android 16 API 36 emulator
