### PR TITLE
ci: use organization self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ permissions:
 
 env:
   FLUTTER_VERSION: "3.44.8"
+  # setup-go owns GOROOT; ignore a host-level toolchain override.
+  GOROOT: ""
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+# GitHub action SHAs and expressions routinely exceed 80 columns.
+# yamllint disable rule:line-length
 name: CI
 
 on:
@@ -27,7 +29,7 @@ jobs:
   # ---------------------------------------------------------------------------
   changes:
     name: Detect Changes
-    runs-on: ubicloud-standard-4
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 5
     outputs:
       run_check: ${{ steps.filter.outputs.run_check }}
@@ -116,7 +118,7 @@ jobs:
     name: No-op
     needs: changes
     if: needs.changes.outputs.run_check != 'true' && needs.changes.outputs.go != 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 2
     steps:
       - name: Skip heavy CI
@@ -128,7 +130,7 @@ jobs:
     name: Build MonkeyMux Assets
     needs: changes
     if: needs.changes.outputs.run_check == 'true'
-    runs-on: ubicloud-standard-4
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -158,7 +160,7 @@ jobs:
     name: Analyze & Format
     needs: [changes, monkeymux-assets]
     if: needs.changes.outputs.run_check == 'true'
-    runs-on: ubicloud-standard-4
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -190,7 +192,7 @@ jobs:
     name: Test (Shard ${{ matrix.shard-index }}/4)
     needs: [changes, monkeymux-assets]
     if: needs.changes.outputs.run_check == 'true'
-    runs-on: ubicloud-standard-4
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -235,16 +237,16 @@ jobs:
     name: Go Tests (${{ matrix.name }})
     needs: [changes, monkeymux-assets]
     if: needs.changes.outputs.go == 'true'
-    runs-on: ${{ matrix.os }}
+    runs-on: [self-hosted, "${{ matrix.os }}"]
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: linux
-            os: ubuntu-latest
+            os: Linux
           - name: windows
-            os: windows-2025
+            os: Windows
     defaults:
       run:
         shell: bash
@@ -314,7 +316,7 @@ jobs:
     name: Build Android
     needs: [changes, monkeymux-assets]
     if: needs.changes.outputs.android == 'true'
-    runs-on: ubicloud-standard-4
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -414,7 +416,7 @@ jobs:
     name: Build iOS
     needs: [changes, monkeymux-assets]
     if: needs.changes.outputs.ios == 'true'
-    runs-on: macos-26
+    runs-on: [self-hosted, macOS]
     env:
       # Keep release validation on the runner Xcode that includes the installed
       # iOS simulator runtime. Newer side-by-side Xcodes can drift ahead of the
@@ -499,7 +501,7 @@ jobs:
     name: Build macOS
     needs: [changes, monkeymux-assets]
     if: needs.changes.outputs.macos == 'true'
-    runs-on: macos-26
+    runs-on: [self-hosted, macOS]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -558,7 +560,7 @@ jobs:
     name: Build Windows
     needs: [changes, monkeymux-assets]
     if: needs.changes.outputs.windows == 'true'
-    runs-on: windows-2025
+    runs-on: [self-hosted, Windows]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -599,7 +601,7 @@ jobs:
     name: Build Linux
     needs: [changes, monkeymux-assets]
     if: needs.changes.outputs.linux == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -649,7 +651,7 @@ jobs:
     name: CI
     if: ${{ always() && !cancelled() }}
     needs: [changes, monkeymux-assets, check, test, go-test, build-android, build-ios, build-macos, build-windows, build-linux]
-    runs-on: ubicloud-standard-4
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 2
     steps:
       - name: Evaluate results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 env:
-  FLUTTER_VERSION: '3.44.8'
+  FLUTTER_VERSION: "3.44.8"
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -176,7 +176,7 @@ jobs:
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: 'stable'
+          channel: "stable"
           cache: true
 
       - name: Install dependencies
@@ -212,7 +212,7 @@ jobs:
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: 'stable'
+          channel: "stable"
           cache: true
 
       - name: Install dependencies
@@ -331,8 +331,8 @@ jobs:
 
       - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
 
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
@@ -351,7 +351,7 @@ jobs:
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: 'stable'
+          channel: "stable"
           cache: true
 
       - name: Install dependencies
@@ -448,7 +448,7 @@ jobs:
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: 'stable'
+          channel: "stable"
           cache: true
 
       - name: Install dependencies
@@ -525,7 +525,7 @@ jobs:
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: 'stable'
+          channel: "stable"
           cache: true
 
       - name: Install dependencies
@@ -576,7 +576,7 @@ jobs:
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: 'stable'
+          channel: "stable"
           cache: true
 
       - name: Install dependencies
@@ -622,7 +622,7 @@ jobs:
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: 'stable'
+          channel: "stable"
           cache: true
 
       - name: Install dependencies
@@ -650,7 +650,19 @@ jobs:
   ci:
     name: CI
     if: ${{ always() && !cancelled() }}
-    needs: [changes, monkeymux-assets, check, test, go-test, build-android, build-ios, build-macos, build-windows, build-linux]
+    needs:
+      [
+        changes,
+        monkeymux-assets,
+        check,
+        test,
+        go-test,
+        build-android,
+        build-ios,
+        build-macos,
+        build-windows,
+        build-linux,
+      ]
     runs-on: [self-hosted, Linux]
     timeout-minutes: 2
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ env:
   FLUTTER_VERSION: "3.44.8"
   # setup-go owns GOROOT; ignore a host-level toolchain override.
   GOROOT: ""
+  # Linux runners share this SDK cache across service accounts.
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: safe.directory
+  GIT_CONFIG_VALUE_0: /opt/hostedtoolcache/flutter/stable-3.44.8-x64/flutter
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -263,6 +267,16 @@ jobs:
         with:
           name: monkeymux-assets
           path: assets/monkeymux/
+
+      - name: Add Git Bash to PATH
+        if: matrix.name == 'windows'
+        shell: pwsh
+        run: |
+          $gitBin = Join-Path $env:ProgramFiles 'Git\bin'
+          if (-not (Test-Path (Join-Path $gitBin 'bash.exe'))) {
+            throw 'Git Bash is not installed under Program Files.'
+          }
+          $gitBin | Out-File $env:GITHUB_PATH -Encoding utf8 -Append
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -574,6 +588,15 @@ jobs:
         with:
           name: monkeymux-assets
           path: assets/monkeymux/
+
+      - name: Add Git Bash to PATH
+        shell: pwsh
+        run: |
+          $gitBin = Join-Path $env:ProgramFiles 'Git\bin'
+          if (-not (Test-Path (Join-Path $gitBin 'bash.exe'))) {
+            throw 'Git Bash is not installed under Program Files.'
+          }
+          $gitBin | Out-File $env:GITHUB_PATH -Encoding utf8 -Append
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:


### PR DESCRIPTION
## Summary

- route all CI jobs to the organization's self-hosted runners
- select runners with the standard `self-hosted` plus `Linux`, `macOS`, or `Windows` labels
- keep the existing test sharding and cross-platform Go matrix unchanged

## Benchmark plan

This workflow-only change forces every platform build, so this PR gives us a full cold-run comparison. A recent full hosted run took 11m20s end to end. Its slowest jobs were macOS at 9m22s, iOS at 7m21s, Windows at 6m51s, and Android at 6m29s.

There are two to four runner services on each machine. Using the hosted job durations as a rough model:

- two Linux slots project to about 15 minutes end to end
- three or four Linux slots project to about 10 minutes end to end
- two or more Mac slots keep iOS and macOS parallel, with a roughly 9m22s platform critical path
- two or more Windows slots keep the Go and Flutter jobs parallel, with a roughly 6m51s platform critical path

Services on the same physical machine share CPU, memory, and disk, so contention may make concurrent builds slower. Persistent tool caches may offset that after the first run.

## Validation

- `actionlint .github/workflows/ci.yml`
- YAML parse
- `flutter analyze --fatal-warnings --fatal-infos --no-pub`
- exact runner labels checked for every CI job

## Before merge

The trial is queued because the repository cannot currently see the new organization runners. Check the runner group's repository access and public-repository policy.

This is a public repository. Persistent self-hosted runners should not execute untrusted fork code. Keep this as a benchmark until runner access is limited to trusted jobs or the runners are ephemeral.
